### PR TITLE
fix: standardize release artifact naming and packaging

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -42,16 +42,20 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: lev-linux-x86_64
+            artifact: leviath-linux-x64
+            ext: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: lev-darwin-arm64
+            artifact: leviath-macos-arm64
+            ext: tar.gz
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact: lev-darwin-x86_64
+            artifact: leviath-macos-x64
+            ext: tar.gz
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact: lev-windows-x86_64.exe
+            artifact: leviath-windows-x64
+            ext: zip
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -62,19 +66,23 @@ jobs:
           key: release-${{ matrix.target }}
       - name: Build release binary
         run: cargo build --release --bin lev --target ${{ matrix.target }}
-      - name: Rename binary
+      - name: Package archive
         shell: bash
         run: |
+          mkdir -p staging/
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            cp target/${{ matrix.target }}/release/lev.exe ${{ matrix.artifact }}
+            cp target/${{ matrix.target }}/release/lev.exe staging/lev.exe
+            cd staging && 7z a -tzip ../${{ matrix.artifact }}.zip lev.exe
           else
-            cp target/${{ matrix.target }}/release/lev ${{ matrix.artifact }}
+            cp target/${{ matrix.target }}/release/lev staging/lev
+            chmod +x staging/lev
+            cd staging && tar czf ../${{ matrix.artifact }}.tar.gz lev
           fi
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+          name: ${{ matrix.artifact }}.${{ matrix.ext }}
+          path: ${{ matrix.artifact }}.${{ matrix.ext }}
 
   release:
     name: Publish Alpha
@@ -103,10 +111,11 @@ jobs:
           for dir in artifacts/*/; do
             name=$(basename "$dir")
             cp "$dir/$name" "release/$name"
-            chmod +x "release/$name"
           done
+          # Generate checksums
+          cd release && sha256sum * > SHA256SUMS
           # Write the commit SHA for downstream promotion
-          echo "${{ steps.info.outputs.sha_full }}" > release/COMMIT_SHA
+          echo "${{ steps.info.outputs.sha_full }}" > COMMIT_SHA
 
       - name: Create/update alpha tag
         run: |
@@ -127,11 +136,23 @@ jobs:
             ⚠️ This is an alpha build. Use at your own risk.
 
             ### Install
+
+            **Homebrew (macOS):**
             ```bash
-            # Download for your platform, then:
-            chmod +x lev-*
-            sudo mv lev-* /usr/local/bin/lev
+            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew install leviath
+            ```
+
+            **Linux:**
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            ```
+
+            **Manual:**
+            ```bash
+            # Download the archive for your platform, then:
+            tar xzf leviath-*.tar.gz
+            sudo mv lev /usr/local/bin/
             ```
           prerelease: true
           files: release/*
-          # TODO: Update homebrew alpha tap once created

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -77,10 +77,22 @@ jobs:
             prod on Thursday if approved.
 
             ### Install
+
+            **Homebrew (macOS):**
             ```bash
-            chmod +x lev-*
-            sudo mv lev-* /usr/local/bin/lev
+            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew install leviath
+            ```
+
+            **Linux:**
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            ```
+
+            **Manual:**
+            ```bash
+            tar xzf leviath-*.tar.gz
+            sudo mv lev /usr/local/bin/
             ```
           prerelease: true
           files: release/*
-          # TODO: Update homebrew beta tap once created

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -81,10 +81,6 @@ jobs:
       - name: Approval received
         run: echo "Prod deployment approved for ${{ needs.check-beta.outputs.sha_short }}"
 
-  # Auto-cancel if not approved by 6pm PST (1am UTC Friday)
-  # GitHub environment protection rules handle the timeout —
-  # set "Required reviewers" and a wait timer on the 'production' environment.
-
   deploy:
     name: Deploy to Prod
     needs: [check-beta, approve]
@@ -121,40 +117,48 @@ jobs:
       - name: Publish prod release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
+          tag_name: ${{ env.VERSION }}
           name: "Leviath ${{ env.VERSION }}"
           body: |
-            **Stable release** promoted from beta.
+            **Stable release** — ${{ env.VERSION }}
 
             Source commit: ${{ needs.check-beta.outputs.sha }}
-            Version: ${{ env.VERSION }}
 
             ### Install
 
-            **Homebrew** (coming soon):
+            **Homebrew (macOS):**
             ```bash
-            brew install gemisis/tap/leviath
+            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew install leviath
             ```
 
-            **Binary download:**
+            **Linux:**
             ```bash
-            # macOS (Apple Silicon)
-            curl -sL <release-url>/lev-darwin-arm64 -o lev && chmod +x lev && sudo mv lev /usr/local/bin/
+            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            ```
 
-            # macOS (Intel)
-            curl -sL <release-url>/lev-darwin-x86_64 -o lev && chmod +x lev && sudo mv lev /usr/local/bin/
+            **Windows (Scoop):**
+            ```powershell
+            scoop bucket add leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            scoop install leviath
+            ```
 
-            # Linux (x86_64)
-            curl -sL <release-url>/lev-linux-x86_64 -o lev && chmod +x lev && sudo mv lev /usr/local/bin/
-
-            # Windows (x86_64) — download lev-windows-x86_64.exe and add to PATH
+            **Manual:**
+            ```bash
+            # Download the archive for your platform, then:
+            tar xzf leviath-*.tar.gz    # or unzip for Windows
+            sudo mv lev /usr/local/bin/
             ```
 
             **From source:**
             ```bash
-            cargo install --git https://github.com/GEMISIS/leviath.git --tag ${{ env.VERSION }} --bin lev
+            cargo install --git https://github.com/Sun-Forge-AI/leviath.git --tag ${{ env.VERSION }} --bin lev
             ```
           prerelease: false
           make_latest: true
           files: release/*
-          # TODO: Update homebrew stable tap once created
+
+      - name: Update latest tag
+        run: |
+          git tag -f latest ${{ needs.check-beta.outputs.sha }}
+          git push -f origin latest


### PR DESCRIPTION
## What

Fixes the release pipeline so artifacts match what the Homebrew formula, install script, and Scoop manifest expect.

### Changes

**Artifact naming** (all three workflows):
| Before | After |
|--------|-------|
| `lev-darwin-arm64` | `leviath-macos-arm64.tar.gz` |
| `lev-darwin-x86_64` | `leviath-macos-x64.tar.gz` |
| `lev-linux-x86_64` | `leviath-linux-x64.tar.gz` |
| `lev-windows-x86_64.exe` | `leviath-windows-x64.zip` |

**Packaging:**
- Unix: binary wrapped in `tar.gz` (required by Homebrew formula)
- Windows: binary wrapped in `zip` (required by Scoop manifest)
- `SHA256SUMS` file added to each release

**Release notes:** Updated install instructions with correct `brew tap` / `curl` / `scoop` commands pointing to Sun-Forge-AI org.

**Prod releases:** Tag format uses semver from Cargo.toml (`v0.1.0`) instead of bare binary names.

### Why

The existing alpha release published bare binaries (`lev-darwin-arm64`) but the dist repo's Homebrew formula expects `leviath-macos-arm64.tar.gz`. This caused 404s on `brew install leviath`.