### PR TITLE
refactor(xtask): gate coverage via native llvm-cov --fail-under; delete custom engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,28 +83,25 @@ jobs:
         run: cargo fmt --all -- --check
 
   # Coverage runs on all three OSes and enforces a hard 100% on regions, lines,
-  # and functions, reading llvm-cov's own per-file summary directly (see
-  # xtask/src/coverage.rs). When llvm-cov summarizes a generic it groups the
-  # monomorphizations, so a source span covered by any instantiation counts as
-  # covered. OS-specific code is covered by tests that run on that OS (e.g.
-  # leviath-sys's `unix` vs `fallback` submodules); code `#[cfg]`'d out of a
-  # target is not compiled there and so never counts against it. If a region is
-  # reported missed on only one OS, that's a real untested instantiation on that
-  # target — close it with a test on that OS, don't relax the gate.
+  # and functions. Each (os × package) runner GATES one package with llvm-cov's
+  # own thresholds: `cargo xtask coverage --package <pkg>` runs `cargo llvm-cov
+  # --package <pkg> --fail-under-{lines,functions,regions} 100`, failing the job
+  # if that package is below 100% (see xtask/src/coverage.rs). No custom
+  # parsing/merging/aggregation — llvm-cov does the counting and the gating.
   #
-  # For speed, coverage is fanned out: this `coverage` job computes ONE
-  # package's coverage per runner (os × package matrix), each writing its own
-  # `coverage/per-package/<pkg>.json` (byte-for-byte the same numbers a single
-  # `cargo xtask coverage` run would produce for that package — the per-package
-  # measurement is unchanged, it's just distributed). The dependent
-  # `coverage-gate` job then aggregates every package's JSON and enforces the
-  # hard 100% gate. `cargo-llvm-cov` is installed from a prebuilt binary via
-  # taiki-e/install-action (was `cargo install --locked`, minutes → seconds).
+  # Per-PACKAGE (not `--workspace`) is deliberate: `-C instrument-coverage`
+  # records every function in every binary that links it — including binaries
+  # that never call it — so the whole-workspace merge lets a never-run record
+  # shadow the covered one and reads genuinely-tested code below 100%. One
+  # package at a time keeps llvm-cov's counts accurate (see coverage.rs + the
+  # upstream LLVM bug it links). Branch coverage is not collected — `--branch`
+  # reliably SIGSEGVs on that same bug. `cargo-llvm-cov` is installed from a
+  # prebuilt binary via taiki-e/install-action.
   coverage:
     name: Coverage (${{ matrix.os }} / ${{ matrix.package }})
     runs-on: ${{ matrix.os }}
     strategy:
-      # One package's failure must still let the others report their numbers.
+      # One package's failure must not cancel the others' runs.
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -131,18 +128,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      # Computes this one package's regions/lines/functions from llvm-cov's own
-      # per-file summary (see xtask/src/coverage.rs) and writes coverage/per-
-      # package/<pkg>.json plus a browsable coverage/html/<pkg> report. Does NOT run the
-      # 100% gate — that's coverage-gate's job, once all packages are collected.
-      - name: Compute coverage for ${{ matrix.package }}
+      # Gates this one package at a hard 100% (regions/lines/functions) via
+      # llvm-cov's --fail-under-* thresholds and writes its browsable HTML to
+      # coverage/html/<pkg>. Fails the job if the package is below 100%.
+      - name: Gate ${{ matrix.package }} at 100%
         run: cargo xtask coverage --package ${{ matrix.package }}
-      - name: Upload per-package coverage JSON
-        uses: actions/upload-artifact@v7
-        with:
-          name: cov-${{ matrix.os }}-${{ matrix.package }}
-          path: coverage/per-package/*.json
-          retention-days: 14
       - name: Upload HTML coverage report
         if: always()
         uses: actions/upload-artifact@v7
@@ -151,12 +141,12 @@ jobs:
           path: coverage/html/
           retention-days: 14
 
-  # Aggregates every per-package JSON for this OS and enforces the hard 100%
-  # gate (fails if ANY file is below 100% on regions, lines, or functions).
-  # This is the authoritative gate that replaced the old inline check; the
-  # measurement is identical, just fed from pre-computed per-package results.
-  # Branch coverage is not collected -- `cargo llvm-cov --branch` reliably
-  # crashes with SIGSEGV on an open upstream LLVM bug (see coverage.rs).
+  # The per-package `coverage` jobs above ARE the gate now (each fails below
+  # 100%). This job is the aggregate signal: `needs: [coverage]` means it only
+  # runs once every package on every OS gated green, so its success == the whole
+  # workspace is 100%. It keeps the stable `Coverage gate (<os>)` check name and
+  # publishes the coverage badges (from ubuntu on push to main). Because the gate
+  # is hard-100%, a green run means 100% by construction — the badges are static.
   coverage-gate:
     name: Coverage gate (${{ matrix.os }})
     needs: [coverage]
@@ -166,29 +156,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      # Collect only THIS OS's per-package JSONs onto one runner. Each artifact
-      # holds a single <pkg>.json at its root; merge-multiple flattens them all
-      # into coverage/per-package/ where `--gate` globs *.json.
-      - name: Download per-package coverage JSONs
-        uses: actions/download-artifact@v8
-        with:
-          pattern: cov-${{ matrix.os }}-*
-          path: coverage/per-package
-          merge-multiple: true
-      - name: Enforce 100% coverage gate
-        id: cov
-        run: cargo xtask coverage --gate
-      # Publish all three coverage-percentage gists — only from ubuntu on
-      # push to main (all three OSes gate; only one need publish). Only the
-      # lines gist is actually rendered as a README badge today (three separate
-      # numbers read as confusing to newcomers there), but regions/functions
-      # are published too so they're a click away in the gist for anyone who
-      # wants the full picture.
+      - name: Confirm every package gated 100%
+        run: echo "All packages gated at a hard 100% in the per-package coverage jobs."
       - name: Update lines coverage badge
         if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@v1.7.0
@@ -197,10 +166,8 @@ jobs:
           gistID: ${{ vars.COVERAGE_GIST_ID }}
           filename: leviath-coverage-lines.json
           label: coverage
-          message: ${{ steps.cov.outputs.lines }}%
-          valColorRange: ${{ steps.cov.outputs.lines }}
-          minColorRange: 50
-          maxColorRange: 100
+          message: 100%
+          color: brightgreen
       - name: Update regions coverage badge
         if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@v1.7.0
@@ -209,10 +176,8 @@ jobs:
           gistID: ${{ vars.COVERAGE_GIST_ID }}
           filename: leviath-coverage-regions.json
           label: regions
-          message: ${{ steps.cov.outputs.regions }}%
-          valColorRange: ${{ steps.cov.outputs.regions }}
-          minColorRange: 50
-          maxColorRange: 100
+          message: 100%
+          color: brightgreen
       - name: Update functions coverage badge
         if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@v1.7.0
@@ -221,10 +186,8 @@ jobs:
           gistID: ${{ vars.COVERAGE_GIST_ID }}
           filename: leviath-coverage-functions.json
           label: functions
-          message: ${{ steps.cov.outputs.functions }}%
-          valColorRange: ${{ steps.cov.outputs.functions }}
-          minColorRange: 50
-          maxColorRange: 100
+          message: 100%
+          color: brightgreen
 
   # The zero-exclusions policy scan runs once (it's OS-independent). It uses
   # ast-grep, which matches Rust/YAML *structurally* (via tree-sitter) rather

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ cargo clean -p cargo-husky && cargo test -p xtask
 
 ### Running coverage locally
 
-`cargo xtask coverage` runs `cargo-llvm-cov` per package across the workspace and reports region/line/function percentages, written to the gitignored `coverage/` folder. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows — any file below 100% fails the build. The gate reads llvm-cov's own per-file summary directly; llvm-cov groups a generic's monomorphizations, so a source span covered by any instantiation counts as covered. A region reported missed on only one OS means a genuinely untested instantiation on that target — close it with a test on that OS.
+`cargo xtask coverage` gates each workspace package with `cargo llvm-cov --package <pkg> --fail-under-{lines,functions,regions} 100` — llvm-cov does the counting *and* the gating; there's no custom parsing or aggregation. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows — any file below 100% fails the build, and a browsable HTML report lands in the gitignored `coverage/` folder. Measurement is deliberately **per-package**, not `--workspace`: `-C instrument-coverage` records every function in every binary that links it (including ones that never call it), and the whole-workspace merge can let a never-run record shadow the covered one — so one package at a time is what keeps llvm-cov's counts accurate. See the doc comment atop `xtask/src/coverage.rs`.
 
 ```bash
 cargo xtask coverage                                   # full workspace

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,62 +1,30 @@
-//! Coverage reporting — runs `cargo llvm-cov` per-package across the
-//! workspace and aggregates region/line/function coverage percentages.
+//! Coverage gate — runs `cargo llvm-cov` per workspace package and enforces a
+//! hard 100% on regions, lines, and functions using llvm-cov's own
+//! `--fail-under-*` thresholds. No custom parsing, merging, or aggregation.
 //!
-//! Branch coverage is intentionally not collected. `cargo llvm-cov --branch`
-//! reliably crashes with SIGSEGV inside
-//! `llvm::coverage::CoverageMapping::getInstantiationGroups` — a currently
-//! open, unresolved upstream LLVM bug
-//! (<https://github.com/llvm/llvm-project/issues/119558>). Reproduced locally
-//! against two nightly toolchains five months apart, for leviath-cli,
-//! leviath-providers, and leviath-runtime specifically, with or without
-//! `-ignore-filename-regex`, and with or without limiting `llvm-cov` to a
-//! single worker thread (`-num-threads=1`) — so it isn't a race in llvm-cov's
-//! own thread pool, it's deterministic. There is no known workaround short of
-//! an upstream LLVM fix, so this project does not request `--branch` at
-//! all, and the toolchain does not need to be pinned to a specific nightly:
-//! branch coverage is the only reason nightly would be required (source-based
-//! coverage instrumentation itself, `-C instrument-coverage`, has worked on
-//! stable Rust for years).
+//! **Why per-package (and not `--workspace`).** `-C instrument-coverage` emits a
+//! coverage record for *every* function in *every* binary that links it —
+//! including binaries that never call it (rustc instruments unused functions).
+//! A workspace has many test binaries, and a `pub fn` from one crate is linked
+//! into every other crate's test binary. When `cargo llvm-cov --workspace`
+//! merges them all, a never-run "unused function" record can shadow the covered
+//! one, so genuinely-tested code reads below 100% (the phantom is codegen- and
+//! OS-dependent, so it can't be closed with a test). Measuring one package at a
+//! time keeps few binaries in each profile, where llvm-cov counts accurately.
+//! This is the standard granularity for reliable Rust coverage, not a
+//! workaround — see <https://github.com/llvm/llvm-project/issues/119558>.
 //!
-//! **Per-package aggregation is still required even without `--branch`.**
-//! A single `cargo llvm-cov --workspace` run does complete without crashing
-//! (unlike with `--branch`), but it silently produces *wrong* — inflated
-//! missed-region — numbers compared to running each package in isolation.
-//! Confirmed deterministic (not run-to-run noise) and reproduced across two
-//! unrelated crates: e.g. `leviath-runtime/src/systems.rs` reads 41 missed
-//! regions under `--workspace` but only 15 under `cargo llvm-cov --package
-//! leviath-runtime` alone; `leviath-providers/src/rate_limit.rs` reads 6
-//! missed under `--workspace` but 0 (100%) in isolation. This is almost
-//! certainly the same underlying `getInstantiationGroups` bug as the
-//! `--branch` crash, manifesting as silent merge inaccuracy instead of a
-//! crash when there's "only" plain region/line/function data (not branch
-//! data) to reconcile across the many object files a full-workspace run
-//! merges together — per-package runs merge far fewer objects and are
-//! measurably accurate. So: always run per-package, with a clean
-//! `llvm-cov-target/` between each (belt-and-suspenders against
-//! cross-package contamination), and aggregate the JSON results ourselves.
+//! Each package is gated by a single `cargo llvm-cov --package <pkg>
+//! --fail-under-{lines,functions,regions} 100` invocation, which also writes a
+//! browsable HTML report to `coverage/html/<pkg>`. `--fail-under-* 100` on the
+//! package total is equivalent to a per-file 100% gate (a total can only be
+//! 100% if every file is). `src/main.rs` — the un-unit-tested bin composition
+//! root — is excluded via `--ignore-filename-regex`.
 //!
-//! Output lands at `coverage/llvm-cov.json` (gitignored) — never under
-//! `target/`, never committed. A browsable HTML report (source-highlighted,
-//! click-through per file) also lands at `coverage/html/index.html` on every
-//! run, for visual inspection -- see [`generate_html_report`]'s doc comment
-//! for why its numbers aren't the authoritative ones `run_report`'s 100% gate
-//! uses.
-//!
-//! **Region coverage uses llvm-cov's own per-file `summary.regions`.** The gate
-//! reads each per-package run's per-file summary exactly as llvm-cov reports it
-//! — regions, lines, and functions alike — and fails any file below 100% on any
-//! metric. When llvm-cov summarizes a generic function it groups the
-//! monomorphizations, so a source position covered by any instantiation counts
-//! as covered. A region reported missed on one OS therefore denotes a real
-//! uncovered instantiation path *on that OS* — closed with a test that
-//! exercises that instantiation, not by re-counting.
-//!
-//! **The gate enforces a hard 100%.** With region jitter removed, any file
-//! below 100% on regions/lines/functions is a real, closeable gap and fails
-//! the build (see [`run_report`]).
+//! Branch coverage is intentionally not collected: `cargo llvm-cov --branch`
+//! reliably SIGSEGVs on the same open upstream LLVM bug linked above.
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
 
 // ── Runner trait (injectable for testing) ────────────────────────────────────
 
@@ -67,9 +35,6 @@ pub trait Runner {
 
     /// Run `cargo metadata --no-deps --format-version 1` and return the JSON.
     fn cargo_metadata(&self) -> Result<serde_json::Value>;
-
-    /// Remove a directory tree (best-effort; silently ignores errors).
-    fn remove_dir(&self, path: &str);
 }
 
 // ── Production runner ─────────────────────────────────────────────────────────
@@ -95,34 +60,19 @@ impl Runner for RealRunner {
         }
         serde_json::from_slice(&out.stdout).context("parsing cargo metadata JSON")
     }
-
-    fn remove_dir(&self, path: &str) {
-        let _ = std::fs::remove_dir_all(path);
-    }
 }
 
 // ── Coverage mode (CLI argument parsing) ──────────────────────────────────────
 
-/// Which coverage computation to perform, parsed from the arguments following
+/// Which packages to gate, parsed from the arguments following
 /// `cargo xtask coverage`.
-///
-/// The measurement math is identical across all three — `Package` and `Gate`
-/// merely split the single-runner `All` flow across CI runners: each package
-/// computes its own `CovData` in parallel (`Package`), then one dependent job
-/// aggregates them and enforces the gate (`Gate`).
 #[derive(Debug, PartialEq, Eq)]
 pub enum CoverageMode {
-    /// No arguments: compute every workspace package, aggregate, enforce the
-    /// hard 100% gate, and render the full HTML report (local-dev convenience).
+    /// No arguments: gate every workspace package (local-dev full check).
     All,
-    /// `--package <pkg>`: compute just one package's coverage, writing its
-    /// `CovData` to `coverage/per-package/<pkg>.json` and its browsable HTML to
-    /// `coverage/html/<pkg>`. Does NOT aggregate or run the gate — that is
-    /// `Gate`'s job, after every package's per-package JSON is collected.
+    /// `--package <pkg>`: gate exactly one package (the CI per-package fan-out —
+    /// each package runs on its own runner, in parallel).
     Package(String),
-    /// `--gate`: aggregate every `coverage/per-package/*.json` and enforce the
-    /// hard 100% gate — the same gap detection and failure message `All` uses.
-    Gate,
 }
 
 impl CoverageMode {
@@ -130,7 +80,6 @@ impl CoverageMode {
     pub fn parse(args: &[String]) -> Result<Self> {
         match args.first().map(String::as_str) {
             None => Ok(Self::All),
-            Some("--gate") => Ok(Self::Gate),
             Some("--package") => {
                 let pkg = args.get(1).context(
                     "`--package` requires a package name, e.g. \
@@ -139,8 +88,8 @@ impl CoverageMode {
                 Ok(Self::Package(pkg.clone()))
             }
             Some(other) => anyhow::bail!(
-                "unknown `coverage` argument `{other}` (expected no arguments, \
-                 `--gate`, or `--package <pkg>`)"
+                "unknown `coverage` argument `{other}` (expected no arguments or \
+                 `--package <pkg>`)"
             ),
         }
     }
@@ -153,470 +102,61 @@ pub fn run(mode: CoverageMode) -> Result<()> {
 }
 
 pub fn run_with(runner: &dyn Runner, mode: CoverageMode) -> Result<()> {
-    std::fs::create_dir_all("coverage")
-        .expect("failed to create coverage/ directory — check filesystem permissions");
     match mode {
         CoverageMode::All => run_all(runner),
-        CoverageMode::Package(pkg) => run_package_mode(runner, &pkg),
-        CoverageMode::Gate => run_gate_mode(),
+        CoverageMode::Package(pkg) => gate_package(runner, &pkg),
     }
 }
 
-/// `cargo xtask coverage` with no arguments: the original all-in-one path —
-/// compute every package, aggregate, enforce the 100% gate, and render HTML.
+/// Gate every workspace package in turn (local-dev convenience). CI gates each
+/// package on its own runner via `--package` instead.
 fn run_all(runner: &dyn Runner) -> Result<()> {
-    let github_output = std::env::var("GITHUB_OUTPUT").ok();
-    let report_result = run_report(runner, "coverage/llvm-cov.json", github_output.as_deref());
-    // Always attempt the HTML report, even if the 100% gate above failed
-    // -- browsing exactly which lines are (un)covered is often the fastest
-    // way to understand *why* a coverage regression happened. A failure
-    // generating it (e.g. a real cargo/IO problem) is still surfaced, but
-    // the original report_result -- the authoritative pass/fail signal --
-    // is what's returned once both have run.
-    generate_html_report(runner)?;
-    report_result
-}
-
-/// `cargo xtask coverage --package <pkg>`: compute exactly one package — via
-/// the identical per-target/merge logic the all-packages path uses — and write
-/// its `CovData` to `coverage/per-package/<pkg>.json`, plus its browsable HTML
-/// to `coverage/html/<pkg>`. Deliberately does NOT aggregate or run the gate:
-/// on CI each package runs this on its own runner in parallel, and one
-/// dependent `--gate` job aggregates the collected JSONs and enforces 100%.
-fn run_package_mode(runner: &dyn Runner, pkg: &str) -> Result<()> {
-    run_package_mode_in(
-        runner,
-        pkg,
-        std::path::Path::new("coverage"),
-        "coverage/per-package",
-    )
-}
-
-fn run_package_mode_in(
-    runner: &dyn Runner,
-    pkg: &str,
-    scratch_dir: &std::path::Path,
-    per_package_dir: &str,
-) -> Result<()> {
-    println!("[coverage] Computing coverage for package {pkg}…");
-    let meta = runner.cargo_metadata()?;
-    let data = coverage_one_package(runner, &meta, pkg, scratch_dir)?;
-
-    std::fs::create_dir_all(per_package_dir)
-        .with_context(|| format!("creating {per_package_dir}"))?;
-    let out_path = format!("{per_package_dir}/{pkg}.json");
-    let json = serde_json::to_string_pretty(&data)
-        .expect("failed to serialise per-package CovData — all fields are serialisable");
-    std::fs::write(&out_path, json).with_context(|| format!("writing {out_path}"))?;
-    println!("[coverage] Wrote per-package coverage to {out_path}");
-
-    // One package's browsable HTML — no top-level index in this mode (the
-    // `--gate` step writes that once all packages' HTML dirs are present).
-    generate_package_html(runner, pkg)?;
-    Ok(())
-}
-
-/// `cargo xtask coverage --gate`: aggregate every per-package JSON and enforce
-/// the hard 100% gate — the SAME gap detection and error message the all-in-one
-/// path uses, just fed from pre-computed per-package `CovData` instead of
-/// recomputing them here.
-fn run_gate_mode() -> Result<()> {
-    let github_output = std::env::var("GITHUB_OUTPUT").ok();
-    run_gate_mode_in(
-        "coverage/per-package",
-        "coverage/html",
-        github_output.as_deref(),
-    )
-}
-
-fn run_gate_mode_in(
-    per_package_dir: &str,
-    html_dir: &str,
-    github_output: Option<&str>,
-) -> Result<()> {
-    println!("[coverage] Aggregating per-package coverage from {per_package_dir}…");
-    let data = aggregate_per_package(per_package_dir)?;
-    // Link whatever per-package HTML dirs exist (each is uploaded separately
-    // on CI); write the index before the gate so it's produced even on failure.
-    write_gate_html_index(html_dir)?;
-    report_data(&data, github_output)
-}
-
-/// Aggregate every `<pkg>.json` `CovData` under `dir` into one report:
-/// concatenate all files and sum totals via [`Metrics::add`], then
-/// [`Metrics::recompute_percents`] — the identical arithmetic the all-in-one
-/// path applies across packages, so the gate result is byte-for-byte the same.
-fn aggregate_per_package(dir: &str) -> Result<CovData> {
-    let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
-        .with_context(|| format!("reading per-package coverage directory {dir}"))?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
-        .collect();
-    paths.sort();
-
-    let mut all_files: Vec<FileCov> = Vec::new();
-    let mut totals = Metrics::default();
-    for path in &paths {
-        let raw = std::fs::read_to_string(path)
-            .with_context(|| format!("reading per-package coverage JSON {}", path.display()))?;
-        let data: CovData = serde_json::from_str(&raw)
-            .with_context(|| format!("parsing per-package coverage JSON {}", path.display()))?;
-        totals.add(&data.totals);
-        all_files.extend(data.files);
-    }
-    totals.recompute_percents();
-    Ok(CovData {
-        files: all_files,
-        totals,
-    })
-}
-
-/// Generate browsable per-package HTML coverage reports — one
-/// `cargo llvm-cov --package <pkg> --lib --html` per workspace crate — plus a
-/// top-level `coverage/html/index.html` linking them.
-///
-/// Per-package `--lib` deliberately mirrors how [`run_coverage`]'s
-/// authoritative gate measures, so the browsable report agrees with the 100%
-/// gate. A single `cargo llvm-cov --workspace --html` pass (the previous
-/// approach) disagreed on two counts: (a) a whole-workspace merge hits the
-/// `getInstantiationGroups` inaccuracy documented at the top of this file,
-/// inflating "missed" counts on generic-heavy files; and (b) `--workspace`
-/// instruments the `[[bin]]` targets, whose
-/// `#[cfg(not(test))]` code is compiled but never executed under `cargo test`,
-/// so their real bodies (e.g. `dispatch.rs`'s process-spawning wrappers)
-/// rendered as uncovered red even though the gate correctly never counts them.
-/// `--lib` scoping excludes bins, and per-package runs avoid the cross-package
-/// summation, so the HTML now matches the gate. `xtask` itself is not in
-/// [`parse_workspace_packages`] (it has no lib and is the coverage tool), so
-/// it's absent here too — consistent with the gate.
-fn generate_html_report(runner: &dyn Runner) -> Result<()> {
-    println!("[coverage] Generating per-package HTML reports…");
-    // Clear any previous report (e.g. a stale whole-workspace one) so the
-    // directory only ever holds the current per-package layout.
-    runner.remove_dir("coverage/html");
     let meta = runner.cargo_metadata()?;
     let packages = parse_workspace_packages(&meta);
     for pkg in &packages {
-        generate_package_html(runner, pkg)?;
+        gate_package(runner, pkg)?;
     }
-    write_html_index("coverage/html", &packages)?;
-    println!("[coverage] HTML report: coverage/html/index.html");
+    println!("[coverage] All {} package(s) at 100%. ✓", packages.len());
     Ok(())
 }
 
-/// Generate one package's browsable `cargo llvm-cov --lib --html` report into
-/// `coverage/html/<pkg>`, cleaning `target/llvm-cov-target` first (same reason
-/// as the coverage runs). Shared by the all-in-one HTML path and `--package`.
-fn generate_package_html(runner: &dyn Runner, pkg: &str) -> Result<()> {
-    // Clean slate between packages (same reason as `run_coverage`).
-    runner.remove_dir("target/llvm-cov-target");
-    let out_dir = format!("coverage/html/{pkg}");
-    if !runner.cargo(&[
+/// Gate a single package at a hard 100% (regions/lines/functions) via llvm-cov's
+/// own `--fail-under-*` thresholds, writing its browsable HTML to
+/// `coverage/html/<pkg>`. Returns an error if the package is below 100% (or its
+/// build/tests fail).
+fn gate_package(runner: &dyn Runner, pkg: &str) -> Result<()> {
+    println!("[coverage] Gating {pkg} at 100%…");
+    let html_dir = format!("coverage/html/{pkg}");
+    let args = [
         "llvm-cov",
-        "--all-features",
         "--package",
         pkg,
-        "--lib",
+        "--all-features",
+        // The bin (src/main.rs) is the un-unit-tested composition root; exclude
+        // it on every OS (llvm-cov reports `...\src\main.rs` on Windows).
+        "--ignore-filename-regex",
+        r"[\\/]main\.rs$",
+        "--fail-under-lines",
+        "100",
+        "--fail-under-functions",
+        "100",
+        "--fail-under-regions",
+        "100",
         "--html",
         "--output-dir",
-        &out_dir,
-    ])? {
-        anyhow::bail!("cargo llvm-cov exited non-zero while generating the HTML report for {pkg}");
-    }
-    Ok(())
-}
-
-/// Write a small top-level `<html_dir>/index.html` linking to each per-package
-/// report at `<html_dir>/<pkg>/html/index.html`.
-fn write_html_index(html_dir: &str, packages: &[String]) -> Result<()> {
-    std::fs::create_dir_all(html_dir).with_context(|| format!("creating {html_dir} directory"))?;
-    let mut html = String::from(
-        "<!doctype html>\n<meta charset=\"utf-8\">\n<title>Leviath coverage</title>\n\
-         <h1>Leviath coverage — per-package reports</h1>\n\
-         <p>Each link is a source-highlighted <code>cargo llvm-cov --lib</code> report, \
-         measured the same way the 100% gate is.</p>\n<ul>\n",
-    );
-    for pkg in packages {
-        html.push_str(&format!(
-            "  <li><a href=\"{pkg}/html/index.html\">{pkg}</a></li>\n"
-        ));
-    }
-    html.push_str("</ul>\n");
-    let index_path = format!("{html_dir}/index.html");
-    std::fs::write(&index_path, html).with_context(|| format!("writing {index_path}"))?;
-    Ok(())
-}
-
-/// Discover whatever per-package HTML report dirs already exist under
-/// `html_dir` (each `--package` run drops one) and write the top-level index
-/// linking them. Used by `--gate`, where the per-package HTML dirs may or may
-/// not have been collected onto this runner.
-fn write_gate_html_index(html_dir: &str) -> Result<()> {
-    let mut packages: Vec<String> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(html_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    packages.push(name.to_owned());
-                }
-            }
-        }
-    }
-    packages.sort();
-    write_html_index(html_dir, &packages)
-}
-
-/// Core reporting logic extracted from `run_with` for unit-testability.
-///
-/// Runs coverage via `runner`, prints a summary, reports any gaps, and writes
-/// CI output variables. Enforces a hard 100% on regions/lines/functions: any
-/// file below 100% fails the build. All paths (including the failure path) are
-/// reachable from tests through the `MockRunner` abstraction.
-pub fn run_report(
-    runner: &dyn Runner,
-    output_path: &str,
-    github_output: Option<&str>,
-) -> Result<()> {
-    println!("[coverage] Running coverage analysis…");
-    let data = run_coverage(runner, output_path)?;
-    report_data(&data, github_output)
-}
-
-/// Print the summary, publish badge percentages, and enforce the hard 100%
-/// gate over `data`.
-///
-/// Shared by the all-in-one path ([`run_report`]) and the `--gate` path
-/// ([`run_gate_mode_in`]) so both emit the identical summary and — crucially —
-/// the identical failure message when any file is below 100%.
-fn report_data(data: &CovData, github_output: Option<&str>) -> Result<()> {
-    print_summary(&data.totals);
-
-    let gaps = gap_files(data);
-
-    // Always publish the computed percentages -- the coverage badges need
-    // real numbers regardless of whether 100% is currently met.
-    write_github_output(&data.totals, github_output)?;
-
-    if gaps.is_empty() {
-        println!("\n[coverage] All metrics at 100%. ✓");
-        return Ok(());
-    }
-
-    print_gaps(&gaps);
-
-    anyhow::bail!(
-        "[coverage] Coverage must be 100% on regions, lines, and functions, but \
-         {} file(s) have gaps (listed above). Each gap is a real, closeable one: \
-         cover it with a test. A region missed on only one OS is an untested \
-         generic instantiation on that target — exercise that instantiation. If \
-         a line is genuinely un-unit-testable real-IO, move it into the \
-         coverage-excluded `lev` binary (main.rs) or behind an injected seam — \
-         never a `#[cfg(not(test))]` (which is banned). Investigate exactly which \
-         lines/regions are uncovered with `cargo llvm-cov show` or the browsable \
-         `coverage/html/index.html` report.",
-        gaps.len()
-    );
-}
-
-// ── Gap detection (pure, testable) ───────────────────────────────────────────
-
-/// Return the subset of files that are not at 100% on all metrics.
-pub fn gap_files(data: &CovData) -> Vec<&FileCov> {
-    data.files
-        .iter()
-        .filter(|f| !f.summary.is_100_percent())
-        .collect()
-}
-
-fn print_gaps(gaps: &[&FileCov]) {
-    eprintln!("\n[coverage] {} file(s) have gaps:", gaps.len());
-    for gap in gaps {
-        let name = match gap.filename.split_once("/crates/") {
-            Some((_, suffix)) => format!("crates/{suffix}"),
-            None => gap.filename.clone(),
-        };
-        eprintln!("  {name}");
-        let s = &gap.summary;
-        if !s.regions.is_fully_covered() {
-            eprintln!("    regions:   missed {}", s.regions.missed());
-        }
-        if !s.lines.is_fully_covered() {
-            eprintln!("    lines:     missed {}", s.lines.missed());
-        }
-        if !s.functions.is_fully_covered() {
-            eprintln!("    functions: missed {}", s.functions.missed());
-        }
-    }
-}
-
-// ── Internal orchestration ───────────────────────────────────────────────────
-
-pub fn run_coverage(runner: &dyn Runner, output_path: &str) -> Result<CovData> {
-    let meta = runner.cargo_metadata()?;
-    let packages = parse_workspace_packages(&meta);
-    println!(
-        "[coverage] Per-package run for {} crates: {}",
-        packages.len(),
-        packages.join(", ")
-    );
-
-    // Place per-target JSON files next to the aggregated output file so they
-    // always land in a writable directory (avoids relative-path issues in tests).
-    let scratch_dir = std::path::Path::new(output_path)
-        .parent()
-        .unwrap_or(std::path::Path::new("."));
-
-    let mut all_files: Vec<FileCov> = Vec::new();
-    let mut totals = Metrics::default();
-
-    for pkg in &packages {
-        println!("[coverage]   → {pkg}");
-        let pkg_data = coverage_one_package(runner, &meta, pkg, scratch_dir)?;
-        totals.add(&pkg_data.totals);
-        all_files.extend(pkg_data.files);
-    }
-
-    totals.recompute_percents();
-    let aggregated = CovData {
-        files: all_files,
-        totals,
-    };
-    // The on-disk report still uses llvm-cov's own `{"data": [...]}` schema
-    // (a single-element array) for consistency with what `cargo llvm-cov`
-    // itself would produce, even though in memory we deal with the one
-    // `CovData` element directly -- there's no realistic way for our own
-    // aggregation to produce zero or multiple entries here, so `run_report`
-    // doesn't need a fallible "does data have an entry" check on top of it.
-    let wrapped = LlvmCovReport {
-        data: vec![aggregated.clone()],
-    };
-    let json = serde_json::to_string_pretty(&wrapped)
-        .expect("failed to serialise aggregated JSON — all fields are serialisable");
-    std::fs::write(output_path, json).with_context(|| format!("writing {output_path}"))?;
-    Ok(aggregated)
-}
-
-/// Compute one package's coverage exactly as the all-packages loop does — the
-/// single source of truth shared by [`run_coverage`] and `--package` mode.
-///
-/// Scopes to `--lib`, then to each integration-test binary, SEPARATELY, rather
-/// than one bare `cargo llvm-cov --package X` call that lets llvm-cov merge
-/// every test binary's profraw data internally. That internal multi-binary
-/// merge is subject to the same `getInstantiationGroups` merge-inaccuracy bug
-/// documented at the top of this file for cross-package `--workspace` runs --
-/// confirmed empirically: leviath-cli's commands/add.rs read 6 missed regions
-/// when merged across all 3 of its test binaries (lib + 2 integration tests) in
-/// one invocation, but only 2 missed when measured via `--lib` alone. A clean
-/// `target/llvm-cov-target` between every scoped run is belt-and-suspenders
-/// against cross-run contamination of the profraw/profdata llvm-cov
-/// accumulates there. Each scoped run's per-file counts come straight from
-/// llvm-cov's own summary via [`run_single_target`]; [`merge_target_reports`]
-/// then recombines the separately-scoped results (`max`-covered per file).
-/// Per-target JSONs are written under `scratch_dir`.
-fn coverage_one_package(
-    runner: &dyn Runner,
-    meta: &serde_json::Value,
-    pkg: &str,
-    scratch_dir: &std::path::Path,
-) -> Result<CovData> {
-    let mut scopes: Vec<Vec<&str>> = vec![vec!["--lib"]];
-    for test_name in package_test_targets(meta, pkg) {
-        scopes.push(vec!["--test", test_name]);
-    }
-
-    let mut target_reports: Vec<CovData> = Vec::new();
-    for scope in &scopes {
-        runner.remove_dir("target/llvm-cov-target");
-
-        let scope_tag = scope.join("-").replace(['-', ' '], "_");
-        let target_output = scratch_dir
-            .join(format!("llvm-cov-{pkg}-{scope_tag}.json"))
-            .to_string_lossy()
-            .into_owned();
-
-        let report = run_single_target(runner, pkg, scope, &target_output)
-            .with_context(|| format!("coverage failed for {pkg} ({})", scope.join(" ")))?;
-
-        if let Some(data) = report.data.into_iter().next() {
-            target_reports.push(data);
-        }
-    }
-
-    Ok(merge_target_reports(target_reports))
-}
-
-/// Merge multiple coverage reports for the SAME package (one per test
-/// target: `--lib`, plus one per integration-test binary) into a single,
-/// more accurate report for that package.
-///
-/// For each file, per metric, take the higher `covered` count across all
-/// target-scoped runs rather than summing. Summing would double-count
-/// regions the compiled library shares across binaries (an integration test
-/// links the same library code the `--lib` unit tests do); `max` is a
-/// mathematically safe lower-bound approximation of the true union of
-/// coverage across all test binaries -- it can never report less coverage
-/// than any single scoped run actually observed, and can never fabricate
-/// coverage no run actually exercised.
-fn merge_target_reports(reports: Vec<CovData>) -> CovData {
-    let mut by_file: std::collections::HashMap<String, FileCov> = std::collections::HashMap::new();
-    for report in reports {
-        for file in report.files {
-            by_file
-                .entry(file.filename.clone())
-                .and_modify(|existing| existing.summary.merge_max(&file.summary))
-                .or_insert(file);
-        }
-    }
-
-    let mut files: Vec<FileCov> = by_file.into_values().collect();
-    files.sort_by(|a, b| a.filename.cmp(&b.filename));
-
-    let mut totals = Metrics::default();
-    for file in &files {
-        totals.add(&file.summary);
-    }
-    totals.recompute_percents();
-
-    CovData { files, totals }
-}
-
-fn run_single_target(
-    runner: &dyn Runner,
-    pkg: &str,
-    scope: &[&str],
-    output_path: &str,
-) -> Result<LlvmCovReport> {
-    let mut args = vec!["llvm-cov", "--all-features", "--package", pkg];
-    args.extend_from_slice(scope);
-    // Exclude binary entry points (`src/main.rs`) from measurement. A bin is
-    // the composition root: it wires real terminal/stdin/network/subprocess
-    // I/O — which no unit test may trigger — into the library's tested cores.
-    // The `--test` scope would otherwise capture the spawned, instrumented
-    // `lev` binary's profile (from `tests/cli_dispatch.rs`), forcing that
-    // un-unit-testable wiring to be "covered". Keeping bins unmeasured is what
-    // lets library code stay 100%-covered with zero `#[cfg(not(test))]`
-    // escape hatches (see `crates/leviath-cli/src/main.rs`). The `[\\/]`
-    // requires a path separator so it matches only real bin roots (never a
-    // file like `domain.rs`) — and accepts BOTH `/` (Unix) and `\` (Windows,
-    // where llvm-cov reports `...\src\main.rs`), so the bin is excluded on
-    // every OS.
-    args.extend_from_slice(&["--ignore-filename-regex", r"[\\/]main\.rs$"]);
-    args.extend_from_slice(&["--json", "--output-path", output_path]);
-
+        &html_dir,
+    ];
     if !runner.cargo(&args)? {
         anyhow::bail!(
-            "cargo llvm-cov exited non-zero for package {pkg} ({})",
-            scope.join(" ")
+            "[coverage] {pkg} is below 100% (or its build/tests failed). Open \
+             {html_dir}/html/index.html to see exactly which lines are uncovered."
         );
     }
-
-    parse_json(output_path)
-        .with_context(|| format!("parsing coverage JSON for {pkg} ({})", scope.join(" ")))
+    Ok(())
 }
 
-/// Parse workspace package names from `cargo metadata` JSON.
+/// Parse workspace package names from `cargo metadata` JSON. `xtask` itself is
+/// excluded — it is the coverage tool, not measured by the gate.
 pub fn parse_workspace_packages(meta: &serde_json::Value) -> Vec<String> {
     let members: std::collections::HashSet<String> = meta["workspace_members"]
         .as_array()
@@ -637,1307 +177,70 @@ pub fn parse_workspace_packages(meta: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
-/// Return the names of a package's integration-test binaries (files under
-/// `tests/`) from `cargo metadata` JSON — NOT its `#[cfg(test)] mod tests`
-/// unit tests (which compile into the `--lib` target itself) and NOT its
-/// `[[bin]]` targets.
-pub fn package_test_targets<'a>(meta: &'a serde_json::Value, pkg: &str) -> Vec<&'a str> {
-    meta["packages"]
-        .as_array()
-        .map(|arr| arr.as_slice())
-        .unwrap_or(&[])
-        .iter()
-        .find(|p| p["name"].as_str() == Some(pkg))
-        .and_then(|p| p["targets"].as_array())
-        .map(|targets| {
-            targets
-                .iter()
-                .filter(|t| {
-                    t["kind"]
-                        .as_array()
-                        .is_some_and(|kinds| kinds.iter().any(|k| k.as_str() == Some("test")))
-                })
-                .filter_map(|t| t["name"].as_str())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-// ── Formatting helpers ───────────────────────────────────────────────────────
-
-fn print_summary(t: &Metrics) {
-    println!("\n[coverage] Summary:");
-    println!(
-        "  Regions:   {}/{} ({:.2}%)",
-        t.regions.covered, t.regions.count, t.regions.percent
-    );
-    println!(
-        "  Lines:     {}/{} ({:.2}%)",
-        t.lines.covered, t.lines.count, t.lines.percent
-    );
-    println!(
-        "  Functions: {}/{} ({:.2}%)",
-        t.functions.covered, t.functions.count, t.functions.percent
-    );
-}
-
-// ── GitHub Actions output ────────────────────────────────────────────────────
-
-/// Write coverage percentages to the GitHub Actions output file when running in CI.
-pub fn write_github_output(totals: &Metrics, output_path: Option<&str>) -> Result<()> {
-    let Some(path) = output_path else {
-        return Ok(());
-    };
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("opening GITHUB_OUTPUT at {path}"))?;
-    write_github_output_content(totals, &mut f).context("writing coverage percentages")
-}
-
-/// Write the three coverage-percentage lines to any `Write` sink.
-///
-/// Extracted from `write_github_output` so that unit tests can pass a mock
-/// writer (e.g. a `FailWriter`) to cover the `write_all` error path without
-/// needing a real filesystem error.
-pub(crate) fn write_github_output_content<W: std::io::Write>(
-    totals: &Metrics,
-    writer: &mut W,
-) -> std::io::Result<()> {
-    let content = format!(
-        "regions={:.1}\nlines={:.1}\nfunctions={:.1}\n",
-        totals.regions.percent, totals.lines.percent, totals.functions.percent,
-    );
-    writer.write_all(content.as_bytes())
-}
-
-// ── JSON parsing/serialisation ───────────────────────────────────────────────
-
-pub fn parse_json(path: &str) -> Result<LlvmCovReport> {
-    let raw = std::fs::read_to_string(path).with_context(|| format!("reading {path}"))?;
-    serde_json::from_str(&raw).with_context(|| format!("parsing JSON from {path}"))
-}
-
-// ── Data types ───────────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LlvmCovReport {
-    pub data: Vec<CovData>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CovData {
-    pub files: Vec<FileCov>,
-    pub totals: Metrics,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FileCov {
-    pub filename: String,
-    pub summary: Metrics,
-}
-
-/// `llvm-cov`'s JSON always includes a `branches` key alongside these three
-/// (0/0 when `--branch` wasn't requested, which is always, per the module
-/// doc comment). `branches` is deliberately not modeled here — serde ignores
-/// unknown JSON fields by default, so it's silently dropped on parse.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Metrics {
-    #[serde(default)]
-    pub regions: Metric,
-    #[serde(default)]
-    pub lines: Metric,
-    #[serde(default)]
-    pub functions: Metric,
-}
-
-impl Metrics {
-    pub fn is_100_percent(&self) -> bool {
-        self.regions.is_fully_covered()
-            && self.lines.is_fully_covered()
-            && self.functions.is_fully_covered()
-    }
-
-    /// Accumulate another package's totals into this running aggregate.
-    pub fn add(&mut self, other: &Metrics) {
-        self.regions.count += other.regions.count;
-        self.regions.covered += other.regions.covered;
-        self.lines.count += other.lines.count;
-        self.lines.covered += other.lines.covered;
-        self.functions.count += other.functions.count;
-        self.functions.covered += other.functions.covered;
-    }
-
-    /// Recompute percentages after accumulating raw counts via `add`.
-    pub fn recompute_percents(&mut self) {
-        self.regions.recompute_percent();
-        self.lines.recompute_percent();
-        self.functions.recompute_percent();
-    }
-
-    /// Merge another observation of the *same* underlying compiled code
-    /// (e.g. the same package's `--lib` run vs. one of its `--test <name>`
-    /// runs) by taking the higher `covered` count per metric — see
-    /// `merge_target_reports`'s doc comment for why `max`, not `add`.
-    pub fn merge_max(&mut self, other: &Metrics) {
-        self.regions.merge_max(&other.regions);
-        self.lines.merge_max(&other.lines);
-        self.functions.merge_max(&other.functions);
-    }
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Metric {
-    pub count: u64,
-    pub covered: u64,
-    pub percent: f64,
-}
-
-impl Metric {
-    pub fn is_fully_covered(&self) -> bool {
-        self.count == 0 || self.covered == self.count
-    }
-
-    pub fn missed(&self) -> u64 {
-        self.count.saturating_sub(self.covered)
-    }
-
-    pub fn recompute_percent(&mut self) {
-        self.percent = if self.count == 0 {
-            100.0
-        } else {
-            (self.covered as f64 / self.count as f64) * 100.0
-        };
-    }
-
-    /// Merge another observation of the same underlying regions/lines/
-    /// functions by taking the higher `covered` value. `count` is taken as
-    /// the max too (defensive — it should already match across runs of the
-    /// same compiled code, but doesn't hurt to guard against it not).
-    pub fn merge_max(&mut self, other: &Metric) {
-        self.count = self.count.max(other.count);
-        self.covered = self.covered.max(other.covered);
-        self.recompute_percent();
-    }
-}
-
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-    use tempfile::TempDir;
+    use std::cell::RefCell;
 
-    // ── Real-`coverage/`-dir serialization ────────────────────────────────────
-    //
-    // A handful of tests exercise the fixed-path wrappers that read/write the
-    // real repo-relative `coverage/` directory (the all-in-one and gate/package
-    // round-trip paths). Serialize them so their concurrent writes to shared
-    // files (e.g. `coverage/html/index.html`) can't collide — notably on
-    // Windows, where two simultaneous writes to one path can fail.
-
-    static FS_LOCK: Mutex<()> = Mutex::new(());
-
-    fn fs_guard() -> std::sync::MutexGuard<'static, ()> {
-        FS_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    // ── Mock runner ──────────────────────────────────────────────────────────
-
-    /// A mock runner for unit-testing orchestration logic without subprocesses.
+    /// Records every `cargo` invocation and returns a configurable success flag.
     struct MockRunner {
-        /// Responses for `cargo llvm-cov --package PKG`: Some(Ok) = success with
-        /// JSON written, Some(Err) = non-zero exit, None = default success with
-        /// an empty (trivially 100%) report.
-        package_results: HashMap<String, Result<LlvmCovReport, String>>,
-        /// JSON to return from cargo_metadata.
+        succeed: bool,
+        calls: RefCell<Vec<Vec<String>>>,
         metadata: serde_json::Value,
-        /// Whether cargo_metadata should return an error.
-        fail_metadata: bool,
-        /// If true, cargo() returns Ok(true) but writes no JSON (simulates a write failure path).
-        fail_write_json: bool,
-        /// If true, cargo() immediately returns Err (simulates a spawn/IO failure).
-        fail_cargo_err: bool,
-        /// If true, an `--html` cargo invocation (generate_html_report) returns Ok(false).
-        fail_html: bool,
     }
 
     impl MockRunner {
-        fn new(metadata: serde_json::Value) -> Self {
+        fn new(succeed: bool, metadata: serde_json::Value) -> Self {
             Self {
-                package_results: HashMap::new(),
+                succeed,
+                calls: RefCell::new(Vec::new()),
                 metadata,
-                fail_metadata: false,
-                fail_write_json: false,
-                fail_cargo_err: false,
-                fail_html: false,
             }
-        }
-
-        fn with_package(mut self, pkg: &str, result: Result<LlvmCovReport, String>) -> Self {
-            self.package_results.insert(pkg.to_owned(), result);
-            self
-        }
-
-        fn with_fail_write(mut self) -> Self {
-            self.fail_write_json = true;
-            self
-        }
-
-        fn with_fail_metadata(mut self) -> Self {
-            self.fail_metadata = true;
-            self
-        }
-
-        fn with_fail_cargo_err(mut self) -> Self {
-            self.fail_cargo_err = true;
-            self
-        }
-
-        fn with_fail_html(mut self) -> Self {
-            self.fail_html = true;
-            self
         }
     }
 
     impl Runner for MockRunner {
         fn cargo(&self, args: &[&str]) -> Result<bool> {
-            if self.fail_cargo_err {
-                anyhow::bail!("simulated cargo spawn failure");
-            }
-            // HTML generation is now per-package (`--package X --lib --html`),
-            // so the fail-html simulation must trigger regardless of whether a
-            // `--package` arg is present.
-            if self.fail_html && args.contains(&"--html") {
-                return Ok(false);
-            }
-            let output_path = args
-                .windows(2)
-                .find(|w| w[0] == "--output-path")
-                .and_then(|w| w.get(1).copied());
-
-            let Some(pkg_idx) = args.iter().position(|a| *a == "--package") else {
-                // Any other non-package cargo invocation (e.g. plain `cargo help`) — no-op success.
-                return Ok(true);
-            };
-            let pkg = args[pkg_idx + 1];
-
-            match self.package_results.get(pkg) {
-                Some(Ok(report)) => {
-                    if !self.fail_write_json {
-                        if let Some(path) = output_path {
-                            let json = serde_json::to_string(report).unwrap();
-                            std::fs::write(path, json).ok();
-                        }
-                    }
-                    Ok(true)
-                }
-                Some(Err(_)) => Ok(false),
-                None => {
-                    if !self.fail_write_json {
-                        if let Some(path) = output_path {
-                            let report = LlvmCovReport {
-                                data: vec![CovData {
-                                    files: vec![],
-                                    totals: full_metrics(0),
-                                }],
-                            };
-                            std::fs::write(path, serde_json::to_string(&report).unwrap()).ok();
-                        }
-                    }
-                    Ok(true)
-                }
-            }
+            self.calls
+                .borrow_mut()
+                .push(args.iter().map(|s| (*s).to_owned()).collect());
+            Ok(self.succeed)
         }
-
         fn cargo_metadata(&self) -> Result<serde_json::Value> {
-            if self.fail_metadata {
-                anyhow::bail!("simulated cargo metadata failure");
-            }
             Ok(self.metadata.clone())
         }
-
-        fn remove_dir(&self, _path: &str) {
-            // no-op in tests
-        }
     }
 
-    // ── Test helpers ─────────────────────────────────────────────────────────
-
-    fn metric(count: u64, covered: u64) -> Metric {
-        let percent = if count == 0 {
-            100.0
-        } else {
-            (covered as f64 / count as f64) * 100.0
-        };
-        Metric {
-            count,
-            covered,
-            percent,
-        }
-    }
-
-    fn full_metrics(n: u64) -> Metrics {
-        let m = metric(n, n);
-        Metrics {
-            regions: m.clone(),
-            lines: m.clone(),
-            functions: m,
-        }
-    }
-
-    fn partial_metrics(count: u64, covered: u64) -> Metrics {
-        let m = metric(count, covered);
-        Metrics {
-            regions: m.clone(),
-            lines: m.clone(),
-            functions: m,
-        }
-    }
-
-    fn simple_metadata(names: &[&str]) -> serde_json::Value {
-        let members: Vec<serde_json::Value> = names
+    /// Build a minimal `cargo metadata` JSON containing the given member names.
+    fn meta_with(pkgs: &[&str]) -> serde_json::Value {
+        let members: Vec<String> = pkgs
             .iter()
-            .map(|n| serde_json::json!(format!("path+file:///ws/{n}#0.1.0")))
+            .map(|p| format!("{p} 0.1.0 (path+file:///w/{p})"))
             .collect();
-        let packages: Vec<serde_json::Value> = names
+        let packages: Vec<serde_json::Value> = pkgs
             .iter()
-            .map(|n| {
-                serde_json::json!({
-                    "id": format!("path+file:///ws/{n}#0.1.0"),
-                    "name": n
-                })
-            })
+            .zip(&members)
+            .map(|(name, id)| serde_json::json!({ "id": id, "name": name }))
             .collect();
-        serde_json::json!({"workspace_members": members, "packages": packages})
+        serde_json::json!({ "workspace_members": members, "packages": packages })
     }
 
-    fn write_json(dir: &TempDir, name: &str, json: &str) -> String {
-        let path = dir.path().join(name);
-        std::fs::write(&path, json).unwrap();
-        path.to_string_lossy().into_owned()
-    }
-
-    // ── Metric ──────────────────────────────────────────────────────────────
-
-    #[test]
-    fn metric_fully_covered_when_count_zero() {
-        assert!(metric(0, 0).is_fully_covered());
-    }
-
-    #[test]
-    fn metric_fully_covered_when_all_hit() {
-        assert!(metric(10, 10).is_fully_covered());
-    }
-
-    #[test]
-    fn metric_not_fully_covered_when_some_missed() {
-        assert!(!metric(10, 9).is_fully_covered());
-    }
-
-    #[test]
-    fn metric_missed_correct() {
-        assert_eq!(metric(10, 7).missed(), 3);
-    }
-
-    #[test]
-    fn metric_missed_zero_when_fully_covered() {
-        assert_eq!(metric(10, 10).missed(), 0);
-    }
-
-    #[test]
-    fn metric_missed_zero_when_count_zero() {
-        assert_eq!(metric(0, 0).missed(), 0);
-    }
-
-    #[test]
-    fn metric_recompute_percent_all_covered() {
-        let mut m = Metric {
-            count: 10,
-            covered: 10,
-            percent: 0.0,
-        };
-        m.recompute_percent();
-        assert!((m.percent - 100.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn metric_recompute_percent_partial() {
-        let mut m = Metric {
-            count: 4,
-            covered: 3,
-            percent: 0.0,
-        };
-        m.recompute_percent();
-        assert!((m.percent - 75.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn metric_recompute_percent_zero_count() {
-        let mut m = Metric {
-            count: 0,
-            covered: 0,
-            percent: 0.0,
-        };
-        m.recompute_percent();
-        assert!((m.percent - 100.0).abs() < f64::EPSILON);
-    }
-
-    // ── Metrics ──────────────────────────────────────────────────────────────
-
-    #[test]
-    fn metrics_100_percent_when_all_full() {
-        assert!(full_metrics(10).is_100_percent());
-    }
-
-    #[test]
-    fn metrics_100_percent_when_counts_zero() {
-        assert!(Metrics::default().is_100_percent());
-    }
-
-    #[test]
-    fn metrics_not_100_when_regions_partial() {
-        let mut m = full_metrics(10);
-        m.regions = metric(10, 9);
-        assert!(!m.is_100_percent());
-    }
-
-    #[test]
-    fn metrics_not_100_when_lines_partial() {
-        let mut m = full_metrics(10);
-        m.lines = metric(10, 9);
-        assert!(!m.is_100_percent());
-    }
-
-    #[test]
-    fn metrics_not_100_when_functions_partial() {
-        let mut m = full_metrics(10);
-        m.functions = metric(10, 9);
-        assert!(!m.is_100_percent());
-    }
-
-    #[test]
-    fn metrics_add_accumulates_all_fields() {
-        let mut a = partial_metrics(10, 8);
-        let b = partial_metrics(20, 18);
-        a.add(&b);
-        assert_eq!(a.regions.count, 30);
-        assert_eq!(a.regions.covered, 26);
-        assert_eq!(a.lines.count, 30);
-        assert_eq!(a.functions.covered, 26);
-    }
-
-    #[test]
-    fn metrics_add_with_zero_other() {
-        let mut a = full_metrics(5);
-        a.add(&Metrics::default());
-        assert_eq!(a.regions.count, 5);
-        assert_eq!(a.regions.covered, 5);
-    }
-
-    #[test]
-    fn metrics_recompute_percents_after_add() {
-        let mut m = Metrics {
-            regions: Metric {
-                count: 4,
-                covered: 3,
-                percent: 0.0,
-            },
-            lines: Metric {
-                count: 10,
-                covered: 10,
-                percent: 0.0,
-            },
-            functions: Metric {
-                count: 2,
-                covered: 1,
-                percent: 0.0,
-            },
-        };
-        m.recompute_percents();
-        assert!((m.regions.percent - 75.0).abs() < f64::EPSILON);
-        assert!((m.lines.percent - 100.0).abs() < f64::EPSILON);
-        assert!((m.functions.percent - 50.0).abs() < f64::EPSILON);
-    }
-
-    // ── parse_workspace_packages ─────────────────────────────────────────────
-
-    #[test]
-    fn parse_workspace_packages_new_format() {
-        let meta = simple_metadata(&["leviath-core", "leviath-runtime"]);
-        let pkgs = parse_workspace_packages(&meta);
-        assert_eq!(pkgs.len(), 2);
-        assert!(pkgs.contains(&"leviath-core".to_owned()));
-        assert!(pkgs.contains(&"leviath-runtime".to_owned()));
-    }
-
-    #[test]
-    fn parse_workspace_packages_excludes_xtask() {
-        let meta = simple_metadata(&["leviath-core", "xtask"]);
-        let pkgs = parse_workspace_packages(&meta);
-        assert_eq!(pkgs.len(), 1);
-        assert!(!pkgs.contains(&"xtask".to_owned()));
-    }
-
-    #[test]
-    fn parse_workspace_packages_empty_metadata() {
-        let meta = serde_json::json!({"workspace_members": [], "packages": []});
-        assert!(parse_workspace_packages(&meta).is_empty());
-    }
-
-    #[test]
-    fn parse_workspace_packages_only_listed_members_included() {
-        // Package in `packages` but not in `workspace_members` is excluded.
-        let meta = serde_json::json!({
-            "workspace_members": ["path+file:///ws/leviath-core#0.1.0"],
-            "packages": [
-                {"id": "path+file:///ws/leviath-core#0.1.0", "name": "leviath-core"},
-                {"id": "path+file:///ext/thirdparty#1.0.0", "name": "thirdparty"}
-            ]
-        });
-        let pkgs = parse_workspace_packages(&meta);
-        assert_eq!(pkgs, vec!["leviath-core"]);
-    }
-
-    // ── package_test_targets ─────────────────────────────────────────────────
-
-    fn metadata_with_targets(pkg: &str, targets: serde_json::Value) -> serde_json::Value {
-        serde_json::json!({
-            "workspace_members": [format!("path+file:///ws/{pkg}#0.1.0")],
-            "packages": [
-                {"id": format!("path+file:///ws/{pkg}#0.1.0"), "name": pkg, "targets": targets}
-            ]
-        })
-    }
-
-    #[test]
-    fn package_test_targets_finds_integration_tests() {
-        let meta = metadata_with_targets(
-            "leviath-cli",
-            serde_json::json!([
-                {"kind": ["lib"], "name": "leviath_cli"},
-                {"kind": ["bin"], "name": "lev"},
-                {"kind": ["test"], "name": "cli_dispatch"},
-                {"kind": ["test"], "name": "manifest_integration"},
-            ]),
-        );
-        let mut targets = package_test_targets(&meta, "leviath-cli");
-        targets.sort_unstable();
-        assert_eq!(targets, vec!["cli_dispatch", "manifest_integration"]);
-    }
-
-    #[test]
-    fn package_test_targets_excludes_lib_and_bin() {
-        let meta = metadata_with_targets(
-            "leviath-core",
-            serde_json::json!([
-                {"kind": ["lib"], "name": "leviath_core"},
-                {"kind": ["bin"], "name": "some-bin"},
-            ]),
-        );
-        assert!(package_test_targets(&meta, "leviath-core").is_empty());
-    }
-
-    #[test]
-    fn package_test_targets_unknown_package_returns_empty() {
-        let meta = metadata_with_targets("leviath-core", serde_json::json!([]));
-        assert!(package_test_targets(&meta, "does-not-exist").is_empty());
-    }
-
-    #[test]
-    fn package_test_targets_missing_targets_field_returns_empty() {
-        // `simple_metadata`-style packages have no "targets" key at all.
-        let meta = simple_metadata(&["leviath-core"]);
-        assert!(package_test_targets(&meta, "leviath-core").is_empty());
-    }
-
-    #[test]
-    fn package_test_targets_empty_packages_array_returns_empty() {
-        let meta = serde_json::json!({"workspace_members": [], "packages": []});
-        assert!(package_test_targets(&meta, "anything").is_empty());
-    }
-
-    // ── Metric/Metrics::merge_max ────────────────────────────────────────────
-
-    #[test]
-    fn metric_merge_max_takes_higher_covered() {
-        let mut a = metric(10, 4);
-        a.merge_max(&metric(10, 7));
-        assert_eq!(a.covered, 7);
-        assert_eq!(a.count, 10);
-        assert!((a.percent - 70.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn metric_merge_max_keeps_higher_when_self_already_larger() {
-        let mut a = metric(10, 9);
-        a.merge_max(&metric(10, 3));
-        assert_eq!(a.covered, 9);
-    }
-
-    #[test]
-    fn metric_merge_max_takes_higher_count() {
-        // Simulates merging a --lib report (whose count includes the file's
-        // own #[cfg(test)] mod tests) with a --test report (which doesn't).
-        let mut a = metric(8, 8);
-        a.merge_max(&metric(10, 6));
-        assert_eq!(a.count, 10);
-        assert_eq!(a.covered, 8);
-    }
-
-    #[test]
-    fn metrics_merge_max_all_fields() {
-        let mut a = Metrics {
-            regions: metric(10, 4),
-            lines: metric(10, 5),
-            functions: metric(2, 1),
-        };
-        a.merge_max(&Metrics {
-            regions: metric(10, 8),
-            lines: metric(10, 2),
-            functions: metric(2, 2),
-        });
-        assert_eq!(a.regions.covered, 8);
-        assert_eq!(a.lines.covered, 5);
-        assert_eq!(a.functions.covered, 2);
-    }
-
-    // ── merge_target_reports ─────────────────────────────────────────────────
-
-    #[test]
-    fn merge_target_reports_empty_is_empty() {
-        let merged = merge_target_reports(vec![]);
-        assert!(merged.files.is_empty());
-        assert!(merged.totals.is_100_percent());
-    }
-
-    #[test]
-    fn merge_target_reports_single_report_passes_through() {
-        let report = CovData {
-            files: vec![FileCov {
-                filename: "/src/a.rs".to_owned(),
-                summary: partial_metrics(10, 8),
-            }],
-            totals: partial_metrics(10, 8),
-        };
-        let merged = merge_target_reports(vec![report]);
-        assert_eq!(merged.files.len(), 1);
-        assert_eq!(merged.totals.regions.covered, 8);
-        assert_eq!(merged.totals.regions.count, 10);
-    }
-
-    #[test]
-    fn merge_target_reports_combines_overlapping_file_with_max_covered() {
-        // Simulates --lib (covered=2) and --test cli_dispatch (covered=5) both
-        // reporting on the same shared library file -- the merged result must
-        // take the higher observed coverage, not sum (which would double-count).
-        let lib_report = CovData {
-            files: vec![FileCov {
-                filename: "/src/commands/add.rs".to_owned(),
-                summary: partial_metrics(10, 2),
-            }],
-            totals: partial_metrics(10, 2),
-        };
-        let test_report = CovData {
-            files: vec![FileCov {
-                filename: "/src/commands/add.rs".to_owned(),
-                summary: partial_metrics(10, 5),
-            }],
-            totals: partial_metrics(10, 5),
-        };
-        let merged = merge_target_reports(vec![lib_report, test_report]);
-        assert_eq!(
-            merged.files.len(),
-            1,
-            "same filename must merge into one entry"
-        );
-        assert_eq!(merged.files[0].summary.regions.covered, 5);
-        assert_eq!(merged.totals.regions.covered, 5);
-    }
-
-    #[test]
-    fn merge_target_reports_disjoint_files_are_both_kept() {
-        let lib_report = CovData {
-            files: vec![FileCov {
-                filename: "/src/a.rs".to_owned(),
-                summary: full_metrics(5),
-            }],
-            totals: full_metrics(5),
-        };
-        let test_report = CovData {
-            files: vec![FileCov {
-                filename: "/src/b.rs".to_owned(),
-                summary: full_metrics(3),
-            }],
-            totals: full_metrics(3),
-        };
-        let merged = merge_target_reports(vec![lib_report, test_report]);
-        assert_eq!(merged.files.len(), 2);
-        assert_eq!(merged.totals.regions.count, 8);
-        assert_eq!(merged.totals.regions.covered, 8);
-    }
-
-    // ── gap_files ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn gap_files_empty_when_all_100_percent() {
-        let data = CovData {
-            files: vec![
-                FileCov {
-                    filename: "a.rs".to_owned(),
-                    summary: full_metrics(10),
-                },
-                FileCov {
-                    filename: "b.rs".to_owned(),
-                    summary: full_metrics(5),
-                },
-            ],
-            totals: full_metrics(15),
-        };
-        assert!(gap_files(&data).is_empty());
-    }
-
-    #[test]
-    fn gap_files_returns_partial_files() {
-        let data = CovData {
-            files: vec![
-                FileCov {
-                    filename: "a.rs".to_owned(),
-                    summary: full_metrics(10),
-                },
-                FileCov {
-                    filename: "b.rs".to_owned(),
-                    summary: partial_metrics(10, 8),
-                },
-            ],
-            totals: partial_metrics(20, 18),
-        };
-        let gaps = gap_files(&data);
-        assert_eq!(gaps.len(), 1);
-        assert_eq!(gaps[0].filename, "b.rs");
-    }
-
-    #[test]
-    fn gap_files_returns_all_when_all_partial() {
-        let data = CovData {
-            files: vec![
-                FileCov {
-                    filename: "a.rs".to_owned(),
-                    summary: partial_metrics(5, 4),
-                },
-                FileCov {
-                    filename: "b.rs".to_owned(),
-                    summary: partial_metrics(3, 2),
-                },
-            ],
-            totals: partial_metrics(8, 6),
-        };
-        assert_eq!(gap_files(&data).len(), 2);
-    }
-
-    // ── parse_json ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn parse_json_full_100_percent() {
-        let dir = tempfile::tempdir().unwrap();
-        let json = r#"{"data":[{"files":[{"filename":"/r/a.rs","summary":{"regions":{"count":10,"covered":10,"percent":100.0},"lines":{"count":20,"covered":20,"percent":100.0},"functions":{"count":5,"covered":5,"percent":100.0},"branches":{"count":0,"covered":0,"percent":0.0}}}],"totals":{"regions":{"count":10,"covered":10,"percent":100.0},"lines":{"count":20,"covered":20,"percent":100.0},"functions":{"count":5,"covered":5,"percent":100.0},"branches":{"count":0,"covered":0,"percent":0.0}}}]}"#;
-        let path = write_json(&dir, "cov.json", json);
-        let report = parse_json(&path).unwrap();
-        assert_eq!(report.data.len(), 1);
-        assert_eq!(report.data[0].files.len(), 1);
-        assert!(report.data[0].totals.is_100_percent());
-    }
-
-    #[test]
-    fn parse_json_partial_coverage() {
-        let dir = tempfile::tempdir().unwrap();
-        let json = r#"{"data":[{"files":[{"filename":"/r/a.rs","summary":{"regions":{"count":10,"covered":8,"percent":80.0},"lines":{"count":20,"covered":18,"percent":90.0},"functions":{"count":5,"covered":5,"percent":100.0},"branches":{"count":0,"covered":0,"percent":0.0}}}],"totals":{"regions":{"count":10,"covered":8,"percent":80.0},"lines":{"count":20,"covered":18,"percent":90.0},"functions":{"count":5,"covered":5,"percent":100.0},"branches":{"count":0,"covered":0,"percent":0.0}}}]}"#;
-        let path = write_json(&dir, "cov.json", json);
-        let report = parse_json(&path).unwrap();
-        assert!(!report.data[0].totals.is_100_percent());
-        assert_eq!(report.data[0].totals.regions.missed(), 2);
-    }
-
-    #[test]
-    fn parse_json_branches_field_ignored() {
-        // llvm-cov's JSON always includes `branches`, even when we never
-        // request --branch (it's just 0/0). Confirms it's silently ignored
-        // rather than causing a deserialization error.
-        let dir = tempfile::tempdir().unwrap();
-        let json = r#"{"data":[{"files":[],"totals":{"regions":{"count":5,"covered":5,"percent":100.0},"lines":{"count":10,"covered":10,"percent":100.0},"functions":{"count":3,"covered":3,"percent":100.0},"branches":{"count":123,"covered":45,"percent":36.5}}}]}"#;
-        let path = write_json(&dir, "cov.json", json);
-        let report = parse_json(&path).unwrap();
-        assert!(report.data[0].totals.is_100_percent());
-    }
-
-    #[test]
-    fn parse_json_extra_unknown_fields_ignored() {
-        let dir = tempfile::tempdir().unwrap();
-        let json = r#"{"data":[{"files":[],"totals":{"regions":{"count":1,"covered":1,"percent":100.0},"lines":{"count":1,"covered":1,"percent":100.0},"functions":{"count":1,"covered":1,"percent":100.0}}}],"type":"llvm.coverage","version":"2"}"#;
-        let path = write_json(&dir, "cov.json", json);
-        assert!(parse_json(&path).is_ok());
-    }
-
-    #[test]
-    fn parse_json_error_on_invalid_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = write_json(&dir, "bad.json", "not json at all");
-        assert!(parse_json(&path).is_err());
-    }
-
-    #[test]
-    fn parse_json_error_on_missing_file() {
-        assert!(parse_json("/tmp/does_not_exist_llvm_cov.json").is_err());
-    }
-
-    #[test]
-    fn parse_json_missing_metrics_default_to_zero() {
-        let dir = tempfile::tempdir().unwrap();
-        let json = r#"{"data":[{"files":[],"totals":{"regions":{"count":3,"covered":3,"percent":100.0},"lines":{"count":3,"covered":3,"percent":100.0}}}]}"#;
-        let path = write_json(&dir, "cov.json", json);
-        let report = parse_json(&path).unwrap();
-        assert!(report.data[0].totals.functions.is_fully_covered());
-    }
-
-    // ── write_github_output ──────────────────────────────────────────────────
-
-    #[test]
-    fn write_github_output_no_path_is_noop() {
-        assert!(write_github_output(&full_metrics(10), None).is_ok());
-    }
-
-    #[test]
-    fn write_github_output_writes_all_three_metrics() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gha_output");
-        std::fs::write(&path, "").unwrap();
-        let m = Metrics {
-            regions: metric(10, 10),
-            lines: metric(20, 18),
-            functions: metric(5, 5),
-        };
-        write_github_output(&m, Some(path.to_str().unwrap())).unwrap();
-        let content = std::fs::read_to_string(&path).unwrap();
-        assert!(content.contains("regions=100.0"), "content: {content}");
-        assert!(content.contains("lines=90.0"), "content: {content}");
-        assert!(content.contains("functions=100.0"), "content: {content}");
-    }
-
-    #[test]
-    fn write_github_output_appends_without_overwriting() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gha_output");
-        std::fs::write(&path, "previous_step_output=yes\n").unwrap();
-        write_github_output(&full_metrics(1), Some(path.to_str().unwrap())).unwrap();
-        let content = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            content.contains("previous_step_output=yes"),
-            "content: {content}"
-        );
-        assert!(content.contains("regions=100.0"), "content: {content}");
-    }
-
-    #[test]
-    fn write_github_output_error_on_unwritable_path() {
-        assert!(write_github_output(&full_metrics(1), Some("/no/such/dir/output")).is_err());
-    }
-
-    // ── Aggregation round-trip ───────────────────────────────────────────────
-
-    #[test]
-    fn aggregated_json_round_trips() {
-        let dir = tempfile::tempdir().unwrap();
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    filename: "/repo/a.rs".to_owned(),
-                    summary: full_metrics(5),
-                }],
-                totals: full_metrics(5),
-            }],
-        };
-        let path = dir.path().join("agg.json");
-        std::fs::write(&path, serde_json::to_string_pretty(&report).unwrap()).unwrap();
-        let rt = parse_json(path.to_str().unwrap()).unwrap();
-        assert_eq!(rt.data[0].files[0].filename, "/repo/a.rs");
-        assert!(rt.data[0].totals.is_100_percent());
-    }
-
-    // ── RealRunner (actual cargo subprocess) ─────────────────────────────────
-
-    #[test]
-    fn real_runner_cargo_help_succeeds() {
-        // `cargo help` is a fast, read-only command — safe to run in tests.
-        assert!(RealRunner.cargo(&["help"]).unwrap());
-    }
-
-    #[test]
-    fn real_runner_cargo_nonexistent_subcommand_returns_false() {
-        // cargo will exit non-zero for an unknown subcommand.
-        // We pass an implausible subcommand to avoid accidental side effects.
-        let result = RealRunner.cargo(&["__no_such_subcommand_xyz__"]);
-        // Either fails to parse or returns false — either way it shouldn't panic.
-        let _ = result;
-    }
-
-    #[test]
-    fn real_runner_cargo_metadata_returns_valid_json() {
-        let meta = RealRunner.cargo_metadata().unwrap();
-        assert!(meta["packages"].is_array());
-        assert!(meta["workspace_members"].is_array());
-    }
-
-    #[test]
-    fn real_runner_remove_dir_nonexistent_is_silent() {
-        // Should not panic or return an error for a non-existent dir.
-        RealRunner.remove_dir("/tmp/nonexistent_xtask_test_dir_xyz_abc_123");
-    }
-
-    #[test]
-    fn real_runner_remove_dir_existing_cleans_up() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().to_str().unwrap().to_owned();
-        std::fs::create_dir_all(&path).unwrap();
-        RealRunner.remove_dir(&path);
-        // Just ensure no panic; TempDir will also clean up on drop.
-    }
-
-    // ── run_report — the core post-analysis logic ────────────────────────────
-
-    #[test]
-    fn run_report_100_percent_is_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(result.is_ok(), "100% coverage should pass: {result:?}");
-    }
-
-    #[test]
-    fn run_report_100_percent_writes_github_output() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let gha = dir.path().join("gha_output");
-        std::fs::write(&gha, "").unwrap();
-        let result = run_report(&runner, &output, Some(gha.to_str().unwrap()));
-        assert!(result.is_ok());
-        let content = std::fs::read_to_string(&gha).unwrap();
-        assert!(content.contains("regions="), "content: {content}");
-    }
-
-    #[test]
-    fn run_report_partial_coverage_fails_but_still_writes_github_output() {
-        // Any file below 100% must fail the build (hard 100% gate), but the
-        // badge percentages are written BEFORE the gate check, so they still
-        // get published even when coverage isn't 100%.
-        let dir = tempfile::tempdir().unwrap();
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    filename: "/src/foo.rs".to_owned(),
-                    summary: partial_metrics(10, 8),
-                }],
-                totals: partial_metrics(10, 8),
-            }],
-        };
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Ok(report));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let gha = dir.path().join("gha_output");
-        std::fs::write(&gha, "").unwrap();
-        let result = run_report(&runner, &output, Some(gha.to_str().unwrap()));
-        assert!(
-            result.is_err(),
-            "coverage below 100% must fail the build: {result:?}"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("must be 100%"),
-            "error should explain the 100% requirement: {msg}"
-        );
-        let content = std::fs::read_to_string(&gha).unwrap();
-        assert!(
-            content.contains("regions="),
-            "badge percentages should still be written when coverage is partial: {content}"
-        );
-    }
-
-    #[test]
-    fn run_report_regions_gap_is_err() {
-        // A file below 100% on regions must fail the build -- this is the
-        // hard 100% gate.
-        let dir = tempfile::tempdir().unwrap();
-        let gap = Metrics {
-            regions: metric(100, 0),
-            lines: metric(10, 10),
-            functions: metric(10, 10),
-        };
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    filename: "/src/foo.rs".to_owned(),
-                    summary: gap.clone(),
-                }],
-                totals: gap,
-            }],
-        };
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Ok(report));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(
-            result.is_err(),
-            "a regions gap must fail the build: {result:?}"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("must be 100%"),
-            "error should explain the 100% requirement: {msg}"
-        );
-    }
-
-    #[test]
-    fn run_report_functions_gap_is_err() {
-        // A file below 100% on functions must also fail the build,
-        // independently of regions/lines being fully covered.
-        let dir = tempfile::tempdir().unwrap();
-        let gap = Metrics {
-            regions: metric(10, 10),
-            lines: metric(10, 10),
-            functions: metric(25, 0),
-        };
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    filename: "/src/foo.rs".to_owned(),
-                    summary: gap.clone(),
-                }],
-                totals: gap,
-            }],
-        };
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Ok(report));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(
-            result.is_err(),
-            "a functions gap must fail the build: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_report_parse_error_is_err() {
-        // cargo() returns Ok(true) but writes no JSON → parse_json fails.
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_write();
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(
-            result.is_err(),
-            "should fail when JSON not written: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_report_partial_only_functions() {
-        // regions=100%, lines=100%, functions=partial.
-        // In print_gaps, the `if !s.regions.is_fully_covered()` and
-        // `if !s.lines.is_fully_covered()` conditions evaluate to FALSE,
-        // covering the "skip if 100%" path.
-        let dir = tempfile::tempdir().unwrap();
-        let mixed = Metrics {
-            regions: metric(10, 10),
-            lines: metric(10, 10),
-            functions: metric(5, 4),
-        };
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    filename: "/src/partial.rs".to_owned(),
-                    summary: mixed.clone(),
-                }],
-                totals: mixed,
-            }],
-        };
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Ok(report));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(
-            result.is_err(),
-            "a functions gap must fail the hard 100% gate: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_report_partial_with_crates_filename() {
-        // regions=partial, lines=partial, functions=100%.
-        // In print_gaps: split_once("/crates/") returns Some → covers the
-        // Some arm of the match; `if !s.functions.is_fully_covered()` →
-        // false (skip branch).
-        let dir = tempfile::tempdir().unwrap();
-        let mixed = Metrics {
-            regions: metric(10, 9),
-            lines: metric(10, 9),
-            functions: metric(5, 5),
-        };
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![FileCov {
-                    // "/crates/" in the path exercises split_once Some arm
-                    filename: "/workspace/crates/my-crate/src/lib.rs".to_owned(),
-                    summary: mixed.clone(),
-                }],
-                totals: mixed,
-            }],
-        };
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Ok(report));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_report(&runner, &output, None);
-        assert!(
-            result.is_err(),
-            "regions/lines gaps must fail the hard 100% gate: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_report_github_output_write_error_propagates() {
-        // Arrange: 100% coverage so gaps.is_empty() = true, but a bad
-        // github_output path so write_github_output() fails. Covers the `?`
-        // Err arm at the `write_github_output(&data.totals, github_output)?`
-        // call in run_report.
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let output = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let bad_gha = "/no/such/directory/gha_output.txt";
-        let result = run_report(&runner, &output, Some(bad_gha));
-        assert!(
-            result.is_err(),
-            "should fail when GITHUB_OUTPUT path is unwritable: {result:?}"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("GITHUB_OUTPUT"),
-            "error should mention GITHUB_OUTPUT: {msg}"
-        );
-    }
-
-    // ── generate_html_report ─────────────────────────────────────────────────
-
-    #[test]
-    fn generate_html_report_success_is_ok() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let result = generate_html_report(&runner);
-        assert!(result.is_ok(), "html generation should succeed: {result:?}");
-    }
-
-    #[test]
-    fn generate_html_report_cargo_exit_failure_is_err() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_html();
-        let result = generate_html_report(&runner);
-        assert!(
-            result.is_err(),
-            "a non-zero cargo llvm-cov --html exit should be an error: {result:?}"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("HTML report"),
-            "error should mention the HTML report: {msg}"
-        );
-    }
-
-    #[test]
-    fn generate_html_report_cargo_spawn_failure_is_err() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_cargo_err();
-        let result = generate_html_report(&runner);
-        assert!(
-            result.is_err(),
-            "a cargo spawn failure should propagate as an error: {result:?}"
-        );
-    }
-
-    // ── run_with ──────────────────────────────────────────────────────────────
-
-    #[test]
-    fn run_with_all_html_generation_failure_is_err_even_when_coverage_passes() {
-        // 100% coverage (report check would be Ok), but HTML generation
-        // itself fails -- the overall result must still surface that error,
-        // not silently swallow it just because the 100% gate passed.
-        let _guard = fs_guard();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_html();
-        let result = run_with(&runner, CoverageMode::All);
-        assert!(
-            result.is_err(),
-            "an HTML generation failure must fail run_with even when coverage itself passed: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_with_all_success_returns_ok() {
-        // Covers run_all's success return: run_report Ok, HTML Ok → Ok.
-        let _guard = fs_guard();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let result = run_with(&runner, CoverageMode::All);
-        assert!(
-            result.is_ok(),
-            "all-in-one 100% run should pass: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_with_package_then_gate_round_trips_at_100_percent() {
-        // End-to-end through the fixed-path wrappers: `--package` writes a
-        // per-package CovData, then `--gate` aggregates it and passes the 100%
-        // gate. This is the only test that touches the real `coverage/` dir for
-        // per-package/gate flows, so the fs lock keeps it isolated from the
-        // all-in-one tests above (which also write under `coverage/`).
-        let _guard = fs_guard();
-        // Clean slate so the gate only sees this test's file.
-        let _ = std::fs::remove_dir_all("coverage/per-package");
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-
-        let pkg_result = run_with(&runner, CoverageMode::Package("leviath-core".to_owned()));
-        assert!(
-            pkg_result.is_ok(),
-            "--package run should pass: {pkg_result:?}"
-        );
-        assert!(
-            std::path::Path::new("coverage/per-package/leviath-core.json").exists(),
-            "per-package JSON should have been written"
-        );
-
-        let gate_result = run_with(&runner, CoverageMode::Gate);
-        assert!(
-            gate_result.is_ok(),
-            "--gate over a 100% per-package report should pass: {gate_result:?}"
-        );
-        let _ = std::fs::remove_dir_all("coverage/per-package");
+    /// True if `args` contains the consecutive pair `[a, b]`.
+    fn has_pair(args: &[String], a: &str, b: &str) -> bool {
+        args.windows(2).any(|w| w[0] == a && w[1] == b)
     }
 
     // ── CoverageMode::parse ───────────────────────────────────────────────────
 
     #[test]
-    fn parse_mode_no_args_is_all() {
+    fn parse_no_args_is_all() {
         assert_eq!(CoverageMode::parse(&[]).unwrap(), CoverageMode::All);
     }
 
     #[test]
-    fn parse_mode_gate() {
-        assert_eq!(
-            CoverageMode::parse(&["--gate".to_owned()]).unwrap(),
-            CoverageMode::Gate
-        );
-    }
-
-    #[test]
-    fn parse_mode_package() {
+    fn parse_package_captures_name() {
         assert_eq!(
             CoverageMode::parse(&["--package".to_owned(), "leviath-core".to_owned()]).unwrap(),
             CoverageMode::Package("leviath-core".to_owned())
@@ -1945,664 +248,76 @@ mod tests {
     }
 
     #[test]
-    fn parse_mode_package_without_name_is_err() {
-        let result = CoverageMode::parse(&["--package".to_owned()]);
-        assert!(
-            result.is_err(),
-            "missing package name must error: {result:?}"
-        );
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("requires a package name"));
+    fn parse_package_without_name_errs() {
+        assert!(CoverageMode::parse(&["--package".to_owned()]).is_err());
     }
 
     #[test]
-    fn parse_mode_unknown_flag_is_err() {
-        let result = CoverageMode::parse(&["--nope".to_owned()]);
-        assert!(result.is_err(), "unknown flag must error: {result:?}");
-        assert!(result.unwrap_err().to_string().contains("--nope"));
+    fn parse_unknown_arg_errs() {
+        assert!(CoverageMode::parse(&["--gate".to_owned()]).is_err());
     }
 
-    // ── coverage_one_package ──────────────────────────────────────────────────
+    // ── gate_package invocation ────────────────────────────────────────────────
 
     #[test]
-    fn coverage_one_package_merges_lib_and_test_scopes() {
-        // A package with an integration test target is scoped per-target
-        // (--lib, then --test <name>) and merged into one CovData.
-        let dir = tempfile::tempdir().unwrap();
-        let meta = metadata_with_targets(
-            "leviath-cli",
-            serde_json::json!([
-                {"kind": ["lib"], "name": "leviath_cli"},
-                {"kind": ["test"], "name": "cli_dispatch"},
-            ]),
-        );
-        let runner = MockRunner::new(meta.clone());
-        let data = coverage_one_package(&runner, &meta, "leviath-cli", dir.path()).unwrap();
-        assert!(data.totals.is_100_percent());
+    fn gate_package_builds_native_fail_under_invocation() {
+        let m = MockRunner::new(true, meta_with(&[]));
+        gate_package(&m, "leviath-core").unwrap();
+        let calls = m.calls.borrow();
+        assert_eq!(calls.len(), 1);
+        let a = &calls[0];
+        assert_eq!(a[0], "llvm-cov");
+        assert!(has_pair(a, "--package", "leviath-core"));
+        assert!(has_pair(a, "--fail-under-lines", "100"));
+        assert!(has_pair(a, "--fail-under-functions", "100"));
+        assert!(has_pair(a, "--fail-under-regions", "100"));
+        assert!(a.iter().any(|s| s == r"[\\/]main\.rs$"));
+        assert!(has_pair(a, "--output-dir", "coverage/html/leviath-core"));
     }
 
     #[test]
-    fn coverage_one_package_propagates_target_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner =
-            MockRunner::new(meta.clone()).with_package("leviath-core", Err("boom".to_owned()));
-        let result = coverage_one_package(&runner, &meta, "leviath-core", dir.path());
-        assert!(
-            result.is_err(),
-            "a failing scope must propagate: {result:?}"
-        );
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("coverage failed for leviath-core"));
+    fn gate_package_bails_when_below_100() {
+        let m = MockRunner::new(false, meta_with(&[]));
+        let err = gate_package(&m, "leviath-core").unwrap_err();
+        assert!(err.to_string().contains("leviath-core"));
     }
 
-    // ── run_package_mode_in ───────────────────────────────────────────────────
+    // ── run_all ────────────────────────────────────────────────────────────────
 
     #[test]
-    fn run_package_mode_in_writes_per_package_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta);
-        let result = run_package_mode_in(
-            &runner,
-            "leviath-core",
-            dir.path(),
-            per_pkg.to_str().unwrap(),
-        );
-        assert!(result.is_ok(), "package mode should succeed: {result:?}");
-        let json_path = per_pkg.join("leviath-core.json");
-        assert!(json_path.exists(), "per-package JSON must be written");
-        // It must deserialize as CovData (the shape --gate aggregates).
-        let raw = std::fs::read_to_string(&json_path).unwrap();
-        let parsed: CovData = serde_json::from_str(&raw).unwrap();
-        assert!(parsed.totals.is_100_percent());
+    fn run_all_gates_every_package_except_xtask() {
+        let m = MockRunner::new(true, meta_with(&["leviath-core", "leviath-cli", "xtask"]));
+        run_with(&m, CoverageMode::All).unwrap();
+        let calls = m.calls.borrow();
+        assert_eq!(calls.len(), 2, "one gate call per non-xtask package");
+        assert!(calls
+            .iter()
+            .any(|a| has_pair(a, "--package", "leviath-core")));
+        assert!(calls
+            .iter()
+            .any(|a| has_pair(a, "--package", "leviath-cli")));
+        assert!(!calls.iter().any(|a| has_pair(a, "--package", "xtask")));
     }
 
     #[test]
-    fn run_package_mode_in_metadata_error_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&[])).with_fail_metadata();
-        let result = run_package_mode_in(&runner, "leviath-core", dir.path(), "unused");
-        assert!(
-            result.is_err(),
-            "metadata failure must propagate: {result:?}"
+    fn run_all_propagates_a_failing_package() {
+        let m = MockRunner::new(false, meta_with(&["leviath-core"]));
+        assert!(run_with(&m, CoverageMode::All).is_err());
+    }
+
+    // ── parse_workspace_packages ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_workspace_packages_excludes_xtask() {
+        let pkgs = parse_workspace_packages(&meta_with(&["leviath-core", "xtask", "leviath-cli"]));
+        assert_eq!(
+            pkgs,
+            vec!["leviath-core".to_owned(), "leviath-cli".to_owned()]
         );
     }
 
     #[test]
-    fn run_package_mode_in_coverage_error_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_package("leviath-core", Err("boom".to_owned()));
-        let result = run_package_mode_in(
-            &runner,
-            "leviath-core",
-            dir.path(),
-            per_pkg.to_str().unwrap(),
-        );
-        assert!(
-            result.is_err(),
-            "coverage failure must propagate: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_package_mode_in_write_error_propagates() {
-        // per_package_dir is a *file*, so create_dir_all fails.
-        let dir = tempfile::tempdir().unwrap();
-        let blocker = dir.path().join("blocker");
-        std::fs::write(&blocker, "not a dir").unwrap();
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta);
-        let result = run_package_mode_in(
-            &runner,
-            "leviath-core",
-            dir.path(),
-            blocker.to_str().unwrap(),
-        );
-        assert!(
-            result.is_err(),
-            "unwritable per-package dir must error: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_package_mode_in_html_failure_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner = MockRunner::new(meta).with_fail_html();
-        let result = run_package_mode_in(
-            &runner,
-            "leviath-core",
-            dir.path(),
-            per_pkg.to_str().unwrap(),
-        );
-        assert!(
-            result.is_err(),
-            "an HTML failure must propagate: {result:?}"
-        );
-    }
-
-    // ── aggregate_per_package ─────────────────────────────────────────────────
-
-    fn write_covdata(dir: &std::path::Path, name: &str, data: &CovData) {
-        let json = serde_json::to_string_pretty(data).unwrap();
-        std::fs::write(dir.join(name), json).unwrap();
-    }
-
-    #[test]
-    fn aggregate_per_package_sums_and_ignores_non_json() {
-        let dir = tempfile::tempdir().unwrap();
-        write_covdata(
-            dir.path(),
-            "a.json",
-            &CovData {
-                files: vec![FileCov {
-                    filename: "/src/a.rs".to_owned(),
-                    summary: full_metrics(5),
-                }],
-                totals: full_metrics(5),
-            },
-        );
-        write_covdata(
-            dir.path(),
-            "b.json",
-            &CovData {
-                files: vec![FileCov {
-                    filename: "/src/b.rs".to_owned(),
-                    summary: full_metrics(3),
-                }],
-                totals: full_metrics(3),
-            },
-        );
-        // A non-.json file that must be ignored by the extension filter.
-        std::fs::write(dir.path().join("notes.txt"), "ignore me").unwrap();
-
-        let agg = aggregate_per_package(dir.path().to_str().unwrap()).unwrap();
-        assert_eq!(agg.files.len(), 2, "both per-package files aggregated");
-        assert_eq!(agg.totals.regions.count, 8);
-        assert_eq!(agg.totals.regions.covered, 8);
-        assert!(agg.totals.is_100_percent());
-    }
-
-    #[test]
-    fn aggregate_per_package_missing_dir_is_err() {
-        let result = aggregate_per_package("/tmp/no_such_per_package_dir_xyz_123");
-        assert!(result.is_err(), "missing dir must error: {result:?}");
-    }
-
-    #[test]
-    fn aggregate_per_package_read_error_propagates() {
-        // A subdirectory named `x.json` — read_to_string fails on a directory.
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir(dir.path().join("x.json")).unwrap();
-        let result = aggregate_per_package(dir.path().to_str().unwrap());
-        assert!(
-            result.is_err(),
-            "reading a dir-as-file must error: {result:?}"
-        );
-    }
-
-    #[test]
-    fn aggregate_per_package_parse_error_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("bad.json"), "not valid json").unwrap();
-        let result = aggregate_per_package(dir.path().to_str().unwrap());
-        assert!(result.is_err(), "invalid JSON must error: {result:?}");
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("parsing per-package coverage JSON"));
-    }
-
-    // ── run_gate_mode_in ──────────────────────────────────────────────────────
-
-    #[test]
-    fn run_gate_mode_in_100_percent_is_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        std::fs::create_dir(&per_pkg).unwrap();
-        write_covdata(
-            &per_pkg,
-            "leviath-core.json",
-            &CovData {
-                files: vec![FileCov {
-                    filename: "/src/a.rs".to_owned(),
-                    summary: full_metrics(5),
-                }],
-                totals: full_metrics(5),
-            },
-        );
-        let html = dir.path().join("html");
-        let result = run_gate_mode_in(per_pkg.to_str().unwrap(), html.to_str().unwrap(), None);
-        assert!(result.is_ok(), "100% gate should pass: {result:?}");
-        assert!(
-            html.join("index.html").exists(),
-            "gate must write the top-level HTML index"
-        );
-    }
-
-    #[test]
-    fn run_gate_mode_in_gap_fails_with_same_message() {
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        std::fs::create_dir(&per_pkg).unwrap();
-        write_covdata(
-            &per_pkg,
-            "leviath-core.json",
-            &CovData {
-                files: vec![FileCov {
-                    filename: "/src/gap.rs".to_owned(),
-                    summary: partial_metrics(10, 8),
-                }],
-                totals: partial_metrics(10, 8),
-            },
-        );
-        let html = dir.path().join("html");
-        let result = run_gate_mode_in(per_pkg.to_str().unwrap(), html.to_str().unwrap(), None);
-        assert!(result.is_err(), "a gap must fail the gate: {result:?}");
-        assert!(
-            result.unwrap_err().to_string().contains("must be 100%"),
-            "gate must reuse run_report's failure message"
-        );
-    }
-
-    #[test]
-    fn run_gate_mode_in_aggregate_error_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let html = dir.path().join("html");
-        // per-package dir doesn't exist → aggregate errors before the gate.
-        let result = run_gate_mode_in(
-            dir.path().join("missing").to_str().unwrap(),
-            html.to_str().unwrap(),
-            None,
-        );
-        assert!(
-            result.is_err(),
-            "missing per-package dir must error: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_gate_mode_in_github_output_error_propagates() {
-        // 100% (gaps empty) but an unwritable GITHUB_OUTPUT path → the
-        // write_github_output `?` inside report_data fails.
-        let dir = tempfile::tempdir().unwrap();
-        let per_pkg = dir.path().join("per-package");
-        std::fs::create_dir(&per_pkg).unwrap();
-        write_covdata(
-            &per_pkg,
-            "leviath-core.json",
-            &CovData {
-                files: vec![],
-                totals: full_metrics(1),
-            },
-        );
-        let html = dir.path().join("html");
-        let result = run_gate_mode_in(
-            per_pkg.to_str().unwrap(),
-            html.to_str().unwrap(),
-            Some("/no/such/dir/gha_output.txt"),
-        );
-        assert!(
-            result.is_err(),
-            "unwritable GITHUB_OUTPUT must error: {result:?}"
-        );
-    }
-
-    // ── generate_package_html ─────────────────────────────────────────────────
-
-    #[test]
-    fn generate_package_html_success_is_ok() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        assert!(generate_package_html(&runner, "leviath-core").is_ok());
-    }
-
-    #[test]
-    fn generate_package_html_cargo_exit_failure_is_err() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_html();
-        let result = generate_package_html(&runner, "leviath-core");
-        assert!(
-            result.is_err(),
-            "non-zero --html exit must error: {result:?}"
-        );
-        assert!(result.unwrap_err().to_string().contains("HTML report"));
-    }
-
-    #[test]
-    fn generate_package_html_cargo_spawn_failure_is_err() {
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_cargo_err();
-        assert!(generate_package_html(&runner, "leviath-core").is_err());
-    }
-
-    // ── write_gate_html_index ─────────────────────────────────────────────────
-
-    #[test]
-    fn write_gate_html_index_lists_existing_dirs_and_skips_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let html = dir.path().join("html");
-        std::fs::create_dir_all(html.join("leviath-core")).unwrap();
-        std::fs::create_dir_all(html.join("leviath-cli")).unwrap();
-        // A stray file at the top level must be skipped (is_dir == false).
-        std::fs::write(html.join("stray.txt"), "x").unwrap();
-
-        write_gate_html_index(html.to_str().unwrap()).unwrap();
-        let index = std::fs::read_to_string(html.join("index.html")).unwrap();
-        assert!(index.contains("leviath-core/html/index.html"));
-        assert!(index.contains("leviath-cli/html/index.html"));
-        assert!(!index.contains("stray.txt"));
-    }
-
-    #[test]
-    fn write_gate_html_index_missing_dir_writes_empty_index() {
-        // read_dir Err branch → no packages, but write_html_index still
-        // creates the dir and writes an (empty) index.
-        let dir = tempfile::tempdir().unwrap();
-        let html = dir.path().join("nonexistent-html");
-        write_gate_html_index(html.to_str().unwrap()).unwrap();
-        assert!(html.join("index.html").exists());
-    }
-
-    // ── write_html_index ──────────────────────────────────────────────────────
-
-    #[test]
-    fn write_html_index_create_dir_error_propagates() {
-        // html_dir is a *file*, so create_dir_all fails.
-        let dir = tempfile::tempdir().unwrap();
-        let blocker = dir.path().join("blocker");
-        std::fs::write(&blocker, "not a dir").unwrap();
-        let result = write_html_index(blocker.to_str().unwrap(), &[]);
-        assert!(
-            result.is_err(),
-            "unwritable html dir must error: {result:?}"
-        );
-    }
-
-    // ── Mock-based orchestration tests ───────────────────────────────────────
-
-    #[test]
-    fn run_coverage_success_returns_ok_data() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(result.is_ok(), "per-package run should succeed: {result:?}");
-    }
-
-    #[test]
-    fn run_coverage_scopes_lib_and_each_integration_test_target() {
-        // A package with an integration test target must be run per-scope
-        // (--lib, then --test <name>) rather than one bare `--package` call,
-        // exercising the same orchestration path used to fix the real
-        // leviath-cli multi-test-binary merge inaccuracy.
-        let meta = metadata_with_targets(
-            "leviath-cli",
-            serde_json::json!([
-                {"kind": ["lib"], "name": "leviath_cli"},
-                {"kind": ["test"], "name": "cli_dispatch"},
-            ]),
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(meta);
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_ok(),
-            "multi-scope per-package run should succeed: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_coverage_package_failure_is_err() {
-        let dir = tempfile::tempdir().unwrap();
-        let meta = simple_metadata(&["leviath-core"]);
-        let runner =
-            MockRunner::new(meta).with_package("leviath-core", Err("simulated failure".to_owned()));
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_err(),
-            "a failing package run should fail outright (no fallback): {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_coverage_cargo_err_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"])).with_fail_cargo_err();
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(result.is_err(), "cargo Err should propagate: {result:?}");
-        let err = result.unwrap_err();
-        assert!(
-            format!("{err:#}").contains("simulated"),
-            "error chain should mention the simulated failure: {err:#}"
-        );
-    }
-
-    #[test]
-    fn run_coverage_metadata_error_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&[])).with_fail_metadata();
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_err(),
-            "metadata failure should propagate: {result:?}"
-        );
-        assert!(
-            result.unwrap_err().to_string().contains("simulated"),
-            "error should mention the simulated metadata failure"
-        );
-    }
-
-    #[test]
-    fn run_coverage_package_with_empty_data_is_skipped() {
-        // When a package's llvm-cov JSON contains an empty `data` array, the
-        // `if let Some(data) = pkg_report.data.into_iter().next()` evaluates to
-        // None and the if-body is skipped.
-        let dir = tempfile::tempdir().unwrap();
-        let meta = simple_metadata(&["my-pkg"]);
-        let empty_report = LlvmCovReport { data: vec![] };
-        let runner = MockRunner::new(meta).with_package("my-pkg", Ok(empty_report));
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_ok(),
-            "empty package data should be silently skipped: {result:?}"
-        );
-        assert!(result.unwrap().files.is_empty());
-    }
-
-    #[test]
-    fn run_coverage_aggregated_write_error_propagates() {
-        // output_path is a directory → std::fs::write will fail with "Is a
-        // directory". Covers the with_context(|| format!("writing
-        // {output_path}")) closure in run_coverage.
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&["leviath-core"]));
-        let output_path = dir.path().to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_err(),
-            "write to a directory should fail: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_coverage_package_json_not_written_is_err() {
-        // With fail_write=true, runner.cargo() returns Ok(true) but writes no
-        // JSON. parse_json then fails, which is wrapped by the
-        // with_context(|| format!("coverage failed for {pkg}")) closure.
-        let dir = tempfile::tempdir().unwrap();
-        let meta = simple_metadata(&["my-pkg"]);
-        let runner = MockRunner::new(meta).with_fail_write();
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_coverage(&runner, &output_path);
-        assert!(
-            result.is_err(),
-            "missing JSON should propagate as error: {result:?}"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("coverage failed for my-pkg"), "error: {msg}");
-    }
-
-    #[test]
-    fn run_single_target_cargo_err_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&[])).with_fail_cargo_err();
-        let output_path = dir.path().join("cov.json").to_str().unwrap().to_owned();
-        let result = run_single_target(&runner, "some-pkg", &["--lib"], &output_path);
-        assert!(
-            result.is_err(),
-            "cargo Err should propagate from run_single_target: {result:?}"
-        );
-    }
-
-    // ── MockRunner direct tests — uncovered branches ─────────────────────────
-    //
-    // The following tests exercise specific branches inside MockRunner that
-    // are never reached by the higher-level orchestration tests above.
-
-    #[test]
-    fn mock_runner_package_ok_result_writes_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![],
-                totals: full_metrics(5),
-            }],
-        };
-        let runner =
-            MockRunner::new(simple_metadata(&["my-pkg"])).with_package("my-pkg", Ok(report));
-        let out = dir.path().join("my-pkg.json");
-        let result = runner.cargo(&[
-            "llvm-cov",
-            "--package",
-            "my-pkg",
-            "--json",
-            "--output-path",
-            out.to_str().unwrap(),
-        ]);
-        assert!(
-            matches!(result, Ok(true)),
-            "package Ok run should succeed: {result:?}"
-        );
-        assert!(out.exists(), "JSON should have been written for Ok result");
-    }
-
-    #[test]
-    fn mock_runner_package_ok_with_fail_write_skips_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![],
-                totals: full_metrics(1),
-            }],
-        };
-        let runner = MockRunner::new(simple_metadata(&["my-pkg"]))
-            .with_package("my-pkg", Ok(report))
-            .with_fail_write();
-        let out = dir.path().join("my-pkg.json");
-        let result = runner.cargo(&[
-            "llvm-cov",
-            "--package",
-            "my-pkg",
-            "--json",
-            "--output-path",
-            out.to_str().unwrap(),
-        ]);
-        assert!(matches!(result, Ok(true)));
-        assert!(
-            !out.exists(),
-            "JSON should not be written when fail_write_json=true"
-        );
-    }
-
-    #[test]
-    fn mock_runner_package_none_with_fail_write_skips_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let runner = MockRunner::new(simple_metadata(&[])).with_fail_write();
-        let out = dir.path().join("cov.json");
-        let result = runner.cargo(&[
-            "llvm-cov",
-            "--package",
-            "ghost-pkg",
-            "--json",
-            "--output-path",
-            out.to_str().unwrap(),
-        ]);
-        assert!(matches!(result, Ok(true)));
-        assert!(!out.exists(), "no JSON when fail_write_json=true");
-    }
-
-    #[test]
-    fn mock_runner_package_ok_without_output_path_skips_write() {
-        // Exercises the `if let Some(path) = output_path` None branch inside
-        // the `Some(Ok)` arm — reached when --output-path is absent.
-        let report = LlvmCovReport {
-            data: vec![CovData {
-                files: vec![],
-                totals: full_metrics(2),
-            }],
-        };
-        let runner =
-            MockRunner::new(simple_metadata(&["my-pkg"])).with_package("my-pkg", Ok(report));
-        let result = runner.cargo(&["llvm-cov", "--package", "my-pkg", "--all-features"]);
-        assert!(matches!(result, Ok(true)));
-    }
-
-    #[test]
-    fn mock_runner_package_none_without_output_path_returns_ok() {
-        // Package not in package_results (None arm) with no --output-path.
-        let runner = MockRunner::new(simple_metadata(&[]));
-        let result = runner.cargo(&["llvm-cov", "--package", "ghost-pkg", "--all-features"]);
-        assert!(matches!(result, Ok(true)));
-    }
-
-    #[test]
-    fn mock_runner_non_package_cargo_call_returns_ok() {
-        // Exercises the early-return branch for a cargo call with no --package.
-        let runner = MockRunner::new(simple_metadata(&[]));
-        let result = runner.cargo(&["build", "--all-targets"]);
-        assert!(matches!(result, Ok(true)));
-    }
-
-    // ── write_github_output_content write-failure path ────────────────────────
-
-    /// A `Write` impl that always fails — used to cover the `write_all` Err path
-    /// inside `write_github_output_content`.
-    struct FailWriter;
-    impl std::io::Write for FailWriter {
-        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::other("disk full"))
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn write_github_output_content_write_failure_is_err() {
-        // Exercises the `write_all(...)` Err path inside write_github_output_content.
-        let mut writer = FailWriter;
-        let result = write_github_output_content(&full_metrics(1), &mut writer);
-        assert!(result.is_err(), "write to FailWriter should fail");
-    }
-
-    #[test]
-    fn fail_writer_flush_is_ok() {
-        // Covers the FailWriter::flush() impl — flush() always succeeds even
-        // though write() always fails (the two are orthogonal).
-        use std::io::Write;
-        let mut writer = FailWriter;
-        assert!(writer.flush().is_ok());
+    fn parse_workspace_packages_empty_metadata_is_empty() {
+        assert!(parse_workspace_packages(&serde_json::json!({})).is_empty());
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,9 +3,8 @@
 //! Run via: `cargo xtask <subcommand>`
 //!
 //! Subcommands:
-//!   coverage                    Compute all packages, aggregate, enforce a hard 100%.
-//!   coverage --package <pkg>    Compute just one package's coverage (CI fan-out).
-//!   coverage --gate             Aggregate collected per-package JSONs and enforce 100%.
+//!   coverage                    Gate every workspace package at a hard 100%.
+//!   coverage --package <pkg>    Gate just one package (the CI per-package fan-out).
 //!
 //! The zero-suppression policy (no `#[cfg(not(test))]`, no tarpaulin/lcov/grcov
 //! markers) is enforced separately by ast-grep — see `sgconfig.yml`/`.sgrules/`.
@@ -44,11 +43,8 @@ pub fn dispatch_with(
             println!("Usage: cargo xtask <subcommand>");
             println!();
             println!("Subcommands:");
-            println!("  coverage                  Compute all packages, aggregate, enforce 100%%");
-            println!("  coverage --package <pkg>  Compute one package's coverage (CI fan-out)");
-            println!(
-                "  coverage --gate           Aggregate collected per-package JSONs, gate 100%%"
-            );
+            println!("  coverage                  Gate every workspace package at 100%%");
+            println!("  coverage --package <pkg>  Gate one package (CI per-package fan-out)");
             Ok(())
         }
         other => anyhow::bail!("Unknown subcommand: '{other}'. Run `cargo xtask help` for usage."),
@@ -136,17 +132,6 @@ mod tests {
         })
         .unwrap();
         assert_eq!(got, Some(CoverageMode::All));
-    }
-
-    #[test]
-    fn dispatch_with_coverage_gate_parses_gate() {
-        let mut got = None;
-        dispatch_with(&args(&["coverage", "--gate"]), |mode| {
-            got = Some(mode);
-            Ok(())
-        })
-        .unwrap();
-        assert_eq!(got, Some(CoverageMode::Gate));
     }
 
     #[test]


### PR DESCRIPTION
Final coverage cleanup. `coverage.rs` shrinks from **~2630 → ~320 lines** by letting llvm-cov do the counting *and* the gating.

## What changed
Each package is gated by a single native invocation:
```
cargo llvm-cov --package <pkg> --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100 --ignore-filename-regex '[\\/]main\.rs$' --html --output-dir coverage/html/<pkg>
```
`--fail-under-* 100` on a package total is equivalent to a per-file 100% gate (a total can only be 100% if every file is). One call gates **and** emits HTML — both verified locally (exit 0 at 100%, exit 1 below).

**Deleted:** the JSON parsing, `LlvmCovReport`/`CovData`/`Metrics` structs, per-target scoping + `merge_target_reports`, per-package aggregation, the hand-rolled gap gate, `write_github_output`, and the `--gate` mode.

**Kept per-package** (not `--workspace`): that's the load-bearing part. `-C instrument-coverage` records every function in every binary that links it — including binaries that never call it — so a whole-workspace merge lets a never-run record shadow the covered one and reads genuinely-tested code below 100%. Bare `cargo llvm-cov --package X` is accurate now (leviath-cli hits 100% even merging its lib + 2 integration tests), so the old per-target scoping is no longer needed.

## CI
- `Coverage (os / package)` jobs now **self-gate** via `--fail-under` and upload HTML.
- `Coverage gate (os)` is kept (stable check name to avoid disturbing branch protection) as a `needs: [coverage]` confirmation + badge publisher — a green run is 100% by construction, so badges are static.

## Verified
Local (macOS): `cargo xtask coverage --package leviath-mcp` gates at 100% + emits HTML; unit + integration tests green; clippy + fmt clean. The 3-OS matrix on this PR is the real confirmation that bare `--package --fail-under` holds on Windows/Linux too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)