### PR TITLE
Finalize testing strategy: zero cfg(not(test)), locked-down bin, clean comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `labeled`/`unlabeled` are included so the `guard-main-rs` job re-runs when
+    # a maintainer applies/removes the `allow-main-rs-change` override label.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,3 +240,35 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check coverage suppression markers
         run: cargo xtask check-exclusions
+
+  # `crates/leviath-cli/src/main.rs` is the ONE file excluded from coverage
+  # measurement — the thin, un-unit-tested composition root where real terminal
+  # / stdin / port / subprocess / `/dev/tty` I/O is wired into the tested lib
+  # cores. Changing it needs deliberate maintainer sign-off: this job fails any
+  # PR that touches main.rs unless the maintainer applies the
+  # `allow-main-rs-change` label.
+  guard-main-rs:
+    name: Guard bin entrypoint (main.rs)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require maintainer override to change main.rs
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE" "$HEAD" | grep -qx 'crates/leviath-cli/src/main.rs'; then
+            case ",$LABELS," in
+              *,allow-main-rs-change,*)
+                echo "main.rs change approved via 'allow-main-rs-change' label." ;;
+              *)
+                echo "::error file=crates/leviath-cli/src/main.rs::main.rs is the coverage-excluded bin entrypoint; changing it needs maintainer approval. Apply the 'allow-main-rs-change' label to override."
+                exit 1 ;;
+            esac
+          else
+            echo "main.rs unchanged."
+          fi

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -332,9 +332,7 @@ description = "test"
     fn copy_dir_recursive_file_over_existing_dir_errors() {
         // Copying a file onto a destination path that already exists as a
         // directory fails on every platform (EISDIR / ERROR_ACCESS_DENIED),
-        // exercising the `std::fs::copy(...)?` error arm. The prior version
-        // made the source file unreadable via `chmod 0o000`, which only fails
-        // on Unix.
+        // exercising the `std::fs::copy(...)?` error arm.
         let src_dir = tempfile::tempdir().unwrap();
         std::fs::write(src_dir.path().join("clash"), "top secret").unwrap();
 
@@ -353,8 +351,7 @@ description = "test"
         // the destination already has a *file* where the recursion needs to
         // create a subdirectory, so the nested `create_dir_all` fails on every
         // platform and that `Err` bubbles up through the parent's
-        // `copy_dir_recursive(...)?`. The prior version made the source
-        // subdirectory unreadable via `chmod 0o000`, which only fails on Unix.
+        // `copy_dir_recursive(...)?`.
         let src_dir = tempfile::tempdir().unwrap();
         let sub = src_dir.path().join("sub");
         std::fs::create_dir_all(&sub).unwrap();
@@ -477,8 +474,7 @@ description = "test"
     fn install_from_dir_remove_dir_all_failure_errors() {
         // The existing install target is a *file*, so `exists()` passes the
         // reinstall guard but `remove_dir_all` (which requires a directory)
-        // fails on every platform, exercising that `?` arm. The prior version
-        // dropped write permission on the parent dir, which only fails on Unix.
+        // fails on every platform, exercising that `?` arm.
         let src = tempfile::tempdir().unwrap();
         std::fs::write(
             src.path().join("agent.leviath"),
@@ -498,8 +494,7 @@ description = "test"
         // `agents_dir` is itself a *file*, so `copy_dir_recursive`'s
         // `create_dir_all` for the install target (a child path of a file)
         // fails on every platform, and that `Err` propagates through
-        // `install_from_dir`'s `copy_dir_recursive(...)?`. The prior version
-        // made a source file unreadable via `chmod 0o000` (Unix-only).
+        // `install_from_dir`'s `copy_dir_recursive(...)?`.
         let src = tempfile::tempdir().unwrap();
         std::fs::write(
             src.path().join("agent.leviath"),

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -20,13 +20,13 @@ pub async fn execute(args: CreateArgs) -> anyhow::Result<()> {
 }
 
 /// Core of `execute()`, parameterized over the file-write primitive so tests
-/// can force any individual write's error arm deterministically -- without
-/// the process-global umask mutation this file used to need (and reject, for
-/// good reason: `cargo test`'s default thread-based parallelism means a
-/// restrictive umask can't be scoped to one test the way an env var or CWD
-/// lock can, so ANY other test creating a file/directory on another thread
-/// during that window would silently get the same zero-permission
-/// treatment). Each real call site still goes through the exact same
+/// can force any individual write's error arm deterministically -- without a
+/// process-global umask mutation (which is rejected here, for good reason:
+/// `cargo test`'s default thread-based parallelism means a restrictive umask
+/// can't be scoped to one test the way an env var or CWD lock can, so ANY
+/// other test creating a file/directory on another thread during that window
+/// would silently get the same zero-permission treatment). Each real call site
+/// still goes through the exact same
 /// `std::fs::write` in production (`execute` above passes it directly, with
 /// zero indirection cost); only tests substitute a fake.
 fn execute_with(

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -128,8 +128,8 @@ pub fn yank_to_clipboard_via(text: &str, osc52_fallback: fn(&str) -> bool) -> bo
 /// [`yank_to_clipboard_via`] with the native-tool command list injected, so a
 /// test can drive the spawn-success and non-zero-exit branches with a program
 /// guaranteed present on the host (the real `pbcopy`/`xclip`/`wl-copy` names
-/// don't exist on Windows, so a fake `#!/bin/sh` script on `PATH` -- the prior
-/// approach -- couldn't exercise these branches there).
+/// don't exist on Windows, so a fake `#!/bin/sh` script on `PATH` couldn't
+/// exercise these branches there).
 fn yank_to_clipboard_with(
     text: &str,
     clipboard_cmds: &[(&str, &[&str])],
@@ -484,29 +484,22 @@ mod tests {
 
     // ── yank_to_clipboard: at least exercises the code path ──────────────────
     //
-    // A previous version of this test ("test_yank_to_clipboard_small_text")
-    // called `yank_to_clipboard_via` with the ambient, untouched `PATH` and
-    // relied on whichever native tool happened to be installed -- which made
-    // whether its nested fallback closure ever actually ran (and thus
-    // whether it was ever covered) depend on the machine `cargo test`
-    // happened to run on. Both the "native tool succeeds" and "falls back to
-    // OSC52" branches of `yank_to_clipboard_via` are already covered
-    // deterministically below (`..._native_tool_success_returns_true_...`,
+    // Ambient-`PATH` smoke tests are avoided here. Both the "native tool
+    // succeeds" and "falls back to OSC52" branches of `yank_to_clipboard_via`
+    // are covered deterministically below (`..._native_tool_success_returns_true_...`,
     // `..._nonzero_exit_falls_through_to_fallback`,
-    // `..._falls_back_to_osc52_when_no_native_tool_on_path`), so that smoke
-    // test added no unique coverage -- it's removed rather than made
-    // deterministic by also starving `PATH`, to avoid growing the number of
-    // `PATH`-mutation windows tests not holding `PATH_ENV_LOCK` (e.g. the
-    // dashboard's real `key('y')` handlers in `input.rs`) could race with.
+    // `..._falls_back_to_osc52_when_no_native_tool_on_path`) by starving
+    // `PATH`, so an ambient-`PATH` test adds no unique coverage while growing
+    // the number of `PATH`-mutation windows that tests not holding
+    // `PATH_ENV_LOCK` (e.g. the dashboard's real `key('y')` handlers in
+    // `input.rs`) could race with.
 
     #[test]
     fn test_yank_to_clipboard_empty() {
         // Starves `PATH` so the injected fallback is reached deterministically
         // regardless of which native clipboard tools happen to be installed
-        // on the machine `cargo test` runs on (see the removed
-        // `test_yank_to_clipboard_small_text`/`..._returns_true` tests'
-        // replacement comments above for why ambient-`PATH` smoke tests are
-        // avoided here).
+        // on the machine `cargo test` runs on (see the ambient-`PATH`
+        // rationale above for why ambient-`PATH` smoke tests are avoided here).
         let _lock = crate::config::PATH_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -543,8 +536,7 @@ mod tests {
     /// host, injected in place of `pbcopy`/`xclip`/`wl-copy` so the spawn-loop
     /// branches are exercised cross-platform. `true`/`false` exist on
     /// macOS/Linux; `cmd /C exit N` is the Windows equivalent (both drain/ignore
-    /// stdin and exit deterministically), replacing the prior Unix-only
-    /// `#!/bin/sh` fake scripts.
+    /// stdin and exit deterministically).
     #[cfg(not(windows))]
     fn exit_cmd(success: bool) -> (&'static str, &'static [&'static str]) {
         if success {
@@ -634,26 +626,22 @@ mod tests {
 
     // ─── yank_to_clipboard ──────────────────────────────────────────────────
     //
-    // A previous version of this test ("test_yank_to_clipboard_returns_true")
-    // called `yank_to_clipboard_via` with the ambient, untouched `PATH`,
-    // relying on the real `pbcopy` this dev machine happens to have
-    // installed. Its nested fallback closure only got covered on runs where
-    // a concurrently-running `PATH`-mutating test happened to race with it --
-    // nondeterministic, and the exact kind of flakiness this file's
-    // `PATH_ENV_LOCK`-guarded tests exist to avoid. `yank_to_clipboard`
-    // itself (the public, un-suffixed wrapper this test also indirectly
-    // covered) is still exercised for real by the dashboard's `key('y')`
-    // handler tests in `input.rs`; the native-success and OSC52-fallback
-    // branches of `yank_to_clipboard_via` it delegates to are covered
-    // deterministically by the tests immediately below.
+    // Ambient-`PATH` smoke tests are avoided here: their nested fallback
+    // closure only gets covered when a concurrently-running `PATH`-mutating
+    // test races with them -- nondeterministic, the exact kind of flakiness
+    // this file's `PATH_ENV_LOCK`-guarded tests exist to avoid.
+    // `yank_to_clipboard` itself (the public, un-suffixed wrapper) is
+    // exercised for real by the dashboard's `key('y')` handler tests in
+    // `input.rs`; the native-success and OSC52-fallback branches of
+    // `yank_to_clipboard_via` it delegates to are covered deterministically by
+    // the tests immediately below.
 
     #[test]
     fn test_yank_to_clipboard_falls_back_to_osc52_when_no_native_tool_on_path() {
         // `PATH` is process-global; `crate::config::PATH_ENV_LOCK` serializes
         // against `commands/run/session.rs`'s PATH-mutating `launch_editor`
-        // tests too (previously each side only held its own file-local lock,
-        // which doesn't actually serialize across files despite the shared
-        // name).
+        // tests too (a per-file lock would not serialize across files despite
+        // the shared name).
         let _lock = crate::config::PATH_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1678,8 +1678,8 @@ mod tests {
 
     #[test]
     fn detail_view_m_key_no_longer_bound() {
-        // 'm' used to be a separate "send message" keybinding; it has been
-        // unified into 'i'. Pressing 'm' must no longer enter input mode.
+        // The message keybinding is 'i', not 'm'. Pressing 'm' must not enter
+        // input mode.
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Active);
         agent.accepts_messages = true;

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -107,15 +107,14 @@ pub trait TerminalSetup {
 }
 
 /// Terminal-independent core: runs the dashboard event loop after terminal
-/// setup. Extracted from [`execute`] so it can be driven in tests via
-/// [`TerminalSetup`] + [`EventSource`] without a real TTY.
+/// setup, driven in tests via [`TerminalSetup`] + [`EventSource`] without a real
+/// TTY.
 ///
-/// Generic over `S: TerminalSetup` and `E: EventSource`. In the measured test
-/// build the only `TerminalSetup` in scope is the test-double [`TestSetup`]
-/// (the real [`CrosstermSetup`] is `#[cfg(not(test))]`), so every
-/// monomorphization of this function -- and of the [`run_dashboard_loop`] it
-/// calls -- runs against a `ratatui::backend::TestBackend` and canned events,
-/// keeping the whole function coverable under `cargo test`.
+/// Generic over `S: TerminalSetup` and `E: EventSource`. The only
+/// `TerminalSetup` in the library is the test double [`TestSetup`] (the real
+/// `CrosstermSetup` lives in the binary), so every monomorphization here — and
+/// in [`run_dashboard_loop`] — runs against a `ratatui::backend::TestBackend`
+/// with canned events, keeping the whole function covered.
 async fn execute_core<S: TerminalSetup, E: EventSource>(
     dashboard: &mut Dashboard,
     engine: &leviath_runtime::EngineHandle,
@@ -951,11 +950,9 @@ mod tests {
 
     // ─── CrosstermEventSource::new constructor ──────────────────────────────
     //
-    // The constructor only ever *stores* fn pointers (crossterm's real
-    // `poll`/`read`) -- taking a function's address never invokes it, so
-    // merely constructing the type touches no real terminal state. The
-    // production `CrosstermSetup` (real raw-mode/alternate-screen/backend
-    // wiring) is `#[cfg(not(test))]`, hence absent from this build entirely.
+    // The constructor only *stores* fn pointers (crossterm's real `poll`/`read`);
+    // taking a function's address never invokes it, so constructing the type
+    // touches no real terminal state.
 
     #[test]
     fn crossterm_event_source_new_constructs_without_touching_real_events() {
@@ -988,11 +985,10 @@ mod tests {
     // ─── execute_core / TestSetup ───────────────────────────────────────────
     //
     // `execute_core` and the `run_dashboard_loop` it calls are generic over
-    // `TerminalSetup`/`EventSource`. In this (test) build the only
-    // `TerminalSetup` in scope is the [`TestSetup`] double (the real
-    // `CrosstermSetup` is `#[cfg(not(test))]`), so these tests drive every
-    // arm of `execute_core` against a `TestBackend` -- deterministically, and
-    // without ever touching a real terminal.
+    // `TerminalSetup`/`EventSource`. The only `TerminalSetup` in the library is
+    // the [`TestSetup`] double (the real `CrosstermSetup` lives in the binary),
+    // so these tests drive every arm of `execute_core` against a `TestBackend`
+    // deterministically, without touching a real terminal.
 
     #[tokio::test]
     async fn execute_core_happy_path_quits_on_esc() {

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -135,11 +135,9 @@ async fn execute_core<S: TerminalSetup, E: EventSource>(
 /// it can run against a [`ratatui::backend::TestBackend`] and a canned
 /// [`EventSource`] in tests, instead of a real terminal. Exits (returning
 /// `Ok(())`) once `dashboard.should_quit` is set; propagates the first I/O
-/// error from drawing or event polling, exactly as the original inline loop
-/// in `execute` did (including leaving raw mode / the alternate screen
-/// untouched on error -- restoring those is `execute`'s responsibility, not
-/// this loop's, and this refactor preserves that pre-existing behavior
-/// rather than changing it as a side effect of a coverage pass).
+/// error from drawing or event polling, leaving raw mode / the alternate
+/// screen untouched on error -- restoring those is `execute`'s
+/// responsibility, not this loop's.
 ///
 /// Generic over `B: Backend` and `impl EventSource`; in the measured test
 /// build it is only ever instantiated once -- with the single
@@ -228,8 +226,8 @@ async fn init_dashboard(
 ///
 /// The real terminal wiring cannot live here: constructing `CrosstermSetup`
 /// enables actual raw mode / the alternate screen and blocks forever on real
-/// keyboard input (an `is_terminal()` guard was tried and removed after it
-/// still hung a real editor terminal full-screen). That irreducible sliver is
+/// keyboard input (an `is_terminal()` guard does not prevent the hang -- it
+/// still hangs a real editor terminal full-screen). That irreducible sliver is
 /// the binary's job; everything it composes is exercised here.
 /// `yank_fn` is the clipboard implementation the dashboard's `y` keypress uses;
 /// the binary passes the real native-tool/OSC52 clipboard (which can write the
@@ -784,13 +782,10 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // A previous version of this comment claimed `crossterm::event::poll`
-    // "has no terminal-mutating side effects... safe to call from a real
-    // unit test regardless of environment" and had a test call
-    // `CrosstermEventSource::new().poll_event(1ms)` for real to prove it.
-    // That claim was wrong, confirmed by hanging for 60+ seconds under a
-    // real pty, in complete isolation (`--test-threads=1`, nothing else
-    // running). Root cause: `crossterm::event::poll`'s internal
+    // `crossterm::event::poll` cannot be called from a real unit test: it
+    // hangs for 60+ seconds under a real pty, even in complete isolation
+    // (`--test-threads=1`, nothing else running). Root cause:
+    // `crossterm::event::poll`'s internal
     // `INTERNAL_EVENT_READER` is a lazily-constructed, process-wide
     // singleton (`parking_lot::Mutex<Option<InternalEventReader>>`); the
     // passed timeout only bounds *acquiring that mutex*
@@ -1093,7 +1088,7 @@ mod tests {
 
     // The real `lev dash` wiring (the crossterm `CrosstermSetup` + the real
     // `CrosstermEventSource` + the `Config::load`/`init_dashboard`/`execute_core`
-    // composition) now lives in the binary's `real_dashboard`; the fully-tested
+    // composition) lives in the binary's `real_dashboard`; the fully-tested
     // seam it composes, `execute_with`, is covered by
     // `execute_with_loads_config_inits_and_runs_the_loop` above.
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -422,11 +422,11 @@ mod tests {
 
     // ─── Regression: mid-run message input pane must actually render ──────
     //
-    // Pressing 'i' (formerly 'm') on an Active agent that accepts mid-run
-    // messages sets input_mode = true, but prompt_height used to only
-    // account for the `is_waiting` case — so the input pane never actually
-    // got laid out or rendered for an Active, non-waiting agent. Verify the
-    // textarea's hint text actually appears in the rendered buffer.
+    // Pressing 'i' on an Active agent that accepts mid-run messages sets
+    // input_mode = true. `prompt_height` must account for this case (not just
+    // the `is_waiting` case), or the input pane never gets laid out or
+    // rendered for an Active, non-waiting agent. Verify the textarea's hint
+    // text actually appears in the rendered buffer.
     #[test]
     fn draw_detail_view_renders_input_pane_for_accepts_messages_while_active() {
         let backend = TestBackend::new(120, 40);

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -470,9 +470,10 @@ mod tests {
 
     // ─── Regression: help overlay must scope to the current page ──────────
     //
-    // draw_help_overlay() used to always render both the "Main list" and
-    // "Detail view"/"Input" sections regardless of self.detail_view, so the
-    // user always saw keybindings for a page they weren't even on.
+    // draw_help_overlay() must scope its sections to `self.detail_view`:
+    // rendering both the "Main list" and "Detail view"/"Input" sections
+    // regardless of page would show the user keybindings for a page they
+    // aren't on.
 
     fn rendered_buffer(terminal: &Terminal<TestBackend>) -> String {
         terminal

--- a/crates/leviath-cli/src/commands/dashboard/test_support.rs
+++ b/crates/leviath-cli/src/commands/dashboard/test_support.rs
@@ -1,10 +1,8 @@
 //! Shared test-only fixtures for the dashboard command modules.
 //!
-//! `make_test_dashboard` was previously duplicated verbatim in ~10 sibling
-//! modules (`mod.rs`, `input.rs`, `state.rs`, and the `render/*` files); it
-//! now lives here once. Per-module `make_test_agent` helpers stay local
-//! because each bakes in module-specific field values that its own tests
-//! assert on (token counts, stage counts, titles, `is_run_state`, etc.).
+//! `make_test_dashboard` is shared here. Per-module `make_test_agent` helpers
+//! stay local because each bakes in module-specific field values that its own
+//! tests assert on (token counts, stage counts, titles, `is_run_state`, etc.).
 
 use crate::commands::dashboard::state::Dashboard;
 use tokio::sync::mpsc;

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -515,10 +515,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     // sequence isn't reproducible: NTFS/Win32 refuse to remove a directory
     // that's a live process's current working directory (a sharing
     // violation), so `remove_dir_all` itself fails there instead of
-    // succeeding -- confirmed via real Windows CI (this test previously
-    // `.unwrap()`ed that removal unconditionally and panicked on
-    // `windows-latest`, which also poisoned the shared `CWD_LOCK` and
-    // cascaded into unrelated `manifest.rs` test failures). Unix-only.
+    // succeeding -- confirmed via real Windows CI. Unix-only.
     #[cfg(unix)]
     #[tokio::test]
     async fn execute_falls_back_to_default_cwd_when_current_dir_is_gone() {

--- a/crates/leviath-cli/src/commands/pack.rs
+++ b/crates/leviath-cli/src/commands/pack.rs
@@ -200,17 +200,6 @@ mod tests {
     // once as a bare statement (rather than wrapping the whole test body) to
     // install the shared `AlwaysOnSubscriber` (see `crate::test_support`) as
     // the process-wide default before the rest of the test runs.
-    //
-    // (A `diagnose_tracing_setup` test used to live here, whose only
-    // purpose was printing dispatcher/level-filter diagnostics and firing
-    // one ad hoc `tracing::info!("test event")` with no assertions. Its
-    // `tracing::info!` message-literal region is the confirmed,
-    // permanently-uncovered llvm-cov macro-codegen artifact documented on
-    // `config.rs`'s `log_permissive_perms_warning` -- and since it asserted
-    // nothing, and the underlying "tracing works once `with_tracing` has
-    // installed the subscriber" behavior is already exercised by every
-    // other test below, removing it drops the artifact from what's
-    // measured without losing any real coverage.)
 
     // ─── format_size ───────────────────────────────────────────────────────
 
@@ -271,8 +260,7 @@ mod tests {
     fn count_files_read_dir_error_returns_zero() {
         // An injected `read_dir` that fails on an existing directory exercises
         // the "read_dir errored -> keep the count so far" arm deterministically
-        // on every platform. The prior version made the directory unreadable
-        // via `chmod 0o000`, which only fails on Unix.
+        // on every platform.
         let dir = tempfile::tempdir().unwrap();
         let result = count_files_with(dir.path(), &|_| {
             Err(std::io::Error::other("simulated read_dir failure"))
@@ -283,8 +271,7 @@ mod tests {
     #[test]
     fn count_path_neither_file_nor_dir_counts_zero() {
         // A nonexistent path is neither a file nor a directory, so `count_path`
-        // contributes 0 -- covering the `else` arm on every platform. The prior
-        // version used a Unix-only dangling symlink.
+        // contributes 0 -- covering the `else` arm on every platform.
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
         assert_eq!(count_path(&missing, &real_read_dir), 0);
@@ -538,8 +525,7 @@ mod tests {
     async fn execute_unreadable_manifest_errors() {
         // `agent.leviath` exists but is a *directory*: `find_manifest` returns
         // it (exists() passes), then `read_to_string` fails on every platform,
-        // covering the "Failed to read manifest" map_err arm. The prior version
-        // used `chmod 0o000`, which only fails on Unix.
+        // covering the "Failed to read manifest" map_err arm.
         with_tracing(|| {});
         let project = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(project.path().join("agent.leviath")).unwrap();
@@ -556,9 +542,7 @@ mod tests {
     #[tokio::test]
     async fn execute_bundle_error_propagated() {
         // Inject a bundling op that fails, covering the `bundle(project_dir)?`
-        // error arm on every platform. The prior version relied on an
-        // unreadable (chmod 0o000) file making the real bundler fail, which
-        // only fails on Unix.
+        // error arm on every platform.
         with_tracing(|| {});
         let project = make_project_dir(false, false);
         let output_dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/commands/remove.rs
+++ b/crates/leviath-cli/src/commands/remove.rs
@@ -139,8 +139,7 @@ mod tests {
         install_test_agent(&installer, "err-agent");
 
         // An injected uninstall that fails exercises the `uninstall(name)?`
-        // error arm deterministically on every platform. The prior version
-        // dropped write permission on the parent dir, which only fails on Unix.
+        // error arm deterministically on every platform.
         let result = remove_agent_with(&installer, "err-agent", &|_| {
             Err(anyhow::anyhow!("simulated uninstall failure"))
         });

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -33,13 +33,12 @@ use leviath_runtime::taint::TaintGate;
 ///
 /// The stage system prompt is essential, must-include instruction context, so a
 /// prompt that doesn't fit its region is a **hard error**, not something to
-/// silently drop. Previously the `add_to_region` rejection (`TokenBudgetExceeded`
-/// when the prompt plus the preloaded task exceeded the region's `max_tokens`,
-/// 2000 by default) was swallowed by `let _ =`, leaving the model running with
-/// no instructions at all and no signal to the operator. Now the failure
-/// propagates as a clear, actionable error telling the author to size the
-/// region (or shorten the prompt); the shipped default agents are all sized to
-/// fit comfortably.
+/// silently drop. The `add_to_region` rejection (`TokenBudgetExceeded` when the
+/// prompt plus the preloaded task exceeds the region's `max_tokens`, 2000 by
+/// default) propagates as a clear, actionable error telling the author to size
+/// the region (or shorten the prompt); swallowing it would leave the model
+/// running with no instructions at all and no signal to the operator. The
+/// shipped default agents are all sized to fit comfortably.
 fn inject_stage_system_prompt(
     window: &mut ContextWindow,
     target_region: &str,
@@ -360,9 +359,7 @@ pub trait StageCallbacks: Send {
 /// as a *single* monomorphization shared by the foreground, worker, and test
 /// callers — rather than one per (`CB`, `F`) combination. That single
 /// instantiation is exercised end-to-end by this module's tests, so its
-/// coverage no longer depends on `cargo-llvm-cov`'s instantiation-group merging
-/// (which previously under-reported this function's regions/lines whenever a
-/// branch was covered only in some other, real-IO-only instantiation).
+/// coverage does not depend on `cargo-llvm-cov`'s instantiation-group merging.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_stage_loop(
     ctx: &mut StageContext<'_>,
@@ -2823,13 +2820,13 @@ mod tests {
 
     // ─── on_stage_result must fire for Interactive/InteractivePoints too ────
     //
-    // Regression test: previously only the Autonomous branch called
-    // cb.on_stage_result(), so the stage record for Interactive/
-    // InteractivePoints stages was never marked Complete — it stayed stuck
+    // Regression test: all stage modes must call cb.on_stage_result(), not
+    // just the Autonomous branch, or the stage record for Interactive/
+    // InteractivePoints stages is never marked Complete — it stays stuck
     // at StageRunStatus::Active forever (confirmed via real run-state data:
     // a "plan" stage with mode = interactive_points stuck at status "active",
     // ended_at: null, long after the run had moved on to later stages). That
-    // made the dashboard keep showing a spinner on a stage tab that wasn't
+    // makes the dashboard keep showing a spinner on a stage tab that isn't
     // actually running anymore.
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -536,9 +536,8 @@ pub async fn run_foreground(args: RunArgs, io: ForegroundIo) -> anyhow::Result<(
 /// generic `impl FnOnce` parameter would make `run_foreground_with_registry`
 /// monomorphize separately per test for no benefit. A concrete `fn` pointer
 /// type lets every call site (production and test) share one instantiation.
-/// (`run_stage_loop` itself is now fully type-erased — see its doc comment —
-/// so this no longer affects its coverage, but the `fn`-pointer form is still
-/// the right minimal-instantiation choice here.)
+/// (`run_stage_loop` itself is fully type-erased — see its doc comment — and
+/// the `fn`-pointer form is the right minimal-instantiation choice here.)
 pub async fn run_foreground_with_registry(
     args: RunArgs,
     build_registry: fn(&Config) -> leviath_runtime::ProviderRegistry,
@@ -960,13 +959,13 @@ mod tests {
         let engine = leviath_runtime::AgentEngine::with_providers(registry);
         // Drives the real spawn+forward logic via `start_message_reader_with`
         // (what `StageCallbacks::start_message_reader` delegates to) with
-        // `tokio::io::empty()` instead of real stdin. This previously called
-        // the trait method directly, which constructs `tokio::io::stdin()`
-        // for real the moment the spawned task starts running -- on a live
-        // TTY that read never reaches EOF, and since it's tracked by tokio's
-        // blocking pool, awaiting/timing-out/aborting the handle doesn't
-        // matter: tearing down this test's runtime at the end of the test
-        // still blocks forever waiting for that leaked real stdin read.
+        // `tokio::io::empty()` instead of real stdin. Calling the trait method
+        // directly would construct `tokio::io::stdin()` for real the moment the
+        // spawned task starts running -- on a live TTY that read never reaches
+        // EOF, and since it's tracked by tokio's blocking pool,
+        // awaiting/timing-out/aborting the handle doesn't matter: tearing down
+        // this test's runtime at the end of the test would still block forever
+        // waiting for that leaked real stdin read.
         // `tokio::io::empty()` reaches EOF immediately with no blocking-pool
         // involvement at all, so this is fully bounded regardless of
         // environment.
@@ -1849,8 +1848,7 @@ model = "mock-model"
     /// Covers `read_to_string(...).map_err(...)` error branch and the
     /// `yolo=false` path that skips the `if args.yolo { ... }` insert.
     /// `agent.leviath` exists but is a *directory*, so `find_manifest` locates
-    /// it via `.exists()` yet `read_to_string` fails on every platform. The
-    /// prior version used `chmod 0o000` (Unix-only).
+    /// it via `.exists()` yet `read_to_string` fails on every platform.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_on_manifest_read_error() {
         let _config_guard = crate::config::isolate_config_path_for_test("fg-manifest-read-error");
@@ -1961,11 +1959,11 @@ prompt = "Do the thing"
     /// Covers `resolve_task(...)? ` error branch (line 389) via the "empty
     /// task file" error, not `task: None`. `task: None` reaches
     /// `resolve_task`'s real, un-injected `std::io::stdin().is_terminal()`
-    /// check (see `session.rs`) -- under `cargo test` run from a real
-    /// interactive terminal that's actually true, so this used to launch a
-    /// real editor (`vim`/`nano`/`vi`, whichever is found first with no
-    /// `$EDITOR`/`$VISUAL` set) with the test process's real inherited
-    /// stdio, hanging the whole test run on real keyboard input. An empty
+    /// check (see `session.rs`) -- which is actually true under `cargo test`
+    /// run from a real interactive terminal, so it would launch a real editor
+    /// (`vim`/`nano`/`vi`, whichever is found first with no `$EDITOR`/`$VISUAL`
+    /// set) with the test process's real inherited stdio, hanging the whole
+    /// test run on real keyboard input. An empty
     /// task file hits a `resolve_task` error deterministically, in every
     /// environment, without depending on whether stdin happens to be a TTY.
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/helpers.rs
+++ b/crates/leviath-cli/src/commands/run/helpers.rs
@@ -803,11 +803,12 @@ mod tests {
 
     // ─── generate_title: fenced-code-block regression ───────────────────
     //
-    // When the model wraps its answer in a markdown fence, taking only the
-    // first line of the response used to grab the fence/language-tag line
-    // itself (e.g. "```python") instead of the actual title on the next
-    // line — confirmed via real run-state data showing title: "python" for
-    // a task about downloading webpages, instead of a real title.
+    // When the model wraps its answer in a markdown fence, naively taking the
+    // first line of the response would grab the fence/language-tag line itself
+    // (e.g. "```python") instead of the actual title on the next line —
+    // confirmed via real run-state data showing title: "python" for a task
+    // about downloading webpages, instead of a real title. `generate_title`
+    // unwraps the fence.
 
     #[tokio::test]
     async fn generate_title_unwraps_fenced_code_block_with_language_tag() {

--- a/crates/leviath-cli/src/commands/run/io.rs
+++ b/crates/leviath-cli/src/commands/run/io.rs
@@ -257,7 +257,7 @@ mod console_io_tests {
     #[test]
     fn get_user_input_from_reader_eof_returns_empty_string() {
         // EOF is `Ok(0)`, not an error, so this yields `Some("")` rather
-        // than `None` -- matches the pre-existing inline behavior.
+        // than `None`.
         let mut reader = Cursor::new(Vec::<u8>::new());
         assert_eq!(get_user_input_from_reader(&mut reader), Some(String::new()));
     }

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -1,8 +1,8 @@
 //! Filesystem discovery of `agent.leviath` manifests.
 //!
-//! The pure `TOML` -> [`leviath_core::Blueprint`] parser now lives in
+//! The pure `TOML` -> [`leviath_core::Blueprint`] parser lives in
 //! [`leviath_core::manifest`]; it is re-exported here as [`parse_manifest`] so
-//! existing `super::manifest::parse_manifest` call sites keep working unchanged.
+//! `super::manifest::parse_manifest` call sites resolve.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -22,9 +22,8 @@ mod stages;
 pub mod tool_source;
 mod worker;
 
-// These seams moved into `leviath-runtime`; re-export under their historical
-// `commands::run::<name>` paths so existing `super::<name>::...` references
-// across the run submodules keep resolving.
+// Re-exports of seams from `leviath-runtime` under their `commands::run::<name>`
+// paths so `super::<name>::...` references across the run submodules resolve.
 pub use leviath_runtime::dynamic_interaction;
 pub use leviath_runtime::graph;
 
@@ -629,8 +628,7 @@ prompt = "Do the thing"
 
     /// RAII guard that runs [`cleanup_runs_with_prefix`] on drop, so a
     /// mid-test assertion failure can't leak real run directories under
-    /// `~/.leviath/runs` (as happened once while developing these tests,
-    /// before this guard existed).
+    /// `~/.leviath/runs`.
     struct RunPrefixCleanup<'a>(&'a str);
     impl Drop for RunPrefixCleanup<'_> {
         fn drop(&mut self) {
@@ -982,10 +980,9 @@ prompt = "Do the thing"
 
     /// Covers `resolve_task(...)? ` (line 136) via the "empty task file"
     /// error, not `task: None`. `task: None` reaches `resolve_task`'s real,
-    /// un-injected `std::io::stdin().is_terminal()` check -- under `cargo
-    /// test` run from a real interactive terminal that's actually true
-    /// (not the "always non-TTY" assumption this test used to make), so it
-    /// launched a real editor (`vim`/`nano`/`vi`) with the test process's
+    /// un-injected `std::io::stdin().is_terminal()` check -- which is actually
+    /// true under `cargo test` run from a real interactive terminal, so it
+    /// would launch a real editor (`vim`/`nano`/`vi`) with the test process's
     /// real inherited stdio, hanging the whole run on real keyboard input.
     /// An empty task file hits a `resolve_task` error deterministically in
     /// every environment, without depending on whether stdin is a TTY.

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -1300,31 +1300,28 @@ mod tests {
     // executable via `Command::new(path)` on Windows, exit instantly, and
     // never touch a real interactive editor.
     //
-    // The "editor ended with no exit code" case (killed by a Unix signal) was
-    // previously believed to be a permanent Windows gap: on Windows
-    // `ExitStatus::code()` is always `Some(_)` (even via
-    // `ExitStatusExt::from_raw`), so no real or fabricated status reaches the
-    // "try next candidate" arm there. That was solved by narrowing the injected
-    // `run` seam's return type from `ExitStatus` to `EditorRunOutcome`: the
-    // status-to-outcome decision now lives in the pure `classify_editor_exit`
+    // The "editor ended with no exit code" case (killed by a Unix signal) is a
+    // Windows testability challenge: on Windows `ExitStatus::code()` is always
+    // `Some(_)` (even via `ExitStatusExt::from_raw`), so no real or fabricated
+    // status reaches the "try next candidate" arm there. The injected `run`
+    // seam returns `EditorRunOutcome` rather than `ExitStatus`: the
+    // status-to-outcome decision lives in the pure `classify_editor_exit`
     // (unit-tested for the code-less case on every platform), and the
     // "outcome == Aborted, try next" arm is driven directly via injection in
     // `launch_editor_with_aborted_candidate_falls_through_to_next` -- both
     // cross-platform, no code-less `ExitStatus` required.
     //
-    // Three other Unix tests that rely on PATH-starvation --
+    // Three other Unix tests rely on PATH-starvation --
     // `launch_editor_empty_visual_and_editor_are_skipped`,
     // `launch_editor_no_editor_found_when_path_has_no_candidates`, and
-    // `resolve_task_with_editor_path_propagates_launch_editor_error` -- were
-    // previously believed to have no safe Windows equivalent either, on the
-    // theory that `Command::new("notepad")` resolves via `System32`
-    // unconditionally before consulting `$PATH`, so PATH-starvation can't
-    // make it fail there. That's true of PATH-starvation specifically, but
-    // it turned out to be the wrong lever: injecting the "run this candidate"
-    // step itself (`launch_editor_with`'s `run` parameter) or the "launch the
-    // editor" step (`resolve_task_with_editor`'s `launch_editor_fn`
-    // parameter) sidesteps real process resolution entirely, closing all
-    // three gaps on every platform -- see
+    // `resolve_task_with_editor_path_propagates_launch_editor_error`.
+    // PATH-starvation has no safe Windows equivalent: `Command::new("notepad")`
+    // resolves via `System32` unconditionally before consulting `$PATH`, so
+    // PATH-starvation can't make it fail there. Instead, injecting the "run
+    // this candidate" step itself (`launch_editor_with`'s `run` parameter) or
+    // the "launch the editor" step (`resolve_task_with_editor`'s
+    // `launch_editor_fn` parameter) sidesteps real process resolution
+    // entirely, closing all three gaps on every platform -- see
     // `launch_editor_with_no_editor_found_when_every_candidate_not_found`,
     // `launch_editor_with_empty_visual_and_editor_are_skipped`, and
     // `resolve_task_with_editor_injected_editor_failure_propagates` above.

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -1964,8 +1964,7 @@ mod tests {
         // (already-written) choice response still works, but the subsequent
         // edit request's write_request fails, so the `?` propagates and the
         // stage returns Err. Blocking the tmp path fails the write on every
-        // platform (the prior version made the run dir read-only via chmod,
-        // Unix-only).
+        // platform.
         use crate::interaction::InteractionResponse;
 
         let _guard = crate::runstate::isolate_runs_dir_for_test(
@@ -3157,8 +3156,7 @@ mod tests {
         );
         // Covers the `?` on `request_interaction_async`: write_request's atomic
         // write targets `pending.json.tmp`, which we replace with a *directory*
-        // so the write fails and the Err propagates -- on every platform (the
-        // prior version made the run dir read-only via chmod, Unix-only).
+        // so the write fails and the Err propagates -- on every platform.
         let bp = make_blueprint(vec![make_stage("main")]);
         let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
         let mut io = MockIO::new();
@@ -3755,8 +3753,7 @@ mod tests {
         //   1) response.json is readable (already written)
         //   2) the directive is injected and the loop re-runs inference
         //   3) round 2's choice request → write_request fails → Err via `?`
-        // Blocking the tmp path fails on every platform (the prior version made
-        // the run dir read-only via chmod, Unix-only).
+        // Blocking the tmp path fails on every platform.
         use crate::interaction::InteractionResponse;
 
         let bp = make_blueprint(vec![make_stage("main")]);

--- a/crates/leviath-cli/src/commands/run/tool_source.rs
+++ b/crates/leviath-cli/src/commands/run/tool_source.rs
@@ -1,7 +1,7 @@
-//! Re-export of the tool-source seam, which now lives in `leviath-runtime`.
+//! Re-export of the tool-source seam, which lives in `leviath-runtime`.
 //!
 //! The concrete `RegistryToolCaller` + `impl StageToolSource for ToolRegistry`
-//! stay in the CLI (`crate::tools`); only the traits moved into the runtime so
-//! the relocated stage engine can name them without a `runtime -> cli` cycle.
+//! stay in the CLI (`crate::tools`); only the traits live in the runtime so
+//! the stage engine can name them without a `runtime -> cli` cycle.
 
 pub use leviath_runtime::tool_source::{StageToolSource, ToolCaller};

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -1188,8 +1188,7 @@ fn finalize_run_status(meta: &mut RunMeta, result: &anyhow::Result<()>) {
 /// generic `impl FnOnce` parameter would make `run_worker_inner` monomorphize
 /// separately per test for no benefit. A concrete `fn` pointer type lets every
 /// call site (production and test) share one instantiation. (`run_stage_loop`
-/// itself is now fully type-erased — see its doc comment — so this no longer
-/// affects its coverage.)
+/// itself is fully type-erased — see its doc comment.)
 async fn run_worker_inner(
     args: &WorkerArgs,
     meta: &mut RunMeta,

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -83,7 +83,7 @@ pub(super) async fn create_blueprint(
 ) -> Result<Json<BlueprintInfo>, (StatusCode, Json<ErrorResponse>)> {
     // Validate manifest first, keeping the parsed Blueprint so the response
     // can be built from it directly below instead of re-reading the file we
-    // just wrote (which used to make the re-read's error arm a TOCTOU-only,
+    // just wrote (re-reading would make the re-read's error arm a TOCTOU-only,
     // untestable dead branch).
     let bp = parse_manifest(&body.manifest).map_err(|e| {
         (

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -50,18 +50,16 @@ pub async fn execute(args: ServeArgs) -> anyhow::Result<()> {
 /// awaiting a `oneshot::Receiver` -- shares exactly ONE monomorphization of
 /// this (large, multi-branch) function instead of one per concrete future
 /// type. Confirmed via HTML/JSON segment inspection that every source
-/// position already had a covered instantiation before this change (this
-/// is the same trait-object-erasure technique used for `io::Write` in
-/// `leviath-package`'s `bundler.rs`), so this is a coverage-attribution fix
-/// with no behavior change, not a fix for an actual gap in testing.
+/// position has a covered instantiation (this is the same trait-object-erasure
+/// technique used for `io::Write` in `leviath-package`'s `bundler.rs`).
 ///
 /// `ready`, if given, is sent the real bound `SocketAddr` right after
 /// `TcpListener::bind` succeeds (before serving starts). Production passes
 /// `None`; tests pass `Some(tx)` with `args.port = 0` so the OS picks a free
 /// port and the test learns which one was actually bound directly -- no
-/// probe-bind-drop-rebind dance, which was a genuine TOCTOU race (confirmed
+/// probe-bind-drop-rebind dance, which is a genuine TOCTOU race (confirmed
 /// to reproduce on real CI: another process/test could grab the just-freed
-/// port before this function's own bind ran) rather than a test-only
+/// port before this function's own bind runs), not just a test-only
 /// convenience.
 async fn execute_with_shutdown(
     args: ServeArgs,
@@ -833,7 +831,7 @@ prompt = "Run"
         // time; execute_with_shutdown reports the real bound SocketAddr back
         // via `ready` the instant it's bound, so there's no
         // probe-bind-drop-rebind gap for another process/test to race into
-        // (a real, CI-reproducing TOCTOU this used to have -- see
+        // (that gap is a real, CI-reproducing TOCTOU -- see
         // execute_with_shutdown's doc comment). Exercises the exact same
         // production code path execute() does (its own body is just this
         // call with `ready: None`), so this remains a real end-to-end test

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -923,9 +923,8 @@ mod tests {
     async fn poll_once_webhook_send_failure_is_logged_not_panicked() {
         // Points callback_url at a closed local port so the spawned webhook
         // task's `client.post(&url)...send().await` genuinely fails,
-        // exercising the `Err(e) => error!(...)` arm -- previously
-        // unreached since the only other webhook test uses a real,
-        // responding mock server.
+        // exercising the `Err(e) => error!(...)` arm (the only other webhook
+        // test uses a real, responding mock server).
         use crate::runstate::{RunMeta, RunStatus};
 
         let (state, mut evt_rx) = make_test_state();
@@ -1201,15 +1200,14 @@ mod tests {
 
     #[tokio::test]
     async fn polling_loop_wrapper_picks_up_real_runs_from_disk() {
-        // Regression note: this test used to spawn the real `polling_loop`
-        // (which scans the real, system-wide `~/.leviath/runs` directory)
-        // and wait for its own run's event to arrive. That made it flaky
-        // under a full-suite run: any genuinely active `lev` background
-        // worker processes on the machine emit a continuous stream of real
-        // events every 200ms poll cycle, and under heavy concurrent-test
-        // CPU contention the bounded broadcast channel could drop this
-        // test's own event via `Lagged` overflow before it was ever
-        // received -- an environmental race with unrelated real activity,
+        // Regression note: spawning the real `polling_loop` (which scans the
+        // real, system-wide `~/.leviath/runs` directory) and waiting for this
+        // run's event to arrive is flaky under a full-suite run: any genuinely
+        // active `lev` background worker processes on the machine emit a
+        // continuous stream of real events every 200ms poll cycle, and under
+        // heavy concurrent-test CPU contention the bounded broadcast channel
+        // can drop this test's own event via `Lagged` overflow before it is
+        // ever received -- an environmental race with unrelated real activity,
         // not a bug in `polling_loop` itself. `polling_loop_with` injects
         // the run list instead, eliminating the real-directory dependency
         // (and the flakiness) entirely while still exercising the exact

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -308,7 +308,7 @@ mod tests {
         // frame to use the 8-byte extended-length encoding (0x7f) instead of
         // the 2-byte one (0x7e) that every other event in this file's tests
         // is small enough to use -- exercising `recv_frame`'s `len == 127`
-        // branch, previously never triggered.
+        // branch.
         let state = test_state();
         let tx = state.event_tx.clone();
         let addr = spawn_test_server(state).await;

--- a/crates/leviath-cli/src/commands/setup.rs
+++ b/crates/leviath-cli/src/commands/setup.rs
@@ -36,11 +36,28 @@ pub struct SetupArgs {
     pub default_model: Option<String>,
 }
 
-/// Core of the `--non-interactive` path, with an explicit `save_path` for
-/// the same testability reason as `run_interactive_setup`. `pub` so the
-/// binary's `real_setup` (the command's real stdin/entrypoint wiring) can
-/// call it.
-pub fn run_non_interactive_setup(
+/// `lev setup`: load the config, then either apply flags non-interactively or
+/// run the interactive prompt sequence, saving to `Config::config_path()`.
+///
+/// The reader is a lazily-constructed factory so the interactive arm can take
+/// the process's real `stdin().lock()` (the un-unit-testable leaf, supplied by
+/// the binary) while the non-interactive arm never builds it. Tests drive both
+/// arms with an isolated config path and an in-memory `Cursor`.
+pub fn execute_with<R: io::BufRead>(
+    args: &SetupArgs,
+    make_reader: impl FnOnce() -> R,
+) -> anyhow::Result<()> {
+    let mut config = Config::load().unwrap_or_default();
+    let save_path = Config::config_path();
+    if args.non_interactive {
+        return run_non_interactive_setup(&mut config, args, &save_path);
+    }
+    run_interactive_setup(&mut config, &mut make_reader(), &save_path)
+}
+
+/// Core of the `--non-interactive` path, with an explicit `save_path` so tests
+/// can target a tempfile instead of the real config.
+fn run_non_interactive_setup(
     config: &mut Config,
     args: &SetupArgs,
     save_path: &std::path::Path,
@@ -51,14 +68,10 @@ pub fn run_non_interactive_setup(
     Ok(())
 }
 
-/// The interactive prompt sequence, reading from any [`io::BufRead`] instead
-/// of hardcoding `io::stdin()`, and saving to an explicit `save_path` instead
-/// of hardcoding the real `~/.leviath/config.toml` — factored out so it can
-/// be exercised in tests with an in-memory reader and a tempfile path
-/// instead of blocking on real stdin and writing to the user's real config.
-/// `pub` so the binary's `real_setup` can drive it with the process's real
-/// `stdin().lock()`.
-pub fn run_interactive_setup<R: io::BufRead>(
+/// The interactive prompt sequence, reading from any [`io::BufRead`] and saving
+/// to an explicit `save_path` so tests can drive it with an in-memory reader and
+/// a tempfile instead of blocking on real stdin and writing the real config.
+fn run_interactive_setup<R: io::BufRead>(
     config: &mut Config,
     reader: &mut R,
     save_path: &std::path::Path,
@@ -957,5 +970,49 @@ mod tests {
             reloaded.providers.anthropic_api_key.as_deref(),
             Some("sk-ant-execute-test")
         );
+    }
+
+    /// Reader factory shared by both `execute_with` tests below: 7 empty lines,
+    /// one per interactive prompt (so every value keeps its default). Using one
+    /// named `fn` in both call sites gives `execute_with` a single
+    /// monomorphization whose two arms are covered across the two tests, and
+    /// keeps this factory's body covered (the interactive test calls it).
+    fn seven_blank_lines() -> Cursor<Vec<u8>> {
+        Cursor::new(b"\n\n\n\n\n\n\n".to_vec())
+    }
+
+    #[test]
+    fn execute_with_non_interactive_applies_flags_and_never_builds_the_reader() {
+        let _guard = crate::config::isolate_config_path_for_test("setup-execute-with-noninteractive");
+        let args = SetupArgs {
+            non_interactive: true,
+            anthropic_key: Some("sk-ant-ew".to_string()),
+            openai_key: None,
+            google_key: None,
+            openrouter_key: None,
+            ollama_url: None,
+            default_model: None,
+        };
+        // `--non-interactive` short-circuits before the reader factory runs.
+        execute_with(&args, seven_blank_lines).unwrap();
+        assert_eq!(
+            Config::load().unwrap().providers.anthropic_api_key.as_deref(),
+            Some("sk-ant-ew")
+        );
+    }
+
+    #[test]
+    fn execute_with_interactive_reads_from_the_injected_factory() {
+        let _guard = crate::config::isolate_config_path_for_test("setup-execute-with-interactive");
+        let args = SetupArgs {
+            non_interactive: false,
+            anthropic_key: None,
+            openai_key: None,
+            google_key: None,
+            openrouter_key: None,
+            ollama_url: None,
+            default_model: None,
+        };
+        execute_with(&args, seven_blank_lines).unwrap();
     }
 }

--- a/crates/leviath-cli/src/commands/setup.rs
+++ b/crates/leviath-cli/src/commands/setup.rs
@@ -939,11 +939,11 @@ mod tests {
     // ─── config-path write-through ───────────────────────────────────────
     //
     // The `execute()` entrypoint (branch on `non_interactive`, and the real
-    // stdin read for the interactive path) now lives in the binary's
-    // `real_setup`; the library keeps the two fully-tested cores. This test
-    // pins the same guarantee `execute_non_interactive_...` used to — that
-    // `run_non_interactive_setup` writes through `Config::config_path()` —
-    // exercised directly against the core with an isolated config path.
+    // stdin read for the interactive path) lives in the binary's `real_setup`;
+    // the library keeps the two fully-tested cores. This test pins the
+    // guarantee that `run_non_interactive_setup` writes through
+    // `Config::config_path()`, exercised directly against the core with an
+    // isolated config path.
 
     #[test]
     fn run_non_interactive_setup_writes_through_config_path() {
@@ -983,7 +983,8 @@ mod tests {
 
     #[test]
     fn execute_with_non_interactive_applies_flags_and_never_builds_the_reader() {
-        let _guard = crate::config::isolate_config_path_for_test("setup-execute-with-noninteractive");
+        let _guard =
+            crate::config::isolate_config_path_for_test("setup-execute-with-noninteractive");
         let args = SetupArgs {
             non_interactive: true,
             anthropic_key: Some("sk-ant-ew".to_string()),
@@ -996,7 +997,11 @@ mod tests {
         // `--non-interactive` short-circuits before the reader factory runs.
         execute_with(&args, seven_blank_lines).unwrap();
         assert_eq!(
-            Config::load().unwrap().providers.anthropic_api_key.as_deref(),
+            Config::load()
+                .unwrap()
+                .providers
+                .anthropic_api_key
+                .as_deref(),
             Some("sk-ant-ew")
         );
     }

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -1344,7 +1344,7 @@ max_tokens = 5000
 
     /// Covers `fs::read_to_string(&manifest_path)?` failing by making
     /// `agent.leviath` a *directory*: `exists()` passes the guard but the read
-    /// fails on every platform (the prior version used `chmod 0o000`, Unix-only).
+    /// fails on every platform.
     #[tokio::test]
     async fn execute_with_registry_manifest_unreadable_errors() {
         let dir = tempfile::tempdir().unwrap();
@@ -1418,8 +1418,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     }
 
     /// Covers `fs::read_dir(&tests_dir)?` failing by making `tests` a *file*:
-    /// `exists()` passes the guard but `read_dir` fails on every platform (the
-    /// prior version used `chmod 0o000`, Unix-only).
+    /// `exists()` passes the guard but `read_dir` fails on every platform.
     #[tokio::test]
     async fn execute_with_registry_tests_dir_unreadable_errors() {
         let dir = tempfile::tempdir().unwrap();
@@ -1447,8 +1446,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     /// Covers `fs::read_to_string(&test_path)?` for a `.toml` entry by making
     /// it a *directory* (extension is still `toml`): `read_dir` yields it but
-    /// the read fails on every platform (the prior version used `chmod 0o000`,
-    /// Unix-only).
+    /// the read fails on every platform.
     #[tokio::test]
     async fn execute_with_registry_toml_unreadable_errors() {
         let dir = tempfile::tempdir().unwrap();
@@ -1477,8 +1475,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     /// Covers `fs::read_to_string(&test_path)?` for a `.rhai` entry by making
     /// it a *directory* (extension is still `rhai`): `read_dir` yields it but
-    /// the read fails on every platform (the prior version used `chmod 0o000`,
-    /// Unix-only).
+    /// the read fails on every platform.
     #[tokio::test]
     async fn execute_with_registry_rhai_unreadable_errors() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -856,8 +856,7 @@ max_iterations = 5
     fn check_manifest_unreadable_file_is_io_error() {
         // `agent.leviath` exists but is a *directory*, so it's found via
         // `.exists()` yet `read_to_string` fails on every platform, exercising
-        // the read_to_string map_err arm. The prior version used `chmod 0o000`,
-        // which only fails on Unix.
+        // the read_to_string map_err arm.
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("agent.leviath")).unwrap();
 

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -22,10 +22,9 @@ pub enum ToolPolicy {
     Deny,
 }
 
-// `TitleConfig` (plain data used by the engine's title generation) now lives in
+// `TitleConfig` (plain data used by the engine's title generation) lives in
 // `leviath_core::config` so `leviath-runtime` can reference it without a CLI
-// dependency. Re-exported here so existing `crate::config::TitleConfig` paths
-// continue to resolve unchanged.
+// dependency. Re-exported here so `crate::config::TitleConfig` paths resolve.
 pub use leviath_core::config::TitleConfig;
 
 /// CLI configuration.
@@ -391,21 +390,19 @@ pub(crate) static CONFIG_PATH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex:
 /// Serializes any test, anywhere in the crate, that mutates the
 /// process-global `PATH` env var (e.g. to starve editor/clipboard-tool
 /// resolution). Declared here for the same reason as `CONFIG_PATH_ENV_LOCK`
-/// above: `commands/run/session.rs`'s `launch_editor` tests and
-/// `commands/dashboard/helpers.rs`'s clipboard-fallback test each used to
-/// hold only their own file-local lock, which doesn't actually serialize
-/// against each other since each is a distinct Rust item despite the shared
-/// name -- a real (if narrow) cross-file race window.
+/// above: a per-file lock (as in `commands/run/session.rs`'s `launch_editor`
+/// tests and `commands/dashboard/helpers.rs`'s clipboard-fallback test) does
+/// not serialize against another file's tests, since each is a distinct Rust
+/// item despite the shared name -- a real (if narrow) cross-file race window.
 #[cfg(test)]
 pub(crate) static PATH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Serializes any test, anywhere in the crate, that mutates the process's
 /// current working directory (via `std::env::set_current_dir`) or whose
 /// assertions implicitly depend on it. Declared here for the same reason as
-/// `CONFIG_PATH_ENV_LOCK`/`PATH_ENV_LOCK` above: `commands/run/manifest.rs`'s
-/// CWD-dependent `find_manifest` tests previously held only their own
-/// file-local lock, which wouldn't actually serialize against a CWD-mutating
-/// test added to a different file later.
+/// `CONFIG_PATH_ENV_LOCK`/`PATH_ENV_LOCK` above: a per-file lock (as in
+/// `commands/run/manifest.rs`'s CWD-dependent `find_manifest` tests) would not
+/// serialize against a CWD-mutating test in a different file.
 #[cfg(test)]
 pub(crate) static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -16,9 +16,8 @@
 //!   as `main.rs`'s `RealExecutors`, which simply wires real I/O into the
 //!   library's already-tested command cores.
 //!
-//! This replaces the previous `#[cfg(not(test))]`/`#[cfg(test)]` twin trick:
-//! injection gives the same "routing is tested, real I/O is never touched by a
-//! test" guarantee without any coverage escape hatch in library code.
+//! Injection gives a "routing is tested, real I/O is never touched by a test"
+//! guarantee without any coverage escape hatch in library code.
 
 use crate::commands;
 

--- a/crates/leviath-cli/src/interaction.rs
+++ b/crates/leviath-cli/src/interaction.rs
@@ -106,12 +106,12 @@ pub fn clear_interaction(run_id: &str) {
 
 /// The decision produced by a single iteration of a request-polling loop.
 ///
-/// The polling loops used to inline the "did a matching response arrive? did we
-/// time out? otherwise keep waiting" logic, which made their coverage depend on
-/// wall-clock timing (whether a response happened to be present on the first
-/// poll or a later one). Extracting that decision into this pure, synchronous
-/// helper lets every arm be unit-tested deterministically — no sleeping, no
-/// races — so the loops themselves collapse into a thin `match`.
+/// Extracting this decision into a pure, synchronous helper — rather than
+/// inlining the "did a matching response arrive? did we time out? otherwise
+/// keep waiting" logic in each polling loop — lets every arm be unit-tested
+/// deterministically (no sleeping, no races, no dependence on whether a
+/// response happened to be present on the first poll or a later one), so the
+/// loops themselves collapse into a thin `match`.
 enum PollStep {
     /// A matching response is available; the loop should resume with it.
     Answer(InteractionResponse),
@@ -1871,9 +1871,9 @@ mod tests {
 
     // ─── Deterministic loop-arm coverage (pre-written stale response) ──────
     //
-    // Each polling loop's `KeepWaiting => continue` arm previously depended on
-    // whether a real response happened to be present on the first poll or a
-    // later one — a wall-clock race that made coverage nondeterministic. These
+    // Naively, each polling loop's `KeepWaiting => continue` arm depends on
+    // whether a real response happens to be present on the first poll or a
+    // later one — a wall-clock race that would make coverage nondeterministic. These
     // tests pre-write a STALE response (a different `request_id`) BEFORE calling,
     // so the very first poll is *guaranteed* to consume it and take the
     // KeepWaiting/continue path — regardless of scheduling — via take_response's

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -21,7 +21,6 @@ use tracing::info;
 
 use leviath_cli::commands;
 use leviath_cli::commands::dashboard::{CrosstermEventSource, DashboardArgs, TerminalSetup};
-use leviath_cli::config::Config;
 use leviath_cli::dispatch::{dispatch, Commands, RiskyExecutors};
 
 /// Leviath CLI - Agent framework with structured context windows
@@ -62,7 +61,9 @@ impl RiskyExecutors for RealExecutors {
     }
 
     async fn setup(&self, args: commands::setup::SetupArgs) -> anyhow::Result<()> {
-        real_setup(args)
+        // The interactive arm reads the process's real stdin; the branch +
+        // config wiring is the tested `setup::execute_with`.
+        commands::setup::execute_with(&args, || io::stdin().lock())
     }
 
     async fn dashboard(&self, args: DashboardArgs) -> anyhow::Result<()> {
@@ -76,21 +77,6 @@ impl RiskyExecutors for RealExecutors {
     async fn worker(&self, args: commands::run::WorkerArgs) -> anyhow::Result<()> {
         commands::run::execute_worker(args).await
     }
-}
-
-/// Real `lev setup`: the branch on `--non-interactive` plus the interactive
-/// path's real `stdin().lock()`. The two cores it calls
-/// (`run_non_interactive_setup` / `run_interactive_setup`) are unit-tested.
-fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
-    let mut config = Config::load().unwrap_or_default();
-    let save_path = Config::config_path();
-
-    if args.non_interactive {
-        return commands::setup::run_non_interactive_setup(&mut config, &args, &save_path);
-    }
-
-    let stdin = io::stdin();
-    commands::setup::run_interactive_setup(&mut config, &mut stdin.lock(), &save_path)
 }
 
 /// Real `lev dash`: supplies the real crossterm terminal backend and event

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -8,6 +8,7 @@
 //! to the library's real command entrypoints — live here rather than behind a
 //! `#[cfg(not(test))]` coverage escape hatch in library code.
 
+use std::fs::File;
 use std::io;
 
 use clap::Parser;
@@ -104,12 +105,30 @@ async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
     commands::dashboard::execute_with(&mut setup, &mut events, real_yank).await
 }
 
-/// Real clipboard copy for the dashboard's `y` keypress: native tool then the
-/// real OSC52 `/dev/tty` write (`leviath_sys::osc52_yank`). The native-tool /
-/// fallback branch logic is unit-tested in `yank_to_clipboard_via`; the real
-/// terminal write is tested in `leviath_sys::tty`.
+/// Real clipboard copy for the dashboard's `y` keypress: try a native tool,
+/// then fall back to writing the OSC52 escape sequence to the real controlling
+/// terminal / stdout. The native-tool + fallback branch logic is unit-tested in
+/// `yank_to_clipboard_via`; `leviath_sys::osc52_write_via`'s branches are
+/// unit-tested via injected fakes. The two real-I/O leaves it composes here —
+/// opening `/dev/tty` and acquiring `stdout()` — are the un-unit-testable slivers.
 fn real_yank(text: &str) -> bool {
-    commands::dashboard::yank_to_clipboard_via(text, leviath_sys::osc52_yank)
+    commands::dashboard::yank_to_clipboard_via(text, |t| {
+        let mut out = io::stdout();
+        leviath_sys::osc52_write_via(t, open_controlling_tty, &mut out)
+    })
+}
+
+/// Open the process's controlling terminal (`/dev/tty` on Unix) for writing the
+/// OSC52 clipboard escape sequence. Errors on non-Unix, where `real_yank` then
+/// falls back to stdout.
+#[cfg(unix)]
+fn open_controlling_tty() -> io::Result<File> {
+    std::fs::OpenOptions::new().write(true).open("/dev/tty")
+}
+
+#[cfg(not(unix))]
+fn open_controlling_tty() -> io::Result<File> {
+    Err(io::Error::other("no controlling terminal on this platform"))
 }
 
 /// Real foreground I/O bundle: real stdin for interactions and the message

--- a/crates/leviath-cli/src/render.rs
+++ b/crates/leviath-cli/src/render.rs
@@ -988,7 +988,7 @@ mod tests {
         // `Start(Item)` pushes the bullet marker into `current_spans`, then
         // `Start(Heading)` fires with no Text/other event in between --
         // exercises the `!self.current_spans.is_empty()` flush at heading
-        // start (previously only ever empty by the time headings occurred).
+        // start.
         let md = "- # nested heading in item\n- item2";
         let text = markdown_to_text(md, 80);
         let all: String = text

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -148,10 +148,10 @@ pub fn append_dashboard_log_to(path: &Path, msg: &str) {
 
 /// Process-wide counter mixed into [`new_run_id`]'s suffix so that multiple
 /// runs spawned in a tight loop (e.g. `lev run --count N`) within the same
-/// wall-clock second never collide. Before this, the suffix was derived
-/// purely from `now` (whole seconds), so every run in a `--count N` batch
-/// got the *same* run ID -- silently collapsing N runs into one on-disk
-/// entry and leaving N-1 worker processes writing state nobody could see.
+/// wall-clock second never collide. Without it, a suffix derived purely from
+/// `now` (whole seconds) gives every run in a `--count N` batch the *same* run
+/// ID -- silently collapsing N runs into one on-disk entry and leaving N-1
+/// worker processes writing state nobody could see.
 static RUN_ID_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 /// Generate a unique run ID: "<agent_name>-<timestamp>-<suffix>".
@@ -423,13 +423,13 @@ impl Drop for RunsDirTestGuard {
 /// ...) never touch the real `~/.leviath/runs/` or `~/.leviath/dashboard.log`.
 ///
 /// This matters more than it looks: those are the exact files `lev dash`/
-/// `lev serve` read from. Before this guard existed, tests wrote real
-/// fixture entries (`agent_name: "test"`, `workdir: "/tmp"`, etc.) straight
-/// into the user's actual runs directory. Most got cleaned up by each test's
-/// own `remove_dir_all` at the end -- but a test process killed mid-run
-/// (e.g. Ctrl+C on a hung test) never reaches that cleanup, so the entries
-/// stayed behind permanently, showing up as orphaned "waiting" agents in the
-/// user's real dashboard.
+/// `lev serve` read from. Without this guard, tests writing real fixture
+/// entries (`agent_name: "test"`, `workdir: "/tmp"`, etc.) straight into the
+/// user's actual runs directory can leave orphans behind: most get cleaned up
+/// by each test's own `remove_dir_all` at the end, but a test process killed
+/// mid-run (e.g. Ctrl+C on a hung test) never reaches that cleanup, so the
+/// entries stay behind permanently, showing up as orphaned "waiting" agents in
+/// the user's real dashboard.
 #[cfg(test)]
 pub(crate) fn isolate_runs_dir_for_test(unique: &str) -> RunsDirTestGuard {
     let lock = RUNS_DIR_ENV_LOCK
@@ -1329,8 +1329,7 @@ mod tests {
         // Covers the `if let Ok(entries) = std::fs::read_dir(&dir)` pattern
         // *not* matching: `dir.exists()` is true (so the earlier early-return
         // is skipped) but `read_dir` fails, so the whole block is silently
-        // skipped. Pointing at a *file* makes `read_dir` fail on every platform
-        // (the prior version used a `chmod 0o000` directory, Unix-only).
+        // skipped. Pointing at a *file* makes `read_dir` fail on every platform.
         let dir = tempfile::tempdir().unwrap();
         let not_a_dir = dir.path().join("runs-is-a-file");
         std::fs::write(&not_a_dir, "not a dir").unwrap();
@@ -1342,9 +1341,7 @@ mod tests {
     fn append_stage_output_open_failure_is_silently_skipped() {
         // When `output.log` already exists as a *directory*, `OpenOptions::open`
         // fails and the write is silently skipped (the `if let Ok(file)` false
-        // path). Making the target a directory fails the open on every platform;
-        // this branch was previously only reached incidentally via a
-        // `chmod 0o555` read-only run dir (Unix-only).
+        // path). Making the target a directory fails the open on every platform.
         let _guard = crate::runstate::isolate_runs_dir_for_test("append_stage_output_open_failure");
         let run_id = "append-out-openfail";
         ensure_stage_dir(run_id, 0);
@@ -1720,8 +1717,7 @@ mod tests {
         // A subdirectory with NO meta.json exercises the *other* skip branch:
         // the `if let Ok(json) = read_to_string(&meta_path)` else arm (the file
         // can't be read), distinct from the parse-fails arm above. Covering
-        // both here keeps list_runs_in_dir at 100% on every OS deterministically
-        // (previously one arm happened to be hit only on some platforms).
+        // both here keeps list_runs_in_dir at 100% on every OS deterministically.
         let no_meta_run_id = "cov-listed-no-meta-run";
         std::fs::create_dir_all(tmpdir.path().join(no_meta_run_id)).unwrap();
 

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -1,24 +1,14 @@
-//! Shared test-only tracing-coverage helper.
+//! Shared test-only helpers for this crate's `#[cfg(test)]` code.
 //!
-//! There is exactly ONE copy of this in the crate on purpose:
-//! `tracing::subscriber::set_global_default` only succeeds once per test
-//! binary, so a single shared `AlwaysOnSubscriber` is the only instance that
-//! can win `set_global_default` and be invoked as the active subscriber. Any
-//! additional private copies would leave the losing copies' `Subscriber`
-//! trait-method impls (`enabled`, `new_span`, `record`, `record_follows_from`,
-//! `enter`, `exit`, ...) as dead code, inflating `cargo llvm-cov` missed
-//! regions.
+//! Keep this as the single crate-wide copy: `set_global_default` succeeds only
+//! once per test binary, so only one `AlwaysOnSubscriber` can become the active
+//! subscriber. Duplicate copies would leave the losing ones' trait methods as
+//! uncovered dead code.
 
-/// Minimal no-op `Subscriber` that reports every callsite as enabled.
-///
-/// Without an active subscriber, `tracing::warn!`/`info!`/`debug!` calls
-/// short-circuit their field-argument evaluation before ever reaching it
-/// (no subscriber means the "is this level enabled" check fails first) --
-/// so a multi-line `tracing::warn!(...)` call's field-list lines show as
-/// uncovered by `cargo llvm-cov` even when the surrounding branch
-/// genuinely executes and is asserted on. This bare `Subscriber` impl is
-/// the proven-working pattern used across this workspace (see
-/// `leviath-core/src/layout.rs`).
+/// No-op `Subscriber` that reports every callsite as enabled. A `tracing::`
+/// macro skips evaluating its fields when no subscriber is interested, so
+/// running code under [`with_tracing`] (which installs this) is what makes
+/// those macro-argument lines execute — and count as covered.
 pub(crate) struct AlwaysOnSubscriber;
 
 impl tracing::Subscriber for AlwaysOnSubscriber {
@@ -37,12 +27,8 @@ impl tracing::Subscriber for AlwaysOnSubscriber {
     fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
     fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
     fn event(&self, event: &tracing::Event<'_>) {
-        // `register_callsite` always returns `Interest::always()`, so
-        // tracing's dispatch macros cache every callsite as
-        // "always enabled" and never call `enabled` again afterward.
-        // Call it directly here (with real metadata from a live event)
-        // so this trait-impl boilerplate method isn't itself left
-        // uncovered.
+        // Callsites are cached as always-enabled, so `enabled` is never called
+        // via the macros; call it here so it's exercised.
         assert!(self.enabled(event.metadata()));
     }
     fn enter(&self, _span: &tracing::span::Id) {}
@@ -57,29 +43,18 @@ impl tracing::Subscriber for AlwaysOnSubscriber {
 pub(crate) fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
     static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INSTALLED.get_or_init(|| {
-        // set_global_default registers AlwaysOnSubscriber in LOCKED_DISPATCHERS
-        // (the global dispatcher registry). rebuild_interest_cache then re-evaluates
-        // every callsite against the global subscriber, setting interest to "always".
-        // Without this, tracing macro inner blocks are unreachable in tests because
-        // with_default (thread-local) is NOT consulted during callsite registration,
-        // leaving every callsite cached as interest=never (no global dispatcher).
+        // `rebuild_interest_cache` is required: callsites registered before the
+        // global default is set are cached as interest=never, so without it the
+        // macro bodies stay unreachable (and uncovered) in tests.
         let _ = tracing::subscriber::set_global_default(AlwaysOnSubscriber);
         tracing::callsite::rebuild_interest_cache();
     });
     f()
 }
 
-/// A value that always fails to serialize, for forcing `?`-propagated
-/// `serde_json::to_string`/`to_string_pretty` error arms in tests.
-///
-/// Every "write JSON to disk" helper across this crate serializes a
-/// trivially-serializable struct (`String`/`usize`/enums/`HashMap`s), so
-/// `serde_json::to_string_pretty(...)?` can never actually fail in
-/// practice -- there is no real input that trips it. Rather than leave
-/// those `?` error arms permanently uncovered (or fake up something more
-/// exotic), this wraps an arbitrary payload behind a `Serialize` impl that
-/// deterministically returns `Err`, so tests can drive the real error path
-/// through the real (non-generic-only-for-tests) code, honestly.
+/// A value whose `Serialize` impl always returns `Err`, so tests can drive the
+/// `?` error arm of the crate's `serde_json::to_string_pretty(...)?` helpers
+/// (which serialize trivially-serializable structs that never fail on real input).
 pub(crate) struct PoisonSerialize;
 
 impl serde::Serialize for PoisonSerialize {
@@ -127,20 +102,9 @@ mod tests {
         assert!(err.to_string().contains("PoisonSerialize always fails"));
     }
 
-    /// Exercises the no-op span-related trait methods (`new_span`, `record`,
-    /// `record_follows_from`, `enter`, `exit`) that aren't reachable via
-    /// plain `tracing::info!`/`warn!` event macros used elsewhere in this
-    /// crate.
-    ///
-    /// COVERAGE-CONFIRMED-ARTIFACT: the `tracing::info!(parent: &span, "inside
-    /// span")` call below genuinely executes (confirmed via HTML: the line
-    /// shows a nonzero hit count) and is what exercises `AlwaysOnSubscriber::event`
-    /// with a real, live event -- but llvm-cov's tracing-macro message-literal
-    /// region-counting quirk (the same one documented on `config.rs`'s
-    /// `log_permissive_perms_warning`) still reports that literal's region as
-    /// a miss. Since this is already test code, no `#[cfg(not(test))]` twin
-    /// applies here (there's nothing to isolate it from -- the whole point of
-    /// this test is exercising the macro under a real subscriber).
+    /// Exercises the span-related trait methods (`new_span`, `record`,
+    /// `record_follows_from`, `enter`, `exit`, `event`) that plain
+    /// `tracing::info!`/`warn!` event macros elsewhere don't reach.
     #[test]
     fn always_on_subscriber_span_methods_are_all_no_ops() {
         with_tracing(|| {

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -2,18 +2,12 @@
 //!
 //! There is exactly ONE copy of this in the crate on purpose:
 //! `tracing::subscriber::set_global_default` only succeeds once per test
-//! binary, so before this module existed, every file in this crate that had
-//! its own private copy of `AlwaysOnSubscriber` left every *other* file's
-//! copy permanently dead code -- whichever file's test happened to run
-//! first "won" `set_global_default`, and the losing files' `Subscriber`
-//! trait-method impls (`enabled`, `new_span`, `record`,
-//! `record_follows_from`, `enter`, `exit`, ...) could never actually be
-//! invoked as an active subscriber, inflating `cargo llvm-cov` missed
-//! regions across most of those files. `rebuild_interest_cache()` still
-//! made tracing-macro coverage globally correct regardless of which
-//! instance won (that's the original bug this pattern fixes), but the
-//! losing copies' own methods stayed dead. Consolidating to one shared
-//! instance fixes that structurally.
+//! binary, so a single shared `AlwaysOnSubscriber` is the only instance that
+//! can win `set_global_default` and be invoked as the active subscriber. Any
+//! additional private copies would leave the losing copies' `Subscriber`
+//! trait-method impls (`enabled`, `new_span`, `record`, `record_follows_from`,
+//! `enter`, `exit`, ...) as dead code, inflating `cargo llvm-cov` missed
+//! regions.
 
 /// Minimal no-op `Subscriber` that reports every callsite as enabled.
 ///

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -1030,16 +1030,14 @@ sys.stdout.close()
     // notification flush gets EPIPE. The process stays alive (sleeping) so the
     // process itself doesn't exit before our write attempt.
     //
-    // Ordering note: os.close(0) happens BEFORE the response is written to
-    // stdout, not after. A previous version closed stdin after flushing the
-    // response, reasoning that "os.close(0) happens synchronously between
-    // Python's stdout.flush() return and our notification write" -- but
-    // that's not actually a happens-before relationship from our side: our
-    // client can finish reading the response and race ahead to the
-    // notification write while the child is still merely *about* to execute
-    // the next line, before the close(0) syscall has actually completed.
-    // That race was flaky (passed on some CI runners, failed on others,
-    // depending on process-scheduling speed). Closing stdin first guarantees
+    // Ordering note: os.close(0) MUST happen BEFORE the response is written to
+    // stdout, not after. Closing after flushing the response is NOT a
+    // happens-before relationship from our side: our client can finish reading
+    // the response and race ahead to the notification write while the child is
+    // still merely *about* to execute the next line, before the close(0)
+    // syscall has actually completed. That race is flaky (passes on some CI
+    // runners, fails on others, depending on process-scheduling speed).
+    // Closing stdin first guarantees
     // the read end is fully closed before the response bytes can even be
     // sent, which our client necessarily observes only after they're sent --
     // so by the time we read the response and attempt the notification

--- a/crates/leviath-mcp/src/test_support.rs
+++ b/crates/leviath-mcp/src/test_support.rs
@@ -11,9 +11,7 @@
 //! `_guard` binding kept alive across `.await` points on a single-threaded
 //! runtime) makes those field expressions actually evaluate.
 //!
-//! This was previously duplicated verbatim in `discovery.rs`, `execution.rs`,
-//! and `client.rs`; it now lives here once and is shared via
-//! `crate::test_support::always_on_tracing_guard`.
+//! Shared via `crate::test_support::always_on_tracing_guard`.
 //!
 //! `tracing::subscriber::set_default` installs a thread-local, scope-guarded
 //! default (returned as a `DefaultGuard`) rather than a process-global one,

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -445,8 +445,7 @@ mod tests {
     // by calling the walk directly with a `base` equal to the file being
     // appended: `strip_prefix(base)` then yields an *empty* relative path, which
     // `tar::Builder::append_path_with_name` rejects on every platform ("paths in
-    // archives must have at least one component"). The prior version made the
-    // file unreadable via `chmod 0o000`, which only fails on Unix.
+    // archives must have at least one component").
     #[test]
     fn test_add_directory_to_tar_append_failure_returns_error() {
         let dir = tempfile::tempdir().unwrap();
@@ -636,8 +635,7 @@ mod tests {
     // exercises, in one go, the recursive read-dir map_err (`Failed to read
     // directory`), the recursion `?` that propagates it back up, and both
     // enclosing `?`s in `write_bundle` and `bundle_with`. Injecting the reader
-    // makes this deterministic on every platform; the prior version relied on
-    // a `chmod 0o000` subdirectory, which only fails on Unix. (During real
+    // makes this deterministic on every platform. (During real
     // recursion `base` is always an ancestor of the entry, so no OS-agnostic
     // path/tar failure can surface *inside* a recursion -- injection is the
     // only cross-platform way to reach these propagation arms.)

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -532,9 +532,7 @@ description = "{}"
         // The installed "agent" entry is a regular file rather than a
         // directory: `exists()` passes the guard, but `remove_dir_all`
         // requires a directory and fails on every platform (NotADirectory),
-        // exercising the "Failed to remove agent" error arm. The prior version
-        // removed write permission from the parent directory, which only fails
-        // on Unix (and not when running as root).
+        // exercising the "Failed to remove agent" error arm.
         let dir = tempfile::tempdir().unwrap();
         let installer = AgentInstaller::with_install_dir(dir.path().to_path_buf());
         let agent_path = dir.path().join("not-a-dir");

--- a/crates/leviath-package/src/test_support.rs
+++ b/crates/leviath-package/src/test_support.rs
@@ -1,7 +1,7 @@
 //! Shared test-only tracing-coverage helper — exactly ONE copy per crate on
 //! purpose. `tracing::subscriber::set_global_default` only succeeds once per
-//! test binary; every file that previously had its own private copy left the
-//! losing copies' trait methods permanently dead. This structurally fixes that.
+//! test binary, so a single shared subscriber keeps every trait method
+//! reachable as the active subscriber.
 
 pub(crate) struct AlwaysOnSubscriber;
 

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -1352,9 +1352,9 @@ mod tests {
     fn build_request_body_caps_total_cache_control_at_4_with_many_system_regions() {
         use leviath_core::CacheHint;
         // issue #12 regression: 5 cacheable system regions (architecture/
-        // program_flows/plan/task pinned + files hashmap) previously emitted 5
-        // `cache_control` blocks → hard Anthropic 400. They must now consolidate
-        // within the 4-block total budget.
+        // program_flows/plan/task pinned + files hashmap) must consolidate
+        // within the 4-block total `cache_control` budget; emitting 5
+        // `cache_control` blocks is a hard Anthropic 400.
         let provider = AnthropicProvider::new("test-key".to_string());
         let system = vec![
             crate::SystemBlock {

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -389,9 +389,9 @@ mod tests {
     #[tokio::test]
     async fn acquire_prunes_expired_token_count_entries() {
         // acquire()'s pruning loop also prunes `token_counts` (shared state
-        // with check_tpm()'s own, separate pruning loop) -- no prior test
-        // seeded an expired token_counts entry before calling acquire()
-        // itself, so that pop_front() call was never exercised from this
+        // with check_tpm()'s own, separate pruning loop) -- no other test
+        // seeds an expired token_counts entry before calling acquire()
+        // itself, so that pop_front() call is otherwise unexercised from this
         // function.
         let limiter = RateLimiter::new(&RateLimitConfig {
             requests_per_minute: 60,

--- a/crates/leviath-providers/src/test_support.rs
+++ b/crates/leviath-providers/src/test_support.rs
@@ -10,9 +10,7 @@
 //! this as the default subscriber for a test's duration makes those field
 //! expressions actually evaluate.
 //!
-//! This was previously duplicated verbatim in `anthropic.rs`, `ollama.rs`,
-//! `gemini.rs`, `openai.rs`, `openrouter.rs`, and `rate_limit.rs`; it now
-//! lives here once and is shared via `crate::test_support::always_on_tracing_guard`.
+//! Shared via `crate::test_support::always_on_tracing_guard`.
 //!
 //! `tracing::subscriber::set_default` installs a thread-local, scope-guarded
 //! default (returned as a `DefaultGuard`) rather than a process-global one,

--- a/crates/leviath-runtime/src/engine.rs
+++ b/crates/leviath-runtime/src/engine.rs
@@ -1215,15 +1215,14 @@ impl AgentEngine {
     ///
     /// This split exists purely for coverage measurement, not behavior.
     /// `cargo-llvm-cov` instruments each monomorphization of a generic
-    /// function separately; this function used to contain the whole loop
-    /// body directly, and with ~15-20 call sites (each passing a distinct
-    /// closure type) that meant ~15-20 separate coverage-mapping instances
-    /// of the same branches. Even though every branch was covered by the
-    /// union of all tests, llvm-cov would occasionally report a region as
-    /// uncovered for one instantiation, undercounting real coverage. Moving
-    /// the logic into one non-generic method compiles it (and instruments
-    /// it) exactly once, regardless of how many distinct closure types call
-    /// through this wrapper.
+    /// function separately: if this function contained the whole loop body
+    /// directly, its ~15-20 call sites (each passing a distinct closure type)
+    /// would produce ~15-20 separate coverage-mapping instances of the same
+    /// branches. Even when every branch is covered by the union of all tests,
+    /// llvm-cov can report a region as uncovered for one instantiation,
+    /// undercounting real coverage. Keeping the logic in one non-generic method
+    /// compiles it (and instruments it) exactly once, regardless of how many
+    /// distinct closure types call through this wrapper.
     #[allow(clippy::too_many_arguments)]
     pub async fn run_inference_loop_filtered<'p, F, Fut>(
         &mut self,
@@ -1672,7 +1671,7 @@ mod tests {
         );
 
         // Sweep every char budget from 0 through the full length: exercises the
-        // mid-multibyte-char cut points that used to panic.
+        // mid-multibyte-char cut points, which must not panic.
         for max_chars in 0..=text.chars().count() + 5 {
             let out = truncate_on_char_boundary(&text, max_chars);
             // `out` is a valid `String` by construction; assert the invariants.

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 //! Shared test-only tracing-coverage helper — exactly ONE copy per crate on
 //! purpose. `tracing::subscriber::set_global_default` only succeeds once per
-//! test binary; every file that previously had its own private copy left the
-//! losing copies' trait methods permanently dead. This structurally fixes that.
+//! test binary, so a single shared subscriber keeps every trait method
+//! reachable as the active subscriber.
 
 pub(crate) struct AlwaysOnSubscriber;
 

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -8,20 +8,22 @@
 //!
 //! ## Why this crate exists
 //!
-//! 1. **De-duplication.** The same `setsid`/`pre_exec` detach, `libc::kill`,
-//!    and `Permissions::from_mode(0o600)` logic was previously copy-pasted
-//!    across a dozen call sites in `leviath-cli`. There is now exactly one
-//!    implementation of each.
+//! 1. **De-duplication.** The `setsid`/`pre_exec` detach, `libc::kill`, and
+//!    `Permissions::from_mode(0o600)` logic each has exactly one implementation
+//!    here, rather than being spread across call sites in `leviath-cli`.
 //! 2. **Per-OS coverage correctness.** Because all platform code is gathered
 //!    into cfg-gated submodules ([`platform`]), the non-target
 //!    implementations (`#[cfg(windows)]` on a Linux CI run) are simply not
 //!    compiled, so the coverage tool never sees them as gaps. The
 //!    Linux-visible code paths are all reachable from real unit tests.
-//! 3. **Testability.** The genuinely-untestable leaf syscalls (installing a
-//!    `pre_exec` hook, opening `/dev/tty`, killing a live pid) keep a
-//!    `#[cfg(not(test))]` real / `#[cfg(test)]` no-op "twin" — but that twin
-//!    now lives *once*, inside this crate, so downstream crates stay clean and
-//!    fully coverable.
+//! 3. **Testability.** Every function in this crate is exercised by real unit
+//!    tests — the syscalls here are either safe to call under test (`setsid`
+//!    fails harmlessly, `kill` on a nonexistent pid returns `ESRCH`, `chmod` on
+//!    a tempfile) or split behind an injected seam ([`tty::osc52_write_via`]
+//!    takes the tty opener + sink; `perms`' hardening op is a `fn` pointer). The
+//!    only genuinely-untestable real-I/O leaves (opening `/dev/tty`, writing the
+//!    real `stdout()`) are composed in the CLI binary, not here — so this crate
+//!    contains no `#[cfg(not(test))]`.
 
 mod platform;
 
@@ -31,4 +33,4 @@ pub mod tty;
 
 pub use perms::{ensure_file_private, secure_dir_perms, secure_file_perms};
 pub use process::{configure_detached, terminate};
-pub use tty::osc52_yank;
+pub use tty::osc52_write_via;

--- a/crates/leviath-sys/src/tty.rs
+++ b/crates/leviath-sys/src/tty.rs
@@ -2,16 +2,15 @@
 //!
 //! OSC52 is a last-resort clipboard mechanism: it asks the *terminal emulator*
 //! to set the system clipboard, so it works over SSH and without any native
-//! clipboard tool. The bytes must reach the real terminal — either the
-//! controlling `/dev/tty` or stdout — which is exactly what cannot be observed
-//! from a unit test without corrupting the terminal that `cargo test` runs in.
+//! clipboard tool. The bytes must reach the real terminal — the controlling
+//! `/dev/tty` or stdout.
 //!
-//! The genuinely-untestable leaves ([`open_controlling_tty`] and the real
-//! `stdout()` write inside [`osc52_yank`]) are isolated behind `#[cfg(test)]`
-//! twins so they are never compiled into a test/coverage build. All of the
-//! surrounding branch logic ([`osc52_sequence`], [`osc52_write_via`]) is
-//! exercised for real on Linux by injecting fake openers and an in-memory sink
-//! (see the tests), so nothing here relies on a coverage exclusion.
+//! This module holds the pure, fully-tested pieces: [`osc52_sequence`] (the
+//! base64/escape encoding) and [`osc52_write_via`] (the tty-then-stdout branch
+//! logic, parameterized over the tty opener and the fallback sink so every
+//! branch is exercised via injected fakes). The genuinely-untestable real-I/O
+//! leaves (opening `/dev/tty`, writing the real `stdout()`) are composed in the
+//! CLI binary — see `real_yank` in `crates/leviath-cli/src/main.rs`.
 
 use std::fs::File;
 use std::io::{self, Write};
@@ -50,42 +49,17 @@ fn osc52_sequence(text: &str) -> String {
     format!("\x1b]52;c;{}\x07", encoded)
 }
 
-/// Open the process's controlling terminal for writing.
-///
-/// REAL-IO-EXCLUDED: the real body opens `/dev/tty` (Unix); exercising it from
-/// a test would write OSC escape bytes to the terminal running `cargo test`.
-/// The `#[cfg(test)]` twin always fails harmlessly instead, and
-/// [`osc52_write_via`]'s branch logic is covered directly via injected openers.
-/// The real body is never compiled into a test build, so it never counts toward
-/// coverage.
-#[cfg(not(test))]
-fn open_controlling_tty() -> io::Result<File> {
-    #[cfg(unix)]
-    {
-        std::fs::OpenOptions::new().write(true).open("/dev/tty")
-    }
-    #[cfg(not(unix))]
-    {
-        Err(io::Error::other("no controlling terminal on this platform"))
-    }
-}
-
-#[cfg(test)]
-fn open_controlling_tty() -> io::Result<File> {
-    Err(io::Error::other(
-        "open_controlling_tty is disabled under cfg(test)",
-    ))
-}
-
 /// Core OSC52 write logic, parameterized over how to open the TTY and where the
 /// stdout fallback writes, so every branch is exercisable without touching a
-/// real terminal.
+/// real terminal. `pub` so the CLI binary can compose it with the real
+/// `/dev/tty` opener + real `stdout()` (the un-unit-testable leaves) — see
+/// `real_yank` in `crates/leviath-cli/src/main.rs`.
 ///
 /// The fallback is a `&mut dyn Write` (not a generic `T: Write`) deliberately:
 /// a single vtable dispatch on this cold, human-driven path costs nothing, and
 /// a non-generic function has exactly one coverage-mapping instance instead of
 /// one per caller type — no phantom-uncovered monomorphization for llvm-cov.
-fn osc52_write_via(
+pub fn osc52_write_via(
     text: &str,
     open_tty: fn() -> io::Result<File>,
     stdout_fallback: &mut dyn Write,
@@ -99,32 +73,6 @@ fn osc52_write_via(
     // Fallback: write to stdout. Report the real outcome so callers can show an
     // error when even this fails.
     stdout_fallback.write_all(osc.as_bytes()).is_ok() && stdout_fallback.flush().is_ok()
-}
-
-/// Copy `text` to the clipboard using the OSC52 terminal escape sequence.
-///
-/// Tries the controlling `/dev/tty` first, then falls back to stdout. Returns
-/// whether the sequence was written. Intended as a last-resort fallback after
-/// native clipboard tools (`pbcopy`/`xclip`/`wl-copy`) have been tried.
-///
-/// REAL-IO-EXCLUDED: the real body writes to the process's actual `stdout()`
-/// (and `/dev/tty`); running it in a test would corrupt the terminal running
-/// `cargo test`. The `#[cfg(test)]` twin swaps an in-memory sink in, keeping
-/// identical control flow, and `osc52_write_via`'s branches are covered
-/// directly. The real body is never compiled into a test build.
-#[cfg(not(test))]
-pub fn osc52_yank(text: &str) -> bool {
-    let mut out = io::stdout();
-    osc52_write_via(text, open_controlling_tty, &mut out)
-}
-
-#[cfg(test)]
-pub fn osc52_yank(text: &str) -> bool {
-    // Never write to the real terminal from a test — it corrupts (and can
-    // hang) the terminal running `cargo test`. The in-memory sink keeps the
-    // exact same control flow while touching nothing real.
-    let mut out = Vec::new();
-    osc52_write_via(text, open_controlling_tty, &mut out)
 }
 
 #[cfg(test)]
@@ -238,17 +186,5 @@ mod tests {
             !sink.buf.is_empty(),
             "write should have run before flush failed"
         );
-    }
-
-    #[test]
-    fn open_controlling_tty_twin_errors_under_test() {
-        assert!(open_controlling_tty().is_err());
-    }
-
-    #[test]
-    fn osc52_yank_writes_without_touching_a_real_terminal() {
-        // Under cfg(test): the failing tty twin + in-memory sink, exercising
-        // the yank entry point end-to-end.
-        assert!(osc52_yank("clipboard text"));
     }
 }

--- a/xtask/src/check_exclusions.rs
+++ b/xtask/src/check_exclusions.rs
@@ -797,8 +797,8 @@ mod tests {
 
     #[test]
     fn cfg_not_test_in_leviath_sys_is_also_a_violation() {
-        // leviath-sys used to be the one allowlisted crate; the ban is now flat,
-        // so a gate there (even marker+twin) is flagged like anywhere else.
+        // The cfg(not(test)) ban is flat (no allowlisted crate), so a gate in
+        // leviath-sys (even marker+twin) is flagged like anywhere else.
         let dir = TempDir::new().unwrap();
         let sys = dir.path().join("crates").join("leviath-sys").join("src");
         std::fs::create_dir_all(&sys).unwrap();

--- a/xtask/src/check_exclusions.rs
+++ b/xtask/src/check_exclusions.rs
@@ -53,9 +53,18 @@ pub fn report_violations(violations: Vec<Violation>) -> Result<()> {
 
 // ── Banned patterns ──────────────────────────────────────────────────────────
 
+/// How a [`BannedPattern`] is matched against a single source line.
+pub enum LineMatch {
+    /// Fire if the line contains `pattern` anywhere (case-sensitive substring).
+    Contains,
+    /// Fire only if the whole *trimmed* line equals `pattern`. Used for
+    /// attributes, so a backtick mention inside a doc comment isn't flagged.
+    WholeLine,
+}
+
 /// A string pattern that must not appear in the codebase.
 pub struct BannedPattern {
-    /// Exact substring to search for (case-sensitive).
+    /// The pattern to look for (case-sensitive).
     pub pattern: &'static str,
     /// Human-readable explanation for the error message.
     pub reason: &'static str,
@@ -63,15 +72,36 @@ pub struct BannedPattern {
     pub check_rs: bool,
     /// Apply this check to CI / config / hook files.
     pub check_config: bool,
+    /// How `pattern` is matched against each line.
+    pub match_mode: LineMatch,
 }
 
+/// Every forbidden marker as one declarative table. Adding a rule is a single
+/// entry here; this is the only place a suppression pattern is checked.
 pub const BANNED: &[BannedPattern] = &[
+    // ── `#[cfg(not(test))]` — the one attribute that hides real code FROM
+    //    coverage, so it's the only way to dodge the 100% gate. Banned in every
+    //    crate, no exceptions: un-unit-testable real-I/O lives in the
+    //    coverage-excluded `lev` binary (main.rs) or behind an injected seam
+    //    (RiskyExecutors / execute_with / ForegroundIo /
+    //    leviath_sys::osc52_write_via), never behind this attribute. Whole-line
+    //    match so a backtick mention in a doc comment isn't a false positive.
+    BannedPattern {
+        pattern: "#[cfg(not(test))]",
+        reason: "#[cfg(not(test))] hides real code from coverage and is banned in every \
+                 crate — put un-unit-testable real-I/O in the coverage-excluded `lev` binary \
+                 (main.rs) or behind an injected seam, not behind this attribute",
+        check_rs: true,
+        check_config: false,
+        match_mode: LineMatch::WholeLine,
+    },
     // ── Coverage-attribute suppression (nightly feature) ────────────────────
     BannedPattern {
         pattern: "coverage(off)",
         reason: "coverage(off) suppression is forbidden — refactor the code to be testable instead",
         check_rs: true,
         check_config: false,
+        match_mode: LineMatch::Contains,
     },
     // ── Tarpaulin markers ────────────────────────────────────────────────────
     BannedPattern {
@@ -79,18 +109,21 @@ pub const BANNED: &[BannedPattern] = &[
         reason: "tarpaulin coverage annotation is forbidden",
         check_rs: true,
         check_config: true,
+        match_mode: LineMatch::Contains,
     },
     BannedPattern {
         pattern: "cfg(tarpaulin)",
         reason: "tarpaulin cfg gate is forbidden",
         check_rs: true,
         check_config: false,
+        match_mode: LineMatch::Contains,
     },
     BannedPattern {
         pattern: "cfg(not(tarpaulin))",
         reason: "tarpaulin cfg gate is forbidden",
         check_rs: true,
         check_config: false,
+        match_mode: LineMatch::Contains,
     },
     // ── grcov / lcov exclusion comments ─────────────────────────────────────
     BannedPattern {
@@ -98,12 +131,14 @@ pub const BANNED: &[BannedPattern] = &[
         reason: "LCOV exclusion marker is forbidden",
         check_rs: true,
         check_config: true,
+        match_mode: LineMatch::Contains,
     },
     BannedPattern {
         pattern: "GRCOV_EXCL",
         reason: "grcov exclusion marker is forbidden",
         check_rs: true,
         check_config: true,
+        match_mode: LineMatch::Contains,
     },
     // ── Tarpaulin as a CI tool ───────────────────────────────────────────────
     BannedPattern {
@@ -111,12 +146,14 @@ pub const BANNED: &[BannedPattern] = &[
         reason: "tarpaulin is not the designated coverage tool; use `cargo xtask coverage` instead",
         check_rs: false,
         check_config: true,
+        match_mode: LineMatch::Contains,
     },
     BannedPattern {
         pattern: "cargo tarpaulin",
         reason: "tarpaulin is not the designated coverage tool; use `cargo xtask coverage` instead",
         check_rs: false,
         check_config: true,
+        match_mode: LineMatch::Contains,
     },
 ];
 
@@ -131,10 +168,9 @@ pub struct Violation {
     pub line_num: usize,
     /// The raw line content (untrimmed).
     pub line: String,
-    /// The banned pattern that matched (or a short tag identifying which
-    /// structural check fired).
+    /// The banned pattern that matched.
     pub pattern: &'static str,
-    /// Human-readable reason (owned so checks can build a message dynamically).
+    /// Human-readable reason.
     pub reason: String,
 }
 
@@ -205,7 +241,14 @@ pub fn scan_file(path: &Path, is_rs: bool, violations: &mut Vec<Violation>) {
     for (line_idx, line) in content.lines().enumerate() {
         for banned in BANNED {
             let applies = (is_rs && banned.check_rs) || (!is_rs && banned.check_config);
-            if applies && line.contains(banned.pattern) {
+            if !applies {
+                continue;
+            }
+            let hit = match banned.match_mode {
+                LineMatch::Contains => line.contains(banned.pattern),
+                LineMatch::WholeLine => line.trim() == banned.pattern,
+            };
+            if hit {
                 violations.push(Violation {
                     file: path.to_owned(),
                     line_num: line_idx + 1,
@@ -215,48 +258,6 @@ pub fn scan_file(path: &Path, is_rs: bool, violations: &mut Vec<Violation>) {
                 });
             }
         }
-    }
-
-    if is_rs {
-        scan_cfg_not_test_escape_hatches(path, &content, violations);
-    }
-}
-
-// ── `#[cfg(not(test))]` ban ──────────────────────────────────────────────────
-//
-// `#[cfg(not(test))]` hides its real body from coverage measurement, so it is
-// the one attribute that could be used to dodge testing. The policy is a single
-// flat rule: it is **banned in every crate, no exceptions** — no marker, no
-// allowlisted crate, no cap. Every library crate is 100%-covered; the only
-// un-unit-testable real-I/O (real terminal, blocking stdin, port bind,
-// subprocess spawn, opening `/dev/tty`, writing real `stdout()`) lives in the
-// coverage-excluded `lev` binary (`main.rs`) or behind an injected seam (the
-// dispatch `RiskyExecutors` trait, dashboard `execute_with`, the run
-// `ForegroundIo` bundle, `leviath_sys::osc52_write_via`). A new real-I/O leaf
-// goes in the (approval-gated) bin, never behind a `#[cfg(not(test))]`.
-//
-// This is a line-style scan: it flags the exact `#[cfg(not(test))]` attribute
-// on its own line, so doc-comment mentions in backticks are ignored.
-
-/// Scan a single file's already-read `content` for the banned
-/// `#[cfg(not(test))]` attribute.
-fn scan_cfg_not_test_escape_hatches(path: &Path, content: &str, violations: &mut Vec<Violation>) {
-    for (idx, line) in content.lines().enumerate() {
-        if line.trim() != "#[cfg(not(test))]" {
-            continue;
-        }
-        violations.push(Violation {
-            file: path.to_owned(),
-            line_num: idx + 1,
-            line: line.to_owned(),
-            pattern: "cfg(not(test)) is banned",
-            reason:
-                "#[cfg(not(test))] hides real code from coverage and is banned in every crate. \
-                 Un-unit-testable real-I/O belongs in the coverage-excluded `lev` binary \
-                 (main.rs) or behind an injected seam (RiskyExecutors / execute_with / \
-                 ForegroundIo / leviath_sys::osc52_write_via), not behind this attribute."
-                    .to_owned(),
-        });
     }
 }
 
@@ -675,8 +676,7 @@ mod tests {
     fn cfg_not_test_is_a_violation() {
         let v = scan_content("#[cfg(not(test))]\nfn real_thing() {}\n", true);
         assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            v.iter().any(|v| v.pattern.contains("cfg(not(test))")),
             "expected a cfg(not(test)) violation: {v:?}"
         );
     }
@@ -698,8 +698,7 @@ mod tests {
         let mut v = Vec::new();
         scan_file(&path, true, &mut v);
         assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            v.iter().any(|v| v.pattern.contains("cfg(not(test))")),
             "leviath-sys is no longer exempt: {v:?}"
         );
     }
@@ -710,8 +709,7 @@ mod tests {
         // the attribute line itself.
         let v = scan_content("#[cfg(not(test))]\nuse std::io::Write;\n", true);
         assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            v.iter().any(|v| v.pattern.contains("cfg(not(test))")),
             "expected a cfg(not(test)) violation: {v:?}"
         );
     }
@@ -724,8 +722,7 @@ mod tests {
             true,
         );
         assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            v.iter().any(|v| v.pattern.contains("cfg(not(test))")),
             "a comment must not whitelist cfg(not(test)): {v:?}"
         );
     }
@@ -745,8 +742,7 @@ mod tests {
             true,
         );
         assert!(
-            !v.iter()
-                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            !v.iter().any(|v| v.pattern.contains("cfg(not(test))")),
             "a doc-comment mention must not be flagged: {v:?}"
         );
     }

--- a/xtask/src/check_exclusions.rs
+++ b/xtask/src/check_exclusions.rs
@@ -132,11 +132,9 @@ pub struct Violation {
     /// The raw line content (untrimmed).
     pub line: String,
     /// The banned pattern that matched (or a short tag identifying which
-    /// structural check fired, for the non-banned-pattern checks below).
+    /// structural check fired).
     pub pattern: &'static str,
-    /// Human-readable reason. Owned (rather than `&'static str`) because the
-    /// `#[cfg(not(test))]` escape-hatch checks below need to interpolate the
-    /// offending function's name into the message.
+    /// Human-readable reason (owned so checks can build a message dynamically).
     pub reason: String,
 }
 
@@ -221,7 +219,6 @@ pub fn scan_file(path: &Path, is_rs: bool, violations: &mut Vec<Violation>) {
 
     if is_rs {
         scan_cfg_not_test_escape_hatches(path, &content, violations);
-        scan_coverage_confirmed_artifact_markers(path, &content, violations);
     }
 }
 
@@ -261,117 +258,6 @@ fn scan_cfg_not_test_escape_hatches(path: &Path, content: &str, violations: &mut
                     .to_owned(),
         });
     }
-}
-
-/// Extract the function name from a line containing a `fn` declaration, e.g.
-/// `pub(crate) async fn foo<T>(x: T) -> T {` -> `Some("foo")`. Returns `None`
-/// if the line has no standalone `fn` token.
-fn extract_fn_name(line: &str) -> Option<String> {
-    let mut tokens = line.split_whitespace();
-    while let Some(tok) = tokens.next() {
-        if tok == "fn" {
-            let name_tok = tokens.next()?;
-            let end = name_tok.find(['(', '<', ':']).unwrap_or(name_tok.len());
-            let name = &name_tok[..end];
-            return if name.is_empty() {
-                None
-            } else {
-                Some(name.to_owned())
-            };
-        }
-    }
-    None
-}
-
-// ── `COVERAGE-CONFIRMED-ARTIFACT` marker audit ──────────────────────────────
-//
-// A narrower, DIFFERENT category from the `#[cfg(not(test))]` escape hatch
-// above: code that IS fully exercised by real, passing tests (every logical
-// branch demonstrably runs -- confirmed by direct JSON/HTML segment
-// inspection showing every source position has at least one covered
-// instantiation) but which `cargo-llvm-cov`'s region-counting mechanism
-// still undercounts anyway, most often because of generic-function
-// monomorphization: a shared generic helper called with several concrete
-// type arguments gets one region-coverage row per source position in the
-// summary table, but that table's cross-instantiation merge does not
-// consistently mark the position covered even when at least one
-// instantiation's copy of it genuinely executed.
-//
-// Using `#[cfg(not(test))]` isolation for this would be dishonest -- it
-// would hide genuinely-tested code from measurement instead of correctly
-// counting it as covered -- so it gets its own marker instead, deliberately
-// with NO twin requirement (there is no swapped-out real/fake pair here,
-// just one real function). Every function tagged with this marker must have a
-// non-empty, reviewable justification, and the marker must actually be attached
-// (via an immediately-following doc-comment/attribute block) to a real `fn` --
-// not left floating as an unattached comment.
-
-/// Doc-comment marker required on any function claimed to be a confirmed
-/// `cargo-llvm-cov` region-counting artifact (tested for real, undercounted
-/// anyway) rather than a genuine coverage gap.
-const COVERAGE_CONFIRMED_ARTIFACT_MARKER: &str = "COVERAGE-CONFIRMED-ARTIFACT:";
-
-/// Scan a single file's already-read `content` for `COVERAGE-CONFIRMED-ARTIFACT`
-/// marker violations: an empty reason, or a marker not attached to a `fn`.
-fn scan_coverage_confirmed_artifact_markers(
-    path: &Path,
-    content: &str,
-    violations: &mut Vec<Violation>,
-) {
-    let lines: Vec<&str> = content.lines().collect();
-
-    for (idx, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with("///") {
-            continue;
-        }
-        let Some(pos) = trimmed.find(COVERAGE_CONFIRMED_ARTIFACT_MARKER) else {
-            continue;
-        };
-
-        let reason = trimmed[pos + COVERAGE_CONFIRMED_ARTIFACT_MARKER.len()..].trim();
-        if reason.is_empty() {
-            violations.push(Violation {
-                file: path.to_owned(),
-                line_num: idx + 1,
-                line: (*line).to_owned(),
-                pattern: "COVERAGE-CONFIRMED-ARTIFACT missing reason",
-                reason: "COVERAGE-CONFIRMED-ARTIFACT marker has no non-empty reason after \
-                          the colon"
-                    .to_owned(),
-            });
-            continue;
-        }
-
-        if fn_name_after_doc_or_attr_block(&lines, idx + 1).is_none() {
-            violations.push(Violation {
-                file: path.to_owned(),
-                line_num: idx + 1,
-                line: (*line).to_owned(),
-                pattern: "COVERAGE-CONFIRMED-ARTIFACT not attached to a fn",
-                reason: "COVERAGE-CONFIRMED-ARTIFACT marker must be immediately followed \
-                          (skipping further doc lines/attributes) by a `fn` declaration"
-                    .to_owned(),
-            });
-        }
-    }
-}
-
-/// Starting at `start_idx`, skip blank lines, further `///` doc-comment
-/// lines, and `#[...]` attribute lines, then try to read a function name off
-/// the first substantive line found. Returns `None` if that line isn't a
-/// `fn` declaration.
-fn fn_name_after_doc_or_attr_block(lines: &[&str], start_idx: usize) -> Option<String> {
-    let mut i = start_idx;
-    while i < lines.len() {
-        let trimmed = lines[i].trim();
-        if trimmed.is_empty() || trimmed.starts_with("///") || trimmed.starts_with("#[") {
-            i += 1;
-            continue;
-        }
-        return extract_fn_name(trimmed);
-    }
-    None
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -863,82 +749,6 @@ mod tests {
                 .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
             "a doc-comment mention must not be flagged: {v:?}"
         );
-    }
-
-    // ── `COVERAGE-CONFIRMED-ARTIFACT` marker audit ────────────────────────────
-
-    #[test]
-    fn coverage_confirmed_artifact_with_reason_and_fn_is_clean() {
-        let v = scan_content(
-            "/// COVERAGE-CONFIRMED-ARTIFACT: generic monomorphization undercounts \
-             this despite every instantiation being covered (confirmed via HTML).\n\
-             fn generic_helper() {}\n",
-            true,
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn coverage_confirmed_artifact_missing_reason_is_violation() {
-        let v = scan_content(
-            "/// COVERAGE-CONFIRMED-ARTIFACT:\nfn generic_helper() {}\n",
-            true,
-        );
-        assert!(
-            v.iter().any(|v| v
-                .pattern
-                .contains("COVERAGE-CONFIRMED-ARTIFACT missing reason")),
-            "expected a missing-reason violation: {v:?}"
-        );
-    }
-
-    #[test]
-    fn coverage_confirmed_artifact_not_attached_to_fn_is_violation() {
-        let v = scan_content(
-            "/// COVERAGE-CONFIRMED-ARTIFACT: some reason\nstruct NotAFunction;\n",
-            true,
-        );
-        assert!(
-            v.iter().any(|v| v
-                .pattern
-                .contains("COVERAGE-CONFIRMED-ARTIFACT not attached to a fn")),
-            "expected a not-attached-to-fn violation: {v:?}"
-        );
-    }
-
-    #[test]
-    fn coverage_confirmed_artifact_as_last_line_of_file_is_violation() {
-        let v = scan_content("/// COVERAGE-CONFIRMED-ARTIFACT: some reason", true);
-        assert!(
-            v.iter().any(|v| v
-                .pattern
-                .contains("COVERAGE-CONFIRMED-ARTIFACT not attached to a fn")),
-            "expected a not-attached-to-fn violation: {v:?}"
-        );
-    }
-
-    #[test]
-    fn coverage_confirmed_artifact_skips_further_doc_lines_and_attributes() {
-        let v = scan_content(
-            "/// COVERAGE-CONFIRMED-ARTIFACT: some reason, explained further\n\
-             /// across multiple doc-comment lines before the attribute.\n\
-             #[allow(dead_code)]\n\
-             fn generic_helper() {}\n",
-            true,
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn coverage_confirmed_artifact_in_plain_comment_is_ignored() {
-        // A plain `//` comment doesn't count as the CONFIRMED-ARTIFACT
-        // doc-comment marker even if it contains the right literal text (this
-        // marker is scoped to `///` lines only).
-        let v = scan_content(
-            "// COVERAGE-CONFIRMED-ARTIFACT: some reason\nfn generic_helper() {}\n",
-            true,
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
     }
 
     #[test]

--- a/xtask/src/check_exclusions.rs
+++ b/xtask/src/check_exclusions.rs
@@ -154,28 +154,6 @@ pub fn scan_workspace_from(root: &Path) -> Result<Vec<Violation>> {
         scan_dir(&crates_dir, true, &mut violations)?;
     }
 
-    // Cap the number of `#[cfg(not(test))]` gates in the one allowed crate
-    // (leviath-sys), so real-IO exclusions can't accrete silently. Raising the
-    // cap is a deliberate, reviewed change to `MAX_SYS_EXCLUSIONS`.
-    let sys_dir = crates_dir.join(ALLOWED_CFG_NOT_TEST_CRATE);
-    if sys_dir.exists() {
-        let count = count_cfg_not_test_gates(&sys_dir);
-        if count > MAX_SYS_EXCLUSIONS {
-            violations.push(Violation {
-                file: sys_dir.clone(),
-                line_num: 0,
-                line: String::new(),
-                pattern: "cfg(not(test)) cap exceeded in leviath-sys",
-                reason: format!(
-                    "crates/{ALLOWED_CFG_NOT_TEST_CRATE}/ has {count} #[cfg(not(test))] gates but \
-                     the cap (MAX_SYS_EXCLUSIONS) is {MAX_SYS_EXCLUSIONS}. Prefer an injected seam \
-                     over a new real-IO exclusion; if one is genuinely unavoidable, raise the cap \
-                     deliberately in xtask/src/check_exclusions.rs."
-                ),
-            });
-        }
-    }
-
     // CI and config files
     for rel in &[
         ".github/workflows/ci.yml",
@@ -247,180 +225,42 @@ pub fn scan_file(path: &Path, is_rs: bool, violations: &mut Vec<Violation>) {
     }
 }
 
-// ── `#[cfg(not(test))]` escape-hatch audit ──────────────────────────────────
+// ── `#[cfg(not(test))]` ban ──────────────────────────────────────────────────
 //
 // `#[cfg(not(test))]` hides its real body from coverage measurement, so it is
-// the one attribute an agent could use to dodge testing. The policy is a single
-// unabusable PATH rule: it is **banned in every crate except `leviath-sys`** —
-// the leaf crate that quarantines raw OS syscalls. There is no marker that
-// makes it acceptable in ordinary library code, so it can't be smuggled in
-// with a plausible-looking justification. Un-unit-testable real-I/O composition
-// (real terminal, blocking stdin, port bind, subprocess spawn, real inference)
-// belongs in the coverage-excluded `lev` binary (`main.rs`) or behind an
-// injected seam (see the dispatch `RiskyExecutors` trait, dashboard
-// `execute_with`, and the run `ForegroundIo` bundle).
+// the one attribute that could be used to dodge testing. The policy is a single
+// flat rule: it is **banned in every crate, no exceptions** — no marker, no
+// allowlisted crate, no cap. Every library crate is 100%-covered; the only
+// un-unit-testable real-I/O (real terminal, blocking stdin, port bind,
+// subprocess spawn, opening `/dev/tty`, writing real `stdout()`) lives in the
+// coverage-excluded `lev` binary (`main.rs`) or behind an injected seam (the
+// dispatch `RiskyExecutors` trait, dashboard `execute_with`, the run
+// `ForegroundIo` bundle, `leviath_sys::osc52_write_via`). A new real-I/O leaf
+// goes in the (approval-gated) bin, never behind a `#[cfg(not(test))]`.
 //
-// Inside `leviath-sys` the attribute is permitted for the final syscall leaves,
-// but still audited:
-// 1. Every gate must be immediately preceded (skipping blanks/attributes) by a
-//    `// REAL-IO-EXCLUDED: <non-empty reason>` comment (`//` or `///`) — a
-//    reviewable justification.
-// 2. Every `#[cfg(not(test))]`-gated `fn NAME` must have a matching
-//    `#[cfg(test)]`-gated `fn NAME` twin in the same file, so the surrounding
-//    logic stays testable.
-// 3. The total number of gates in `leviath-sys` is capped at
-//    [`MAX_SYS_EXCLUSIONS`] (enforced in `scan_workspace_from`) — raising it is
-//    a deliberate, reviewed diff.
-//
-// This is a line/regex-style scan (matching the rest of this file), not a full
-// parser: it looks for the exact `#[cfg(not(test))]` / `#[cfg(test)]` attribute
-// on its own line, and reads a function name off the next non-blank,
-// non-attribute line by splitting on the `fn` token. It is deliberately
-// tolerant of being fooled by unusual formatting — the existing scanner in this
-// file makes the same trade-off.
+// This is a line-style scan: it flags the exact `#[cfg(not(test))]` attribute
+// on its own line, so doc-comment mentions in backticks are ignored.
 
-/// Doc-comment marker required immediately before every `#[cfg(not(test))]`
-/// item that lives in `crates/leviath-sys/` (the ONE crate permitted to use the
-/// attribute — see the module doc above), explaining why the real body cannot
-/// be exercised by a real test.
-const REAL_IO_EXCLUDED_MARKER: &str = "REAL-IO-EXCLUDED:";
-
-/// The directory whose `#[cfg(not(test))]` uses are permitted (the leaf crate
-/// that quarantines raw OS syscalls). Matched as a path component so it never
-/// false-matches a substring.
-const ALLOWED_CFG_NOT_TEST_CRATE: &str = "leviath-sys";
-
-/// Hard cap on the number of `#[cfg(not(test))]` gates allowed inside
-/// `crates/leviath-sys/`. Raising it is a deliberate, reviewed one-line diff —
-/// the ratchet that stops real-IO exclusions accreting silently.
-const MAX_SYS_EXCLUSIONS: usize = 2;
-
-/// True if `path` is inside the one crate permitted to use `#[cfg(not(test))]`.
-fn is_allowed_cfg_not_test_path(path: &Path) -> bool {
-    path.components()
-        .any(|c| c.as_os_str() == ALLOWED_CFG_NOT_TEST_CRATE)
-}
-
-/// Recursively count `#[cfg(not(test))]` attribute lines under `dir` (a
-/// trimmed exact match, so doc-comment mentions in backticks don't count),
-/// skipping `target/` and hidden dirs. Used to enforce [`MAX_SYS_EXCLUSIONS`].
-fn count_cfg_not_test_gates(dir: &Path) -> usize {
-    let mut count = 0;
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if name != "target" && !name.starts_with('.') {
-                count += count_cfg_not_test_gates(&path);
-            }
-        } else if path.extension().is_some_and(|e| e == "rs") {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                count += content
-                    .lines()
-                    .filter(|l| l.trim() == "#[cfg(not(test))]")
-                    .count();
-            }
-        }
-    }
-    count
-}
-
-/// Scan a single file's already-read `content` for `#[cfg(not(test))]`
-/// escape-hatch violations (see the module doc above for the two rules).
+/// Scan a single file's already-read `content` for the banned
+/// `#[cfg(not(test))]` attribute.
 fn scan_cfg_not_test_escape_hatches(path: &Path, content: &str, violations: &mut Vec<Violation>) {
-    let lines: Vec<&str> = content.lines().collect();
-    let allowed = is_allowed_cfg_not_test_path(path);
-
-    // Every `fn NAME` immediately gated by `#[cfg(test)]` anywhere in the
-    // file — the pool of legitimate "twins" (only relevant inside the allowed
-    // crate).
-    let mut test_fn_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for (idx, line) in lines.iter().enumerate() {
-        if line.trim() == "#[cfg(test)]" {
-            if let Some(name) = fn_name_after_attribute(&lines, idx) {
-                test_fn_names.insert(name);
-            }
-        }
-    }
-
-    for (idx, line) in lines.iter().enumerate() {
+    for (idx, line) in content.lines().enumerate() {
         if line.trim() != "#[cfg(not(test))]" {
             continue;
         }
-
-        // Rule 1 (path ban): `#[cfg(not(test))]` is forbidden in every crate
-        // except `leviath-sys`. There is no marker that can satisfy this in
-        // ordinary library code — the escape hatch is a physical location, not
-        // a comment, so it can't be forged by dropping in a justification.
-        if !allowed {
-            violations.push(Violation {
-                file: path.to_owned(),
-                line_num: idx + 1,
-                line: (*line).to_owned(),
-                pattern: "cfg(not(test)) outside crates/leviath-sys",
-                reason:
-                    "#[cfg(not(test))] is banned in library code. Real-I/O composition belongs in \
-                     the (coverage-excluded) `lev` binary or behind an injected seam (see the \
-                     dispatch `RiskyExecutors` pattern and `main.rs`); only crates/leviath-sys/ \
-                     (raw OS syscalls) may use #[cfg(not(test))], and only with a \
-                     `REAL-IO-EXCLUDED:` justification + a #[cfg(test)] twin"
-                        .to_owned(),
-            });
-            continue;
-        }
-
-        // Inside leviath-sys: require the `REAL-IO-EXCLUDED:` justification on
-        // every gate (fn/method, `use`, `impl`, `struct`, or inline block)...
-        if !preceded_by_real_io_excluded_marker(&lines, idx) {
-            violations.push(Violation {
-                file: path.to_owned(),
-                line_num: idx + 1,
-                line: (*line).to_owned(),
-                pattern: "cfg(not(test)) missing REAL-IO-EXCLUDED marker",
-                reason: "#[cfg(not(test))] in leviath-sys must be immediately preceded by a \
-                     `// REAL-IO-EXCLUDED: <reason>` comment explaining why the real body cannot \
-                     be exercised by a test"
+        violations.push(Violation {
+            file: path.to_owned(),
+            line_num: idx + 1,
+            line: line.to_owned(),
+            pattern: "cfg(not(test)) is banned",
+            reason:
+                "#[cfg(not(test))] hides real code from coverage and is banned in every crate. \
+                 Un-unit-testable real-I/O belongs in the coverage-excluded `lev` binary \
+                 (main.rs) or behind an injected seam (RiskyExecutors / execute_with / \
+                 ForegroundIo / leviath_sys::osc52_write_via), not behind this attribute."
                     .to_owned(),
-            });
-        }
-
-        // ...and, when it gates a `fn`, a matching `#[cfg(test)]` twin so the
-        // surrounding logic stays testable.
-        if let Some(fn_name) = fn_name_after_attribute(&lines, idx) {
-            if !test_fn_names.contains(&fn_name) {
-                violations.push(Violation {
-                    file: path.to_owned(),
-                    line_num: idx + 1,
-                    line: (*line).to_owned(),
-                    pattern: "cfg(not(test)) missing #[cfg(test)] twin",
-                    reason: format!(
-                        "fn `{fn_name}` is #[cfg(not(test))] but has no matching #[cfg(test)] \
-                         fn `{fn_name}` in the same file"
-                    ),
-                });
-            }
-        }
+        });
     }
-}
-
-/// Starting just after `attr_idx`, skip blank lines and other `#[...]`
-/// attribute lines, then try to read a function name off the first
-/// substantive line found. Returns `None` if that line isn't a `fn`
-/// declaration (e.g. it's a `use`, a `mod`, or a plain `{`).
-fn fn_name_after_attribute(lines: &[&str], attr_idx: usize) -> Option<String> {
-    let mut i = attr_idx + 1;
-    while i < lines.len() {
-        let trimmed = lines[i].trim();
-        if trimmed.is_empty() || trimmed.starts_with("#[") {
-            i += 1;
-            continue;
-        }
-        return extract_fn_name(trimmed);
-    }
-    None
 }
 
 /// Extract the function name from a line containing a `fn` declaration, e.g.
@@ -443,60 +283,6 @@ fn extract_fn_name(line: &str) -> Option<String> {
     None
 }
 
-/// Scan backward from `attr_idx` (the `#[cfg(not(test))]` line), skipping
-/// blank lines and other attribute lines, to find the contiguous comment
-/// block (`//` or `///`, if any) immediately touching the attribute, then
-/// check whether ANY line in that block contains `REAL-IO-EXCLUDED:` followed
-/// by a non-empty reason.
-///
-/// Justifications are frequently multi-line -- the marker on the first line
-/// of the paragraph, with the reason continuing across further comment lines
-/// below it before the attribute -- so this doesn't require the marker to be
-/// on the single line touching the attribute, only somewhere in the comment
-/// block that does. Both `//` line comments (used on `use`/block gates) and
-/// `///` doc comments (used on `fn` gates) are accepted.
-fn preceded_by_real_io_excluded_marker(lines: &[&str], attr_idx: usize) -> bool {
-    // Skip blank lines and other attributes stacked above `attr_idx` to find
-    // where the comment block (if any) ends.
-    let mut i = attr_idx;
-    let doc_end = loop {
-        if i == 0 {
-            return false; // nothing precedes the attribute at all
-        }
-        i -= 1;
-        let trimmed = lines[i].trim();
-        if trimmed.is_empty() || trimmed.starts_with("#[") {
-            continue;
-        }
-        if !trimmed.starts_with("//") {
-            return false; // nearest substantive line isn't a comment
-        }
-        break i;
-    };
-
-    // Walk backward through the contiguous comment block starting at
-    // `doc_end`, checking every line in it for the marker.
-    let mut j = doc_end;
-    loop {
-        let trimmed = lines[j].trim();
-        if let Some(pos) = trimmed.find(REAL_IO_EXCLUDED_MARKER) {
-            if !trimmed[pos + REAL_IO_EXCLUDED_MARKER.len()..]
-                .trim()
-                .is_empty()
-            {
-                return true;
-            }
-        }
-        if j == 0 {
-            return false;
-        }
-        j -= 1;
-        if !lines[j].trim().starts_with("//") {
-            return false;
-        }
-    }
-}
-
 // ── `COVERAGE-CONFIRMED-ARTIFACT` marker audit ──────────────────────────────
 //
 // A narrower, DIFFERENT category from the `#[cfg(not(test))]` escape hatch
@@ -515,10 +301,9 @@ fn preceded_by_real_io_excluded_marker(lines: &[&str], attr_idx: usize) -> bool 
 // would hide genuinely-tested code from measurement instead of correctly
 // counting it as covered -- so it gets its own marker instead, deliberately
 // with NO twin requirement (there is no swapped-out real/fake pair here,
-// just one real function). Every function tagged with this marker must
-// still have a non-empty, reviewable justification, exactly like
-// `REAL-IO-EXCLUDED` above, and the marker must actually be attached (via
-// an immediately-following doc-comment/attribute block) to a real `fn` --
+// just one real function). Every function tagged with this marker must have a
+// non-empty, reviewable justification, and the marker must actually be attached
+// (via an immediately-following doc-comment/attribute block) to a real `fn` --
 // not left floating as an unattached comment.
 
 /// Doc-comment marker required on any function claimed to be a confirmed
@@ -605,20 +390,6 @@ mod tests {
         std::fs::write(&path, content).unwrap();
         let mut violations = Vec::new();
         scan_file(&path, is_rs, &mut violations);
-        violations
-    }
-
-    /// Like [`scan_content`] but writes under a path with a `leviath-sys`
-    /// component, so the file is treated as the one crate permitted to use
-    /// `#[cfg(not(test))]`.
-    fn scan_sys_content(content: &str) -> Vec<Violation> {
-        let dir = TempDir::new().unwrap();
-        let sys_dir = dir.path().join("crates").join("leviath-sys").join("src");
-        std::fs::create_dir_all(&sys_dir).unwrap();
-        let path = sys_dir.join("test.rs");
-        std::fs::write(&path, content).unwrap();
-        let mut violations = Vec::new();
-        scan_file(&path, true, &mut violations);
         violations
     }
 
@@ -1012,43 +783,64 @@ mod tests {
         );
     }
 
-    // ── `#[cfg(not(test))]` path-based ban ────────────────────────────────────
+    // ── `#[cfg(not(test))]` is banned everywhere ─────────────────────────────
 
     #[test]
-    fn cfg_not_test_outside_leviath_sys_is_violation() {
-        // Ordinary library code may not use `#[cfg(not(test))]` at all.
+    fn cfg_not_test_is_a_violation() {
         let v = scan_content("#[cfg(not(test))]\nfn real_thing() {}\n", true);
         assert!(
             v.iter()
-                .any(|v| v.pattern.contains("outside crates/leviath-sys")),
-            "expected an outside-leviath-sys violation: {v:?}"
+                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            "expected a cfg(not(test)) violation: {v:?}"
         );
     }
 
     #[test]
-    fn cfg_not_test_outside_leviath_sys_even_with_marker_and_twin_is_violation() {
-        // No comment can whitelist the attribute outside leviath-sys — the
-        // escape hatch is a physical location, not a forgeable marker.
+    fn cfg_not_test_in_leviath_sys_is_also_a_violation() {
+        // leviath-sys used to be the one allowlisted crate; the ban is now flat,
+        // so a gate there (even marker+twin) is flagged like anywhere else.
+        let dir = TempDir::new().unwrap();
+        let sys = dir.path().join("crates").join("leviath-sys").join("src");
+        std::fs::create_dir_all(&sys).unwrap();
+        let path = sys.join("tty.rs");
+        std::fs::write(
+            &path,
+            "// REAL-IO-EXCLUDED: whatever\n#[cfg(not(test))]\nfn leaf() {}\n\
+             #[cfg(test)]\nfn leaf() {}\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        scan_file(&path, true, &mut v);
+        assert!(
+            v.iter()
+                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            "leviath-sys is no longer exempt: {v:?}"
+        );
+    }
+
+    #[test]
+    fn cfg_not_test_on_use_is_a_violation() {
+        // Non-`fn` gates (`use`/block/etc.) are flagged too — the scan matches
+        // the attribute line itself.
+        let v = scan_content("#[cfg(not(test))]\nuse std::io::Write;\n", true);
+        assert!(
+            v.iter()
+                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            "expected a cfg(not(test)) violation: {v:?}"
+        );
+    }
+
+    #[test]
+    fn cfg_not_test_marker_does_not_whitelist() {
+        // No comment/marker exempts it — the ban is unconditional.
         let v = scan_content(
-            "// REAL-IO-EXCLUDED: real terminal write\n#[cfg(not(test))]\nfn real_thing() {}\n\n\
-             #[cfg(test)]\nfn real_thing() {}\n",
+            "// REAL-IO-EXCLUDED: real terminal write\n#[cfg(not(test))]\nfn t() {}\n",
             true,
         );
         assert!(
             v.iter()
-                .any(|v| v.pattern.contains("outside crates/leviath-sys")),
-            "a marker must not whitelist cfg(not(test)) outside leviath-sys: {v:?}"
-        );
-    }
-
-    #[test]
-    fn cfg_not_test_on_use_outside_leviath_sys_is_violation() {
-        // Even non-`fn` gates (`use`/block/etc.) are banned outside the crate.
-        let v = scan_content("#[cfg(not(test))]\nuse std::io::Write;\n", true);
-        assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("outside crates/leviath-sys")),
-            "expected an outside-leviath-sys violation: {v:?}"
+                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            "a comment must not whitelist cfg(not(test)): {v:?}"
         );
     }
 
@@ -1059,152 +851,17 @@ mod tests {
         assert!(v.is_empty(), "config files should not be scanned: {v:?}");
     }
 
-    // ── `#[cfg(not(test))]` audit inside leviath-sys (the one allowed crate) ──
-
     #[test]
-    fn sys_cfg_not_test_fn_without_marker_is_violation() {
-        let v = scan_sys_content(
-            "#[cfg(not(test))]\nfn real_thing() {}\n\n#[cfg(test)]\nfn real_thing() {}\n",
+    fn cfg_not_test_doc_comment_mention_is_not_flagged() {
+        // A backtick mention inside a doc comment is not the attribute itself.
+        let v = scan_content(
+            "/// avoid `#[cfg(not(test))]` here\nfn real_thing() {}\n",
+            true,
         );
         assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("missing REAL-IO-EXCLUDED marker")),
-            "expected a missing-marker violation: {v:?}"
-        );
-    }
-
-    #[test]
-    fn sys_cfg_not_test_fn_without_twin_is_violation() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED: real terminal write, cannot be tested\n\
-             #[cfg(not(test))]\nfn real_thing() {}\n",
-        );
-        assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("missing #[cfg(test)] twin")),
-            "expected a missing-twin violation: {v:?}"
-        );
-    }
-
-    #[test]
-    fn sys_cfg_not_test_fn_with_marker_and_twin_is_clean() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED: real terminal write, cannot be tested\n\
-             #[cfg(not(test))]\nfn real_thing() -> std::io::Result<()> { Ok(()) }\n\n\
-             #[cfg(test)]\nfn real_thing() -> std::io::Result<()> { Ok(()) }\n",
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn sys_cfg_not_test_line_comment_marker_is_accepted() {
-        // A plain `//` marker (not `///`) is accepted — non-`fn` gates in
-        // leviath-sys use line comments.
-        let v = scan_sys_content(
-            "// REAL-IO-EXCLUDED: real terminal write\n#[cfg(not(test))]\n\
-             use std::io::Write;\n",
-        );
-        assert!(v.is_empty(), "line-comment marker should satisfy: {v:?}");
-    }
-
-    #[test]
-    fn sys_cfg_not_test_marker_with_empty_reason_is_violation() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED:\n#[cfg(not(test))]\nfn real_thing() {}\n\n\
-             #[cfg(test)]\nfn real_thing() {}\n",
-        );
-        assert!(
-            v.iter()
-                .any(|v| v.pattern.contains("missing REAL-IO-EXCLUDED marker")),
-            "empty reason should still be flagged: {v:?}"
-        );
-    }
-
-    #[test]
-    fn sys_cfg_not_test_marker_skips_other_attributes_and_blank_lines() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED: real terminal write, cannot be tested\n\
-             \n\
-             #[allow(dead_code)]\n\
-             #[cfg(not(test))]\n\
-             fn real_thing() {}\n\n\
-             #[cfg(test)]\nfn real_thing() {}\n",
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn sys_cfg_not_test_marker_on_first_line_of_multiline_block_is_accepted() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED: opens the real /dev/tty; exercising it would\n\
-             /// write escape bytes to the terminal running `cargo test`.\n\
-             #[cfg(not(test))]\nfn real_thing() {}\n\n\
-             #[cfg(test)]\nfn real_thing() {}\n",
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn sys_cfg_not_test_fn_name_extraction_handles_pub_async_generic() {
-        let v = scan_sys_content(
-            "/// REAL-IO-EXCLUDED: real subprocess spawn, cannot be tested\n\
-             #[cfg(not(test))]\npub(crate) async fn spawn_it<T>(x: T) -> T { x }\n\n\
-             #[cfg(test)]\npub(crate) async fn spawn_it<T>(x: T) -> T { x }\n",
-        );
-        assert!(v.is_empty(), "expected no violations: {v:?}");
-    }
-
-    #[test]
-    fn sys_cfg_not_test_missing_both_marker_and_twin_reports_two_violations() {
-        let v = scan_sys_content("#[cfg(not(test))]\nfn real_thing() {}\n");
-        assert_eq!(v.len(), 2, "expected both violations: {v:?}");
-    }
-
-    // ── leviath-sys exclusion cap ─────────────────────────────────────────────
-
-    #[test]
-    fn sys_cfg_not_test_over_cap_is_violation() {
-        // A fake workspace whose leviath-sys crate has MAX_SYS_EXCLUSIONS + 1
-        // gates must trip the cap.
-        let dir = TempDir::new().unwrap();
-        let sys = dir.path().join("crates").join("leviath-sys").join("src");
-        std::fs::create_dir_all(&sys).unwrap();
-        let mut body = String::new();
-        for i in 0..MAX_SYS_EXCLUSIONS + 1 {
-            body.push_str(&format!(
-                "// REAL-IO-EXCLUDED: leaf {i}\n#[cfg(not(test))]\nfn leaf_{i}() {{}}\n\
-                 #[cfg(test)]\nfn leaf_{i}() {{}}\n\n"
-            ));
-        }
-        std::fs::write(sys.join("lib.rs"), body).unwrap();
-        let violations = scan_workspace_from(dir.path()).unwrap();
-        assert!(
-            violations
-                .iter()
-                .any(|v| v.pattern.contains("cap exceeded in leviath-sys")),
-            "expected a cap violation: {violations:?}"
-        );
-    }
-
-    #[test]
-    fn sys_cfg_not_test_at_cap_is_clean() {
-        let dir = TempDir::new().unwrap();
-        let sys = dir.path().join("crates").join("leviath-sys").join("src");
-        std::fs::create_dir_all(&sys).unwrap();
-        let mut body = String::new();
-        for i in 0..MAX_SYS_EXCLUSIONS {
-            body.push_str(&format!(
-                "// REAL-IO-EXCLUDED: leaf {i}\n#[cfg(not(test))]\nfn leaf_{i}() {{}}\n\
-                 #[cfg(test)]\nfn leaf_{i}() {{}}\n\n"
-            ));
-        }
-        std::fs::write(sys.join("lib.rs"), body).unwrap();
-        let violations = scan_workspace_from(dir.path()).unwrap();
-        assert!(
-            !violations
-                .iter()
-                .any(|v| v.pattern.contains("cap exceeded")),
-            "at-cap should be clean: {violations:?}"
+            !v.iter()
+                .any(|v| v.pattern.contains("cfg(not(test)) is banned")),
+            "a doc-comment mention must not be flagged: {v:?}"
         );
     }
 

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -11,9 +11,9 @@
 //! `-ignore-filename-regex`, and with or without limiting `llvm-cov` to a
 //! single worker thread (`-num-threads=1`) — so it isn't a race in llvm-cov's
 //! own thread pool, it's deterministic. There is no known workaround short of
-//! an upstream LLVM fix, so this project no longer requests `--branch` at
-//! all, and the toolchain no longer needs to be pinned to a specific nightly:
-//! branch coverage was the only reason nightly was required (source-based
+//! an upstream LLVM fix, so this project does not request `--branch` at
+//! all, and the toolchain does not need to be pinned to a specific nightly:
+//! branch coverage is the only reason nightly would be required (source-based
 //! coverage instrumentation itself, `-C instrument-coverage`, has worked on
 //! stable Rust for years).
 //!
@@ -49,9 +49,8 @@
 //! one instantiation exercises but another doesn't is counted as missed. That
 //! per-instantiation jitter (its size and even *which* files it lands on vary
 //! by OS/toolchain — the same `getInstantiationGroups` family of quirks behind
-//! the `--branch` crash and the `--workspace` inaccuracy above) is why this
-//! project historically enforced a tolerance ceiling on missed regions rather
-//! than a hard 100%. Instead of tolerating that noise, we eliminate it: we read
+//! the `--branch` crash and the `--workspace` inaccuracy above) is noise this
+//! project eliminates rather than tolerating: we read
 //! llvm-cov's per-function `regions` arrays directly and key each **code**
 //! region (`Kind == 0`) by `(filename, line/col start, line/col end)`, counting
 //! a position as covered if *any* instantiation executed it (see


### PR DESCRIPTION
Follow-up to #20. Finishes the testing strategy: **the entire library is now genuinely 100% unit-tested** and the *only* untested code is a minimal, approval-gated binary entrypoint.

## 1. Eliminate the final 2 `#[cfg(not(test))]`
Moved the tty real-I/O leaves (`open_controlling_tty` + the real `stdout()` write) out of `leviath-sys/tty.rs` into the coverage-excluded `lev` binary. `leviath-sys` keeps the pure `osc52_sequence` + branch-logic `osc52_write_via` (now `pub`), still 100%-covered via injected fakes on every OS. **The workspace now has ZERO `#[cfg(not(test))]`.**

## 2. Lint: ban `cfg(not(test))` everywhere
Collapsed `xtask`'s escape-hatch audit to one flat rule — the attribute is a violation in every crate, no allowlist / marker / cap (deleted ~120 lines of now-dead machinery). Real-I/O that can't be unit-tested goes in the bin or behind an injected seam.

## 3. Lock down `main.rs`
- Pushed the last branch (`if args.non_interactive`) into a tested `setup::execute_with` seam, so `main.rs` is now pure construction/delegation — **no logic, no branches**.
- Added a `guard-main-rs` CI job: any PR touching `crates/leviath-cli/src/main.rs` fails unless the maintainer applies the `allow-main-rs-change` label. (This PR carries the label — it moves the tty leaf in + shrinks `real_setup`.)

## 4. Strip historical comments
Swept ~30 files to remove "previously / used to / was tried / now lives / twin trick" narration (history belongs in git), keeping load-bearing current rationale (the llvm-cov single-monomorphization reasoning, the crossterm poll-hang + is_terminal caveats, SAFETY notes). Comment-only.

## Verification (local, macOS)
- `cargo test --workspace` green; `cargo clippy --workspace --all-targets` clean; `cargo fmt --all --check` clean.
- `cargo run -p xtask -- coverage` gate = **100.00%** regions/lines/functions, all packages.
- `grep` confirms **zero** `#[cfg(not(test))]` in the workspace; `check-exclusions` passes and a probe attribute (even in leviath-sys) now fails it.
- Windows cross-compile clean; bin smoke (`lev --version`/`list`/`setup --non-interactive`/`serve`) works.

## Note (pre-existing, not from this PR)
`leviath-mcp`'s `test_connect_fails_when_notification_write_errors` is a rare timing-flake under coverage instrumentation (relies on an EPIPE from a closed-read-end pipe race). It's byte-identical to `main` here (this PR only reworded its comment). If a `Coverage (… / leviath-mcp)` job flakes, a re-run clears it — worth a deterministic follow-up fix, like the interaction.rs poll-loop flake was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)