### PR TITLE
test: cover new read_files/file-tracking/context-tool code — green the coverage ratchet

### DIFF
--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -751,4 +751,38 @@ mod tests {
         assert!(result.is_ok());
         assert!(path.exists());
     }
+
+    #[test]
+    fn add_with_parent_that_is_a_file_errors() {
+        // When the target path's parent is an existing regular file,
+        // create_dir_all fails and the `?` propagates — covers the error arm.
+        let dir = tempfile::tempdir().unwrap();
+        let file_as_parent = dir.path().join("iamafile");
+        std::fs::write(&file_as_parent, "not a dir").unwrap();
+        let path = file_as_parent.join("policy.toml");
+        let config = leviath_core::PolicyConfig::default();
+        let args = PolicyAddArgs {
+            tool: "shell".to_string(),
+            target: None,
+            max_sensitivity: "public".to_string(),
+        };
+        let result = execute_add_with(args, &path, &config);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_dispatches_add_subcommand() {
+        // Route the top-level dispatcher through the Add arm. An invalid
+        // sensitivity makes execute_add fail before it writes anything to the
+        // real config path, so no filesystem side effects occur.
+        let result = execute(PolicyArgs {
+            command: PolicyCommand::Add(PolicyAddArgs {
+                tool: "shell".to_string(),
+                target: None,
+                max_sensitivity: "definitely-not-valid".to_string(),
+            }),
+        })
+        .await;
+        assert!(result.is_err());
+    }
 }

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -2663,7 +2663,7 @@ mod tests {
         let mut policy = PolicyConfig::default();
         policy.mcp_overrides.insert(
             "srv.sender".to_string(),
-            leviath_core::policy::McpToolOverride {
+            leviath_core::McpToolOverride {
                 sensitivity: Some(leviath_core::TaintLevel::Public),
                 direction: Some("outbound".to_string()),
                 clearance: Some(leviath_core::TaintLevel::Public),
@@ -2908,5 +2908,246 @@ mod tests {
                 .map(|s| s.as_str()),
             Some("special_region")
         );
+    }
+
+    // ─── file-tracking tool-description patching ────────────────────────────
+
+    #[tokio::test]
+    async fn file_tracking_patches_file_tool_descriptions() {
+        // With `file_tracking` enabled and the four file tools available, the
+        // stage loop rewrites their descriptions to reference the tracked
+        // system-prompt region (the description-patching block). This exercises
+        // all four match arms (read_file / read_files / write_file / edit_file).
+        let mut stage = make_stage("main");
+        stage.available_tools = vec![
+            "read_file".to_string(),
+            "read_files".to_string(),
+            "write_file".to_string(),
+            "edit_file".to_string(),
+        ];
+        let mut bp = make_blueprint(vec![stage]);
+        bp.file_tracking = Some(leviath_core::blueprint::FileTrackingConfig {
+            region: "workspace_files".to_string(),
+            track_reads: true,
+            track_writes: true,
+            max_file_tokens: None,
+        });
+        let (mut engine, mut pool, entity) = make_engine_and_entity(&bp);
+        let tool_registry = make_tool_registry().await;
+        let mut cb = MockCallbacks::new();
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        // The stage still completes normally after the tools are patched.
+        assert_eq!(cb.completed_at, Some(0));
+    }
+
+    #[tokio::test]
+    async fn file_tracking_reads_only_leaves_write_tools_untouched() {
+        // track_writes=false must skip the write_file/edit_file arms while
+        // still patching read_file/read_files (track_reads=true).
+        let mut stage = make_stage("main");
+        stage.available_tools = vec![
+            "read_file".to_string(),
+            "read_files".to_string(),
+            "write_file".to_string(),
+            "edit_file".to_string(),
+        ];
+        let mut bp = make_blueprint(vec![stage]);
+        bp.file_tracking = Some(leviath_core::blueprint::FileTrackingConfig {
+            region: "reads_region".to_string(),
+            track_reads: true,
+            track_writes: false,
+            max_file_tokens: None,
+        });
+        let (mut engine, mut pool, entity) = make_engine_and_entity(&bp);
+        let tool_registry = make_tool_registry().await;
+        let mut cb = MockCallbacks::new();
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(cb.completed_at, Some(0));
+    }
+
+    // ─── multi-model priority fallback + tracing field evaluation ───────────
+
+    #[tokio::test]
+    async fn multi_model_selects_lower_priority_available_provider() {
+        // models[0] is an unregistered provider, so the model-resolution loop
+        // skips it and selects the registered `anthropic` at index 1 (the
+        // "lower-priority model chosen" path).
+        let mut stage = make_stage("main");
+        stage.model.models.insert(
+            0,
+            ModelEntry::new("nonexistent".to_string(), "x".to_string()),
+        );
+        let bp = make_blueprint(vec![stage]);
+        let (mut engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+        let tool_registry = make_tool_registry().await;
+        let mut cb = MockCallbacks::new();
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        // The registered lower-priority provider was chosen.
+        assert_eq!(cb.resolved_models[0].0, "anthropic");
+        assert_eq!(cb.completed_at, Some(0));
+    }
+
+    // ─── interactive-points abort cancels a live message reader ─────────────
+
+    #[tokio::test]
+    async fn interactive_points_abort_aborts_active_stdin_reader() {
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "interactive_points_abort_aborts_active_stdin_reader",
+        );
+        use crate::runstate::{self, RunMeta};
+        use leviath_core::blueprint::InteractionPoint;
+
+        // accepts_messages = true makes start_message_reader return Some, so the
+        // abort path's `handle.abort()` (stdin-reader cleanup) is exercised.
+        let mut stage = make_stage("plan");
+        stage.mode = StageMode::InteractivePoints {
+            points: vec![InteractionPoint {
+                name: "plan_approval".to_string(),
+                prompt: "Approve?".to_string(),
+                required: false,
+                style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+                options: vec!["Approve".to_string(), "Abort".to_string()],
+                directives: Default::default(),
+                abort_options: vec!["Abort".to_string()],
+                edit_options: Default::default(),
+            }],
+        };
+        stage.max_iterations = Some(2);
+        stage.accepts_messages = true;
+        let bp = make_blueprint(vec![stage]);
+        let (mut engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+        let tool_registry = make_tool_registry().await;
+
+        let run_id = "exec-abort-reader-run".to_string();
+        let meta = RunMeta::new(
+            run_id.clone(),
+            "test".into(),
+            "/p".into(),
+            "t".into(),
+            None,
+            "/tmp".into(),
+            1,
+        );
+        runstate::create_run(&meta).unwrap();
+
+        let mut cb = MockCallbacks::new();
+        cb.run_context = Some((run_id.clone(), meta));
+
+        let responder_run_id = run_id.clone();
+        let responder = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                if let Some(req) = crate::interaction::read_request(&responder_run_id) {
+                    let mut resp = crate::interaction::InteractionResponse::choice("", 1);
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&responder_run_id, &resp).unwrap();
+                    break;
+                }
+            }
+        });
+
+        let mut ctx = StageContext {
+            blueprint: &bp,
+            engine: &mut engine,
+            entity,
+            pool: &mut pool,
+            tool_registry: &tool_registry,
+            current_stage_name: Arc::new(Mutex::new(String::new())),
+            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+            current_stage_idx: Arc::new(Mutex::new(0)),
+            model_override: None,
+            user_default_model: None,
+            compaction_ref: None,
+        };
+
+        run_stage_loop(
+            &mut ctx,
+            &mut cb,
+            "agent-1",
+            &mut MockIO::new(),
+            &mut noop_exec,
+        )
+        .await
+        .unwrap();
+
+        let _ = responder.await;
+
+        assert_eq!(cb.cancelled_at, Some(0));
+        assert_eq!(cb.completed_at, None);
+        assert!(cb.transitions.is_empty());
+
+        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
     }
 }

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -1944,4 +1944,17 @@ allowed = ["read_file"]
         });
         assert_eq!(r, leviath_runtime::taint::GateResolution::Deny);
     }
+
+    #[tokio::test]
+    async fn foreground_gate_prompt_resolve_allows_without_stdin() {
+        // A non-blocked decision short-circuits inside resolve_gate_with_asker
+        // to AllowOnce *without* invoking the real stdin asker, so the
+        // ForegroundGatePrompt::resolve method itself can be driven safely.
+        use leviath_runtime::taint::GatePrompt;
+        let prompt = ForegroundGatePrompt;
+        let r = prompt
+            .resolve(&leviath_core::taint::GateDecision::Allowed)
+            .await;
+        assert_eq!(r, leviath_runtime::taint::GateResolution::AllowOnce);
+    }
 }

--- a/crates/leviath-cli/src/commands/run/helpers.rs
+++ b/crates/leviath-cli/src/commands/run/helpers.rs
@@ -771,6 +771,25 @@ mod tests {
         assert!(kinds.contains(&"history"));
     }
 
+    #[test]
+    fn build_context_snapshot_hashmap_region_kind() {
+        // Covers the RegionKind::HashMap arm of the region-kind → label match.
+        let bp = make_blueprint_with_regions(vec![
+            RegionDefinition::new("system".to_string(), RegionKind::Pinned, 2000),
+            RegionDefinition::new(
+                "files".to_string(),
+                RegionKind::HashMap { max_entries: None },
+                1000,
+            ),
+        ]);
+        let (mut engine, entity) = make_engine_and_entity(&bp);
+        initialize_context_window(&mut engine, entity, &bp, "task");
+
+        let snap = build_context_snapshot(&engine, entity, "test").unwrap();
+        let kinds: Vec<&str> = snap.regions.iter().map(|r| r.kind.as_str()).collect();
+        assert!(kinds.contains(&"hashmap"));
+    }
+
     // ─── build_context_snapshot: returns None for invalid entity ────────
 
     #[test]

--- a/crates/leviath-cli/src/commands/run/inference.rs
+++ b/crates/leviath-cli/src/commands/run/inference.rs
@@ -1028,4 +1028,15 @@ mod tests {
             .await
             .is_err());
     }
+
+    #[tokio::test]
+    async fn capturing_provider_trivial_trait_methods() {
+        // The CapturingProvider's non-`infer` trait methods are only reached
+        // when invoked directly (the engine paths under test never call them).
+        let provider = CapturingProvider::new();
+        assert_eq!(Provider::count_tokens(&provider, "abcd", "m"), 1);
+        assert_eq!(Provider::max_context_tokens(&provider, "m"), 100_000);
+        assert_eq!(Provider::name(&provider), "capturing");
+        assert!(Provider::list_models(&provider).await.unwrap().is_empty());
+    }
 }

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -2533,4 +2533,59 @@ max_result_tokens = 8192
         assert!(routing.persist);
         assert!(routing.tool_overrides.is_empty());
     }
+
+    #[test]
+    fn parse_manifest_sliding_window_bulk_and_compact_strategies() {
+        // Exercises the `bulk` and `compact` eviction-strategy arms of the
+        // sliding_window region parser (with and without their optional counts).
+        let toml = r#"
+[agent]
+name = "eviction-strategies"
+
+[context.regions]
+bulk_default = { kind = "sliding_window", max_items = 20, max_tokens = 3000, strategy = "bulk" }
+bulk_overflow = { kind = "sliding_window", max_items = 20, max_tokens = 3000, strategy = "bulk", overflow = 5 }
+compact_default = { kind = "sliding_window", max_items = 20, max_tokens = 3000, strategy = "compact" }
+compact_count = { kind = "sliding_window", max_items = 20, max_tokens = 3000, strategy = "compact", compact_count = 7 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let region = |name: &str| {
+            bp.context_layout
+                .regions
+                .iter()
+                .find(|r| r.name == name)
+                .unwrap()
+                .kind
+                .clone()
+        };
+
+        assert_eq!(
+            region("bulk_default"),
+            RegionKind::SlidingWindow {
+                max_items: 20,
+                eviction_strategy: EvictionStrategy::Bulk { overflow: 10 },
+            }
+        );
+        assert_eq!(
+            region("bulk_overflow"),
+            RegionKind::SlidingWindow {
+                max_items: 20,
+                eviction_strategy: EvictionStrategy::Bulk { overflow: 5 },
+            }
+        );
+        assert_eq!(
+            region("compact_default"),
+            RegionKind::SlidingWindow {
+                max_items: 20,
+                eviction_strategy: EvictionStrategy::Compact { compact_count: 10 },
+            }
+        );
+        assert_eq!(
+            region("compact_count"),
+            RegionKind::SlidingWindow {
+                max_items: 20,
+                eviction_strategy: EvictionStrategy::Compact { compact_count: 7 },
+            }
+        );
+    }
 }

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -3819,4 +3819,104 @@ mod tests {
         // Empty abort list
         assert!(!super::is_abort_option(&[], "Abort"));
     }
+
+    #[tokio::test]
+    async fn foreground_edit_option_breaks_when_iteration_budget_exhausted() {
+        // An edit option selected once the per-point iteration budget is spent
+        // hits the `remaining_iterations == 0` guard in the edit branch and
+        // breaks out of the point loop.
+        use crate::interaction::{InteractionKind, InteractionResponse};
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let points = vec![make_multiple_choice_point_with_edit(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Edit".to_string()],
+            vec!["Edit".to_string()],
+        )];
+
+        // Always pick "Edit" (index 1) and always return non-empty edited text.
+        // max_iterations = 2 with one point (2 segments) gives 1 iteration per
+        // segment, so remaining hits 0 by the second round's guard check.
+        let ask_foreground = |req: &crate::interaction::InteractionRequest| match req.kind {
+            InteractionKind::EditText => InteractionResponse::text(&req.id, "edited text"),
+            _ => InteractionResponse::choice(&req.id, 1),
+        };
+
+        let outcome = run_interactive_points_stage_with(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            2,
+            &[],
+            None,
+            &points,
+            None,
+            &mut io,
+            &mut noop_exec,
+            &ask_foreground,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, PointsOutcome::Completed);
+    }
+
+    #[tokio::test]
+    async fn foreground_edit_option_empty_edit_is_skipped_and_no_directive_completes() {
+        // Round 1: pick the edit option but submit an EMPTY edit → the
+        // `if !edited.is_empty()` block is skipped. Round 2: pick a plain option
+        // with no directive → the no-directive `else` branch completes the
+        // stage.
+        use crate::interaction::{InteractionKind, InteractionResponse};
+        use std::sync::Mutex;
+
+        let bp = make_blueprint(vec![make_stage("main")]);
+        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+        let mut io = MockIO::new();
+
+        let points = vec![make_multiple_choice_point_with_edit(
+            "plan_approval",
+            "Approve the plan?",
+            vec!["Approve".to_string(), "Edit".to_string()],
+            vec!["Edit".to_string()],
+        )];
+
+        let choice_round = Mutex::new(0usize);
+        let ask_foreground = |req: &crate::interaction::InteractionRequest| match req.kind {
+            // Empty edit → the inject block is skipped.
+            InteractionKind::EditText => InteractionResponse::text(&req.id, ""),
+            _ => {
+                // Round 1: "Edit" (index 1). Round 2: "Approve" (index 0, no
+                // directive → completes).
+                let mut r = choice_round.lock().unwrap();
+                let idx = if *r == 0 { 1 } else { 0 };
+                *r += 1;
+                InteractionResponse::choice(&req.id, idx)
+            }
+        };
+
+        let outcome = run_interactive_points_stage_with(
+            &mut engine,
+            entity,
+            "mock",
+            "test-model",
+            8,
+            &[],
+            None,
+            &points,
+            None,
+            &mut io,
+            &mut noop_exec,
+            &ask_foreground,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, PointsOutcome::Completed);
+    }
 }

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -4997,4 +4997,637 @@ for line in sys.stdin:
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    #[tokio::test]
+    async fn maybe_track_file_region_not_found_returns_original() {
+        // The configured tracking region is absent from the window, so the
+        // `get_region_mut` lookup misses and the original result is returned.
+        let tmp = std::env::temp_dir().join("lev-test-track-region-absent");
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("f.txt"), "body").unwrap();
+
+        let ctx = leviath_tools::ToolContext::new(tmp.clone());
+        let builtins = leviath_tools::BuiltinTools::new(ctx);
+        // Window has region "other", but tracking config points at "files".
+        let cw = make_context_window_with_hashmap("other");
+        let ft = make_file_tracking_config("files", true, false);
+
+        let args = serde_json::json!({ "path": "f.txt" });
+        let original = "body";
+        let result = maybe_track_file(
+            "read_file",
+            &args,
+            original.to_string(),
+            &ft,
+            &cw,
+            &builtins,
+        )
+        .await;
+        assert_eq!(result, original);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_file_no_context_window_returns_original() {
+        // No context window at all → the upsert block is skipped and the
+        // original result is returned.
+        let tmp = std::env::temp_dir().join("lev-test-track-no-window");
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("f.txt"), "body").unwrap();
+
+        let ctx = leviath_tools::ToolContext::new(tmp.clone());
+        let builtins = leviath_tools::BuiltinTools::new(ctx);
+        let cw: Arc<Mutex<Option<ContextWindow>>> = Arc::new(Mutex::new(None));
+        let ft = make_file_tracking_config("files", true, false);
+
+        let args = serde_json::json!({ "path": "f.txt" });
+        let original = "body";
+        let result = maybe_track_file(
+            "read_file",
+            &args,
+            original.to_string(),
+            &ft,
+            &cw,
+            &builtins,
+        )
+        .await;
+        assert_eq!(result, original);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_file_edit_file_failed_read() {
+        // edit_file whose re-read errors (line 546): track_writes on, but the
+        // path doesn't exist so the re-read returns "[error] ..." → original
+        // result is returned unchanged.
+        let tmp = std::env::temp_dir().join("lev-test-track-edit-fail");
+        let _ = std::fs::create_dir_all(&tmp);
+
+        let ctx = leviath_tools::ToolContext::new(tmp.clone());
+        let builtins = leviath_tools::BuiltinTools::new(ctx);
+        let cw = make_context_window_with_hashmap("files");
+        let ft = make_file_tracking_config("files", false, true);
+
+        let args = serde_json::json!({ "path": "nonexistent.txt" });
+        let original = "File edited";
+        let result = maybe_track_file(
+            "edit_file",
+            &args,
+            original.to_string(),
+            &ft,
+            &cw,
+            &builtins,
+        )
+        .await;
+
+        assert_eq!(result, original);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_file_truncation_under_limit_keeps_content() {
+        // max_file_tokens is set, but the file is under the limit, so the
+        // truncation `else` branch (line 573) is taken and the content is
+        // stored verbatim.
+        let tmp = std::env::temp_dir().join("lev-test-track-under-limit");
+        let _ = std::fs::create_dir_all(&tmp);
+
+        let ctx = leviath_tools::ToolContext::new(tmp.clone());
+        let builtins = leviath_tools::BuiltinTools::new(ctx);
+        let cw = make_context_window_with_hashmap("files");
+        let mut ft = make_file_tracking_config("files", true, false);
+        ft.max_file_tokens = Some(10_000); // generous — content stays untruncated
+
+        let args = serde_json::json!({ "path": "small.txt" });
+        let result =
+            maybe_track_file("read_file", &args, "tiny".to_string(), &ft, &cw, &builtins).await;
+
+        assert!(result.contains("[files]"));
+        let guard = cw.lock().await;
+        let entry = guard
+            .as_ref()
+            .unwrap()
+            .get_region("files")
+            .unwrap()
+            .get_by_key("small.txt")
+            .unwrap();
+        assert_eq!(entry.content, "tiny");
+        assert!(!entry.content.contains("truncated"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ─── maybe_track_batch_read (read_files) ─────────────────────────────────
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_tracking_disabled_returns_original() {
+        let tmp = std::env::temp_dir().join("lev-test-batch-disabled");
+        let _ = std::fs::create_dir_all(&tmp);
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let cw = make_context_window_with_hashmap("files");
+        let ft = make_file_tracking_config("files", false, false); // track_reads = false
+
+        let args = serde_json::json!({ "paths": ["a.txt"] });
+        let original = "orig batch result";
+        let result = maybe_track_batch_read(&args, original.to_string(), &ft, &cw, &builtins).await;
+        assert_eq!(result, original);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_missing_paths_returns_original() {
+        let tmp = std::env::temp_dir().join("lev-test-batch-no-paths");
+        let _ = std::fs::create_dir_all(&tmp);
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let cw = make_context_window_with_hashmap("files");
+        let ft = make_file_tracking_config("files", true, false);
+
+        // No "paths" key at all.
+        let args = serde_json::json!({});
+        let original = "orig";
+        assert_eq!(
+            maybe_track_batch_read(&args, original.to_string(), &ft, &cw, &builtins).await,
+            original
+        );
+
+        // "paths" present but not an array.
+        let args2 = serde_json::json!({ "paths": "not-an-array" });
+        assert_eq!(
+            maybe_track_batch_read(&args2, original.to_string(), &ft, &cw, &builtins).await,
+            original
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_no_context_window_returns_original() {
+        let tmp = std::env::temp_dir().join("lev-test-batch-no-cw");
+        let _ = std::fs::create_dir_all(&tmp);
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let cw: Arc<Mutex<Option<ContextWindow>>> = Arc::new(Mutex::new(None));
+        let ft = make_file_tracking_config("files", true, false);
+
+        let args = serde_json::json!({ "paths": ["a.txt"] });
+        let original = "orig";
+        assert_eq!(
+            maybe_track_batch_read(&args, original.to_string(), &ft, &cw, &builtins).await,
+            original
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_region_not_found_or_not_hashmap_returns_original() {
+        let tmp = std::env::temp_dir().join("lev-test-batch-bad-region");
+        let _ = std::fs::create_dir_all(&tmp);
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let args = serde_json::json!({ "paths": ["a.txt"] });
+        let original = "orig";
+
+        // Region name doesn't exist in the window.
+        let cw = make_context_window_with_hashmap("files");
+        let ft_missing = make_file_tracking_config("missing", true, false);
+        assert_eq!(
+            maybe_track_batch_read(&args, original.to_string(), &ft_missing, &cw, &builtins).await,
+            original
+        );
+
+        // Region exists but is not a HashMap.
+        let mut window = ContextWindow::new(100000);
+        window.add_region(leviath_core::Region::new(
+            "files".to_string(),
+            leviath_core::RegionKind::SlidingWindow {
+                max_items: 10,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            50000,
+        ));
+        let cw2 = Arc::new(Mutex::new(Some(window)));
+        let ft = make_file_tracking_config("files", true, false);
+        assert_eq!(
+            maybe_track_batch_read(&args, original.to_string(), &ft, &cw2, &builtins).await,
+            original
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_tracks_files_and_summarizes() {
+        // Happy path: a normal file (upserted + token count), a non-string
+        // path element (skipped), and a path whose read errors (tracked as
+        // "→ error"). max_file_tokens is None so the truncation `else`
+        // branch is taken.
+        let tmp = std::env::temp_dir().join("lev-test-batch-track");
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("a.txt"), "content of a").unwrap();
+        std::fs::write(tmp.join("b.txt"), "content of b").unwrap();
+
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let cw = make_context_window_with_hashmap("files");
+        let ft = make_file_tracking_config("files", true, false);
+
+        // Mixed array: two real files, a non-string element (skipped), and a
+        // missing file (→ error).
+        let args = serde_json::json!({
+            "paths": ["a.txt", 42, "b.txt", "nonexistent.txt"]
+        });
+        let result = maybe_track_batch_read(&args, "orig".to_string(), &ft, &cw, &builtins).await;
+
+        assert!(result.contains("stored in your system prompt under [files]"));
+        assert!(result.contains("- a.txt ("));
+        assert!(result.contains("- b.txt ("));
+        assert!(result.contains("- nonexistent.txt → error"));
+        assert!(result.contains("do not re-read"));
+
+        // The two real files were upserted into the HashMap region.
+        let guard = cw.lock().await;
+        let region = guard.as_ref().unwrap().get_region("files").unwrap();
+        assert_eq!(region.get_by_key("a.txt").unwrap().content, "content of a");
+        assert_eq!(region.get_by_key("b.txt").unwrap().content, "content of b");
+        // The non-string element and the errored path were not stored.
+        assert!(region.get_by_key("nonexistent.txt").is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn maybe_track_batch_read_truncation_over_and_under_limit() {
+        // Covers both truncation branches: one file over the token limit
+        // (truncated) and one under the limit (kept verbatim).
+        let tmp = std::env::temp_dir().join("lev-test-batch-trunc");
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("big.txt"), "x".repeat(500)).unwrap();
+        std::fs::write(tmp.join("small.txt"), "tiny").unwrap();
+
+        let builtins =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(tmp.clone()));
+        let cw = make_context_window_with_hashmap("files");
+        let mut ft = make_file_tracking_config("files", true, false);
+        ft.max_file_tokens = Some(10); // approx 40 chars
+
+        let args = serde_json::json!({ "paths": ["big.txt", "small.txt"] });
+        let result = maybe_track_batch_read(&args, "orig".to_string(), &ft, &cw, &builtins).await;
+        assert!(result.contains("- big.txt ("));
+        assert!(result.contains("- small.txt ("));
+
+        let guard = cw.lock().await;
+        let region = guard.as_ref().unwrap().get_region("files").unwrap();
+        // big.txt was truncated; small.txt kept verbatim.
+        assert!(region
+            .get_by_key("big.txt")
+            .unwrap()
+            .content
+            .contains("truncated"));
+        assert_eq!(region.get_by_key("small.txt").unwrap().content, "tiny");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ─── dispatch_tool_calls: context-tool and file-tracking branches ────────
+
+    #[tokio::test]
+    async fn dispatch_tool_calls_context_tool_routes_to_handler() {
+        // A `context_*` tool call is routed to handle_context_tool and logged,
+        // covering the `tc.name.starts_with("context_")` branch (lines 76-84).
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "dispatch_tool_calls_context_tool_routes_to_handler",
+        );
+        let run_id = "test-dispatch-context-tool";
+        let dir = crate::runstate::run_dir(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut state = make_dispatch_state(run_id).await;
+        state.context_window = make_context_window_with_hashmap("notes");
+
+        let calls = vec![make_tool_call(
+            "context_write",
+            serde_json::json!({ "region": "notes", "key": "k", "content": "v" }),
+        )];
+        let out = dispatch_tool_calls(&state, calls).await;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, "call-context_write");
+        assert!(
+            out[0].1.contains("Stored in 'notes'"),
+            "unexpected result: {}",
+            out[0].1
+        );
+
+        let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
+        assert!(log.contains("context_write"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_calls_file_tracking_read_and_batch() {
+        // With file tracking configured, `read_files` routes to
+        // maybe_track_batch_read and other read/write tools route to
+        // maybe_track_file, covering the file-tracking block (lines 201-221).
+        let _guard = crate::runstate::isolate_runs_dir_for_test(
+            "dispatch_tool_calls_file_tracking_read_and_batch",
+        );
+        let run_id = "test-dispatch-file-tracking";
+        let dir = crate::runstate::run_dir(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Create real files under the dispatch state's workdir (temp_dir).
+        let workdir = std::env::temp_dir();
+        let pid = std::process::id();
+        let single = format!("lev-dispatch-ft-single-{pid}.txt");
+        let batch = format!("lev-dispatch-ft-batch-{pid}.txt");
+        std::fs::write(workdir.join(&single), "single file body").unwrap();
+        std::fs::write(workdir.join(&batch), "batch file body").unwrap();
+
+        let mut state = make_dispatch_state(run_id).await;
+        let mut launch = std::collections::HashMap::new();
+        launch.insert("*".to_string(), ToolPolicy::Allow);
+        state.launch_overrides = Arc::new(launch);
+        state.context_window = make_context_window_with_hashmap("files");
+        state.file_tracking = Some(make_file_tracking_config("files", true, true));
+
+        let calls = vec![
+            make_tool_call(
+                "read_files",
+                serde_json::json!({ "paths": [batch.clone()] }),
+            ),
+            make_tool_call("read_file", serde_json::json!({ "path": single.clone() })),
+        ];
+        let out = dispatch_tool_calls(&state, calls).await;
+
+        assert_eq!(out.len(), 2);
+        // read_files result was replaced with the batch summary.
+        assert!(
+            out[0]
+                .1
+                .contains("stored in your system prompt under [files]"),
+            "unexpected batch result: {}",
+            out[0].1
+        );
+        // read_file result was replaced with the single-file reference message.
+        assert!(
+            out[1].1.contains("[files]") && out[1].1.contains("### ["),
+            "unexpected single result: {}",
+            out[1].1
+        );
+
+        // Both files ended up in the HashMap region.
+        let guard = state.context_window.lock().await;
+        let region = guard.as_ref().unwrap().get_region("files").unwrap();
+        assert!(region.get_by_key(&batch).is_some());
+        assert!(region.get_by_key(&single).is_some());
+        drop(guard);
+
+        let _ = std::fs::remove_file(workdir.join(&single));
+        let _ = std::fs::remove_file(workdir.join(&batch));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ─── handle_context_tool: remaining error / branch coverage ──────────────
+
+    /// Build a ContextWindow with a single HashMap region with a tiny token
+    /// budget, so that writes/appends exceed the budget and surface an error.
+    fn make_tiny_hashmap_window(region_name: &str) -> Arc<Mutex<Option<ContextWindow>>> {
+        let mut window = ContextWindow::new(1000);
+        window.add_region(leviath_core::Region::new(
+            region_name.to_string(),
+            leviath_core::RegionKind::HashMap { max_entries: None },
+            2, // tiny budget
+        ));
+        Arc::new(Mutex::new(Some(window)))
+    }
+
+    /// Build a ContextWindow with a single SlidingWindow region with a tiny
+    /// token budget.
+    fn make_tiny_sliding_window(region_name: &str) -> Arc<Mutex<Option<ContextWindow>>> {
+        let mut window = ContextWindow::new(1000);
+        window.add_region(leviath_core::Region::new(
+            region_name.to_string(),
+            leviath_core::RegionKind::SlidingWindow {
+                max_items: 10,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            2, // tiny budget
+        ));
+        Arc::new(Mutex::new(Some(window)))
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_write_hashmap_over_budget_errors() {
+        let cw = make_tiny_hashmap_window("notes");
+        let args = serde_json::json!({
+            "region": "notes",
+            "key": "k",
+            "content": "this content is far too large for the budget"
+        });
+        let result = handle_context_tool("context_write", &args, &cw).await;
+        assert!(
+            result.starts_with("[error]"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_write_non_hashmap_over_budget_errors() {
+        let cw = make_tiny_sliding_window("temp");
+        let args = serde_json::json!({
+            "region": "temp",
+            "content": "this content is far too large for the budget"
+        });
+        let result = handle_context_tool("context_write", &args, &cw).await;
+        assert!(
+            result.starts_with("[error]"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_append_new_key_creates_entry() {
+        // Appending under a key that does not yet exist creates a new entry
+        // (the "Created entry" branch).
+        let cw = make_context_window_with_hashmap("notes");
+        let args = serde_json::json!({
+            "region": "notes",
+            "key": "fresh",
+            "content": "first line"
+        });
+        let result = handle_context_tool("context_append", &args, &cw).await;
+        assert!(
+            result.contains("Created entry in 'notes' section under key 'fresh'"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_append_new_key_over_budget_errors() {
+        let cw = make_tiny_hashmap_window("notes");
+        let args = serde_json::json!({
+            "region": "notes",
+            "key": "fresh",
+            "content": "this content is far too large for the budget"
+        });
+        let result = handle_context_tool("context_append", &args, &cw).await;
+        assert!(
+            result.starts_with("[error]"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_append_non_hashmap_over_budget_errors() {
+        let cw = make_tiny_sliding_window("temp");
+        let args = serde_json::json!({
+            "region": "temp",
+            "content": "this content is far too large for the budget"
+        });
+        let result = handle_context_tool("context_append", &args, &cw).await;
+        assert!(
+            result.starts_with("[error]"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_read_hashmap_key_miss_returns_not_found() {
+        let cw = make_context_window_with_hashmap("notes");
+        let args = serde_json::json!({ "region": "notes", "key": "ghost" });
+        let result = handle_context_tool("context_read", &args, &cw).await;
+        assert!(
+            result.contains("[not found]") && result.contains("ghost"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_list_region_not_found() {
+        let cw = make_context_window_with_hashmap("notes");
+        let args = serde_json::json!({ "region": "nonexistent" });
+        let result = handle_context_tool("context_list", &args, &cw).await;
+        assert!(
+            result.contains("Section 'nonexistent' not found"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_list_specific_region_keyless_entries() {
+        // A non-HashMap region's entries have no key, so context_list renders
+        // them as "(entry, N tokens)".
+        let cw = make_context_window_with_sliding_window();
+        handle_context_tool(
+            "context_write",
+            &serde_json::json!({ "region": "temp", "content": "some data" }),
+            &cw,
+        )
+        .await;
+        let result = handle_context_tool(
+            "context_list",
+            &serde_json::json!({ "region": "temp" }),
+            &cw,
+        )
+        .await;
+        assert!(
+            result.contains("(entry,") && result.contains("tokens"),
+            "unexpected result: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_list_all_regions_covers_every_kind() {
+        // A window with one region of every kind, so the kind_str match in the
+        // "list all regions" branch exercises all its arms.
+        let mut window = ContextWindow::new(1_000_000);
+        window.add_region(leviath_core::Region::new(
+            "pin".to_string(),
+            leviath_core::RegionKind::Pinned,
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "conv".to_string(),
+            leviath_core::RegionKind::SlidingWindow {
+                max_items: 10,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "tmp".to_string(),
+            leviath_core::RegionKind::Temporary,
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "cmp".to_string(),
+            leviath_core::RegionKind::Compacting {
+                threshold_tokens: 500,
+            },
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "clr".to_string(),
+            leviath_core::RegionKind::Clearable,
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "hist".to_string(),
+            leviath_core::RegionKind::CompactHistory {
+                source_region: "conv".to_string(),
+            },
+            1000,
+        ));
+        window.add_region(leviath_core::Region::new(
+            "kv".to_string(),
+            leviath_core::RegionKind::HashMap { max_entries: None },
+            1000,
+        ));
+        let cw = Arc::new(Mutex::new(Some(window)));
+
+        let result = handle_context_tool("context_list", &serde_json::json!({}), &cw).await;
+        for label in [
+            "permanent",
+            "conversation",
+            "temporary",
+            "summarized when full",
+            "summary archive",
+            "key-value store",
+        ] {
+            assert!(
+                result.contains(label),
+                "expected '{}' in: {}",
+                label,
+                result
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_context_tool_list_no_regions_configured() {
+        let cw: Arc<Mutex<Option<ContextWindow>>> =
+            Arc::new(Mutex::new(Some(ContextWindow::new(1000))));
+        let result = handle_context_tool("context_list", &serde_json::json!({}), &cw).await;
+        assert!(
+            result.contains("No context window sections configured"),
+            "unexpected result: {}",
+            result
+        );
+    }
 }

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -342,4 +342,26 @@ mod tests {
             .with_description("holds architecture notes".to_string());
         assert_eq!(def.description.as_deref(), Some("holds architecture notes"));
     }
+
+    #[test]
+    fn test_validate_with_sliding_window_present() {
+        // A layout that DOES contain a SlidingWindow region exercises the
+        // has_sliding_window detection returning true, so the "no sliding
+        // window" warning branch is skipped.
+        let regions = vec![
+            RegionDefinition::new("pinned".to_string(), RegionKind::Pinned, 5000),
+            RegionDefinition::new(
+                "conv".to_string(),
+                RegionKind::SlidingWindow {
+                    max_items: 50,
+                    eviction_strategy: crate::region::EvictionStrategy::PerItem,
+                },
+                5000,
+            ),
+        ];
+        let layout = ContextLayout::new(regions, 20000);
+        with_tracing(|| {
+            assert!(layout.validate().is_ok());
+        });
+    }
 }

--- a/crates/leviath-core/src/policy.rs
+++ b/crates/leviath-core/src/policy.rs
@@ -444,4 +444,30 @@ send_email = { sensitivity = "private", direction = "egress", clearance = "publi
         let back: McpToolOverride = serde_json::from_str(&json).unwrap();
         assert_eq!(o, back);
     }
+
+    #[test]
+    fn test_matches_false_when_only_channel_pattern_set_but_no_target() {
+        let rule = AllowlistRule {
+            tool: "post_message".to_string(),
+            to: vec![],
+            channel: vec!["#general".to_string()],
+            max_sensitivity: TaintLevel::Private,
+        };
+        // `to` is empty (first operand false), which forces evaluation of the
+        // `channel` operand in the "patterns set but no target" guard; with no
+        // target the rule must not match.
+        assert!(!rule.matches("post_message", None, TaintLevel::Public));
+    }
+
+    #[test]
+    fn test_from_toml_mcp_override_server_without_tools_table() {
+        // A server entry that has no `tools` sub-table exercises the
+        // `if let Some(tools_table)` None branch — nothing is inserted.
+        let toml = r#"
+[mcp_overrides.emptyserver]
+note = "no tools declared here"
+"#;
+        let config = PolicyConfig::from_toml(toml).unwrap();
+        assert!(config.mcp_overrides.is_empty());
+    }
 }

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -2761,4 +2761,55 @@ mod tests {
             crate::cache::CacheHint::UntilChanged
         );
     }
+
+    // ─── taint-vector fixups on keyed removal / LRU eviction ───────────────
+
+    #[test]
+    fn test_remove_by_key_recomputes_taint_when_tracking_enabled() {
+        // A taint-tracked region: remove_by_key must run its taint-vector
+        // fixup branch (`taint.remove_at`) without panicking.
+        let mut region = Region::new(
+            "kv".to_string(),
+            RegionKind::HashMap { max_entries: None },
+            10_000,
+        )
+        .with_taint_tracking();
+        region
+            .upsert_by_key("k1", "value one".to_string(), 10)
+            .unwrap();
+        region
+            .upsert_by_key("k2", "value two".to_string(), 10)
+            .unwrap();
+
+        assert!(region.remove_by_key("k1"));
+        assert!(!region.remove_by_key("missing"));
+        assert_eq!(region.entry_count(), 1);
+        assert_eq!(region.current_tokens, 10);
+    }
+
+    #[test]
+    fn test_evict_lru_entry_runs_taint_fixup() {
+        // A taint-tracked HashMap region with a max_entries cap: inserting past
+        // the cap triggers evict_lru_entry, which must run its taint-vector
+        // fixup branch.
+        let mut region = Region::new(
+            "kv".to_string(),
+            RegionKind::HashMap {
+                max_entries: Some(1),
+            },
+            10_000,
+        )
+        .with_taint_tracking();
+        region
+            .upsert_by_key("first", "aaa".to_string(), 10)
+            .unwrap();
+        region
+            .upsert_by_key("second", "bbb".to_string(), 10)
+            .unwrap();
+
+        // Only the most-recently-inserted key survives after LRU eviction.
+        assert_eq!(region.entry_count(), 1);
+        assert!(region.get_by_key("second").is_some());
+        assert!(region.get_by_key("first").is_none());
+    }
 }

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -1335,4 +1335,53 @@ mod tests {
         // Stage present → wins over agent.
         assert!(resolve_security(false, Some(&sec(false)), Some(&sec(true))).taint_tracking);
     }
+
+    #[test]
+    fn test_region_taint_remove_at_recomputes_level() {
+        let mut rt = RegionTaint::new();
+        rt.add_entry(TaintLevel::Public);
+        rt.add_entry(TaintLevel::Private);
+        rt.add_entry(TaintLevel::Public);
+        assert_eq!(rt.level(), TaintLevel::Private);
+
+        // Removing the Private entry at index 1 recomputes the level down.
+        rt.remove_at(1);
+        assert_eq!(rt.entry_count(), 2);
+        assert_eq!(rt.level(), TaintLevel::Public);
+
+        // An out-of-range index is a no-op.
+        rt.remove_at(99);
+        assert_eq!(rt.entry_count(), 2);
+    }
+
+    #[test]
+    fn test_security_config_next_fallback() {
+        let config = SecurityConfig {
+            taint_tracking: true,
+            pointer_mode: true,
+            filter_mode: None,
+            degradation: vec![
+                InputMode::Pointer,
+                InputMode::Filter,
+                InputMode::Traditional,
+            ],
+        };
+        assert_eq!(
+            config.next_fallback(&InputMode::Pointer),
+            Some(&InputMode::Filter)
+        );
+        assert_eq!(
+            config.next_fallback(&InputMode::Filter),
+            Some(&InputMode::Traditional)
+        );
+        // The last mode in the path has no fallback.
+        assert_eq!(config.next_fallback(&InputMode::Traditional), None);
+
+        // A mode absent from the degradation path has no fallback.
+        let cfg2 = SecurityConfig {
+            degradation: vec![InputMode::Traditional],
+            ..SecurityConfig::default()
+        };
+        assert_eq!(cfg2.next_fallback(&InputMode::Pointer), None);
+    }
 }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -1501,6 +1501,67 @@ mod tests {
         assert!(body.get("system").is_none());
     }
 
+    #[test]
+    fn test_build_request_body_system_block_never_hint_omits_cache_control() {
+        // A system block with CacheHint::Never exercises the false branch of
+        // the `cache_hint != Never` guard, so no cache_control is attached.
+        let provider = AnthropicProvider::new("key".to_string());
+        let request = InferenceRequest {
+            system: vec![crate::SystemBlock {
+                text: "No caching here.".to_string(),
+                cache_hint: leviath_core::CacheHint::Never,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        // Single system block → serialized as its plain text, never as a
+        // block carrying cache_control.
+        assert_eq!(body["system"], "No caching here.");
+    }
+
+    #[test]
+    fn test_build_request_body_cache_breakpoint_with_block_content() {
+        // A message with cache_breakpoint = true AND block (non-Text) content
+        // exercises the MessageContent::Blocks arm of the breakpoint handling,
+        // which serializes the content normally rather than wrapping it.
+        let provider = AnthropicProvider::new("key".to_string());
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "assistant".to_string(),
+                content: crate::MessageContent::Blocks(vec![crate::ContentBlock::Text {
+                    text: "block text".to_string(),
+                }]),
+                cache_breakpoint: true,
+            }],
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        // Block content is serialized normally (an array of content blocks),
+        // not wrapped in a synthetic cache_control text block.
+        assert_eq!(messages[0]["role"], "assistant");
+        assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"][0]["type"], "text");
+        assert_eq!(messages[0]["content"][0]["text"], "block text");
+    }
+
     // ── SSE parsing tests ──────────────────────────────────────────────────
 
     #[test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -3203,4 +3203,66 @@ mod tests {
             "SlidingWindow entries should appear as messages"
         );
     }
+
+    #[test]
+    fn test_add_tainted_to_region_propagates_budget_error() {
+        // Region is found, but the entry exceeds its token budget, so the
+        // inner `add_tainted_entry` error must propagate through the `?`.
+        let mut window = ContextWindow::new(10_000);
+        let mut region = Region::new("conv".to_string(), RegionKind::Temporary, 10);
+        region.enable_taint_tracking();
+        window.add_region(region);
+
+        let result = window.add_tainted_to_region(
+            "conv",
+            "far too many tokens".to_string(),
+            100,
+            leviath_core::TaintLevel::Private,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_typed_tainted_to_region_propagates_budget_error() {
+        // Region is found, but the entry exceeds its token budget, so the
+        // inner `add_typed_tainted_entry` error must propagate through the `?`.
+        let mut window = ContextWindow::new(10_000);
+        let region = Region::new("conv".to_string(), RegionKind::Temporary, 10);
+        window.add_region(region);
+
+        let result = window.add_typed_tainted_to_region(
+            "conv",
+            leviath_core::EntryKind::Text,
+            "far too many tokens".to_string(),
+            100,
+            leviath_core::TaintLevel::Public,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_assemble_hashmap_region_entry_without_key() {
+        // A HashMap-region entry with no key falls back to its raw content
+        // (rather than a "### [key]" header) when assembled.
+        let mut window = ContextWindow::new(10_000);
+        let region = Region::new(
+            "kv".to_string(),
+            RegionKind::HashMap { max_entries: None },
+            5000,
+        );
+        window.add_region(region);
+        // add_to_region stores the entry with key: None.
+        window
+            .add_to_region("kv", "keyless content".to_string(), 10)
+            .unwrap();
+
+        let assembled = window.assemble();
+        assert!(
+            assembled
+                .system_blocks
+                .iter()
+                .any(|b| b.text.contains("keyless content")),
+            "keyless HashMap entry should appear verbatim in a system block"
+        );
+    }
 }

--- a/crates/leviath-runtime/src/engine.rs
+++ b/crates/leviath-runtime/src/engine.rs
@@ -5819,4 +5819,25 @@ mod tests {
         })
         .await;
     }
+
+    #[test]
+    fn drain_pending_messages_noop_when_entity_has_no_inbox() {
+        let mut engine = AgentEngine::new();
+        // Spawn an entity that has an AgentState but NO MessageInbox component.
+        let entity = engine
+            .world_mut()
+            .spawn(AgentState {
+                agent_id: "no-inbox".to_string(),
+                current_stage: "main".to_string(),
+                iteration: 0,
+                status: AgentStatus::Active,
+                spawned_children_ids: Vec::new(),
+                pending_wait: None,
+                accepts_messages: true,
+            })
+            .id();
+        // get_mut::<MessageInbox> returns None → the if-let body is skipped and
+        // the call is a no-op that must not panic.
+        engine.drain_pending_messages(entity);
+    }
 }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1265,6 +1265,98 @@ mod tests {
         assert!(result.contains("Failed to read"));
     }
 
+    // ── read_files (batch reads) ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn read_files_multiple_valid_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        fs::write(dir.path().join("a.txt"), "alpha").unwrap();
+        fs::write(dir.path().join("b.txt"), "beta").unwrap();
+
+        let result = tools
+            .execute("read_files", json!({"paths": ["a.txt", "b.txt"]}))
+            .await;
+        assert!(result.contains("### [a.txt]"));
+        assert!(result.contains("alpha"));
+        assert!(result.contains("### [b.txt]"));
+        assert!(result.contains("beta"));
+        // Results are joined with a blank line between entries.
+        assert!(result.contains("\n\n"));
+    }
+
+    #[tokio::test]
+    async fn read_files_missing_paths_arg() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools.execute("read_files", json!({})).await;
+        assert!(result.contains("[error]"));
+        assert!(result.contains("missing 'paths'"));
+    }
+
+    #[tokio::test]
+    async fn read_files_non_array_paths_arg() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        // A string (not an array) → as_array() returns None → same error path.
+        let result = tools.execute("read_files", json!({"paths": "a.txt"})).await;
+        assert!(result.contains("[error]"));
+        assert!(result.contains("missing 'paths'"));
+    }
+
+    #[tokio::test]
+    async fn read_files_empty_paths_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools.execute("read_files", json!({"paths": []})).await;
+        assert!(result.contains("[error]"));
+        assert!(result.contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn read_files_missing_file_reports_per_file_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        fs::write(dir.path().join("present.txt"), "here").unwrap();
+
+        let result = tools
+            .execute(
+                "read_files",
+                json!({"paths": ["present.txt", "absent.txt"]}),
+            )
+            .await;
+        // Valid file still returned…
+        assert!(result.contains("### [present.txt]"));
+        assert!(result.contains("here"));
+        // …while the missing one produces a per-file error under its header.
+        assert!(result.contains("### [absent.txt]"));
+        assert!(result.contains("Failed to read"));
+    }
+
+    #[tokio::test]
+    async fn read_files_non_string_element_reports_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        fs::write(dir.path().join("ok.txt"), "content").unwrap();
+
+        let result = tools
+            .execute("read_files", json!({"paths": ["ok.txt", 42]}))
+            .await;
+        assert!(result.contains("content"));
+        assert!(result.contains("non-string path in array"));
+    }
+
+    #[tokio::test]
+    async fn read_files_path_escape_reported_per_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .execute("read_files", json!({"paths": ["../../etc/passwd"]}))
+            .await;
+        assert!(result.contains("### [../../etc/passwd]"));
+        assert!(result.contains("escape"));
+    }
+
     // ── resolve() absolute paths ────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Why

The coverage ratchet (`xtask/src/coverage.rs`, ceilings **200/90/20** regions/lines/functions) went red after the recent `read_files` batch tool + file-tracking + context-tool + executor-description-patching work landed largely untested. On the current toolchain, clean `main` measured **404 / 263 / 20** missed — well over ceiling.

This PR adds **tests only** (no production-code changes) for that new code.

## Result

`cargo xtask coverage` locally: **regions 132/200, lines 68/90, functions 8/20** — under ceiling with healthy margin. Full suite: **3805 passed, 0 failed**; clippy + fmt clean.

## What's covered (54 new tests)

- **`worker.rs`** (153→13 regions): `maybe_track_batch_read` (was fully uncovered), `handle_context_tool` arms, `maybe_track_file`, `dispatch_tool_calls` routing.
- **`leviath-tools/lib.rs`**: the `read_files` batch tool end-to-end (multiple files, per-file errors, bad args).
- **`executor.rs`**: dynamic tool-description patching for file tracking; multi-model fallback; interactive-points abort.
- **`policy.rs`, `manifest.rs`, `inference.rs`, `stages.rs`, `foreground.rs`, `helpers.rs`**: assorted new/uncovered branches.
- **`leviath-core`** (region/policy/taint/layout) and **`leviath-runtime`** (components/engine): typed-tainted region entries + budget-error paths.
- **`anthropic.rs`**: cache-hint / block-content request-body branches.

Lines deliberately left uncovered are confirmed-permanent gaps (generic-function monomorphization, `tracing!`/`assert!` message-arg regions, unreachable defensive arms, detached-task closures, and the taint-audit callback that needs a full integration harness) — consistent with the categories documented in `xtask/src/coverage.rs`. The ceiling is **not** changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)