### PR TITLE
docs(readme): add Testing policy note (100%, no suppression, thin bin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ cargo clean -p cargo-husky && cargo test -p xtask
 
 </details>
 
+### Testing policy
+
+The workspace is gated at a hard **100%** on lines, regions, and functions — with no way to opt out. Coverage-suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov annotations) are banned by the ast-grep lint above, so code can't be hidden from measurement — it has to be refactored until it's testable. The *only* un-unit-tested code is the thin `lev` binary entrypoint (`crates/leviath-cli/src/main.rs`): the composition root that wires real terminal, stdin, network, and subprocess I/O into the library's tested cores. It's excluded from coverage measurement and guarded by a CI check that requires maintainer sign-off to change.
+
 ### Running coverage locally
 
 `cargo xtask coverage` gates each workspace package with `cargo llvm-cov --package <pkg> --fail-under-{lines,functions,regions} 100` — llvm-cov does the counting *and* the gating; there's no custom parsing or aggregation. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows — any file below 100% fails the build, and a browsable HTML report lands in the gitignored `coverage/` folder. Measurement is deliberately **per-package**, not `--workspace`: `-C instrument-coverage` records every function in every binary that links it (including ones that never call it), and the whole-workspace merge can let a never-run record shadow the covered one — so one package at a time is what keeps llvm-cov's counts accurate. See the doc comment atop `xtask/src/coverage.rs`.


### PR DESCRIPTION
The README covered the coverage/ast-grep/hook mechanics but never stated the *policy* behind this session's changes. Adds one concise **Testing policy** subsection: hard 100% with no opt-out, suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov) banned by the ast-grep lint, and the only un-unit-tested code being the thin `lev` binary entrypoint (excluded from measurement, guarded by maintainer sign-off).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)