### PR TITLE
docs: make rustdoc clean under -D warnings + enforce in CI/hook

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -26,13 +26,19 @@ cargo clippy --all-targets --all-features -- -D warnings \
   || fail "cargo clippy failed. Fix the warnings above."
 pass "Clippy OK"
 
-# 3. Tests
+# 3. Docs — no broken/private intra-doc links, no stray HTML tags
+info "Checking docs..."
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --quiet \
+  || fail "cargo doc failed — broken/private intra-doc links or invalid HTML. Fix the warnings above."
+pass "Docs OK"
+
+# 4. Tests
 info "Running tests..."
 cargo test --all \
   || fail "Tests failed. Fix the failing tests above."
 pass "Tests OK"
 
-# 4. No coverage-suppression markers (ast-grep structural lint)
+# 5. No coverage-suppression markers (ast-grep structural lint)
 info "Checking for coverage suppression markers..."
 if command -v ast-grep >/dev/null 2>&1; then
   ast-grep scan crates xtask .github/workflows \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,21 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  # Rejects broken or private intra-doc links and stray HTML tags in doc
+  # comments (`-D warnings` promotes every rustdoc lint to an error). Cheap and
+  # OS-independent, so it runs once on ubuntu.
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check docs
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
   # Coverage runs on all three OSes and enforces a hard 100% on regions, lines,
   # and functions. Each (os × package) runner GATES one package with llvm-cov's
   # own thresholds: `cargo xtask coverage --package <pkg>` runs `cargo llvm-cov

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ The hook enforces, before every commit:
 
 - **formatting** (`cargo fmt --check`)
 - **clippy** with warnings-as-errors
+- **doc lints** (`cargo doc` with `-D warnings` — no broken/private intra-doc links or stray HTML)
 - the **full test suite**
 - the **coverage-suppression-marker lint** (`ast-grep scan`, if `ast-grep` is installed; CI always enforces it)
 

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -58,7 +58,7 @@ async fn engine_background_loop(
 
 /// Abstracts "give me the next input event, or `None` if the poll timeout
 /// elapses" (i.e. `crossterm::event::poll` + `event::read`), so the
-/// dashboard's main loop ([`run_dashboard_loop`]) can be driven by canned
+/// dashboard's main loop (`run_dashboard_loop`) can be driven by canned
 /// events in tests instead of blocking on a real terminal.
 pub trait EventSource {
     fn poll_event(&mut self, timeout: Duration) -> std::io::Result<Option<Event>>;
@@ -94,7 +94,7 @@ impl EventSource for CrosstermEventSource {
     }
 }
 
-/// Abstracts terminal setup/teardown so [`execute_core`] can be tested with
+/// Abstracts terminal setup/teardown so `execute_core` can be tested with
 /// a [`ratatui::backend::TestBackend`] and no-op TTY operations. The real
 /// crossterm implementation (`CrosstermSetup`) lives in the binary — see
 /// `real_dashboard` — since it can only be exercised against a real terminal.

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -209,7 +209,7 @@ pub struct StageContext<'a> {
 
 /// A foreground interaction-point asker: resolves an `InteractionRequest` to a
 /// response (real stdin in the binary, a mock in tests). Used by
-/// [`crate::commands::run::stages::run_interactive_points_stage`] on the
+/// `run_interactive_points_stage` on the
 /// foreground (no-run-context) path.
 pub type InteractionAsker =
     fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse;
@@ -256,7 +256,7 @@ pub trait StageCallbacks: Send {
     /// Foreground overrides this to return `Some(..)` (its injected asker);
     /// background/worker callers keep the default `None` and resolve interaction
     /// points via IPC (`get_run_context` returns `Some`).
-    /// [`crate::commands::run::stages::run_interactive_points_stage`] requires a
+    /// `run_interactive_points_stage` requires a
     /// `Some` asker only when there's no run context (true foreground).
     fn interaction_point_asker(&self) -> Option<InteractionAsker> {
         None

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -153,7 +153,7 @@ fn open_log_file(log_path: &std::path::Path) -> (std::fs::File, std::fs::File) {
 /// `io` carries the real-stdin dependencies the binary injects (see
 /// [`foreground::ForegroundIo`]). Foreground runs use all of them; background
 /// runs only need the `stdin_is_terminal` probe (for task resolution's
-/// editor-launch path), which is threaded down to [`execute_background`].
+/// editor-launch path), which is threaded down to `execute_background`.
 pub async fn execute(args: RunArgs, io: foreground::ForegroundIo) -> anyhow::Result<()> {
     if args.foreground {
         if args.count > 1 {

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -80,7 +80,7 @@ impl RiskyExecutors for RealExecutors {
 }
 
 /// Real `lev dash`: supplies the real crossterm terminal backend and event
-/// source to the library's fully-tested [`dashboard::execute_with`]. Wiring
+/// source to the library's fully-tested `dashboard::execute_with`. Wiring
 /// only — the loop, rendering, input handling, and engine setup it composes
 /// are all exercised under `cargo test`.
 async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1,6 +1,6 @@
 //! On-disk run state for background agent executions.
 //!
-//! Each run lives under ~/.leviath/runs/<run-id>/ with:
+//! Each run lives under `~/.leviath/runs/<run-id>/` with:
 //! - `meta.json`    — run metadata, updated atomically (tmp + rename)
 //! - `output.log`  — append-only combined worker stdout (legacy/fallback)
 //! - `stages.json` — index of per-stage records
@@ -102,7 +102,7 @@ fn dashboard_log_path_from(env_override: Option<&str>) -> PathBuf {
 /// Path to the persistent dashboard activity log (~/.leviath/dashboard.log).
 ///
 /// Honours the `LEVIATH_DASHBOARD_LOG_PATH` override when set (tests use it via
-/// [`isolate_runs_dir_for_test`]); otherwise resolves the real home-relative
+/// `isolate_runs_dir_for_test`); otherwise resolves the real home-relative
 /// path. This function only *computes* a `PathBuf` — it never writes — so both
 /// arms are safe to exercise directly in tests. The write side
 /// ([`append_dashboard_log`] and `Dashboard::add_log`) is what must stay off
@@ -153,7 +153,7 @@ pub fn append_dashboard_log_to(path: &Path, msg: &str) {
 /// worker processes writing state nobody could see.
 static RUN_ID_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
-/// Generate a unique run ID: "<agent_name>-<timestamp>-<suffix>".
+/// Generate a unique run ID: `<agent_name>-<timestamp>-<suffix>`.
 pub fn new_run_id(agent_name: &str) -> String {
     let now = now_secs();
     let counter = RUN_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as i64;

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -444,7 +444,7 @@ pub enum WorkerFailurePolicy {
 /// Configuration for a [`StageMode::FanOut`] stage.
 ///
 /// Exactly one of `worker_agent` / `worker_stage` / `worker_query` selects the
-/// worker's agent type (validated in [`Blueprint::validate_graph`]).
+/// worker's agent type (validated when the blueprint's graph is checked).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FanOutConfig {
     /// A separate registered/installed blueprint run as the worker agent type.

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -375,7 +375,7 @@ const READ_STALL_TIMEOUT_SECS: u64 = 900;
 ///   so forcing a fresh connection per request, not the protocol, is the fix.
 ///   The cost is a TLS handshake per request, negligible for the sequential
 ///   request/response calls these providers make.
-/// - a `read_timeout` (idle/stall timeout — see [`READ_STALL_TIMEOUT_SECS`]) as
+/// - a `read_timeout` (idle/stall timeout — see `READ_STALL_TIMEOUT_SECS`) as
 ///   a backstop so a stalled connection can never hang the process forever;
 /// - TCP keep-alive.
 ///

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -207,7 +207,7 @@ impl ContextWindow {
     /// Add a typed entry to a specific region.
     ///
     /// Like [`add_to_region`](Self::add_to_region) but the entry carries an
-    /// [`EntryKind`] so message roles are determined by type, not text-prefix
+    /// `EntryKind` so message roles are determined by type, not text-prefix
     /// parsing.
     pub fn add_typed_entry(
         &mut self,
@@ -703,7 +703,7 @@ impl ContextWindow {
     ///
     /// The typed+tainted counterpart of [`add_typed_entry`](Self::add_typed_entry)
     /// and [`add_tainted_to_region`](Self::add_tainted_to_region): the entry keeps
-    /// its [`EntryKind`] (so turn-group eviction stays intact) while contributing
+    /// its `EntryKind` (so turn-group eviction stays intact) while contributing
     /// the given taint level (so the taint gate sees sensitive tool output).
     pub fn add_typed_tainted_to_region(
         &mut self,

--- a/crates/leviath-runtime/src/tool_source.rs
+++ b/crates/leviath-runtime/src/tool_source.rs
@@ -1,7 +1,7 @@
 //! Decoupling seam between the stage loop and the concrete tool registry.
 //!
 //! The stage loop / stages / fan-out only
-//! need two things from the CLI's [`ToolRegistry`](crate::tools::ToolRegistry):
+//! need two things from the CLI's `ToolRegistry`:
 //! the set of tool definitions to advertise, and a way to execute a single tool
 //! call by name. Capturing exactly that in [`StageToolSource`] keeps the stage
 //! loop free of a `runtime -> cli` dependency on `ToolRegistry`. The concrete

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -12,7 +12,7 @@
 //!    `Permissions::from_mode(0o600)` logic each has exactly one implementation
 //!    here, rather than being spread across call sites in `leviath-cli`.
 //! 2. **Per-OS coverage correctness.** Because all platform code is gathered
-//!    into cfg-gated submodules ([`platform`]), the non-target
+//!    into cfg-gated submodules (`platform`), the non-target
 //!    implementations (`#[cfg(windows)]` on a Linux CI run) are simply not
 //!    compiled, so the coverage tool never sees them as gaps. The
 //!    Linux-visible code paths are all reachable from real unit tests.

--- a/crates/leviath-sys/src/tty.rs
+++ b/crates/leviath-sys/src/tty.rs
@@ -5,7 +5,7 @@
 //! clipboard tool. The bytes must reach the real terminal — the controlling
 //! `/dev/tty` or stdout.
 //!
-//! This module holds the pure, fully-tested pieces: [`osc52_sequence`] (the
+//! This module holds the pure, fully-tested pieces: `osc52_sequence` (the
 //! base64/escape encoding) and [`osc52_write_via`] (the tty-then-stdout branch
 //! logic, parameterized over the tty opener and the fallback sink so every
 //! branch is exercised via injected fakes). The genuinely-untestable real-I/O

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,8 +3,8 @@
 //! Run via: `cargo xtask <subcommand>`
 //!
 //! Subcommands:
-//!   coverage                    Gate every workspace package at a hard 100%.
-//!   coverage --package <pkg>    Gate just one package (the CI per-package fan-out).
+//!   `coverage`                  Gate every workspace package at a hard 100%.
+//!   `coverage --package <pkg>`  Gate just one package (the CI per-package fan-out).
 
 mod coverage;
 


### PR DESCRIPTION
Fixes **18 pre-existing rustdoc warnings** across the workspace and enforces a clean doc build going forward.

## Fixes (comment-only, no code changed, all tests green)
- Broken and private intra-doc links (`[`validate_graph`]`, `[`EntryKind`]`, `[`ToolRegistry`]`, `[`execute_core`]`, …) demoted to plain code spans.
- `<...>` tokens in doc comments (`<pkg>`, `<timestamp>`, `<suffix>`, `<run-id>`, …) backticked so rustdoc doesn't parse them as HTML.

`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` now exits clean.

## Enforcement (the lightweight check you asked for)
- **CI:** new `Docs` job runs the doc check (ubuntu-only, OS-independent).
- **pre-commit hook:** same check, as step 3.

> Touches `crates/leviath-cli/src/main.rs` (one doc-comment line), so `guard-main-rs` needs the `allow-main-rs-change` label — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)