### PR TITLE
docs: strip historical/cross-subsystem comment cruft across the workspace

### DIFF
--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -373,9 +373,8 @@ mod tests {
     // ─── execute_with: injected write-failure arms ─────────────────────────
     //
     // These exercise the 3 `write_file(...)?` error arms deterministically,
-    // without the process-global umask mutation `execute`'s own comment
-    // history rejected (see git blame) -- each test injects a plain local
-    // closure that fails for one specific target filename, leaving the
+    // without any process-global umask mutation -- each test injects a plain
+    // local closure that fails for one specific target filename, leaving the
     // others to succeed exactly as production would.
 
     fn args_for(dir: &std::path::Path, name: &str) -> CreateArgs {

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -861,22 +861,16 @@ mod tests {
         assert!(dashboard.should_quit);
     }
 
-    // `run_crossterm_events_loop` (and this test, which was its only caller)
-    // were removed. That helper wired a real `CrosstermEventSource` into
-    // `run_dashboard_loop`, and this test tried to bound the result with a
-    // 300ms `tokio::time::timeout`. That bound does not work:
-    // `run_dashboard_loop`'s `loop { ... }` has no `.await` point anywhere in
-    // its body (`poll_event`, `try_lock`, `terminal.draw` are all
-    // synchronous), so on the default current-thread `#[tokio::test]`
-    // runtime the executor's single thread never regains control long
-    // enough for the timeout's own timer to fire -- a future that never
-    // yields can't be preempted by a sibling future racing it. In a non-TTY
-    // sandbox `CrosstermEventSource::poll_event` fails immediately, which is
-    // why this looked bounded in headless testing; on a real terminal (no
-    // scripted key ever sets `should_quit`) it hung indefinitely, observed
-    // as "has been running for over 60 seconds" in practice. This helper had
-    // no production caller (`execute`/`execute_core` call `run_dashboard_loop`
-    // directly), so there was nothing left to preserve coverage of.
+    // Caveat for anyone tempted to bound `run_dashboard_loop` with a
+    // `tokio::time::timeout`: its `loop { ... }` has no `.await` point
+    // (`poll_event`, `try_lock`, `terminal.draw` are all synchronous), so on
+    // the default current-thread `#[tokio::test]` runtime the executor's
+    // single thread never regains control long enough for the timeout's own
+    // timer to fire -- a future that never yields can't be preempted by a
+    // sibling future racing it. In a non-TTY sandbox
+    // `CrosstermEventSource::poll_event` fails immediately (so it looks
+    // bounded in headless testing); on a real terminal, with no scripted key
+    // ever setting `should_quit`, it hangs indefinitely.
 
     // ─── CrosstermEventSource poll branches ─────────────────────────────────
 

--- a/crates/leviath-cli/src/commands/run/helpers.rs
+++ b/crates/leviath-cli/src/commands/run/helpers.rs
@@ -126,7 +126,7 @@ pub async fn generate_title(
     }
 }
 
-// `initialize_context_window` + `swap_context_layout` moved into
+// `initialize_context_window` + `swap_context_layout` live in
 // `leviath-runtime::context_setup` (pure engine/context operations, no CLI
 // dependency). Re-exported so `super::helpers::...` /
 // `crate::commands::run::helpers::...` call sites keep resolving.

--- a/crates/leviath-cli/src/commands/run/io.rs
+++ b/crates/leviath-cli/src/commands/run/io.rs
@@ -11,17 +11,16 @@ use leviath_core::Stage;
 
 use crate::runstate::RegionSnapshot;
 
-// The `RunIO` trait moved into `leviath-runtime` (so the relocated stage engine
-// can name it without a `runtime -> cli` cycle). Re-exported here so existing
+// The `RunIO` trait lives in `leviath-runtime` (so the stage engine can name it
+// without a `runtime -> cli` cycle). Re-exported here so
 // `crate::commands::run::io::RunIO` / `super::io::RunIO` paths keep resolving,
 // and so the concrete `ConsoleIO`/`MockIO` impls below can name it.
 pub use leviath_runtime::run_io::RunIO;
 
 /// Reads a single line from `reader` and returns it trimmed, or `None` on a
 /// read error (note: EOF is `Ok(0)`, not an error, so it yields
-/// `Some(String::new())` -- preserved as-is from the original inline
-/// implementation). Takes `&mut dyn BufRead` (rather than a generic `R` or
-/// real stdin) so it has a single coverage-mapping instance and tests can
+/// `Some(String::new())`). Takes `&mut dyn BufRead` (rather than a generic `R`
+/// or real stdin) so it has a single coverage-mapping instance and tests can
 /// drive it with an in-memory reader instead of blocking on real stdin.
 fn get_user_input_from_reader(reader: &mut dyn std::io::BufRead) -> Option<String> {
     let mut buf = String::new();

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -3,7 +3,7 @@
 use crate::config::Config;
 use leviath_runtime::ProviderRegistry;
 
-// `ProviderCreds` + `build_provider_registry(&[ProviderCreds])` moved into
+// `ProviderCreds` + `build_provider_registry(&[ProviderCreds])` live in
 // `leviath-runtime` (plain data + provider instantiation, no `Config`
 // dependency). Re-exported here so `commands::run`'s public re-export and all
 // existing call sites keep resolving. The `Config`-based translators
@@ -660,9 +660,6 @@ mod tests {
         assert_eq!(ollama.base_url.as_deref(), Some("http://custom:11434"));
         assert!(ollama.api_key.is_none());
     }
-
-    // `build_provider_registry_from_creds_slice` moved with
-    // `build_provider_registry` into `leviath-runtime::provider_creds`.
 
     // ─── resolve_task: multiline file content ───────────────────────────
 

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -2909,10 +2909,10 @@ mod tests {
     #[tokio::test]
     async fn interactive_stage_tools_foreground_completes_one_turn() {
         // Exercises the `has_tools = true` branch of `run_interactive_stage`:
-        //   • run_inference_loop_filtered succeeds → lines 76-112 (including the
-        //     `if let Some(mut window)` at line 105 whose `}` at line 112 was a gap)
-        //   • foreground path for user input → empty → loop breaks at line 177
-        // No meta/run_id → takes the foreground input path (line 172).
+        //   • run_inference_loop_filtered succeeds → the `if let Some(mut window)`
+        //     context-sync branch
+        //   • foreground path for user input → empty → loop breaks
+        // No meta/run_id → takes the foreground input path.
         let bp = make_blueprint(vec![make_stage("main")]);
         let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
         let mut io = EmptyInputIO;

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -658,7 +658,6 @@ prompt = "Run"
     /// directory, so making the directory `0o555` is what forces
     /// `remove_dir_all` to fail there. Windows has no equivalent
     /// "directory write permission" concept via `std::fs::Permissions`, and
-    /// -- contrary to what an earlier version of this test assumed --
     /// marking a file inside the directory read-only does NOT make
     /// `remove_dir_all` fail on Windows: it clears the read-only attribute
     /// before deleting, the same way it silently succeeds through other

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -790,14 +790,13 @@ mod tests {
     }
 
     /// Single shared copy of the `run_id`-extraction match every test below
-    /// exercises, instead of each test carrying its own inline copy. Before
-    /// this, 4 separate tests each duplicated the full match expression at
-    /// a different source line but only ever constructed 1-5 of the 7
-    /// `ServerEvent` variants, so `llvm-cov` (which counts per source line,
-    /// not per logical match) saw most arms of most of those copies as
-    /// never hit -- even though every arm undeniably works, just not from
-    /// that specific copy's test data. A single shared function means every
-    /// arm only needs to be hit once, from any caller, to be covered.
+    /// exercises, instead of each test carrying its own inline copy.
+    /// `llvm-cov` counts coverage per source line, not per logical match: with
+    /// the match duplicated inline across tests that each construct only 1-5 of
+    /// the 7 `ServerEvent` variants, most arms of most copies read as never hit
+    /// -- even though every arm works, just not from that copy's test data. A
+    /// single shared function means every arm only needs to be hit once, from
+    /// any caller, to be covered.
     fn get_run_id(ev: &ServerEvent) -> &str {
         match ev {
             ServerEvent::AgentStatus { run_id, .. } => run_id,

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -1348,8 +1348,8 @@ max_output_tokens = 2048
         // `Drop` always takes the `None => remove_var(..)` arm. This test
         // seeds both vars with sentinel values first, so `Drop` must take the
         // `Some(path) => set_var(..)` arm instead, restoring them rather than
-        // removing them. The lock is held continuously (moved into the guard
-        // itself) so no concurrently-running test elsewhere in the crate can
+        // removing them. The lock is held continuously (by the guard itself)
+        // so no concurrently-running test elsewhere in the crate can
         // observe or clobber the sentinel values in between.
         let lock = CONFIG_PATH_ENV_LOCK
             .lock()

--- a/crates/leviath-cli/src/interaction.rs
+++ b/crates/leviath-cli/src/interaction.rs
@@ -23,12 +23,12 @@ use std::time::{Duration, Instant};
 
 use crate::runstate::{run_dir, write_meta, RunMeta, RunStatus};
 
-// ─── Value types (moved to `leviath-core`, re-exported for compat) ────────────
+// ─── Value types (re-exported from `leviath-core`) ────────────
 //
-// The plain serde value types and their pure resolver helpers now live in
+// The plain serde value types and their pure resolver helpers live in
 // `leviath_core::interaction` so the engine in `leviath-runtime` can reference
-// them without depending on the CLI. They are re-exported here so existing
-// `crate::interaction::*` paths continue to resolve unchanged.
+// them without depending on the CLI. Re-exported here so `crate::interaction::*`
+// paths resolve.
 pub use leviath_core::interaction::{
     make_interaction_id, response_approved, response_as_choice, response_as_text, ApprovalScope,
     BodyFormat, InteractionKind, InteractionRequest, InteractionResponse,

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -15,10 +15,9 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // The plain run-state data types (RunMeta, RunStatus, the snapshot structs, and
-// the per-stage records) now live in `leviath_core::run_meta`. They are
-// re-exported here unchanged so existing `crate::runstate::RunMeta` /
-// `runstate::RunMeta` call sites across the cli keep compiling. All on-disk IO
-// for these types remains in this module.
+// the per-stage records) live in `leviath_core::run_meta`. Re-exported here so
+// `crate::runstate::RunMeta` / `runstate::RunMeta` call sites across the cli
+// resolve. All on-disk IO for these types remains in this module.
 pub use leviath_core::run_meta::{
     ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta, RunStatus, StageRecord,
     StageRunStatus,

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -169,9 +169,9 @@ use leviath_runtime::{
 };
 use tokio::sync::RwLock;
 
-// `spawn_child_agent` moved into `leviath-runtime` (it operates purely on the
+// `spawn_child_agent` lives in `leviath-runtime` (it operates purely on the
 // engine pool/world + a `Blueprint`). Re-exported here so `crate::tools::
-// spawn_child_agent` / `super::spawn_child_agent` call sites keep resolving.
+// spawn_child_agent` / `super::spawn_child_agent` call sites resolve.
 pub use leviath_runtime::spawn_child_agent;
 
 /// Shared state for sub-agent tool execution.

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -2,7 +2,7 @@
 //!
 //! These are pure data (`serde`-derived structs/enums plus trivial constructors)
 //! with no filesystem or async dependencies, so they can be named by both
-//! `leviath-cli` and the (future) `leviath-runtime` engine. All on-disk IO for
+//! `leviath-cli` and the `leviath-runtime` engine. All on-disk IO for
 //! these types (reading/writing `meta.json`, run directories, snapshots, etc.)
 //! lives in `leviath_cli::runstate`.
 

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -19,14 +19,6 @@ fn maybe_dump_request(body: &serde_json::Value) {
     );
 }
 
-/// Always log the serialized request size at debug, and — when `dir` is
-/// `Some` — write the full JSON body to `<dir>/anthropic-req-<unix_nanos>.json`.
-///
-/// Diagnostic for the `read_files` stall: it lets us see exactly how the
-/// request that stalls (the one after a batch read, with file-tracked content
-/// injected into the system prompt) differs from the small requests that
-/// succeed — size, structure, and content — without a special build. Enable by
-/// setting `LEVIATH_DUMP_REQUEST_DIR`.
 /// Choose which system-block indices carry a `cache_control` breakpoint.
 ///
 /// Anthropic allows at most 4 `cache_control` blocks per request, counted
@@ -68,6 +60,14 @@ fn system_cache_breakpoints(hints: &[leviath_core::CacheHint], budget: usize) ->
     ends
 }
 
+/// Always log the serialized request size at debug, and — when `dir` is
+/// `Some` — write the full JSON body to `<dir>/anthropic-req-<unix_nanos>.json`.
+///
+/// Diagnostic for comparing request bodies: it lets us see exactly how a
+/// request that stalls (e.g. one after a batch read, with file-tracked content
+/// injected into the system prompt) differs from the small requests that
+/// succeed — size, structure, and content — without a special build. Enable by
+/// setting `LEVIATH_DUMP_REQUEST_DIR`.
 fn dump_request(body: &serde_json::Value, dir: Option<&str>) {
     let bytes = serde_json::to_vec(body).map(|v| v.len()).unwrap_or(0);
     tracing::debug!(request_bytes = bytes, "anthropic request body");

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -1,4 +1,4 @@
-//! Engine context-window setup helpers shared by the relocated stage engine.
+//! Engine context-window setup helpers shared by the stage engine.
 //!
 //! These are pure operations over an [`AgentEngine`]'s [`ContextWindow`] driven
 //! by a blueprint/layout, so they live in the runtime (the CLI re-exports them

--- a/crates/leviath-runtime/src/engine.rs
+++ b/crates/leviath-runtime/src/engine.rs
@@ -460,10 +460,9 @@ impl AgentEngine {
     /// always-allow / deny); a deny substitutes a `[blocked]` result and skips
     /// execution. When the gate is inactive, every call executes.
     /// Synchronously classify a batch of tool calls against the current taint
-    /// state. Extracted from [`Self::taint_gate_partition`] so all the
-    /// gate/policy logic lives in a non-async function (fully unit-testable and
-    /// not subject to async-instantiation coverage artifacts); the async fn
-    /// only awaits the prompt.
+    /// state. Keeping all the gate/policy logic in a non-async function makes it
+    /// fully unit-testable and not subject to async-instantiation coverage
+    /// artifacts; the async [`Self::taint_gate_partition`] only awaits the prompt.
     fn gate_decisions(
         &mut self,
         entity: Entity,
@@ -7008,9 +7007,9 @@ mod tests {
     /// max_result_tokens truncation of a multi-byte UTF-8 tool result.
     ///
     /// max_result_tokens=5 → max_chars=20. Byte 20 of the content below lands
-    /// inside a 3-byte "—", so the old `result_text.truncate(20)` panicked; that
-    /// panic in the tool-result path is what stalled `read_files` runs. With the
-    /// char-safe truncation this completes and produces valid UTF-8.
+    /// inside a 3-byte "—", which a byte-index `truncate(20)` would split,
+    /// panicking in the tool-result path and stalling `read_files` runs. The
+    /// char-safe truncation completes and produces valid UTF-8.
     #[tokio::test]
     async fn test_tool_result_truncation_multibyte_utf8_does_not_panic() {
         with_tracing_async(async {

--- a/crates/leviath-runtime/src/graph.rs
+++ b/crates/leviath-runtime/src/graph.rs
@@ -6,12 +6,6 @@ use leviath_core::lifecycle::CompactionConfig;
 use leviath_core::{Blueprint, RegionKind, Stage};
 use std::collections::HashMap;
 
-/// COVERAGE-EXCLUDED: llvm-cov's tracing-macro message-literal region is
-/// permanently uncovered regardless of restructuring (event!/pre-formatted
-/// let/inline(never)/crate-version were all tried and ruled out this
-/// session) -- isolating the bare macro call behind a twin removes the
-/// unfixable region from what's measured without touching the surrounding,
-/// fully-testable control flow that decides WHETHER to call it.
 /// Determine whether a blueprint uses graph mode (any stage has transitions set).
 pub fn is_graph_mode(blueprint: &Blueprint) -> bool {
     blueprint.stages.iter().any(|s| s.transitions.is_some())

--- a/crates/leviath-runtime/src/run_io.rs
+++ b/crates/leviath-runtime/src/run_io.rs
@@ -1,6 +1,6 @@
 //! Abstraction over I/O for the stage executor.
 //!
-//! The trait lives in `leviath-runtime` so the relocated stage engine can talk
+//! The trait lives in `leviath-runtime` so the stage engine can talk
 //! to it without depending on the CLI. Concrete implementations
 //! (`ConsoleIO`, the foreground/worker adapters, and the test `MockIO`) live in
 //! `leviath-cli`.

--- a/crates/leviath-runtime/src/tool_source.rs
+++ b/crates/leviath-runtime/src/tool_source.rs
@@ -1,11 +1,11 @@
 //! Decoupling seam between the stage loop and the concrete tool registry.
 //!
-//! Phase 3 of the engine relocation. The stage loop / stages / fan-out only
+//! The stage loop / stages / fan-out only
 //! need two things from the CLI's [`ToolRegistry`](crate::tools::ToolRegistry):
 //! the set of tool definitions to advertise, and a way to execute a single tool
-//! call by name. Capturing exactly that in [`StageToolSource`] lets a later
-//! phase move the stage loop into `leviath-runtime` without a `runtime -> cli`
-//! dependency on `ToolRegistry`. The concrete `impl`s stay in `tools.rs`.
+//! call by name. Capturing exactly that in [`StageToolSource`] keeps the stage
+//! loop free of a `runtime -> cli` dependency on `ToolRegistry`. The concrete
+//! `impl`s stay in `tools.rs`.
 
 use std::sync::Arc;
 

--- a/crates/leviath-scripting/src/functions.rs
+++ b/crates/leviath-scripting/src/functions.rs
@@ -32,7 +32,7 @@ pub fn register_functions(engine: &mut Engine) {
             .collect()
     });
 
-    // Token counting (approximate for now)
+    // Token counting (approximate)
     engine.register_fn("count_tokens", |text: &str| -> i64 {
         text.len().div_ceil(4) as i64
     });

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,9 +5,6 @@
 //! Subcommands:
 //!   coverage                    Gate every workspace package at a hard 100%.
 //!   coverage --package <pkg>    Gate just one package (the CI per-package fan-out).
-//!
-//! The zero-suppression policy (no `#[cfg(not(test))]`, no tarpaulin/lcov/grcov
-//! markers) is enforced separately by ast-grep — see `sgconfig.yml`/`.sgrules/`.
 
 mod coverage;
 


### PR DESCRIPTION
A codebase-wide, **comment-only** sweep (verified: 0 non-comment lines changed; build + clippy clean). Swept every crate in parallel with a rubric biased toward *keeping* load-bearing rationale.

## Removed
- History narration — "previously / used to / was moved from / formerly did"; tightened "previously X; now Y because Z" to just "Y because Z".
- Cross-subsystem asides that don't belong to their file (e.g. the ast-grep suppression-policy note inside `xtask/main.rs`).
- A couple of tombstone comments and a stale `COVERAGE-EXCLUDED` block that no longer applied.
- One orphaned doc-comment relocated to the function it actually documents (`anthropic.rs` `dump_request`).

## Deliberately kept
SAFETY rationale, the `cargo-llvm-cov` monomorphization / tracing-macro coverage quirks, the crossterm poll-hang caveat, lock/ordering/protocol invariants, and the currently-live cross-platform test "twin" variants.

21 files, −24 net lines. History lives in git; present-tense rationale stays in the comments.

> Note: an unrelated **pre-existing** broken private-intra-doc-link (`FanOutConfig` → `Blueprint::validate_graph`) was surfaced by a strict `cargo doc -D warnings` check — not touched here (not a regression), flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)