### PR TITLE
fix(run): make plan-stage Revise/Add-detail/Abort deterministic

### DIFF
--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -21,21 +21,21 @@ bash       = "ask"
 mode = "interactive_points"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Explore the codebase and produce a step-by-step implementation plan"
-available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice"]
+available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document"]
 max_iterations = 20
 max_revisits = 6
-# Lets the run end here (via the "DONE" response — see transition_prompt)
-# when the user chooses to abort instead of forcing a transition.
+# "Abort" is handled deterministically by the engine (see abort_options on the
+# plan_approval interaction point), so allow_complete is no longer required for
+# it — kept true only so the LLM may still end here in edge cases.
 allow_complete = true
 transition_prompt = """
 You've shown the plan to the user and asked them to approve it, request
-revisions, expand a section, or abort.
+revisions, or edit it directly.
 
 - If they approved the plan, transition to 'implement'.
-- If they asked for revisions or more detail, transition back to 'plan',
-  address their specific feedback (see the "detail" message in context),
-  and produce an updated plan before asking again.
-- If they chose to abort, respond DONE — do not implement anything.
+- If they asked for revisions or edited the plan, transition back to 'plan',
+  incorporate their feedback (see the "directive"/"detail" messages in
+  context), and produce an updated plan before asking again.
 """
 system_prompt = """
 You are the planning stage of a code assistant.
@@ -69,6 +69,7 @@ read_file = "allow"
 list_dir  = "allow"
 ask_user_text   = "allow"
 ask_user_choice = "allow"
+edit_document   = "allow"
 
 [stages.plan.transitions.implement]
 hint = "Plan approved — proceed to implementation"
@@ -87,12 +88,16 @@ required = true
 style    = "multiple_choice"
 options  = ["Approve — proceed to implementation", "Revise — I'll describe changes", "Add detail — expand a section", "Abort — cancel this run"]
 
-# Picking "Revise" or "Add detail" alone only carries the static option label —
-# ask the user to actually describe what they want so the plan revision is
-# grounded in their real feedback instead of a generic label.
-[stages.plan.interaction_points.followups]
-"Revise — I'll describe changes" = "What would you like to change about the plan?"
-"Add detail — expand a section" = "Which section would you like expanded, and what should it cover?"
+# "Abort" ends the run immediately (engine-level, deterministic) — no further
+# inference, no transition.
+abort_options = ["Abort — cancel this run"]
+
+# Directives keyed by option label. Selecting one keeps the run in the plan
+# stage and injects the directive into the agent's context so it drives the
+# next step via a tool call (deterministic routing, agent-driven capture).
+[stages.plan.interaction_points.directives]
+"Revise — I'll describe changes" = "The user wants to revise the plan. Call the ask_user_text tool to ask exactly what they want changed, then produce an updated plan ending with the '## Plan' and '## Files' sections so it can be re-approved."
+"Add detail — expand a section" = "The user wants to edit the plan directly. Call the edit_document tool, passing the CURRENT full plan text as the `content` argument, so they can edit it in place. Treat the returned edited document as the new authoritative plan and re-present it."
 
 # ─── Stage 2: Implement ──────────────────────────────────────────────────────
 # Executes the approved plan. Write/edit/bash require tool-approval unless

--- a/agents/writing-assistant/agent.leviath
+++ b/agents/writing-assistant/agent.leviath
@@ -57,7 +57,6 @@ You've shown the outline and asked the user what to do:
   their specific feedback (see the "detail" message in context), and present an
   updated outline before asking again.
 - If they want to gather more material first, transition to 'research'.
-- If they chose to abort, respond DONE — do not draft anything.
 """
 system_prompt = """
 Based on your research, propose an outline for the piece:
@@ -93,11 +92,15 @@ required = true
 style    = "multiple_choice"
 options  = ["Approve — write the draft", "Revise — I'll describe changes", "Expand a section — I'll say which", "Research more first", "Abort — cancel this piece"]
 
-# Revise/Expand promise the user a chance to describe what they want — without a
-# followup, only the static label reaches the model and the intent is lost.
-[stages.outline.interaction_points.followups]
-"Revise — I'll describe changes" = "What would you like to change about the outline?"
-"Expand a section — I'll say which" = "Which section should be expanded, and what should it cover?"
+# "Abort" ends the run immediately (engine-level, deterministic).
+abort_options = ["Abort — cancel this piece"]
+
+# Directives keep the run in the outline stage and tell the agent to gather the
+# user's intent via a tool call before revising, rather than acting on the bare
+# option label.
+[stages.outline.interaction_points.directives]
+"Revise — I'll describe changes" = "The user wants to revise the outline. Call the ask_user_text tool to ask exactly what they want changed, then present an updated outline before asking again."
+"Expand a section — I'll say which" = "The user wants to expand a section. Call the ask_user_text tool to ask which section and what it should cover, then present an updated outline before asking again."
 
 # ─── Stage 3: Draft ───────────────────────────────────────────────────────────
 [stages.draft]

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -98,6 +98,37 @@ impl Dashboard {
         self.handle_main_list_key(key_code);
     }
 
+    /// Seed the input textarea when entering input mode. For an `EditText`
+    /// pending request the buffer is pre-filled with the request's `body` (the
+    /// current document) so the user edits it in place; otherwise it starts empty.
+    fn seed_input_textarea(&mut self) {
+        use interaction::InteractionKind;
+        let seed = self
+            .selected_agent()
+            .and_then(|a| a.pending_request.as_ref())
+            .filter(|r| r.kind == InteractionKind::EditText)
+            .and_then(|r| r.body.clone());
+        self.input_textarea = match seed {
+            Some(body) => {
+                tui_textarea::TextArea::new(body.lines().map(|s| s.to_string()).collect())
+            }
+            None => tui_textarea::TextArea::default(),
+        };
+    }
+
+    /// Whether the pending request carries a scrollable review document.
+    /// `EditText` also uses `body`, but for editing (not scrolling), so it is
+    /// explicitly excluded here.
+    fn has_scrollable_review(&self) -> bool {
+        use interaction::InteractionKind;
+        self.selected_agent()
+            .and_then(|a| a.pending_request.as_ref())
+            .filter(|r| r.kind != InteractionKind::EditText)
+            .and_then(|r| r.body.as_deref())
+            .map(|b| !b.is_empty())
+            .unwrap_or(false)
+    }
+
     fn handle_input_mode_key(&mut self, key_code: KeyCode, key: crossterm::event::KeyEvent) {
         use interaction::InteractionKind;
         let kind = self
@@ -111,19 +142,21 @@ impl Dashboard {
             .unwrap_or(0);
 
         match &kind {
-            Some(InteractionKind::FreeText) | None => match key_code {
-                KeyCode::Enter if key.modifiers.is_empty() => {
-                    self.submit_input();
+            Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None => {
+                match key_code {
+                    KeyCode::Enter if key.modifiers.is_empty() => {
+                        self.submit_input();
+                    }
+                    KeyCode::Esc => {
+                        self.input_mode = false;
+                        self.input_textarea = tui_textarea::TextArea::default();
+                        self.choice_selected = 0;
+                    }
+                    _ => {
+                        self.input_textarea.input(tui_textarea::Input::from(key));
+                    }
                 }
-                KeyCode::Esc => {
-                    self.input_mode = false;
-                    self.input_textarea = tui_textarea::TextArea::default();
-                    self.choice_selected = 0;
-                }
-                _ => {
-                    self.input_textarea.input(tui_textarea::Input::from(key));
-                }
-            },
+            }
             _ => match key_code {
                 KeyCode::Esc => {
                     self.input_mode = false;
@@ -219,17 +252,12 @@ impl Dashboard {
                 if self.selected_stage_can_respond() || self.selected_agent_accepts_messages() {
                     self.input_mode = true;
                     self.choice_selected = 0;
-                    self.input_textarea = tui_textarea::TextArea::default();
+                    self.seed_input_textarea();
                 }
             }
             KeyCode::Up => {
                 // When a review body is present, Up scrolls the review document
-                let has_review = self
-                    .selected_agent()
-                    .and_then(|a| a.pending_request.as_ref())
-                    .and_then(|r| r.body.as_deref())
-                    .map(|b| !b.is_empty())
-                    .unwrap_or(false);
+                let has_review = self.has_scrollable_review();
                 if has_review {
                     self.review_scroll = self.review_scroll.saturating_add(1);
                 } else {
@@ -237,12 +265,7 @@ impl Dashboard {
                 }
             }
             KeyCode::Down => {
-                let has_review = self
-                    .selected_agent()
-                    .and_then(|a| a.pending_request.as_ref())
-                    .and_then(|r| r.body.as_deref())
-                    .map(|b| !b.is_empty())
-                    .unwrap_or(false);
+                let has_review = self.has_scrollable_review();
                 if has_review {
                     self.review_scroll = self.review_scroll.saturating_sub(1);
                 } else {
@@ -250,12 +273,7 @@ impl Dashboard {
                 }
             }
             KeyCode::PageUp => {
-                let has_review = self
-                    .selected_agent()
-                    .and_then(|a| a.pending_request.as_ref())
-                    .and_then(|r| r.body.as_deref())
-                    .map(|b| !b.is_empty())
-                    .unwrap_or(false);
+                let has_review = self.has_scrollable_review();
                 if has_review {
                     self.review_scroll = self.review_scroll.saturating_add(10);
                 } else {
@@ -263,12 +281,7 @@ impl Dashboard {
                 }
             }
             KeyCode::PageDown => {
-                let has_review = self
-                    .selected_agent()
-                    .and_then(|a| a.pending_request.as_ref())
-                    .and_then(|r| r.body.as_deref())
-                    .map(|b| !b.is_empty())
-                    .unwrap_or(false);
+                let has_review = self.has_scrollable_review();
                 if has_review {
                     self.review_scroll = self.review_scroll.saturating_sub(10);
                 } else {
@@ -585,6 +598,17 @@ impl Dashboard {
                         "(end)".to_string()
                     } else {
                         truncate(&input, 40)
+                    };
+                    (InteractionResponse::text(&r.id, &input), d)
+                }
+                InteractionKind::EditText => {
+                    // Preserve indentation / internal newlines — only trim the
+                    // display label, not the submitted content.
+                    let input = self.input_textarea.lines().join("\n");
+                    let d = if input.trim().is_empty() {
+                        "(no changes)".to_string()
+                    } else {
+                        truncate(input.trim(), 40)
                     };
                     (InteractionResponse::text(&r.id, &input), d)
                 }
@@ -1202,6 +1226,88 @@ mod tests {
         dash.handle_key(key(KeyCode::Char('h')));
         dash.handle_key(key(KeyCode::Char('i')));
         assert_eq!(dash.input_textarea.lines(), vec!["hi".to_string()]);
+    }
+
+    #[test]
+    fn input_mode_edit_text_typing_appends_to_textarea() {
+        // EditText routes through the text-editing key arm just like FreeText.
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(crate::interaction::InteractionRequest::edit_text(
+            "et1", "Edit", "main", "seed",
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+
+        dash.handle_key(key(KeyCode::Char('!')));
+        assert_eq!(dash.input_textarea.lines(), vec!["!".to_string()]);
+    }
+
+    #[test]
+    fn seed_input_textarea_prefills_edit_text_body() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(crate::interaction::InteractionRequest::edit_text(
+            "et1",
+            "Edit",
+            "main",
+            "line A\nline B",
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+
+        dash.seed_input_textarea();
+        assert_eq!(
+            dash.input_textarea.lines(),
+            vec!["line A".to_string(), "line B".to_string()]
+        );
+    }
+
+    #[test]
+    fn seed_input_textarea_empty_for_free_text() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(crate::interaction::InteractionRequest::free_text(
+            "ft1", "Q?", "main", true,
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+
+        dash.input_textarea.insert_str("stale");
+        dash.seed_input_textarea();
+        // FreeText is not seeded from body → cleared to empty.
+        assert_eq!(dash.input_textarea.lines(), vec!["".to_string()]);
+    }
+
+    #[test]
+    fn submit_input_edit_text_preserves_newlines() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.is_run_state = false; // cmd_tx path — capture the SendInput value
+        agent.pending_request = Some(crate::interaction::InteractionRequest::edit_text(
+            "et1", "Edit", "main", "old",
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+
+        dash.input_textarea =
+            tui_textarea::TextArea::new(vec!["  indented".to_string(), "second line".to_string()]);
+        dash.submit_input();
+
+        assert!(!dash.input_mode);
+        assert!(dash.agents[0].pending_request.is_none());
+        // The edited text reached the engine with indentation + newline intact.
+        match cmd_rx.try_recv() {
+            Ok(EngineCommand::SendInput { input, .. }) => {
+                assert_eq!(input, "  indented\nsecond line");
+            }
+            other => panic!("expected SendInput, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -93,8 +93,13 @@ impl Dashboard {
     ) {
         use interaction::InteractionKind;
 
-        if self.input_mode && matches!(kind, Some(InteractionKind::FreeText) | None) {
-            // ── FreeText: render the multi-line tui-textarea widget ──────────
+        if self.input_mode
+            && matches!(
+                kind,
+                Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None
+            )
+        {
+            // ── FreeText / EditText: render the multi-line tui-textarea widget ──
             // No pending interaction request/prompt means this is a mid-run
             // message to a still-running agent rather than a response to a
             // specific question — label it accordingly for consistent UX.

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -106,9 +106,15 @@ impl Dashboard {
             0
         };
 
-        // Review body: shown when the pending interaction carries markdown for review
+        // Review body: shown when the pending interaction carries markdown for
+        // review. `EditText` also uses `body`, but that is the editable document
+        // (rendered in the seeded textarea once the user starts editing), not a
+        // read-only review doc — so it is excluded here.
         let review_body = if !self.input_mode && has_prompt {
-            pending_req.as_ref().and_then(|r| r.body.as_deref())
+            pending_req
+                .as_ref()
+                .filter(|r| r.kind != InteractionKind::EditText)
+                .and_then(|r| r.body.as_deref())
         } else {
             None
         };

--- a/crates/leviath-cli/src/commands/run/dynamic_interaction.rs
+++ b/crates/leviath-cli/src/commands/run/dynamic_interaction.rs
@@ -1,5 +1,5 @@
 //! Agent-initiated dynamic interaction tools: `present_for_review`,
-//! `ask_user_text`, `ask_user_choice`, `ask_user_confirm`.
+//! `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `edit_document`.
 //!
 //! Unlike `interaction_points` (declared statically in a blueprint and
 //! always fired), these are ordinary tool calls the model makes on its own
@@ -64,6 +64,9 @@ pub async fn dispatch_dynamic_interaction(
         }
         "ask_user_confirm" => {
             Some(handle_ask_user_confirm(backend, tool_call_id, arguments, stage_name).await)
+        }
+        "edit_document" => {
+            Some(handle_edit_document(backend, tool_call_id, arguments, stage_name).await)
         }
         _ => None,
     }
@@ -201,6 +204,39 @@ async fn handle_ask_user_confirm(
     format!("User answered: {}", if approved { "Yes" } else { "No" })
 }
 
+async fn handle_edit_document(
+    backend: &dyn InteractionBackend,
+    tool_call_id: &str,
+    arguments: &serde_json::Value,
+    stage_name: &str,
+) -> String {
+    let content = arg_str(arguments, "content", "");
+    let prompt = arg_str(
+        arguments,
+        "prompt",
+        "Edit the document below, then submit your changes:",
+    );
+
+    backend.log("[tool] edit_document \u{2192} waiting for user edits");
+
+    let req = InteractionRequest::edit_text(
+        format!("edit-{}", tool_call_id),
+        &prompt,
+        stage_name,
+        &content,
+    );
+    let resp = backend.ask(req).await;
+    let edited = response_as_text(&resp);
+
+    backend.log("[tool] edit_document \u{2192} done");
+
+    if edited.trim().is_empty() {
+        format!("User made no changes. Current document:\n{}", content)
+    } else {
+        format!("User-edited document:\n{}", edited)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +310,7 @@ mod tests {
             "ask_user_text",
             "ask_user_choice",
             "ask_user_confirm",
+            "edit_document",
         ];
         for name in names {
             let backend = MockBackend::with_responses(vec![InteractionResponse::text("", "ok")]);
@@ -615,6 +652,44 @@ mod tests {
         assert_eq!(asked[0].id, "ask-call4");
         assert_eq!(asked[0].kind, crate::interaction::InteractionKind::Confirm);
         assert_eq!(asked[0].options, vec!["Yes".to_string(), "No".to_string()]);
+    }
+
+    // ─── edit_document ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn edit_document_returns_edited_text() {
+        let backend =
+            MockBackend::with_responses(vec![InteractionResponse::text("", "edited plan")]);
+        let result = dispatch_dynamic_interaction(
+            &backend,
+            "edit_document",
+            "call1",
+            &serde_json::json!({"content": "original plan"}),
+            "plan",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, "User-edited document:\nedited plan");
+        let asked = backend.asked.lock().unwrap();
+        assert_eq!(asked[0].id, "edit-call1");
+        assert_eq!(asked[0].kind, crate::interaction::InteractionKind::EditText);
+        assert_eq!(asked[0].body.as_deref(), Some("original plan"));
+    }
+
+    #[tokio::test]
+    async fn edit_document_empty_edit_returns_original_content() {
+        let backend = MockBackend::with_responses(vec![InteractionResponse::text("", "")]);
+        let result = dispatch_dynamic_interaction(
+            &backend,
+            "edit_document",
+            "call2",
+            &serde_json::json!({"content": "keep this"}),
+            "plan",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, "User made no changes. Current document:\nkeep this");
     }
 
     // ─── log() / on_review_document() default no-ops don't panic ──────────

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -21,7 +21,7 @@ use crate::tools::ToolRegistry;
 use super::graph::{apply_edge_transform, is_graph_mode, resolve_transition};
 use super::helpers::swap_context_layout;
 use super::io::RunIO;
-use super::stages::{run_interactive_points_stage, run_interactive_stage};
+use super::stages::{run_interactive_points_stage, run_interactive_stage, PointsOutcome};
 
 use crate::runstate::RunMeta;
 
@@ -142,6 +142,14 @@ pub trait StageCallbacks: Send {
     /// Called after all stages complete.
     async fn on_complete(&mut self, last_stage_idx: usize);
 
+    /// Called when an interactive-points stage is aborted by the user. The
+    /// implementer should mark the run cancelled and persist that state. The
+    /// run then ends terminally with no further inference or transition.
+    /// Default no-op for callers with no run state (e.g. tests, foreground).
+    async fn on_cancel(&mut self, stage_idx: usize) {
+        let _ = stage_idx;
+    }
+
     /// Post-stage state update (worker writes meta + context snapshot).
     async fn on_post_stage(
         &mut self,
@@ -179,6 +187,7 @@ pub async fn run_stage_loop(
         .position(|s| s.name == current_stage_name_val)
         .unwrap_or(0);
     let mut visit_counts: HashMap<String, usize> = HashMap::new();
+    let mut aborted = false;
 
     loop {
         let stage = ctx
@@ -449,7 +458,7 @@ pub async fn run_stage_loop(
             StageMode::InteractivePoints { points } => {
                 let pts = points.clone();
                 let run_context = cb.get_run_context();
-                run_interactive_points_stage(
+                let outcome = run_interactive_points_stage(
                     ctx.engine,
                     ctx.entity,
                     provider_name,
@@ -464,16 +473,30 @@ pub async fn run_stage_loop(
                     exec,
                 )
                 .await?;
-                stage_result_val = StageResult::Success;
-                cb.on_stage_result(
-                    &stage_name_owned,
-                    stage_idx,
-                    &stage_result_val,
-                    None,
-                    ctx.engine,
-                    ctx.entity,
-                )
-                .await;
+                match outcome {
+                    PointsOutcome::Aborted => {
+                        // Deterministic user abort: mark the run cancelled and
+                        // end terminally — no transition, no completion.
+                        cb.on_cancel(stage_idx).await;
+                        aborted = true;
+                        if let Some(handle) = stdin_handle {
+                            handle.abort();
+                        }
+                        break;
+                    }
+                    PointsOutcome::Completed => {
+                        stage_result_val = StageResult::Success;
+                        cb.on_stage_result(
+                            &stage_name_owned,
+                            stage_idx,
+                            &stage_result_val,
+                            None,
+                            ctx.engine,
+                            ctx.entity,
+                        )
+                        .await;
+                    }
+                }
             }
             StageMode::Autonomous => {
                 match cb
@@ -596,7 +619,9 @@ pub async fn run_stage_loop(
         }
     }
 
-    cb.on_complete(current_stage_idx_val).await;
+    if !aborted {
+        cb.on_complete(current_stage_idx_val).await;
+    }
     Ok(())
 }
 
@@ -632,6 +657,8 @@ mod tests {
         run_autonomous_should_error: bool,
         /// When Some, get_run_context returns a borrow of this pair instead of None.
         run_context: Option<(String, RunMeta)>,
+        /// Stage index recorded by on_cancel (None if never cancelled).
+        cancelled_at: Option<usize>,
     }
 
     impl MockCallbacks {
@@ -650,6 +677,7 @@ mod tests {
                 graph_error_result: true,
                 run_autonomous_should_error: false,
                 run_context: None,
+                cancelled_at: None,
             }
         }
     }
@@ -756,6 +784,10 @@ mod tests {
 
         async fn on_complete(&mut self, last_stage_idx: usize) {
             self.completed_at = Some(last_stage_idx);
+        }
+
+        async fn on_cancel(&mut self, stage_idx: usize) {
+            self.cancelled_at = Some(stage_idx);
         }
 
         async fn on_post_stage(
@@ -1683,6 +1715,100 @@ mod tests {
         assert_eq!(cb.completed_at, Some(0));
     }
 
+    #[tokio::test]
+    async fn interactive_points_abort_cancels_run_and_skips_transition() {
+        // Selecting an abort option must call on_cancel and end the run
+        // terminally: NO transition resolution, NO on_stage_result, and
+        // on_complete must NOT fire (the run is cancelled, not completed).
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "interactive_points_abort_cancels_run_and_skips_transition",
+        );
+        use crate::runstate::{self, RunMeta};
+        use leviath_core::blueprint::InteractionPoint;
+
+        let mut stage = make_stage("plan");
+        stage.mode = StageMode::InteractivePoints {
+            points: vec![InteractionPoint {
+                name: "plan_approval".to_string(),
+                prompt: "Approve?".to_string(),
+                required: false,
+                style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+                options: vec!["Approve".to_string(), "Abort".to_string()],
+                directives: Default::default(),
+                abort_options: vec!["Abort".to_string()],
+            }],
+        };
+        stage.max_iterations = Some(2);
+        stage.accepts_messages = false;
+        let bp = make_blueprint(vec![stage]);
+        let (mut engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+        let tool_registry = make_tool_registry().await;
+
+        let run_id = "exec-abort-run".to_string();
+        let meta = RunMeta::new(
+            run_id.clone(),
+            "test".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/tmp".into(),
+            1,
+        );
+        runstate::create_run(&meta).unwrap();
+
+        let mut cb = MockCallbacks::new();
+        cb.run_context = Some((run_id.clone(), meta));
+
+        // Answer the plan_approval choice with "Abort" (index 1).
+        let responder_run_id = run_id.clone();
+        let responder = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                if let Some(req) = crate::interaction::read_request(&responder_run_id) {
+                    let mut resp = crate::interaction::InteractionResponse::choice("", 1);
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&responder_run_id, &resp).unwrap();
+                    break;
+                }
+            }
+        });
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        let _ = responder.await;
+
+        // on_cancel fired for stage 0; the run did NOT complete or transition,
+        // and no stage_result was recorded (the stage was aborted, not run).
+        assert_eq!(cb.cancelled_at, Some(0));
+        assert_eq!(cb.completed_at, None);
+        assert!(cb.transitions.is_empty());
+        assert!(cb.stage_results.is_empty());
+
+        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+    }
+
     // ─── Interactive/InteractivePoints error propagation ────────────────────
 
     #[tokio::test]
@@ -1744,7 +1870,8 @@ mod tests {
                 required: false,
                 style: Default::default(),
                 options: vec![],
-                followups: Default::default(),
+                directives: Default::default(),
+                abort_options: Default::default(),
             }],
         };
         stage.accepts_messages = false;

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -410,6 +410,11 @@ impl StageCallbacks for ForegroundCallbacks {
         println!("\n[All stages complete]");
     }
 
+    async fn on_cancel(&mut self, _stage_idx: usize) {
+        // Foreground has no run-state meta to persist; just notify the user.
+        println!("\n[Run cancelled by user]");
+    }
+
     async fn on_post_stage(
         &mut self,
         _engine: &leviath_runtime::AgentEngine,

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -229,11 +229,13 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
                                             .collect()
                                     })
                                     .unwrap_or_default();
-                                // Follow-up free-text prompts, keyed by option label:
-                                // [stages.<name>.interaction_points.followups]
-                                // "Revise — I'll describe changes" = "What would you like to change?"
-                                let pt_followups: std::collections::HashMap<String, String> = pt
-                                    .get("followups")
+                                // Per-option directives, keyed by option label:
+                                // [stages.<name>.interaction_points.directives]
+                                // "Revise — I'll describe changes" = "Call ask_user_text ..."
+                                // `followups` is accepted as a backward-compat alias.
+                                let pt_directives: std::collections::HashMap<String, String> = pt
+                                    .get("directives")
+                                    .or_else(|| pt.get("followups"))
                                     .and_then(|v| v.as_table())
                                     .map(|tbl| {
                                         tbl.iter()
@@ -243,13 +245,25 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
                                             .collect()
                                     })
                                     .unwrap_or_default();
+                                // Options that immediately abort the run:
+                                // abort_options = ["Abort — cancel this run"]
+                                let pt_abort_options: Vec<String> = pt
+                                    .get("abort_options")
+                                    .and_then(|v| v.as_array())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
                                 points.push(leviath_core::blueprint::InteractionPoint {
                                     name: pt_name,
                                     prompt: pt_prompt,
                                     required: pt_required,
                                     style: pt_style,
                                     options: pt_options,
-                                    followups: pt_followups,
+                                    directives: pt_directives,
+                                    abort_options: pt_abort_options,
                                 });
                             }
                         }
@@ -1190,10 +1204,10 @@ style = "confirm"
     }
 
     #[test]
-    fn parse_manifest_interaction_point_followups() {
+    fn parse_manifest_interaction_point_directives_and_abort() {
         let toml = r#"
 [agent]
-name = "followup-test"
+name = "directive-test"
 
 [stages.plan]
 mode = "interactive_points"
@@ -1204,25 +1218,53 @@ prompt   = "Approve?"
 required = true
 style    = "multiple_choice"
 options  = ["Approve", "Revise", "Abort"]
-followups = { "Revise" = "What would you like to change?" }
+abort_options = ["Abort"]
+directives = { "Revise" = "Call ask_user_text to find out what to change." }
 "#;
         let bp = parse_manifest(toml).unwrap();
         let stage = bp.find_stage("plan").unwrap();
         let points = unwrap_interactive_points(&stage.mode);
         assert_eq!(points.len(), 1);
         assert_eq!(
-            points[0].followups.get("Revise").map(|s| s.as_str()),
-            Some("What would you like to change?")
+            points[0].directives.get("Revise").map(|s| s.as_str()),
+            Some("Call ask_user_text to find out what to change.")
         );
-        assert!(!points[0].followups.contains_key("Approve"));
-        assert!(!points[0].followups.contains_key("Abort"));
+        assert!(!points[0].directives.contains_key("Approve"));
+        assert_eq!(points[0].abort_options, vec!["Abort".to_string()]);
     }
 
     #[test]
-    fn parse_manifest_interaction_point_no_followups_defaults_empty() {
+    fn parse_manifest_interaction_point_followups_alias_maps_to_directives() {
+        // Backward compat: the old `followups` key is accepted as an alias.
         let toml = r#"
 [agent]
-name = "no-followup-test"
+name = "followup-alias-test"
+
+[stages.plan]
+mode = "interactive_points"
+
+[[stages.plan.interaction_points]]
+name     = "plan_approval"
+prompt   = "Approve?"
+required = true
+style    = "multiple_choice"
+options  = ["Approve", "Revise"]
+followups = { "Revise" = "What would you like to change?" }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let stage = bp.find_stage("plan").unwrap();
+        let points = unwrap_interactive_points(&stage.mode);
+        assert_eq!(
+            points[0].directives.get("Revise").map(|s| s.as_str()),
+            Some("What would you like to change?")
+        );
+    }
+
+    #[test]
+    fn parse_manifest_interaction_point_no_directives_defaults_empty() {
+        let toml = r#"
+[agent]
+name = "no-directive-test"
 
 [stages.main]
 mode = "interactive_points"
@@ -1235,7 +1277,8 @@ style    = "confirm"
         let bp = parse_manifest(toml).unwrap();
         let stage = bp.find_stage("main").unwrap();
         let points = unwrap_interactive_points(&stage.mode);
-        assert!(points[0].followups.is_empty());
+        assert!(points[0].directives.is_empty());
+        assert!(points[0].abort_options.is_empty());
     }
 
     #[test]
@@ -1715,7 +1758,7 @@ version = "1.0.0"
     }
 
     #[test]
-    fn software_engineer_plan_approval_has_followups_for_non_terminal_choices() {
+    fn software_engineer_plan_approval_has_directives_and_abort_option() {
         let manifest_content =
             include_str!("../../../../../agents/software-engineer/agent.leviath");
         let bp = parse_manifest(manifest_content).unwrap();
@@ -1726,9 +1769,8 @@ version = "1.0.0"
             .find(|p| p.name == "plan_approval")
             .expect("plan_approval interaction point must exist");
 
-        // "Revise" and "Add detail" promise the user a chance to describe
-        // what they want — without a followup prompt, only the static label
-        // ever reaches the model and the user's actual feedback is lost.
+        // "Revise" and "Add detail" carry directives so the run stays in-stage
+        // and the agent drives the next step via a tool call.
         let revise_key = approval
             .options
             .iter()
@@ -1739,17 +1781,27 @@ version = "1.0.0"
             .iter()
             .find(|o| o.starts_with("Add detail"))
             .expect("an Add detail option must exist");
-        // Revise/Add detail options must have a followup prompt asking for details.
-        assert!(approval.followups.contains_key(revise_key));
-        assert!(approval.followups.contains_key(detail_key));
+        assert!(approval.directives.contains_key(revise_key));
+        assert!(approval.directives.contains_key(detail_key));
+        // The Add-detail directive drives the direct-edit tool.
+        assert!(approval.directives[detail_key].contains("edit_document"));
 
-        // Approve/Abort are terminal/decisive — they must NOT have followups
-        // (no further elaboration needed).
-        for opt in &approval.options {
-            if opt.starts_with("Approve") || opt.starts_with("Abort") {
-                assert!(!approval.followups.contains_key(opt));
-            }
-        }
+        // Approve is a plain (completing) option — no directive.
+        let approve_key = approval
+            .options
+            .iter()
+            .find(|o| o.starts_with("Approve"))
+            .expect("an Approve option must exist");
+        assert!(!approval.directives.contains_key(approve_key));
+
+        // Abort is handled deterministically via abort_options, not a directive.
+        let abort_key = approval
+            .options
+            .iter()
+            .find(|o| o.starts_with("Abort"))
+            .expect("an Abort option must exist");
+        assert!(!approval.directives.contains_key(abort_key));
+        assert!(approval.abort_options.contains(abort_key));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -25,29 +25,50 @@ fn normalize_for_followup(s: &str) -> String {
         .join(" ")
 }
 
-/// Look up a followup prompt in the followups map, trying exact match first,
+/// Look up a directive in the directives map, trying exact match first,
 /// then normalized comparison (whitespace + Unicode dash normalization).
-fn lookup_followup<'a>(
-    followups: &'a std::collections::HashMap<String, String>,
+fn lookup_directive<'a>(
+    directives: &'a std::collections::HashMap<String, String>,
     user_text: &str,
 ) -> Option<&'a str> {
     // Exact match first
-    if let Some(prompt) = followups.get(user_text) {
-        return Some(prompt.as_str());
+    if let Some(directive) = directives.get(user_text) {
+        return Some(directive.as_str());
     }
     // Normalized match
     let normalized = normalize_for_followup(user_text);
-    for (key, prompt) in followups {
+    for (key, directive) in directives {
         if normalize_for_followup(key) == normalized {
             tracing::debug!(
                 user_text = %user_text,
                 key = %key,
-                "Followup matched via normalization (original text didn't match exactly)"
+                "Directive matched via normalization (original text didn't match exactly)"
             );
-            return Some(prompt.as_str());
+            return Some(directive.as_str());
         }
     }
     None
+}
+
+/// Whether `user_text` matches one of the point's abort options (exact match
+/// first, then the same normalization used for directive lookup).
+fn is_abort_option(abort_options: &[String], user_text: &str) -> bool {
+    if abort_options.iter().any(|o| o == user_text) {
+        return true;
+    }
+    let normalized = normalize_for_followup(user_text);
+    abort_options
+        .iter()
+        .any(|o| normalize_for_followup(o) == normalized)
+}
+
+/// Outcome of running an interactive-points stage. `Aborted` signals the
+/// executor to cancel the run immediately — no final inference and no stage
+/// transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointsOutcome {
+    Completed,
+    Aborted,
 }
 
 /// COVERAGE-EXCLUDED: llvm-cov's tracing-macro message-literal region is
@@ -302,7 +323,7 @@ pub async fn run_interactive_points_stage(
     run_context: Option<(&str, &mut RunMeta)>,
     io: &mut dyn RunIO,
     executor: &mut ToolExecutorDyn<'_>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PointsOutcome> {
     run_interactive_points_stage_with(
         engine,
         entity,
@@ -342,7 +363,7 @@ async fn run_interactive_points_stage_with(
     executor: &mut ToolExecutorDyn<'_>,
     ask_foreground: &(dyn Fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse
           + Sync),
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PointsOutcome> {
     use crate::interaction::{
         make_interaction_id, request_interaction_async, response_as_choice, response_as_text,
         InteractionRequest,
@@ -350,7 +371,7 @@ async fn run_interactive_points_stage_with(
     use leviath_runtime::ContextWindow;
 
     if points.is_empty() {
-        return run_autonomous_stage(
+        run_autonomous_stage(
             engine,
             entity,
             provider_name,
@@ -362,7 +383,8 @@ async fn run_interactive_points_stage_with(
             io,
             executor,
         )
-        .await;
+        .await?;
+        return Ok(PointsOutcome::Completed);
     }
 
     let (run_id_owned, mut meta_holder): (Option<String>, Option<&mut RunMeta>) = match run_context
@@ -483,6 +505,19 @@ async fn run_interactive_points_stage_with(
                 }
             };
 
+            // Deterministic abort: if the selection is an abort option, signal
+            // the executor to cancel the run immediately. No label injection,
+            // no final inference, no transition — the executor's `on_cancel`
+            // owns marking the run Cancelled (consistent with `on_stage_error`).
+            if is_abort_option(&point.abort_options, &user_text) {
+                tracing::info!(
+                    point = %point.name,
+                    selection = %user_text,
+                    "Interaction point aborted by user"
+                );
+                return Ok(PointsOutcome::Aborted);
+            }
+
             if !user_text.is_empty() {
                 if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
                     let tokens = user_text.len() / 4 + 1;
@@ -491,15 +526,18 @@ async fn run_interactive_points_stage_with(
                 }
             }
 
-            // If the chosen option has a configured followup, ask the user to
-            // actually describe what they want instead of letting the model
-            // act on the bare option label alone, then loop back and re-ask
-            // the same point so the user can review what changed.
-            let Some(followup_prompt) = lookup_followup(&point.followups, &user_text) else {
+            // If the chosen option has a configured directive, inject it into
+            // the agent's context and loop back to re-run inference IN-STAGE.
+            // The agent reads the directive and drives the next step itself
+            // (e.g. calling `ask_user_text` or `edit_document`), then the same
+            // point is re-presented — deterministic routing, no fall-through to
+            // a stage transition. A plain option (no directive) breaks and
+            // completes the stage normally.
+            let Some(directive) = lookup_directive(&point.directives, &user_text) else {
                 tracing::debug!(
                     user_text = %user_text,
-                    followup_keys = ?point.followups.keys().collect::<Vec<_>>(),
-                    "No followup match found for user selection"
+                    directive_keys = ?point.directives.keys().collect::<Vec<_>>(),
+                    "No directive match found for user selection — completing stage"
                 );
                 break 'point;
             };
@@ -507,23 +545,10 @@ async fn run_interactive_points_stage_with(
                 break 'point;
             }
 
-            let followup_req_id = make_interaction_id(pt_idx, revision_round * 2 + 1);
-            let followup_req =
-                InteractionRequest::free_text(followup_req_id, followup_prompt, &point.name, true);
-            let followup_text =
-                if let (Some(run_id), Some(ref mut meta)) = (&run_id_owned, &mut meta_holder) {
-                    let resp = request_interaction_async(run_id, meta, followup_req, None).await?;
-                    response_as_text(&resp)
-                } else {
-                    response_as_text(&ask_foreground(&followup_req))
-                };
-
-            if !followup_text.is_empty() {
-                if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
-                    let tokens = followup_text.len() / 4 + 1;
-                    let content = format!("User [{}] detail: {}", point.name, followup_text);
-                    let _ = window.add_to_region("conversation", content, tokens);
-                }
+            if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
+                let content = format!("User [{}] directive: {}", point.name, directive);
+                let tokens = content.len() / 4 + 1;
+                let _ = window.add_to_region("conversation", content, tokens);
             }
 
             revision_round += 1;
@@ -568,7 +593,7 @@ async fn run_interactive_points_stage_with(
         }
     }
 
-    Ok(())
+    Ok(PointsOutcome::Completed)
 }
 
 #[cfg(test)]
@@ -1398,7 +1423,8 @@ mod tests {
             required: false,
             style: leviath_core::blueprint::InteractionStyle::FreeText,
             options: vec![],
-            followups: std::collections::HashMap::new(),
+            directives: std::collections::HashMap::new(),
+            abort_options: Vec::new(),
         }
     }
 
@@ -1413,15 +1439,16 @@ mod tests {
             required: false,
             style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
             options,
-            followups: std::collections::HashMap::new(),
+            directives: std::collections::HashMap::new(),
+            abort_options: Vec::new(),
         }
     }
 
-    fn make_multiple_choice_point_with_followups(
+    fn make_multiple_choice_point_with_directives(
         name: &str,
         prompt: &str,
         options: Vec<String>,
-        followups: std::collections::HashMap<String, String>,
+        directives: std::collections::HashMap<String, String>,
     ) -> leviath_core::blueprint::InteractionPoint {
         leviath_core::blueprint::InteractionPoint {
             name: name.to_string(),
@@ -1429,7 +1456,25 @@ mod tests {
             required: false,
             style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
             options,
-            followups,
+            directives,
+            abort_options: Vec::new(),
+        }
+    }
+
+    fn make_multiple_choice_point_with_abort(
+        name: &str,
+        prompt: &str,
+        options: Vec<String>,
+        abort_options: Vec<String>,
+    ) -> leviath_core::blueprint::InteractionPoint {
+        leviath_core::blueprint::InteractionPoint {
+            name: name.to_string(),
+            prompt: prompt.to_string(),
+            required: false,
+            style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+            options,
+            directives: std::collections::HashMap::new(),
+            abort_options,
         }
     }
 
@@ -1440,7 +1485,8 @@ mod tests {
             required: false,
             style: leviath_core::blueprint::InteractionStyle::Confirm,
             options: vec![],
-            followups: std::collections::HashMap::new(),
+            directives: std::collections::HashMap::new(),
+            abort_options: Vec::new(),
         }
     }
 
@@ -1597,9 +1643,9 @@ mod tests {
     // chosen option's bare label (e.g. "Revise") being the only thing that
     // ever reaches the model.
     #[tokio::test]
-    async fn interactive_points_choice_with_followup_loops_back_for_revision() {
+    async fn interactive_points_directive_option_stays_in_stage_and_injects_directive() {
         let _guard = crate::runstate::isolate_runs_dir_for_test(
-            "interactive_points_choice_with_followup_loops_back_for_revision",
+            "interactive_points_directive_option_stays_in_stage_and_injects_directive",
         );
         use crate::interaction::InteractionResponse;
 
@@ -1626,31 +1672,31 @@ mod tests {
         );
         runstate::create_run(&meta).unwrap();
 
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise".to_string(),
-            "What would you like to change?".to_string(),
+            "Call ask_user_text to learn what to change, then re-plan.".to_string(),
         );
-        let points = vec![make_multiple_choice_point_with_followups(
+        let points = vec![make_multiple_choice_point_with_directives(
             "plan_approval",
             "Approve the plan?",
             vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
         )];
 
-        // Round 1: pick "Revise" (choice_index 1) → must trigger a followup
-        // FreeText request. Answer it. Round 2: pick "Approve" (choice_index 0,
-        // no followup) → the point loop must end after this.
+        // Round 1: pick "Revise" (choice_index 1) → must inject the directive
+        // and loop back IN-STAGE (no second free-text request is issued — the
+        // agent drives the next step itself). Round 2: pick "Approve"
+        // (choice_index 0, no directive) → the point loop ends.
         let responder = spawn_interaction_responder(
             run_id.clone(),
             vec![
                 InteractionResponse::choice("", 1),
-                InteractionResponse::text("", "please add error handling"),
                 InteractionResponse::choice("", 0),
             ],
         );
 
-        run_interactive_points_stage(
+        let outcome = run_interactive_points_stage(
             &mut engine,
             entity,
             "mock",
@@ -1669,9 +1715,11 @@ mod tests {
 
         responder.abort();
 
-        // The elaboration text must have made it into the agent's context —
-        // proof the user's actual feedback (not just the option label) was
-        // surfaced to the model.
+        // Completed (not aborted) after the revision loop.
+        assert_eq!(outcome, PointsOutcome::Completed);
+
+        // The directive text must have been injected into the agent's context,
+        // proving the run stayed in-stage and told the agent what to do next.
         let window = engine
             .world()
             .get::<leviath_runtime::ContextWindow>(entity)
@@ -1684,14 +1732,137 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         assert_contains_display(
-            all_content.contains("please add error handling"),
-            "expected the followup elaboration in context, got",
+            all_content.contains("directive: Call ask_user_text"),
+            "expected the injected directive in context, got",
             &all_content,
         );
         assert!(all_content.contains("Revise"));
         assert!(all_content.contains("Approve"));
 
         let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+    }
+
+    #[tokio::test]
+    async fn interactive_points_abort_option_returns_aborted() {
+        // Selecting an abort option must short-circuit the stage with
+        // PointsOutcome::Aborted — no directive, no fall-through — so the
+        // executor can cancel the run deterministically.
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "interactive_points_abort_option_returns_aborted",
+        );
+        use crate::interaction::InteractionResponse;
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let run_id = format!(
+            "test-ip-abort-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        );
+        let mut meta = RunMeta::new(
+            run_id.clone(),
+            "test".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/tmp".into(),
+            1,
+        );
+        runstate::create_run(&meta).unwrap();
+
+        let points = vec![make_multiple_choice_point_with_abort(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Abort".to_string()],
+            vec!["Abort".to_string()],
+        )];
+
+        // Pick "Abort" (choice_index 1).
+        let responder =
+            spawn_interaction_responder(run_id.clone(), vec![InteractionResponse::choice("", 1)]);
+
+        let outcome = run_interactive_points_stage(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            8,
+            &[],
+            None,
+            None,
+            &points,
+            Some((&run_id, &mut meta)),
+            &mut io,
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        responder.abort();
+
+        assert_eq!(outcome, PointsOutcome::Aborted);
+
+        // The abort short-circuits before the option label is injected, so the
+        // conversation region must NOT carry an "Abort" acknowledgement line.
+        let window = engine
+            .world()
+            .get::<leviath_runtime::ContextWindow>(entity)
+            .unwrap();
+        let conversation = window.get_region("conversation").unwrap();
+        let all_content: String = conversation
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!all_content.contains("User [plan_approval]: Abort"));
+
+        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+    }
+
+    #[tokio::test]
+    async fn interactive_points_foreground_abort_option_returns_aborted() {
+        // Same deterministic abort on the foreground (stdin) path.
+        use crate::interaction::InteractionResponse;
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let points = vec![make_multiple_choice_point_with_abort(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Abort".to_string()],
+            vec!["Abort".to_string()],
+        )];
+
+        let ask_foreground =
+            move |_req: &crate::interaction::InteractionRequest| InteractionResponse::choice("", 1);
+
+        let outcome = run_interactive_points_stage_with(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            8,
+            &[],
+            None,
+            None,
+            &points,
+            None,
+            &mut io,
+            &mut noop_exec,
+            &ask_foreground,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, PointsOutcome::Aborted);
     }
 
     // ─── run_interactive_points_stage: real foreground (stdin) path ─────────
@@ -1803,7 +1974,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn foreground_path_choice_with_followup_loops_back_for_revision() {
+    async fn foreground_path_directive_option_stays_in_stage_and_injects_directive() {
         use crate::interaction::InteractionResponse;
         use std::collections::VecDeque;
         use std::sync::Mutex;
@@ -1812,35 +1983,34 @@ mod tests {
         let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
         let mut io = MockIO::new();
 
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise".to_string(),
-            "What would you like to change?".to_string(),
+            "Call ask_user_text to learn what to change.".to_string(),
         );
-        let points = vec![make_multiple_choice_point_with_followups(
+        let points = vec![make_multiple_choice_point_with_directives(
             "plan_approval",
             "Approve the plan?",
             vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
         )];
 
-        // Round 1: "Revise" (index 1) -> triggers the followup FreeText ask
-        // (also dispatched through `ask_foreground`). Round 2: "Approve"
-        // (index 0, no followup) -> the point loop ends.
+        // Round 1: "Revise" (index 1) -> injects the directive and loops back
+        // IN-STAGE (no second free-text ask). Round 2: "Approve" (index 0, no
+        // directive) -> the point loop ends. So `ask_foreground` is called
+        // exactly twice — proving no engine-issued elaboration prompt.
         let queued = Mutex::new(VecDeque::from(vec![
             InteractionResponse::choice("", 1),
-            InteractionResponse::text("", "please add error handling"),
             InteractionResponse::choice("", 0),
         ]));
-        let ask_foreground = move |_req: &crate::interaction::InteractionRequest| {
-            queued
-                .lock()
-                .unwrap()
-                .pop_front()
-                .expect("ask_foreground called more times than expected")
-        };
+        let ask_foreground =
+            move |_req: &crate::interaction::InteractionRequest| {
+                queued.lock().unwrap().pop_front().expect(
+                    "ask_foreground called more times than expected (no elaboration prompt)",
+                )
+            };
 
-        run_interactive_points_stage_with(
+        let outcome = run_interactive_points_stage_with(
             &mut engine,
             entity,
             "mock",
@@ -1858,6 +2028,8 @@ mod tests {
         .await
         .unwrap();
 
+        assert_eq!(outcome, PointsOutcome::Completed);
+
         let window = engine
             .world()
             .get::<leviath_runtime::ContextWindow>(entity)
@@ -1870,8 +2042,8 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         assert_contains_display(
-            all_content.contains("please add error handling"),
-            "expected the followup elaboration in context, got",
+            all_content.contains("directive: Call ask_user_text"),
+            "expected the injected directive in context, got",
             &all_content,
         );
         assert!(all_content.contains("Revise"));
@@ -1884,36 +2056,33 @@ mod tests {
         use std::collections::VecDeque;
         use std::sync::Mutex;
 
-        // A user who always picks "Revise" must eventually be cut off by
-        // MAX_REVISION_ROUNDS (4) rather than looping forever -- this
-        // exercises the `revision_round + 1 >= MAX_REVISION_ROUNDS` guard,
-        // previously unreached by any test (every other followup test picks
-        // "Approve" after exactly one revision).
+        // A user who always picks a directive option ("Revise") must eventually
+        // be cut off by MAX_REVISION_ROUNDS (4) rather than looping forever.
+        // `max_iterations = 1` makes the per-segment iteration budget 0, so the
+        // `remaining_iterations == 0` guard never fires and ONLY the
+        // `revision_round + 1 >= MAX_REVISION_ROUNDS` guard can break the loop.
         let bp = make_blueprint(vec![make_stage("main")]);
         let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
         let mut io = MockIO::new();
 
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise".to_string(),
-            "What would you like to change?".to_string(),
+            "Call ask_user_text to learn what to change.".to_string(),
         );
-        let points = vec![make_multiple_choice_point_with_followups(
+        let points = vec![make_multiple_choice_point_with_directives(
             "plan_approval",
             "Approve the plan?",
             vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
         )];
 
-        // "Revise" every time; a followup answer follows each "Revise" until
-        // the cap breaks the loop before a 4th followup is ever asked.
+        // "Revise" every round. The cap breaks the loop after exactly 4 asks;
+        // a 5th `pop_front` would panic on the empty queue.
         let queued = Mutex::new(VecDeque::from(vec![
             InteractionResponse::choice("", 1),
-            InteractionResponse::text("", "change 1"),
             InteractionResponse::choice("", 1),
-            InteractionResponse::text("", "change 2"),
             InteractionResponse::choice("", 1),
-            InteractionResponse::text("", "change 3"),
             InteractionResponse::choice("", 1),
         ]));
         let ask_foreground = move |_req: &crate::interaction::InteractionRequest| {
@@ -1924,12 +2093,12 @@ mod tests {
                 .expect("ask_foreground called more times than the revision cap allows")
         };
 
-        run_interactive_points_stage_with(
+        let outcome = run_interactive_points_stage_with(
             &mut engine,
             entity,
             "mock",
             "test-model",
-            100,
+            1,
             &[],
             None,
             None,
@@ -1942,9 +2111,8 @@ mod tests {
         .await
         .unwrap();
 
-        // The loop must have stopped after exactly 4 choice picks (no 4th
-        // followup ask) -- if it looped forever, `pop_front` above would
-        // have panicked on an empty queue instead.
+        // Terminated normally (not aborted) after the cap — no infinite loop.
+        assert_eq!(outcome, PointsOutcome::Completed);
     }
 
     #[tokio::test]
@@ -2819,12 +2987,14 @@ mod tests {
         .unwrap();
     }
 
-    // ─── Coverage: followup empty text (lines 485:17, 486:13) ───────────────
+    // ─── Coverage: directive injection with no ContextWindow ────────────────
 
     #[tokio::test]
-    async fn interactive_points_followup_empty_text_no_context_window() {
-        // Covers lines 485:17 and 486:13: followup_text.is_empty() is true.
-        // Entity has no ContextWindow → else branch also hit.
+    async fn interactive_points_directive_no_context_window() {
+        // Covers the `None` branch of the directive-injection `if let Some(mut
+        // window) = ...get_mut::<ContextWindow>` — a bare entity has no
+        // ContextWindow, so the directive can't be injected but the loop must
+        // still proceed and complete without panicking.
         use crate::interaction::InteractionResponse;
         use std::collections::VecDeque;
         use std::sync::Mutex;
@@ -2832,21 +3002,20 @@ mod tests {
         let (mut engine, entity) = make_engine_bare_entity("Agent response");
         let mut io = MockIO::new();
 
-        let mut followups = std::collections::HashMap::new();
-        followups.insert("Revise".to_string(), "What to change?".to_string());
-        let points = vec![make_multiple_choice_point_with_followups(
+        let mut directives = std::collections::HashMap::new();
+        directives.insert("Revise".to_string(), "Ask what to change.".to_string());
+        let points = vec![make_multiple_choice_point_with_directives(
             "plan",
             "Pick",
             vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
         )];
 
-        // Round 1: "Revise" → followup asked → empty answer → hits line 485 else.
+        // Round 1: "Revise" → directive path (no ContextWindow to inject into).
         // Round 2: "Approve" → exits.
         let queued = Mutex::new(VecDeque::from(vec![
-            InteractionResponse::choice("", 1), // "Revise" → triggers followup
-            InteractionResponse::text("", ""),  // empty followup → hits line 485 else
-            InteractionResponse::choice("", 0), // "Approve" → exits
+            InteractionResponse::choice("", 1),
+            InteractionResponse::choice("", 0),
         ]));
         let ask_foreground = move |_req: &crate::interaction::InteractionRequest| {
             queued
@@ -2856,7 +3025,7 @@ mod tests {
                 .expect("ask_foreground called more times than expected")
         };
 
-        run_interactive_points_stage_with(
+        let outcome = run_interactive_points_stage_with(
             &mut engine,
             entity,
             "mock",
@@ -2873,6 +3042,7 @@ mod tests {
         )
         .await
         .unwrap();
+        assert_eq!(outcome, PointsOutcome::Completed);
     }
 
     // ─── Coverage: final segment None run_context (line 513:13) ─────────────
@@ -3064,19 +3234,17 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn interactive_points_followup_request_interaction_async_error() {
+    async fn interactive_points_request_interaction_async_error_propagates() {
         let _guard = crate::runstate::isolate_runs_dir_for_test(
-            "interactive_points_followup_request_interaction_async_error",
+            "interactive_points_request_interaction_async_error_propagates",
         );
-        // Covers line 474:97: `?` on `request_interaction_async` for the followup
-        // request in the background path.
+        // Covers the `?` on `request_interaction_async` in the background path.
         //
-        // We respond to the main choice with "Revise" (which has a followup).
-        // We immediately make the run dir read-only after writing the response so:
+        // We respond to the first choice with "Revise" (which has a directive),
+        // then immediately make the run dir read-only so:
         //   1) response.json is readable (already written before chmod)
-        //   2) take_response reads it; remove_file silently fails (read-only dir)
-        //   3) write_meta silently fails (let _); request_interaction_async → Ok(resp)
-        //   4) stage builds followup → write_request fails → Err propagates via ?
+        //   2) the directive is injected and the loop re-runs inference
+        //   3) round 2's choice request → write_request fails → Err via `?`
         use crate::interaction::InteractionResponse;
         use std::os::unix::fs::PermissionsExt;
 
@@ -3103,13 +3271,13 @@ mod tests {
         );
         runstate::create_run(&meta).unwrap();
 
-        let mut followups = std::collections::HashMap::new();
-        followups.insert("Revise".to_string(), "What to change?".to_string());
-        let points = vec![make_multiple_choice_point_with_followups(
+        let mut directives = std::collections::HashMap::new();
+        directives.insert("Revise".to_string(), "Ask what to change.".to_string());
+        let points = vec![make_multiple_choice_point_with_directives(
             "plan",
             "Pick",
             vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
         )];
 
         let run_id_for_responder = run_id.clone();
@@ -3166,7 +3334,7 @@ mod tests {
         });
         let _ = std::fs::remove_dir_all(&dir);
 
-        // The error from write_request (read-only dir) propagates via `?` at line 474
+        // The error from write_request (read-only dir) propagates via `?`.
         assert!(result.is_err());
     }
 
@@ -3309,66 +3477,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ─── Coverage: followup non-empty text + no ContextWindow (line 485:17) ────
-
-    #[tokio::test]
-    async fn interactive_points_followup_nonempty_text_no_context_window() {
-        // Covers line 485:17: `}` of `if let Some(mut window)` in the followup
-        // block when followup_text IS non-empty but the entity has NO ContextWindow.
-        // The `get_mut::<ContextWindow>` returns None → inner block is skipped.
-        use crate::interaction::InteractionResponse;
-        use std::collections::VecDeque;
-        use std::sync::Mutex;
-
-        // Bare entity — spawned without ContextWindow
-        let (mut engine, entity) = make_engine_bare_entity("Agent response");
-        let mut io = MockIO::new();
-
-        let mut followups = std::collections::HashMap::new();
-        followups.insert("Revise".to_string(), "What to change?".to_string());
-        let points = vec![make_multiple_choice_point_with_followups(
-            "plan",
-            "Pick",
-            vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
-        )];
-
-        // Round 1: "Revise" → followup asked → NON-empty text → entity has no
-        //          ContextWindow → if let Some(mut window) is None → line 485:17 hit.
-        // Round 2: "Approve" → exits.
-        let queued = Mutex::new(VecDeque::from(vec![
-            InteractionResponse::choice("", 1), // "Revise" → triggers followup
-            InteractionResponse::text("", "add more tests"), // non-empty followup
-            InteractionResponse::choice("", 0), // "Approve" → exits
-        ]));
-        let ask_foreground = move |_req: &crate::interaction::InteractionRequest| {
-            queued
-                .lock()
-                .unwrap()
-                .pop_front()
-                .expect("ask_foreground called more times than expected")
-        };
-
-        run_interactive_points_stage_with(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            None,
-            &points,
-            None,
-            &mut io,
-            &mut noop_exec,
-            &ask_foreground,
-        )
-        .await
-        .unwrap();
-    }
-
-    // ─── normalize_for_followup + lookup_followup tests ──────────────────
+    // ─── normalize_for_followup + lookup_directive tests ──────────────────
 
     #[test]
     fn normalize_for_followup_preserves_simple_text() {
@@ -3400,46 +3509,65 @@ mod tests {
     }
 
     #[test]
-    fn lookup_followup_exact_match() {
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+    fn lookup_directive_exact_match() {
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise \u{2014} I'll describe changes".to_string(),
-            "What would you like to change?".to_string(),
+            "Ask what to change.".to_string(),
         );
-        let result = super::lookup_followup(&followups, "Revise \u{2014} I'll describe changes");
-        assert_eq!(result, Some("What would you like to change?"));
+        let result = super::lookup_directive(&directives, "Revise \u{2014} I'll describe changes");
+        assert_eq!(result, Some("Ask what to change."));
     }
 
     #[test]
-    fn lookup_followup_normalized_match_em_dash_vs_hyphen() {
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+    fn lookup_directive_normalized_match_em_dash_vs_hyphen() {
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise \u{2014} I'll describe changes".to_string(),
-            "What would you like to change?".to_string(),
+            "Ask what to change.".to_string(),
         );
         // User text uses ASCII hyphen instead of em dash
-        let result = super::lookup_followup(&followups, "Revise - I'll describe changes");
-        assert_eq!(result, Some("What would you like to change?"));
+        let result = super::lookup_directive(&directives, "Revise - I'll describe changes");
+        assert_eq!(result, Some("Ask what to change."));
     }
 
     #[test]
-    fn lookup_followup_normalized_match_extra_whitespace() {
-        let mut followups = std::collections::HashMap::new();
-        followups.insert(
+    fn lookup_directive_normalized_match_extra_whitespace() {
+        let mut directives = std::collections::HashMap::new();
+        directives.insert(
             "Revise \u{2014} I'll describe changes".to_string(),
-            "What would you like to change?".to_string(),
+            "Ask what to change.".to_string(),
         );
         // User text has extra whitespace and an en dash
         let result =
-            super::lookup_followup(&followups, "Revise  \u{2013}  I'll  describe  changes");
-        assert_eq!(result, Some("What would you like to change?"));
+            super::lookup_directive(&directives, "Revise  \u{2013}  I'll  describe  changes");
+        assert_eq!(result, Some("Ask what to change."));
     }
 
     #[test]
-    fn lookup_followup_no_match() {
-        let mut followups = std::collections::HashMap::new();
-        followups.insert("Revise".to_string(), "prompt".to_string());
-        let result = super::lookup_followup(&followups, "Approve");
+    fn lookup_directive_no_match() {
+        let mut directives = std::collections::HashMap::new();
+        directives.insert("Revise".to_string(), "prompt".to_string());
+        let result = super::lookup_directive(&directives, "Approve");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn is_abort_option_exact_and_normalized() {
+        let aborts = vec!["Abort \u{2014} cancel this run".to_string()];
+        // Exact match
+        assert!(super::is_abort_option(
+            &aborts,
+            "Abort \u{2014} cancel this run"
+        ));
+        // Normalized (ASCII hyphen + extra whitespace)
+        assert!(super::is_abort_option(
+            &aborts,
+            "Abort  -  cancel  this  run"
+        ));
+        // Non-abort option
+        assert!(!super::is_abort_option(&aborts, "Approve"));
+        // Empty abort list
+        assert!(!super::is_abort_option(&[], "Abort"));
     }
 }

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -471,6 +471,15 @@ impl<'a> StageCallbacks for WorkerCallbacks<'a> {
         }
     }
 
+    async fn on_cancel(&mut self, stage_idx: usize) {
+        let msg = "[Run cancelled by user]";
+        println!("\n{}", msg);
+        record_stage_log(&self.run_id, stage_idx, msg);
+        self.meta.status = RunStatus::Cancelled;
+        self.meta.touch();
+        let _ = runstate::write_meta(self.meta);
+    }
+
     async fn on_post_stage(
         &mut self,
         engine: &leviath_runtime::AgentEngine,
@@ -515,7 +524,13 @@ pub async fn execute_worker(args: WorkerArgs) -> anyhow::Result<()> {
     let result = run_worker_inner(&args, &mut meta, build_provider_registry).await;
 
     match &result {
-        Ok(()) => meta.status = RunStatus::Complete,
+        // A user abort sets `Cancelled` mid-run (via on_cancel); don't clobber
+        // it with `Complete` on the successful-return path.
+        Ok(()) => {
+            if meta.status != RunStatus::Cancelled {
+                meta.status = RunStatus::Complete;
+            }
+        }
         Err(e) => {
             meta.status = RunStatus::Error;
             meta.error = Some(e.to_string());
@@ -920,6 +935,32 @@ mod tests {
             blueprint_stages_len: 2,
         };
         cb.on_transition("plan", "code", 0).await;
+    }
+
+    #[tokio::test]
+    async fn worker_callbacks_on_cancel_sets_cancelled_and_persists() {
+        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-cancel");
+        let mut meta = RunMeta::new(
+            "test-cancel".into(),
+            "agent".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/w".into(),
+            2,
+        );
+        runstate::create_run(&meta).unwrap();
+        let mut cb = WorkerCallbacks {
+            run_id: "test-cancel".to_string(),
+            meta: &mut meta,
+            blueprint_stages_len: 2,
+        };
+        cb.on_cancel(0).await;
+
+        assert_eq!(meta.status, RunStatus::Cancelled);
+        // Persisted to disk as well.
+        let persisted = runstate::read_meta("test-cancel").unwrap();
+        assert_eq!(persisted.status, RunStatus::Cancelled);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/interaction.rs
+++ b/crates/leviath-cli/src/interaction.rs
@@ -38,6 +38,9 @@ pub enum InteractionKind {
     Confirm,
     /// Approve or deny a specific tool call before it executes.
     ToolApproval,
+    /// Edit a document in place: the request carries the current text in
+    /// `body`; the user edits it and the (possibly modified) text is returned.
+    EditText,
 }
 
 /// Format of an optional rich body attached to an interaction request.
@@ -125,6 +128,29 @@ impl InteractionRequest {
             stage_name: stage.into(),
             body: Some(markdown.into()),
             body_format: BodyFormat::Markdown,
+        }
+    }
+
+    /// Create an "edit document" request: shows `initial_content` in an
+    /// editable field pre-seeded with it (via `body`); the user edits it and
+    /// the modified text is returned as the response text.
+    pub fn edit_text(
+        id: impl Into<String>,
+        prompt: impl Into<String>,
+        stage: impl Into<String>,
+        initial_content: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            kind: InteractionKind::EditText,
+            prompt: prompt.into(),
+            options: vec![],
+            tool_name: None,
+            tool_arguments: None,
+            required: true,
+            stage_name: stage.into(),
+            body: Some(initial_content.into()),
+            body_format: BodyFormat::Plain,
         }
     }
 
@@ -616,6 +642,26 @@ pub fn request_interaction_from_reader<R: std::io::BufRead>(
             InteractionResponse::text(&req.id, input.trim())
         }
 
+        InteractionKind::EditText => {
+            println!("{}", req.prompt);
+            let current = req.body.clone().unwrap_or_default();
+            println!("--- current content ---\n{}", current);
+            println!("--- enter replacement (empty line keeps current) ---");
+            print!("Edit: ");
+            std::io::stdout().flush().ok();
+            let mut input = String::new();
+            if reader.read_line(&mut input).unwrap_or(0) == 0 {
+                // EOF — keep the current content unchanged.
+                return InteractionResponse::text(&req.id, current);
+            }
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                InteractionResponse::text(&req.id, current)
+            } else {
+                InteractionResponse::text(&req.id, trimmed)
+            }
+        }
+
         InteractionKind::MultipleChoice => {
             println!("{}", req.prompt);
             for (i, opt) in req.options.iter().enumerate() {
@@ -725,6 +771,26 @@ mod tests {
         );
         assert_eq!(r.kind, InteractionKind::ToolApproval);
         assert_eq!(r.options.len(), 3);
+    }
+
+    #[test]
+    fn test_edit_text_request_builder_seeds_body() {
+        let r = InteractionRequest::edit_text("id4", "Edit this", "plan", "current text");
+        assert_eq!(r.kind, InteractionKind::EditText);
+        assert!(r.required);
+        assert_eq!(r.body.as_deref(), Some("current text"));
+        assert_eq!(r.prompt, "Edit this");
+    }
+
+    #[test]
+    fn test_edit_text_kind_serde_roundtrip_snake_case() {
+        let r = InteractionRequest::edit_text("id5", "p", "plan", "seed");
+        let json = serde_json::to_string(&r).unwrap();
+        // snake_case rename ⇒ "edit_text"
+        assert!(json.contains("\"edit_text\""));
+        let back: InteractionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, InteractionKind::EditText);
+        assert_eq!(back.body.as_deref(), Some("seed"));
     }
 
     #[test]
@@ -2411,6 +2477,47 @@ mod tests {
         let mut reader = reader_from(""); // immediate EOF, no newline
         let resp = request_interaction_from_reader(&req, &mut reader);
         assert_eq!(resp.value.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn stdin_edit_text_replacement_line_replaces_body() {
+        let req = InteractionRequest::edit_text("et1", "Edit", "plan", "old content");
+        let mut reader = reader_from("new content\n");
+        let resp = request_interaction_from_reader(&req, &mut reader);
+        assert_eq!(resp.value.as_deref(), Some("new content"));
+        assert_eq!(resp.request_id, "et1");
+    }
+
+    #[test]
+    fn stdin_edit_text_empty_line_keeps_body() {
+        let req = InteractionRequest::edit_text("et2", "Edit", "plan", "keep me");
+        let mut reader = reader_from("\n");
+        let resp = request_interaction_from_reader(&req, &mut reader);
+        assert_eq!(resp.value.as_deref(), Some("keep me"));
+    }
+
+    #[test]
+    fn stdin_edit_text_eof_keeps_body() {
+        let req = InteractionRequest::edit_text("et3", "Edit", "plan", "unchanged");
+        let mut reader = reader_from(""); // immediate EOF
+        let resp = request_interaction_from_reader(&req, &mut reader);
+        assert_eq!(resp.value.as_deref(), Some("unchanged"));
+    }
+
+    #[test]
+    fn test_edit_text_request_ipc_roundtrip() {
+        let _guard =
+            crate::runstate::isolate_runs_dir_for_test("test_edit_text_request_ipc_roundtrip");
+        let run_id = "edit-ipc-run";
+        let dir = crate::runstate::run_dir(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let req = InteractionRequest::edit_text("er1", "Edit the plan", "plan", "line 1\nline 2");
+        write_request(run_id, &req).unwrap();
+        let back = read_request(run_id).expect("request should round-trip");
+        assert_eq!(back.kind, InteractionKind::EditText);
+        assert_eq!(back.body.as_deref(), Some("line 1\nline 2"));
+        assert_eq!(back.id, "er1");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -662,7 +662,9 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         // These tools ARE the human-in-the-loop mechanism — gating them behind
         // a separate tool-approval prompt would mean asking the user "may I
         // ask you something?" before actually asking them.
-        "ask_user_text" | "ask_user_choice" | "ask_user_confirm" => ToolPolicy::Allow,
+        "ask_user_text" | "ask_user_choice" | "ask_user_confirm" | "edit_document" => {
+            ToolPolicy::Allow
+        }
         _ => {
             // All other tools (built-in or MCP) default to Ask
             let _ = is_builtin;
@@ -1677,6 +1679,10 @@ mod policy_tests {
         );
         assert_eq!(
             default_tool_policy("ask_user_confirm", true),
+            ToolPolicy::Allow
+        );
+        assert_eq!(
+            default_tool_policy("edit_document", true),
             ToolPolicy::Allow
         );
     }

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -323,17 +323,25 @@ pub struct InteractionPoint {
     #[serde(default)]
     pub options: Vec<String>,
 
-    /// Follow-up free-text prompts, keyed by option label.
+    /// Directives keyed by option label.
     ///
     /// When the user picks an option present in this map (e.g. "Revise — I'll
-    /// describe changes"), a second `FreeText` interaction is requested using
-    /// the mapped prompt so the user can actually describe what they want —
-    /// otherwise only the static option label ever reaches the model, and
-    /// the user's intent is lost. After the follow-up is answered, the stage
-    /// runs another inference segment and re-prompts the same interaction
-    /// point (bounded by a retry cap) instead of falling through.
+    /// describe changes"), the mapped directive text is injected into the
+    /// agent's conversation context and the stage re-runs inference IN-STAGE
+    /// (bounded by a revision cap) instead of falling through to a stage
+    /// transition. The directive tells the agent what to do next — e.g. call
+    /// `ask_user_text` to learn what to change, or `edit_document` to let the
+    /// user edit the plan directly — so the routing decision is deterministic
+    /// (code) while the actual input capture is an agent tool call.
+    #[serde(default, alias = "followups")]
+    pub directives: HashMap<String, String>,
+
+    /// Options that, when selected, immediately abort the run: the engine
+    /// marks the run cancelled and stops with no further inference and no
+    /// transition resolution. Matched against the selected option label with
+    /// the same dash/whitespace normalization used for directive lookup.
     #[serde(default)]
-    pub followups: HashMap<String, String>,
+    pub abort_options: Vec<String>,
 }
 
 /// Configuration for routing tool results to specific context window regions.
@@ -1003,24 +1011,26 @@ mod tests {
     }
 
     #[test]
-    fn test_interaction_point_followups_default_empty() {
+    fn test_interaction_point_directives_default_empty() {
         let point = InteractionPoint {
             name: "plan_approval".to_string(),
             prompt: "Approve?".to_string(),
             required: true,
             style: InteractionStyle::MultipleChoice,
             options: vec!["Approve".to_string(), "Revise".to_string()],
-            followups: HashMap::new(),
+            directives: HashMap::new(),
+            abort_options: Vec::new(),
         };
-        assert!(point.followups.is_empty());
+        assert!(point.directives.is_empty());
+        assert!(point.abort_options.is_empty());
     }
 
     #[test]
-    fn test_interaction_point_followups_roundtrip() {
-        let mut followups = HashMap::new();
-        followups.insert(
+    fn test_interaction_point_directives_roundtrip() {
+        let mut directives = HashMap::new();
+        directives.insert(
             "Revise".to_string(),
-            "What would you like to change?".to_string(),
+            "Ask what to change, then re-plan.".to_string(),
         );
         let point = InteractionPoint {
             name: "plan_approval".to_string(),
@@ -1028,18 +1038,20 @@ mod tests {
             required: true,
             style: InteractionStyle::MultipleChoice,
             options: vec!["Approve".to_string(), "Revise".to_string()],
-            followups,
+            directives,
+            abort_options: vec!["Abort".to_string()],
         };
         let json = serde_json::to_string(&point).unwrap();
         let back: InteractionPoint = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            back.followups.get("Revise").map(|s| s.as_str()),
-            Some("What would you like to change?")
+            back.directives.get("Revise").map(|s| s.as_str()),
+            Some("Ask what to change, then re-plan.")
         );
+        assert_eq!(back.abort_options, vec!["Abort".to_string()]);
     }
 
     #[test]
-    fn test_interaction_point_followups_serde_default_when_missing() {
+    fn test_interaction_point_directives_serde_default_when_missing() {
         let json = r#"{
             "name": "plan_approval",
             "prompt": "Approve?",
@@ -1048,7 +1060,26 @@ mod tests {
             "options": ["Approve", "Revise"]
         }"#;
         let point: InteractionPoint = serde_json::from_str(json).unwrap();
-        assert!(point.followups.is_empty());
+        assert!(point.directives.is_empty());
+        assert!(point.abort_options.is_empty());
+    }
+
+    #[test]
+    fn test_interaction_point_followups_alias_still_deserializes() {
+        // Backward compat: old serialized blueprints used "followups".
+        let json = r#"{
+            "name": "plan_approval",
+            "prompt": "Approve?",
+            "required": true,
+            "style": "multiple_choice",
+            "options": ["Approve", "Revise"],
+            "followups": { "Revise": "What to change?" }
+        }"#;
+        let point: InteractionPoint = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            point.directives.get("Revise").map(|s| s.as_str()),
+            Some("What to change?")
+        );
     }
 
     #[test]

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -110,7 +110,7 @@ impl ToolExecutor {
     /// are discarded here too.
     pub async fn shutdown_all(&mut self) -> anyhow::Result<()> {
         tracing::info!("Shutting down all MCP clients");
-        for (_, client) in self.clients.iter_mut() {
+        for client in self.clients.values_mut() {
             let _ = client.shutdown().await;
         }
         self.clients.clear();

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -183,6 +183,24 @@ impl BuiltinTools {
                     "required": ["prompt"]
                 }),
             },
+            Tool {
+                name: "edit_document".to_string(),
+                description: "Present a document to the user in an editable field pre-filled with its current text, and wait for them to edit it directly. The run pauses until they submit. Use this when the user wants to modify content themselves (e.g. tweak a plan or draft) rather than describe changes for you to make. Pass the current full text as `content`; the returned text is the user's edited version, which you should adopt as authoritative.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The current full document text to present for editing"
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "Optional instruction shown above the editable field"
+                        }
+                    },
+                    "required": ["content"]
+                }),
+            },
         ]
     }
 
@@ -314,6 +332,7 @@ impl BuiltinTools {
             "ask_user_text".to_string(),
             "ask_user_choice".to_string(),
             "ask_user_confirm".to_string(),
+            "edit_document".to_string(),
         ]
     }
 
@@ -608,11 +627,11 @@ mod tests {
     // ── Tool definitions ──────────────────────────────────────────────────
 
     #[test]
-    fn tool_defs_returns_nine_tools() {
+    fn tool_defs_returns_ten_tools() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         let defs = tools.tool_defs();
-        assert_eq!(defs.len(), 9);
+        assert_eq!(defs.len(), 10);
     }
 
     #[test]
@@ -629,6 +648,23 @@ mod tests {
         assert!(names.contains(&"ask_user_text".to_string()));
         assert!(names.contains(&"ask_user_choice".to_string()));
         assert!(names.contains(&"ask_user_confirm".to_string()));
+        assert!(names.contains(&"edit_document".to_string()));
+    }
+
+    #[test]
+    fn tool_defs_edit_document_requires_content() {
+        let dir = std::env::temp_dir();
+        let tools = make_tools(&dir);
+        let def = tools
+            .tool_defs()
+            .into_iter()
+            .find(|t| t.name == "edit_document")
+            .expect("edit_document tool def must exist");
+        let required = def.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "content"));
+        assert_eq!(def.parameters["properties"]["content"]["type"], "string");
+        // Also present in the builtin name list.
+        assert!(tools.names().contains(&"edit_document".to_string()));
     }
 
     #[test]
@@ -652,7 +688,12 @@ mod tests {
         // exactly like present_for_review — execute() must never run them.
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        for name in ["ask_user_text", "ask_user_choice", "ask_user_confirm"] {
+        for name in [
+            "ask_user_text",
+            "ask_user_choice",
+            "ask_user_confirm",
+            "edit_document",
+        ] {
             let result = tools.execute(name, serde_json::json!({})).await;
             assert!(result.contains("Unknown built-in tool"));
         }
@@ -712,10 +753,10 @@ mod tests {
     }
 
     #[test]
-    fn names_returns_ten_entries() {
+    fn names_returns_eleven_entries() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        assert_eq!(tools.names().len(), 10);
+        assert_eq!(tools.names().len(), 11);
     }
 
     // ── Sub-agent tool definitions ────────────────────────────────────────


### PR DESCRIPTION
## Problem

In the `software-engineer` plan stage, the WAITING "Response" options were all decided by the transition LLM (`graph.rs`), whose no-match fallback silently picks the first edge → `implement`. So **Abort** still ran the work, and **Revise**/**Add detail** leaked to the next stage instead of staying in plan.

## Fix — deterministic routing, agent-driven capture

- **Abort → deterministic.** New `abort_options` on the interaction point. Selecting one returns `PointsOutcome::Aborted`; the executor calls a new `on_cancel` callback (marks the run `Cancelled`) and ends terminally — no final inference, no transition. `execute_worker` no longer clobbers `Cancelled` with `Complete`.
- **Revise → agent-tool-driven.** `followups` reworked into `directives` (with a `followups` serde/manifest alias for back-compat). Selecting Revise injects a directive and re-runs inference **in-stage**, so the agent calls `ask_user_text` itself and the plan is re-presented.
- **Add detail → direct edit.** New `InteractionKind::EditText` + `edit_text` request (seeds current plan into `body`), new `edit_document` agent tool, dashboard editable-field seeding/submit, and stdin support.

Blueprints (`software-engineer`, `writing-assistant`) updated to declare `abort_options` + `directives`.

## Tests & verification

- Tests reproduce each bug and confirm the fix across `stages`, `executor`, `worker`, `interaction`, `dynamic_interaction`, `dashboard`, and `manifest` — including the abort short-circuit driven through `run_stage_loop` with real file-IPC. All tests use mock providers/backends — no network or credentials.
- Full workspace suite green, coverage ratchet passed, clippy + fmt clean, both blueprints pass `lev validate`.
- Verified end-to-end against the real Anthropic LLM locally: Abort → `cancelled` (implement never ran); Revise → agent calls `ask_user_text` then re-presents in-stage; Add detail → agent calls `edit_document` with the plan pre-seeded, then re-presents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)