### PR TITLE
feat(taint): wire taint tracking into the live agent run loop

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1302,11 +1302,36 @@ mod tests {
         assert!(!dash.input_mode);
         assert!(dash.agents[0].pending_request.is_none());
         // The edited text reached the engine with indentation + newline intact.
-        match cmd_rx.try_recv() {
-            Ok(EngineCommand::SendInput { input, .. }) => {
-                assert_eq!(input, "  indented\nsecond line");
-            }
-            other => panic!("expected SendInput, got {:?}", other),
+        let cmd = cmd_rx.try_recv().expect("a SendInput command was queued");
+        assert!(matches!(cmd, EngineCommand::SendInput { .. }));
+        if let EngineCommand::SendInput { input, .. } = cmd {
+            assert_eq!(input, "  indented\nsecond line");
+        }
+    }
+
+    #[test]
+    fn submit_input_edit_text_empty_reports_no_changes() {
+        // Covers the empty-edit display branch of the EditText submit arm.
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.is_run_state = false;
+        agent.pending_request = Some(crate::interaction::InteractionRequest::edit_text(
+            "et1", "Edit", "main", "old",
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+
+        // Whitespace-only edit → trimmed empty → "(no changes)" display path.
+        dash.input_textarea = tui_textarea::TextArea::new(vec!["   ".to_string()]);
+        dash.submit_input();
+
+        assert!(!dash.input_mode);
+        let cmd = cmd_rx.try_recv().expect("a SendInput command was queued");
+        if let EngineCommand::SendInput { input, .. } = cmd {
+            assert_eq!(input, "   ");
         }
     }
 

--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -56,7 +56,7 @@ pub async fn execute(args: PolicyArgs) -> anyhow::Result<()> {
 }
 
 /// Load the policy config from the default path.
-fn load_policy() -> anyhow::Result<leviath_core::PolicyConfig> {
+pub(crate) fn load_policy() -> anyhow::Result<leviath_core::PolicyConfig> {
     load_policy_from(&policy_path())
 }
 
@@ -351,6 +351,25 @@ mod tests {
         // Just verify it doesn't panic
         let result = execute_list().await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_dispatches_subcommands() {
+        // Exercise the top-level `execute` dispatcher for the read-only arms.
+        assert!(execute(PolicyArgs {
+            command: PolicyCommand::List(PolicyListArgs {}),
+        })
+        .await
+        .is_ok());
+        assert!(execute(PolicyArgs {
+            command: PolicyCommand::Test(PolicyTestArgs {
+                tool: "read_file".to_string(),
+                target: None,
+                taint: "internal".to_string(),
+            }),
+        })
+        .await
+        .is_ok());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/dynamic_interaction.rs
+++ b/crates/leviath-cli/src/commands/run/dynamic_interaction.rs
@@ -13,7 +13,81 @@
 use async_trait::async_trait;
 
 use crate::interaction::{response_approved, response_as_choice, response_as_text};
-use crate::interaction::{InteractionRequest, InteractionResponse};
+use crate::interaction::{ApprovalScope, InteractionRequest, InteractionResponse};
+
+// ─── Shared taint-gate prompt helpers ──────────────────────────────────────
+// Used by both the worker (IPC) and foreground (stdin) GatePrompt impls so the
+// decision-parsing / arg-building / approval-mapping logic is written and
+// tested once, not duplicated across two untestable I/O closures.
+
+/// Extract `(tool_name, taint, clearance)` from a blocked gate decision, or
+/// `None` if the decision isn't a block.
+pub(crate) fn gate_block_info(
+    decision: &leviath_core::taint::GateDecision,
+) -> Option<(String, leviath_core::TaintLevel, leviath_core::TaintLevel)> {
+    match decision {
+        leviath_core::taint::GateDecision::Blocked {
+            tool_name,
+            taint_level,
+            clearance,
+            ..
+        } => Some((tool_name.clone(), *taint_level, *clearance)),
+        _ => None,
+    }
+}
+
+/// Build the approval-prompt arguments explaining why an outbound call was gated.
+pub(crate) fn gate_prompt_args(
+    tool_name: &str,
+    taint: leviath_core::TaintLevel,
+    clearance: leviath_core::TaintLevel,
+) -> serde_json::Value {
+    serde_json::json!({
+        "taint_gate": true,
+        "reason": format!(
+            "Outbound tool '{}' would carry {}-sensitivity data above its {} clearance.",
+            tool_name, taint, clearance
+        ),
+    })
+}
+
+/// Map an approval outcome (approved, session-scope) to a gate resolution.
+pub(crate) fn map_gate_approval(
+    approved: bool,
+    session: bool,
+) -> leviath_runtime::taint::GateResolution {
+    use leviath_runtime::taint::GateResolution;
+    match (approved, session) {
+        (false, _) => GateResolution::Deny,
+        (true, true) => GateResolution::AlwaysAllow,
+        (true, false) => GateResolution::AllowOnce,
+    }
+}
+
+/// Resolve a foreground taint-gate block by asking via `ask` (real stdin in
+/// production, a mock in tests) and mapping the response. Kept free of the
+/// blocking stdin call itself so the request-building + mapping are testable.
+pub(crate) fn resolve_gate_with_asker(
+    decision: &leviath_core::taint::GateDecision,
+    stage_name: &str,
+    ask: impl Fn(&InteractionRequest) -> InteractionResponse,
+) -> leviath_runtime::taint::GateResolution {
+    use leviath_runtime::taint::GateResolution;
+    let Some((tool_name, taint, clearance)) = gate_block_info(decision) else {
+        return GateResolution::AllowOnce;
+    };
+    let req = InteractionRequest::tool_approval(
+        format!("taint-{}", tool_name),
+        &tool_name,
+        gate_prompt_args(&tool_name, taint, clearance),
+        stage_name,
+    );
+    let resp = ask(&req);
+    map_gate_approval(
+        response_approved(&resp),
+        resp.scope == Some(ApprovalScope::Session),
+    )
+}
 
 /// How a dynamically-requested interaction is dispatched and logged.
 ///
@@ -725,5 +799,72 @@ mod tests {
         )
         .await;
         assert_eq!(result, Some("User feedback: answer".to_string()));
+    }
+
+    // ─── taint-gate prompt helpers ──────────────────────────────────────────
+
+    fn blocked_decision(tool: &str) -> leviath_core::taint::GateDecision {
+        leviath_core::taint::GateDecision::Blocked {
+            taint_level: leviath_core::TaintLevel::Private,
+            clearance: leviath_core::TaintLevel::Public,
+            source_regions: vec!["notes".into()],
+            tool_name: tool.to_string(),
+        }
+    }
+
+    #[test]
+    fn gate_block_info_extracts_blocked_fields() {
+        let (tool, taint, clearance) = gate_block_info(&blocked_decision("shell")).unwrap();
+        assert_eq!(tool, "shell");
+        assert_eq!(taint, leviath_core::TaintLevel::Private);
+        assert_eq!(clearance, leviath_core::TaintLevel::Public);
+        // Allowed decisions yield None.
+        assert!(gate_block_info(&leviath_core::taint::GateDecision::Allowed).is_none());
+    }
+
+    #[test]
+    fn gate_prompt_args_mentions_tool() {
+        let args = gate_prompt_args(
+            "send_email",
+            leviath_core::TaintLevel::Private,
+            leviath_core::TaintLevel::Public,
+        );
+        assert_eq!(args["taint_gate"], true);
+        assert!(args["reason"].as_str().unwrap().contains("send_email"));
+    }
+
+    #[test]
+    fn map_gate_approval_covers_all_outcomes() {
+        use leviath_runtime::taint::GateResolution;
+        assert_eq!(map_gate_approval(false, false), GateResolution::Deny);
+        assert_eq!(map_gate_approval(false, true), GateResolution::Deny);
+        assert_eq!(map_gate_approval(true, false), GateResolution::AllowOnce);
+        assert_eq!(map_gate_approval(true, true), GateResolution::AlwaysAllow);
+    }
+
+    #[test]
+    fn resolve_gate_with_asker_maps_response() {
+        use leviath_runtime::taint::GateResolution;
+        // Deny.
+        let r = resolve_gate_with_asker(&blocked_decision("shell"), "plan", |_req| {
+            InteractionResponse::approval("", false, ApprovalScope::Once)
+        });
+        assert_eq!(r, GateResolution::Deny);
+        // Always-allow (session scope). Also assert the request the asker saw is
+        // a taint-gate tool-approval for the right tool.
+        let r = resolve_gate_with_asker(&blocked_decision("shell"), "plan", |req| {
+            assert_eq!(req.tool_name.as_deref(), Some("shell"));
+            assert_eq!(req.stage_name, "plan");
+            InteractionResponse::approval("", true, ApprovalScope::Session)
+        });
+        assert_eq!(r, GateResolution::AlwaysAllow);
+        // A non-block decision short-circuits to AllowOnce without asking (the
+        // asker is never invoked, so its body is a single trivial line).
+        let r = resolve_gate_with_asker(
+            &leviath_core::taint::GateDecision::Allowed,
+            "plan",
+            |_req| InteractionResponse::text("", ""),
+        );
+        assert_eq!(r, GateResolution::AllowOnce);
     }
 }

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -20,6 +20,45 @@ use super::graph::{apply_edge_transform, is_graph_mode, resolve_transition};
 use super::helpers::swap_context_layout;
 use super::io::RunIO;
 use super::stages::{run_interactive_points_stage, run_interactive_stage, PointsOutcome};
+use leviath_core::taint::{
+    resolve_security, resolve_taint_enabled, SecurityConfig, ToolClassification, ToolDirection,
+};
+use leviath_core::PolicyConfig;
+use leviath_runtime::taint::TaintGate;
+
+/// Build the taint gate for a stage, cascading global → agent → stage. Returns
+/// `None` when taint tracking resolves to disabled for this stage. Applies any
+/// per-tool classification overrides from the policy's `mcp_overrides`.
+fn build_stage_taint_gate(
+    global: bool,
+    agent_sec: Option<&SecurityConfig>,
+    stage_sec: Option<&SecurityConfig>,
+    policy: &PolicyConfig,
+) -> Option<TaintGate> {
+    if !resolve_taint_enabled(global, agent_sec, stage_sec) {
+        return None;
+    }
+    let sec = resolve_security(global, agent_sec, stage_sec);
+    let mut gate = TaintGate::new(sec);
+    for (tool_key, ov) in &policy.mcp_overrides {
+        let mut cls = ToolClassification::default();
+        if let Some(s) = ov.sensitivity {
+            cls.sensitivity = s;
+        }
+        if let Some(dir) = ov
+            .direction
+            .as_deref()
+            .and_then(ToolDirection::from_str_loose)
+        {
+            cls.direction = dir;
+        }
+        if let Some(c) = ov.clearance {
+            cls.clearance = c;
+        }
+        gate.set_tool_classification(tool_key.clone(), cls);
+    }
+    Some(gate)
+}
 
 use crate::runstate::RunMeta;
 
@@ -145,6 +184,34 @@ pub trait StageCallbacks: Send {
     /// Default no-op for callers with no run state (e.g. tests, foreground).
     async fn on_cancel(&mut self, stage_idx: usize) {
         let _ = stage_idx;
+    }
+
+    /// Global taint-tracking master switch (from user config). Default off, so
+    /// callers that don't opt in (tests) get no enforcement.
+    fn taint_global_enabled(&self) -> bool {
+        false
+    }
+
+    /// Policy (allowlists / MCP overrides) consulted when the gate blocks.
+    fn taint_policy(&self) -> leviath_core::PolicyConfig {
+        leviath_core::PolicyConfig::default()
+    }
+
+    /// Build a resolver for interactively deciding a blocked outbound call.
+    /// `None` → blocked calls are denied outright. Foreground/worker override
+    /// this to prompt via stdin / the dashboard.
+    fn make_gate_prompt(&self) -> Option<Box<dyn leviath_runtime::taint::GatePrompt>> {
+        None
+    }
+
+    /// Called at the end of a stage with the taint audit events recorded during
+    /// it, so the implementer can persist them. Default no-op.
+    async fn on_taint_audit(
+        &mut self,
+        stage_idx: usize,
+        events: &[leviath_core::taint::GateEvent],
+    ) {
+        let _ = (stage_idx, events);
     }
 
     /// Post-stage state update (worker writes meta + context snapshot).
@@ -411,6 +478,24 @@ pub async fn run_stage_loop(
         // Clone values needed after the match (stage is borrowed from blueprint)
         let stage_name_owned = stage.name.clone();
         let stage_mode = stage.mode.clone();
+
+        // ── Taint enforcement: resolve global → agent → stage and configure
+        // the engine's gate for this stage (or clear it when disabled). ──
+        {
+            let global = cb.taint_global_enabled();
+            let agent_sec = ctx.blueprint.security.as_ref();
+            let stage_sec = stage.security.as_ref();
+            if let Some(gate) =
+                build_stage_taint_gate(global, agent_sec, stage_sec, &cb.taint_policy())
+            {
+                ctx.engine
+                    .configure_taint(gate, cb.taint_policy(), cb.make_gate_prompt());
+                ctx.engine.enable_entity_taint_tracking(ctx.entity);
+            } else {
+                ctx.engine.clear_taint();
+            }
+        }
+
         // Stage execution
         let stage_result_val: StageResult;
 
@@ -533,6 +618,12 @@ pub async fn run_stage_loop(
             }
         }
 
+        // Persist this stage's taint audit events (if any) before moving on.
+        let taint_audit = ctx.engine.taint_audit_log().to_vec();
+        if !taint_audit.is_empty() {
+            cb.on_taint_audit(stage_idx, &taint_audit).await;
+        }
+
         // Cancel the stdin reader task now that the stage is complete
         if let Some(handle) = stdin_handle {
             handle.abort();
@@ -643,6 +734,11 @@ mod tests {
         run_context: Option<(String, RunMeta)>,
         /// Stage index recorded by on_cancel (None if never cancelled).
         cancelled_at: Option<usize>,
+        /// When true, taint_global_enabled() returns true (drives the per-stage
+        /// taint-config path in run_stage_loop).
+        taint_global: bool,
+        /// Stage indexes for which on_taint_audit fired.
+        taint_audits: Vec<usize>,
     }
 
     impl MockCallbacks {
@@ -662,6 +758,8 @@ mod tests {
                 run_autonomous_should_error: false,
                 run_context: None,
                 cancelled_at: None,
+                taint_global: false,
+                taint_audits: Vec::new(),
             }
         }
     }
@@ -767,6 +865,18 @@ mod tests {
 
         async fn on_complete(&mut self, last_stage_idx: usize) {
             self.completed_at = Some(last_stage_idx);
+        }
+
+        fn taint_global_enabled(&self) -> bool {
+            self.taint_global
+        }
+
+        async fn on_taint_audit(
+            &mut self,
+            stage_idx: usize,
+            _events: &[leviath_core::taint::GateEvent],
+        ) {
+            self.taint_audits.push(stage_idx);
         }
 
         async fn on_cancel(&mut self, stage_idx: usize) {
@@ -1432,6 +1542,12 @@ mod tests {
         cb.on_transition("a", "b", 0).await;
         cb.on_complete(0).await;
         cb.on_post_stage(&engine, entity, "main").await;
+        // Default (non-overridden) taint/cancel trait-method bodies.
+        cb.on_cancel(0).await;
+        assert!(!cb.taint_global_enabled());
+        let _ = cb.taint_policy();
+        assert!(cb.make_gate_prompt().is_none());
+        cb.on_taint_audit(0, &[]).await;
     }
 
     #[tokio::test]
@@ -2341,5 +2457,93 @@ mod tests {
             .expect("InferenceConfig should be set from stage parameters");
         assert_eq!(cfg.temperature, Some(0.5));
         assert_eq!(cfg.max_output_tokens, Some(1024));
+    }
+
+    // ─── build_stage_taint_gate ─────────────────────────────────────────────
+
+    fn sec(taint: bool) -> SecurityConfig {
+        SecurityConfig {
+            taint_tracking: taint,
+            ..SecurityConfig::default()
+        }
+    }
+
+    #[test]
+    fn build_stage_taint_gate_disabled_returns_none() {
+        // Global off, nothing opts in.
+        assert!(build_stage_taint_gate(false, None, None, &PolicyConfig::default()).is_none());
+        // Global on but agent opts out.
+        assert!(
+            build_stage_taint_gate(true, Some(&sec(false)), None, &PolicyConfig::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn build_stage_taint_gate_enabled_when_global_on() {
+        let gate = build_stage_taint_gate(true, None, None, &PolicyConfig::default())
+            .expect("gate should be built when global taint is on");
+        assert!(gate.is_enabled());
+    }
+
+    #[test]
+    fn build_stage_taint_gate_applies_mcp_overrides() {
+        let mut policy = PolicyConfig::default();
+        policy.mcp_overrides.insert(
+            "srv.sender".to_string(),
+            leviath_core::policy::McpToolOverride {
+                sensitivity: Some(leviath_core::TaintLevel::Public),
+                direction: Some("outbound".to_string()),
+                clearance: Some(leviath_core::TaintLevel::Public),
+            },
+        );
+        // Stage opts in even though global is off.
+        let gate = build_stage_taint_gate(false, None, Some(&sec(true)), &policy)
+            .expect("stage opt-in should build a gate");
+        let cls = gate.tool_classification("srv.sender");
+        assert!(cls.is_outbound());
+        assert_eq!(cls.clearance, leviath_core::TaintLevel::Public);
+    }
+
+    #[tokio::test]
+    async fn run_stage_loop_configures_taint_when_global_enabled() {
+        // With the global taint switch on, the per-stage taint-config path in
+        // run_stage_loop must build+configure the gate and enable window taint
+        // tracking for the stage (then run to completion).
+        let mut stage = make_stage("main");
+        stage.max_iterations = Some(1);
+        let bp = make_blueprint(vec![stage]);
+        let (mut engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+        let tool_registry = make_tool_registry().await;
+        let mut cb = MockCallbacks::new();
+        cb.taint_global = true;
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        // The run completed with the per-stage taint-config path exercised
+        // (build_stage_taint_gate → configure_taint → enable_entity_taint_tracking).
+        assert_eq!(cb.completed_at, Some(0));
     }
 }

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -413,6 +413,22 @@ impl StageCallbacks for ForegroundCallbacks {
         println!("\n[Run cancelled by user]");
     }
 
+    fn taint_global_enabled(&self) -> bool {
+        // Foreground is a single short-lived process; load lazily rather than
+        // threading config through every ForegroundCallbacks literal.
+        crate::config::Config::load()
+            .map(|c| c.taint_tracking)
+            .unwrap_or(false)
+    }
+
+    fn taint_policy(&self) -> leviath_core::PolicyConfig {
+        crate::commands::policy::load_policy().unwrap_or_default()
+    }
+
+    fn make_gate_prompt(&self) -> Option<Box<dyn leviath_runtime::taint::GatePrompt>> {
+        Some(Box::new(ForegroundGatePrompt))
+    }
+
     async fn on_post_stage(
         &mut self,
         _engine: &leviath_runtime::AgentEngine,
@@ -420,6 +436,26 @@ impl StageCallbacks for ForegroundCallbacks {
         _stage_name: &str,
     ) {
         // Foreground: no-op
+    }
+}
+
+/// Foreground taint [`GatePrompt`]: prompts on stdin (allow-once / session /
+/// deny) when the gate blocks an outbound call.
+struct ForegroundGatePrompt;
+
+#[async_trait::async_trait]
+impl leviath_runtime::taint::GatePrompt for ForegroundGatePrompt {
+    async fn resolve(
+        &self,
+        decision: &leviath_core::taint::GateDecision,
+    ) -> leviath_runtime::taint::GateResolution {
+        // All request-building + response-mapping lives in the tested
+        // `resolve_gate_with_asker`; only the real-stdin read is untestable.
+        super::dynamic_interaction::resolve_gate_with_asker(
+            decision,
+            "taint-gate",
+            crate::interaction::request_interaction_stdin,
+        )
     }
 }
 
@@ -1876,5 +1912,36 @@ allowed = ["read_file"]
         assert!(result.is_err());
 
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn foreground_taint_trait_methods_callable() {
+        // Exercises the foreground taint overrides + default hooks (Config/policy
+        // load are read-only real IO; we assert shape, not specific values).
+        let mut cb = ForegroundCallbacks {};
+        let _enabled: bool = cb.taint_global_enabled();
+        let _policy = cb.taint_policy();
+        assert!(cb.make_gate_prompt().is_some());
+        // on_cancel + the default on_taint_audit hook must not panic.
+        cb.on_cancel(0).await;
+        cb.on_taint_audit(0, &[]).await;
+    }
+
+    #[tokio::test]
+    async fn foreground_gate_prompt_resolve_denies_via_stdin_reader() {
+        // Drive ForegroundGatePrompt::resolve through the tested helper by
+        // constructing the same path with a mock asker (Deny).
+        use super::super::dynamic_interaction::resolve_gate_with_asker;
+        use crate::interaction::{ApprovalScope, InteractionResponse};
+        let decision = leviath_core::taint::GateDecision::Blocked {
+            taint_level: leviath_core::TaintLevel::Private,
+            clearance: leviath_core::TaintLevel::Public,
+            source_regions: vec![],
+            tool_name: "shell".into(),
+        };
+        let r = resolve_gate_with_asker(&decision, "taint-gate", |_req| {
+            InteractionResponse::approval("", false, ApprovalScope::Once)
+        });
+        assert_eq!(r, leviath_runtime::taint::GateResolution::Deny);
     }
 }

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -323,6 +323,11 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
                 stage.allow_complete = ac;
             }
 
+            // Parse per-stage security override: [stages.<name>.security]
+            if let Some(sec_table) = stage_value.get("security").and_then(|v| v.as_table()) {
+                stage.security = Some(parse_security_config(sec_table));
+            }
+
             // Parse accepts_messages flag: whether mid-run user messages are
             // injected into context between inference calls. Defaults to true
             // (via the Stage constructor); set false for stages that shouldn't
@@ -564,37 +569,9 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
         blueprint.compaction_config = Some(cc);
     }
 
-    // Parse security config: [security]
+    // Parse agent-level security config: [security]
     if let Some(security_table) = parsed.get("security").and_then(|v| v.as_table()) {
-        let mut sc = leviath_core::SecurityConfig::default();
-
-        if let Some(tt) = security_table
-            .get("taint_tracking")
-            .and_then(|v| v.as_bool())
-        {
-            sc.taint_tracking = tt;
-        }
-        if let Some(pm) = security_table.get("pointer_mode").and_then(|v| v.as_bool()) {
-            sc.pointer_mode = pm;
-        }
-        if let Some(fm_val) = security_table.get("filter_mode") {
-            if let Some(fm_str) = fm_val.as_str() {
-                sc.filter_mode = leviath_core::FilterMode::from_str_loose(fm_str);
-            } else if let Some(false) = fm_val.as_bool() {
-                sc.filter_mode = None;
-            }
-        }
-        if let Some(deg_arr) = security_table.get("degradation").and_then(|v| v.as_array()) {
-            let modes: Vec<leviath_core::InputMode> = deg_arr
-                .iter()
-                .filter_map(|v| v.as_str().and_then(leviath_core::InputMode::from_str_loose))
-                .collect();
-            if !modes.is_empty() {
-                sc.degradation = modes;
-            }
-        }
-
-        blueprint.security = Some(sc);
+        blueprint.security = Some(parse_security_config(security_table));
     }
 
     // Parse agent-level tool permissions: [tool_permissions]
@@ -610,6 +587,40 @@ pub fn parse_manifest(content: &str) -> anyhow::Result<Blueprint> {
     }
 
     Ok(blueprint)
+}
+
+/// Parse a `[security]` / `[stages.X.security]` table into a `SecurityConfig`.
+/// A present block defaults `taint_tracking` to `true` (block presence implies
+/// intent to configure security); omit the block entirely to inherit the
+/// broader (agent/global) setting.
+fn parse_security_config(security_table: &toml::value::Table) -> leviath_core::SecurityConfig {
+    let mut sc = leviath_core::SecurityConfig::default();
+    if let Some(tt) = security_table
+        .get("taint_tracking")
+        .and_then(|v| v.as_bool())
+    {
+        sc.taint_tracking = tt;
+    }
+    if let Some(pm) = security_table.get("pointer_mode").and_then(|v| v.as_bool()) {
+        sc.pointer_mode = pm;
+    }
+    if let Some(fm_val) = security_table.get("filter_mode") {
+        if let Some(fm_str) = fm_val.as_str() {
+            sc.filter_mode = leviath_core::FilterMode::from_str_loose(fm_str);
+        } else if let Some(false) = fm_val.as_bool() {
+            sc.filter_mode = None;
+        }
+    }
+    if let Some(deg_arr) = security_table.get("degradation").and_then(|v| v.as_array()) {
+        let modes: Vec<leviath_core::InputMode> = deg_arr
+            .iter()
+            .filter_map(|v| v.as_str().and_then(leviath_core::InputMode::from_str_loose))
+            .collect();
+        if !modes.is_empty() {
+            sc.degradation = modes;
+        }
+    }
+    sc
 }
 
 #[cfg(test)]
@@ -1206,6 +1217,52 @@ followups = { "Revise" = "What would you like to change?" }
             points[0].directives.get("Revise").map(|s| s.as_str()),
             Some("What would you like to change?")
         );
+    }
+
+    #[test]
+    fn parse_manifest_agent_and_stage_security() {
+        let toml = r#"
+[agent]
+name = "sec-test"
+
+[security]
+taint_tracking = true
+
+[stages.plan]
+mode = "autonomous"
+
+[stages.plan.security]
+taint_tracking = false
+
+[stages.build]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        // Agent-level [security] parsed.
+        assert!(bp.security.as_ref().unwrap().taint_tracking);
+        // Stage-level [stages.plan.security] opts this stage out.
+        let plan = bp.find_stage("plan").unwrap();
+        assert_eq!(
+            plan.security.as_ref().map(|s| s.taint_tracking),
+            Some(false)
+        );
+        // A stage with no [security] inherits (None).
+        let build = bp.find_stage("build").unwrap();
+        assert!(build.security.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_no_security_is_none() {
+        let toml = r#"
+[agent]
+name = "no-sec"
+
+[stages.main]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert!(bp.security.is_none());
+        assert!(bp.find_stage("main").unwrap().security.is_none());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -507,6 +507,13 @@ prompt = "Implement"
         // when the executable path does not exist. We call execute_background
         // directly (the private inner function) with a non-existent exe path so
         // the spawn fails immediately.
+        // Hold the runs-dir isolation lock for the whole test (like the
+        // happy-path siblings) so a concurrent test can't swap LEVIATH_RUNS_DIR
+        // between `create_run` and `open_log_file` and delete the dir underneath
+        // us — a race llvm-cov's slower timing reliably exposed.
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "execute_background_bad_exe_returns_spawn_error",
+        );
         let agent_name = "test-execute-bg-bad-exe";
         let _cleanup = RunPrefixCleanup(agent_name);
         let temp_dir = std::env::temp_dir().join(agent_name);

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -1923,6 +1923,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn interactive_points_edit_option_ipc_path() {
+        // Edit option over the background file-IPC path: the engine issues an
+        // EditText request, the user's edited text is injected, then the point
+        // is re-presented. (The foreground path is covered separately.)
+        let _guard =
+            crate::runstate::isolate_runs_dir_for_test("interactive_points_edit_option_ipc_path");
+        use crate::interaction::InteractionResponse;
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let run_id = format!(
+            "test-ip-edit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        );
+        let mut meta = RunMeta::new(
+            run_id.clone(),
+            "test".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/tmp".into(),
+            1,
+        );
+        runstate::create_run(&meta).unwrap();
+
+        let points = vec![make_multiple_choice_point_with_edit(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Add detail".to_string()],
+            vec!["Add detail".to_string()],
+        )];
+
+        // Round 1: "Add detail" (index 1) → engine issues EditText → user
+        // submits edited text → Round 2: "Approve" (index 0) → complete.
+        let responder = spawn_interaction_responder(
+            run_id.clone(),
+            vec![
+                InteractionResponse::choice("", 1),
+                InteractionResponse::text("", "EDITED VIA IPC"),
+                InteractionResponse::choice("", 0),
+            ],
+        );
+
+        let outcome = run_interactive_points_stage(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            8,
+            &[],
+            None,
+            &points,
+            Some((&run_id, &mut meta)),
+            &mut io,
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        responder.abort();
+        assert_eq!(outcome, PointsOutcome::Completed);
+
+        let window = engine
+            .world()
+            .get::<leviath_runtime::ContextWindow>(entity)
+            .unwrap();
+        let conversation = window.get_region("conversation").unwrap();
+        let all_content: String = conversation
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(all_content.contains("edited the output directly"));
+        assert!(all_content.contains("EDITED VIA IPC"));
+
+        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+    }
+
+    #[tokio::test]
     async fn interactive_points_foreground_abort_option_returns_aborted() {
         // Same deterministic abort on the foreground (stdin) path.
         use crate::interaction::InteractionResponse;

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -200,6 +200,42 @@ async fn dispatch_tool_calls(
     out
 }
 
+/// Background-worker taint [`GatePrompt`]: when the gate blocks an outbound
+/// call, ask the user via the file-based IPC approval channel (allow-once /
+/// allow-session / deny) and map the answer to a [`GateResolution`].
+struct WorkerGatePrompt {
+    run_id: String,
+}
+
+#[async_trait::async_trait]
+impl leviath_runtime::taint::GatePrompt for WorkerGatePrompt {
+    async fn resolve(
+        &self,
+        decision: &leviath_core::taint::GateDecision,
+    ) -> leviath_runtime::taint::GateResolution {
+        use super::dynamic_interaction::{gate_block_info, gate_prompt_args, map_gate_approval};
+        use crate::interaction::{
+            request_tool_approval_background, ApprovalScope, TOOL_APPROVAL_TIMEOUT,
+        };
+        use leviath_runtime::taint::GateResolution;
+
+        let Some((tool_name, taint_level, clearance)) = gate_block_info(decision) else {
+            // Not a block — nothing to resolve.
+            return GateResolution::AllowOnce;
+        };
+        let args = gate_prompt_args(&tool_name, taint_level, clearance);
+        let (approved, scope) = request_tool_approval_background(
+            &self.run_id,
+            &tool_name,
+            &args,
+            "taint-gate",
+            TOOL_APPROVAL_TIMEOUT,
+        )
+        .await;
+        map_gate_approval(approved, scope == ApprovalScope::Session)
+    }
+}
+
 /// Background-worker [`InteractionBackend`]: answers via the file-based IPC
 /// channel and logs to the per-stage log file.
 struct WorkerInteractionBackend<'a> {
@@ -242,6 +278,10 @@ struct WorkerCallbacks<'a> {
     meta: &'a mut RunMeta,
     blueprint_stages_len: usize,
     tool_calls_counter: Arc<std::sync::atomic::AtomicUsize>,
+    /// Global taint-tracking master switch (from user config).
+    taint_global: bool,
+    /// Taint policy (allowlists / MCP overrides) for the run.
+    taint_policy: leviath_core::PolicyConfig,
 }
 
 impl<'a> WorkerCallbacks<'a> {
@@ -497,6 +537,37 @@ impl<'a> StageCallbacks for WorkerCallbacks<'a> {
         let _ = runstate::write_meta(self.meta);
     }
 
+    fn taint_global_enabled(&self) -> bool {
+        self.taint_global
+    }
+
+    fn taint_policy(&self) -> leviath_core::PolicyConfig {
+        self.taint_policy.clone()
+    }
+
+    fn make_gate_prompt(&self) -> Option<Box<dyn leviath_runtime::taint::GatePrompt>> {
+        Some(Box::new(WorkerGatePrompt {
+            run_id: self.run_id.clone(),
+        }))
+    }
+
+    async fn on_taint_audit(
+        &mut self,
+        stage_idx: usize,
+        events: &[leviath_core::taint::GateEvent],
+    ) {
+        let dir = runstate::stage_dir(&self.run_id, stage_idx);
+        let _ = std::fs::create_dir_all(&dir);
+        if let Ok(json) = serde_json::to_string_pretty(events) {
+            let _ = std::fs::write(dir.join("taint_audit.json"), json);
+        }
+        record_stage_log(
+            &self.run_id,
+            stage_idx,
+            &format!("[taint] {} gate event(s) recorded", events.len()),
+        );
+    }
+
     async fn on_post_stage(
         &mut self,
         engine: &leviath_runtime::AgentEngine,
@@ -713,11 +784,14 @@ async fn run_worker_inner(
 
     let blueprint_stages_len = blueprint.stages.len();
 
+    let taint_policy = crate::commands::policy::load_policy().unwrap_or_default();
     let mut callbacks = WorkerCallbacks {
         run_id: args.run_id.clone(),
         meta,
         blueprint_stages_len,
         tool_calls_counter: tool_calls_counter.clone(),
+        taint_global: config.taint_tracking,
+        taint_policy,
     };
     let mut io = ConsoleIO::new();
 
@@ -850,6 +924,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 3,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         assert_eq!(cb.run_id, "test-run");
         assert_eq!(cb.blueprint_stages_len, 3);
@@ -871,6 +947,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 0,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         // Should not panic even with 0 stages
         cb.on_complete(0).await;
@@ -892,6 +970,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         let ctx = cb.get_run_context();
         assert!(ctx.is_some());
@@ -915,6 +995,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         let registry = leviath_runtime::ProviderRegistry::new();
         let engine = leviath_runtime::AgentEngine::with_providers(registry);
@@ -944,6 +1026,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 3,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         // Should not panic with positive stages
         cb.on_complete(2).await;
@@ -968,6 +1052,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 2,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         cb.on_transition("plan", "code", 0).await;
     }
@@ -990,6 +1076,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 2,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         cb.on_cancel(0).await;
 
@@ -997,6 +1085,139 @@ mod tests {
         // Persisted to disk as well.
         let persisted = runstate::read_meta("test-cancel").unwrap();
         assert_eq!(persisted.status, RunStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn worker_on_taint_audit_persists_events() {
+        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-taint-audit");
+        let mut meta = RunMeta::new(
+            "test-taint-audit".into(),
+            "agent".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/w".into(),
+            1,
+        );
+        runstate::create_run(&meta).unwrap();
+        let mut cb = WorkerCallbacks {
+            run_id: "test-taint-audit".to_string(),
+            meta: &mut meta,
+            blueprint_stages_len: 1,
+            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: true,
+            taint_policy: leviath_core::PolicyConfig::default(),
+        };
+        let events = vec![leviath_core::taint::GateEvent {
+            timestamp: 0,
+            agent_id: "a".into(),
+            tool_name: "shell".into(),
+            input_mode: leviath_core::taint::InputMode::Traditional,
+            taint_level: leviath_core::TaintLevel::Private,
+            clearance: leviath_core::TaintLevel::Public,
+            allowed: false,
+            decision_source: leviath_core::taint::GateDecisionSource::UserDenied,
+        }];
+        cb.on_taint_audit(0, &events).await;
+
+        let path = runstate::stage_dir("test-taint-audit", 0).join("taint_audit.json");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("shell"));
+        // Trait accessors reflect the configured values.
+        assert!(cb.taint_global_enabled());
+    }
+
+    async fn resolve_gate_prompt_with(
+        run_id: &str,
+        approved: bool,
+        scope: crate::interaction::ApprovalScope,
+    ) -> leviath_runtime::taint::GateResolution {
+        use leviath_runtime::taint::GatePrompt;
+        let _ = runstate::create_run(&RunMeta::new(
+            run_id.into(),
+            "agent".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/w".into(),
+            1,
+        ));
+        let rid = run_id.to_string();
+        let responder = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+                if let Some(req) = crate::interaction::read_request(&rid) {
+                    let mut resp =
+                        crate::interaction::InteractionResponse::approval("", approved, scope);
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&rid, &resp).unwrap();
+                    break;
+                }
+            }
+        });
+        let prompt = WorkerGatePrompt {
+            run_id: run_id.to_string(),
+        };
+        let decision = leviath_core::taint::GateDecision::Blocked {
+            taint_level: leviath_core::TaintLevel::Private,
+            clearance: leviath_core::TaintLevel::Public,
+            source_regions: vec![],
+            tool_name: "shell".to_string(),
+        };
+        let res = prompt.resolve(&decision).await;
+        // Await (not abort) so the responder's write+exit is deterministic.
+        let _ = responder.await;
+        res
+    }
+
+    #[test]
+    fn worker_callbacks_taint_accessors() {
+        let mut meta = RunMeta::new(
+            "wc-taint".into(),
+            "agent".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/w".into(),
+            1,
+        );
+        let cb = WorkerCallbacks {
+            run_id: "wc-taint".to_string(),
+            meta: &mut meta,
+            blueprint_stages_len: 1,
+            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: true,
+            taint_policy: leviath_core::PolicyConfig::default(),
+        };
+        assert!(cb.taint_global_enabled());
+        let _ = cb.taint_policy();
+        assert!(cb.make_gate_prompt().is_some());
+    }
+
+    #[tokio::test]
+    async fn worker_gate_prompt_maps_deny() {
+        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-gate-prompt-deny");
+        let res =
+            resolve_gate_prompt_with("gp-deny", false, crate::interaction::ApprovalScope::Once)
+                .await;
+        assert_eq!(res, leviath_runtime::taint::GateResolution::Deny);
+    }
+
+    #[tokio::test]
+    async fn worker_gate_prompt_maps_allow_once_and_session() {
+        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-gate-prompt-allow");
+        let once =
+            resolve_gate_prompt_with("gp-once", true, crate::interaction::ApprovalScope::Once)
+                .await;
+        assert_eq!(once, leviath_runtime::taint::GateResolution::AllowOnce);
+        let session = resolve_gate_prompt_with(
+            "gp-session",
+            true,
+            crate::interaction::ApprovalScope::Session,
+        )
+        .await;
+        assert_eq!(session, leviath_runtime::taint::GateResolution::AlwaysAllow);
     }
 
     #[tokio::test]
@@ -1018,6 +1239,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         cb.on_claude_code_warning(0).await;
     }
@@ -1050,6 +1273,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         let result = cb.on_provider_missing("nonexistent", 0).await;
         // on_provider_missing should return true (abort).
@@ -1090,6 +1315,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 2,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         cb.on_stage_enter("plan", 0, "anthropic", "claude-sonnet-4-6", "")
             .await;
@@ -1126,6 +1353,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
         cb.on_stage_enter("code", 0, "anthropic", "claude-sonnet-4-6", " (visit 2)")
             .await;
@@ -1160,6 +1389,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let err = anyhow::anyhow!("test error");
@@ -1195,6 +1426,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let err = anyhow::anyhow!("linear error");
@@ -1235,6 +1468,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let registry = leviath_runtime::ProviderRegistry::new();
@@ -1305,6 +1540,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let registry = leviath_runtime::ProviderRegistry::new();
@@ -1354,6 +1591,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // Empty content — the `add_to_region` branch is NOT taken
@@ -1401,6 +1640,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // Non-empty content — `add_to_region` branch IS taken
@@ -1445,6 +1686,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // Should not panic; updates meta.iteration from AgentState and writes meta
@@ -1476,6 +1719,8 @@ mod tests {
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // on_post_stage with an entity that has no AgentState — should not panic
@@ -2189,6 +2434,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let registry = leviath_runtime::ProviderRegistry::new();
@@ -2251,6 +2498,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 2,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // graph mode → Some(StageResult::Error) returned; meta NOT set to Error
@@ -2284,6 +2533,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 0,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let result = cb.on_provider_missing("missing-provider", 0).await;
@@ -2314,6 +2565,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 3,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // Should not panic even with stages > 0
@@ -2345,6 +2598,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 1,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         // stage_idx=5 but only 1 stage — the `if let Some(r)` guard handles this safely
@@ -2378,6 +2633,8 @@ mode = "autonomous"
             meta: &mut meta,
             blueprint_stages_len: 0,
             tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            taint_global: false,
+            taint_policy: leviath_core::PolicyConfig::default(),
         };
 
         let err = anyhow::anyhow!("oob error");

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -115,6 +115,15 @@ pub struct Config {
     /// When set, requests that exceed this duration will be aborted.
     /// Default is None (no timeout).
     pub request_timeout_secs: Option<u64>,
+
+    /// Global master switch for taint tracking / data-flow enforcement.
+    ///
+    /// **Off by default (opt-in).** When `true`, every agent enforces taint
+    /// tracking by default; individual agents or stages can opt out via a
+    /// `[security] taint_tracking = false` block. When `false`, an agent still
+    /// opts *in* by setting `taint_tracking = true` in its own `[security]`.
+    #[serde(default)]
+    pub taint_tracking: bool,
 }
 
 /// Provider configuration.
@@ -149,6 +158,7 @@ impl Default for Config {
             tool_permissions: HashMap::new(),
             title: TitleConfig::default(),
             request_timeout_secs: None,
+            taint_tracking: false,
         }
     }
 }
@@ -1798,6 +1808,7 @@ anthropic_api_key = "sk-ant-test-key"
                 model: Some("gpt-5-mini".to_string()),
             },
             request_timeout_secs: None,
+            taint_tracking: false,
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -425,6 +425,13 @@ pub struct Stage {
     /// available edge.
     #[serde(default)]
     pub allow_complete: bool,
+
+    /// Per-stage taint/security override. `None` inherits the agent-level
+    /// `Blueprint.security` (which in turn inherits the global config toggle).
+    /// Set `taint_tracking = false` here to opt a single stage out, or `true`
+    /// to opt it in independently of the agent/global setting.
+    #[serde(default)]
+    pub security: Option<crate::taint::SecurityConfig>,
 }
 
 /// Default value for bool fields that should default to true.
@@ -451,6 +458,7 @@ impl Stage {
             transition_prompt: None,
             accepts_messages: true,
             allow_complete: false,
+            security: None,
         }
     }
 

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -246,6 +246,55 @@ impl Region {
         Ok(())
     }
 
+    /// Add a typed entry with a taint level.
+    ///
+    /// Combines [`add_typed_entry`](Self::add_typed_entry) (the entry carries a
+    /// typed [`EntryKind`] so eviction can group turns) with
+    /// [`add_tainted_entry`](Self::add_tainted_entry) (the entry contributes a
+    /// specific taint level rather than defaulting to `Public`). Used for tool
+    /// results when taint tracking is enabled, so a sensitive tool's output
+    /// both keeps its `ToolResult` kind and raises the region's taint level.
+    pub fn add_typed_tainted_entry(
+        &mut self,
+        content: String,
+        tokens: usize,
+        kind: EntryKind,
+        taint_level: crate::taint::TaintLevel,
+    ) -> crate::error::Result<()> {
+        // Validate against schema if present
+        if let Some(schema) = &self.schema {
+            schema.validate(&content)?;
+        }
+
+        // Check token budget
+        if self.current_tokens + tokens > self.max_tokens {
+            return Err(crate::error::Error::TokenBudgetExceeded {
+                used: self.current_tokens + tokens,
+                max: self.max_tokens,
+            });
+        }
+
+        // Add entry
+        self.content.push(RegionEntry {
+            content,
+            tokens,
+            timestamp: chrono::Utc::now().timestamp(),
+            metadata: None,
+            kind,
+        });
+        self.current_tokens += tokens;
+
+        // Update taint tracking with the supplied level
+        if let Some(taint) = &mut self.taint {
+            taint.add_entry(taint_level);
+        }
+
+        // Enforce SlidingWindow max_items limit
+        self.enforce_sliding_window();
+
+        Ok(())
+    }
+
     /// Add a validation schema to this region.
     pub fn with_schema(mut self, schema: RegionSchema) -> Self {
         self.schema = Some(schema);

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -441,6 +441,40 @@ impl Default for SecurityConfig {
     }
 }
 
+/// Resolve whether taint tracking is enabled for a stage, cascading
+/// stage → agent → global (default off when nothing is set). A `Some(_)`
+/// config at a level overrides broader levels with its `taint_tracking`.
+pub fn resolve_taint_enabled(
+    global: bool,
+    agent: Option<&SecurityConfig>,
+    stage: Option<&SecurityConfig>,
+) -> bool {
+    stage
+        .map(|s| s.taint_tracking)
+        .or_else(|| agent.map(|a| a.taint_tracking))
+        .unwrap_or(global)
+}
+
+/// Resolve the effective [`SecurityConfig`] for a stage: the most specific
+/// present config (stage over agent), or a default whose `taint_tracking`
+/// follows the global toggle when neither level configures it.
+pub fn resolve_security(
+    global: bool,
+    agent: Option<&SecurityConfig>,
+    stage: Option<&SecurityConfig>,
+) -> SecurityConfig {
+    if let Some(s) = stage {
+        return s.clone();
+    }
+    if let Some(a) = agent {
+        return a.clone();
+    }
+    SecurityConfig {
+        taint_tracking: global,
+        ..SecurityConfig::default()
+    }
+}
+
 /// Result of a gate check — whether a tool invocation is allowed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GateDecision {
@@ -463,6 +497,19 @@ impl GateDecision {
     /// Returns true if the gate allows the action.
     pub fn is_allowed(&self) -> bool {
         matches!(self, GateDecision::Allowed)
+    }
+
+    /// For a `Blocked` decision, the `(taint_level, clearance)` that caused the
+    /// block; `None` for `Allowed`.
+    pub fn blocked_levels(&self) -> Option<(TaintLevel, TaintLevel)> {
+        match self {
+            GateDecision::Blocked {
+                taint_level,
+                clearance,
+                ..
+            } => Some((*taint_level, *clearance)),
+            GateDecision::Allowed => None,
+        }
     }
 }
 
@@ -1213,5 +1260,70 @@ mod tests {
         assert_eq!(tc.sensitivity, TaintLevel::Internal);
         assert_eq!(tc.direction, ToolDirection::Inbound);
         assert_eq!(tc.clearance, TaintLevel::Public);
+    }
+
+    // ─── resolve_taint_enabled / resolve_security cascade ───────────────────
+
+    fn sec(taint: bool) -> SecurityConfig {
+        SecurityConfig {
+            taint_tracking: taint,
+            ..SecurityConfig::default()
+        }
+    }
+
+    #[test]
+    fn resolve_taint_enabled_inherits_global_when_unset() {
+        assert!(!resolve_taint_enabled(false, None, None));
+        assert!(resolve_taint_enabled(true, None, None));
+    }
+
+    #[test]
+    fn resolve_taint_enabled_agent_overrides_global() {
+        // Global on, agent opts out.
+        assert!(!resolve_taint_enabled(true, Some(&sec(false)), None));
+        // Global off, agent opts in.
+        assert!(resolve_taint_enabled(false, Some(&sec(true)), None));
+    }
+
+    #[test]
+    fn resolve_taint_enabled_stage_overrides_agent_and_global() {
+        // Stage opt-out beats agent opt-in and global on.
+        assert!(!resolve_taint_enabled(
+            true,
+            Some(&sec(true)),
+            Some(&sec(false))
+        ));
+        // Stage opt-in beats agent opt-out and global off.
+        assert!(resolve_taint_enabled(
+            false,
+            Some(&sec(false)),
+            Some(&sec(true))
+        ));
+    }
+
+    #[test]
+    fn gate_decision_blocked_levels() {
+        let blocked = GateDecision::Blocked {
+            taint_level: TaintLevel::Private,
+            clearance: TaintLevel::Public,
+            source_regions: vec![],
+            tool_name: "shell".into(),
+        };
+        assert_eq!(
+            blocked.blocked_levels(),
+            Some((TaintLevel::Private, TaintLevel::Public))
+        );
+        assert_eq!(GateDecision::Allowed.blocked_levels(), None);
+    }
+
+    #[test]
+    fn resolve_security_prefers_most_specific() {
+        // Neither set → default whose taint_tracking follows global.
+        assert!(resolve_security(true, None, None).taint_tracking);
+        assert!(!resolve_security(false, None, None).taint_tracking);
+        // Agent present → used.
+        assert!(!resolve_security(true, Some(&sec(false)), None).taint_tracking);
+        // Stage present → wins over agent.
+        assert!(resolve_security(false, Some(&sec(false)), Some(&sec(true))).taint_tracking);
     }
 }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -929,6 +929,27 @@ mod tests {
     }
 
     #[test]
+    fn test_builtin_capabilities_sonnet5() {
+        let provider = AnthropicProvider::new("test-key".to_string());
+        let caps = provider.builtin_capabilities("claude-sonnet-5");
+        assert!(!caps.supports_temperature);
+        assert!(caps.supports_streaming);
+        assert!(caps.supports_tools);
+        assert_eq!(caps.max_context_tokens, 1_000_000);
+        assert_eq!(caps.max_output_tokens, 128_000);
+    }
+
+    #[test]
+    fn test_builtin_capabilities_fable_and_opus46() {
+        let provider = AnthropicProvider::new("test-key".to_string());
+        for m in ["claude-fable-5", "claude-mythos-5", "claude-opus-4-6"] {
+            let caps = provider.builtin_capabilities(m);
+            assert!(caps.supports_streaming);
+            assert!(caps.max_context_tokens >= 200_000);
+        }
+    }
+
+    #[test]
     fn test_builtin_capabilities_haiku45() {
         let provider = AnthropicProvider::new("test-key".to_string());
         let caps = provider.builtin_capabilities("claude-haiku-4-5-20251001");

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
+async-trait = "0.1"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -557,6 +557,29 @@ impl ContextWindow {
         }
     }
 
+    /// Add a typed entry to a region with a specific taint level.
+    ///
+    /// The typed+tainted counterpart of [`add_typed_entry`](Self::add_typed_entry)
+    /// and [`add_tainted_to_region`](Self::add_tainted_to_region): the entry keeps
+    /// its [`EntryKind`] (so turn-group eviction stays intact) while contributing
+    /// the given taint level (so the taint gate sees sensitive tool output).
+    pub fn add_typed_tainted_to_region(
+        &mut self,
+        region_name: &str,
+        kind: leviath_core::EntryKind,
+        content: String,
+        tokens: usize,
+        taint_level: leviath_core::TaintLevel,
+    ) -> leviath_core::Result<()> {
+        if let Some(region) = self.get_region_mut(region_name) {
+            region.add_typed_tainted_entry(content, tokens, kind, taint_level)?;
+            self.current_tokens = self.calculate_tokens();
+            Ok(())
+        } else {
+            Err(leviath_core::Error::RegionNotFound(region_name.to_string()))
+        }
+    }
+
     /// Get the overall taint level (max across all regions).
     /// Returns None if no region has taint tracking enabled.
     pub fn overall_taint(&self) -> Option<leviath_core::TaintLevel> {

--- a/crates/leviath-runtime/src/engine.rs
+++ b/crates/leviath-runtime/src/engine.rs
@@ -78,6 +78,18 @@ pub struct AgentEngine {
 
     /// Receiver side of the message channel
     message_rx: mpsc::UnboundedReceiver<AgentMessage>,
+
+    /// Taint gate for the current stage, when taint tracking is active. `None`
+    /// means no enforcement (the common/default case). Reconfigured per stage
+    /// by the CLI via [`AgentEngine::configure_taint`].
+    taint_gate: Option<crate::taint::TaintGate>,
+
+    /// Policy (allowlists / MCP overrides) consulted when the gate blocks.
+    taint_policy: leviath_core::PolicyConfig,
+
+    /// Injected resolver used to interactively decide a blocked outbound call.
+    /// `None` → blocked calls are denied outright.
+    gate_prompt: Option<Box<dyn crate::taint::GatePrompt>>,
 }
 
 /// Boxed future returned by a type-erased tool executor. See
@@ -117,6 +129,9 @@ impl AgentEngine {
             provider_registry: ProviderRegistry::new(),
             message_tx,
             message_rx,
+            taint_gate: None,
+            taint_policy: leviath_core::PolicyConfig::default(),
+            gate_prompt: None,
         }
     }
 
@@ -145,6 +160,9 @@ impl AgentEngine {
             provider_registry,
             message_tx,
             message_rx,
+            taint_gate: None,
+            taint_policy: leviath_core::PolicyConfig::default(),
+            gate_prompt: None,
         }
     }
 
@@ -163,6 +181,123 @@ impl AgentEngine {
     /// Get a mutable reference to the ECS world.
     pub fn world_mut(&mut self) -> &mut World {
         &mut self.world
+    }
+
+    /// Configure taint enforcement for the upcoming stage. When set, the
+    /// inference loop tags tool results with the tool's declared sensitivity
+    /// and gates outbound calls whose data exceeds the tool's clearance,
+    /// prompting via `prompt` (or denying outright when `prompt` is `None`).
+    pub fn configure_taint(
+        &mut self,
+        gate: crate::taint::TaintGate,
+        policy: leviath_core::PolicyConfig,
+        prompt: Option<Box<dyn crate::taint::GatePrompt>>,
+    ) {
+        self.taint_gate = Some(gate);
+        self.taint_policy = policy;
+        self.gate_prompt = prompt;
+    }
+
+    /// Disable taint enforcement (no tagging, no gating).
+    pub fn clear_taint(&mut self) {
+        self.taint_gate = None;
+        self.gate_prompt = None;
+    }
+
+    /// Turn on taint tracking for the given entity's context window (idempotent).
+    pub fn enable_entity_taint_tracking(&mut self, entity: bevy_ecs::prelude::Entity) {
+        if let Some(mut w) = self.world.get_mut::<ContextWindow>(entity) {
+            w.enable_taint_tracking();
+        }
+    }
+
+    /// The current stage's taint audit log (empty when taint is inactive).
+    pub fn taint_audit_log(&self) -> &[leviath_core::taint::GateEvent] {
+        self.taint_gate
+            .as_ref()
+            .map(|g| g.audit_log())
+            .unwrap_or(&[])
+    }
+
+    /// Partition a batch of tool calls into `(calls_to_execute, denied_results)`
+    /// per the taint gate. Outbound calls whose incoming data exceeds the
+    /// tool's clearance are resolved via the injected prompt (allow-once /
+    /// always-allow / deny); a deny substitutes a `[blocked]` result and skips
+    /// execution. When the gate is inactive, every call executes.
+    /// Synchronously classify a batch of tool calls against the current taint
+    /// state. Extracted from [`Self::taint_gate_partition`] so all the
+    /// gate/policy logic lives in a non-async function (fully unit-testable and
+    /// not subject to async-instantiation coverage artifacts); the async fn
+    /// only awaits the prompt.
+    fn gate_decisions(
+        &mut self,
+        entity: Entity,
+        agent_id: &str,
+        policy: &leviath_core::PolicyConfig,
+        calls: &[leviath_providers::ToolCall],
+    ) -> Vec<(
+        leviath_providers::ToolCall,
+        leviath_core::taint::GateDecision,
+    )> {
+        let window = self.world.get::<ContextWindow>(entity).unwrap();
+        let gate = self.taint_gate.as_mut().unwrap();
+        calls
+            .iter()
+            .map(|tc| {
+                let d = gate.check_with_policy(agent_id, &tc.name, window, None, policy, None);
+                (tc.clone(), d)
+            })
+            .collect()
+    }
+
+    async fn taint_gate_partition(
+        &mut self,
+        entity: Entity,
+        calls: &[leviath_providers::ToolCall],
+    ) -> (Vec<leviath_providers::ToolCall>, Vec<(String, String)>) {
+        use crate::taint::GateResolution;
+
+        if !self
+            .taint_gate
+            .as_ref()
+            .map(|g| g.is_enabled())
+            .unwrap_or(false)
+        {
+            return (calls.to_vec(), Vec::new());
+        }
+
+        let agent_id = self
+            .world
+            .get::<AgentState>(entity)
+            .map(|s| s.agent_id.clone())
+            .unwrap_or_default();
+        let policy = self.taint_policy.clone();
+        let decisions = self.gate_decisions(entity, &agent_id, &policy, calls);
+
+        // Resolve blocks (the only async step) and partition. All non-async
+        // work is delegated to the synchronous `TaintGate::apply_resolution`.
+        let mut to_execute = Vec::new();
+        let mut denied = Vec::new();
+        for (tc, decision) in decisions {
+            let Some((taint, clearance)) = decision.blocked_levels() else {
+                to_execute.push(tc);
+                continue;
+            };
+            let resolution = match self.gate_prompt.as_ref() {
+                Some(prompt) => prompt.resolve(&decision).await,
+                None => GateResolution::Deny,
+            };
+            let outcome = self
+                .taint_gate
+                .as_mut()
+                .unwrap()
+                .apply_resolution(&agent_id, &tc.name, &tc.id, taint, clearance, resolution);
+            match outcome {
+                Some(blocked) => denied.push(blocked),
+                None => to_execute.push(tc),
+            }
+        }
+        (to_execute, denied)
     }
 
     /// Get a reference to the provider registry.
@@ -659,7 +794,31 @@ impl AgentEngine {
             // Execute tool calls
             let tool_calls_snapshot = response.tool_calls.clone();
             total_tool_calls += tool_calls_snapshot.len();
-            let tool_results = tool_executor(tool_calls_snapshot.clone()).await;
+
+            // ── Taint gate ──────────────────────────────────────────────────
+            // When taint tracking is active, check each outbound call against
+            // the current context taint BEFORE executing it. Blocked calls are
+            // resolved interactively (allow-once / always-allow / deny) via the
+            // injected prompt, or denied outright when no prompt is available.
+            let (calls_to_execute, mut denied_results) = self
+                .taint_gate_partition(entity, &tool_calls_snapshot)
+                .await;
+            let mut tool_results = tool_executor(calls_to_execute).await;
+            tool_results.append(&mut denied_results);
+
+            // When taint tracking is active, precompute each tool's declared
+            // output sensitivity (before borrowing the window) so results are
+            // tagged as they are routed into regions.
+            let tool_sensitivities: Option<HashMap<String, leviath_core::TaintLevel>> = self
+                .taint_gate
+                .as_ref()
+                .filter(|g| g.is_enabled())
+                .map(|g| {
+                    tool_calls_snapshot
+                        .iter()
+                        .map(|tc| (tc.name.clone(), g.tool_classification(&tc.name).sensitivity))
+                        .collect()
+                });
 
             // Add tool results to context window.
             // Safety: `run_inference_filtered` already confirmed the entity has
@@ -703,22 +862,49 @@ impl AgentEngine {
 
                 let kind = leviath_core::EntryKind::ToolResult {
                     tool_call_id: tool_call_id.clone(),
-                    tool_name,
+                    tool_name: tool_name.clone(),
                     is_error: false,
                 };
 
-                // Try adding the full result first
-                if window
-                    .add_typed_entry(
-                        "conversation",
-                        kind.clone(),
-                        result_text.clone(),
-                        result_tokens,
-                    )
-                    .is_err()
+                // When taint tracking is enabled, a tool result carries the
+                // tool's configured sensitivity level so the taint gate sees
+                // sensitive output flow into context; otherwise it's added as a
+                // plain typed entry (tracked as Public). Either way it keeps its
+                // ToolResult kind so turn-group eviction stays intact.
+                let taint_level = tool_sensitivities.as_ref().map(|sens| {
+                    sens.get(&tool_name)
+                        .copied()
+                        .unwrap_or(leviath_core::TaintLevel::Public)
+                });
+                let add_tool_result = |window: &mut ContextWindow,
+                                       kind: leviath_core::EntryKind,
+                                       content: String,
+                                       tokens: usize| {
+                    match taint_level {
+                        Some(level) => window.add_typed_tainted_to_region(
+                            "conversation",
+                            kind,
+                            content,
+                            tokens,
+                            level,
+                        ),
+                        None => window.add_typed_entry("conversation", kind, content, tokens),
+                    }
+                };
+
+                // Try adding the full result first. These MUST succeed — an
+                // AssistantTurn with tool_calls was just added above, and
+                // Anthropic requires every tool_use to have a matching
+                // tool_result. If the region is at its token budget, truncate
+                // rather than dropping (which would orphan the tool_use block).
+                if add_tool_result(
+                    &mut window,
+                    kind.clone(),
+                    result_text.clone(),
+                    result_tokens,
+                )
+                .is_err()
                 {
-                    // Token budget exceeded — truncate to fit rather than
-                    // dropping (which would orphan the tool_use block).
                     let available = window
                         .get_region("conversation")
                         .map(|r| r.max_tokens.saturating_sub(r.current_tokens))
@@ -737,21 +923,14 @@ impl AgentEngine {
                     };
                     let trunc_tokens = truncated.len() / 4 + 1;
 
-                    if window
-                        .add_typed_entry("conversation", kind, truncated, trunc_tokens)
-                        .is_err()
-                    {
+                    if add_tool_result(&mut window, kind, truncated, trunc_tokens).is_err() {
                         // Last resort: add a minimal placeholder
                         let placeholder = "[result omitted]".to_string();
-                        let _ = window.add_typed_entry(
-                            "conversation",
+                        let _ = add_tool_result(
+                            &mut window,
                             leviath_core::EntryKind::ToolResult {
                                 tool_call_id: tool_call_id.clone(),
-                                tool_name: tool_calls_snapshot
-                                    .iter()
-                                    .find(|tc| tc.id == *tool_call_id)
-                                    .map(|tc| tc.name.clone())
-                                    .unwrap_or_default(),
+                                tool_name: tool_name.clone(),
                                 is_error: false,
                             },
                             placeholder,
@@ -3606,5 +3785,313 @@ mod tests {
             100_000
         );
         assert_eq!(leviath_providers::Provider::name(&probe), "max-echo");
+    }
+
+    // ─── Taint gate enforcement in the inference loop ───────────────────────
+
+    struct FixedPrompt(crate::taint::GateResolution);
+
+    #[async_trait::async_trait]
+    impl crate::taint::GatePrompt for FixedPrompt {
+        async fn resolve(
+            &self,
+            _decision: &leviath_core::taint::GateDecision,
+        ) -> crate::taint::GateResolution {
+            self.0
+        }
+    }
+
+    fn outbound_tool_response(tool: &str) -> InferenceResponse {
+        InferenceResponse {
+            content: "calling a tool".to_string(),
+            tool_calls: vec![leviath_providers::ToolCall {
+                id: "call_1".to_string(),
+                name: tool.to_string(),
+                arguments: serde_json::json!({}),
+            }],
+            tokens_used: leviath_providers::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+            },
+            finish_reason: leviath_providers::FinishReason::ToolCall,
+        }
+    }
+
+    /// Engine with a Private-tainted context and the gate enabled; the model's
+    /// first response calls `tool`. `prompt` is the injected resolver (None →
+    /// blocked calls auto-deny), `policy` supplies allowlist rules.
+    fn tainted_engine_with(
+        tool: &str,
+        prompt: Option<Box<dyn crate::taint::GatePrompt>>,
+        policy: leviath_core::PolicyConfig,
+    ) -> (AgentEngine, Entity) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(
+            "mock".to_string(),
+            Arc::new(MockProvider::with_responses(
+                "mock",
+                vec![outbound_tool_response(tool), default_response()],
+            )),
+        );
+        let mut engine = AgentEngine::with_providers(registry);
+        let entity = engine
+            .world_mut()
+            .spawn({
+                let mut window = ContextWindow::new(1000);
+                window.add_region(leviath_core::Region::new(
+                    "notes".to_string(),
+                    leviath_core::RegionKind::Pinned,
+                    500,
+                ));
+                window.add_region(leviath_core::Region::new(
+                    "conversation".to_string(),
+                    leviath_core::RegionKind::SlidingWindow { max_items: 50 },
+                    200,
+                ));
+                window.enable_taint_tracking();
+                window
+                    .add_tainted_to_region(
+                        "notes",
+                        "secret data".to_string(),
+                        10,
+                        leviath_core::TaintLevel::Private,
+                    )
+                    .unwrap();
+                window
+            })
+            .id();
+        let gate = crate::taint::TaintGate::new(leviath_core::SecurityConfig {
+            taint_tracking: true,
+            ..leviath_core::SecurityConfig::default()
+        });
+        engine.configure_taint(gate, policy, prompt);
+        (engine, entity)
+    }
+
+    fn tainted_engine(resolution: crate::taint::GateResolution) -> (AgentEngine, Entity) {
+        tainted_engine_with(
+            "shell",
+            Some(Box::new(FixedPrompt(resolution))),
+            leviath_core::PolicyConfig::default(),
+        )
+    }
+
+    async fn run_and_record_executed(
+        engine: &mut AgentEngine,
+        entity: Entity,
+    ) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
+        let executed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let ex = executed.clone();
+        engine
+            .run_inference_loop_filtered(
+                entity,
+                "mock",
+                "test-model",
+                Vec::new(),
+                5,
+                None,
+                None,
+                &mut |calls: Vec<leviath_providers::ToolCall>| {
+                    let ex = ex.clone();
+                    async move {
+                        let mut names = ex.lock().unwrap();
+                        calls
+                            .iter()
+                            .map(|c| {
+                                names.push(c.name.clone());
+                                (c.id.clone(), "executed".to_string())
+                            })
+                            .collect()
+                    }
+                },
+            )
+            .await
+            .unwrap();
+        executed
+    }
+
+    fn tool_results_text(engine: &AgentEngine, entity: Entity) -> String {
+        let window = engine.world().get::<ContextWindow>(entity).unwrap();
+        window
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[tokio::test]
+    async fn taint_gate_denies_blocked_outbound_call() {
+        let (mut engine, entity) = tainted_engine(crate::taint::GateResolution::Deny);
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        // shell was NOT executed (gate denied it before the executor ran).
+        assert!(!executed.lock().unwrap().contains(&"shell".to_string()));
+        // A [blocked] result was substituted into context.
+        assert!(tool_results_text(&engine, entity).contains("[blocked]"));
+        // A denied event was audited.
+        assert!(engine.taint_audit_log().iter().any(|e| !e.allowed));
+    }
+
+    #[tokio::test]
+    async fn taint_gate_allow_once_executes_blocked_call() {
+        let (mut engine, entity) = tainted_engine(crate::taint::GateResolution::AllowOnce);
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        // shell WAS executed after the user allowed it once.
+        assert!(executed.lock().unwrap().contains(&"shell".to_string()));
+        assert!(!tool_results_text(&engine, entity).contains("[blocked]"));
+        // The allow was audited.
+        assert!(engine.taint_audit_log().iter().any(|e| e.allowed
+            && matches!(
+                e.decision_source,
+                leviath_core::taint::GateDecisionSource::UserAllowOnce
+            )));
+    }
+
+    #[tokio::test]
+    async fn taint_gate_always_allow_executes_and_raises_clearance() {
+        let (mut engine, entity) = tainted_engine(crate::taint::GateResolution::AlwaysAllow);
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        // Executed after the user chose "always allow".
+        assert!(executed.lock().unwrap().contains(&"shell".to_string()));
+        // Audited as an always-allow decision.
+        assert!(engine.taint_audit_log().iter().any(|e| e.allowed
+            && matches!(
+                e.decision_source,
+                leviath_core::taint::GateDecisionSource::UserAlwaysAllow
+            )));
+        // The tool's clearance was raised to Private for the rest of the run.
+        let cls = engine
+            .taint_gate
+            .as_ref()
+            .unwrap()
+            .tool_classification("shell");
+        assert_eq!(cls.clearance, leviath_core::TaintLevel::Private);
+    }
+
+    #[tokio::test]
+    async fn taint_gate_disabled_executes_everything() {
+        // No gate configured → fast path, tool executes, no audit.
+        let mut registry = ProviderRegistry::new();
+        registry.register(
+            "mock".to_string(),
+            Arc::new(MockProvider::with_responses(
+                "mock",
+                vec![outbound_tool_response("shell"), default_response()],
+            )),
+        );
+        let mut engine = AgentEngine::with_providers(registry);
+        let entity = engine
+            .world_mut()
+            .spawn({
+                let mut window = ContextWindow::new(1000);
+                window.add_region(leviath_core::Region::new(
+                    "tool_results".to_string(),
+                    leviath_core::RegionKind::SlidingWindow { max_items: 50 },
+                    200,
+                ));
+                window
+            })
+            .id();
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        assert!(executed.lock().unwrap().contains(&"shell".to_string()));
+        assert!(engine.taint_audit_log().is_empty());
+    }
+
+    #[tokio::test]
+    async fn taint_gate_no_prompt_auto_denies() {
+        // Gate enabled but no resolver injected → a blocked outbound call is
+        // denied outright (covers the `None => Deny` arm of the partition).
+        let (mut engine, entity) =
+            tainted_engine_with("shell", None, leviath_core::PolicyConfig::default());
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        assert!(!executed.lock().unwrap().contains(&"shell".to_string()));
+        assert!(tool_results_text(&engine, entity).contains("[blocked]"));
+        assert!(engine.taint_audit_log().iter().any(|e| !e.allowed));
+    }
+
+    #[tokio::test]
+    async fn taint_gate_allows_non_outbound_tool() {
+        // An inbound tool (read_file) is never gated even with tainted context;
+        // it executes without any prompt (covers the non-outbound path).
+        let (mut engine, entity) = tainted_engine_with(
+            "read_file",
+            None, // resolver must never be consulted for a non-outbound tool
+            leviath_core::PolicyConfig::default(),
+        );
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        assert!(executed.lock().unwrap().contains(&"read_file".to_string()));
+        assert!(!tool_results_text(&engine, entity).contains("[blocked]"));
+    }
+
+    #[tokio::test]
+    async fn taint_gate_allowlist_rule_permits_blocked_call() {
+        // A matching allowlist rule lets an over-clearance outbound call
+        // through without prompting (covers the AllowlistRule branch).
+        let mut policy = leviath_core::PolicyConfig::default();
+        policy.allowlist.push(leviath_core::policy::AllowlistRule {
+            tool: "shell".to_string(),
+            to: vec![],
+            channel: vec![],
+            max_sensitivity: leviath_core::TaintLevel::Private,
+        });
+        let (mut engine, entity) = tainted_engine_with("shell", None, policy);
+        let executed = run_and_record_executed(&mut engine, entity).await;
+        assert!(executed.lock().unwrap().contains(&"shell".to_string()));
+        assert!(engine.taint_audit_log().iter().any(|e| e.allowed
+            && matches!(
+                e.decision_source,
+                leviath_core::taint::GateDecisionSource::AllowlistRule { .. }
+            )));
+    }
+
+    #[test]
+    fn configure_and_clear_taint() {
+        let mut engine = AgentEngine::new();
+        assert!(engine.taint_audit_log().is_empty());
+        let gate = crate::taint::TaintGate::new(leviath_core::SecurityConfig::default());
+        engine.configure_taint(gate, leviath_core::PolicyConfig::default(), None);
+        engine.clear_taint();
+        assert!(engine.taint_audit_log().is_empty());
+    }
+
+    #[test]
+    fn enable_entity_taint_tracking_turns_on_region_taint() {
+        let mut engine = AgentEngine::new();
+        let entity = engine
+            .world_mut()
+            .spawn({
+                let mut window = ContextWindow::new(1000);
+                window.add_region(leviath_core::Region::new(
+                    "notes".to_string(),
+                    leviath_core::RegionKind::Pinned,
+                    500,
+                ));
+                window
+            })
+            .id();
+        // No taint tracking yet → overall_taint is None.
+        assert!(engine
+            .world()
+            .get::<ContextWindow>(entity)
+            .unwrap()
+            .overall_taint()
+            .is_none());
+        engine.enable_entity_taint_tracking(entity);
+        // Now tracking is on → overall_taint reports (Public with no tainted data).
+        assert_eq!(
+            engine
+                .world()
+                .get::<ContextWindow>(entity)
+                .unwrap()
+                .overall_taint(),
+            Some(leviath_core::TaintLevel::Public)
+        );
+        // Idempotent + safe on a missing entity.
+        engine.enable_entity_taint_tracking(entity);
     }
 }

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -12,6 +12,29 @@ use std::collections::HashMap;
 
 use crate::components::ContextWindow;
 
+/// The user's resolution of a blocked outbound tool call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateResolution {
+    /// Allow this one call.
+    AllowOnce,
+    /// Allow this tool for the rest of the run (session allow).
+    AlwaysAllow,
+    /// Deny the call — it is not executed; the model gets a blocked result.
+    Deny,
+}
+
+/// Injected resolver used when the gate blocks an outbound tool call.
+///
+/// The runtime cannot prompt the user itself (no stdin/IPC), so the CLI
+/// provides an implementation that asks via the dashboard/stdin and returns
+/// the user's decision. Mirrors how tool execution is injected as a closure.
+#[async_trait::async_trait]
+pub trait GatePrompt: Send + Sync {
+    /// Ask the user how to resolve a blocked outbound call. Implementations
+    /// should default to [`GateResolution::Deny`] when no answer is available.
+    async fn resolve(&self, decision: &GateDecision) -> GateResolution;
+}
+
 /// Type alias for a scripted rule checker function.
 /// Takes (tool_name, target, taint_level) and returns Some(script_name) if the rule allows.
 pub type ScriptRuleChecker = dyn Fn(&str, Option<&str>, TaintLevel) -> Option<String>;
@@ -349,6 +372,84 @@ impl TaintGate {
         self.log_event(
             agent_id, tool_name, input_mode, taint, clearance, true, source,
         );
+    }
+
+    /// Record a deny decision (the user or a default policy denied the call).
+    pub fn record_deny(
+        &mut self,
+        agent_id: &str,
+        tool_name: &str,
+        input_mode: InputMode,
+        taint: TaintLevel,
+        clearance: TaintLevel,
+        source: GateDecisionSource,
+    ) {
+        self.log_event(
+            agent_id, tool_name, input_mode, taint, clearance, false, source,
+        );
+    }
+
+    /// Apply the user's resolution of a blocked outbound call: record the
+    /// audit event and, for `AlwaysAllow`, raise the tool's clearance for the
+    /// rest of the run. Returns `Some((tool_id, message))` when the call is
+    /// denied (and must be skipped), or `None` when it should execute.
+    ///
+    /// Synchronous so it can be unit-tested directly, keeping the async run-loop
+    /// path that awaits the prompt as thin as possible.
+    pub fn apply_resolution(
+        &mut self,
+        agent_id: &str,
+        tool_name: &str,
+        tool_id: &str,
+        taint: TaintLevel,
+        clearance: TaintLevel,
+        resolution: GateResolution,
+    ) -> Option<(String, String)> {
+        match resolution {
+            GateResolution::AllowOnce => {
+                self.record_allow(
+                    agent_id,
+                    tool_name,
+                    InputMode::Traditional,
+                    taint,
+                    clearance,
+                    GateDecisionSource::UserAllowOnce,
+                );
+                None
+            }
+            GateResolution::AlwaysAllow => {
+                self.record_allow(
+                    agent_id,
+                    tool_name,
+                    InputMode::Traditional,
+                    taint,
+                    clearance,
+                    GateDecisionSource::UserAlwaysAllow,
+                );
+                let mut cls = self.tool_classification(tool_name);
+                cls.clearance = TaintLevel::Private;
+                self.set_tool_classification(tool_name.to_string(), cls);
+                None
+            }
+            GateResolution::Deny => {
+                self.record_deny(
+                    agent_id,
+                    tool_name,
+                    InputMode::Traditional,
+                    taint,
+                    clearance,
+                    GateDecisionSource::UserDenied,
+                );
+                Some((
+                    tool_id.to_string(),
+                    format!(
+                        "[blocked] Tool '{}' would send data at {} sensitivity, above its {} \
+                         clearance. Denied by user.",
+                        tool_name, taint, clearance
+                    ),
+                ))
+            }
+        }
     }
 
     /// Get the audit log.
@@ -1818,5 +1919,70 @@ mod tests {
         // tool_b has Private clearance — should be allowed
         let decision_b = gate.check_traditional("agent-1", "tool_b", &window);
         assert!(decision_b.is_allowed());
+    }
+
+    // ─── apply_resolution (synchronous resolution handling) ─────────────────
+
+    #[test]
+    fn apply_resolution_allow_once_records_and_executes() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let out = gate.apply_resolution(
+            "a",
+            "shell",
+            "call1",
+            TaintLevel::Private,
+            TaintLevel::Public,
+            GateResolution::AllowOnce,
+        );
+        assert!(out.is_none()); // execute
+        assert!(gate
+            .audit_log()
+            .iter()
+            .any(|e| e.allowed && matches!(e.decision_source, GateDecisionSource::UserAllowOnce)));
+    }
+
+    #[test]
+    fn apply_resolution_always_allow_raises_clearance() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let out = gate.apply_resolution(
+            "a",
+            "shell",
+            "call1",
+            TaintLevel::Private,
+            TaintLevel::Public,
+            GateResolution::AlwaysAllow,
+        );
+        assert!(out.is_none());
+        // Clearance raised so future calls of this tool auto-pass.
+        assert_eq!(
+            gate.tool_classification("shell").clearance,
+            TaintLevel::Private
+        );
+        assert!(
+            gate.audit_log()
+                .iter()
+                .any(|e| e.allowed
+                    && matches!(e.decision_source, GateDecisionSource::UserAlwaysAllow))
+        );
+    }
+
+    #[test]
+    fn apply_resolution_deny_returns_blocked_result() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let out = gate.apply_resolution(
+            "a",
+            "shell",
+            "call1",
+            TaintLevel::Private,
+            TaintLevel::Public,
+            GateResolution::Deny,
+        );
+        let (id, msg) = out.expect("deny yields a blocked result");
+        assert_eq!(id, "call1");
+        assert!(msg.contains("[blocked]") && msg.contains("shell"));
+        assert!(gate
+            .audit_log()
+            .iter()
+            .any(|e| !e.allowed && matches!(e.decision_source, GateDecisionSource::UserDenied)));
     }
 }


### PR DESCRIPTION
## Summary

The taint subsystem (sensitivity model, gate, policy, `lev policy test`) existed as a tested library but was **never invoked during a run**. This wires it in end-to-end — implementing the "Taint-Tracked Data Flow (In Progress)" README card.

## Enforcement (engine inference loop)
- `AgentEngine` gains an optional `TaintGate` + `PolicyConfig` + injected `GatePrompt` resolver (`configure_taint`/`clear_taint`), set per stage by the CLI.
- Before executing tool calls, outbound calls whose incoming context taint exceeds the tool's clearance are **blocked** and resolved **interactively** (allow-once / always-allow / deny). Denied calls aren't executed — a `[blocked]` result goes back to the model. Every decision is audited.
- Tool results are **tagged** into regions with the tool's declared sensitivity, so taint accrues and recovers on eviction.

## Config cascade (off by default, opt-in)
- Global `taint_tracking` toggle in user config (default **false**).
- Per-stage `[stages.X.security]` (agent-level `[security]` already existed).
- `resolve_taint_enabled` / `resolve_security` cascade **stage → agent → global**; when the global switch is on, all agents enforce unless a specific agent/stage opts out.

## CLI wiring
- `StageCallbacks` gains taint hooks (defaults keep non-opted-in runs + existing tests unaffected).
- Worker: IPC-based `GatePrompt` (reuses the approval channel) + audit persisted to `stages/<idx>/taint_audit.json`. Foreground: stdin `GatePrompt`.

## Tests
Cover the gate (deny / allow-once / disabled) driven through the real inference loop, tagging, cascade resolution, manifest parsing, gate construction, and the worker prompt mapping + audit persistence. Also fixes a latent runs-dir isolation race exposed by llvm-cov timing. Coverage ratchet, clippy (stable 1.97), fmt all clean.

## Deferred (follow-up)
Per-region taint indicator in the dashboard (`ContextSnapshot.taint_summary`) and Rhai scripted-rule wiring; the per-stage audit log is the surfacing mechanism for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)