### PR TITLE
fix(run): make "Add detail" a deterministic engine-driven edit

### DIFF
--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -92,12 +92,16 @@ options  = ["Approve — proceed to implementation", "Revise — I'll describe c
 # inference, no transition.
 abort_options = ["Abort — cancel this run"]
 
+# "Add detail" opens the current plan in an editable field (engine-level,
+# deterministic) so the user modifies it directly — no dependence on the model
+# choosing to call an edit tool. The edited text becomes the authoritative plan.
+edit_options = ["Add detail — expand a section"]
+
 # Directives keyed by option label. Selecting one keeps the run in the plan
 # stage and injects the directive into the agent's context so it drives the
 # next step via a tool call (deterministic routing, agent-driven capture).
 [stages.plan.interaction_points.directives]
 "Revise — I'll describe changes" = "The user wants to revise the plan. Call the ask_user_text tool to ask exactly what they want changed, then produce an updated plan ending with the '## Plan' and '## Files' sections so it can be re-approved."
-"Add detail — expand a section" = "The user wants to edit the plan directly. Call the edit_document tool, passing the CURRENT full plan text as the `content` argument, so they can edit it in place. Treat the returned edited document as the new authoritative plan and re-present it."
 
 # ─── Stage 2: Implement ──────────────────────────────────────────────────────
 # Executes the approved plan. Write/edit/bash require tool-approval unless

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -1736,6 +1736,7 @@ mod tests {
                 options: vec!["Approve".to_string(), "Abort".to_string()],
                 directives: Default::default(),
                 abort_options: vec!["Abort".to_string()],
+                edit_options: Default::default(),
             }],
         };
         stage.max_iterations = Some(2);
@@ -1872,6 +1873,7 @@ mod tests {
                 options: vec![],
                 directives: Default::default(),
                 abort_options: Default::default(),
+                edit_options: Default::default(),
             }],
         };
         stage.accepts_messages = false;

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -256,6 +256,17 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
                                             .collect()
                                     })
                                     .unwrap_or_default();
+                                // Options that open the last output for direct editing:
+                                // edit_options = ["Add detail — expand a section"]
+                                let pt_edit_options: Vec<String> = pt
+                                    .get("edit_options")
+                                    .and_then(|v| v.as_array())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
                                 points.push(leviath_core::blueprint::InteractionPoint {
                                     name: pt_name,
                                     prompt: pt_prompt,
@@ -264,6 +275,7 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
                                     options: pt_options,
                                     directives: pt_directives,
                                     abort_options: pt_abort_options,
+                                    edit_options: pt_edit_options,
                                 });
                             }
                         }
@@ -1217,8 +1229,9 @@ name     = "plan_approval"
 prompt   = "Approve?"
 required = true
 style    = "multiple_choice"
-options  = ["Approve", "Revise", "Abort"]
+options  = ["Approve", "Revise", "Edit", "Abort"]
 abort_options = ["Abort"]
+edit_options = ["Edit"]
 directives = { "Revise" = "Call ask_user_text to find out what to change." }
 "#;
         let bp = parse_manifest(toml).unwrap();
@@ -1231,6 +1244,7 @@ directives = { "Revise" = "Call ask_user_text to find out what to change." }
         );
         assert!(!points[0].directives.contains_key("Approve"));
         assert_eq!(points[0].abort_options, vec!["Abort".to_string()]);
+        assert_eq!(points[0].edit_options, vec!["Edit".to_string()]);
     }
 
     #[test]
@@ -1279,6 +1293,7 @@ style    = "confirm"
         let points = unwrap_interactive_points(&stage.mode);
         assert!(points[0].directives.is_empty());
         assert!(points[0].abort_options.is_empty());
+        assert!(points[0].edit_options.is_empty());
     }
 
     #[test]
@@ -1758,7 +1773,7 @@ version = "1.0.0"
     }
 
     #[test]
-    fn software_engineer_plan_approval_has_directives_and_abort_option() {
+    fn software_engineer_plan_approval_option_routing() {
         let manifest_content =
             include_str!("../../../../../agents/software-engineer/agent.leviath");
         let bp = parse_manifest(manifest_content).unwrap();
@@ -1769,39 +1784,30 @@ version = "1.0.0"
             .find(|p| p.name == "plan_approval")
             .expect("plan_approval interaction point must exist");
 
-        // "Revise" and "Add detail" carry directives so the run stays in-stage
-        // and the agent drives the next step via a tool call.
-        let revise_key = approval
-            .options
-            .iter()
-            .find(|o| o.starts_with("Revise"))
-            .expect("a Revise option must exist");
-        let detail_key = approval
-            .options
-            .iter()
-            .find(|o| o.starts_with("Add detail"))
-            .expect("an Add detail option must exist");
-        assert!(approval.directives.contains_key(revise_key));
-        assert!(approval.directives.contains_key(detail_key));
-        // The Add-detail directive drives the direct-edit tool.
-        assert!(approval.directives[detail_key].contains("edit_document"));
+        let opt = |prefix: &str| {
+            approval
+                .options
+                .iter()
+                .find(|o| o.starts_with(prefix))
+                .unwrap_or_else(|| panic!("a {} option must exist", prefix))
+                .clone()
+        };
+        let approve = opt("Approve");
+        let revise = opt("Revise");
+        let detail = opt("Add detail");
+        let abort = opt("Abort");
 
-        // Approve is a plain (completing) option — no directive.
-        let approve_key = approval
-            .options
-            .iter()
-            .find(|o| o.starts_with("Approve"))
-            .expect("an Approve option must exist");
-        assert!(!approval.directives.contains_key(approve_key));
-
-        // Abort is handled deterministically via abort_options, not a directive.
-        let abort_key = approval
-            .options
-            .iter()
-            .find(|o| o.starts_with("Abort"))
-            .expect("an Abort option must exist");
-        assert!(!approval.directives.contains_key(abort_key));
-        assert!(approval.abort_options.contains(abort_key));
+        // "Revise" carries a directive (agent-driven, calls ask_user_text).
+        assert!(approval.directives.contains_key(&revise));
+        // "Add detail" is a deterministic edit option (engine opens an editor).
+        assert!(approval.edit_options.contains(&detail));
+        assert!(!approval.directives.contains_key(&detail));
+        // "Abort" is a deterministic abort option.
+        assert!(approval.abort_options.contains(&abort));
+        // "Approve" is a plain completing option — none of the above.
+        assert!(!approval.directives.contains_key(&approve));
+        assert!(!approval.abort_options.contains(&approve));
+        assert!(!approval.edit_options.contains(&approve));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -50,16 +50,27 @@ fn lookup_directive<'a>(
     None
 }
 
-/// Whether `user_text` matches one of the point's abort options (exact match
-/// first, then the same normalization used for directive lookup).
-fn is_abort_option(abort_options: &[String], user_text: &str) -> bool {
-    if abort_options.iter().any(|o| o == user_text) {
+/// Whether `user_text` matches one of the given option labels (exact match
+/// first, then the same normalization used for directive lookup). Shared by
+/// the abort- and edit-option checks.
+fn option_matches(candidates: &[String], user_text: &str) -> bool {
+    if candidates.iter().any(|o| o == user_text) {
         return true;
     }
     let normalized = normalize_for_followup(user_text);
-    abort_options
+    candidates
         .iter()
         .any(|o| normalize_for_followup(o) == normalized)
+}
+
+/// Whether `user_text` matches one of the point's abort options.
+fn is_abort_option(abort_options: &[String], user_text: &str) -> bool {
+    option_matches(abort_options, user_text)
+}
+
+/// Whether `user_text` matches one of the point's edit options.
+fn is_edit_option(edit_options: &[String], user_text: &str) -> bool {
+    option_matches(edit_options, user_text)
 }
 
 /// Outcome of running an interactive-points stage. `Aborted` signals the
@@ -397,6 +408,11 @@ async fn run_interactive_points_stage_with(
     let iterations_per_segment = max_iterations / segments;
     let mut remaining_iterations = max_iterations;
 
+    // The most recent non-empty inference output for the current stage (e.g.
+    // the plan). Used to seed an "edit" option's editable field with the text
+    // the user is choosing to modify.
+    let mut last_output: Option<String> = None;
+
     // Cap how many times a single interaction point can loop back on itself
     // via a followup (e.g. repeatedly picking "Revise"). Bounded independently
     // of the iteration budget so a chatty user can't spin forever.
@@ -429,6 +445,7 @@ async fn run_interactive_points_stage_with(
                         if let (Some(run_id), Some(ref m)) = (&run_id_owned, &meta_holder) {
                             record_stage_output(run_id, m.stage_index, &resp.content);
                         }
+                        last_output = Some(resp.content.clone());
                     }
                     // Update token counts in meta so the dashboard shows them before WaitingInput
                     if let Some(ref mut m) = meta_holder {
@@ -524,6 +541,49 @@ async fn run_interactive_points_stage_with(
                     let content = format!("User [{}]: {}", point.name, user_text);
                     let _ = window.add_to_region("conversation", content, tokens);
                 }
+            }
+
+            // Deterministic direct-edit: if the selection is an edit option,
+            // the engine itself opens the stage's most recent output in an
+            // editable field (seeded via `body`) and injects the user's edited
+            // text back into context, then loops back to re-present the point.
+            // Unlike a directive, this does NOT depend on the model choosing to
+            // call an edit tool — the editor always appears.
+            if is_edit_option(&point.edit_options, &user_text) {
+                if revision_round + 1 >= MAX_REVISION_ROUNDS || remaining_iterations == 0 {
+                    break 'point;
+                }
+                let edit_req_id = make_interaction_id(pt_idx, revision_round * 2 + 1);
+                let seed = last_output.clone().unwrap_or_default();
+                let edit_req = InteractionRequest::edit_text(
+                    edit_req_id,
+                    "Edit the text below, then submit your changes:",
+                    &point.name,
+                    seed,
+                );
+                let edited =
+                    if let (Some(run_id), Some(ref mut meta)) = (&run_id_owned, &mut meta_holder) {
+                        let resp = request_interaction_async(run_id, meta, edit_req, None).await?;
+                        response_as_text(&resp)
+                    } else {
+                        response_as_text(&ask_foreground(&edit_req))
+                    };
+                if !edited.is_empty() {
+                    if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
+                        let content = format!(
+                            "User [{}] edited the output directly. Adopt this exact text as the \
+                             authoritative version and re-present it:\n{}",
+                            point.name, edited
+                        );
+                        let tokens = content.len() / 4 + 1;
+                        let _ = window.add_to_region("conversation", content, tokens);
+                    }
+                    // Reflect the edit as the current output too, so the next
+                    // seed (if edited again) and the dashboard stay in sync.
+                    last_output = Some(edited);
+                }
+                revision_round += 1;
+                continue 'point;
             }
 
             // If the chosen option has a configured directive, inject it into
@@ -1425,6 +1485,7 @@ mod tests {
             options: vec![],
             directives: std::collections::HashMap::new(),
             abort_options: Vec::new(),
+            edit_options: Vec::new(),
         }
     }
 
@@ -1441,6 +1502,7 @@ mod tests {
             options,
             directives: std::collections::HashMap::new(),
             abort_options: Vec::new(),
+            edit_options: Vec::new(),
         }
     }
 
@@ -1458,6 +1520,7 @@ mod tests {
             options,
             directives,
             abort_options: Vec::new(),
+            edit_options: Vec::new(),
         }
     }
 
@@ -1475,6 +1538,25 @@ mod tests {
             options,
             directives: std::collections::HashMap::new(),
             abort_options,
+            edit_options: Vec::new(),
+        }
+    }
+
+    fn make_multiple_choice_point_with_edit(
+        name: &str,
+        prompt: &str,
+        options: Vec<String>,
+        edit_options: Vec<String>,
+    ) -> leviath_core::blueprint::InteractionPoint {
+        leviath_core::blueprint::InteractionPoint {
+            name: name.to_string(),
+            prompt: prompt.to_string(),
+            required: false,
+            style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+            options,
+            directives: std::collections::HashMap::new(),
+            abort_options: Vec::new(),
+            edit_options,
         }
     }
 
@@ -1487,6 +1569,7 @@ mod tests {
             options: vec![],
             directives: std::collections::HashMap::new(),
             abort_options: Vec::new(),
+            edit_options: Vec::new(),
         }
     }
 
@@ -1863,6 +1946,89 @@ mod tests {
         .unwrap();
 
         assert_eq!(outcome, PointsOutcome::Aborted);
+    }
+
+    #[tokio::test]
+    async fn interactive_points_edit_option_opens_editor_seeded_with_output() {
+        // Selecting an edit option must DETERMINISTICALLY open an EditText
+        // interaction seeded with the stage's last output (the plan), inject
+        // the edited text, and re-present the point — no dependence on the
+        // model calling an edit tool.
+        use crate::interaction::{InteractionKind, InteractionResponse};
+        use std::sync::Mutex;
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        // Mock provider returns "Agent response" → becomes the edit seed.
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let points = vec![make_multiple_choice_point_with_edit(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Add detail".to_string()],
+            vec!["Add detail".to_string()],
+        )];
+
+        // Records the body of the EditText request the engine issued.
+        let seen_edit_body: Mutex<Option<String>> = Mutex::new(None);
+        let choice_round = Mutex::new(0usize);
+        let ask_foreground = |req: &crate::interaction::InteractionRequest| match req.kind {
+            InteractionKind::EditText => {
+                *seen_edit_body.lock().unwrap() = req.body.clone();
+                InteractionResponse::text(&req.id, "EDITED PLAN")
+            }
+            _ => {
+                // Round 1: "Add detail" (index 1). Round 2: "Approve" (index 0).
+                let mut r = choice_round.lock().unwrap();
+                let idx = if *r == 0 { 1 } else { 0 };
+                *r += 1;
+                InteractionResponse::choice(&req.id, idx)
+            }
+        };
+
+        let outcome = run_interactive_points_stage_with(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            8,
+            &[],
+            None,
+            None,
+            &points,
+            None,
+            &mut io,
+            &mut noop_exec,
+            &ask_foreground,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, PointsOutcome::Completed);
+        // The editor was seeded with the stage's last output (the plan).
+        assert_eq!(
+            seen_edit_body.lock().unwrap().as_deref(),
+            Some("Agent response")
+        );
+
+        // The edited text was injected into the agent's context.
+        let window = engine
+            .world()
+            .get::<leviath_runtime::ContextWindow>(entity)
+            .unwrap();
+        let conversation = window.get_region("conversation").unwrap();
+        let all_content: String = conversation
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_contains_display(
+            all_content.contains("edited the output directly")
+                && all_content.contains("EDITED PLAN"),
+            "expected the edited text injected into context, got",
+            &all_content,
+        );
     }
 
     // ─── run_interactive_points_stage: real foreground (stdin) path ─────────

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -342,6 +342,14 @@ pub struct InteractionPoint {
     /// the same dash/whitespace normalization used for directive lookup.
     #[serde(default)]
     pub abort_options: Vec<String>,
+
+    /// Options that, when selected, open the stage's most recent output (e.g.
+    /// the plan) in an editable field so the user can modify it directly. The
+    /// engine issues the edit interaction itself and injects the edited text
+    /// back into context — deterministic, with no dependence on the model
+    /// choosing to call an edit tool. Matched with the same normalization.
+    #[serde(default)]
+    pub edit_options: Vec<String>,
 }
 
 /// Configuration for routing tool results to specific context window regions.
@@ -1020,9 +1028,11 @@ mod tests {
             options: vec!["Approve".to_string(), "Revise".to_string()],
             directives: HashMap::new(),
             abort_options: Vec::new(),
+            edit_options: Vec::new(),
         };
         assert!(point.directives.is_empty());
         assert!(point.abort_options.is_empty());
+        assert!(point.edit_options.is_empty());
     }
 
     #[test]
@@ -1040,6 +1050,7 @@ mod tests {
             options: vec!["Approve".to_string(), "Revise".to_string()],
             directives,
             abort_options: vec!["Abort".to_string()],
+            edit_options: vec!["Add detail".to_string()],
         };
         let json = serde_json::to_string(&point).unwrap();
         let back: InteractionPoint = serde_json::from_str(&json).unwrap();
@@ -1048,6 +1059,7 @@ mod tests {
             Some("Ask what to change, then re-plan.")
         );
         assert_eq!(back.abort_options, vec!["Abort".to_string()]);
+        assert_eq!(back.edit_options, vec!["Add detail".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The agent-tool-driven "Add detail" directive (telling the model to call `edit_document` with the plan) was unreliable: sonnet-4-6 received the directive but re-produced the plan as text and asked a conversational follow-up instead of calling the tool — so the editor never opened and the user just saw `plan_approval` again.

## Fix

New `edit_options` list on `InteractionPoint` (parallel to `abort_options`). Selecting an edit option makes the **stage runner itself** open the stage's most recent output in an `EditText` interaction (seeded via `body`), inject the user's edited text back into context, and re-present the point — no dependence on the model choosing to call a tool. `edit_document` stays available for agents that want dynamic editing.

`software-engineer`'s "Add detail" moves from `directives` → `edit_options`.

## Verification

- Full suite (2058 tests), clippy (stable 1.97), fmt — clean.
- End-to-end against the real LLM: selecting "Add detail" opens the editor seeded with the current plan, the edited text becomes the plan, and `plan_approval` re-fires in-stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)