### PR TITLE
Fix CI release pipelines (alpha/beta/prod) and deflake ETXTBSY spawn race

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+# Default to read-only; the release job elevates itself explicitly.
+permissions:
+  contents: read
+
 jobs:
   # Re-run all CI gates before building alpha
   gate:
@@ -117,21 +121,20 @@ jobs:
           # Write the commit SHA for downstream promotion
           echo "${{ steps.info.outputs.sha_full }}" > COMMIT_SHA
 
-      - name: Create/update alpha tag
+      # 'alpha' is a rolling channel release: delete the previous release
+      # AND its tag together before republishing. Deleting only the tag
+      # (the old approach) orphans the attached release as a draft, and
+      # the next publish then fails with tag_name already_exists.
+      - name: Reset alpha channel release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          SHA=$(git rev-parse HEAD)
-          # Delete existing tag ref if present, then recreate
-          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/alpha 2>/dev/null || true
-          gh api -X POST repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/alpha" \
-            -f sha="$SHA"
+        run: gh release delete alpha --yes --cleanup-tag --repo ${{ github.repository }} || true
 
       - name: Publish alpha release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: alpha
+          target_commitish: ${{ steps.info.outputs.sha_full }}
           name: "Alpha · ${{ steps.info.outputs.date }} · ${{ steps.info.outputs.sha_short }}"
           body: |
             **Nightly alpha build** from `main` at ${{ steps.info.outputs.sha_full }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -55,21 +55,21 @@ jobs:
           gh release download alpha --dir release/
           ls -la release/
 
-      - name: Create/update beta tag
+      # 'beta' is a rolling channel release: delete the previous release
+      # AND its tag together before republishing (deleting only the tag
+      # orphans the release as a draft and the next publish collides).
+      - name: Reset beta channel release
         if: steps.alpha.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/beta 2>/dev/null || true
-          gh api -X POST repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/beta" \
-            -f sha="${{ steps.alpha.outputs.sha }}"
+        run: gh release delete beta --yes --cleanup-tag --repo ${{ github.repository }} || true
 
       - name: Publish beta release
         if: steps.alpha.outputs.skip != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: beta
+          target_commitish: ${{ steps.alpha.outputs.sha }}
           name: "Beta · ${{ steps.alpha.outputs.date }} · ${{ steps.alpha.outputs.sha_short }}"
           body: |
             **Weekly beta build** promoted from alpha.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+# CI never writes to the repo; badge publishing uses the scoped GIST_TOKEN
+# secret, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -6,8 +6,9 @@ on:
     - cron: '0 16 * * 4'
   workflow_dispatch: # Manual trigger
 
+# Default to read-only; only the deploy job needs to write releases.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-beta:
@@ -68,7 +69,9 @@ jobs:
         id: version
         if: steps.beta.outputs.skip != 'true'
         run: |
-          version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          # Read the version from the promoted commit, not the tip of main --
+          # main may have moved past the beta build since it was cut.
+          version=$(git show "${{ steps.beta.outputs.sha }}:Cargo.toml" | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
           echo "version=$version" >> $GITHUB_OUTPUT
 
   approve:
@@ -85,6 +88,8 @@ jobs:
     name: Deploy to Prod
     needs: [check-beta, approve]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -98,35 +103,24 @@ jobs:
           gh release download beta --dir release/
           ls -la release/
 
-      - name: Create version tag
+      - name: Determine version tag
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="v${{ needs.check-beta.outputs.version }}"
-          SHA="${{ needs.check-beta.outputs.sha }}"
-          # If tag exists, append date
+          # If the tag was already released (version not bumped since the
+          # last prod deploy), disambiguate with the date rather than
+          # moving the existing tag.
           if gh api repos/${{ github.repository }}/git/refs/tags/$VERSION >/dev/null 2>&1; then
             VERSION="${VERSION}+$(date -u +%Y%m%d)"
           fi
-          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/$VERSION 2>/dev/null || true
-          gh api -X POST repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/$VERSION" \
-            -f sha="$SHA"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create/update latest tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/latest 2>/dev/null || true
-          gh api -X POST repos/${{ github.repository }}/git/refs \
-            -f ref="refs/tags/latest" \
-            -f sha="${{ needs.check-beta.outputs.sha }}"
 
       - name: Publish prod release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.VERSION }}
+          target_commitish: ${{ needs.check-beta.outputs.sha }}
           name: "Leviath ${{ env.VERSION }}"
           body: |
             **Stable release** — ${{ env.VERSION }}
@@ -165,6 +159,32 @@ jobs:
             ```
           prerelease: false
           make_latest: true
+          files: release/*
+
+      # The install script's stable channel resolves releases/tags/latest,
+      # so 'latest' must be a rolling channel release with the same assets
+      # (like 'alpha' and 'beta'), not just a git tag. Delete release+tag
+      # together before republishing to avoid orphaned-draft collisions.
+      - name: Update latest channel release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete latest --yes --cleanup-tag --repo ${{ github.repository }} || true
+
+      - name: Publish latest channel release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: latest
+          target_commitish: ${{ needs.check-beta.outputs.sha }}
+          name: "Leviath ${{ env.VERSION }} (stable channel)"
+          body: |
+            Rolling **stable channel** release, currently ${{ env.VERSION }}.
+
+            Source commit: ${{ needs.check-beta.outputs.sha }}
+
+            This tag always points at the newest stable release; see the
+            ${{ env.VERSION }} release for details and install instructions.
+          prerelease: false
+          make_latest: false
           files: release/*
 
 

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -35,11 +35,14 @@ jobs:
             TARGET_TAG="${{ inputs.version }}"
             echo "Reverting to specified version: $TARGET_TAG"
           else
-            # Find the previous prod release (not alpha/beta/latest)
-            # List releases, skip current latest, find first non-prerelease
-            PREV_TAG=$(gh release list --limit 20 | grep -v "Pre-release" | grep -v "^Latest" | head -1 | awk '{print $1}' || echo "")
+            # Find the previous prod release: versioned (vX.Y.Z) stable
+            # releases only, skipping index 0 (the current one being
+            # reverted). Channel releases (alpha/beta/latest) and drafts
+            # are excluded.
+            PREV_TAG=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[] | select((.draft or .prerelease) | not) | .tag_name | select(startswith("v"))][1] // empty')
             if [ -z "$PREV_TAG" ]; then
-              echo "ERROR: No previous release found to revert to."
+              echo "ERROR: No previous versioned release found to revert to."
               exit 1
             fi
             TARGET_TAG="$PREV_TAG"
@@ -69,15 +72,20 @@ jobs:
           }
           ls -la release/
 
-      - name: Update latest tag
-        run: |
-          git tag -f latest ${{ steps.target.outputs.sha }}
-          git push -f origin latest
+      # Rebuild the rolling 'latest' channel release from the target
+      # version's assets. Same delete-release-and-tag-together pattern as
+      # prod (a bare tag delete/force-push orphans the release as a draft,
+      # and direct git pushes are blocked by branch/tag protection).
+      - name: Reset latest channel release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete latest --yes --cleanup-tag --repo ${{ github.repository }} || true
 
       - name: Publish reverted release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: latest
+          target_commitish: ${{ steps.target.outputs.sha }}
           name: "Leviath ${{ steps.target.outputs.tag }} (reverted)"
           body: |
             **⚠️ REVERTED** to ${{ steps.target.outputs.tag }}

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -21,3 +21,7 @@ futures-core = { workspace = true }
 tokio-stream = { workspace = true }
 pin-project-lite = { workspace = true }
 bytes = "1"
+
+[dev-dependencies]
+# test-util enables tokio::time::pause so retry/backoff tests run instantly
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -297,6 +297,30 @@ impl Stream for ClaudeCodeStream {
     }
 }
 
+/// Run `op` (a spawn attempt), retrying briefly when it fails with
+/// `ETXTBSY`. On POSIX, `exec` fails with "Text file busy" while *any*
+/// process holds a write handle to the executable — including a write fd
+/// inherited by another process's in-flight fork/exec, or an installer
+/// rewriting the claude binary mid-spawn. The condition clears as soon as
+/// the writer closes, so a short bounded retry is the standard remedy
+/// (cargo does the same). On Windows the error kind never occurs, so this
+/// is a plain pass-through there.
+async fn retry_etxtbsy<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    const MAX_RETRIES: u32 = 40;
+    let mut attempt = 0;
+    loop {
+        match op() {
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ExecutableFileBusy && attempt < MAX_RETRIES =>
+            {
+                attempt += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            other => return other,
+        }
+    }
+}
+
 impl ClaudeCodeProvider {
     /// Core of [`Provider::infer`], with the process timeout injected so
     /// tests can exercise the timeout branch without a real 5-minute wait.
@@ -332,7 +356,7 @@ impl ClaudeCodeProvider {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let child = cmd.spawn().map_err(|e| {
+        let child = retry_etxtbsy(|| cmd.spawn()).await.map_err(|e| {
             ProviderError::RequestFailed(format!(
                 "Failed to spawn '{}': {}. Is Claude Code installed?",
                 self.binary_path, e
@@ -398,7 +422,7 @@ impl Provider for ClaudeCodeProvider {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let mut child = cmd.spawn().map_err(|e| {
+        let mut child = retry_etxtbsy(|| cmd.spawn()).await.map_err(|e| {
             ProviderError::RequestFailed(format!(
                 "Failed to spawn '{}': {}. Is Claude Code installed?",
                 self.binary_path, e
@@ -992,8 +1016,93 @@ mod tests {
             .infer_with_timeout(make_request(), std::time::Duration::from_millis(100))
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("timed out"));
+        let msg = err.to_string();
+        assert!(msg.contains("timed out"), "unexpected error: {msg}");
         let _ = std::fs::remove_file(&script);
+    }
+
+    /// Holds the stub script open for writing so exec fails `ETXTBSY`,
+    /// then releases it mid-retry: `spawn_child` must ride out the busy
+    /// window and the inference must still succeed. Deterministic
+    /// re-creation of the race that made stub tests flake on Linux CI.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_child_retries_until_etxtbsy_writer_releases() {
+        let script = write_stub_script(
+            "etxtbsy-retry",
+            "echo '{\"result\": \"hello from stub\"}'\n",
+            "",
+        );
+        let holder = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&script)
+            .unwrap();
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            drop(holder);
+        });
+        let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
+        let resp = provider.infer(make_request()).await.unwrap();
+        assert_eq!(resp.content, "hello from stub");
+        release.await.unwrap();
+        let _ = std::fs::remove_file(&script);
+    }
+
+    // The retry policy itself is unit-tested with injected errors rather
+    // than real busy executables: macOS does not enforce ETXTBSY at all,
+    // so a real-file simulation only exercises the branches on Linux.
+    // `start_paused` fast-forwards the backoff sleeps so these run
+    // instantly.
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_etxtbsy_retries_then_succeeds() {
+        let mut calls = 0;
+        let result = retry_etxtbsy(|| {
+            calls += 1;
+            if calls < 3 {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ExecutableFileBusy,
+                    "Text file busy",
+                ))
+            } else {
+                Ok(42)
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_etxtbsy_gives_up_when_busy_never_clears() {
+        let mut calls = 0;
+        let result: std::io::Result<()> = retry_etxtbsy(|| {
+            calls += 1;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ExecutableFileBusy,
+                "Text file busy",
+            ))
+        })
+        .await;
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::ExecutableFileBusy);
+        // Initial attempt plus MAX_RETRIES retries.
+        assert_eq!(calls, 41);
+    }
+
+    #[tokio::test]
+    async fn retry_etxtbsy_other_errors_pass_through_immediately() {
+        let mut calls = 0;
+        let result: std::io::Result<()> = retry_etxtbsy(|| {
+            calls += 1;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no such file",
+            ))
+        })
+        .await;
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+        assert_eq!(calls, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two independent failures were breaking the release pipelines:

1. **Flaky gate test** (`infer_with_timeout_fires_on_slow_process` et al.): on Linux, `exec` fails with `ETXTBSY` when any process holds a write fd to the stub script — including fds inherited by a concurrent test's in-flight fork/exec, which the earlier `sync_all` fix (dd1df65) could not prevent. The spawn sites now retry briefly on `ExecutableFileBusy` (the same remedy cargo uses). The retry policy is unit-tested with injected errors (macOS doesn't enforce ETXTBSY at all), plus a real writer-release race test that exercises the full path on Linux.

2. **Release publish always failed** (`already_exists` → "Too many retries"): deleting the `alpha` tag ref orphaned the previous release as a draft, which then collided with the next publish. All channel releases (`alpha`, `beta`, `latest`) now use `gh release delete --cleanup-tag` + softprops `target_commitish`, deleting release and tag together and recreating the tag via the Releases API (no git pushes).

Also:
- **prod** now publishes a real rolling `latest` **release** with binaries — the dist repo's `install.sh` stable channel resolves `releases/tags/latest`, which previously was only a bare git tag, so stable installs could never work. Version is read from the promoted SHA rather than tip-of-main.
- **revert** no longer force-pushes tags; it rebuilds the `latest` channel release from the target version's assets.
- **Least privilege**: `GITHUB_TOKEN` defaults to `contents: read` in ci/alpha/prod, elevated only in the jobs that publish releases.

## Test plan
- [x] `cargo test` / clippy / fmt clean locally (pre-commit runs full workspace)
- [ ] CI green on this PR
- [ ] After merge: dispatch Alpha → verify `alpha` release with assets
- [ ] Dispatch Beta → verify promotion from alpha's COMMIT_SHA
- [ ] Dispatch Prod → verify versioned + `latest` channel releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)