### PR TITLE
Add Linux ARM64 release builds; switch reqwest to rustls

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -48,6 +48,10 @@ jobs:
             os: ubuntu-latest
             artifact: leviath-linux-x64
             ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: leviath-linux-arm64
+            ext: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: leviath-macos-arm64
@@ -68,7 +72,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: release-${{ matrix.target }}
+      # aarch64-linux is cross-compiled from the x64 runner (hosted ARM
+      # runners aren't available for private repos on this plan). rustls
+      # keeps this simple: the only C to cross-compile is ring's, which
+      # just needs the gcc cross toolchain.
+      - name: Install aarch64 Linux cross toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build release binary
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
         run: cargo build --release --bin lev --target ${{ matrix.target }}
       - name: Package archive
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,11 @@ tokio = { version = "1.41", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
+# rustls instead of default native-tls: keeps Linux binaries free of a
+# runtime libssl dependency (single static binary) and lets the
+# aarch64-linux release target cross-compile without an OpenSSL sysroot.
+# native-roots so system/corporate CA stores are still honored.
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-native-roots", "charset", "http2", "macos-system-configuration"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
- Switch reqwest from default native-tls to `rustls-tls-native-roots`: Linux release binaries no longer require a runtime `libssl` (making the "single binary, no runtime deps" claim true on Linux), and system certificate stores are still honored.
- Add `aarch64-unknown-linux-gnu` to the alpha build matrix, cross-compiled from the x64 runner (hosted ARM runners aren't available for private repos on this plan). With rustls the only C to cross-compile is ring's, which just needs `gcc-aarch64-linux-gnu`.

The dist repo's formulas and `install.sh` already reference `leviath-linux-arm64.tar.gz`; this makes that asset exist. The asset flows to beta/prod automatically via promotion.

## Test plan
- [x] Full workspace test suite passes with rustls (3,456 tests, 0 failures)
- [x] `cargo tree`: no `native-tls`/`openssl-sys` in the Linux graph
- [ ] CI green
- [ ] Alpha dispatch after merge produces `leviath-linux-arm64.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)