### PR TITLE
Eliminate all unsafe; forbid(unsafe_code) workspace-wide; edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,18 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@gmail.com>"]
 repository = "https://github.com/Sun-Forge-AI/leviath"
 description = "A structured agent runtime for LLMs — context memory, multi-stage workflows, and ECS-based orchestration"
+
+# Lints applied to every workspace member that opts in with `[lints] workspace = true`.
+# `unsafe_code = "forbid"` is a hard compile error that cannot be re-enabled by a
+# local `#[allow(unsafe_code)]` -- the OS-level unsafe leviath needs lives in audited
+# dependencies (nix, temp-env), so none is written in our own crates.
+[workspace.lints.rust]
+unsafe_code = "forbid"
 
 [workspace.dependencies]
 # Core crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ dirs = "6.0.0"
 dotenvy = "0.15"
 libc = "0.2"
 nix = { version = "0.28", default-features = false, features = ["signal", "process"] }
+temp-env = "0.3"
 crossterm = "0.28"
 ratatui = "0.29"
 pulldown-cmark = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tar = "0.4"
 dirs = "6.0.0"
 dotenvy = "0.15"
 libc = "0.2"
+nix = { version = "0.28", default-features = false, features = ["signal", "process"] }
 crossterm = "0.28"
 ratatui = "0.29"
 pulldown-cmark = "0.12"

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -54,3 +54,4 @@ tower = { version = "0.5", features = ["util"] }
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = { workspace = true, features = ["async_closure"] }

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -55,3 +55,6 @@ tower = { version = "0.5", features = ["util"] }
 [dev-dependencies]
 tempfile = "3"
 temp-env = { workspace = true, features = ["async_closure"] }
+
+[lints]
+workspace = true

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -704,37 +704,44 @@ description = "test"
                 // same `LEVIATH_CONFIG_PATH` seam to point it at a
                 // deliberately-malformed file -- without this, this test can
                 // flakily observe that other test's mid-flight override.
-                let _guard = crate::config::isolate_config_path_for_test("add-registry-installs");
-                let project_dir = tempfile::tempdir().unwrap();
-                std::fs::write(
+                crate::config::with_isolated_config_path_async(
+                    "add-registry-installs",
+                    |_fake_dir| async move {
+                        let project_dir = tempfile::tempdir().unwrap();
+                        std::fs::write(
                     project_dir.path().join("agent.leviath"),
                     "[agent]\nname = \"reg-pkg\"\nversion = \"1.0.0\"\ndescription = \"d\"\n",
                 )
                 .unwrap();
-                let bundle_bytes = leviath_package::AgentBundler::new()
-                    .bundle(project_dir.path())
-                    .unwrap();
+                        let bundle_bytes = leviath_package::AgentBundler::new()
+                            .bundle(project_dir.path())
+                            .unwrap();
 
-                let info_json =
+                        let info_json =
                     br#"{"name":"reg-pkg","version":"1.0.0","description":"A registry package"}"#;
-                let url =
-                    spawn_mock_registry(info_json, Box::leak(bundle_bytes.into_boxed_slice()))
+                        let url = spawn_mock_registry(
+                            info_json,
+                            Box::leak(bundle_bytes.into_boxed_slice()),
+                        )
                         .await;
 
-                let agents_dir = tempfile::tempdir().unwrap();
-                let installer = leviath_package::AgentInstaller::with_install_dir(
-                    agents_dir.path().to_path_buf(),
-                );
-                let args = AddArgs {
-                    package: "reg-pkg".to_string(),
-                    registry: Some(url),
-                };
+                        let agents_dir = tempfile::tempdir().unwrap();
+                        let installer = leviath_package::AgentInstaller::with_install_dir(
+                            agents_dir.path().to_path_buf(),
+                        );
+                        let args = AddArgs {
+                            package: "reg-pkg".to_string(),
+                            registry: Some(url),
+                        };
 
-                execute_with(&args, &installer, agents_dir.path())
-                    .await
-                    .unwrap();
+                        execute_with(&args, &installer, agents_dir.path())
+                            .await
+                            .unwrap();
 
-                assert!(agents_dir.path().join("reg-pkg").exists());
+                        assert!(agents_dir.path().join("reg-pkg").exists());
+                    },
+                )
+                .await;
             })
         });
     }
@@ -777,21 +784,25 @@ description = "test"
         let rt = tokio::runtime::Runtime::new().unwrap();
         with_tracing(|| {
             rt.block_on(async {
-                let guard =
-                    crate::config::isolate_config_path_for_test("add-registry-config-error");
-                std::fs::write(guard.fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
+                crate::config::with_isolated_config_path_async(
+                    "add-registry-config-error",
+                    |fake_dir| async move {
+                        std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
 
-                let agents_dir = tempfile::tempdir().unwrap();
-                let installer = leviath_package::AgentInstaller::with_install_dir(
-                    agents_dir.path().to_path_buf(),
-                );
-                let args = AddArgs {
-                    package: "some-registry-package".to_string(),
-                    registry: None,
-                };
+                        let agents_dir = tempfile::tempdir().unwrap();
+                        let installer = leviath_package::AgentInstaller::with_install_dir(
+                            agents_dir.path().to_path_buf(),
+                        );
+                        let args = AddArgs {
+                            package: "some-registry-package".to_string(),
+                            registry: None,
+                        };
 
-                let result = execute_with(&args, &installer, agents_dir.path()).await;
-                assert!(result.is_err());
+                        let result = execute_with(&args, &installer, agents_dir.path()).await;
+                        assert!(result.is_err());
+                    },
+                )
+                .await;
             })
         });
     }
@@ -804,25 +815,29 @@ description = "test"
                 // See `execute_with_registry_package_installs` for why this
                 // guard is needed even though this test never writes a
                 // config file of its own.
-                let _guard =
-                    crate::config::isolate_config_path_for_test("add-registry-get-info-refused");
-                // Fixed, never-bound high port (same pattern used in
-                // leviath-package's own connection-refused tests) --
-                // deterministic, unlike bind-then-drop which races against
-                // other parallel tests' ephemeral-port allocations.
-                let agents_dir = tempfile::tempdir().unwrap();
-                let installer = leviath_package::AgentInstaller::with_install_dir(
-                    agents_dir.path().to_path_buf(),
-                );
-                let args = AddArgs {
-                    package: "some-registry-package".to_string(),
-                    registry: Some("http://127.0.0.1:19999".to_string()),
-                };
+                crate::config::with_isolated_config_path_async(
+                    "add-registry-get-info-refused",
+                    |_fake_dir| async move {
+                        // Fixed, never-bound high port (same pattern used in
+                        // leviath-package's own connection-refused tests) --
+                        // deterministic, unlike bind-then-drop which races against
+                        // other parallel tests' ephemeral-port allocations.
+                        let agents_dir = tempfile::tempdir().unwrap();
+                        let installer = leviath_package::AgentInstaller::with_install_dir(
+                            agents_dir.path().to_path_buf(),
+                        );
+                        let args = AddArgs {
+                            package: "some-registry-package".to_string(),
+                            registry: Some("http://127.0.0.1:19999".to_string()),
+                        };
 
-                let err = execute_with(&args, &installer, agents_dir.path())
-                    .await
-                    .unwrap_err();
-                assert!(err.to_string().contains("Failed to get package info"));
+                        let err = execute_with(&args, &installer, agents_dir.path())
+                            .await
+                            .unwrap_err();
+                        assert!(err.to_string().contains("Failed to get package info"));
+                    },
+                )
+                .await;
             })
         });
     }
@@ -835,25 +850,29 @@ description = "test"
                 // See `execute_with_registry_package_installs` for why this
                 // guard is needed even though this test never writes a
                 // config file of its own.
-                let _guard =
-                    crate::config::isolate_config_path_for_test("add-registry-download-failure");
-                let info_json =
-                    br#"{"name":"reg-pkg-dl-fail","version":"1.0.0","description":"d"}"#;
-                let url = spawn_mock_registry_download_error(info_json).await;
+                crate::config::with_isolated_config_path_async(
+                    "add-registry-download-failure",
+                    |_fake_dir| async move {
+                        let info_json =
+                            br#"{"name":"reg-pkg-dl-fail","version":"1.0.0","description":"d"}"#;
+                        let url = spawn_mock_registry_download_error(info_json).await;
 
-                let agents_dir = tempfile::tempdir().unwrap();
-                let installer = leviath_package::AgentInstaller::with_install_dir(
-                    agents_dir.path().to_path_buf(),
-                );
-                let args = AddArgs {
-                    package: "reg-pkg-dl-fail".to_string(),
-                    registry: Some(url),
-                };
+                        let agents_dir = tempfile::tempdir().unwrap();
+                        let installer = leviath_package::AgentInstaller::with_install_dir(
+                            agents_dir.path().to_path_buf(),
+                        );
+                        let args = AddArgs {
+                            package: "reg-pkg-dl-fail".to_string(),
+                            registry: Some(url),
+                        };
 
-                let err = execute_with(&args, &installer, agents_dir.path())
-                    .await
-                    .unwrap_err();
-                assert!(err.to_string().contains("Package download failed"));
+                        let err = execute_with(&args, &installer, agents_dir.path())
+                            .await
+                            .unwrap_err();
+                        assert!(err.to_string().contains("Package download failed"));
+                    },
+                )
+                .await;
             })
         });
     }
@@ -866,25 +885,29 @@ description = "test"
                 // See `execute_with_registry_package_installs` for why this
                 // guard is needed even though this test never writes a
                 // config file of its own.
-                let _guard =
-                    crate::config::isolate_config_path_for_test("add-registry-invalid-data");
-                let info_json =
-                    br#"{"name":"reg-pkg-bad-data","version":"1.0.0","description":"d"}"#;
-                let url = spawn_mock_registry(info_json, b"not a valid gzip archive").await;
+                crate::config::with_isolated_config_path_async(
+                    "add-registry-invalid-data",
+                    |_fake_dir| async move {
+                        let info_json =
+                            br#"{"name":"reg-pkg-bad-data","version":"1.0.0","description":"d"}"#;
+                        let url = spawn_mock_registry(info_json, b"not a valid gzip archive").await;
 
-                let agents_dir = tempfile::tempdir().unwrap();
-                let installer = leviath_package::AgentInstaller::with_install_dir(
-                    agents_dir.path().to_path_buf(),
-                );
-                let args = AddArgs {
-                    package: "reg-pkg-bad-data".to_string(),
-                    registry: Some(url),
-                };
+                        let agents_dir = tempfile::tempdir().unwrap();
+                        let installer = leviath_package::AgentInstaller::with_install_dir(
+                            agents_dir.path().to_path_buf(),
+                        );
+                        let args = AddArgs {
+                            package: "reg-pkg-bad-data".to_string(),
+                            registry: Some(url),
+                        };
 
-                let err = execute_with(&args, &installer, agents_dir.path())
-                    .await
-                    .unwrap_err();
-                assert!(err.to_string().contains("Failed to extract package"));
+                        let err = execute_with(&args, &installer, agents_dir.path())
+                            .await
+                            .unwrap_err();
+                        assert!(err.to_string().contains("Failed to extract package"));
+                    },
+                )
+                .await;
             })
         });
     }

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -226,9 +226,10 @@ mod tests {
     #[test]
     fn agents_dir_from_home_none_returns_error() {
         let err = agents_dir_from_home(None).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Could not determine home directory"));
+        assert!(
+            err.to_string()
+                .contains("Could not determine home directory")
+        );
     }
 
     // ─── parse_agent_name ──────────────────────────────────────────────────
@@ -770,8 +771,7 @@ description = "test"
             let (mut socket, _) = listener.accept().await.unwrap();
             let mut buf = [0u8; 8192];
             let _ = socket.read(&mut buf).await;
-            let resp =
-                "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            let resp = "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
             let _ = socket.write_all(resp.as_bytes()).await;
             let _ = socket.shutdown().await;
         });
@@ -1026,9 +1026,10 @@ name = "second"
         FORCE_AGENTS_DIR_ERROR.with(|f| f.set(false));
 
         let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Could not determine home directory"));
+        assert!(
+            err.to_string()
+                .contains("Could not determine home directory")
+        );
     }
 
     // ─── install_from_dir with valid manifest ─────────────────────────────

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -401,9 +401,10 @@ mod tests {
         });
 
         let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("injected agent.leviath write failure"));
+        assert!(
+            err.to_string()
+                .contains("injected agent.leviath write failure")
+        );
     }
 
     #[test]
@@ -420,15 +421,17 @@ mod tests {
         });
 
         let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("injected .gitignore write failure"));
+        assert!(
+            err.to_string()
+                .contains("injected .gitignore write failure")
+        );
         // The manifest write before it genuinely happened.
-        assert!(dir
-            .path()
-            .join("gitignore-write-fails")
-            .join("agent.leviath")
-            .exists());
+        assert!(
+            dir.path()
+                .join("gitignore-write-fails")
+                .join("agent.leviath")
+                .exists()
+        );
     }
 
     #[test]
@@ -445,9 +448,10 @@ mod tests {
         });
 
         let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("injected .env.example write failure"));
+        assert!(
+            err.to_string()
+                .contains("injected .env.example write failure")
+        );
         // The two writes before it genuinely happened.
         let created = dir.path().join("env-example-write-fails");
         assert!(created.join("agent.leviath").exists());

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -171,39 +171,6 @@ fn yank_to_clipboard_with(
 mod tests {
     use super::*;
 
-    // ─── PATH env var save/restore helper for clipboard tests ────────────────
-    //
-    // Several tests below shadow `PATH` with a directory of fake clipboard
-    // binaries and must restore the original value afterwards -- or, if
-    // `PATH` was unset beforehand, remove it again rather than setting it to
-    // an empty string. Shared here (both branches covered: the `Some` arm by
-    // every call site below, the `None` arm by
-    // `test_restore_path_removes_path_when_originally_unset`) so the "was
-    // originally unset" branch only needs covering once instead of at every
-    // call site.
-    fn restore_path(original: Option<std::ffi::OsString>) {
-        unsafe {
-            match original {
-                Some(p) => std::env::set_var("PATH", p),
-                None => std::env::remove_var("PATH"),
-            }
-        }
-    }
-
-    #[test]
-    fn test_restore_path_removes_path_when_originally_unset() {
-        let _lock = crate::config::PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let real_original_path = std::env::var_os("PATH");
-
-        restore_path(None);
-        assert!(std::env::var_os("PATH").is_none());
-
-        // Put the real PATH back so no other test in this process is affected.
-        restore_path(real_original_path);
-    }
-
     #[test]
     fn test_truncate_short() {
         assert_eq!(truncate("hello", 10), "hello");
@@ -500,18 +467,12 @@ mod tests {
         // regardless of which native clipboard tools happen to be installed
         // on the machine `cargo test` runs on (see the ambient-`PATH`
         // rationale above for why ambient-`PATH` smoke tests are avoided here).
-        let _lock = crate::config::PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         fn fake_osc52_fallback(_text: &str) -> bool {
             true
         }
-        let original_path = std::env::var_os("PATH");
-        unsafe {
-            std::env::set_var("PATH", "/lev-definitely-empty-path-dir");
-        }
-        let result = yank_to_clipboard_via("", fake_osc52_fallback);
-        restore_path(original_path);
+        let result = temp_env::with_var("PATH", Some("/lev-definitely-empty-path-dir"), || {
+            yank_to_clipboard_via("", fake_osc52_fallback)
+        });
         assert!(result);
     }
 
@@ -559,17 +520,17 @@ mod tests {
         // A guaranteed-present command that exits 0 exercises the native-tool
         // success path (the `return true` inside the spawn loop) on every
         // platform, without depending on a real clipboard tool being installed.
-        // Holds PATH_ENV_LOCK because this depends on an intact `PATH` (to
-        // resolve `true`/`cmd`) and must not race a PATH-starving test.
-        let _lock = crate::config::PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // This only *reads* `PATH` (to resolve `true`/`cmd`), so it takes
+        // temp-env's exclusive lock without changing any var -- serializing it
+        // against the PATH-starving tests so it never observes a starved PATH.
         let (cmd, args) = exit_cmd(true);
-        let result = yank_to_clipboard_with(
-            "native tool success test",
-            &[(cmd, args)],
-            unreachable_osc52_fallback,
-        );
+        let result = temp_env::with_vars_unset(Vec::<&str>::new(), || {
+            yank_to_clipboard_with(
+                "native tool success test",
+                &[(cmd, args)],
+                unreachable_osc52_fallback,
+            )
+        });
         assert!(result);
     }
 
@@ -578,14 +539,14 @@ mod tests {
         // A guaranteed-present command that exits non-zero makes
         // `child.wait().map(|s| s.success())` false, so the loop falls through
         // to the OSC52 fallback -- the branch the success test doesn't reach.
-        let _lock = crate::config::PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Reads `PATH` only, so serialize via temp-env's lock without mutating.
         fn fallback_reached(_text: &str) -> bool {
             true
         }
         let (cmd, args) = exit_cmd(false);
-        let result = yank_to_clipboard_with("nonzero exit test", &[(cmd, args)], fallback_reached);
+        let result = temp_env::with_vars_unset(Vec::<&str>::new(), || {
+            yank_to_clipboard_with("nonzero exit test", &[(cmd, args)], fallback_reached)
+        });
         // The native tool "ran" but failed, so control reached the fallback.
         assert!(result);
     }
@@ -594,27 +555,29 @@ mod tests {
 
     #[test]
     fn test_kill_write_cancelled_updates_existing_meta() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_kill_write_cancelled_updates_existing_meta",
+            |_d| {
+                let run_id = "test-kill-write-cancelled";
+                let meta = runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
+
+                kill_write_cancelled(run_id);
+
+                let after = runstate::read_meta(run_id).unwrap();
+                assert_eq!(after.status, runstate::RunStatus::Cancelled);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-kill-write-cancelled";
-        let meta = runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
-
-        kill_write_cancelled(run_id);
-
-        let after = runstate::read_meta(run_id).unwrap();
-        assert_eq!(after.status, runstate::RunStatus::Cancelled);
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
     }
 
     #[test]
@@ -638,28 +601,21 @@ mod tests {
 
     #[test]
     fn test_yank_to_clipboard_falls_back_to_osc52_when_no_native_tool_on_path() {
-        // `PATH` is process-global; `crate::config::PATH_ENV_LOCK` serializes
-        // against `commands/run/session.rs`'s PATH-mutating `launch_editor`
-        // tests too (a per-file lock would not serialize across files despite
-        // the shared name).
-        let _lock = crate::config::PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Starve PATH so `Command::new("pbcopy"/"xclip"/"wl-copy").spawn()`
         // fails with NotFound for all three -- the `if let Ok(mut child) = `
         // guard is simply false each time (no external process is ever
         // launched), falling through to the OSC52 fallback. That fallback is
         // injected as a fn pointer that never touches the real TTY (unlike
         // the real `osc52_yank_raw`, which would open `/dev/tty` here).
+        // `temp_env::with_var` (serialized process-wide, then restored) also
+        // serializes against `commands/run/session.rs`'s PATH-mutating
+        // `launch_editor` tests, which share the same global temp-env lock.
         fn fake_osc52_fallback(_text: &str) -> bool {
             true
         }
-        let original_path = std::env::var_os("PATH");
-        unsafe {
-            std::env::set_var("PATH", "/lev-definitely-empty-path-dir");
-        }
-        let result = yank_to_clipboard_via("fallback path test content", fake_osc52_fallback);
-        restore_path(original_path);
+        let result = temp_env::with_var("PATH", Some("/lev-definitely-empty-path-dir"), || {
+            yank_to_clipboard_via("fallback path test content", fake_osc52_fallback)
+        });
         // The point of this test is proving the native-tool loop was skipped
         // entirely and control reached the injected OSC52 fallback -- not
         // exercising the real `osc52_yank_raw` (see its own tests above).

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -331,91 +331,91 @@ impl Dashboard {
     }
 
     fn handle_yank_with_fn(&mut self, yank_fn: fn(&str) -> bool) {
-        if let Some(agent) = self.selected_agent() {
-            if agent.is_run_state {
-                let (content, label) = match self.stage_content_mode {
-                    StageContentMode::Output => (
-                        runstate::tail_stage_output(&agent.id, self.selected_stage, 524_288),
-                        "Output",
-                    ),
-                    StageContentMode::Logs => (
-                        runstate::tail_stage_log(&agent.id, self.selected_stage, 524_288),
-                        "Logs",
-                    ),
-                    StageContentMode::Context => {
-                        let json = std::fs::read_to_string(
-                            runstate::stage_dir(&agent.id, self.selected_stage)
-                                .join("context.json"),
-                        )
-                        .unwrap_or_default();
-                        (json, "Context JSON")
-                    }
-                };
-                if content.is_empty() {
-                    self.toasts.push(Toast {
-                        message: format!("No {} content to yank", label),
-                        remaining_ticks: 25,
-                        level: ToastLevel::Warning,
-                    });
-                } else if yank_fn(&content) {
-                    self.toasts.push(Toast {
-                        message: format!("{} yanked to clipboard", label),
-                        remaining_ticks: 25,
-                        level: ToastLevel::Info,
-                    });
-                } else {
-                    self.toasts.push(Toast {
-                        message: "Clipboard unavailable (no pbcopy/xclip/OSC52)".to_string(),
-                        remaining_ticks: 30,
-                        level: ToastLevel::Error,
-                    });
+        if let Some(agent) = self.selected_agent()
+            && agent.is_run_state
+        {
+            let (content, label) = match self.stage_content_mode {
+                StageContentMode::Output => (
+                    runstate::tail_stage_output(&agent.id, self.selected_stage, 524_288),
+                    "Output",
+                ),
+                StageContentMode::Logs => (
+                    runstate::tail_stage_log(&agent.id, self.selected_stage, 524_288),
+                    "Logs",
+                ),
+                StageContentMode::Context => {
+                    let json = std::fs::read_to_string(
+                        runstate::stage_dir(&agent.id, self.selected_stage).join("context.json"),
+                    )
+                    .unwrap_or_default();
+                    (json, "Context JSON")
                 }
+            };
+            if content.is_empty() {
+                self.toasts.push(Toast {
+                    message: format!("No {} content to yank", label),
+                    remaining_ticks: 25,
+                    level: ToastLevel::Warning,
+                });
+            } else if yank_fn(&content) {
+                self.toasts.push(Toast {
+                    message: format!("{} yanked to clipboard", label),
+                    remaining_ticks: 25,
+                    level: ToastLevel::Info,
+                });
+            } else {
+                self.toasts.push(Toast {
+                    message: "Clipboard unavailable (no pbcopy/xclip/OSC52)".to_string(),
+                    remaining_ticks: 30,
+                    level: ToastLevel::Error,
+                });
             }
         }
     }
 
     fn handle_kill_from_detail(&mut self) {
-        if let Some(agent) = self.selected_agent() {
-            if matches!(
+        if let Some(agent) = self.selected_agent()
+            && matches!(
                 agent.status,
                 AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            ) {
-                let agent_id = agent.id.clone();
-                let _pid = agent.pid;
-                let is_run_state = agent.is_run_state;
-                let was_waiting = matches!(agent.status, AgentDisplayStatus::Waiting);
-                if is_run_state {
-                    leviath_sys::terminate(_pid);
-                    kill_write_cancelled(&agent_id);
-                    if was_waiting {
-                        interaction::clear_interaction(&agent_id);
-                    }
-                } else {
-                    let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
-                        agent_id: agent_id.clone(),
-                    });
+            )
+        {
+            let agent_id = agent.id.clone();
+            let _pid = agent.pid;
+            let is_run_state = agent.is_run_state;
+            let was_waiting = matches!(agent.status, AgentDisplayStatus::Waiting);
+            if is_run_state {
+                leviath_sys::terminate(_pid);
+                kill_write_cancelled(&agent_id);
+                if was_waiting {
+                    interaction::clear_interaction(&agent_id);
                 }
-                // The index came from `display_indices`/`agents` just above,
-                // via the `self.selected_agent()` lookup that got us into
-                // this branch, and nothing in between (the OS kill signal,
-                // `kill_write_cancelled`, `clear_interaction`, or the
-                // `cmd_tx.send`) mutates either collection or `self.selected`
-                // -- so it's always still valid. An `if let` guard here would
-                // add an "index went stale" branch that can never actually be
-                // exercised.
-                let idx = self
-                    .selected_agent_raw_idx()
-                    .expect("selected_agent() returned Some above");
-                let a = self.agents.get_mut(idx).expect(
-                    "index snapshotted from the still-unchanged display_indices/agents above",
-                );
-                a.status = AgentDisplayStatus::Cancelled;
-                a.waiting_prompt = None;
-                a.pending_request = None;
-                self.input_mode = false;
-                self.input_textarea = tui_textarea::TextArea::default();
-                self.add_log(format!("{}: Killed", agent_id));
+            } else {
+                let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
+                    agent_id: agent_id.clone(),
+                });
             }
+            // The index came from `display_indices`/`agents` just above,
+            // via the `self.selected_agent()` lookup that got us into
+            // this branch, and nothing in between (the OS kill signal,
+            // `kill_write_cancelled`, `clear_interaction`, or the
+            // `cmd_tx.send`) mutates either collection or `self.selected`
+            // -- so it's always still valid. An `if let` guard here would
+            // add an "index went stale" branch that can never actually be
+            // exercised.
+            let idx = self
+                .selected_agent_raw_idx()
+                .expect("selected_agent() returned Some above");
+            let a = self
+                .agents
+                .get_mut(idx)
+                .expect("index snapshotted from the still-unchanged display_indices/agents above");
+            a.status = AgentDisplayStatus::Cancelled;
+            a.waiting_prompt = None;
+            a.pending_request = None;
+            self.input_mode = false;
+            self.input_textarea = tui_textarea::TextArea::default();
+            self.add_log(format!("{}: Killed", agent_id));
         }
     }
 
@@ -491,61 +491,21 @@ impl Dashboard {
     }
 
     fn handle_cancel_from_list(&mut self) {
-        if let Some(agent) = self.selected_agent() {
-            if matches!(
+        if let Some(agent) = self.selected_agent()
+            && matches!(
                 agent.status,
                 AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            ) {
-                let agent_id = agent.id.clone();
-                if agent.is_run_state {
-                    leviath_sys::terminate(agent.pid);
-                    kill_write_cancelled(&agent_id);
-                    if matches!(agent.status, AgentDisplayStatus::Waiting) {
-                        interaction::clear_interaction(&agent_id);
-                    }
-                    // See the comment in `handle_kill_from_detail` -- the
-                    // index is still valid because nothing since the
-                    // `self.selected_agent()` lookup above touches
-                    // `display_indices`/`agents`/`selected`.
-                    let idx = self
-                        .selected_agent_raw_idx()
-                        .expect("selected_agent() returned Some above");
-                    let a = self.agents.get_mut(idx).expect(
-                        "index snapshotted from the still-unchanged display_indices/agents above",
-                    );
-                    a.status = AgentDisplayStatus::Cancelled;
-                    a.waiting_prompt = None;
-                    a.pending_request = None;
-                } else {
-                    let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
-                        agent_id: agent_id.clone(),
-                    });
+            )
+        {
+            let agent_id = agent.id.clone();
+            if agent.is_run_state {
+                leviath_sys::terminate(agent.pid);
+                kill_write_cancelled(&agent_id);
+                if matches!(agent.status, AgentDisplayStatus::Waiting) {
+                    interaction::clear_interaction(&agent_id);
                 }
-                self.add_log(format!("{}: Cancel requested", agent_id));
-            }
-        }
-    }
-
-    fn handle_kill_from_list(&mut self) {
-        if let Some(agent) = self.selected_agent() {
-            if matches!(
-                agent.status,
-                AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            ) {
-                let agent_id = agent.id.clone();
-                if agent.is_run_state {
-                    leviath_sys::terminate(agent.pid);
-                    kill_write_cancelled(&agent_id);
-                    if matches!(agent.status, AgentDisplayStatus::Waiting) {
-                        interaction::clear_interaction(&agent_id);
-                    }
-                } else {
-                    let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
-                        agent_id: agent_id.clone(),
-                    });
-                }
-                // See the comment in `handle_kill_from_detail` -- the index
-                // is still valid because nothing since the
+                // See the comment in `handle_kill_from_detail` -- the
+                // index is still valid because nothing since the
                 // `self.selected_agent()` lookup above touches
                 // `display_indices`/`agents`/`selected`.
                 let idx = self
@@ -557,8 +517,49 @@ impl Dashboard {
                 a.status = AgentDisplayStatus::Cancelled;
                 a.waiting_prompt = None;
                 a.pending_request = None;
-                self.add_log(format!("{}: Killed", agent_id));
+            } else {
+                let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
+                    agent_id: agent_id.clone(),
+                });
             }
+            self.add_log(format!("{}: Cancel requested", agent_id));
+        }
+    }
+
+    fn handle_kill_from_list(&mut self) {
+        if let Some(agent) = self.selected_agent()
+            && matches!(
+                agent.status,
+                AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
+            )
+        {
+            let agent_id = agent.id.clone();
+            if agent.is_run_state {
+                leviath_sys::terminate(agent.pid);
+                kill_write_cancelled(&agent_id);
+                if matches!(agent.status, AgentDisplayStatus::Waiting) {
+                    interaction::clear_interaction(&agent_id);
+                }
+            } else {
+                let _ = self.cmd_tx.send(EngineCommand::CancelAgent {
+                    agent_id: agent_id.clone(),
+                });
+            }
+            // See the comment in `handle_kill_from_detail` -- the index
+            // is still valid because nothing since the
+            // `self.selected_agent()` lookup above touches
+            // `display_indices`/`agents`/`selected`.
+            let idx = self
+                .selected_agent_raw_idx()
+                .expect("selected_agent() returned Some above");
+            let a = self
+                .agents
+                .get_mut(idx)
+                .expect("index snapshotted from the still-unchanged display_indices/agents above");
+            a.status = AgentDisplayStatus::Cancelled;
+            a.waiting_prompt = None;
+            a.pending_request = None;
+            self.add_log(format!("{}: Killed", agent_id));
         }
     }
 
@@ -757,13 +758,13 @@ impl Dashboard {
                     self.add_log(msg);
                 }
                 AgentEvent::AgentDone { agent_id } => {
-                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
-                        if !matches!(
+                    if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id)
+                        && !matches!(
                             agent.status,
                             AgentDisplayStatus::Error(_) | AgentDisplayStatus::Cancelled
-                        ) {
-                            agent.status = AgentDisplayStatus::Complete;
-                        }
+                        )
+                    {
+                        agent.status = AgentDisplayStatus::Complete;
                     }
                     self.add_log(format!("{}: Done", agent_id));
                 }
@@ -2297,10 +2298,11 @@ mod tests {
 
             dash.handle_yank_with_fn(|_| true);
 
-            assert!(dash
-                .toasts
-                .iter()
-                .any(|t| t.message.contains("yanked to clipboard")));
+            assert!(
+                dash.toasts
+                    .iter()
+                    .any(|t| t.message.contains("yanked to clipboard"))
+            );
 
             let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
         });
@@ -2331,10 +2333,11 @@ mod tests {
         dash.handle_key(key(KeyCode::Char('d')));
 
         assert!(!dash.confirm_delete);
-        assert!(dash
-            .log
-            .iter()
-            .any(|e| e.message.contains("Only background runs")));
+        assert!(
+            dash.log
+                .iter()
+                .any(|e| e.message.contains("Only background runs"))
+        );
     }
 
     // ─── input_mode_key: FreeText Enter submits ───────────────────────────
@@ -2845,10 +2848,11 @@ mod tests {
 
                 dash.handle_yank_with_fn(|_| false);
 
-                assert!(dash
-                    .toasts
-                    .iter()
-                    .any(|t| t.message.contains("Clipboard unavailable")));
+                assert!(
+                    dash.toasts
+                        .iter()
+                        .any(|t| t.message.contains("Clipboard unavailable"))
+                );
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
             },

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1388,25 +1388,28 @@ mod tests {
 
     #[test]
     fn cancel_from_list_waiting_agent_clears_interaction() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "cancel_from_list_waiting_agent_clears_interaction",
+            |_d| {
+                let run_id = "test-cancel-list-waiting-clears";
+                std::fs::create_dir_all(crate::runstate::run_dir(run_id)).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::free_text("q1", "?", "main", true);
+                let _ = crate::interaction::write_request(run_id, &req);
+
+                let mut dash = make_test_dashboard();
+                let mut agent = make_test_agent(run_id, AgentDisplayStatus::Waiting);
+                agent.waiting_prompt = Some("?".to_string());
+                dash.agents.push(agent);
+                dash.update_display_indices();
+                dash.handle_key(key(KeyCode::Char('c')));
+
+                assert_cancelled(&dash.agents[0].status);
+                assert!(crate::interaction::read_request(run_id).is_none());
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-cancel-list-waiting-clears";
-        std::fs::create_dir_all(crate::runstate::run_dir(run_id)).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text("q1", "?", "main", true);
-        let _ = crate::interaction::write_request(run_id, &req);
-
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent(run_id, AgentDisplayStatus::Waiting);
-        agent.waiting_prompt = Some("?".to_string());
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('c')));
-
-        assert_cancelled(&dash.agents[0].status);
-        assert!(crate::interaction::read_request(run_id).is_none());
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     #[test]
@@ -1563,27 +1566,30 @@ mod tests {
 
     #[test]
     fn kill_from_detail_waiting_agent_clears_interaction() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "kill_from_detail_waiting_agent_clears_interaction",
+            |_d| {
+                let run_id = "test-kill-waiting-clears";
+                std::fs::create_dir_all(crate::runstate::run_dir(run_id)).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::free_text("q1", "?", "main", true);
+                let _ = crate::interaction::write_request(run_id, &req);
+                assert!(crate::interaction::read_request(run_id).is_some());
+
+                let mut dash = make_test_dashboard();
+                let mut agent = make_test_agent(run_id, AgentDisplayStatus::Waiting);
+                agent.waiting_prompt = Some("?".to_string());
+                dash.agents.push(agent);
+                dash.update_display_indices();
+                dash.detail_view = true;
+                dash.handle_key(key(KeyCode::Char('k')));
+
+                assert_cancelled(&dash.agents[0].status);
+                assert!(crate::interaction::read_request(run_id).is_none());
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-kill-waiting-clears";
-        std::fs::create_dir_all(crate::runstate::run_dir(run_id)).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text("q1", "?", "main", true);
-        let _ = crate::interaction::write_request(run_id, &req);
-        assert!(crate::interaction::read_request(run_id).is_some());
-
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent(run_id, AgentDisplayStatus::Waiting);
-        agent.waiting_prompt = Some("?".to_string());
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.detail_view = true;
-        dash.handle_key(key(KeyCode::Char('k')));
-
-        assert_cancelled(&dash.agents[0].status);
-        assert!(crate::interaction::read_request(run_id).is_none());
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     // ─── detail view: search n/N ──────────────────────────────────────────
@@ -2278,26 +2284,26 @@ mod tests {
         // `make_test_dashboard`; the native-tool-vs-OSC52 branches live in
         // `helpers::yank_to_clipboard_via`'s own tests, and the real OSC52
         // write in `leviath_sys::tty`.)
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("yank_with_real_content_reports_success");
-        let run_id = "test-yank-real-content";
-        crate::runstate::append_stage_output(run_id, 0, "some real output");
+        crate::runstate::with_isolated_runs_dir("yank_with_real_content_reports_success", |_d| {
+            let run_id = "test-yank-real-content";
+            crate::runstate::append_stage_output(run_id, 0, "some real output");
 
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent(run_id, AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.detail_view = true;
-        dash.stage_content_mode = StageContentMode::Output;
+            let mut dash = make_test_dashboard();
+            let agent = make_test_agent(run_id, AgentDisplayStatus::Active);
+            dash.agents.push(agent);
+            dash.update_display_indices();
+            dash.detail_view = true;
+            dash.stage_content_mode = StageContentMode::Output;
 
-        dash.handle_yank_with_fn(|_| true);
+            dash.handle_yank_with_fn(|_| true);
 
-        assert!(dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("yanked to clipboard")));
+            assert!(dash
+                .toasts
+                .iter()
+                .any(|t| t.message.contains("yanked to clipboard")));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
@@ -2357,32 +2363,32 @@ mod tests {
 
     #[test]
     fn input_mode_multiple_choice_enter_submits() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("input_mode_multiple_choice_enter_submits");
-        let run_id = format!("test-mc-enter-{}", std::process::id());
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent(&run_id, AgentDisplayStatus::Waiting);
-        agent.pending_request = Some(crate::interaction::InteractionRequest::multiple_choice(
-            "mc1",
-            "Pick",
-            vec!["A".into(), "B".into()],
-            "main",
-        ));
-        agent.waiting_prompt = Some("Pick".to_string());
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.detail_view = true;
-        dash.input_mode = true;
-        dash.choice_selected = 0;
+        crate::runstate::with_isolated_runs_dir("input_mode_multiple_choice_enter_submits", |_d| {
+            let run_id = format!("test-mc-enter-{}", std::process::id());
+            let mut dash = make_test_dashboard();
+            let mut agent = make_test_agent(&run_id, AgentDisplayStatus::Waiting);
+            agent.pending_request = Some(crate::interaction::InteractionRequest::multiple_choice(
+                "mc1",
+                "Pick",
+                vec!["A".into(), "B".into()],
+                "main",
+            ));
+            agent.waiting_prompt = Some("Pick".to_string());
+            dash.agents.push(agent);
+            dash.update_display_indices();
+            dash.detail_view = true;
+            dash.input_mode = true;
+            dash.choice_selected = 0;
 
-        // Ensure the run directory exists so write_response succeeds
-        let _ = std::fs::create_dir_all(crate::runstate::run_dir(&run_id));
+            // Ensure the run directory exists so write_response succeeds
+            let _ = std::fs::create_dir_all(crate::runstate::run_dir(&run_id));
 
-        dash.handle_key(key(KeyCode::Enter));
-        assert!(!dash.input_mode);
-        assert!(dash.log.iter().any(|e| e.message.contains("A")));
+            dash.handle_key(key(KeyCode::Enter));
+            assert!(!dash.input_mode);
+            assert!(dash.log.iter().any(|e| e.message.contains("A")));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+        });
     }
 
     // ─── Multiple events processed in sequence ────────────────────────────
@@ -2820,30 +2826,32 @@ mod tests {
 
     #[test]
     fn yank_clipboard_unavailable_shows_error_toast() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "yank_clipboard_unavailable_shows_error_toast",
+            |_d| {
+                use crate::runstate;
+                let run_id = "test-yank-clipboard-unavailable-x7z9";
+                let stage_path = runstate::stage_dir(run_id, 0);
+                std::fs::create_dir_all(&stage_path).ok();
+                std::fs::write(stage_path.join("context.json"), r#"{"test":true}"#).ok();
+
+                let mut dash = make_test_dashboard();
+                let agent = make_test_agent(run_id, AgentDisplayStatus::Active);
+                dash.agents.push(agent);
+                dash.update_display_indices();
+                dash.detail_view = true;
+                dash.stage_content_mode = StageContentMode::Context;
+                dash.selected_stage = 0;
+
+                dash.handle_yank_with_fn(|_| false);
+
+                assert!(dash
+                    .toasts
+                    .iter()
+                    .any(|t| t.message.contains("Clipboard unavailable")));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
         );
-        use crate::runstate;
-        let run_id = "test-yank-clipboard-unavailable-x7z9";
-        let stage_path = runstate::stage_dir(run_id, 0);
-        std::fs::create_dir_all(&stage_path).ok();
-        std::fs::write(stage_path.join("context.json"), r#"{"test":true}"#).ok();
-
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent(run_id, AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.detail_view = true;
-        dash.stage_content_mode = StageContentMode::Context;
-        dash.selected_stage = 0;
-
-        dash.handle_yank_with_fn(|_| false);
-
-        assert!(dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("Clipboard unavailable")));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -333,27 +333,30 @@ mod tests {
 
     #[tokio::test]
     async fn init_dashboard_seeds_startup_log_and_starts_background_loop() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "init_dashboard_seeds_startup_log_and_starts_background_loop",
-        );
-        let config = Config::default();
-        let (dashboard, engine) = init_dashboard(&config, |_| false).await;
+            |_d| async move {
+                let config = Config::default();
+                let (dashboard, engine) = init_dashboard(&config, |_| false).await;
 
-        assert!(dashboard
-            .log
-            .iter()
-            .any(|entry| entry.message.contains("Dashboard started")));
+                assert!(dashboard
+                    .log
+                    .iter()
+                    .any(|entry| entry.message.contains("Dashboard started")));
 
-        // The background loop is live: a CancelAgent command sent on
-        // dashboard's own cmd_tx should be processed without panicking.
-        dashboard
-            .cmd_tx
-            .send(EngineCommand::CancelAgent {
-                agent_id: "nonexistent".to_string(),
-            })
-            .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let _ = engine.try_read();
+                // The background loop is live: a CancelAgent command sent on
+                // dashboard's own cmd_tx should be processed without panicking.
+                dashboard
+                    .cmd_tx
+                    .send(EngineCommand::CancelAgent {
+                        agent_id: "nonexistent".to_string(),
+                    })
+                    .unwrap();
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let _ = engine.try_read();
+            },
+        )
+        .await;
     }
 
     // ─── engine_background_loop: CancelAgent command ─────────────────────
@@ -854,9 +857,6 @@ mod tests {
         )
         .await;
 
-        // Release the lock explicitly (drop order is otherwise unspecified).
-        drop(_guard);
-
         assert!(result.is_ok());
         assert!(dashboard.should_quit);
     }
@@ -986,15 +986,19 @@ mod tests {
 
     #[tokio::test]
     async fn execute_core_happy_path_quits_on_esc() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("execute_core_happy_path_quits_on_esc");
-        let config = Config::default();
-        let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
-        let mut setup = TestSetup::new();
-        let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
-        let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
-        assert!(result.is_ok());
-        assert!(dashboard.should_quit);
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_core_happy_path_quits_on_esc",
+            |_d| async move {
+                let config = Config::default();
+                let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
+                let mut setup = TestSetup::new();
+                let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
+                let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
+                assert!(result.is_ok());
+                assert!(dashboard.should_quit);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1003,12 +1007,22 @@ mod tests {
         // init_dashboard + execute_core) against the test terminal doubles,
         // with both the config path and the dashboard log path isolated so
         // nothing touches the developer's real ~/.leviath.
-        let _cfg = crate::config::isolate_config_path_for_test("execute_with_dashboard");
-        let _runs = crate::runstate::isolate_runs_dir_for_test("execute_with_dashboard");
-        let mut setup = TestSetup::new();
-        let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
-        let result = execute_with(&mut setup, &mut events, |_| false).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "execute_with_dashboard",
+            |_fake_dir| async move {
+                crate::runstate::with_isolated_runs_dir_async(
+                    "execute_with_dashboard",
+                    |_d| async move {
+                        let mut setup = TestSetup::new();
+                        let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
+                        let result = execute_with(&mut setup, &mut events, |_| false).await;
+                        assert!(result.is_ok());
+                    },
+                )
+                .await;
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1018,62 +1032,78 @@ mod tests {
         // `?` propagates before the dashboard/engine are ever built.
         // `isolate_config_path_for_test` creates the fake config dir, so the
         // path's parent already exists — write the malformed file directly.
-        let _cfg = crate::config::isolate_config_path_for_test("execute_with_dashboard_bad_config");
-        std::fs::write(
-            crate::config::Config::config_path(),
-            b"this is not valid toml ][ = =",
+        crate::config::with_isolated_config_path_async(
+            "execute_with_dashboard_bad_config",
+            |_fake_dir| async move {
+                std::fs::write(
+                    crate::config::Config::config_path(),
+                    b"this is not valid toml ][ = =",
+                )
+                .unwrap();
+                let mut setup = TestSetup::new();
+                let mut events = TestEventSource::new(vec![]);
+                let result = execute_with(&mut setup, &mut events, |_| false).await;
+                assert!(result.is_err());
+            },
         )
-        .unwrap();
-        let mut setup = TestSetup::new();
-        let mut events = TestEventSource::new(vec![]);
-        let result = execute_with(&mut setup, &mut events, |_| false).await;
-        assert!(result.is_err());
+        .await;
     }
 
     #[tokio::test]
     async fn execute_core_enable_error_propagates() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("execute_core_enable_error_propagates");
-        let config = Config::default();
-        let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
-        // `setup.enable()?` fails first, so the loop is never reached.
-        let mut setup = TestSetup {
-            enable_should_fail: true,
-            create_should_fail: false,
-        };
-        let mut events = TestEventSource::new(vec![]);
-        let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
-        assert!(result.is_err());
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_core_enable_error_propagates",
+            |_d| async move {
+                let config = Config::default();
+                let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
+                // `setup.enable()?` fails first, so the loop is never reached.
+                let mut setup = TestSetup {
+                    enable_should_fail: true,
+                    create_should_fail: false,
+                };
+                let mut events = TestEventSource::new(vec![]);
+                let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_core_create_terminal_error_propagates() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_core_create_terminal_error_propagates",
-        );
-        let config = Config::default();
-        let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
-        // `enable()` succeeds, then `create_terminal()?` fails -- deterministic
-        // (no real backend / TTY involved), so this can never hang.
-        let mut setup = TestSetup {
-            enable_should_fail: false,
-            create_should_fail: true,
-        };
-        let mut events = TestEventSource::new(vec![]);
-        let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
-        assert!(result.is_err());
+            |_d| async move {
+                let config = Config::default();
+                let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
+                // `enable()` succeeds, then `create_terminal()?` fails -- deterministic
+                // (no real backend / TTY involved), so this can never hang.
+                let mut setup = TestSetup {
+                    enable_should_fail: false,
+                    create_should_fail: true,
+                };
+                let mut events = TestEventSource::new(vec![]);
+                let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_core_loop_error_propagates() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("execute_core_loop_error_propagates");
-        let config = Config::default();
-        let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
-        let mut setup = TestSetup::new();
-        let mut events = TestEventSource::failing();
-        let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
-        assert!(result.is_err());
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_core_loop_error_propagates",
+            |_d| async move {
+                let config = Config::default();
+                let (mut dashboard, engine) = init_dashboard(&config, |_| false).await;
+                let mut setup = TestSetup::new();
+                let mut events = TestEventSource::failing();
+                let result = execute_core(&mut dashboard, &engine, &mut setup, &mut events).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     // The real `lev dash` wiring (the crossterm `CrosstermSetup` + the real

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -339,10 +339,12 @@ mod tests {
                 let config = Config::default();
                 let (dashboard, engine) = init_dashboard(&config, |_| false).await;
 
-                assert!(dashboard
-                    .log
-                    .iter()
-                    .any(|entry| entry.message.contains("Dashboard started")));
+                assert!(
+                    dashboard
+                        .log
+                        .iter()
+                        .any(|entry| entry.message.contains("Dashboard started"))
+                );
 
                 // The background loop is live: a CancelAgent command sent on
                 // dashboard's own cmd_tx should be processed without panicking.
@@ -439,8 +441,8 @@ mod tests {
 
     #[test]
     fn dashboard_draw_renders_without_panic() {
-        use ratatui::backend::TestBackend;
         use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
@@ -967,9 +969,11 @@ mod tests {
         assert!(backend.hide_cursor().is_ok());
         assert!(backend.show_cursor().is_ok());
         assert!(backend.get_cursor_position().is_ok());
-        assert!(backend
-            .set_cursor_position(ratatui::layout::Position::new(1, 1))
-            .is_ok());
+        assert!(
+            backend
+                .set_cursor_position(ratatui::layout::Position::new(1, 1))
+                .is_ok()
+        );
         assert!(backend.clear().is_ok());
         assert!(backend.size().is_ok());
         assert!(backend.window_size().is_ok());

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -1,12 +1,12 @@
 //! Content pane rendering: output, logs, context view, search highlighting.
 
+use ratatui::Frame;
 use ratatui::layout::{Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
     Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
 };
-use ratatui::Frame;
 
 use crate::commands::dashboard::helpers::format_tokens;
 use crate::commands::dashboard::state::Dashboard;
@@ -684,9 +684,9 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
+    use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
-    use ratatui::Terminal;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -1054,68 +1054,72 @@ mod tests {
 
     #[test]
     fn render_content_pane_logs_mode_shows_tool_count_badge() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "render_content_pane_logs_mode_shows_tool_count_badge",
+            |_d| {
+                let run_id = "test-content-tool-badge";
+                let agent = setup_run_state_agent_with_logs(
+                    run_id,
+                    &["[tool] read_file(x.rs)", "[tool] write_file(y.rs)"],
+                    None,
+                );
+
+                let backend = TestBackend::new(120, 40);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::Logs;
+                terminal
+                    .draw(|f| {
+                        let area = Rect::new(0, 0, 100, 20);
+                        dash.render_content_pane(f, area, &agent, 100);
+                    })
+                    .unwrap();
+
+                let content: String = terminal
+                    .backend()
+                    .buffer()
+                    .content()
+                    .iter()
+                    .map(|c| c.symbol())
+                    .collect();
+                assert!(content.contains("2 tools"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-content-tool-badge";
-        let agent = setup_run_state_agent_with_logs(
-            run_id,
-            &["[tool] read_file(x.rs)", "[tool] write_file(y.rs)"],
-            None,
-        );
-
-        let backend = TestBackend::new(120, 40);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut dash = make_test_dashboard();
-        dash.stage_content_mode = StageContentMode::Logs;
-        terminal
-            .draw(|f| {
-                let area = Rect::new(0, 0, 100, 20);
-                dash.render_content_pane(f, area, &agent, 100);
-            })
-            .unwrap();
-
-        let content: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|c| c.symbol())
-            .collect();
-        assert!(content.contains("2 tools"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
     }
 
     #[test]
     fn render_content_pane_output_mode_run_state_shows_file_path_hint() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "render_content_pane_output_mode_run_state_shows_file_path_hint",
+            |_d| {
+                let run_id = "test-content-output-hint";
+                let agent = setup_run_state_agent_with_logs(run_id, &[], Some("hello output"));
+
+                let backend = TestBackend::new(120, 40);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::Output;
+                terminal
+                    .draw(|f| {
+                        let area = Rect::new(0, 0, 100, 20);
+                        dash.render_content_pane(f, area, &agent, 100);
+                    })
+                    .unwrap();
+
+                let content: String = terminal
+                    .backend()
+                    .buffer()
+                    .content()
+                    .iter()
+                    .map(|c| c.symbol())
+                    .collect();
+                assert!(content.contains("output.log"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-content-output-hint";
-        let agent = setup_run_state_agent_with_logs(run_id, &[], Some("hello output"));
-
-        let backend = TestBackend::new(120, 40);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut dash = make_test_dashboard();
-        dash.stage_content_mode = StageContentMode::Output;
-        terminal
-            .draw(|f| {
-                let area = Rect::new(0, 0, 100, 20);
-                dash.render_content_pane(f, area, &agent, 100);
-            })
-            .unwrap();
-
-        let content: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|c| c.symbol())
-            .collect();
-        assert!(content.contains("output.log"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
     }
 
     // The file-path hint's home-shortening logic is exercised directly against
@@ -1151,60 +1155,65 @@ mod tests {
 
     #[test]
     fn build_output_lines_logs_mode_colors_by_line_prefix() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "build_output_lines_logs_mode_colors_by_line_prefix",
-        );
-        let run_id = "test-content-log-prefixes";
-        let agent = setup_run_state_agent_with_logs(
-            run_id,
-            &[
-                "[tool] did a thing",
-                "[error] it broke",
-                "[denied] not allowed",
-                "--- separator ---",
-                "[All stages complete]",
-                "a plain message",
-            ],
-            None,
-        );
+            |_d| {
+                let run_id = "test-content-log-prefixes";
+                let agent = setup_run_state_agent_with_logs(
+                    run_id,
+                    &[
+                        "[tool] did a thing",
+                        "[error] it broke",
+                        "[denied] not allowed",
+                        "--- separator ---",
+                        "[All stages complete]",
+                        "a plain message",
+                    ],
+                    None,
+                );
 
-        let dash = make_test_dashboard();
-        let lines = dash.build_output_lines(&agent, false, 100);
-        let text: String = lines
-            .iter()
-            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(text.contains("did a thing"));
-        assert!(text.contains("it broke"));
-        assert!(text.contains("not allowed"));
-        assert!(text.contains("separator"));
-        assert!(text.contains("All stages complete"));
-        assert!(text.contains("a plain message"));
+                let dash = make_test_dashboard();
+                let lines = dash.build_output_lines(&agent, false, 100);
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(text.contains("did a thing"));
+                assert!(text.contains("it broke"));
+                assert!(text.contains("not allowed"));
+                assert!(text.contains("separator"));
+                assert!(text.contains("All stages complete"));
+                assert!(text.contains("a plain message"));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
     }
 
     #[test]
     fn build_output_lines_output_mode_renders_markdown_when_non_empty() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "build_output_lines_output_mode_renders_markdown_when_non_empty",
+            |_d| {
+                let run_id = "test-content-output-markdown";
+                let agent =
+                    setup_run_state_agent_with_logs(run_id, &[], Some("# Heading\n\nbody text"));
+
+                let dash = make_test_dashboard();
+                let lines = dash.build_output_lines(&agent, true, 100);
+                assert!(!lines.is_empty());
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(text.contains("Heading"));
+                assert!(text.contains("body text"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
         );
-        let run_id = "test-content-output-markdown";
-        let agent = setup_run_state_agent_with_logs(run_id, &[], Some("# Heading\n\nbody text"));
-
-        let dash = make_test_dashboard();
-        let lines = dash.build_output_lines(&agent, true, 100);
-        assert!(!lines.is_empty());
-        let text: String = lines
-            .iter()
-            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(text.contains("Heading"));
-        assert!(text.contains("body text"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -1,10 +1,10 @@
 //! Header breadcrumb and info strip rendering.
 
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph};
-use ratatui::Frame;
 
 use crate::commands::dashboard::helpers::{
     elapsed_str, elapsed_str_until, format_tokens, truncate,
@@ -162,8 +162,8 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
-    use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -1,12 +1,12 @@
 //! Input/prompt pane and review body rendering.
 
+use ratatui::Frame;
 use ratatui::layout::{Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
     Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
 };
-use ratatui::Frame;
 
 use crate::commands::dashboard::helpers::truncate;
 use crate::commands::dashboard::state::Dashboard;
@@ -217,9 +217,9 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
+    use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
-    use ratatui::Terminal;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -9,8 +9,8 @@ mod overlays;
 mod stages;
 mod table;
 
-use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout};
 
 use super::state::Dashboard;
 use super::types::*;
@@ -223,8 +223,8 @@ mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
     use crate::commands::dashboard::types::{Toast, ToastLevel};
-    use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -1,10 +1,10 @@
 //! Toast notifications, help overlay, and confirmation popup rendering.
 
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
-use ratatui::Frame;
 
 use crate::commands::dashboard::helpers::truncate;
 use crate::commands::dashboard::state::Dashboard;
@@ -325,8 +325,8 @@ impl Dashboard {
 mod tests {
     use crate::commands::dashboard::test_support::make_test_dashboard;
     use crate::commands::dashboard::types::*;
-    use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -1,10 +1,10 @@
 //! Stage tab bar and graph view rendering.
 
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Tabs};
-use ratatui::Frame;
 
 use crate::commands::dashboard::graph::{GraphEdge, GraphTransitionInfo};
 use crate::commands::dashboard::helpers::truncate;
@@ -518,9 +518,9 @@ mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
     use crate::runstate::{StageRecord, StageRunStatus};
+    use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
-    use ratatui::Terminal;
     use std::collections::HashMap;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
@@ -1149,9 +1149,9 @@ mod tests {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-stale", AgentDisplayStatus::Active);
         agent.stage_index = 1; // run has moved on to stage 1 ("implement")
-                               // Stage 0 ("plan") record is stuck Active — simulating the bug where
-                               // on_stage_result was never called for an Interactive/InteractivePoints
-                               // stage.
+        // Stage 0 ("plan") record is stuck Active — simulating the bug where
+        // on_stage_result was never called for an Interactive/InteractivePoints
+        // stage.
         let stale_plan = make_stage_record("plan", StageRunStatus::Active);
         let line = dash.build_stage_tab_title(0, &stale_plan, &agent);
 

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -1,10 +1,10 @@
 //! Agent table, log panel, and help bar rendering.
 
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
-use ratatui::Frame;
 
 use crate::commands::dashboard::helpers::{format_tokens, relative_time, truncate};
 use crate::commands::dashboard::state::Dashboard;
@@ -442,8 +442,8 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
-    use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
 
     fn make_test_agent(id: &str, status: AgentDisplayStatus) -> DashboardAgent {
         DashboardAgent {

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -1013,10 +1013,11 @@ mod tests {
             .unwrap();
         dash.process_events();
         assert!(!dash.log.is_empty());
-        assert!(dash
-            .log
-            .iter()
-            .any(|e| e.message.contains("test log message")));
+        assert!(
+            dash.log
+                .iter()
+                .any(|e| e.message.contains("test log message"))
+        );
     }
 
     #[test]
@@ -1149,10 +1150,10 @@ mod tests {
         assert_eq!(tree.len(), 3);
         assert_eq!(tree[0].0, 0); // parent
         assert!(tree[0].1.is_empty()); // root has no prefix
-                                       // First child
+        // First child
         assert_eq!(tree[1].0, 1);
         assert!(tree[1].1.contains("├─")); // not last child
-                                           // Second child (last)
+        // Second child (last)
         assert_eq!(tree[2].0, 2);
         assert!(tree[2].1.contains("└─")); // last child
     }
@@ -1478,7 +1479,7 @@ mod tests {
         assert_eq!(tree[1].0, 1); // child1
         assert!(tree[1].1.contains("├─")); // not last child
         assert_eq!(tree[2].0, 3); // grandchild (under child1)
-                                  // grandchild should have deeper connector
+        // grandchild should have deeper connector
         assert!(tree[2].1.len() > tree[1].1.len());
         assert_eq!(tree[3].0, 2); // child2
         assert!(tree[3].1.contains("└─")); // last child
@@ -1520,10 +1521,11 @@ mod tests {
 
         // Should not have removed the agent
         assert_eq!(dash.agents.len(), 1);
-        assert!(dash
-            .log
-            .iter()
-            .any(|e| e.message.contains("Can only delete")));
+        assert!(
+            dash.log
+                .iter()
+                .any(|e| e.message.contains("Can only delete"))
+        );
     }
 
     // ─── delete_selected_agent: no agent selected ─────────────────────────
@@ -2098,10 +2100,11 @@ mod tests {
 
                 dash.sync_from_run_state();
 
-                assert!(dash
-                    .toasts
-                    .iter()
-                    .any(|t| t.message.contains("needs input")));
+                assert!(
+                    dash.toasts
+                        .iter()
+                        .any(|t| t.message.contains("needs input"))
+                );
 
                 cleanup_run(run_id);
             },
@@ -2120,35 +2123,40 @@ mod tests {
         // so with `run.status == WaitingInput`, so that `matches!`'s `false`
         // arm (CompleteInteractive input is optional, no "needs input"
         // toast) was never taken there.
-        crate::runstate::with_isolated_runs_dir("sync_from_run_state_new_agent_complete_interactive_after_initial_sync_no_needs_input_toast", |_d| {
-        let run_id = "test-sync-new-ci-after-initial-no-toast";
-        cleanup_run(run_id);
+        crate::runstate::with_isolated_runs_dir(
+            "sync_from_run_state_new_agent_complete_interactive_after_initial_sync_no_needs_input_toast",
+            |_d| {
+                let run_id = "test-sync-new-ci-after-initial-no-toast";
+                cleanup_run(run_id);
 
-        let mut dash = make_test_dashboard();
-        dash.initial_sync_done = true; // simulate: not the app's first sync
+                let mut dash = make_test_dashboard();
+                dash.initial_sync_done = true; // simulate: not the app's first sync
 
-        let meta = make_run_meta(run_id, RunStatus::CompleteInteractive);
-        runstate::create_run(&meta).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text(
-            "req1",
-            "Any final feedback?",
-            "review",
-            false,
+                let meta = make_run_meta(run_id, RunStatus::CompleteInteractive);
+                runstate::create_run(&meta).unwrap();
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "req1",
+                    "Any final feedback?",
+                    "review",
+                    false,
+                );
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                dash.sync_from_run_state();
+
+                assert!(
+                    !dash
+                        .toasts
+                        .iter()
+                        .any(|t| t.message.contains("needs input"))
+                );
+                // The separate "completed" toast branch still fires for a brand-new
+                // Complete/CompleteInteractive agent.
+                assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
+
+                cleanup_run(run_id);
+            },
         );
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        dash.sync_from_run_state();
-
-        assert!(!dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("needs input")));
-        // The separate "completed" toast branch still fires for a brand-new
-        // Complete/CompleteInteractive agent.
-        assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
-
-        cleanup_run(run_id);
-    });
     }
 
     #[test]
@@ -2197,10 +2205,11 @@ mod tests {
                     agent.status,
                     AgentDisplayStatus::Error("disk full".to_string())
                 );
-                assert!(dash
-                    .toasts
-                    .iter()
-                    .any(|t| t.message.contains("failed") && t.message.contains("disk full")));
+                assert!(
+                    dash.toasts
+                        .iter()
+                        .any(|t| t.message.contains("failed") && t.message.contains("disk full"))
+                );
 
                 cleanup_run(run_id);
             },
@@ -2382,13 +2391,14 @@ mod tests {
 
                 let mut dash = make_test_dashboard();
                 dash.sync_from_run_state();
-                assert!(dash
-                    .agents
-                    .iter()
-                    .find(|a| a.id == run_id)
-                    .unwrap()
-                    .active_until
-                    .is_none());
+                assert!(
+                    dash.agents
+                        .iter()
+                        .find(|a| a.id == run_id)
+                        .unwrap()
+                        .active_until
+                        .is_none()
+                );
 
                 let mut meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
                 meta2.updated_at = meta.started_at + 42;
@@ -2402,10 +2412,11 @@ mod tests {
                 assert_eq!(agent.status, AgentDisplayStatus::Waiting);
                 assert_eq!(agent.active_until, Some(meta2.updated_at));
                 assert_eq!(agent.waiting_prompt.as_deref(), Some("Q?"));
-                assert!(dash
-                    .toasts
-                    .iter()
-                    .any(|t| t.message.contains("needs input")));
+                assert!(
+                    dash.toasts
+                        .iter()
+                        .any(|t| t.message.contains("needs input"))
+                );
 
                 cleanup_run(run_id);
             },

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -1231,13 +1231,14 @@ mod tests {
 
     #[test]
     fn add_log_trims_to_200() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("add_log_trims_to_200");
-        let mut dash = make_test_dashboard();
-        dash.log.clear(); // Clear any seeded log entries
-        for i in 0..250 {
-            dash.add_log(format!("msg {}", i));
-        }
-        assert!(dash.log.len() <= 200);
+        crate::runstate::with_isolated_runs_dir("add_log_trims_to_200", |_d| {
+            let mut dash = make_test_dashboard();
+            dash.log.clear(); // Clear any seeded log entries
+            for i in 0..250 {
+                dash.add_log(format!("msg {}", i));
+            }
+            assert!(dash.log.len() <= 200);
+        });
     }
 
     #[test]
@@ -1605,33 +1606,35 @@ mod tests {
 
     #[test]
     fn add_log_appends_entry() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("add_log_appends_entry");
-        let mut dash = make_test_dashboard();
-        dash.log.clear();
-        dash.add_log("hello from test".to_string());
-        assert!(!dash.log.is_empty());
-        assert!(dash.log.last().unwrap().message == "hello from test");
-        // Timestamp should look like HH:MM:SS
-        let ts = &dash.log.last().unwrap().timestamp;
-        assert!(ts.contains(':'));
+        crate::runstate::with_isolated_runs_dir("add_log_appends_entry", |_d| {
+            let mut dash = make_test_dashboard();
+            dash.log.clear();
+            dash.add_log("hello from test".to_string());
+            assert!(!dash.log.is_empty());
+            assert!(dash.log.last().unwrap().message == "hello from test");
+            // Timestamp should look like HH:MM:SS
+            let ts = &dash.log.last().unwrap().timestamp;
+            assert!(ts.contains(':'));
+        });
     }
 
     #[test]
     fn add_log_trims_when_over_200() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("add_log_trims_when_over_200");
-        let mut dash = make_test_dashboard();
-        dash.log.clear();
-        // Fill to exactly 200
-        for i in 0..200 {
-            dash.log.push(crate::commands::dashboard::types::LogEntry {
-                timestamp: "00:00:00".to_string(),
-                message: format!("seed {}", i),
-            });
-        }
-        // Adding one more should remove oldest
-        dash.add_log("newest".to_string());
-        assert!(dash.log.len() <= 200);
-        assert_eq!(dash.log.last().unwrap().message, "newest");
+        crate::runstate::with_isolated_runs_dir("add_log_trims_when_over_200", |_d| {
+            let mut dash = make_test_dashboard();
+            dash.log.clear();
+            // Fill to exactly 200
+            for i in 0..200 {
+                dash.log.push(crate::commands::dashboard::types::LogEntry {
+                    timestamp: "00:00:00".to_string(),
+                    message: format!("seed {}", i),
+                });
+            }
+            // Adding one more should remove oldest
+            dash.add_log("newest".to_string());
+            assert!(dash.log.len() <= 200);
+            assert_eq!(dash.log.last().unwrap().message, "newest");
+        });
     }
 
     // ─── load_log_seed: exercises the parsing code ───────────────────────
@@ -1782,67 +1785,71 @@ mod tests {
 
     #[test]
     fn delete_selected_agent_removes_run_state_agent() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "delete_selected_agent_removes_run_state_agent",
+            |_d| {
+                let mut dash = make_test_dashboard();
+                dash.log.clear();
+                // Use a real temp dir that exists to avoid "delete failed" log
+                let tmp_id = format!("test-run-{}", std::process::id());
+                let run_dir = crate::runstate::run_dir(&tmp_id);
+                let _ = std::fs::create_dir_all(&run_dir);
+
+                let mut agent = make_test_agent(&tmp_id, AgentDisplayStatus::Complete);
+                agent.is_run_state = true;
+                agent.pid = 0; // no actual process to kill
+                dash.agents.push(agent);
+                dash.update_display_indices();
+
+                dash.delete_selected_agent();
+
+                // Agent should have been removed from the list
+                assert!(dash.agents.is_empty());
+            },
         );
-        let mut dash = make_test_dashboard();
-        dash.log.clear();
-        // Use a real temp dir that exists to avoid "delete failed" log
-        let tmp_id = format!("test-run-{}", std::process::id());
-        let run_dir = crate::runstate::run_dir(&tmp_id);
-        let _ = std::fs::create_dir_all(&run_dir);
-
-        let mut agent = make_test_agent(&tmp_id, AgentDisplayStatus::Complete);
-        agent.is_run_state = true;
-        agent.pid = 0; // no actual process to kill
-        dash.agents.push(agent);
-        dash.update_display_indices();
-
-        dash.delete_selected_agent();
-
-        // Agent should have been removed from the list
-        assert!(dash.agents.is_empty());
     }
 
     #[cfg(unix)]
     #[test]
     fn delete_selected_agent_sends_sigterm_to_real_pid() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "delete_selected_agent_sends_sigterm_to_real_pid",
+            |_d| {
+                // Spawns a real, throwaway child process we fully own (so sending it
+                // SIGTERM is safe, unlike an arbitrary PID) to exercise the
+                // `#[cfg(unix)] if _pid > 0 { libc::kill(...) }` branch, which every
+                // other `delete_selected_agent` test avoids via `pid = 0`. Uses the
+                // absolute path rather than a bare `"sleep"` looked up via `PATH` --
+                // other tests in this module momentarily narrow `PATH` down to a
+                // temp dir of fake clipboard binaries (see `helpers.rs`'s
+                // PATH-swapping tests), and a bare-name spawn racing against that
+                // window fails with `NotFound`.
+                let mut child = std::process::Command::new("/bin/sleep")
+                    .arg("30")
+                    .spawn()
+                    .expect("failed to spawn a throwaway child process");
+                let child_pid = child.id();
+
+                let mut dash = make_test_dashboard();
+                dash.log.clear();
+                let tmp_id = format!("test-run-kill-{}", std::process::id());
+                let run_dir = crate::runstate::run_dir(&tmp_id);
+                let _ = std::fs::create_dir_all(&run_dir);
+
+                let mut agent = make_test_agent(&tmp_id, AgentDisplayStatus::Active);
+                agent.is_run_state = true;
+                agent.pid = child_pid;
+                dash.agents.push(agent);
+                dash.update_display_indices();
+
+                dash.delete_selected_agent();
+
+                let status = child
+                    .wait()
+                    .expect("failed to wait on the throwaway child process");
+                assert!(!status.success());
+            },
         );
-        // Spawns a real, throwaway child process we fully own (so sending it
-        // SIGTERM is safe, unlike an arbitrary PID) to exercise the
-        // `#[cfg(unix)] if _pid > 0 { libc::kill(...) }` branch, which every
-        // other `delete_selected_agent` test avoids via `pid = 0`. Uses the
-        // absolute path rather than a bare `"sleep"` looked up via `PATH` --
-        // other tests in this module momentarily narrow `PATH` down to a
-        // temp dir of fake clipboard binaries (see `helpers.rs`'s
-        // PATH-swapping tests), and a bare-name spawn racing against that
-        // window fails with `NotFound`.
-        let mut child = std::process::Command::new("/bin/sleep")
-            .arg("30")
-            .spawn()
-            .expect("failed to spawn a throwaway child process");
-        let child_pid = child.id();
-
-        let mut dash = make_test_dashboard();
-        dash.log.clear();
-        let tmp_id = format!("test-run-kill-{}", std::process::id());
-        let run_dir = crate::runstate::run_dir(&tmp_id);
-        let _ = std::fs::create_dir_all(&run_dir);
-
-        let mut agent = make_test_agent(&tmp_id, AgentDisplayStatus::Active);
-        agent.is_run_state = true;
-        agent.pid = child_pid;
-        dash.agents.push(agent);
-        dash.update_display_indices();
-
-        dash.delete_selected_agent();
-
-        let status = child
-            .wait()
-            .expect("failed to wait on the throwaway child process");
-        assert!(!status.success());
     }
 
     #[test]
@@ -1927,161 +1934,178 @@ mod tests {
 
     #[test]
     fn sync_from_run_state_new_agent_active() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("sync_from_run_state_new_agent_active");
-        let run_id = "test-sync-new-active";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir("sync_from_run_state_new_agent_active", |_d| {
+            let run_id = "test-sync-new-active";
+            cleanup_run(run_id);
+            let meta = make_run_meta(run_id, RunStatus::Running);
+            runstate::create_run(&meta).unwrap();
 
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
+            let mut dash = make_test_dashboard();
+            dash.sync_from_run_state();
 
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Active);
-        assert!(agent.is_run_state);
-        assert!(dash.initial_sync_done);
-        // No toasts on the very first sync (startup), even though this is a "new" agent.
-        assert!(dash.toasts.is_empty());
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Active);
+            assert!(agent.is_run_state);
+            assert!(dash.initial_sync_done);
+            // No toasts on the very first sync (startup), even though this is a "new" agent.
+            assert!(dash.toasts.is_empty());
 
-        cleanup_run(run_id);
+            cleanup_run(run_id);
+        });
     }
 
     #[test]
     fn sync_from_run_state_new_agent_starting_maps_to_active() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_starting_maps_to_active",
+            |_d| {
+                let run_id = "test-sync-new-starting";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Starting);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Active);
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-starting";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Starting);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Active);
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_new_agent_error_status() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_error_status",
+            |_d| {
+                let run_id = "test-sync-new-error";
+                cleanup_run(run_id);
+                let mut meta = make_run_meta(run_id, RunStatus::Error);
+                meta.error = Some("boom".to_string());
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert!(matches!(&agent.status, AgentDisplayStatus::Error(msg) if msg == "boom"));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-error";
-        cleanup_run(run_id);
-        let mut meta = make_run_meta(run_id, RunStatus::Error);
-        meta.error = Some("boom".to_string());
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert!(matches!(&agent.status, AgentDisplayStatus::Error(msg) if msg == "boom"));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_new_agent_cancelled_status() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_cancelled_status",
+            |_d| {
+                let run_id = "test-sync-new-cancelled";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Cancelled);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Cancelled);
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-cancelled";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Cancelled);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Cancelled);
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_new_agent_waiting_input_reads_pending_request() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_waiting_input_reads_pending_request",
+            |_d| {
+                let run_id = "test-sync-new-waiting";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::WaitingInput);
+                runstate::create_run(&meta).unwrap();
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "req1",
+                    "What next?",
+                    "main",
+                    true,
+                );
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Waiting);
+                assert_eq!(agent.waiting_prompt.as_deref(), Some("What next?"));
+                assert!(agent.pending_request.is_some());
+                assert!(agent.active_until.is_some());
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-waiting";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::WaitingInput);
-        runstate::create_run(&meta).unwrap();
-        let req =
-            crate::interaction::InteractionRequest::free_text("req1", "What next?", "main", true);
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Waiting);
-        assert_eq!(agent.waiting_prompt.as_deref(), Some("What next?"));
-        assert!(agent.pending_request.is_some());
-        assert!(agent.active_until.is_some());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_new_agent_complete_interactive() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_complete_interactive",
+            |_d| {
+                let run_id = "test-sync-new-complete-interactive";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::CompleteInteractive);
+                runstate::create_run(&meta).unwrap();
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "req1",
+                    "Any feedback?",
+                    "review",
+                    false,
+                );
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::CompleteInteractive);
+                assert!(agent.waiting_prompt.is_some());
+                assert!(agent.active_until.is_some());
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-complete-interactive";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::CompleteInteractive);
-        runstate::create_run(&meta).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text(
-            "req1",
-            "Any feedback?",
-            "review",
-            false,
-        );
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::CompleteInteractive);
-        assert!(agent.waiting_prompt.is_some());
-        assert!(agent.active_until.is_some());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_new_agent_toasts_after_initial_sync_waiting() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_toasts_after_initial_sync_waiting",
+            |_d| {
+                let run_id = "test-sync-new-toast-waiting";
+                cleanup_run(run_id);
+
+                let mut dash = make_test_dashboard();
+                dash.initial_sync_done = true; // simulate: not the app's first sync
+
+                let meta = make_run_meta(run_id, RunStatus::WaitingInput);
+                runstate::create_run(&meta).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::confirm("req1", "Proceed?", "main");
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                dash.sync_from_run_state();
+
+                assert!(dash
+                    .toasts
+                    .iter()
+                    .any(|t| t.message.contains("needs input")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-toast-waiting";
-        cleanup_run(run_id);
-
-        let mut dash = make_test_dashboard();
-        dash.initial_sync_done = true; // simulate: not the app's first sync
-
-        let meta = make_run_meta(run_id, RunStatus::WaitingInput);
-        runstate::create_run(&meta).unwrap();
-        let req = crate::interaction::InteractionRequest::confirm("req1", "Proceed?", "main");
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        dash.sync_from_run_state();
-
-        assert!(dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("needs input")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
@@ -2096,9 +2120,7 @@ mod tests {
         // so with `run.status == WaitingInput`, so that `matches!`'s `false`
         // arm (CompleteInteractive input is optional, no "needs input"
         // toast) was never taken there.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
-            "sync_from_run_state_new_agent_complete_interactive_after_initial_sync_no_needs_input_toast",
-        );
+        crate::runstate::with_isolated_runs_dir("sync_from_run_state_new_agent_complete_interactive_after_initial_sync_no_needs_input_toast", |_d| {
         let run_id = "test-sync-new-ci-after-initial-no-toast";
         cleanup_run(run_id);
 
@@ -2126,132 +2148,143 @@ mod tests {
         assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
 
         cleanup_run(run_id);
+    });
     }
 
     #[test]
     fn sync_from_run_state_new_agent_toasts_after_initial_sync_complete() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_new_agent_toasts_after_initial_sync_complete",
+            |_d| {
+                let run_id = "test-sync-new-toast-complete";
+                cleanup_run(run_id);
+
+                let mut dash = make_test_dashboard();
+                dash.initial_sync_done = true;
+
+                let meta = make_run_meta(run_id, RunStatus::Complete);
+                runstate::create_run(&meta).unwrap();
+
+                dash.sync_from_run_state();
+
+                assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-new-toast-complete";
-        cleanup_run(run_id);
-
-        let mut dash = make_test_dashboard();
-        dash.initial_sync_done = true;
-
-        let meta = make_run_meta(run_id, RunStatus::Complete);
-        runstate::create_run(&meta).unwrap();
-
-        dash.sync_from_run_state();
-
-        assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_active_to_error_toasts_with_message() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_active_to_error_toasts_with_message",
+            |_d| {
+                let run_id = "test-sync-existing-to-error";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state(); // first sync: creates the agent, Active
+
+                let mut meta2 = make_run_meta(run_id, RunStatus::Error);
+                meta2.error = Some("disk full".to_string());
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state(); // second sync: transitions to Error
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(
+                    agent.status,
+                    AgentDisplayStatus::Error("disk full".to_string())
+                );
+                assert!(dash
+                    .toasts
+                    .iter()
+                    .any(|t| t.message.contains("failed") && t.message.contains("disk full")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-to-error";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state(); // first sync: creates the agent, Active
-
-        let mut meta2 = make_run_meta(run_id, RunStatus::Error);
-        meta2.error = Some("disk full".to_string());
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state(); // second sync: transitions to Error
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(
-            agent.status,
-            AgentDisplayStatus::Error("disk full".to_string())
-        );
-        assert!(dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("failed") && t.message.contains("disk full")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_active_to_error_empty_message() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_active_to_error_empty_message",
+            |_d| {
+                let run_id = "test-sync-existing-to-error-empty";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let meta2 = make_run_meta(run_id, RunStatus::Error); // error left None
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                let failed_toast = dash
+                    .toasts
+                    .iter()
+                    .find(|t| t.message.contains("failed"))
+                    .unwrap();
+                // No ": <preview>" suffix when the error message is empty.
+                assert!(!failed_toast.message.contains(":"));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-to-error-empty";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let meta2 = make_run_meta(run_id, RunStatus::Error); // error left None
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        let failed_toast = dash
-            .toasts
-            .iter()
-            .find(|t| t.message.contains("failed"))
-            .unwrap();
-        // No ": <preview>" suffix when the error message is empty.
-        assert!(!failed_toast.message.contains(":"));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_active_to_complete_toasts() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_active_to_complete_toasts",
+            |_d| {
+                let run_id = "test-sync-existing-to-complete";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let meta2 = make_run_meta(run_id, RunStatus::Complete);
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Complete);
+                assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-to-complete";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let meta2 = make_run_meta(run_id, RunStatus::Complete);
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Complete);
-        assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_active_to_complete_interactive_toasts() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_active_to_complete_interactive_toasts",
+            |_d| {
+                let run_id = "test-sync-existing-to-complete-interactive";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let meta2 = make_run_meta(run_id, RunStatus::CompleteInteractive);
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-to-complete-interactive";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let meta2 = make_run_meta(run_id, RunStatus::CompleteInteractive);
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        assert!(dash.toasts.iter().any(|t| t.message.contains("completed")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
@@ -2264,373 +2297,396 @@ mod tests {
         // entirely on the next sync -- even though the underlying
         // `RunStatus` does change -- covering the `prev_status_was_active ==
         // false` path.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_was_already_terminal_skips_transition_toast_block",
+            |_d| {
+                let run_id = "test-sync-existing-already-terminal";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Complete);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state(); // first sync: creates the agent, already Complete
+                assert_eq!(
+                    dash.agents.iter().find(|a| a.id == run_id).unwrap().status,
+                    AgentDisplayStatus::Complete
+                );
+
+                let meta2 = make_run_meta(run_id, RunStatus::Error);
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state(); // second sync: transitions Complete -> Error
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                // `meta2` above has no `.error` set, so the mapped message defaults
+                // to the empty string (`run.error.clone().unwrap_or_default()`).
+                assert_eq!(agent.status, AgentDisplayStatus::Error(String::new()));
+                // No transition toast fires -- the block only runs when the agent
+                // was previously Active/Waiting, which it wasn't here.
+                // Seed an unrelated toast first so `.any()` below actually invokes
+                // its predicate at least once instead of short-circuiting on an
+                // empty vec (which would leave the closure itself uncalled).
+                dash.toasts.push(Toast {
+                    message: "unrelated toast".to_string(),
+                    remaining_ticks: 1,
+                    level: ToastLevel::Info,
+                });
+                assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-already-terminal";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Complete);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state(); // first sync: creates the agent, already Complete
-        assert_eq!(
-            dash.agents.iter().find(|a| a.id == run_id).unwrap().status,
-            AgentDisplayStatus::Complete
-        );
-
-        let meta2 = make_run_meta(run_id, RunStatus::Error);
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state(); // second sync: transitions Complete -> Error
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        // `meta2` above has no `.error` set, so the mapped message defaults
-        // to the empty string (`run.error.clone().unwrap_or_default()`).
-        assert_eq!(agent.status, AgentDisplayStatus::Error(String::new()));
-        // No transition toast fires -- the block only runs when the agent
-        // was previously Active/Waiting, which it wasn't here.
-        // Seed an unrelated toast first so `.any()` below actually invokes
-        // its predicate at least once instead of short-circuiting on an
-        // empty vec (which would leave the closure itself uncalled).
-        dash.toasts.push(Toast {
-            message: "unrelated toast".to_string(),
-            remaining_ticks: 1,
-            level: ToastLevel::Info,
-        });
-        assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_stays_active_no_toast() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_stays_active_no_toast",
+            |_d| {
+                let run_id = "test-sync-existing-stays-active";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+                dash.sync_from_run_state(); // still Running -> Active, no transition
+
+                // Scoped to this test's (uniquely-named) agent rather than
+                // `dash.toasts.is_empty()` — the dashboard also picks up any other
+                // real/concurrently-running-test runs on disk via list_runs(), whose
+                // own transitions may toast independently of this one.
+                // Seed an unrelated toast first so `.any()` below actually invokes
+                // its predicate at least once instead of short-circuiting on an
+                // empty vec (which would leave the closure itself uncalled).
+                dash.toasts.push(Toast {
+                    message: "unrelated toast".to_string(),
+                    remaining_ticks: 1,
+                    level: ToastLevel::Info,
+                });
+                assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-stays-active";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-        dash.sync_from_run_state(); // still Running -> Active, no transition
-
-        // Scoped to this test's (uniquely-named) agent rather than
-        // `dash.toasts.is_empty()` — the dashboard also picks up any other
-        // real/concurrently-running-test runs on disk via list_runs(), whose
-        // own transitions may toast independently of this one.
-        // Seed an unrelated toast first so `.any()` below actually invokes
-        // its predicate at least once instead of short-circuiting on an
-        // empty vec (which would leave the closure itself uncalled).
-        dash.toasts.push(Toast {
-            message: "unrelated toast".to_string(),
-            remaining_ticks: 1,
-            level: ToastLevel::Info,
-        });
-        assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_enters_waiting_toasts_and_freezes_timer() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_enters_waiting_toasts_and_freezes_timer",
+            |_d| {
+                let run_id = "test-sync-existing-enters-waiting";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+                assert!(dash
+                    .agents
+                    .iter()
+                    .find(|a| a.id == run_id)
+                    .unwrap()
+                    .active_until
+                    .is_none());
+
+                let mut meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
+                meta2.updated_at = meta.started_at + 42;
+                runstate::write_meta(&meta2).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::free_text("req1", "Q?", "main", true);
+                crate::interaction::write_request(run_id, &req).unwrap();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Waiting);
+                assert_eq!(agent.active_until, Some(meta2.updated_at));
+                assert_eq!(agent.waiting_prompt.as_deref(), Some("Q?"));
+                assert!(dash
+                    .toasts
+                    .iter()
+                    .any(|t| t.message.contains("needs input")));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-enters-waiting";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-        assert!(dash
-            .agents
-            .iter()
-            .find(|a| a.id == run_id)
-            .unwrap()
-            .active_until
-            .is_none());
-
-        let mut meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
-        meta2.updated_at = meta.started_at + 42;
-        runstate::write_meta(&meta2).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text("req1", "Q?", "main", true);
-        crate::interaction::write_request(run_id, &req).unwrap();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Waiting);
-        assert_eq!(agent.active_until, Some(meta2.updated_at));
-        assert_eq!(agent.waiting_prompt.as_deref(), Some("Q?"));
-        assert!(dash
-            .toasts
-            .iter()
-            .any(|t| t.message.contains("needs input")));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_leaves_waiting_accumulates_waiting_secs() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_leaves_waiting_accumulates_waiting_secs",
+            |_d| {
+                let run_id = "test-sync-existing-leaves-waiting";
+                cleanup_run(run_id);
+                let mut meta = make_run_meta(run_id, RunStatus::WaitingInput);
+                meta.updated_at = meta.started_at + 10;
+                runstate::create_run(&meta).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::free_text("req1", "Q?", "main", true);
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+                let entered_wait_at = dash
+                    .agents
+                    .iter()
+                    .find(|a| a.id == run_id)
+                    .unwrap()
+                    .active_until
+                    .unwrap();
+
+                // Now the run resumes (Running) — clear the interaction and re-sync.
+                crate::interaction::clear_interaction(run_id);
+                let mut meta2 = make_run_meta(run_id, RunStatus::Running);
+                meta2.updated_at = entered_wait_at + 25;
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert!(agent.active_until.is_none());
+                assert_eq!(agent.waiting_secs, 25);
+                assert!(agent.waiting_prompt.is_none());
+                assert!(agent.pending_request.is_none());
+                assert!(agent.last_answered_request_id.is_none());
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-existing-leaves-waiting";
-        cleanup_run(run_id);
-        let mut meta = make_run_meta(run_id, RunStatus::WaitingInput);
-        meta.updated_at = meta.started_at + 10;
-        runstate::create_run(&meta).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text("req1", "Q?", "main", true);
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-        let entered_wait_at = dash
-            .agents
-            .iter()
-            .find(|a| a.id == run_id)
-            .unwrap()
-            .active_until
-            .unwrap();
-
-        // Now the run resumes (Running) — clear the interaction and re-sync.
-        crate::interaction::clear_interaction(run_id);
-        let mut meta2 = make_run_meta(run_id, RunStatus::Running);
-        meta2.updated_at = entered_wait_at + 25;
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert!(agent.active_until.is_none());
-        assert_eq!(agent.waiting_secs, 25);
-        assert!(agent.waiting_prompt.is_none());
-        assert!(agent.pending_request.is_none());
-        assert!(agent.last_answered_request_id.is_none());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_already_answered_request_not_reapplied() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_already_answered_request_not_reapplied",
+            |_d| {
+                let run_id = "test-sync-already-answered";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+                // Simulate having just answered a request with this id.
+                {
+                    let agent = dash.agents.iter_mut().find(|a| a.id == run_id).unwrap();
+                    agent.last_answered_request_id = Some("req-answered".to_string());
+                }
+
+                let meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
+                runstate::write_meta(&meta2).unwrap();
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "req-answered",
+                    "Already answered?",
+                    "main",
+                    true,
+                );
+                crate::interaction::write_request(run_id, &req).unwrap();
+                dash.sync_from_run_state();
+
+                // Should NOT re-populate waiting_prompt/pending_request for a
+                // request id that was already answered.
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert!(agent.waiting_prompt.is_none());
+                assert!(agent.pending_request.is_none());
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-already-answered";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-        // Simulate having just answered a request with this id.
-        {
-            let agent = dash.agents.iter_mut().find(|a| a.id == run_id).unwrap();
-            agent.last_answered_request_id = Some("req-answered".to_string());
-        }
-
-        let meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
-        runstate::write_meta(&meta2).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text(
-            "req-answered",
-            "Already answered?",
-            "main",
-            true,
-        );
-        crate::interaction::write_request(run_id, &req).unwrap();
-        dash.sync_from_run_state();
-
-        // Should NOT re-populate waiting_prompt/pending_request for a
-        // request id that was already answered.
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert!(agent.waiting_prompt.is_none());
-        assert!(agent.pending_request.is_none());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_no_reptoast_when_already_waiting() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_no_reptoast_when_already_waiting",
+            |_d| {
+                let run_id = "test-sync-no-retoast";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::WaitingInput);
+                runstate::create_run(&meta).unwrap();
+                let req =
+                    crate::interaction::InteractionRequest::free_text("req1", "Q1?", "main", true);
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state(); // first sync creates the agent, already Waiting -> no toast (new agent, initial sync)
+                dash.toasts.clear();
+
+                // Still waiting, same kind of request — re-sync must not toast again.
+                dash.sync_from_run_state();
+                // Seed an unrelated toast first so `.any()` below actually invokes
+                // its predicate at least once instead of short-circuiting on an
+                // empty vec (which would leave the closure itself uncalled).
+                dash.toasts.push(Toast {
+                    message: "unrelated toast".to_string(),
+                    remaining_ticks: 1,
+                    level: ToastLevel::Info,
+                });
+                assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-no-retoast";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::WaitingInput);
-        runstate::create_run(&meta).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text("req1", "Q1?", "main", true);
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state(); // first sync creates the agent, already Waiting -> no toast (new agent, initial sync)
-        dash.toasts.clear();
-
-        // Still waiting, same kind of request — re-sync must not toast again.
-        dash.sync_from_run_state();
-        // Seed an unrelated toast first so `.any()` below actually invokes
-        // its predicate at least once instead of short-circuiting on an
-        // empty vec (which would leave the closure itself uncalled).
-        dash.toasts.push(Toast {
-            message: "unrelated toast".to_string(),
-            remaining_ticks: 1,
-            level: ToastLevel::Info,
-        });
-        assert!(!dash.toasts.iter().any(|t| t.message.contains(run_id)));
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_updates_stage_and_token_fields() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_updates_stage_and_token_fields",
+            |_d| {
+                let run_id = "test-sync-updates-fields";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let mut meta2 = make_run_meta(run_id, RunStatus::Running);
+                meta2.current_stage = "implement".to_string();
+                meta2.stage_index = 1;
+                meta2.num_stages = 3;
+                meta2.iteration = 5;
+                meta2.prompt_tokens = 100;
+                meta2.completion_tokens = 50;
+                meta2.cached_tokens = 10;
+                meta2.title = Some("My Title".to_string());
+                meta2.pid = 4242;
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.stage, "implement");
+                assert_eq!(agent.stage_index, 1);
+                assert_eq!(agent.num_stages, 3);
+                assert_eq!(agent.iteration, 5);
+                assert_eq!(agent.tokens_in, 100);
+                assert_eq!(agent.tokens_out, 50);
+                assert_eq!(agent.cached_tokens, 10);
+                assert_eq!(agent.title.as_deref(), Some("My Title"));
+                assert_eq!(agent.pid, 4242);
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-updates-fields";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let mut meta2 = make_run_meta(run_id, RunStatus::Running);
-        meta2.current_stage = "implement".to_string();
-        meta2.stage_index = 1;
-        meta2.num_stages = 3;
-        meta2.iteration = 5;
-        meta2.prompt_tokens = 100;
-        meta2.completion_tokens = 50;
-        meta2.cached_tokens = 10;
-        meta2.title = Some("My Title".to_string());
-        meta2.pid = 4242;
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.stage, "implement");
-        assert_eq!(agent.stage_index, 1);
-        assert_eq!(agent.num_stages, 3);
-        assert_eq!(agent.iteration, 5);
-        assert_eq!(agent.tokens_in, 100);
-        assert_eq!(agent.tokens_out, 50);
-        assert_eq!(agent.cached_tokens, 10);
-        assert_eq!(agent.title.as_deref(), Some("My Title"));
-        assert_eq!(agent.pid, 4242);
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_waiting_with_no_pending_request_leaves_agent_unchanged() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_waiting_with_no_pending_request_leaves_agent_unchanged",
+            |_d| {
+                // WaitingInput but no pending.json on disk (e.g. race/cleanup) — the
+                // `if waiting_prompt.is_some()` branch is skipped entirely.
+                let run_id = "test-sync-waiting-no-pending";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
+                runstate::write_meta(&meta2).unwrap();
+                // No pending.json written.
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Waiting);
+                assert!(agent.waiting_prompt.is_none());
+
+                cleanup_run(run_id);
+            },
         );
-        // WaitingInput but no pending.json on disk (e.g. race/cleanup) — the
-        // `if waiting_prompt.is_some()` branch is skipped entirely.
-        let run_id = "test-sync-waiting-no-pending";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let meta2 = make_run_meta(run_id, RunStatus::WaitingInput);
-        runstate::write_meta(&meta2).unwrap();
-        // No pending.json written.
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::Waiting);
-        assert!(agent.waiting_prompt.is_none());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_updates_workdir_and_display_indices() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_updates_workdir_and_display_indices",
+            |_d| {
+                let run_id = "test-sync-workdir";
+                cleanup_run(run_id);
+                let mut meta = make_run_meta(run_id, RunStatus::Running);
+                meta.workdir = "/first/workdir".to_string();
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state();
+
+                let mut meta2 = make_run_meta(run_id, RunStatus::Running);
+                meta2.workdir = "/second/workdir".to_string();
+                runstate::write_meta(&meta2).unwrap();
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.workdir, "/second/workdir");
+                assert!(!dash.display_indices.is_empty());
+
+                cleanup_run(run_id);
+            },
         );
-        let run_id = "test-sync-workdir";
-        cleanup_run(run_id);
-        let mut meta = make_run_meta(run_id, RunStatus::Running);
-        meta.workdir = "/first/workdir".to_string();
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state();
-
-        let mut meta2 = make_run_meta(run_id, RunStatus::Running);
-        meta2.workdir = "/second/workdir".to_string();
-        runstate::write_meta(&meta2).unwrap();
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.workdir, "/second/workdir");
-        assert!(!dash.display_indices.is_empty());
-
-        cleanup_run(run_id);
     }
 
     #[test]
     fn sync_from_run_state_existing_agent_enters_complete_interactive_no_needs_input_toast() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_enters_complete_interactive_no_needs_input_toast",
+            |_d| {
+                // Exercise the branch where:
+                //   agent.waiting_prompt.is_none()          -> true  (agent was Active, no prompt yet)
+                //   && waiting_prompt.is_some()              -> true  (a pending request is present)
+                //   && matches!(run.status, WaitingInput)    -> FALSE (status is CompleteInteractive)
+                //
+                // The full condition is false, so no "needs input" toast is emitted
+                // (CompleteInteractive input is optional, unlike WaitingInput).
+                let run_id = "test-sync-ci-no-toast";
+                cleanup_run(run_id);
+                let meta = make_run_meta(run_id, RunStatus::Running);
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.sync_from_run_state(); // first sync: agent is Active, waiting_prompt=None
+
+                // Transition to CompleteInteractive and write a pending request
+                let meta2 = make_run_meta(run_id, RunStatus::CompleteInteractive);
+                runstate::write_meta(&meta2).unwrap();
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "req-ci",
+                    "Any final feedback?",
+                    "review",
+                    false,
+                );
+                crate::interaction::write_request(run_id, &req).unwrap();
+
+                dash.toasts.clear(); // clear any earlier toasts
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::CompleteInteractive);
+                // waiting_prompt is populated (the request exists)
+                assert!(agent.waiting_prompt.is_some());
+                // Seed a toast that *does* contain `run_id` (but not "needs input")
+                // so the closure below's `has_id && has_tag` actually evaluates
+                // `has_tag` at least once -- the real "completed" toast pushed by
+                // `sync_from_run_state` uses `truncate(&agent.blueprint_name, 20)`,
+                // and `run_id` here is longer than 20 chars, so it never contains
+                // the full `run_id` substring on its own.
+                dash.toasts.push(Toast {
+                    message: format!("{run_id}: unrelated toast"),
+                    remaining_ticks: 1,
+                    level: ToastLevel::Info,
+                });
+                // But no "needs input" toast because CompleteInteractive input is optional
+                let needs_input_toast = dash.toasts.iter().find(|t| {
+                    let has_id = t.message.contains(run_id);
+                    let has_tag = t.message.contains("needs input");
+                    has_id && has_tag
+                });
+                assert!(needs_input_toast.is_none());
+
+                cleanup_run(run_id);
+            },
         );
-        // Exercise the branch where:
-        //   agent.waiting_prompt.is_none()          -> true  (agent was Active, no prompt yet)
-        //   && waiting_prompt.is_some()              -> true  (a pending request is present)
-        //   && matches!(run.status, WaitingInput)    -> FALSE (status is CompleteInteractive)
-        //
-        // The full condition is false, so no "needs input" toast is emitted
-        // (CompleteInteractive input is optional, unlike WaitingInput).
-        let run_id = "test-sync-ci-no-toast";
-        cleanup_run(run_id);
-        let meta = make_run_meta(run_id, RunStatus::Running);
-        runstate::create_run(&meta).unwrap();
-
-        let mut dash = make_test_dashboard();
-        dash.sync_from_run_state(); // first sync: agent is Active, waiting_prompt=None
-
-        // Transition to CompleteInteractive and write a pending request
-        let meta2 = make_run_meta(run_id, RunStatus::CompleteInteractive);
-        runstate::write_meta(&meta2).unwrap();
-        let req = crate::interaction::InteractionRequest::free_text(
-            "req-ci",
-            "Any final feedback?",
-            "review",
-            false,
-        );
-        crate::interaction::write_request(run_id, &req).unwrap();
-
-        dash.toasts.clear(); // clear any earlier toasts
-        dash.sync_from_run_state();
-
-        let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
-        assert_eq!(agent.status, AgentDisplayStatus::CompleteInteractive);
-        // waiting_prompt is populated (the request exists)
-        assert!(agent.waiting_prompt.is_some());
-        // Seed a toast that *does* contain `run_id` (but not "needs input")
-        // so the closure below's `has_id && has_tag` actually evaluates
-        // `has_tag` at least once -- the real "completed" toast pushed by
-        // `sync_from_run_state` uses `truncate(&agent.blueprint_name, 20)`,
-        // and `run_id` here is longer than 20 chars, so it never contains
-        // the full `run_id` substring on its own.
-        dash.toasts.push(Toast {
-            message: format!("{run_id}: unrelated toast"),
-            remaining_ticks: 1,
-            level: ToastLevel::Info,
-        });
-        // But no "needs input" toast because CompleteInteractive input is optional
-        let needs_input_toast = dash.toasts.iter().find(|t| {
-            let has_id = t.message.contains(run_id);
-            let has_tag = t.message.contains("needs input");
-            has_id && has_tag
-        });
-        assert!(needs_input_toast.is_none());
-
-        cleanup_run(run_id);
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -213,15 +213,21 @@ mod tests {
     fn agent_display_status_display() {
         assert!(AgentDisplayStatus::Active.to_string().contains("ACTIVE"));
         assert!(AgentDisplayStatus::Waiting.to_string().contains("WAITING"));
-        assert!(AgentDisplayStatus::Complete
-            .to_string()
-            .contains("COMPLETE"));
-        assert!(AgentDisplayStatus::CompleteInteractive
-            .to_string()
-            .contains("COMPLETE"));
-        assert!(AgentDisplayStatus::Error("boom".to_string())
-            .to_string()
-            .contains("boom"));
+        assert!(
+            AgentDisplayStatus::Complete
+                .to_string()
+                .contains("COMPLETE")
+        );
+        assert!(
+            AgentDisplayStatus::CompleteInteractive
+                .to_string()
+                .contains("COMPLETE")
+        );
+        assert!(
+            AgentDisplayStatus::Error("boom".to_string())
+                .to_string()
+                .contains("boom")
+        );
         assert!(AgentDisplayStatus::Idle.to_string().contains("IDLE"));
         assert!(AgentDisplayStatus::Cancelled.to_string().contains("CANCEL"));
     }

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -39,10 +39,10 @@ fn scan_directory_for_agents(dir: &Path) -> Vec<(PathBuf, AgentInfo)> {
 
     // Check if this directory itself has an agent.leviath
     let direct_manifest = dir.join("agent.leviath");
-    if direct_manifest.exists() {
-        if let Some(info) = read_agent_info(&direct_manifest) {
-            agents.push((dir.to_path_buf(), info));
-        }
+    if direct_manifest.exists()
+        && let Some(info) = read_agent_info(&direct_manifest)
+    {
+        agents.push((dir.to_path_buf(), info));
     }
 
     // Check subdirectories
@@ -51,10 +51,10 @@ fn scan_directory_for_agents(dir: &Path) -> Vec<(PathBuf, AgentInfo)> {
             let path = entry.path();
             if path.is_dir() {
                 let manifest_path = path.join("agent.leviath");
-                if manifest_path.exists() {
-                    if let Some(info) = read_agent_info(&manifest_path) {
-                        agents.push((path, info));
-                    }
+                if manifest_path.exists()
+                    && let Some(info) = read_agent_info(&manifest_path)
+                {
+                    agents.push((path, info));
                 }
             }
         }
@@ -126,18 +126,18 @@ fn print_agent_listing(
 
     // 2. Local (current directory)
     let local_manifest = cwd.join("agent.leviath");
-    if local_manifest.exists() {
-        if let Some(info) = read_agent_info(&local_manifest) {
-            found_anything = true;
-            let desc = if info.description.is_empty() {
-                String::new()
-            } else {
-                format!(" — {}", info.description)
-            };
-            println!("Local (current directory):");
-            println!("  {} (v{}){}", info.name, info.version, desc);
-            println!();
-        }
+    if local_manifest.exists()
+        && let Some(info) = read_agent_info(&local_manifest)
+    {
+        found_anything = true;
+        let desc = if info.description.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", info.description)
+        };
+        println!("Local (current directory):");
+        println!("  {} (v{}){}", info.name, info.version, desc);
+        println!();
     }
 
     // 3. Config's agent_paths directories
@@ -425,9 +425,10 @@ system = {{ kind = "pinned", max_tokens = 1000 }}
     #[test]
     fn get_agents_dir_from_home_none_returns_error() {
         let err = get_agents_dir_from_home(None).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Could not determine home directory"));
+        assert!(
+            err.to_string()
+                .contains("Could not determine home directory")
+        );
     }
 
     // ─── read_agent_info: minimal manifest ──────────────────────────────
@@ -507,9 +508,10 @@ system = { kind = "pinned", max_tokens = 1000 }
         FORCE_AGENTS_DIR_ERROR.with(|f| f.set(false));
 
         let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Could not determine home directory"));
+        assert!(
+            err.to_string()
+                .contains("Could not determine home directory")
+        );
     }
 
     // `execute`'s `std::env::current_dir().unwrap_or_default()` can only take

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -478,14 +478,19 @@ system = { kind = "pinned", max_tokens = 1000 }
         // `load_propagates_error_when_real_config_file_is_malformed`)
         // forces that for real, and `execute` must still succeed by
         // falling back to `Config::default()`.
-        let guard = crate::config::isolate_config_path_for_test("list-execute-malformed-config");
-        std::fs::write(guard.fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
+        crate::config::with_isolated_config_path_async(
+            "list-execute-malformed-config",
+            |fake_dir| async move {
+                std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
 
-        let args = ListArgs {
-            filter: "all".to_string(),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+                let args = ListArgs {
+                    filter: "all".to_string(),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -871,117 +871,138 @@ mod tests {
 
     #[tokio::test]
     async fn execute_list_command_runs_without_error() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_list_command_runs_without_error",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::List(ListArgs {
-                provider: None,
-                remote: false,
-            }),
-        };
-        // Should succeed: prints the builtin table
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::List(ListArgs {
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                // Should succeed: prints the builtin table
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_list_with_provider_filter_runs_without_error() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_list_with_provider_filter_runs_without_error",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::List(ListArgs {
-                provider: Some("anthropic".to_string()),
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::List(ListArgs {
+                        provider: Some("anthropic".to_string()),
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_list_with_nonexistent_provider_filter() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_list_with_nonexistent_provider_filter",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::List(ListArgs {
-                provider: Some("nonexistent_provider".to_string()),
-                remote: false,
-            }),
-        };
-        // Should succeed but print "No models found."
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::List(ListArgs {
+                        provider: Some("nonexistent_provider".to_string()),
+                        remote: false,
+                    }),
+                };
+                // Should succeed but print "No models found."
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_show_known_model_runs_without_error() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_show_known_model_runs_without_error",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "claude-sonnet-4-6".to_string(),
-                provider: None,
-                remote: false,
-            }),
-        };
-        // Should find model in builtin table and print details
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "claude-sonnet-4-6".to_string(),
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                // Should find model in builtin table and print details
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_show_unknown_model_runs_without_error() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_show_unknown_model_runs_without_error",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "totally-unknown-model-xyz".to_string(),
-                provider: None,
-                remote: false,
-            }),
-        };
-        // Should print "Model not found" message without error
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "totally-unknown-model-xyz".to_string(),
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                // Should print "Model not found" message without error
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_show_unknown_model_with_remote_no_provider() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_show_unknown_model_with_remote_no_provider",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "totally-unknown-model-xyz".to_string(),
-                provider: None,
-                remote: true, // remote but no provider = skips remote lookup
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "totally-unknown-model-xyz".to_string(),
+                        provider: None,
+                        remote: true, // remote but no provider = skips remote lookup
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_show_unknown_model_with_remote_unconfigured_provider() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-execute_show_unknown_model_with_remote_unconfigured_provider",
-        );
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "totally-unknown-model-xyz".to_string(),
-                provider: Some("anthropic".to_string()),
-                remote: true,
-                // Provider won't be configured in test env (no API key)
-            }),
-        };
-        // Should warn about unconfigured provider and then show not-found message
-        let result = execute(args).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "totally-unknown-model-xyz".to_string(),
+                        provider: Some("anthropic".to_string()),
+                        remote: true,
+                        // Provider won't be configured in test env (no API key)
+                    }),
+                };
+                // Should warn about unconfigured provider and then show not-found message
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     // ─── list() with builtin model having overrides in config ─────────────
@@ -995,78 +1016,103 @@ mod tests {
         // list_with_registry_propagates_config_load_error) can make this
         // test observe that torn state and fail nondeterministically --
         // exactly what happened on CI.
-        let _guard = crate::config::isolate_config_path_for_test("models-list-openrouter-filter");
-        let args = ModelsArgs {
-            command: ModelsCommand::List(ListArgs {
-                provider: Some("openrouter".to_string()),
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-list-openrouter-filter",
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::List(ListArgs {
+                        provider: Some("openrouter".to_string()),
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_with_openai_filter() {
         // See the comment on list_with_openrouter_filter -- same real
         // Config::load() race.
-        let _guard = crate::config::isolate_config_path_for_test("models-list-openai-filter");
-        let args = ModelsArgs {
-            command: ModelsCommand::List(ListArgs {
-                provider: Some("openai".to_string()),
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-list-openai-filter",
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::List(ListArgs {
+                        provider: Some("openai".to_string()),
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_builtin_anthropic_opus() {
         // See the comment on list_with_openrouter_filter -- same real
         // Config::load() race.
-        let _guard = crate::config::isolate_config_path_for_test("models-show-anthropic-opus");
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "claude-opus-4-6".to_string(),
-                provider: None,
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-show-anthropic-opus",
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "claude-opus-4-6".to_string(),
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_builtin_openai_model() {
         // See the comment on list_with_openrouter_filter -- same real
         // Config::load() race.
-        let _guard = crate::config::isolate_config_path_for_test("models-show-openai-model");
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "gpt-5.5".to_string(),
-                provider: None,
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-show-openai-model",
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "gpt-5.5".to_string(),
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_builtin_deepseek_r1() {
         // See the comment on list_with_openrouter_filter -- same real
         // Config::load() race.
-        let _guard = crate::config::isolate_config_path_for_test("models-show-deepseek-r1");
-        let args = ModelsArgs {
-            command: ModelsCommand::Show(ShowArgs {
-                model: "deepseek/deepseek-r1".to_string(),
-                provider: None,
-                remote: false,
-            }),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-show-deepseek-r1",
+            |_fake_dir| async move {
+                let args = ModelsArgs {
+                    command: ModelsCommand::Show(ShowArgs {
+                        model: "deepseek/deepseek-r1".to_string(),
+                        provider: None,
+                        remote: false,
+                    }),
+                };
+                let result = execute(args).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     // ─── builtin_table as ModelInfo conversion ──────────────────────────
@@ -1154,87 +1200,107 @@ mod tests {
 
     #[tokio::test]
     async fn list_builtin_no_filter_succeeds() {
-        let _guard =
-            crate::config::isolate_config_path_for_test("models-list_builtin_no_filter_succeeds");
-        let args = ListArgs {
-            remote: false,
-            provider: None,
-        };
-        let result = list_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-list_builtin_no_filter_succeeds",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: None,
+                };
+                let result = list_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_builtin_with_provider_filter_succeeds() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_builtin_with_provider_filter_succeeds",
-        );
-        let args = ListArgs {
-            remote: false,
-            provider: Some("anthropic".to_string()),
-        };
-        let result = list_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("anthropic".to_string()),
+                };
+                let result = list_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_unknown_provider_filter_finds_nothing() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_unknown_provider_filter_finds_nothing",
-        );
-        let args = ListArgs {
-            remote: false,
-            provider: Some("no-such-provider".to_string()),
-        };
-        // Should print "No models found." and still succeed, not error.
-        let result = list_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("no-such-provider".to_string()),
+                };
+                // Should print "No models found." and still succeed, not error.
+                let result = list_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_builtin_model_succeeds() {
-        let _guard =
-            crate::config::isolate_config_path_for_test("models-show_builtin_model_succeeds");
-        // Use a model ID guaranteed to be in the builtin table.
-        let known_id = builtin_table()[0].model_id.to_string();
-        let args = ShowArgs {
-            model: known_id,
-            remote: false,
-            provider: None,
-        };
-        let result = show_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "models-show_builtin_model_succeeds",
+            |_fake_dir| async move {
+                // Use a model ID guaranteed to be in the builtin table.
+                let known_id = builtin_table()[0].model_id.to_string();
+                let args = ShowArgs {
+                    model: known_id,
+                    remote: false,
+                    provider: None,
+                };
+                let result = show_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_unknown_model_without_remote_succeeds_with_warning() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_unknown_model_without_remote_succeeds_with_warning",
-        );
-        let args = ShowArgs {
-            model: "totally-unknown-model-xyz".to_string(),
-            remote: false,
-            provider: None,
-        };
-        // Falls through all lookup tiers; must not error even when not found.
-        let result = show_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ShowArgs {
+                    model: "totally-unknown-model-xyz".to_string(),
+                    remote: false,
+                    provider: None,
+                };
+                // Falls through all lookup tiers; must not error even when not found.
+                let result = show_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_remote_without_provider_falls_through_gracefully() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_remote_without_provider_falls_through_gracefully",
-        );
-        // args.remote = true but no --provider given -> the remote-fetch
-        // branch's inner `if let Some(ref provider_name)` is skipped.
-        let args = ShowArgs {
-            model: "totally-unknown-model-xyz".to_string(),
-            remote: true,
-            provider: None,
-        };
-        let result = show_with_registry(args, &build_provider_registry_from_config).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                // args.remote = true but no --provider given -> the remote-fetch
+                // branch's inner `if let Some(ref provider_name)` is skipped.
+                let args = ShowArgs {
+                    model: "totally-unknown-model-xyz".to_string(),
+                    remote: true,
+                    provider: None,
+                };
+                let result = show_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     // ─── list()/show() --remote paths, with a mock provider ────────────────
@@ -1318,21 +1384,25 @@ mod tests {
 
     #[tokio::test]
     async fn list_remote_merges_new_model_from_provider() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_remote_merges_new_model_from_provider",
-        );
-        let args = ListArgs {
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let new_model = ModelInfo {
-            id: "mock-brand-new-model".to_string(),
-            display_name: Some("Mock Brand New Model".to_string()),
-            provider: "mock".to_string(),
-            capabilities: ModelCapabilities::default(),
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![new_model], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let new_model = ModelInfo {
+                    id: "mock-brand-new-model".to_string(),
+                    display_name: Some("Mock Brand New Model".to_string()),
+                    provider: "mock".to_string(),
+                    capabilities: ModelCapabilities::default(),
+                };
+                let result =
+                    list_with_registry(args, &mock_registry("mock", vec![new_model], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1341,136 +1411,163 @@ mod tests {
         // be queried for remote models (the `if let Some(ref filter) = ...`
         // pattern-doesn't-match arm, never exercised by the other
         // `list_remote_*` tests below, which all pass a provider filter).
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_remote_without_provider_filter_queries_all_providers",
-        );
-        let args = ListArgs {
-            remote: true,
-            provider: None,
-        };
-        let new_model = ModelInfo {
-            id: "mock-brand-new-model".to_string(),
-            display_name: Some("Mock Brand New Model".to_string()),
-            provider: "mock".to_string(),
-            capabilities: ModelCapabilities::default(),
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![new_model], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: true,
+                    provider: None,
+                };
+                let new_model = ModelInfo {
+                    id: "mock-brand-new-model".to_string(),
+                    display_name: Some("Mock Brand New Model".to_string()),
+                    provider: "mock".to_string(),
+                    capabilities: ModelCapabilities::default(),
+                };
+                let result =
+                    list_with_registry(args, &mock_registry("mock", vec![new_model], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_remote_overrides_builtin_entry_with_same_id() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_remote_overrides_builtin_entry_with_same_id",
-        );
-        let known_id = builtin_table()[0].model_id.to_string();
-        let args = ListArgs {
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let overriding_model = ModelInfo {
-            id: known_id,
-            display_name: Some("Overridden".to_string()),
-            provider: "mock".to_string(),
-            capabilities: ModelCapabilities::default(),
-        };
-        let result =
-            list_with_registry(args, &mock_registry("mock", vec![overriding_model], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let known_id = builtin_table()[0].model_id.to_string();
+                let args = ListArgs {
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let overriding_model = ModelInfo {
+                    id: known_id,
+                    display_name: Some("Overridden".to_string()),
+                    provider: "mock".to_string(),
+                    capabilities: ModelCapabilities::default(),
+                };
+                let result =
+                    list_with_registry(args, &mock_registry("mock", vec![overriding_model], false))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_remote_provider_error_warns_and_continues() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_remote_provider_error_warns_and_continues",
-        );
-        let args = ListArgs {
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![], true)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let result = list_with_registry(args, &mock_registry("mock", vec![], true)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn list_remote_skips_providers_not_matching_filter() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_remote_skips_providers_not_matching_filter",
-        );
-        // provider filter is "mock-other", but the registry only has "mock"
-        // registered -> the `if filter != provider_name { continue; }`
-        // branch is exercised, and the mock is never queried.
-        let args = ListArgs {
-            remote: true,
-            provider: Some("mock-other".to_string()),
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                // provider filter is "mock-other", but the registry only has "mock"
+                // registered -> the `if filter != provider_name { continue; }`
+                // branch is exercised, and the mock is never queried.
+                let args = ListArgs {
+                    remote: true,
+                    provider: Some("mock-other".to_string()),
+                };
+                let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_remote_finds_model_from_provider() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_remote_finds_model_from_provider",
-        );
-        let args = ShowArgs {
-            model: "mock-remote-model".to_string(),
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let remote_model = ModelInfo {
-            id: "mock-remote-model".to_string(),
-            display_name: Some("Mock Remote Model".to_string()),
-            provider: "mock".to_string(),
-            capabilities: ModelCapabilities::default(),
-        };
-        let result =
-            show_with_registry(args, &mock_registry("mock", vec![remote_model], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ShowArgs {
+                    model: "mock-remote-model".to_string(),
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let remote_model = ModelInfo {
+                    id: "mock-remote-model".to_string(),
+                    display_name: Some("Mock Remote Model".to_string()),
+                    provider: "mock".to_string(),
+                    capabilities: ModelCapabilities::default(),
+                };
+                let result =
+                    show_with_registry(args, &mock_registry("mock", vec![remote_model], false))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_remote_model_not_found_in_provider_list_falls_through() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_remote_model_not_found_in_provider_list_falls_through",
-        );
-        let args = ShowArgs {
-            model: "totally-unknown-model-xyz".to_string(),
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ShowArgs {
+                    model: "totally-unknown-model-xyz".to_string(),
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_remote_provider_error_warns_and_falls_through() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_remote_provider_error_warns_and_falls_through",
-        );
-        let args = ShowArgs {
-            model: "totally-unknown-model-xyz".to_string(),
-            remote: true,
-            provider: Some("mock".to_string()),
-        };
-        let result = show_with_registry(args, &mock_registry("mock", vec![], true)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                let args = ShowArgs {
+                    model: "totally-unknown-model-xyz".to_string(),
+                    remote: true,
+                    provider: Some("mock".to_string()),
+                };
+                let result = show_with_registry(args, &mock_registry("mock", vec![], true)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_remote_unconfigured_provider_warns_and_falls_through() {
-        let _guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_remote_unconfigured_provider_warns_and_falls_through",
-        );
-        // provider filter names a provider that isn't in the registry at all
-        // -> the `if let Some(provider) = registry.get(...)` else branch.
-        let args = ShowArgs {
-            model: "totally-unknown-model-xyz".to_string(),
-            remote: true,
-            provider: Some("nonexistent-provider".to_string()),
-        };
-        let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_ok());
+            |_fake_dir| async move {
+                // provider filter names a provider that isn't in the registry at all
+                // -> the `if let Some(provider) = registry.get(...)` else branch.
+                let args = ShowArgs {
+                    model: "totally-unknown-model-xyz".to_string(),
+                    remote: true,
+                    provider: Some("nonexistent-provider".to_string()),
+                };
+                let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     // ─── validate_keys() warnings + [model_capabilities] overrides ─────────
@@ -1483,65 +1580,75 @@ mod tests {
 
     #[tokio::test]
     async fn list_prints_warning_and_applies_model_capabilities_override() {
-        let _guard = crate::config::isolate_config_path_for_test("models-list-override");
-        let known_id = builtin_table()[0].model_id.to_string();
-        let mut fake_config = Config::default();
-        fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
-        fake_config.model_capabilities.insert(
-            known_id,
-            ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: false,
-                supports_tools: false,
-                supports_system_prompt: false,
-                max_context_tokens: 1,
-                max_output_tokens: 1,
-            },
-        );
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
+        crate::config::with_isolated_config_path_async(
+            "models-list-override",
+            |_fake_dir| async move {
+                let known_id = builtin_table()[0].model_id.to_string();
+                let mut fake_config = Config::default();
+                fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
+                fake_config.model_capabilities.insert(
+                    known_id,
+                    ModelCapabilities {
+                        supports_temperature: false,
+                        supports_streaming: false,
+                        supports_tools: false,
+                        supports_system_prompt: false,
+                        max_context_tokens: 1,
+                        max_output_tokens: 1,
+                    },
+                );
+                std::fs::write(
+                    Config::config_path(),
+                    toml::to_string(&fake_config).unwrap(),
+                )
+                .unwrap();
 
-        let args = ListArgs {
-            remote: false,
-            provider: None,
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_ok());
+                let args = ListArgs {
+                    remote: false,
+                    provider: None,
+                };
+                let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn show_prints_warning_and_uses_model_capabilities_override() {
-        let _guard = crate::config::isolate_config_path_for_test("models-show-override");
-        let known_id = builtin_table()[0].model_id.to_string();
-        let mut fake_config = Config::default();
-        fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
-        fake_config.model_capabilities.insert(
-            known_id.clone(),
-            ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: false,
-                supports_tools: false,
-                supports_system_prompt: false,
-                max_context_tokens: 1,
-                max_output_tokens: 1,
-            },
-        );
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
+        crate::config::with_isolated_config_path_async(
+            "models-show-override",
+            |_fake_dir| async move {
+                let known_id = builtin_table()[0].model_id.to_string();
+                let mut fake_config = Config::default();
+                fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
+                fake_config.model_capabilities.insert(
+                    known_id.clone(),
+                    ModelCapabilities {
+                        supports_temperature: false,
+                        supports_streaming: false,
+                        supports_tools: false,
+                        supports_system_prompt: false,
+                        max_context_tokens: 1,
+                        max_output_tokens: 1,
+                    },
+                );
+                std::fs::write(
+                    Config::config_path(),
+                    toml::to_string(&fake_config).unwrap(),
+                )
+                .unwrap();
 
-        let args = ShowArgs {
-            model: known_id,
-            remote: false,
-            provider: None,
-        };
-        let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_ok());
+                let args = ShowArgs {
+                    model: known_id,
+                    remote: false,
+                    provider: None,
+                };
+                let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1579,16 +1686,19 @@ mod tests {
 
     #[tokio::test]
     async fn list_with_registry_propagates_config_load_error() {
-        let guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-list_with_registry_propagates_config_load_error",
-        );
-        std::fs::write(guard.fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
-        let args = ListArgs {
-            remote: false,
-            provider: None,
-        };
-        let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_err());
+            |fake_dir| async move {
+                std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
+                let args = ListArgs {
+                    remote: false,
+                    provider: None,
+                };
+                let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     // ─── CLI argument parsing (clap derive) ────────────────────────────────
@@ -1717,16 +1827,19 @@ mod tests {
 
     #[tokio::test]
     async fn show_with_registry_propagates_config_load_error() {
-        let guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "models-show_with_registry_propagates_config_load_error",
-        );
-        std::fs::write(guard.fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
-        let args = ShowArgs {
-            model: "any-model".to_string(),
-            remote: false,
-            provider: None,
-        };
-        let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
-        assert!(result.is_err());
+            |fake_dir| async move {
+                std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
+                let args = ShowArgs {
+                    model: "any-model".to_string(),
+                    remote: false,
+                    provider: None,
+                };
+                let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 }

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -70,8 +70,8 @@ struct BuiltinEntry {
 fn builtin_table() -> Vec<BuiltinEntry> {
     macro_rules! entry {
         // Short form — tools defaults to true
-        ($provider:expr, $id:expr, $name:expr,
-         temp=$t:expr, ctx=$ctx:expr, out=$out:expr) => {
+        ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
+         temp=$t:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
             entry!(
                 $provider,
                 $id,
@@ -83,8 +83,8 @@ fn builtin_table() -> Vec<BuiltinEntry> {
             )
         };
         // Full form — explicit tools flag
-        ($provider:expr, $id:expr, $name:expr,
-         temp=$t:expr, tools=$to:expr, ctx=$ctx:expr, out=$out:expr) => {
+        ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
+         temp=$t:expr_2021, tools=$to:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
             BuiltinEntry {
                 provider: $provider,
                 model_id: $id,
@@ -377,10 +377,10 @@ async fn list_with_registry(
         let registry = build_registry(&config);
         for provider_name in registry.provider_names() {
             // If the caller filtered to a specific provider, skip others.
-            if let Some(ref filter) = args.provider {
-                if filter != provider_name {
-                    continue;
-                }
+            if let Some(ref filter) = args.provider
+                && filter != provider_name
+            {
+                continue;
             }
 
             // `registry.get(provider_name)` is structurally guaranteed
@@ -517,36 +517,36 @@ async fn show_with_registry(
     }
 
     // 3. Optionally fetch from provider API if --remote and --provider are both given.
-    if args.remote {
-        if let Some(ref provider_name) = args.provider {
-            let registry = build_registry(&config);
-            if let Some(provider) = registry.get(provider_name) {
-                match provider.list_models().await {
-                    Ok(models) => {
-                        if let Some(info) = models.iter().find(|m| &m.id == model_id) {
-                            print_model_detail(
-                                model_id,
-                                info.display_name.as_deref(),
-                                &info.provider,
-                                &info.capabilities,
-                                false,
-                            );
-                            return Ok(());
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: could not fetch models from '{}': {}",
-                            provider_name, e
+    if args.remote
+        && let Some(ref provider_name) = args.provider
+    {
+        let registry = build_registry(&config);
+        if let Some(provider) = registry.get(provider_name) {
+            match provider.list_models().await {
+                Ok(models) => {
+                    if let Some(info) = models.iter().find(|m| &m.id == model_id) {
+                        print_model_detail(
+                            model_id,
+                            info.display_name.as_deref(),
+                            &info.provider,
+                            &info.capabilities,
+                            false,
                         );
+                        return Ok(());
                     }
                 }
-            } else {
-                eprintln!(
-                    "Warning: provider '{}' is not configured (missing API key?)",
-                    provider_name
-                );
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not fetch models from '{}': {}",
+                        provider_name, e
+                    );
+                }
             }
+        } else {
+            eprintln!(
+                "Warning: provider '{}' is not configured (missing API key?)",
+                provider_name
+            );
         }
     }
 
@@ -573,11 +573,7 @@ async fn show_with_registry(
 // ─── Display helpers ──────────────────────────────────────────────────────────
 
 fn bool_icon(b: bool) -> &'static str {
-    if b {
-        "✓"
-    } else {
-        "✗"
-    }
+    if b { "✓" } else { "✗" }
 }
 
 /// Format a raw token count as a human-friendly string (e.g. 1M, 200K, 128K, 8K).

--- a/crates/leviath-cli/src/commands/pack.rs
+++ b/crates/leviath-cli/src/commands/pack.rs
@@ -161,11 +161,11 @@ fn count_files_with(
     read_dir: &dyn Fn(&Path) -> std::io::Result<std::fs::ReadDir>,
 ) -> usize {
     let mut count = 0;
-    if dir.is_dir() {
-        if let Ok(entries) = read_dir(dir) {
-            for entry in entries.filter_map(|e| e.ok()) {
-                count += count_path(&entry.path(), read_dir);
-            }
+    if dir.is_dir()
+        && let Ok(entries) = read_dir(dir)
+    {
+        for entry in entries.filter_map(|e| e.ok()) {
+            count += count_path(&entry.path(), read_dir);
         }
     }
     count

--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -496,20 +496,24 @@ mod tests {
     #[tokio::test]
     async fn execute_dispatches_subcommands() {
         // Exercise the top-level `execute` dispatcher for the read-only arms.
-        assert!(execute(PolicyArgs {
-            command: PolicyCommand::List(PolicyListArgs {}),
-        })
-        .await
-        .is_ok());
-        assert!(execute(PolicyArgs {
-            command: PolicyCommand::Test(PolicyTestArgs {
-                tool: "read_file".to_string(),
-                target: None,
-                taint: "internal".to_string(),
-            }),
-        })
-        .await
-        .is_ok());
+        assert!(
+            execute(PolicyArgs {
+                command: PolicyCommand::List(PolicyListArgs {}),
+            })
+            .await
+            .is_ok()
+        );
+        assert!(
+            execute(PolicyArgs {
+                command: PolicyCommand::Test(PolicyTestArgs {
+                    tool: "read_file".to_string(),
+                    target: None,
+                    taint: "internal".to_string(),
+                }),
+            })
+            .await
+            .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -2922,94 +2922,97 @@ mod tests {
         // Selecting an abort option must call on_cancel and end the run
         // terminally: NO transition resolution, NO on_stage_result, and
         // on_complete must NOT fire (the run is cancelled, not completed).
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_abort_cancels_run_and_skips_transition",
-        );
-        use crate::runstate::{self, RunMeta};
-        use leviath_core::blueprint::InteractionPoint;
+            |_d| async move {
+                use crate::runstate::{self, RunMeta};
+                use leviath_core::blueprint::InteractionPoint;
 
-        let mut stage = make_stage("plan");
-        stage.mode = StageMode::InteractivePoints {
-            points: vec![InteractionPoint {
-                name: "plan_approval".to_string(),
-                prompt: "Approve?".to_string(),
-                required: false,
-                style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
-                options: vec!["Approve".to_string(), "Abort".to_string()],
-                directives: Default::default(),
-                abort_options: vec!["Abort".to_string()],
-                edit_options: Default::default(),
-            }],
-        };
-        stage.max_iterations = Some(2);
-        stage.accepts_messages = false;
-        let bp = make_blueprint(vec![stage]);
-        let (engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
-        let tool_registry = make_tool_registry().await;
+                let mut stage = make_stage("plan");
+                stage.mode = StageMode::InteractivePoints {
+                    points: vec![InteractionPoint {
+                        name: "plan_approval".to_string(),
+                        prompt: "Approve?".to_string(),
+                        required: false,
+                        style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+                        options: vec!["Approve".to_string(), "Abort".to_string()],
+                        directives: Default::default(),
+                        abort_options: vec!["Abort".to_string()],
+                        edit_options: Default::default(),
+                    }],
+                };
+                stage.max_iterations = Some(2);
+                stage.accepts_messages = false;
+                let bp = make_blueprint(vec![stage]);
+                let (engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+                let tool_registry = make_tool_registry().await;
 
-        let run_id = "exec-abort-run".to_string();
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = "exec-abort-run".to_string();
+                let meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let mut cb = MockCallbacks::new();
-        cb.run_context = Some((run_id.clone(), meta));
+                let mut cb = MockCallbacks::new();
+                cb.run_context = Some((run_id.clone(), meta));
 
-        // Answer the plan_approval choice with "Abort" (index 1).
-        let responder_run_id = run_id.clone();
-        let responder = tokio::spawn(async move {
-            // The stage posts its interaction request before awaiting the
-            // response, so the request is present once this task is scheduled.
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-            let req = crate::interaction::read_request(&responder_run_id)
-                .expect("stage posts its interaction request before awaiting a response");
-            let mut resp = crate::interaction::InteractionResponse::choice("", 1);
-            resp.request_id = req.id.clone();
-            crate::interaction::write_response(&responder_run_id, &resp).unwrap();
-        });
+                // Answer the plan_approval choice with "Abort" (index 1).
+                let responder_run_id = run_id.clone();
+                let responder = tokio::spawn(async move {
+                    // The stage posts its interaction request before awaiting the
+                    // response, so the request is present once this task is scheduled.
+                    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                    let req = crate::interaction::read_request(&responder_run_id)
+                        .expect("stage posts its interaction request before awaiting a response");
+                    let mut resp = crate::interaction::InteractionResponse::choice("", 1);
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&responder_run_id, &resp).unwrap();
+                });
 
-        let mut ctx = StageContext {
-            blueprint: &bp,
-            engine: engine.clone(),
-            entity,
-            pool: &mut pool,
-            tool_source: tool_registry.as_ref(),
-            current_stage_name: Arc::new(Mutex::new(String::new())),
-            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
-            current_stage_idx: Arc::new(Mutex::new(0)),
-            model_override: None,
-            user_default_model: None,
-            compaction_ref: None,
-            agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
-        };
+                let mut ctx = StageContext {
+                    blueprint: &bp,
+                    engine: engine.clone(),
+                    entity,
+                    pool: &mut pool,
+                    tool_source: tool_registry.as_ref(),
+                    current_stage_name: Arc::new(Mutex::new(String::new())),
+                    current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+                    current_stage_idx: Arc::new(Mutex::new(0)),
+                    model_override: None,
+                    user_default_model: None,
+                    compaction_ref: None,
+                    agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
+                };
 
-        run_stage_loop(
-            &mut ctx,
-            &mut cb,
-            "agent-1",
-            &mut MockIO::new(),
-            &mut noop_exec,
+                run_stage_loop(
+                    &mut ctx,
+                    &mut cb,
+                    "agent-1",
+                    &mut MockIO::new(),
+                    &mut noop_exec,
+                )
+                .await
+                .unwrap();
+
+                let _ = responder.await;
+
+                // on_cancel fired for stage 0; the run did NOT complete or transition,
+                // and no stage_result was recorded (the stage was aborted, not run).
+                assert_eq!(cb.cancelled_at, Some(0));
+                assert_eq!(cb.completed_at, None);
+                assert!(cb.transitions.is_empty());
+                assert!(cb.stage_results.is_empty());
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        let _ = responder.await;
-
-        // on_cancel fired for stage 0; the run did NOT complete or transition,
-        // and no stage_result was recorded (the stage was aborted, not run).
-        assert_eq!(cb.cancelled_at, Some(0));
-        assert_eq!(cb.completed_at, None);
-        assert!(cb.transitions.is_empty());
-        assert!(cb.stage_results.is_empty());
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     // ─── Interactive/InteractivePoints error propagation ────────────────────
@@ -3057,74 +3060,78 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_stage_ipc_write_failure_propagates_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_stage_ipc_write_failure_propagates_error",
-        );
-        // InteractivePoints with a non-empty points slice and a run_context whose
-        // run_dir doesn't exist → write_request fails inside request_interaction_async
-        // → Err propagates via the ? at the InteractivePoints match arm.
-        use crate::runstate::RunMeta;
-        use leviath_core::blueprint::InteractionPoint;
+            |_d| async move {
+                // InteractivePoints with a non-empty points slice and a run_context whose
+                // run_dir doesn't exist → write_request fails inside request_interaction_async
+                // → Err propagates via the ? at the InteractivePoints match arm.
+                use crate::runstate::RunMeta;
+                use leviath_core::blueprint::InteractionPoint;
 
-        let mut stage = make_stage("main");
-        stage.mode = StageMode::InteractivePoints {
-            points: vec![InteractionPoint {
-                name: "confirm".to_string(),
-                prompt: "Continue?".to_string(),
-                required: false,
-                style: Default::default(),
-                options: vec![],
-                directives: Default::default(),
-                abort_options: Default::default(),
-                edit_options: Default::default(),
-            }],
-        };
-        stage.accepts_messages = false;
-        let bp = make_blueprint(vec![stage]);
-        let (engine, mut pool, entity) = make_engine_and_entity(&bp);
-        let tool_registry = make_tool_registry().await;
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir("executor-test-no-dir-ipc"));
+                let mut stage = make_stage("main");
+                stage.mode = StageMode::InteractivePoints {
+                    points: vec![InteractionPoint {
+                        name: "confirm".to_string(),
+                        prompt: "Continue?".to_string(),
+                        required: false,
+                        style: Default::default(),
+                        options: vec![],
+                        directives: Default::default(),
+                        abort_options: Default::default(),
+                        edit_options: Default::default(),
+                    }],
+                };
+                stage.accepts_messages = false;
+                let bp = make_blueprint(vec![stage]);
+                let (engine, mut pool, entity) = make_engine_and_entity(&bp);
+                let tool_registry = make_tool_registry().await;
+                let _ =
+                    std::fs::remove_dir_all(crate::runstate::run_dir("executor-test-no-dir-ipc"));
 
-        let mut cb = MockCallbacks::new();
-        cb.run_context = Some((
-            "executor-test-no-dir-ipc".to_string(),
-            RunMeta::new(
-                "executor-test-no-dir-ipc".to_string(),
-                "test-agent".to_string(),
-                "/path".to_string(),
-                "task".to_string(),
-                None,
-                "/tmp".to_string(),
-                1,
-            ),
-        ));
+                let mut cb = MockCallbacks::new();
+                cb.run_context = Some((
+                    "executor-test-no-dir-ipc".to_string(),
+                    RunMeta::new(
+                        "executor-test-no-dir-ipc".to_string(),
+                        "test-agent".to_string(),
+                        "/path".to_string(),
+                        "task".to_string(),
+                        None,
+                        "/tmp".to_string(),
+                        1,
+                    ),
+                ));
 
-        let mut ctx = StageContext {
-            blueprint: &bp,
-            engine: engine.clone(),
-            entity,
-            pool: &mut pool,
-            tool_source: tool_registry.as_ref(),
-            current_stage_name: Arc::new(Mutex::new(String::new())),
-            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
-            current_stage_idx: Arc::new(Mutex::new(0)),
-            model_override: None,
-            user_default_model: None,
-            compaction_ref: None,
-            agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
-        };
+                let mut ctx = StageContext {
+                    blueprint: &bp,
+                    engine: engine.clone(),
+                    entity,
+                    pool: &mut pool,
+                    tool_source: tool_registry.as_ref(),
+                    current_stage_name: Arc::new(Mutex::new(String::new())),
+                    current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+                    current_stage_idx: Arc::new(Mutex::new(0)),
+                    model_override: None,
+                    user_default_model: None,
+                    compaction_ref: None,
+                    agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
+                };
 
-        let result = run_stage_loop(
-            &mut ctx,
-            &mut cb,
-            "agent-1",
-            &mut MockIO::new(),
-            &mut noop_exec,
+                let result = run_stage_loop(
+                    &mut ctx,
+                    &mut cb,
+                    "agent-1",
+                    &mut MockIO::new(),
+                    &mut noop_exec,
+                )
+                .await;
+
+                // IPC write failure should propagate Err from InteractivePoints.
+                assert!(result.is_err());
+            },
         )
         .await;
-
-        // IPC write failure should propagate Err from InteractivePoints.
-        assert!(result.is_err());
     }
 
     // ─── Models list priority tests ──────────────────────────────────────
@@ -4081,91 +4088,94 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_abort_aborts_active_stdin_reader() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_abort_aborts_active_stdin_reader",
-        );
-        use crate::runstate::{self, RunMeta};
-        use leviath_core::blueprint::InteractionPoint;
+            |_d| async move {
+                use crate::runstate::{self, RunMeta};
+                use leviath_core::blueprint::InteractionPoint;
 
-        // accepts_messages = true makes start_message_reader return Some, so the
-        // abort path's `handle.abort()` (stdin-reader cleanup) is exercised.
-        let mut stage = make_stage("plan");
-        stage.mode = StageMode::InteractivePoints {
-            points: vec![InteractionPoint {
-                name: "plan_approval".to_string(),
-                prompt: "Approve?".to_string(),
-                required: false,
-                style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
-                options: vec!["Approve".to_string(), "Abort".to_string()],
-                directives: Default::default(),
-                abort_options: vec!["Abort".to_string()],
-                edit_options: Default::default(),
-            }],
-        };
-        stage.max_iterations = Some(2);
-        stage.accepts_messages = true;
-        let bp = make_blueprint(vec![stage]);
-        let (engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
-        let tool_registry = make_tool_registry().await;
+                // accepts_messages = true makes start_message_reader return Some, so the
+                // abort path's `handle.abort()` (stdin-reader cleanup) is exercised.
+                let mut stage = make_stage("plan");
+                stage.mode = StageMode::InteractivePoints {
+                    points: vec![InteractionPoint {
+                        name: "plan_approval".to_string(),
+                        prompt: "Approve?".to_string(),
+                        required: false,
+                        style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+                        options: vec!["Approve".to_string(), "Abort".to_string()],
+                        directives: Default::default(),
+                        abort_options: vec!["Abort".to_string()],
+                        edit_options: Default::default(),
+                    }],
+                };
+                stage.max_iterations = Some(2);
+                stage.accepts_messages = true;
+                let bp = make_blueprint(vec![stage]);
+                let (engine, mut pool, entity) = make_engine_and_entity_with_provider(&bp);
+                let tool_registry = make_tool_registry().await;
 
-        let run_id = "exec-abort-reader-run".to_string();
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = "exec-abort-reader-run".to_string();
+                let meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let mut cb = MockCallbacks::new();
-        cb.run_context = Some((run_id.clone(), meta));
+                let mut cb = MockCallbacks::new();
+                cb.run_context = Some((run_id.clone(), meta));
 
-        let responder_run_id = run_id.clone();
-        let responder = tokio::spawn(async move {
-            // The stage posts its interaction request before awaiting the
-            // response, so the request is present once this task is scheduled.
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-            let req = crate::interaction::read_request(&responder_run_id)
-                .expect("stage posts its interaction request before awaiting a response");
-            let mut resp = crate::interaction::InteractionResponse::choice("", 1);
-            resp.request_id = req.id.clone();
-            crate::interaction::write_response(&responder_run_id, &resp).unwrap();
-        });
+                let responder_run_id = run_id.clone();
+                let responder = tokio::spawn(async move {
+                    // The stage posts its interaction request before awaiting the
+                    // response, so the request is present once this task is scheduled.
+                    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                    let req = crate::interaction::read_request(&responder_run_id)
+                        .expect("stage posts its interaction request before awaiting a response");
+                    let mut resp = crate::interaction::InteractionResponse::choice("", 1);
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&responder_run_id, &resp).unwrap();
+                });
 
-        let mut ctx = StageContext {
-            blueprint: &bp,
-            engine: engine.clone(),
-            entity,
-            pool: &mut pool,
-            tool_source: tool_registry.as_ref(),
-            current_stage_name: Arc::new(Mutex::new(String::new())),
-            current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
-            current_stage_idx: Arc::new(Mutex::new(0)),
-            model_override: None,
-            user_default_model: None,
-            compaction_ref: None,
-            agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
-        };
+                let mut ctx = StageContext {
+                    blueprint: &bp,
+                    engine: engine.clone(),
+                    entity,
+                    pool: &mut pool,
+                    tool_source: tool_registry.as_ref(),
+                    current_stage_name: Arc::new(Mutex::new(String::new())),
+                    current_stage_perms: Arc::new(Mutex::new(HashMap::new())),
+                    current_stage_idx: Arc::new(Mutex::new(0)),
+                    model_override: None,
+                    user_default_model: None,
+                    compaction_ref: None,
+                    agent_registry: std::sync::Arc::new(std::collections::HashMap::new()),
+                };
 
-        run_stage_loop(
-            &mut ctx,
-            &mut cb,
-            "agent-1",
-            &mut MockIO::new(),
-            &mut noop_exec,
+                run_stage_loop(
+                    &mut ctx,
+                    &mut cb,
+                    "agent-1",
+                    &mut MockIO::new(),
+                    &mut noop_exec,
+                )
+                .await
+                .unwrap();
+
+                let _ = responder.await;
+
+                assert_eq!(cb.cancelled_at, Some(0));
+                assert_eq!(cb.completed_at, None);
+                assert!(cb.transitions.is_empty());
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        let _ = responder.await;
-
-        assert_eq!(cb.cancelled_at, Some(0));
-        assert_eq!(cb.completed_at, None);
-        assert!(cb.transitions.is_empty());
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 }

--- a/crates/leviath-cli/src/commands/run/executor.rs
+++ b/crates/leviath-cli/src/commands/run/executor.rs
@@ -5,9 +5,9 @@
 //! `foreground.rs` and `worker.rs`.
 
 use async_trait::async_trait;
+use leviath_core::Blueprint;
 use leviath_core::blueprint::{StageMode, StageResult};
 use leviath_core::lifecycle::CompactionConfig;
-use leviath_core::Blueprint;
 use leviath_providers::InferenceResponse;
 use leviath_runtime::{
     AgentEngine, AgentPool, AgentState, ContextWindow, EngineHandle, InferenceConfig,
@@ -21,11 +21,11 @@ use super::tool_source::StageToolSource;
 use super::graph::{apply_edge_transform, is_graph_mode, resolve_transition};
 use super::helpers::swap_context_layout;
 use super::io::RunIO;
-use super::stages::{run_interactive_points_stage, run_interactive_stage, PointsOutcome};
-use leviath_core::taint::{
-    resolve_security, resolve_taint_enabled, SecurityConfig, ToolClassification, ToolDirection,
-};
+use super::stages::{PointsOutcome, run_interactive_points_stage, run_interactive_stage};
 use leviath_core::PolicyConfig;
+use leviath_core::taint::{
+    SecurityConfig, ToolClassification, ToolDirection, resolve_security, resolve_taint_enabled,
+};
 use leviath_runtime::taint::TaintGate;
 
 /// Inject a stage's `system_prompt` into `target_region` as pinned
@@ -550,7 +550,9 @@ pub async fn run_stage_loop(
             .accepts_messages = stage.accepts_messages;
 
         if stage.accepts_messages {
-            println!("\u{1f4ac} Type a message and press Enter to send input to the agent while it runs.");
+            println!(
+                "\u{1f4ac} Type a message and press Enter to send input to the agent while it runs."
+            );
         }
 
         // Stage layout swap
@@ -1581,10 +1583,11 @@ mod tests {
         .unwrap();
 
         // The loop visited the fan_out stage then jumped to the merge stage.
-        assert!(cb
-            .transitions
-            .iter()
-            .any(|(f, t)| f == "parallel" && t == "merge"));
+        assert!(
+            cb.transitions
+                .iter()
+                .any(|(f, t)| f == "parallel" && t == "merge")
+        );
         // Two workers were spawned as children of the root.
         let eng = engine.read().await;
         let children = eng
@@ -1733,10 +1736,11 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(cb
-            .transitions
-            .iter()
-            .any(|(f, t)| f == "parallel" && t == "done"));
+        assert!(
+            cb.transitions
+                .iter()
+                .any(|(f, t)| f == "parallel" && t == "done")
+        );
     }
 
     #[tokio::test]
@@ -1809,10 +1813,11 @@ mod tests {
         .await
         .unwrap();
         // No workers spawned (split failed), and the error edge was taken.
-        assert!(cb
-            .transitions
-            .iter()
-            .any(|(f, t)| f == "parallel" && t == "recover"));
+        assert!(
+            cb.transitions
+                .iter()
+                .any(|(f, t)| f == "parallel" && t == "recover")
+        );
     }
 
     struct CannedProvider;
@@ -2210,10 +2215,12 @@ mod tests {
 
         // Linear mode must propagate the error.
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("simulated autonomous failure"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("simulated autonomous failure")
+        );
         assert_eq!(cb.errors.len(), 1);
         // on_complete is never reached when the error propagates.
         assert!(cb.completed_at.is_none());
@@ -2632,14 +2639,16 @@ mod tests {
         // reaches on its own -- the same production behavior for each is
         // already covered via `MockCallbacks` elsewhere in this file.
         cb.on_claude_code_warning(0).await;
-        assert!(cb
-            .start_message_reader(&*engine.read().await, "agent-1", false)
-            .is_none());
+        assert!(
+            cb.start_message_reader(&*engine.read().await, "agent-1", false)
+                .is_none()
+        );
         assert!(cb.get_run_context().is_none());
-        assert!(cb
-            .on_stage_error("main", 0, &anyhow::anyhow!("e"), false)
-            .await
-            .is_none());
+        assert!(
+            cb.on_stage_error("main", 0, &anyhow::anyhow!("e"), false)
+                .await
+                .is_none()
+        );
         cb.on_transition("a", "b", 0).await;
         cb.on_complete(0).await;
         cb.on_post_stage(&*engine.read().await, entity, "main")
@@ -2805,9 +2814,10 @@ mod tests {
         // its own -- the same production behavior for each is already
         // covered via `MockCallbacks` elsewhere in this file.
         cb.on_claude_code_warning(0).await;
-        assert!(cb
-            .start_message_reader(&*engine.read().await, "agent-1", false)
-            .is_none());
+        assert!(
+            cb.start_message_reader(&*engine.read().await, "agent-1", false)
+                .is_none()
+        );
         assert!(cb.get_run_context().is_none());
         assert_eq!(
             cb.on_stage_error("a", 0, &anyhow::anyhow!("e"), true).await,
@@ -3808,12 +3818,14 @@ mod tests {
         );
 
         // Sanity: confirm it's there before the loop.
-        assert!(engine
-            .read()
-            .await
-            .world()
-            .get::<leviath_runtime::ToolResultRoutingComponent>(entity)
-            .is_some());
+        assert!(
+            engine
+                .read()
+                .await
+                .world()
+                .get::<leviath_runtime::ToolResultRoutingComponent>(entity)
+                .is_some()
+        );
 
         let mut ctx = StageContext {
             blueprint: &bp,
@@ -3842,13 +3854,14 @@ mod tests {
 
         // After running a stage with tool_result_routing = None, the
         // component must have been removed.
-        assert!(ctx
-            .engine
-            .read()
-            .await
-            .world()
-            .get::<leviath_runtime::ToolResultRoutingComponent>(ctx.entity)
-            .is_none());
+        assert!(
+            ctx.engine
+                .read()
+                .await
+                .world()
+                .get::<leviath_runtime::ToolResultRoutingComponent>(ctx.entity)
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/fanout.rs
+++ b/crates/leviath-cli/src/commands/run/fanout.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bevy_ecs::prelude::Entity;
-use leviath_core::blueprint::{FanOutConfig, ModelConfig, WorkerFailurePolicy};
 use leviath_core::Blueprint;
+use leviath_core::blueprint::{FanOutConfig, ModelConfig, WorkerFailurePolicy};
 use leviath_package::AgentInstaller;
 use leviath_runtime::{
-    run_inference_loop_shared, AgentPool, AgentState, AgentStatus, ContextWindow, EngineHandle,
-    ParentRef, ToolResultsFuture,
+    AgentPool, AgentState, AgentStatus, ContextWindow, EngineHandle, ParentRef, ToolResultsFuture,
+    run_inference_loop_shared,
 };
 
 use super::io::RunIO;
@@ -156,10 +156,10 @@ fn agent_matches(bp: &Blueprint, needle: &str) -> bool {
         return true;
     }
     for key in ["tags", "capabilities"] {
-        if let Some(val) = bp.metadata.get(key) {
-            if metadata_value_contains(val, needle) {
-                return true;
-            }
+        if let Some(val) = bp.metadata.get(key)
+            && metadata_value_contains(val, needle)
+        {
+            return true;
         }
     }
     false
@@ -544,9 +544,9 @@ pub async fn run_fan_out_stage(
 mod tests {
     use super::*;
     use crate::tools::ToolRegistry;
+    use leviath_core::RegionKind;
     use leviath_core::blueprint::{ModelConfig, Stage, WorkerFailurePolicy};
     use leviath_core::layout::{ContextLayout, RegionDefinition};
-    use leviath_core::RegionKind;
 
     fn bp(name: &str) -> Blueprint {
         let layout = ContextLayout::new(
@@ -647,10 +647,12 @@ mod tests {
         registry.insert("alpha".to_string(), bp("alpha"));
         registry.insert("alto".to_string(), bp("alto"));
         // zero
-        assert!(discover_worker("zzz", &registry)
-            .unwrap_err()
-            .to_string()
-            .contains("matched no"));
+        assert!(
+            discover_worker("zzz", &registry)
+                .unwrap_err()
+                .to_string()
+                .contains("matched no")
+        );
         // ambiguous ("al" matches both), error lists sorted candidates
         let err = discover_worker("al", &registry).unwrap_err().to_string();
         assert!(err.contains("ambiguous"));
@@ -797,7 +799,7 @@ model = { models = [{ provider = "mock", model = "m" }] }
                 None if self.error_when_empty => {
                     return Err(leviath_providers::ProviderError::Other(
                         "worker boom".into(),
-                    ))
+                    ));
                 }
                 None => ("done".to_string(), vec![]),
             };
@@ -839,8 +841,8 @@ model = { models = [{ provider = "mock", model = "m" }] }
 
     /// Blueprint with a fan_out stage (worker_stage=worker) + merge stage.
     fn fanout_blueprint(config: FanOutConfig) -> Blueprint {
-        use leviath_core::layout::{ContextLayout, RegionDefinition};
         use leviath_core::RegionKind;
+        use leviath_core::layout::{ContextLayout, RegionDefinition};
         let layout = ContextLayout::new(
             vec![RegionDefinition::new(
                 "sys".into(),
@@ -1467,12 +1469,14 @@ model = { models = [{ provider = "mock", model = "m" }] }
         .unwrap();
         assert_eq!(outcome, FanOutOutcome::Merge("merge".to_string()));
         // No workers spawned.
-        assert!(engine
-            .read()
-            .await
-            .world()
-            .get::<SubAgentChildren>(parent)
-            .is_none());
+        assert!(
+            engine
+                .read()
+                .await
+                .world()
+                .get::<SubAgentChildren>(parent)
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/fanout.rs
+++ b/crates/leviath-cli/src/commands/run/fanout.rs
@@ -1522,9 +1522,9 @@ model = { models = [{ provider = "mock", model = "m" }] }
         // registers.
         let tmp = std::env::temp_dir().join(format!("lev-fanout-home-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
-        std::env::set_var("LEVIATH_HOME", &tmp);
-        let registry = load_agent_registry(&bp("solo-agent"));
-        std::env::remove_var("LEVIATH_HOME");
+        let registry = temp_env::with_var("LEVIATH_HOME", Some(&tmp), || {
+            load_agent_registry(&bp("solo-agent"))
+        });
         assert!(registry.contains_key("solo-agent"));
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -12,14 +12,14 @@ use std::collections::{HashMap, HashSet};
 use crate::config::{Config, ToolPolicy};
 use crate::interaction::{InteractionRequest, InteractionResponse};
 use crate::runstate::RunMeta;
-use crate::tools::{resolve_policy, ToolRegistry};
+use crate::tools::{ToolRegistry, resolve_policy};
 
-use super::executor::{run_stage_loop, StageCallbacks, StageContext};
+use super::RunArgs;
+use super::executor::{StageCallbacks, StageContext, run_stage_loop};
 use super::helpers::initialize_context_window;
 use super::io::{ConsoleIO, RunIO};
 use super::manifest::{find_manifest, parse_manifest};
 use super::session::{build_provider_registry_from_config, resolve_task};
-use super::RunArgs;
 
 /// Type-erased async buffered reader supplied by
 /// [`ForegroundIo::make_message_reader`].
@@ -178,7 +178,7 @@ async fn dispatch_tool_calls_foreground(
                 format!("[denied] Tool '{}' is not permitted for this run.", tc.name)
             }
             ToolPolicy::Ask => {
-                use crate::interaction::{response_approved, ApprovalScope};
+                use crate::interaction::{ApprovalScope, response_approved};
                 let req = InteractionRequest::tool_approval(
                     format!("fg-{}", tc.id),
                     &tc.name,

--- a/crates/leviath-cli/src/commands/run/foreground.rs
+++ b/crates/leviath-cli/src/commands/run/foreground.rs
@@ -1431,11 +1431,12 @@ mod tests {
 
     #[tokio::test]
     async fn run_foreground_with_valid_manifest_aborts_at_missing_provider() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-valid-manifest");
-
-        let temp_dir = std::env::temp_dir().join("lev-test-foreground-valid-manifest");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+        crate::config::with_isolated_config_path_async(
+            "fg-valid-manifest",
+            |_fake_dir| async move {
+                let temp_dir = std::env::temp_dir().join("lev-test-foreground-valid-manifest");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                let manifest_content = r#"
 [agent]
 name = "test-foreground-agent"
 version = "1.0.0"
@@ -1452,31 +1453,34 @@ model = "claude-sonnet-4-6"
 [tool_permissions]
 bash = "ask"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+                write_test_agent(&temp_dir, manifest_content);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: true,
-            allow: vec!["read_file".to_string()],
-            ask: vec!["bash".to_string()],
-            deny: vec!["write_file".to_string()],
-            max_depth: None,
-            count: 1,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: true,
+                    allow: vec!["read_file".to_string()],
+                    ask: vec!["bash".to_string()],
+                    deny: vec!["write_file".to_string()],
+                    max_depth: None,
+                    count: 1,
+                };
 
-        // No provider is configured (config isolated above), so this should
-        // abort cleanly via `on_provider_missing` returning `true` -- which
-        // `run_stage_loop` surfaces as `Ok(())`, not an error. Wrapped in
-        // `with_tracing` because this path reaches the `tracing::info!` at
-        // the top of `run_foreground_with_registry`.
-        with_tracing(|| run_foreground(args, test_foreground_io()))
-            .await
-            .unwrap();
+                // No provider is configured (config isolated above), so this should
+                // abort cleanly via `on_provider_missing` returning `true` -- which
+                // `run_stage_loop` surfaces as `Ok(())`, not an error. Wrapped in
+                // `with_tracing` because this path reaches the `tracing::info!` at
+                // the top of `run_foreground_with_registry`.
+                with_tracing(|| run_foreground(args, test_foreground_io()))
+                    .await
+                    .unwrap();
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     // ─── run_foreground_with_registry (mock provider, no network) ───────────
@@ -1558,22 +1562,24 @@ bash = "ask"
 
     #[tokio::test]
     async fn run_foreground_with_mock_provider_completes_full_round_trip() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-mock-provider");
-        // A malformed key still exercises the `validate_keys()` warning
-        // branch without being usable as a real credential -- and since the
-        // provider registry is fully mocked below, no real network call can
-        // happen regardless.
-        let mut fake_config = Config::default();
-        fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
+        crate::config::with_isolated_config_path_async(
+            "fg-mock-provider",
+            |_fake_dir| async move {
+                // A malformed key still exercises the `validate_keys()` warning
+                // branch without being usable as a real credential -- and since the
+                // provider registry is fully mocked below, no real network call can
+                // happen regardless.
+                let mut fake_config = Config::default();
+                fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
+                std::fs::write(
+                    Config::config_path(),
+                    toml::to_string(&fake_config).unwrap(),
+                )
+                .unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-foreground-mock-provider");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+                let temp_dir = std::env::temp_dir().join("lev-test-foreground-mock-provider");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                let manifest_content = r#"
 [agent]
 name = "test-foreground-mock-agent"
 version = "1.0.0"
@@ -1587,46 +1593,49 @@ max_iterations = 2
 provider = "mock"
 model = "mock-model"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+                write_test_agent(&temp_dir, manifest_content);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: true,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: true,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
 
-        // Wrapped in `with_tracing` because this path reaches the
-        // `tracing::info!` at the top of `run_foreground_with_registry`.
-        with_tracing(|| {
-            run_foreground_with_registry(
-                args,
-                |_config| {
-                    let mut registry = leviath_runtime::ProviderRegistry::new();
-                    registry.register("mock".to_string(), Arc::new(MockProvider::new()));
-                    registry
-                },
-                test_foreground_io(),
-            )
-        })
-        .await
-        .unwrap();
+                // Wrapped in `with_tracing` because this path reaches the
+                // `tracing::info!` at the top of `run_foreground_with_registry`.
+                with_tracing(|| {
+                    run_foreground_with_registry(
+                        args,
+                        |_config| {
+                            let mut registry = leviath_runtime::ProviderRegistry::new();
+                            registry.register("mock".to_string(), Arc::new(MockProvider::new()));
+                            registry
+                        },
+                        test_foreground_io(),
+                    )
+                })
+                .await
+                .unwrap();
 
-        // Cover the remaining `Provider` trait methods that this particular
-        // run never exercises through the engine.
-        let provider = MockProvider::new();
-        assert_eq!(provider.count_tokens("abcd", "mock-model"), 1);
-        assert_eq!(provider.max_context_tokens("mock-model"), 100_000);
-        assert_eq!(provider.name(), "mock");
-        assert!(provider.list_models().await.unwrap().is_empty());
+                // Cover the remaining `Provider` trait methods that this particular
+                // run never exercises through the engine.
+                let provider = MockProvider::new();
+                assert_eq!(provider.count_tokens("abcd", "mock-model"), 1);
+                assert_eq!(provider.max_context_tokens("mock-model"), 100_000);
+                assert_eq!(provider.name(), "mock");
+                assert!(provider.list_models().await.unwrap().is_empty());
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     struct InferFailProvider;
@@ -1672,11 +1681,10 @@ model = "mock-model"
     /// a provider whose `infer` always fails.
     #[tokio::test]
     async fn run_foreground_with_registry_propagates_inference_error() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-infer-fail");
-
-        let temp_dir = std::env::temp_dir().join("lev-test-foreground-infer-fail");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+        crate::config::with_isolated_config_path_async("fg-infer-fail", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-foreground-infer-fail");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            let manifest_content = r#"
 [agent]
 name = "test-foreground-infer-fail"
 version = "1.0.0"
@@ -1690,44 +1698,46 @@ max_iterations = 2
 provider = "mock"
 model = "mock-model"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+            write_test_agent(&temp_dir, manifest_content);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: true,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+            let args = RunArgs {
+                path: Some(temp_dir.to_string_lossy().to_string()),
+                task: Some("test task".to_string()),
+                model: None,
+                foreground: true,
+                yolo: true,
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-        let result = with_tracing(|| {
-            run_foreground_with_registry(
-                args,
-                |_config| {
-                    let mut registry = leviath_runtime::ProviderRegistry::new();
-                    registry.register("mock".to_string(), Arc::new(InferFailProvider));
-                    registry
-                },
-                test_foreground_io(),
-            )
+            let result = with_tracing(|| {
+                run_foreground_with_registry(
+                    args,
+                    |_config| {
+                        let mut registry = leviath_runtime::ProviderRegistry::new();
+                        registry.register("mock".to_string(), Arc::new(InferFailProvider));
+                        registry
+                    },
+                    test_foreground_io(),
+                )
+            })
+            .await;
+            assert!(result.is_err());
+
+            // Cover the `Provider` trait methods the failing run never exercises.
+            let provider = InferFailProvider;
+            assert_eq!(provider.count_tokens("abcd", "mock-model"), 1);
+            assert_eq!(provider.max_context_tokens("mock-model"), 100_000);
+            assert_eq!(provider.name(), "mock");
+            let _ = provider.capabilities("mock-model");
+            assert!(provider.list_models().await.unwrap().is_empty());
+
+            let _ = std::fs::remove_dir_all(&temp_dir);
         })
         .await;
-        assert!(result.is_err());
-
-        // Cover the `Provider` trait methods the failing run never exercises.
-        let provider = InferFailProvider;
-        assert_eq!(provider.count_tokens("abcd", "mock-model"), 1);
-        assert_eq!(provider.max_context_tokens("mock-model"), 100_000);
-        assert_eq!(provider.name(), "mock");
-        let _ = provider.capabilities("mock-model");
-        assert!(provider.list_models().await.unwrap().is_empty());
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[tokio::test]
@@ -1777,37 +1787,41 @@ model = "mock-model"
     /// real inference needed.
     #[tokio::test]
     async fn run_foreground_with_registry_reaches_registry_build_when_provider_missing() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("fg-registry-build-provider-missing");
+        crate::config::with_isolated_config_path_async(
+            "fg-registry-build-provider-missing",
+            |_fake_dir| async move {
+                let temp_dir =
+                    std::env::temp_dir().join("lev-test-fg-registry-build-provider-missing");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                std::fs::write(
+                    temp_dir.join("agent.leviath"),
+                    "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
+                )
+                .unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-registry-build-provider-missing");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        std::fs::write(
-            temp_dir.join("agent.leviath"),
-            "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
+
+                let result = with_tracing(|| {
+                    run_foreground_with_registry(args, empty_registry, test_foreground_io())
+                })
+                .await;
+                assert!(result.is_ok());
+
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
         )
-        .unwrap();
-
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
-
-        let result = with_tracing(|| {
-            run_foreground_with_registry(args, empty_registry, test_foreground_io())
-        })
         .await;
-        assert!(result.is_ok());
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     /// Covers the `args.path = None` → `unwrap_or_else(|| ".".to_string())`
@@ -1816,33 +1830,35 @@ model = "mock-model"
     /// (with any result).
     #[tokio::test]
     async fn run_foreground_with_registry_path_none_uses_dot() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-path-none");
+        crate::config::with_isolated_config_path_async("fg-path-none", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-fg-path-none");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            // Write a manifest so find_manifest("." relative to temp_dir) works.
+            // We can't change cwd reliably in a test, so use an explicit path
+            // instead — but we DO pass path: None to exercise the else branch.
+            // Since the working directory during tests is the workspace root and
+            // likely has no agent.leviath, the call will fail at find_manifest,
+            // which is fine — we only need to cover the unwrap_or_else closure.
+            let args = RunArgs {
+                path: None, // ← exercises unwrap_or_else(|| ".".to_string())
+                task: Some("test".to_string()),
+                model: None,
+                foreground: true,
+                yolo: false,
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-path-none");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        // Write a manifest so find_manifest("." relative to temp_dir) works.
-        // We can't change cwd reliably in a test, so use an explicit path
-        // instead — but we DO pass path: None to exercise the else branch.
-        // Since the working directory during tests is the workspace root and
-        // likely has no agent.leviath, the call will fail at find_manifest,
-        // which is fine — we only need to cover the unwrap_or_else closure.
-        let args = RunArgs {
-            path: None, // ← exercises unwrap_or_else(|| ".".to_string())
-            task: Some("test".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
-
-        // find_manifest(".") will fail unless there's an agent.leviath in cwd
-        let result = run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
-        // Accept either Ok or Err — we just need the unwrap_or_else to fire.
-        let _ = result;
+            // find_manifest(".") will fail unless there's an agent.leviath in cwd
+            let result =
+                run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
+            // Accept either Ok or Err — we just need the unwrap_or_else to fire.
+            let _ = result;
+        })
+        .await;
     }
 
     /// Covers `read_to_string(...).map_err(...)` error branch and the
@@ -1851,60 +1867,71 @@ model = "mock-model"
     /// it via `.exists()` yet `read_to_string` fails on every platform.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_on_manifest_read_error() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-manifest-read-error");
+        crate::config::with_isolated_config_path_async(
+            "fg-manifest-read-error",
+            |_fake_dir| async move {
+                let temp_dir = std::env::temp_dir().join("lev-test-fg-manifest-read");
+                let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                // agent.leviath is a directory: found via exists(), unreadable as a file.
+                std::fs::create_dir_all(temp_dir.join("agent.leviath")).unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-manifest-read");
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        // agent.leviath is a directory: found via exists(), unreadable as a file.
-        std::fs::create_dir_all(temp_dir.join("agent.leviath")).unwrap();
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: false, // ← exercises the yolo=false path
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false, // ← exercises the yolo=false path
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+                let result =
+                    run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
+                assert!(result.is_err());
 
-        let result = run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     /// Covers `parse_manifest(...)? ` error branch (line 386) — the manifest
     /// file exists and is readable but contains invalid TOML / bad structure.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_on_invalid_manifest() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-invalid-manifest");
+        crate::config::with_isolated_config_path_async(
+            "fg-invalid-manifest",
+            |_fake_dir| async move {
+                let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-manifest");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                std::fs::write(temp_dir.join("agent.leviath"), "this is not valid toml }{")
+                    .unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-manifest");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        std::fs::write(temp_dir.join("agent.leviath"), "this is not valid toml }{").unwrap();
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+                let result =
+                    run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
+                assert!(result.is_err());
 
-        let result = run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     /// Covers the `blueprint.validate().map_err(|e| ... "blueprint validation
@@ -1912,13 +1939,12 @@ model = "mock-model"
     /// `validate()` because `entry_stage` names a nonexistent stage.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_on_blueprint_validation() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-invalid-bp");
-
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-bp");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        std::fs::write(
-            temp_dir.join("agent.leviath"),
-            r#"
+        crate::config::with_isolated_config_path_async("fg-invalid-bp", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-bp");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            std::fs::write(
+                temp_dir.join("agent.leviath"),
+                r#"
 [agent]
 name = "invalid-bp"
 version = "1.0.0"
@@ -1929,31 +1955,34 @@ entry_stage = "does-not-exist"
 mode = "autonomous"
 prompt = "Do the thing"
 "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+            let args = RunArgs {
+                path: Some(temp_dir.to_string_lossy().to_string()),
+                task: Some("test".to_string()),
+                model: None,
+                foreground: true,
+                yolo: false,
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-        let result = run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
-        assert!(result.is_err());
-        let err = format!("{:#}", result.unwrap_err());
-        assert!(
-            err.contains("blueprint validation failed"),
-            "expected validation-failure error, got: {err}"
-        );
+            let result =
+                run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
+            assert!(result.is_err());
+            let err = format!("{:#}", result.unwrap_err());
+            assert!(
+                err.contains("blueprint validation failed"),
+                "expected validation-failure error, got: {err}"
+            );
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        })
+        .await;
     }
 
     /// Covers `resolve_task(...)? ` error branch (line 389) via the "empty
@@ -1968,37 +1997,39 @@ prompt = "Do the thing"
     /// environment, without depending on whether stdin happens to be a TTY.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_when_task_file_is_empty() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-no-task");
+        crate::config::with_isolated_config_path_async("fg-no-task", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-fg-no-task");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            std::fs::write(
+                temp_dir.join("agent.leviath"),
+                "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
+            )
+            .unwrap();
+            let empty_task_file = temp_dir.join("empty-task.txt");
+            std::fs::write(&empty_task_file, "").unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-no-task");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        std::fs::write(
-            temp_dir.join("agent.leviath"),
-            "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
-        )
-        .unwrap();
-        let empty_task_file = temp_dir.join("empty-task.txt");
-        std::fs::write(&empty_task_file, "").unwrap();
+            let args = RunArgs {
+                path: Some(temp_dir.to_string_lossy().to_string()),
+                task: Some(empty_task_file.to_string_lossy().to_string()),
+                model: None,
+                foreground: true,
+                yolo: false,
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some(empty_task_file.to_string_lossy().to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+            let result =
+                run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert_contains_display(err_msg.contains("is empty"), "unexpected error", &err_msg);
 
-        let result = run_foreground_with_registry(args, empty_registry, test_foreground_io()).await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert_contains_display(err_msg.contains("is empty"), "unexpected error", &err_msg);
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        })
+        .await;
     }
 
     /// Covers `Config::load()?`'s error branch — a manifest and task both
@@ -2008,50 +2039,55 @@ prompt = "Do the thing"
     /// ever reaching provider-registry construction.
     #[tokio::test]
     async fn run_foreground_with_registry_fails_on_invalid_config() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-invalid-config");
-        std::fs::write(
-            crate::config::Config::config_path(),
-            "this is not valid toml }{",
+        crate::config::with_isolated_config_path_async(
+            "fg-invalid-config",
+            |_fake_dir| async move {
+                std::fs::write(
+                    crate::config::Config::config_path(),
+                    "this is not valid toml }{",
+                )
+                .unwrap();
+
+                let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-config");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                std::fs::write(
+                    temp_dir.join("agent.leviath"),
+                    "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
+                )
+                .unwrap();
+
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: true,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
+
+                // Wrapped in `with_tracing` because this path reaches the
+                // `tracing::info!` at the top of `run_foreground_with_registry`
+                // (after manifest parsing, before `Config::load()` fails).
+                let result = with_tracing(|| {
+                    run_foreground_with_registry(args, empty_registry, test_foreground_io())
+                })
+                .await;
+                assert!(result.is_err());
+                let err_msg = result.unwrap_err().to_string();
+                assert_contains_display(
+                    err_msg.contains("Failed to parse config"),
+                    "unexpected error",
+                    &err_msg,
+                );
+
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
         )
-        .unwrap();
-
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-invalid-config");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        std::fs::write(
-            temp_dir.join("agent.leviath"),
-            "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"x\"\n",
-        )
-        .unwrap();
-
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
-
-        // Wrapped in `with_tracing` because this path reaches the
-        // `tracing::info!` at the top of `run_foreground_with_registry`
-        // (after manifest parsing, before `Config::load()` fails).
-        let result = with_tracing(|| {
-            run_foreground_with_registry(args, empty_registry, test_foreground_io())
-        })
         .await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert_contains_display(
-            err_msg.contains("Failed to parse config"),
-            "unexpected error",
-            &err_msg,
-        );
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     /// Covers the `if args.yolo { ... }` false arm (the "skip" branch) in a
@@ -2063,11 +2099,10 @@ prompt = "Do the thing"
     /// `run_foreground_with_valid_manifest_aborts_at_missing_provider`.
     #[tokio::test]
     async fn run_foreground_with_registry_yolo_false_reaches_provider_missing() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-yolo-false");
-
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-yolo-false");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+        crate::config::with_isolated_config_path_async("fg-yolo-false", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-fg-yolo-false");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            let manifest_content = r#"
 [agent]
 name = "test-fg-yolo-false-agent"
 version = "1.0.0"
@@ -2081,28 +2116,30 @@ max_iterations = 1
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+            write_test_agent(&temp_dir, manifest_content);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: false, // ← exercises the `if args.yolo` false/skip branch
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+            let args = RunArgs {
+                path: Some(temp_dir.to_string_lossy().to_string()),
+                task: Some("test task".to_string()),
+                model: None,
+                foreground: true,
+                yolo: false, // ← exercises the `if args.yolo` false/skip branch
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-        // No provider configured (config isolated above) → aborts cleanly at
-        // `on_provider_missing`, same as the yolo:true counterpart above.
-        with_tracing(|| run_foreground(args, test_foreground_io()))
-            .await
-            .unwrap();
+            // No provider configured (config isolated above) → aborts cleanly at
+            // `on_provider_missing`, same as the yolo:true counterpart above.
+            with_tracing(|| run_foreground(args, test_foreground_io()))
+                .await
+                .unwrap();
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        })
+        .await;
     }
 
     /// Covers `run_stage_loop(...)?.await` error branch (line 507) — a
@@ -2113,14 +2150,13 @@ model = "claude-sonnet-4-6"
     /// `run_foreground_with_registry` returns Err.
     #[tokio::test]
     async fn run_foreground_with_registry_propagates_stage_error() {
-        let _config_guard = crate::config::isolate_config_path_for_test("fg-stage-error");
-
-        let temp_dir = std::env::temp_dir().join("lev-test-fg-stage-error");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        // mode = "interactive" with tools: the has_tools=true path inside
-        // run_interactive_stage propagates inference errors rather than
-        // swallowing them.
-        let manifest_content = r#"
+        crate::config::with_isolated_config_path_async("fg-stage-error", |_fake_dir| async move {
+            let temp_dir = std::env::temp_dir().join("lev-test-fg-stage-error");
+            let _ = std::fs::create_dir_all(&temp_dir);
+            // mode = "interactive" with tools: the has_tools=true path inside
+            // run_interactive_stage propagates inference errors rather than
+            // swallowing them.
+            let manifest_content = r#"
 [agent]
 name = "test-fg-error-agent"
 version = "1.0.0"
@@ -2137,86 +2173,88 @@ model = "error-model"
 [stages.main.tools]
 allowed = ["read_file"]
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+            write_test_agent(&temp_dir, manifest_content);
 
-        struct ErrorProvider;
+            struct ErrorProvider;
 
-        #[async_trait]
-        impl leviath_providers::Provider for ErrorProvider {
-            async fn infer(
-                &self,
-                _request: leviath_providers::InferenceRequest,
-            ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
-            {
-                Err(leviath_providers::ProviderError::ApiError(
-                    "intentional test error".to_string(),
-                ))
+            #[async_trait]
+            impl leviath_providers::Provider for ErrorProvider {
+                async fn infer(
+                    &self,
+                    _request: leviath_providers::InferenceRequest,
+                ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
+                {
+                    Err(leviath_providers::ProviderError::ApiError(
+                        "intentional test error".to_string(),
+                    ))
+                }
+
+                fn count_tokens(&self, _text: &str, _model: &str) -> usize {
+                    0
+                }
+
+                fn max_context_tokens(&self, _model: &str) -> usize {
+                    100_000
+                }
+
+                fn name(&self) -> &str {
+                    "error-mock"
+                }
+
+                fn capabilities(&self, _model: &str) -> leviath_providers::ModelCapabilities {
+                    leviath_providers::ModelCapabilities::default()
+                }
+
+                async fn list_models(
+                    &self,
+                ) -> Result<Vec<leviath_providers::ModelInfo>, leviath_providers::ProviderError>
+                {
+                    Ok(vec![])
+                }
             }
 
-            fn count_tokens(&self, _text: &str, _model: &str) -> usize {
-                0
-            }
+            let args = RunArgs {
+                path: Some(temp_dir.to_string_lossy().to_string()),
+                task: Some("test task".to_string()),
+                model: None,
+                foreground: true,
+                yolo: true,
+                allow: vec![],
+                ask: vec![],
+                deny: vec![],
+                max_depth: None,
+                count: 1,
+            };
 
-            fn max_context_tokens(&self, _model: &str) -> usize {
-                100_000
-            }
+            // Exercise the trivial trait methods so their bodies are covered.
+            let probe = ErrorProvider;
+            assert_eq!(probe.count_tokens("hello", "model"), 0);
+            assert_eq!(probe.max_context_tokens("model"), 100_000);
+            assert_eq!(probe.name(), "error-mock");
+            let _ = probe.capabilities("model");
+            let _ = probe.list_models().await;
 
-            fn name(&self) -> &str {
-                "error-mock"
-            }
+            // Wrapped in `with_tracing` because this path reaches the
+            // `tracing::info!` at the top of `run_foreground_with_registry`.
+            let result = with_tracing(|| {
+                run_foreground_with_registry(
+                    args,
+                    |_config| {
+                        let mut registry = leviath_runtime::ProviderRegistry::new();
+                        registry.register("error-mock".to_string(), Arc::new(ErrorProvider));
+                        registry
+                    },
+                    test_foreground_io(),
+                )
+            })
+            .await;
 
-            fn capabilities(&self, _model: &str) -> leviath_providers::ModelCapabilities {
-                leviath_providers::ModelCapabilities::default()
-            }
+            // The stage loop propagates the provider error in linear mode
+            assert!(result.is_err());
 
-            async fn list_models(
-                &self,
-            ) -> Result<Vec<leviath_providers::ModelInfo>, leviath_providers::ProviderError>
-            {
-                Ok(vec![])
-            }
-        }
-
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: true,
-            yolo: true,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
-
-        // Exercise the trivial trait methods so their bodies are covered.
-        let probe = ErrorProvider;
-        assert_eq!(probe.count_tokens("hello", "model"), 0);
-        assert_eq!(probe.max_context_tokens("model"), 100_000);
-        assert_eq!(probe.name(), "error-mock");
-        let _ = probe.capabilities("model");
-        let _ = probe.list_models().await;
-
-        // Wrapped in `with_tracing` because this path reaches the
-        // `tracing::info!` at the top of `run_foreground_with_registry`.
-        let result = with_tracing(|| {
-            run_foreground_with_registry(
-                args,
-                |_config| {
-                    let mut registry = leviath_runtime::ProviderRegistry::new();
-                    registry.register("error-mock".to_string(), Arc::new(ErrorProvider));
-                    registry
-                },
-                test_foreground_io(),
-            )
+            let _ = std::fs::remove_dir_all(&temp_dir);
         })
         .await;
-
-        // The stage loop propagates the provider error in linear mode
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/helpers.rs
+++ b/crates/leviath-cli/src/commands/run/helpers.rs
@@ -1036,21 +1036,23 @@ mod tests {
 
     #[test]
     fn record_stage_output_and_log_write_through_to_runstate() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "record_stage_output_and_log_write_through_to_runstate",
+            |_d| {
+                let run_id = "test-helpers-record-stage";
+                let dir = runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+
+                record_stage_output(run_id, 0, "some output line");
+                record_stage_log(run_id, 0, "some log line");
+
+                let output = runstate::tail_stage_output(run_id, 0, 65536);
+                let log = runstate::tail_stage_log(run_id, 0, 65536);
+                assert!(output.contains("some output line"));
+                assert!(log.contains("some log line"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-helpers-record-stage";
-        let dir = runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-
-        record_stage_output(run_id, 0, "some output line");
-        record_stage_log(run_id, 0, "some log line");
-
-        let output = runstate::tail_stage_output(run_id, 0, 65536);
-        let log = runstate::tail_stage_log(run_id, 0, 65536);
-        assert!(output.contains("some output line"));
-        assert!(log.contains("some log line"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/leviath-cli/src/commands/run/helpers.rs
+++ b/crates/leviath-cli/src/commands/run/helpers.rs
@@ -113,11 +113,7 @@ pub async fn generate_title(
                 .trim_end_matches('\'')
                 .trim()
                 .to_string();
-            if title.is_empty() {
-                None
-            } else {
-                Some(title)
-            }
+            if title.is_empty() { None } else { Some(title) }
         }
         Err(e) => {
             println!("Warning: title generation failed ({})", e);
@@ -140,7 +136,7 @@ pub fn write_context_snapshot_if_bg(
     stage_name: &str,
     run_id: &Option<String>,
 ) {
-    let Some(ref rid) = run_id else { return };
+    let Some(rid) = run_id else { return };
     let Some(snap) = build_context_snapshot(engine, entity, stage_name) else {
         return;
     };

--- a/crates/leviath-cli/src/commands/run/inference.rs
+++ b/crates/leviath-cli/src/commands/run/inference.rs
@@ -106,10 +106,11 @@ pub async fn stream_inference(
             if let Some(ref name) = tc_delta.name {
                 tc.name.clone_from(name);
             }
-            if !tc_delta.arguments_delta.is_empty() && tc.arguments.is_null() {
-                if let Ok(val) = serde_json::from_str(&tc_delta.arguments_delta) {
-                    tc.arguments = val;
-                }
+            if !tc_delta.arguments_delta.is_empty()
+                && tc.arguments.is_null()
+                && let Ok(val) = serde_json::from_str(&tc_delta.arguments_delta)
+            {
+                tc.arguments = val;
             }
         }
     }
@@ -712,10 +713,12 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Stream chunk error"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Stream chunk error")
+        );
     }
 
     #[tokio::test]
@@ -996,18 +999,20 @@ mod tests {
         assert_eq!(multi.name(), "multi-chunk");
         assert!(multi.list_models().await.unwrap().is_empty());
         // Cover the `infer()` fallback path (returns an error rather than panicking).
-        assert!(multi
-            .infer(InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-            })
-            .await
-            .is_err());
+        assert!(
+            multi
+                .infer(InferenceRequest {
+                    system: vec![],
+                    messages: vec![],
+                    model: "m".to_string(),
+                    max_tokens: 1,
+                    temperature: 0.0,
+                    tools: vec![],
+                    extra: serde_json::Value::Null,
+                })
+                .await
+                .is_err()
+        );
 
         let error_chunk = ErrorChunkStreamProvider;
         assert_eq!(error_chunk.count_tokens("abcd", "m"), 1);
@@ -1015,18 +1020,20 @@ mod tests {
         assert_eq!(error_chunk.name(), "error-chunk");
         assert!(error_chunk.list_models().await.unwrap().is_empty());
         // Cover the `infer()` fallback path (returns an error rather than panicking).
-        assert!(error_chunk
-            .infer(InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-            })
-            .await
-            .is_err());
+        assert!(
+            error_chunk
+                .infer(InferenceRequest {
+                    system: vec![],
+                    messages: vec![],
+                    model: "m".to_string(),
+                    max_tokens: 1,
+                    temperature: 0.0,
+                    tools: vec![],
+                    extra: serde_json::Value::Null,
+                })
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/io.rs
+++ b/crates/leviath-cli/src/commands/run/io.rs
@@ -6,8 +6,8 @@
 //! - `MockIO` (testing) — captures all output for assertions
 
 use async_trait::async_trait;
-use leviath_core::blueprint::StageResult;
 use leviath_core::Stage;
+use leviath_core::blueprint::StageResult;
 
 use crate::runstate::RegionSnapshot;
 

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -515,36 +515,41 @@ prompt = "Implement"
         // happy-path siblings) so a concurrent test can't swap LEVIATH_RUNS_DIR
         // between `create_run` and `open_log_file` and delete the dir underneath
         // us — a race llvm-cov's slower timing reliably exposed.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_background_bad_exe_returns_spawn_error",
-        );
-        let agent_name = "test-execute-bg-bad-exe";
-        let _cleanup = RunPrefixCleanup(agent_name);
-        let temp_dir = std::env::temp_dir().join(agent_name);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        write_valid_manifest(&temp_dir, agent_name);
+            |_d| async move {
+                let agent_name = "test-execute-bg-bad-exe";
+                let _cleanup = RunPrefixCleanup(agent_name);
+                let temp_dir = std::env::temp_dir().join(agent_name);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                write_valid_manifest(&temp_dir, agent_name);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: false,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 1,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: false,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 1,
+                };
 
-        let bad_exe = std::path::Path::new("/nonexistent/executable/path/leviath-cli");
-        let result = super::execute_background(args, bad_exe, foreground::test_not_a_tty).await;
-        // Expected spawn error.
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        let has_spawn_err =
-            err.contains("Failed to spawn") | err.contains("spawn") | err.contains("No such file");
-        assert!(has_spawn_err);
+                let bad_exe = std::path::Path::new("/nonexistent/executable/path/leviath-cli");
+                let result =
+                    super::execute_background(args, bad_exe, foreground::test_not_a_tty).await;
+                // Expected spawn error.
+                assert!(result.is_err());
+                let err = result.unwrap_err().to_string();
+                let has_spawn_err = err.contains("Failed to spawn")
+                    | err.contains("spawn")
+                    | err.contains("No such file");
+                assert!(has_spawn_err);
+            },
+        )
+        .await;
     }
 
     // ─── WorkerArgs: more coverage ─────────────────────────────────────────
@@ -654,76 +659,82 @@ prompt = "Do the thing"
     #[cfg(unix)]
     #[tokio::test]
     async fn execute_background_happy_path_spawns_single_worker() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_background_happy_path_spawns_single_worker",
-        );
-        let agent_name = "test-execute-bg-happy-single";
-        let _cleanup = RunPrefixCleanup(agent_name);
-        let temp_dir = std::env::temp_dir().join(agent_name);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        write_valid_manifest(&temp_dir, agent_name);
+            |_d| async move {
+                let agent_name = "test-execute-bg-happy-single";
+                let _cleanup = RunPrefixCleanup(agent_name);
+                let temp_dir = std::env::temp_dir().join(agent_name);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                write_valid_manifest(&temp_dir, agent_name);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: Some("claude-sonnet-4-6".to_string()),
-            foreground: false,
-            yolo: true,
-            allow: vec!["read_file".to_string()],
-            ask: vec!["bash".to_string()],
-            deny: vec!["write_file".to_string()],
-            max_depth: Some(2),
-            count: 1,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: Some("claude-sonnet-4-6".to_string()),
+                    foreground: false,
+                    yolo: true,
+                    allow: vec!["read_file".to_string()],
+                    ask: vec!["bash".to_string()],
+                    deny: vec!["write_file".to_string()],
+                    max_depth: Some(2),
+                    count: 1,
+                };
 
-        let harmless_exe = std::path::Path::new("/usr/bin/true");
-        super::execute_background(args, harmless_exe, foreground::test_not_a_tty)
-            .await
-            .expect("expected background execute to succeed");
+                let harmless_exe = std::path::Path::new("/usr/bin/true");
+                super::execute_background(args, harmless_exe, foreground::test_not_a_tty)
+                    .await
+                    .expect("expected background execute to succeed");
 
-        let runs = runstate::list_runs();
-        let run_was_created = runs.iter().any(|m| m.agent_name == agent_name);
-        // Expected a run to have been created.
-        assert!(run_was_created);
+                let runs = runstate::list_runs();
+                let run_was_created = runs.iter().any(|m| m.agent_name == agent_name);
+                // Expected a run to have been created.
+                assert!(run_was_created);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn execute_background_happy_path_spawns_multiple_workers() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_background_happy_path_spawns_multiple_workers",
-        );
-        let agent_name = "test-execute-bg-happy-multi";
-        let _cleanup = RunPrefixCleanup(agent_name);
-        let temp_dir = std::env::temp_dir().join(agent_name);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        write_valid_manifest(&temp_dir, agent_name);
+            |_d| async move {
+                let agent_name = "test-execute-bg-happy-multi";
+                let _cleanup = RunPrefixCleanup(agent_name);
+                let temp_dir = std::env::temp_dir().join(agent_name);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                write_valid_manifest(&temp_dir, agent_name);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: false,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 3,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: false,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 3,
+                };
 
-        let harmless_exe = std::path::Path::new("/usr/bin/true");
-        super::execute_background(args, harmless_exe, foreground::test_not_a_tty)
-            .await
-            .expect("expected multi-count background execute to succeed");
+                let harmless_exe = std::path::Path::new("/usr/bin/true");
+                super::execute_background(args, harmless_exe, foreground::test_not_a_tty)
+                    .await
+                    .expect("expected multi-count background execute to succeed");
 
-        let runs = runstate::list_runs();
-        let matching = runs.iter().filter(|m| m.agent_name == agent_name).count();
-        assert_eq!(matching, 3);
+                let runs = runstate::list_runs();
+                let matching = runs.iter().filter(|m| m.agent_name == agent_name).count();
+                assert_eq!(matching, 3);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     // Windows twins of the two tests above: there's no `/usr/bin/true` on
@@ -744,102 +755,112 @@ prompt = "Do the thing"
     #[cfg(windows)]
     #[tokio::test]
     async fn execute_background_happy_path_spawns_single_worker() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_background_happy_path_spawns_single_worker",
-        );
-        let agent_name = "test-execute-bg-happy-single-win";
-        let _cleanup = RunPrefixCleanup(agent_name);
-        let temp_dir = std::env::temp_dir().join(agent_name);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        write_valid_manifest(&temp_dir, agent_name);
+            |_d| async move {
+                let agent_name = "test-execute-bg-happy-single-win";
+                let _cleanup = RunPrefixCleanup(agent_name);
+                let temp_dir = std::env::temp_dir().join(agent_name);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                write_valid_manifest(&temp_dir, agent_name);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: Some("claude-sonnet-4-6".to_string()),
-            foreground: false,
-            yolo: true,
-            allow: vec!["read_file".to_string()],
-            ask: vec!["bash".to_string()],
-            deny: vec!["write_file".to_string()],
-            max_depth: Some(2),
-            count: 1,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: Some("claude-sonnet-4-6".to_string()),
+                    foreground: false,
+                    yolo: true,
+                    allow: vec!["read_file".to_string()],
+                    ask: vec!["bash".to_string()],
+                    deny: vec!["write_file".to_string()],
+                    max_depth: Some(2),
+                    count: 1,
+                };
 
-        let harmless_exe = temp_dir.join("harmless.bat");
-        write_harmless_bat(&harmless_exe);
-        super::execute_background(args, &harmless_exe, foreground::test_not_a_tty)
-            .await
-            .expect("expected background execute to succeed");
+                let harmless_exe = temp_dir.join("harmless.bat");
+                write_harmless_bat(&harmless_exe);
+                super::execute_background(args, &harmless_exe, foreground::test_not_a_tty)
+                    .await
+                    .expect("expected background execute to succeed");
 
-        let runs = runstate::list_runs();
-        let run_was_created = runs.iter().any(|m| m.agent_name == agent_name);
-        assert!(run_was_created);
+                let runs = runstate::list_runs();
+                let run_was_created = runs.iter().any(|m| m.agent_name == agent_name);
+                assert!(run_was_created);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     #[cfg(windows)]
     #[tokio::test]
     async fn execute_background_happy_path_spawns_multiple_workers() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_background_happy_path_spawns_multiple_workers",
-        );
-        let agent_name = "test-execute-bg-happy-multi-win";
-        let _cleanup = RunPrefixCleanup(agent_name);
-        let temp_dir = std::env::temp_dir().join(agent_name);
-        let _ = std::fs::create_dir_all(&temp_dir);
-        write_valid_manifest(&temp_dir, agent_name);
+            |_d| async move {
+                let agent_name = "test-execute-bg-happy-multi-win";
+                let _cleanup = RunPrefixCleanup(agent_name);
+                let temp_dir = std::env::temp_dir().join(agent_name);
+                let _ = std::fs::create_dir_all(&temp_dir);
+                write_valid_manifest(&temp_dir, agent_name);
 
-        let args = RunArgs {
-            path: Some(temp_dir.to_string_lossy().to_string()),
-            task: Some("test task".to_string()),
-            model: None,
-            foreground: false,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-            count: 3,
-        };
+                let args = RunArgs {
+                    path: Some(temp_dir.to_string_lossy().to_string()),
+                    task: Some("test task".to_string()),
+                    model: None,
+                    foreground: false,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                    count: 3,
+                };
 
-        let harmless_exe = temp_dir.join("harmless.bat");
-        write_harmless_bat(&harmless_exe);
-        super::execute_background(args, &harmless_exe, foreground::test_not_a_tty)
-            .await
-            .expect("expected multi-count background execute to succeed");
+                let harmless_exe = temp_dir.join("harmless.bat");
+                write_harmless_bat(&harmless_exe);
+                super::execute_background(args, &harmless_exe, foreground::test_not_a_tty)
+                    .await
+                    .expect("expected multi-count background execute to succeed");
 
-        let runs = runstate::list_runs();
-        let matching = runs.iter().filter(|m| m.agent_name == agent_name).count();
-        assert_eq!(matching, 3);
+                let runs = runstate::list_runs();
+                let matching = runs.iter().filter(|m| m.agent_name == agent_name).count();
+                assert_eq!(matching, 3);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_worker_thin_wrapper_delegates_to_worker_module() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_worker_thin_wrapper_delegates_to_worker_module",
-        );
-        // `execute_worker` (the public re-export) is a one-line delegation to
-        // `worker::execute_worker` -- exercised end-to-end (not mocked) by
-        // `worker.rs`'s own test suite. This just proves the delegation
-        // itself runs without panicking, using a path that fails fast.
-        let args = WorkerArgs {
-            path: "/nonexistent/path/for/mod-rs-delegation-test".to_string(),
-            task: "task".to_string(),
-            run_id: "test-execute-worker-delegation".to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
-        let result = execute_worker(args).await;
-        assert!(result.is_err());
-        let _ = std::fs::remove_dir_all(runstate::run_dir("test-execute-worker-delegation"));
+            |_d| async move {
+                // `execute_worker` (the public re-export) is a one-line delegation to
+                // `worker::execute_worker` -- exercised end-to-end (not mocked) by
+                // `worker.rs`'s own test suite. This just proves the delegation
+                // itself runs without panicking, using a path that fails fast.
+                let args = WorkerArgs {
+                    path: "/nonexistent/path/for/mod-rs-delegation-test".to_string(),
+                    task: "task".to_string(),
+                    run_id: "test-execute-worker-delegation".to_string(),
+                    model: None,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                };
+                let result = execute_worker(args).await;
+                assert!(result.is_err());
+                let _ =
+                    std::fs::remove_dir_all(runstate::run_dir("test-execute-worker-delegation"));
+            },
+        )
+        .await;
     }
 
     // ─── RunArgs: more coverage ────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -34,15 +34,15 @@ use crate::runstate;
 
 // Re-export public API used by other commands
 pub use session::{
-    build_provider_registry, build_provider_registry_from_config, provider_creds_from_config,
-    ProviderCreds,
+    ProviderCreds, build_provider_registry, build_provider_registry_from_config,
+    provider_creds_from_config,
 };
 
 // Foreground run entry points + the real-stdin dependency bundle the binary
 // injects. `foreground` is a private module, so these re-exports are how
 // `main.rs` names `ForegroundIo` and calls the foreground run with real stdin.
 pub use foreground::{
-    run_foreground, run_foreground_with_registry, BoxedAsyncBufRead, ForegroundIo,
+    BoxedAsyncBufRead, ForegroundIo, run_foreground, run_foreground_with_registry,
 };
 
 #[derive(Args)]

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -367,14 +367,6 @@ pub fn build_provider_registry_from_config(config: &Config) -> ProviderRegistry 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Serializes tests that mutate the process-wide `VISUAL`/`EDITOR` env
-    /// vars, since `cargo test` runs tests in parallel threads within the
-    /// same process. Shared across both the Unix and Windows `launch_editor`
-    /// test suites below (each platform mutates the same two env vars, just
-    /// with platform-appropriate script paths).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Shared "stdin is never a TTY" probe for the `resolve_task` tests whose
     /// argument is `Some(..)` (so the probe is never consulted) or that
@@ -383,18 +375,6 @@ mod tests {
     /// one instantiation and one covered region.
     fn never_a_tty() -> bool {
         false
-    }
-
-    /// RAII guard that clears `VISUAL`/`EDITOR` on drop, restoring a clean
-    /// environment for subsequent tests regardless of panics.
-    struct EnvGuard;
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var("VISUAL");
-                std::env::remove_var("EDITOR");
-            }
-        }
     }
 
     /// Shared `assert!`-with-dynamic-message helper: several `launch_editor`
@@ -874,21 +854,20 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_visual_env_success() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            std::env::set_var("VISUAL", "/usr/bin/true");
-            std::env::remove_var("EDITOR");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-visual");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", Some("/usr/bin/true")), ("EDITOR", None)],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-visual");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: EDITOR used when VISUAL unset ────────────────────
@@ -896,21 +875,20 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_editor_env_success() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            std::env::remove_var("VISUAL");
-            std::env::set_var("EDITOR", "/usr/bin/true");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-editor");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", None), ("EDITOR", Some("/usr/bin/true"))],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-editor");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: exit code (even non-zero) is treated as success ──
@@ -918,22 +896,22 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_nonzero_exit_still_ok() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            std::env::set_var("VISUAL", "/usr/bin/false");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-nonzero");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", Some("/usr/bin/false")), ("EDITOR", None)],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-nonzero");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        // A non-zero-but-present exit code is treated as the user having
-        // closed the editor -- not an error.
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                // A non-zero-but-present exit code is treated as the user having
+                // closed the editor -- not an error.
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: terminated by signal (no exit code) tries next ───
@@ -969,27 +947,26 @@ mod tests {
         // arm (try the next candidate) on every platform, without needing a real
         // signal-killed subprocess (which can't be fabricated on Windows). With
         // every candidate aborting, the loop exhausts them and bails.
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            std::env::set_var("VISUAL", "editor-a");
-            std::env::set_var("EDITOR", "editor-b");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-aborted");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", Some("editor-a")), ("EDITOR", Some("editor-b"))],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-aborted");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let mut calls = 0;
-        let result = launch_editor_with(&file, &mut |_cmd| {
-            calls += 1;
-            Ok(EditorRunOutcome::Aborted)
-        });
-        // Every candidate "ran" but aborted, so it tried them all then bailed.
-        assert!(result.is_err());
-        assert!(calls >= 2, "expected multiple candidates to be tried");
+                let mut calls = 0;
+                let result = launch_editor_with(&file, &mut |_cmd| {
+                    calls += 1;
+                    Ok(EditorRunOutcome::Aborted)
+                });
+                // Every candidate "ran" but aborted, so it tried them all then bailed.
+                assert!(result.is_err());
+                assert!(calls >= 2, "expected multiple candidates to be tried");
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: command with flags is split correctly ────────────
@@ -997,24 +974,27 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_command_with_flags_splits_correctly() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            // `/usr/bin/true` ignores all arguments, so appending a flag
-            // and the file path is harmless; this exercises the
-            // whitespace-splitting logic for editor strings like
-            // "code --wait".
-            std::env::set_var("VISUAL", "/usr/bin/true --some-flag");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-flags");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // `/usr/bin/true` ignores all arguments, so appending a flag
+        // and the file path is harmless; this exercises the
+        // whitespace-splitting logic for editor strings like
+        // "code --wait".
+        temp_env::with_vars(
+            [
+                ("VISUAL", Some("/usr/bin/true --some-flag")),
+                ("EDITOR", None),
+            ],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-flags");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: whitespace-only VISUAL falls through, EDITOR used ─
@@ -1022,24 +1002,23 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_whitespace_only_visual_falls_through_to_editor() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            // Whitespace-only string is non-empty so it IS pushed as a
-            // candidate, but splitting on whitespace yields an empty parts
-            // vec, which triggers the `continue` branch.
-            std::env::set_var("VISUAL", "   ");
-            std::env::set_var("EDITOR", "/usr/bin/true");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-ws-visual");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // Whitespace-only string is non-empty so it IS pushed as a
+        // candidate, but splitting on whitespace yields an empty parts
+        // vec, which triggers the `continue` branch.
+        temp_env::with_vars(
+            [("VISUAL", Some("   ")), ("EDITOR", Some("/usr/bin/true"))],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-ws-visual");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor_with: truly-empty VISUAL/EDITOR, injected (cross-platform) ─
@@ -1063,32 +1042,27 @@ mod tests {
     /// process without depending on what it actually does.
     #[test]
     fn launch_editor_with_empty_visual_and_editor_are_skipped() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            std::env::set_var("VISUAL", "");
-            std::env::set_var("EDITOR", "");
-        }
+        temp_env::with_vars([("VISUAL", Some("")), ("EDITOR", Some(""))], || {
+            let dir = std::env::temp_dir().join("lev-test-launch-editor-with-empty-skip");
+            let _ = std::fs::create_dir_all(&dir);
+            let file = dir.join("edit.txt");
+            std::fs::write(&file, "content").unwrap();
 
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-with-empty-skip");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+            let result = launch_editor_with(&file, &mut |_cmd| {
+                // Ignores the actual candidate `launch_editor_with` resolved to
+                // (the platform default, since VISUAL/EDITOR are both empty) and
+                // spawns the current test binary instead -- any exit status it
+                // produces (even a nonzero "unrecognized option" error) classifies
+                // as `Completed`.
+                std::process::Command::new(std::env::current_exe().unwrap())
+                    .arg("--this-flag-does-not-exist")
+                    .status()
+                    .map(|s| classify_editor_exit(s.success(), s.code()))
+            });
+            assert_launch_ok(&result);
 
-        let result = launch_editor_with(&file, &mut |_cmd| {
-            // Ignores the actual candidate `launch_editor_with` resolved to
-            // (the platform default, since VISUAL/EDITOR are both empty) and
-            // spawns the current test binary instead -- any exit status it
-            // produces (even a nonzero "unrecognized option" error) classifies
-            // as `Completed`.
-            std::process::Command::new(std::env::current_exe().unwrap())
-                .arg("--this-flag-does-not-exist")
-                .status()
-                .map(|s| classify_editor_exit(s.success(), s.code()))
+            let _ = std::fs::remove_dir_all(&dir);
         });
-        assert_launch_ok(&result);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── launch_editor: truly-empty VISUAL/EDITOR are skipped entirely ────
@@ -1108,39 +1082,29 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_empty_visual_and_editor_are_skipped() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _path_lock = crate::config::PATH_ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
+        temp_env::with_vars(
+            [
+                ("VISUAL", Some("")),
+                ("EDITOR", Some("")),
+                ("PATH", Some("/lev-definitely-empty-path-dir")),
+            ],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-empty-visual-editor");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        struct PathGuard(std::ffi::OsString);
-        impl Drop for PathGuard {
-            fn drop(&mut self) {
-                unsafe {
-                    std::env::set_var("PATH", &self.0);
-                }
-            }
-        }
-        let _path_guard = PathGuard(std::env::var_os("PATH").unwrap_or_default());
+                // Neither empty var is pushed as a candidate, and PATH starvation
+                // means even the unix platform defaults (vim/nano/vi) fail to
+                // resolve -- so this deterministically reaches "no editor found"
+                // rather than ever spawning a real editor.
+                let result = launch_editor(&file);
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("No editor found"));
 
-        unsafe {
-            std::env::set_var("VISUAL", "");
-            std::env::set_var("EDITOR", "");
-            std::env::set_var("PATH", "/lev-definitely-empty-path-dir");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-empty-visual-editor");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
-
-        // Neither empty var is pushed as a candidate, and PATH starvation
-        // means even the unix platform defaults (vim/nano/vi) fail to
-        // resolve -- so this deterministically reaches "no editor found"
-        // rather than ever spawning a real editor.
-        let result = launch_editor(&file);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No editor found"));
-
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: NotFound candidate is skipped, next one used ─────
@@ -1148,23 +1112,25 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_not_found_candidate_falls_through_to_next() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        unsafe {
-            // VISUAL points at a nonexistent binary, which should be
-            // skipped (NotFound branch, `continue`) in favor of EDITOR.
-            std::env::set_var("VISUAL", "lev-definitely-not-a-real-binary-xyz");
-            std::env::set_var("EDITOR", "/usr/bin/true");
-        }
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-notfound");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // VISUAL points at a nonexistent binary, which should be
+        // skipped (NotFound branch, `continue`) in favor of EDITOR.
+        temp_env::with_vars(
+            [
+                ("VISUAL", Some("lev-definitely-not-a-real-binary-xyz")),
+                ("EDITOR", Some("/usr/bin/true")),
+            ],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-notfound");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: non-NotFound spawn error propagates ──────────────
@@ -1172,8 +1138,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_permission_denied_returns_error() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         use std::os::unix::fs::PermissionsExt;
 
         let dir = std::env::temp_dir().join("lev-test-launch-editor-perm-denied");
@@ -1188,20 +1152,22 @@ mod tests {
         perms.set_mode(0o600);
         std::fs::set_permissions(&not_executable, perms).unwrap();
 
-        unsafe {
-            std::env::set_var("VISUAL", &not_executable);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", Some(&not_executable)), ("EDITOR", None)],
+            || {
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to launch editor"));
+                let result = launch_editor(&file);
+                assert!(result.is_err());
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Failed to launch editor"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor_with: no candidate resolves (injected, cross-platform) ─
@@ -1248,44 +1214,28 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_no_editor_found_when_path_has_no_candidates() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        // `PATH` is process-global; this also serializes against any other
-        // test in the crate (e.g. `dashboard::helpers`'s clipboard-fallback
-        // test) that mutates it, since `ENV_LOCK` here only covers
-        // VISUAL/EDITOR, not PATH.
-        let _path_lock = crate::config::PATH_ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
+        // No VISUAL/EDITOR (both unset), and PATH points nowhere -- so even
+        // the unix platform-default candidates (vim/nano/vi) all fail to
+        // resolve.
+        temp_env::with_vars(
+            [
+                ("VISUAL", None),
+                ("EDITOR", None),
+                ("PATH", Some("/lev-definitely-empty-path-dir")),
+            ],
+            || {
+                let dir = std::env::temp_dir().join("lev-test-launch-editor-no-editor");
+                let _ = std::fs::create_dir_all(&dir);
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        /// Restores the real `PATH` on drop -- separate from `EnvGuard`
-        /// (which only handles `VISUAL`/`EDITOR`) since breaking `PATH` for
-        /// the rest of the test process would be far more disruptive than
-        /// leaving those two unset.
-        struct PathGuard(std::ffi::OsString);
-        impl Drop for PathGuard {
-            fn drop(&mut self) {
-                unsafe {
-                    std::env::set_var("PATH", &self.0);
-                }
-            }
-        }
-        let _path_guard = PathGuard(std::env::var_os("PATH").unwrap_or_default());
-        unsafe {
-            // No VISUAL/EDITOR (cleared by EnvGuard already), and PATH
-            // points nowhere -- so even the unix platform-default
-            // candidates (vim/nano/vi) all fail to resolve.
-            std::env::set_var("PATH", "/lev-definitely-empty-path-dir");
-        }
+                let result = launch_editor(&file);
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("No editor found"));
 
-        let dir = std::env::temp_dir().join("lev-test-launch-editor-no-editor");
-        let _ = std::fs::create_dir_all(&dir);
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
-
-        let result = launch_editor(&file);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No editor found"));
-
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── launch_editor: Windows twin suite ────────────────────────────────
@@ -1331,156 +1281,154 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn launch_editor_visual_env_success() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-visual-win");
         let _ = std::fs::create_dir_all(&dir);
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            std::env::set_var("VISUAL", &ok_bat);
-            std::env::remove_var("EDITOR");
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars([("VISUAL", Some(&ok_bat)), ("EDITOR", None)], || {
+            let file = dir.join("edit.txt");
+            std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+            let result = launch_editor(&file);
+            assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_editor_env_success() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-editor-win");
         let _ = std::fs::create_dir_all(&dir);
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            std::env::remove_var("VISUAL");
-            std::env::set_var("EDITOR", &ok_bat);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars([("VISUAL", None), ("EDITOR", Some(&ok_bat))], || {
+            let file = dir.join("edit.txt");
+            std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+            let result = launch_editor(&file);
+            assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_nonzero_exit_still_ok() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-nonzero-win");
         let _ = std::fs::create_dir_all(&dir);
         let fail_bat = dir.join("fail.bat");
         write_bat(&fail_bat, "exit /b 1");
 
-        unsafe {
-            std::env::set_var("VISUAL", &fail_bat);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars([("VISUAL", Some(&fail_bat)), ("EDITOR", None)], || {
+            let file = dir.join("edit.txt");
+            std::fs::write(&file, "content").unwrap();
 
-        // A non-zero-but-present exit code is treated as the user having
-        // closed the editor -- not an error.
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+            // A non-zero-but-present exit code is treated as the user having
+            // closed the editor -- not an error.
+            let result = launch_editor(&file);
+            assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_command_with_flags_splits_correctly() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-flags-win");
         let _ = std::fs::create_dir_all(&dir);
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            // The batch file ignores all arguments, so appending a flag and
-            // the file path is harmless; this exercises the
-            // whitespace-splitting logic for editor strings like
-            // "code --wait".
-            std::env::set_var("VISUAL", format!("{} --some-flag", ok_bat.display()));
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // The batch file ignores all arguments, so appending a flag and
+        // the file path is harmless; this exercises the
+        // whitespace-splitting logic for editor strings like
+        // "code --wait".
+        temp_env::with_vars(
+            [
+                ("VISUAL", Some(format!("{} --some-flag", ok_bat.display()))),
+                ("EDITOR", None),
+            ],
+            || {
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_whitespace_only_visual_falls_through_to_editor() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-ws-visual-win");
         let _ = std::fs::create_dir_all(&dir);
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            // Whitespace-only string is non-empty so it IS pushed as a
-            // candidate, but splitting on whitespace yields an empty parts
-            // vec, which triggers the `continue` branch.
-            std::env::set_var("VISUAL", "   ");
-            std::env::set_var("EDITOR", &ok_bat);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // Whitespace-only string is non-empty so it IS pushed as a
+        // candidate, but splitting on whitespace yields an empty parts
+        // vec, which triggers the `continue` branch.
+        temp_env::with_vars(
+            [
+                ("VISUAL", Some(std::ffi::OsString::from("   "))),
+                ("EDITOR", Some(ok_bat.clone().into_os_string())),
+            ],
+            || {
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_not_found_candidate_falls_through_to_next() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         let dir = std::env::temp_dir().join("lev-test-launch-editor-notfound-win");
         let _ = std::fs::create_dir_all(&dir);
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            // VISUAL points at a nonexistent binary, which should be
-            // skipped (NotFound branch, `continue`) in favor of EDITOR.
-            std::env::set_var("VISUAL", "lev-definitely-not-a-real-binary-xyz");
-            std::env::set_var("EDITOR", &ok_bat);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        // VISUAL points at a nonexistent binary, which should be
+        // skipped (NotFound branch, `continue`) in favor of EDITOR.
+        temp_env::with_vars(
+            [
+                (
+                    "VISUAL",
+                    Some(std::ffi::OsString::from(
+                        "lev-definitely-not-a-real-binary-xyz",
+                    )),
+                ),
+                ("EDITOR", Some(ok_bat.clone().into_os_string())),
+            ],
+            || {
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert_launch_ok(&result);
+                let result = launch_editor(&file);
+                assert_launch_ok(&result);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     #[cfg(windows)]
     #[test]
     fn launch_editor_permission_denied_returns_error() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-
         let dir = std::env::temp_dir().join("lev-test-launch-editor-perm-denied-win");
         let _ = std::fs::create_dir_all(&dir);
         // A plain, non-executable text file: Windows' `CreateProcess` can't
@@ -1491,20 +1439,22 @@ mod tests {
         let not_executable = dir.join("not-executable.txt");
         std::fs::write(&not_executable, "not a script").unwrap();
 
-        unsafe {
-            std::env::set_var("VISUAL", &not_executable);
-        }
-        let file = dir.join("edit.txt");
-        std::fs::write(&file, "content").unwrap();
+        temp_env::with_vars(
+            [("VISUAL", Some(&not_executable)), ("EDITOR", None)],
+            || {
+                let file = dir.join("edit.txt");
+                std::fs::write(&file, "content").unwrap();
 
-        let result = launch_editor(&file);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to launch editor"));
+                let result = launch_editor(&file);
+                assert!(result.is_err());
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Failed to launch editor"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        );
     }
 
     // ─── resolve_task_with: editor path (stdin is a TTY) ──────────────────
@@ -1512,8 +1462,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolve_task_with_editor_path_happy_case() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         use std::os::unix::fs::PermissionsExt;
 
         // A tiny "editor" script that appends a non-comment line to
@@ -1531,35 +1479,32 @@ mod tests {
         perms.set_mode(0o700);
         std::fs::set_permissions(&script, perms).unwrap();
 
-        unsafe {
-            std::env::set_var("VISUAL", &script);
-        }
+        temp_env::with_vars([("VISUAL", Some(&script)), ("EDITOR", None)], || {
+            let result = resolve_task_with(
+                &None,
+                "test-agent",
+                Some("a non-empty description"),
+                &|| true,
+            );
+            assert_eq!(result.unwrap(), "task body from editor");
 
-        let result = resolve_task_with(
-            &None,
-            "test-agent",
-            Some("a non-empty description"),
-            &|| true,
-        );
-        assert_eq!(result.unwrap(), "task body from editor");
-
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[cfg(unix)]
     #[test]
     fn resolve_task_with_editor_path_empty_after_stripping_comments_errors() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         // /usr/bin/true "opens" the file and does nothing to it, so only the
         // commented-out template remains -- stripped down to an empty task.
-        unsafe {
-            std::env::set_var("VISUAL", "/usr/bin/true");
-        }
-
-        let result = resolve_task_with(&None, "test-agent", None, &|| true);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Aborting run"));
+        temp_env::with_vars(
+            [("VISUAL", Some("/usr/bin/true")), ("EDITOR", None)],
+            || {
+                let result = resolve_task_with(&None, "test-agent", None, &|| true);
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("Aborting run"));
+            },
+        );
     }
 
     // Same Windows PATH-starvation caveat as
@@ -1569,26 +1514,21 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolve_task_with_editor_path_propagates_launch_editor_error() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        // See the comment in `launch_editor_no_editor_found_when_path_has_no_candidates`.
-        let _path_lock = crate::config::PATH_ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-        struct PathGuard(std::ffi::OsString);
-        impl Drop for PathGuard {
-            fn drop(&mut self) {
-                unsafe {
-                    std::env::set_var("PATH", &self.0);
-                }
-            }
-        }
-        let _path_guard = PathGuard(std::env::var_os("PATH").unwrap_or_default());
-        unsafe {
-            std::env::set_var("PATH", "/lev-definitely-empty-path-dir");
-        }
-
-        let result = resolve_task_with(&None, "test-agent", None, &|| true);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No editor found"));
+        // No VISUAL/EDITOR (both unset), and PATH points nowhere -- so even
+        // the unix platform-default candidates (vim/nano/vi) all fail to
+        // resolve, propagating the "no editor found" error.
+        temp_env::with_vars(
+            [
+                ("VISUAL", None),
+                ("EDITOR", None),
+                ("PATH", Some("/lev-definitely-empty-path-dir")),
+            ],
+            || {
+                let result = resolve_task_with(&None, "test-agent", None, &|| true);
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("No editor found"));
+            },
+        );
     }
 
     /// Shared stub editor-launcher used by both
@@ -1666,9 +1606,6 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn resolve_task_with_editor_path_happy_case() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
-
         // A tiny batch "editor" that appends a non-comment line to whatever
         // file it's invoked on (%~1) -- standing in for a real interactive
         // editor session. `%~1` strips any surrounding quotes Windows adds
@@ -1678,26 +1615,22 @@ mod tests {
         let script = dir.join("fake-editor.bat");
         write_bat(&script, "echo task body from editor>>\"%~1\"");
 
-        unsafe {
-            std::env::set_var("VISUAL", &script);
-        }
+        temp_env::with_vars([("VISUAL", Some(&script)), ("EDITOR", None)], || {
+            let result = resolve_task_with(
+                &None,
+                "test-agent",
+                Some("a non-empty description"),
+                &|| true,
+            );
+            assert_eq!(result.unwrap(), "task body from editor");
 
-        let result = resolve_task_with(
-            &None,
-            "test-agent",
-            Some("a non-empty description"),
-            &|| true,
-        );
-        assert_eq!(result.unwrap(), "task body from editor");
-
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[cfg(windows)]
     #[test]
     fn resolve_task_with_editor_path_empty_after_stripping_comments_errors() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard;
         // A no-op batch file "opens" the file and does nothing to it, so
         // only the commented-out template remains -- stripped down to an
         // empty task.
@@ -1706,15 +1639,13 @@ mod tests {
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
-        unsafe {
-            std::env::set_var("VISUAL", &ok_bat);
-        }
+        temp_env::with_vars([("VISUAL", Some(&ok_bat)), ("EDITOR", None)], || {
+            let result = resolve_task_with(&None, "test-agent", None, &|| true);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Aborting run"));
 
-        let result = resolve_task_with(&None, "test-agent", None, &|| true);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Aborting run"));
-
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     // ─── build_task_template: description branch ──────────────────────────

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -9,7 +9,7 @@ use leviath_runtime::ProviderRegistry;
 // existing call sites keep resolving. The `Config`-based translators
 // (`provider_creds_from_config` / `build_provider_registry_from_config`) stay
 // below because they need the CLI's `Config`.
-pub use leviath_runtime::provider_creds::{build_provider_registry, ProviderCreds};
+pub use leviath_runtime::provider_creds::{ProviderCreds, build_provider_registry};
 
 /// Resolve the task string from a CLI argument.
 ///
@@ -146,10 +146,10 @@ fn resolve_task_with_editor(
 
 fn build_task_template(agent_name: &str, description: Option<&str>) -> String {
     let mut template = format!("# Task for agent: {}\n", agent_name);
-    if let Some(desc) = description {
-        if !desc.is_empty() {
-            template.push_str(&format!("# {}\n", desc));
-        }
+    if let Some(desc) = description
+        && !desc.is_empty()
+    {
+        template.push_str(&format!("# {}\n", desc));
     }
     template.push_str("#\n# Describe your task below. Lines starting with '#' are ignored.\n\n");
     template
@@ -249,15 +249,15 @@ fn launch_editor_with(
 
     // Resolve editor candidates in priority order
     let mut candidates: Vec<String> = Vec::new();
-    if let Ok(v) = std::env::var("VISUAL") {
-        if !v.is_empty() {
-            candidates.push(v);
-        }
+    if let Ok(v) = std::env::var("VISUAL")
+        && !v.is_empty()
+    {
+        candidates.push(v);
     }
-    if let Ok(e) = std::env::var("EDITOR") {
-        if !e.is_empty() {
-            candidates.push(e);
-        }
+    if let Ok(e) = std::env::var("EDITOR")
+        && !e.is_empty()
+    {
+        candidates.push(e);
     }
 
     candidates.extend(platform_default_editors());
@@ -1160,10 +1160,12 @@ mod tests {
 
                 let result = launch_editor(&file);
                 assert!(result.is_err());
-                assert!(result
-                    .unwrap_err()
-                    .to_string()
-                    .contains("Failed to launch editor"));
+                assert!(
+                    result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("Failed to launch editor")
+                );
 
                 let _ = std::fs::remove_dir_all(&dir);
             },
@@ -1447,10 +1449,12 @@ mod tests {
 
                 let result = launch_editor(&file);
                 assert!(result.is_err());
-                assert!(result
-                    .unwrap_err()
-                    .to_string()
-                    .contains("Failed to launch editor"));
+                assert!(
+                    result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("Failed to launch editor")
+                );
 
                 let _ = std::fs::remove_dir_all(&dir);
             },
@@ -1595,10 +1599,12 @@ mod tests {
             &move || bad_tmp_dir.clone(),
         );
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to create task temp file"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to create task temp file")
+        );
     }
 
     // ─── resolve_task_with: editor path (stdin is a TTY) — Windows twins ──
@@ -1684,10 +1690,12 @@ mod tests {
             .join("task.txt");
         let result = write_task_template(&bad_path, "content");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to create task temp file"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to create task temp file")
+        );
     }
 
     // ─── resolve_task: unreadable file errors ────────────────────────────
@@ -1717,10 +1725,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to read task file"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to read task file")
+        );
     }
 
     // Windows has no chmod-style permission bits; instead, opening the file
@@ -1759,9 +1769,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to read task file"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to read task file")
+        );
     }
 }

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -1068,135 +1068,143 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_stage_with_run_context_and_tools_records_meta_and_output() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_stage_with_run_context_and_tools_records_meta_and_output",
-        );
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent reply with tools");
-        let mut io = MockIO::new();
+            |_d| async move {
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) =
+                    make_engine_and_entity(&bp, "Agent reply with tools");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-is-tools-ctx-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-is-tools-ctx-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![crate::interaction::InteractionResponse::text("", "")],
-        );
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![crate::interaction::InteractionResponse::text("", "")],
+                );
 
-        run_interactive_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            10,
-            &[leviath_providers::Tool {
-                name: "noop".to_string(),
-                description: "does nothing".to_string(),
-                parameters: serde_json::json!({"type": "object", "properties": {}}),
-            }],
-            Some((&run_id, &mut meta)),
-            "main",
-            &mut io,
-            &mut noop_exec,
+                run_interactive_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    10,
+                    &[leviath_providers::Tool {
+                        name: "noop".to_string(),
+                        description: "does nothing".to_string(),
+                        parameters: serde_json::json!({"type": "object", "properties": {}}),
+                    }],
+                    Some((&run_id, &mut meta)),
+                    "main",
+                    &mut io,
+                    &mut noop_exec,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+
+                // Tokens are now cumulative across all inference calls in the loop.
+                // The mock returns 10 prompt / 5 completion per call; the exact total
+                // depends on how many iterations the loop runs.
+                assert!(
+                    meta.prompt_tokens >= 10,
+                    "expected cumulative prompt tokens >= 10, got {}",
+                    meta.prompt_tokens
+                );
+                assert!(
+                    meta.completion_tokens >= 5,
+                    "expected cumulative completion tokens >= 5, got {}",
+                    meta.completion_tokens
+                );
+                let output = crate::runstate::tail_stage_output(&run_id, meta.stage_index, 65536);
+                assert_contains_display(
+                    output.contains("Agent reply with tools"),
+                    "expected stage output to be recorded, got",
+                    &output,
+                );
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-
-        // Tokens are now cumulative across all inference calls in the loop.
-        // The mock returns 10 prompt / 5 completion per call; the exact total
-        // depends on how many iterations the loop runs.
-        assert!(
-            meta.prompt_tokens >= 10,
-            "expected cumulative prompt tokens >= 10, got {}",
-            meta.prompt_tokens
-        );
-        assert!(
-            meta.completion_tokens >= 5,
-            "expected cumulative completion tokens >= 5, got {}",
-            meta.completion_tokens
-        );
-        let output = crate::runstate::tail_stage_output(&run_id, meta.stage_index, 65536);
-        assert_contains_display(
-            output.contains("Agent reply with tools"),
-            "expected stage output to be recorded, got",
-            &output,
-        );
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
     async fn interactive_stage_with_run_context_no_tools_records_meta() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_stage_with_run_context_no_tools_records_meta",
-        );
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Streamed agent reply");
-        let mut io = MockIO::new();
+            |_d| async move {
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) =
+                    make_engine_and_entity(&bp, "Streamed agent reply");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-is-notools-ctx-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-is-notools-ctx-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![crate::interaction::InteractionResponse::text("", "")],
-        );
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![crate::interaction::InteractionResponse::text("", "")],
+                );
 
-        run_interactive_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            10,
-            &[], // no tools → tool-less streaming path, background run_context
-            Some((&run_id, &mut meta)),
-            "main",
-            &mut io,
-            &mut noop_exec,
+                run_interactive_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    10,
+                    &[], // no tools → tool-less streaming path, background run_context
+                    Some((&run_id, &mut meta)),
+                    "main",
+                    &mut io,
+                    &mut noop_exec,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+
+                assert_eq!(meta.prompt_tokens, 10);
+                assert_eq!(meta.completion_tokens, 5);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-
-        assert_eq!(meta.prompt_tokens, 10);
-        assert_eq!(meta.completion_tokens, 5);
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[test]
@@ -1653,120 +1661,129 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_single_free_text_point_stdin() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_single_free_text_point_stdin",
-        );
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent answer");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent answer");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-ft-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-ft-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_free_text_point("feedback", "What do you think?")];
+                let points = vec![make_free_text_point("feedback", "What do you think?")];
 
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![InteractionResponse::text("", "my feedback")],
-        );
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::text("", "my feedback")],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
     async fn interactive_points_multiple_choice_stdin() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("interactive_points_multiple_choice_stdin");
-        use crate::interaction::InteractionResponse;
+        crate::runstate::with_isolated_runs_dir_async(
+            "interactive_points_multiple_choice_stdin",
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-mc-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-mc-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_multiple_choice_point(
-            "pick_one",
-            "Choose an option",
-            vec!["Option A".to_string(), "Option B".to_string()],
-        )];
+                let points = vec![make_multiple_choice_point(
+                    "pick_one",
+                    "Choose an option",
+                    vec!["Option A".to_string(), "Option B".to_string()],
+                )];
 
-        // choice_index 1 = "Option B" (0-based)
-        let responder =
-            spawn_interaction_responder(run_id.clone(), vec![InteractionResponse::choice("", 1)]);
+                // choice_index 1 = "Option B" (0-based)
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::choice("", 1)],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     // ─── Regression: a choice with a configured followup must ask for ─────
@@ -1775,102 +1792,105 @@ mod tests {
     // ever reaches the model.
     #[tokio::test]
     async fn interactive_points_directive_option_stays_in_stage_and_injects_directive() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_directive_option_stays_in_stage_and_injects_directive",
-        );
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-mc-followup-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-mc-followup-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let mut directives = std::collections::HashMap::new();
-        directives.insert(
-            "Revise".to_string(),
-            "Call ask_user_text to learn what to change, then re-plan.".to_string(),
-        );
-        let points = vec![make_multiple_choice_point_with_directives(
-            "plan_approval",
-            "Approve the plan?",
-            vec!["Approve".to_string(), "Revise".to_string()],
-            directives,
-        )];
+                let mut directives = std::collections::HashMap::new();
+                directives.insert(
+                    "Revise".to_string(),
+                    "Call ask_user_text to learn what to change, then re-plan.".to_string(),
+                );
+                let points = vec![make_multiple_choice_point_with_directives(
+                    "plan_approval",
+                    "Approve the plan?",
+                    vec!["Approve".to_string(), "Revise".to_string()],
+                    directives,
+                )];
 
-        // Round 1: pick "Revise" (choice_index 1) → must inject the directive
-        // and loop back IN-STAGE (no second free-text request is issued — the
-        // agent drives the next step itself). Round 2: pick "Approve"
-        // (choice_index 0, no directive) → the point loop ends.
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![
-                InteractionResponse::choice("", 1),
-                InteractionResponse::choice("", 0),
-            ],
-        );
+                // Round 1: pick "Revise" (choice_index 1) → must inject the directive
+                // and loop back IN-STAGE (no second free-text request is issued — the
+                // agent drives the next step itself). Round 2: pick "Approve"
+                // (choice_index 0, no directive) → the point loop ends.
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![
+                        InteractionResponse::choice("", 1),
+                        InteractionResponse::choice("", 0),
+                    ],
+                );
 
-        let outcome = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let outcome = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    8,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+
+                // Completed (not aborted) after the revision loop.
+                assert_eq!(outcome, PointsOutcome::Completed);
+
+                // The directive text must have been injected into the agent's context,
+                // proving the run stayed in-stage and told the agent what to do next.
+                let window = engine
+                    .world()
+                    .get::<leviath_runtime::ContextWindow>(entity)
+                    .unwrap();
+                let conversation = window.get_region("conversation").unwrap();
+                let all_content: String = conversation
+                    .content
+                    .iter()
+                    .map(|e| e.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert_contains_display(
+                    all_content.contains("directive: Call ask_user_text"),
+                    "expected the injected directive in context, got",
+                    &all_content,
+                );
+                assert!(all_content.contains("Revise"));
+                assert!(all_content.contains("Approve"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-
-        // Completed (not aborted) after the revision loop.
-        assert_eq!(outcome, PointsOutcome::Completed);
-
-        // The directive text must have been injected into the agent's context,
-        // proving the run stayed in-stage and told the agent what to do next.
-        let window = engine
-            .world()
-            .get::<leviath_runtime::ContextWindow>(entity)
-            .unwrap();
-        let conversation = window.get_region("conversation").unwrap();
-        let all_content: String = conversation
-            .content
-            .iter()
-            .map(|e| e.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert_contains_display(
-            all_content.contains("directive: Call ask_user_text"),
-            "expected the injected directive in context, got",
-            &all_content,
-        );
-        assert!(all_content.contains("Revise"));
-        assert!(all_content.contains("Approve"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
@@ -1878,82 +1898,87 @@ mod tests {
         // Selecting an abort option must short-circuit the stage with
         // PointsOutcome::Aborted — no directive, no fall-through — so the
         // executor can cancel the run deterministically.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_abort_option_returns_aborted",
-        );
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-abort-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-abort-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_multiple_choice_point_with_abort(
-            "plan_approval",
-            "Approve the plan?",
-            vec!["Approve".to_string(), "Abort".to_string()],
-            vec!["Abort".to_string()],
-        )];
+                let points = vec![make_multiple_choice_point_with_abort(
+                    "plan_approval",
+                    "Approve the plan?",
+                    vec!["Approve".to_string(), "Abort".to_string()],
+                    vec!["Abort".to_string()],
+                )];
 
-        // Pick "Abort" (choice_index 1).
-        let responder =
-            spawn_interaction_responder(run_id.clone(), vec![InteractionResponse::choice("", 1)]);
+                // Pick "Abort" (choice_index 1).
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::choice("", 1)],
+                );
 
-        let outcome = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let outcome = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    8,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+
+                assert_eq!(outcome, PointsOutcome::Aborted);
+
+                // The abort short-circuits before the option label is injected, so the
+                // conversation region must NOT carry an "Abort" acknowledgement line.
+                let window = engine
+                    .world()
+                    .get::<leviath_runtime::ContextWindow>(entity)
+                    .unwrap();
+                let conversation = window.get_region("conversation").unwrap();
+                let all_content: String = conversation
+                    .content
+                    .iter()
+                    .map(|e| e.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(!all_content.contains("User [plan_approval]: Abort"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-
-        assert_eq!(outcome, PointsOutcome::Aborted);
-
-        // The abort short-circuits before the option label is injected, so the
-        // conversation region must NOT carry an "Abort" acknowledgement line.
-        let window = engine
-            .world()
-            .get::<leviath_runtime::ContextWindow>(entity)
-            .unwrap();
-        let conversation = window.get_region("conversation").unwrap();
-        let all_content: String = conversation
-            .content
-            .iter()
-            .map(|e| e.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(!all_content.contains("User [plan_approval]: Abort"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
@@ -1967,77 +1992,80 @@ mod tests {
         // platform.
         use crate::interaction::InteractionResponse;
 
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_edit_ipc_request_write_error",
-        );
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+            |_d| async move {
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-edit-werr-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-edit-werr-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_multiple_choice_point_with_edit(
-            "plan_approval",
-            "Approve the plan?",
-            vec!["Approve".to_string(), "Add detail".to_string()],
-            vec!["Add detail".to_string()],
-        )];
+                let points = vec![make_multiple_choice_point_with_edit(
+                    "plan_approval",
+                    "Approve the plan?",
+                    vec!["Approve".to_string(), "Add detail".to_string()],
+                    vec!["Add detail".to_string()],
+                )];
 
-        let rid = run_id.clone();
-        let responder = tokio::spawn(async move {
-            // The stage posts its (choice) request before awaiting a response,
-            // so it is present once this task is scheduled.
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            let req = crate::interaction::read_request(&rid)
-                .expect("stage posts its interaction request before awaiting a response");
-            let mut resp = InteractionResponse::choice("", 1); // "Add detail" (edit)
-            resp.request_id = req.id.clone();
-            crate::interaction::write_response(&rid, &resp).unwrap();
-            // Block the next atomic write: the choice response above is still
-            // readable, but the edit request's write_request writes to
-            // `pending.json.tmp`, which we replace with a *directory* so that
-            // write fails on every platform.
-            let dir = runstate::run_dir(&rid);
-            std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
-        });
+                let rid = run_id.clone();
+                let responder = tokio::spawn(async move {
+                    // The stage posts its (choice) request before awaiting a response,
+                    // so it is present once this task is scheduled.
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    let req = crate::interaction::read_request(&rid)
+                        .expect("stage posts its interaction request before awaiting a response");
+                    let mut resp = InteractionResponse::choice("", 1); // "Add detail" (edit)
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&rid, &resp).unwrap();
+                    // Block the next atomic write: the choice response above is still
+                    // readable, but the edit request's write_request writes to
+                    // `pending.json.tmp`, which we replace with a *directory* so that
+                    // write fails on every platform.
+                    let dir = runstate::run_dir(&rid);
+                    std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
+                });
 
-        let result = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let result = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    8,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await;
+
+                let _ = responder.await;
+                let dir = runstate::run_dir(&run_id);
+                assert!(result.is_err());
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-
-        let _ = responder.await;
-        let dir = runstate::run_dir(&run_id);
-        assert!(result.is_err());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -2045,86 +2073,90 @@ mod tests {
         // Edit option over the background file-IPC path: the engine issues an
         // EditText request, the user's edited text is injected, then the point
         // is re-presented. (The foreground path is covered separately.)
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("interactive_points_edit_option_ipc_path");
-        use crate::interaction::InteractionResponse;
+        crate::runstate::with_isolated_runs_dir_async(
+            "interactive_points_edit_option_ipc_path",
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-edit-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-edit-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_multiple_choice_point_with_edit(
-            "plan_approval",
-            "Approve the plan?",
-            vec!["Approve".to_string(), "Add detail".to_string()],
-            vec!["Add detail".to_string()],
-        )];
+                let points = vec![make_multiple_choice_point_with_edit(
+                    "plan_approval",
+                    "Approve the plan?",
+                    vec!["Approve".to_string(), "Add detail".to_string()],
+                    vec!["Add detail".to_string()],
+                )];
 
-        // Round 1: "Add detail" (index 1) → engine issues EditText → user
-        // submits edited text → Round 2: "Approve" (index 0) → complete.
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![
-                InteractionResponse::choice("", 1),
-                InteractionResponse::text("", "EDITED VIA IPC"),
-                InteractionResponse::choice("", 0),
-            ],
-        );
+                // Round 1: "Add detail" (index 1) → engine issues EditText → user
+                // submits edited text → Round 2: "Approve" (index 0) → complete.
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![
+                        InteractionResponse::choice("", 1),
+                        InteractionResponse::text("", "EDITED VIA IPC"),
+                        InteractionResponse::choice("", 0),
+                    ],
+                );
 
-        let outcome = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let outcome = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    8,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                assert_eq!(outcome, PointsOutcome::Completed);
+
+                let window = engine
+                    .world()
+                    .get::<leviath_runtime::ContextWindow>(entity)
+                    .unwrap();
+                let conversation = window.get_region("conversation").unwrap();
+                let all_content: String = conversation
+                    .content
+                    .iter()
+                    .map(|e| e.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(all_content.contains("edited the output directly"));
+                assert!(all_content.contains("EDITED VIA IPC"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        assert_eq!(outcome, PointsOutcome::Completed);
-
-        let window = engine
-            .world()
-            .get::<leviath_runtime::ContextWindow>(entity)
-            .unwrap();
-        let conversation = window.get_region("conversation").unwrap();
-        let all_content: String = conversation
-            .content
-            .iter()
-            .map(|e| e.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(all_content.contains("edited the output directly"));
-        assert!(all_content.contains("EDITED VIA IPC"));
-
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
@@ -2592,245 +2624,268 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_confirm_stdin() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("interactive_points_confirm_stdin");
-        use crate::interaction::InteractionResponse;
+        crate::runstate::with_isolated_runs_dir_async(
+            "interactive_points_confirm_stdin",
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-cf-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-cf-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_confirm_point("confirm_step", "Are you sure?")];
+                let points = vec![make_confirm_point("confirm_step", "Are you sure?")];
 
-        let responder =
-            spawn_interaction_responder(run_id.clone(), vec![InteractionResponse::text("", "yes")]);
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::text("", "yes")],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
     async fn interactive_points_multiple_points_all_visited() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_multiple_points_all_visited",
-        );
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Mid-stage response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Mid-stage response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-mp-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-mp-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![
-            make_free_text_point("step1", "Tell me about step 1"),
-            make_multiple_choice_point("step2", "Pick one", vec!["A".to_string(), "B".to_string()]),
-            make_confirm_point("step3", "Confirm?"),
-        ];
+                let points = vec![
+                    make_free_text_point("step1", "Tell me about step 1"),
+                    make_multiple_choice_point(
+                        "step2",
+                        "Pick one",
+                        vec!["A".to_string(), "B".to_string()],
+                    ),
+                    make_confirm_point("step3", "Confirm?"),
+                ];
 
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![
-                InteractionResponse::text("", "first input"),
-                InteractionResponse::choice("", 0),
-                InteractionResponse::text("", "yes"),
-            ],
-        );
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![
+                        InteractionResponse::text("", "first input"),
+                        InteractionResponse::choice("", 0),
+                        InteractionResponse::text("", "yes"),
+                    ],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            9,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    9,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
     async fn interactive_points_with_zero_remaining_iterations() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_with_zero_remaining_iterations",
-        );
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        // max_iterations = 1, points = 2 → iterations_per_segment rounds down to 0
-        // The stage should still run (just skips inference) and ask interaction points
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
-        let mut io = MockIO::new();
+                // max_iterations = 1, points = 2 → iterations_per_segment rounds down to 0
+                // The stage should still run (just skips inference) and ask interaction points
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-zero-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-zero-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![
-            make_free_text_point("p1", "Point 1"),
-            make_free_text_point("p2", "Point 2"),
-        ];
+                let points = vec![
+                    make_free_text_point("p1", "Point 1"),
+                    make_free_text_point("p2", "Point 2"),
+                ];
 
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![
-                InteractionResponse::text("", "a"),
-                InteractionResponse::text("", "b"),
-            ],
-        );
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![
+                        InteractionResponse::text("", "a"),
+                        InteractionResponse::text("", "b"),
+                    ],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            1, // small max_iterations
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    1, // small max_iterations
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
     async fn interactive_points_empty_user_input_is_ok() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("interactive_points_empty_user_input_is_ok");
-        use crate::interaction::InteractionResponse;
+        crate::runstate::with_isolated_runs_dir_async(
+            "interactive_points_empty_user_input_is_ok",
+            |_d| async move {
+                use crate::interaction::InteractionResponse;
 
-        // Empty answer → nothing injected into context window (branch coverage)
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
-        let mut io = MockIO::new();
+                // Empty answer → nothing injected into context window (branch coverage)
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-empty-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-empty-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_free_text_point("ask", "Say something")];
+                let points = vec![make_free_text_point("ask", "Say something")];
 
-        // Respond with empty text
-        let responder =
-            spawn_interaction_responder(run_id.clone(), vec![InteractionResponse::text("", "")]);
+                // Respond with empty text
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::text("", "")],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            2,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    2,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     #[tokio::test]
@@ -3151,113 +3206,119 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_stage_tools_request_interaction_async_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_stage_tools_request_interaction_async_error",
-        );
-        // Covers the `?` on `request_interaction_async`: write_request's atomic
-        // write targets `pending.json.tmp`, which we replace with a *directory*
-        // so the write fails and the Err propagates -- on every platform.
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
-        let mut io = MockIO::new();
+            |_d| async move {
+                // Covers the `?` on `request_interaction_async`: write_request's atomic
+                // write targets `pending.json.tmp`, which we replace with a *directory*
+                // so the write fails and the Err propagates -- on every platform.
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-rdonly-tools-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        // Create the run directory, then block the atomic write's tmp target
-        // with a directory so write_request fails.
-        runstate::create_run(&meta).unwrap();
-        let dir = runstate::run_dir(&run_id);
-        std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
+                let run_id = format!(
+                    "test-rdonly-tools-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                // Create the run directory, then block the atomic write's tmp target
+                // with a directory so write_request fails.
+                runstate::create_run(&meta).unwrap();
+                let dir = runstate::run_dir(&run_id);
+                std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
 
-        let tools = vec![leviath_providers::Tool {
-            name: "t".to_string(),
-            description: "t".to_string(),
-            parameters: serde_json::json!({}),
-        }];
+                let tools = vec![leviath_providers::Tool {
+                    name: "t".to_string(),
+                    description: "t".to_string(),
+                    parameters: serde_json::json!({}),
+                }];
 
-        let result = run_interactive_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            5,
-            &tools,
-            Some((&run_id, &mut meta)),
-            "main",
-            &mut io,
-            &mut noop_exec,
+                let result = run_interactive_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    5,
+                    &tools,
+                    Some((&run_id, &mut meta)),
+                    "main",
+                    &mut io,
+                    &mut noop_exec,
+                )
+                .await;
+
+                let _ = std::fs::remove_dir_all(&dir);
+
+                assert!(result.is_err());
+            },
         )
         .await;
-
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn interactive_stage_no_tools_request_interaction_async_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_stage_no_tools_request_interaction_async_error",
-        );
-        // Same as above but no-tools path (streaming). Covers the same `?` via
-        // the else branch (no tools).
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
-        let mut io = MockIO::new();
+            |_d| async move {
+                // Same as above but no-tools path (streaming). Covers the same `?` via
+                // the else branch (no tools).
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-rdonly-notools-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
-        let dir = runstate::run_dir(&run_id);
-        std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
+                let run_id = format!(
+                    "test-rdonly-notools-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
+                let dir = runstate::run_dir(&run_id);
+                std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
 
-        let result = run_interactive_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            5,
-            &[], // no tools → streaming path
-            Some((&run_id, &mut meta)),
-            "main",
-            &mut io,
-            &mut noop_exec,
+                let result = run_interactive_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    5,
+                    &[], // no tools → streaming path
+                    Some((&run_id, &mut meta)),
+                    "main",
+                    &mut io,
+                    &mut noop_exec,
+                )
+                .await;
+
+                let _ = std::fs::remove_dir_all(&dir);
+
+                assert!(result.is_err());
+            },
         )
         .await;
-
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(result.is_err());
     }
 
     // ─── Coverage: interactive_points None run_context (lines 374:21, 388:17) ─
@@ -3348,65 +3409,68 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_out_of_range_choice_falls_back_to_text_background() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_out_of_range_choice_falls_back_to_text_background",
-        );
-        // Covers line 421:96: background (IPC) path, choice_index out of range →
-        // unwrap_or_else closure called.
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                // Covers line 421:96: background (IPC) path, choice_index out of range →
+                // unwrap_or_else closure called.
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-oob-bg-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-oob-bg-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_multiple_choice_point(
-            "pick",
-            "Choose",
-            vec!["X".to_string(), "Y".to_string()],
-        )];
+                let points = vec![make_multiple_choice_point(
+                    "pick",
+                    "Choose",
+                    vec!["X".to_string(), "Y".to_string()],
+                )];
 
-        let mut oob_resp = InteractionResponse::choice("", 99);
-        oob_resp.value = Some("fallback-text".to_string());
-        let responder = spawn_interaction_responder(run_id.clone(), vec![oob_resp]);
+                let mut oob_resp = InteractionResponse::choice("", 99);
+                oob_resp.value = Some("fallback-text".to_string());
+                let responder = spawn_interaction_responder(run_id.clone(), vec![oob_resp]);
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        .await;
     }
 
     // ─── Coverage: empty user_text with no ContextWindow (line 455:17) ───────
@@ -3637,76 +3701,79 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_interaction_responder_exhausts_and_exits_loop() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "spawn_interaction_responder_exhausts_and_exits_loop",
-        );
-        // Covers lines 1382:25, 1384:17, 1386:9: the `else { break; }` branch in
-        // spawn_interaction_responder when resp_iter is exhausted.
-        //
-        // We provide 1 response for 2 interaction points. The responder handles
-        // point-1, exhausts its iterator, then when point-2's request appears it
-        // takes the `else { break }` path. The stage will be waiting on point-2
-        // forever — we use a timeout to avoid blocking.
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                // Covers lines 1382:25, 1384:17, 1386:9: the `else { break; }` branch in
+                // spawn_interaction_responder when resp_iter is exhausted.
+                //
+                // We provide 1 response for 2 interaction points. The responder handles
+                // point-1, exhausts its iterator, then when point-2's request appears it
+                // takes the `else { break }` path. The stage will be waiting on point-2
+                // forever — we use a timeout to avoid blocking.
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-responder-exhaust-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-responder-exhaust-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![
-            make_free_text_point("p1", "First question"),
-            make_free_text_point("p2", "Second question"),
-        ];
+                let points = vec![
+                    make_free_text_point("p1", "First question"),
+                    make_free_text_point("p2", "Second question"),
+                ];
 
-        // 1 response for 2 points → iterator exhausted when p2 arrives
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![InteractionResponse::text("", "answer to p1")],
-        );
+                // 1 response for 2 points → iterator exhausted when p2 arrives
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::text("", "answer to p1")],
+                );
 
-        let mut exec_binding = noop_exec;
-        let stage_fut = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut exec_binding,
-            None,
-        );
-        // Stage will block on p2 forever; we cancel it after a timeout
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), stage_fut).await;
+                let mut exec_binding = noop_exec;
+                let stage_fut = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut exec_binding,
+                    None,
+                );
+                // Stage will block on p2 forever; we cancel it after a timeout
+                let _ = tokio::time::timeout(std::time::Duration::from_secs(5), stage_fut).await;
 
-        // The responder should have broken out of its loop when p2 arrived
-        let responder_result =
-            tokio::time::timeout(std::time::Duration::from_secs(5), responder).await;
-        assert!(responder_result.is_ok());
+                // The responder should have broken out of its loop when p2 arrived
+                let responder_result =
+                    tokio::time::timeout(std::time::Duration::from_secs(5), responder).await;
+                assert!(responder_result.is_ok());
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── Coverage: spawn_interaction_responder None arm ─────────────────────────
@@ -3742,229 +3809,238 @@ mod tests {
 
     #[tokio::test]
     async fn interactive_points_request_interaction_async_error_propagates() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_request_interaction_async_error_propagates",
-        );
-        // Covers the `?` on `request_interaction_async` in the background path.
-        //
-        // We respond to the first choice with "Revise" (which has a directive),
-        // then immediately block the atomic write's tmp target with a directory
-        // so:
-        //   1) response.json is readable (already written)
-        //   2) the directive is injected and the loop re-runs inference
-        //   3) round 2's choice request → write_request fails → Err via `?`
-        // Blocking the tmp path fails on every platform.
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                // Covers the `?` on `request_interaction_async` in the background path.
+                //
+                // We respond to the first choice with "Revise" (which has a directive),
+                // then immediately block the atomic write's tmp target with a directory
+                // so:
+                //   1) response.json is readable (already written)
+                //   2) the directive is injected and the loop re-runs inference
+                //   3) round 2's choice request → write_request fails → Err via `?`
+                // Blocking the tmp path fails on every platform.
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-followup-err-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-followup-err-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let mut directives = std::collections::HashMap::new();
-        directives.insert("Revise".to_string(), "Ask what to change.".to_string());
-        let points = vec![make_multiple_choice_point_with_directives(
-            "plan",
-            "Pick",
-            vec!["Approve".to_string(), "Revise".to_string()],
-            directives,
-        )];
+                let mut directives = std::collections::HashMap::new();
+                directives.insert("Revise".to_string(), "Ask what to change.".to_string());
+                let points = vec![make_multiple_choice_point_with_directives(
+                    "plan",
+                    "Pick",
+                    vec!["Approve".to_string(), "Revise".to_string()],
+                    directives,
+                )];
 
-        let run_id_for_responder = run_id.clone();
-        let responder: tokio::task::JoinHandle<()> = tokio::spawn(async move {
-            // Poll immediately — request not yet written (main task hasn't yielded
-            // to run_interactive_points_stage yet), so this returns None on the
-            // first iteration. This exercises the while-loop-body (true) path.
-            while crate::interaction::read_request(&run_id_for_responder).is_none() {
-                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-            }
-            // Now read_request returned Some — retrieve and handle the request.
-            let req = crate::interaction::read_request(&run_id_for_responder).unwrap();
-            let mut resp = InteractionResponse::choice("", 1); // "Revise"
-            resp.request_id = req.id.clone();
-            crate::interaction::write_response(&run_id_for_responder, &resp).unwrap();
-            // Immediately block the next atomic write: response.json is on disk
-            // so take_response can still read it, but the followup's
-            // write_request writes `pending.json.tmp`, which we replace with a
-            // directory so that write fails.
-            let dir = runstate::run_dir(&run_id_for_responder);
-            let _ = std::fs::create_dir_all(dir.join("pending.json.tmp"));
-        });
-        // Yield so the spawned task runs its first read_request check (returns None)
-        // before we start run_interactive_points_stage (which writes the request).
-        tokio::task::yield_now().await;
+                let run_id_for_responder = run_id.clone();
+                let responder: tokio::task::JoinHandle<()> = tokio::spawn(async move {
+                    // Poll immediately — request not yet written (main task hasn't yielded
+                    // to run_interactive_points_stage yet), so this returns None on the
+                    // first iteration. This exercises the while-loop-body (true) path.
+                    while crate::interaction::read_request(&run_id_for_responder).is_none() {
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    }
+                    // Now read_request returned Some — retrieve and handle the request.
+                    let req = crate::interaction::read_request(&run_id_for_responder).unwrap();
+                    let mut resp = InteractionResponse::choice("", 1); // "Revise"
+                    resp.request_id = req.id.clone();
+                    crate::interaction::write_response(&run_id_for_responder, &resp).unwrap();
+                    // Immediately block the next atomic write: response.json is on disk
+                    // so take_response can still read it, but the followup's
+                    // write_request writes `pending.json.tmp`, which we replace with a
+                    // directory so that write fails.
+                    let dir = runstate::run_dir(&run_id_for_responder);
+                    let _ = std::fs::create_dir_all(dir.join("pending.json.tmp"));
+                });
+                // Yield so the spawned task runs its first read_request check (returns None)
+                // before we start run_interactive_points_stage (which writes the request).
+                tokio::task::yield_now().await;
 
-        let result = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            8,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let result = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    8,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await;
+
+                let _ = responder.await;
+
+                let dir = runstate::run_dir(&run_id);
+                let _ = std::fs::remove_dir_all(&dir);
+
+                // The error from the failed write_request propagates via `?`.
+                assert!(result.is_err());
+            },
         )
         .await;
-
-        let _ = responder.await;
-
-        let dir = runstate::run_dir(&run_id);
-        let _ = std::fs::remove_dir_all(&dir);
-
-        // The error from the failed write_request propagates via `?`.
-        assert!(result.is_err());
     }
 
     // ─── Coverage: empty inference content with run context (lines 374:21, 513:13) ─
 
     #[tokio::test]
     async fn interactive_points_empty_content_with_run_context() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_empty_content_with_run_context",
-        );
-        // Covers lines 374:21 and 513:13: `}` of `if !resp.content.is_empty()` when
-        // the provider returns empty content ("") AND run_context is Some.
-        // The if-block is skipped (false branch), producing the uncovered segment.
-        use crate::interaction::InteractionResponse;
+            |_d| async move {
+                // Covers lines 374:21 and 513:13: `}` of `if !resp.content.is_empty()` when
+                // the provider returns empty content ("") AND run_context is Some.
+                // The if-block is skipped (false branch), producing the uncovered segment.
+                use crate::interaction::InteractionResponse;
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        // MockProvider with empty string → resp.content.is_empty() == true
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                // MockProvider with empty string → resp.content.is_empty() == true
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-empty-content-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-empty-content-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        let points = vec![make_free_text_point("q", "Any thoughts?")];
-        let responder = spawn_interaction_responder(
-            run_id.clone(),
-            vec![InteractionResponse::text("", "my answer")],
-        );
+                let points = vec![make_free_text_point("q", "Any thoughts?")];
+                let responder = spawn_interaction_responder(
+                    run_id.clone(),
+                    vec![InteractionResponse::text("", "my answer")],
+                );
 
-        run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                responder.abort();
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+
+                // When content is empty, io.on_output was NOT called
+                assert!(io.outputs.is_empty());
+            },
         )
-        .await
-        .unwrap();
-
-        responder.abort();
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
-
-        // When content is empty, io.on_output was NOT called
-        assert!(io.outputs.is_empty());
+        .await;
     }
 
     // ─── Coverage: first request_interaction_async fails (line 421:96) ─────────
 
     #[tokio::test]
     async fn interactive_points_first_request_interaction_async_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "interactive_points_first_request_interaction_async_error",
-        );
-        // Covers the `?` on `request_interaction_async` for the initial
-        // (non-followup) interaction point when `write_request` fails because
-        // the atomic write's tmp target is blocked before the stage starts.
+            |_d| async move {
+                // Covers the `?` on `request_interaction_async` for the initial
+                // (non-followup) interaction point when `write_request` fails because
+                // the atomic write's tmp target is blocked before the stage starts.
 
-        let bp = make_blueprint(vec![make_stage("main")]);
-        let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
-        let mut io = MockIO::new();
+                let bp = make_blueprint(vec![make_stage("main")]);
+                let (mut engine, _pool, entity) = make_engine_and_entity(&bp, "Agent response");
+                let mut io = MockIO::new();
 
-        let run_id = format!(
-            "test-ip-first-req-err-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let mut meta = RunMeta::new(
-            run_id.clone(),
-            "test".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-ip-first-req-err-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let mut meta = RunMeta::new(
+                    run_id.clone(),
+                    "test".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                runstate::create_run(&meta).unwrap();
 
-        // Block the atomic write's tmp target BEFORE calling the stage so that
-        // `write_request` (called by `request_interaction_async`) fails
-        // immediately → propagates via `?`. A directory at `pending.json.tmp`
-        // makes the write fail on every platform.
-        let dir = runstate::run_dir(&run_id);
-        std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
+                // Block the atomic write's tmp target BEFORE calling the stage so that
+                // `write_request` (called by `request_interaction_async`) fails
+                // immediately → propagates via `?`. A directory at `pending.json.tmp`
+                // makes the write fail on every platform.
+                let dir = runstate::run_dir(&run_id);
+                std::fs::create_dir_all(dir.join("pending.json.tmp")).unwrap();
 
-        let points = vec![make_free_text_point("q", "What now?")];
+                let points = vec![make_free_text_point("q", "What now?")];
 
-        let result = run_interactive_points_stage(
-            &mut engine,
-            entity,
-            "mock",
-            "test-model",
-            4,
-            &[],
-            None,
-            &points,
-            Some((&run_id, &mut meta)),
-            &mut io,
-            &mut noop_exec,
-            None,
+                let result = run_interactive_points_stage(
+                    &mut engine,
+                    entity,
+                    "mock",
+                    "test-model",
+                    4,
+                    &[],
+                    None,
+                    &points,
+                    Some((&run_id, &mut meta)),
+                    &mut io,
+                    &mut noop_exec,
+                    None,
+                )
+                .await;
+
+                let _ = std::fs::remove_dir_all(&dir);
+
+                assert!(result.is_err());
+            },
         )
         .await;
-
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(result.is_err());
     }
 
     // ─── normalize_for_followup + lookup_directive tests ──────────────────

--- a/crates/leviath-cli/src/commands/run/stages.rs
+++ b/crates/leviath-cli/src/commands/run/stages.rs
@@ -101,7 +101,7 @@ pub async fn run_interactive_stage(
     executor: &mut ToolExecutorDyn<'_>,
 ) -> anyhow::Result<()> {
     use crate::interaction::{
-        make_interaction_id, request_interaction_async, response_as_text, InteractionRequest,
+        InteractionRequest, make_interaction_id, request_interaction_async, response_as_text,
     };
     use leviath_runtime::ContextWindow;
 
@@ -154,7 +154,7 @@ pub async fn run_interactive_stage(
                 "[Tokens: {} in, {} out]",
                 response.tokens_used.prompt_tokens, response.tokens_used.completion_tokens
             );
-            if let (Some(run_id), Some(ref m)) = (&run_id_owned, &meta_holder) {
+            if let (Some(run_id), Some(m)) = (&run_id_owned, &meta_holder) {
                 record_stage_output(run_id, m.stage_index, &response.content);
                 record_stage_log(run_id, m.stage_index, &token_line);
             }
@@ -243,7 +243,7 @@ pub async fn run_interactive_stage(
             false, // not required — empty ends the loop
         );
 
-        let input = if let (Some(run_id), Some(ref mut meta)) = (&run_id_owned, &mut meta_holder) {
+        let input = if let (Some(run_id), Some(meta)) = (&run_id_owned, &mut meta_holder) {
             let resp = request_interaction_async(run_id, meta, req, None).await?;
             response_as_text(&resp)
         } else {
@@ -360,8 +360,10 @@ pub async fn run_interactive_points_stage(
     // foreground mode (no run_context) it is required; background mode resolves
     // interaction points via IPC and never consults it, so a placeholder is
     // bound there.
-    let ask: &(dyn Fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse
-          + Sync) = match asker {
+    let ask: &(
+         dyn Fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse
+             + Sync
+     ) = match asker {
         Some(ref f) => f,
         // Background (IPC) mode and the empty-points autonomous fallback never
         // consult the asker, so bind the placeholder there rather than bailing.
@@ -403,12 +405,14 @@ async fn run_interactive_points_stage_with(
     run_context: Option<(&str, &mut RunMeta)>,
     io: &mut dyn RunIO,
     executor: &mut ToolExecutorDyn<'_>,
-    ask_foreground: &(dyn Fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse
-          + Sync),
+    ask_foreground: &(
+         dyn Fn(&crate::interaction::InteractionRequest) -> crate::interaction::InteractionResponse
+             + Sync
+     ),
 ) -> anyhow::Result<PointsOutcome> {
     use crate::interaction::{
-        make_interaction_id, request_interaction_async, response_as_choice, response_as_text,
-        InteractionRequest,
+        InteractionRequest, make_interaction_id, request_interaction_async, response_as_choice,
+        response_as_text,
     };
     use leviath_runtime::ContextWindow;
 
@@ -474,7 +478,7 @@ async fn run_interactive_points_stage_with(
                     if !resp.content.is_empty() {
                         io.on_output(&resp.content).await;
                         // Route agent response to the per-stage output file so the dashboard can display it
-                        if let (Some(run_id), Some(ref m)) = (&run_id_owned, &meta_holder) {
+                        if let (Some(run_id), Some(m)) = (&run_id_owned, &meta_holder) {
                             record_stage_output(run_id, m.stage_index, &resp.content);
                         }
                         last_output = Some(resp.content.clone());
@@ -522,9 +526,7 @@ async fn run_interactive_points_stage_with(
             };
 
             // Dispatch via file IPC or stdin
-            let user_text = if let (Some(run_id), Some(ref mut meta)) =
-                (&run_id_owned, &mut meta_holder)
-            {
+            let user_text = if let (Some(run_id), Some(meta)) = (&run_id_owned, &mut meta_holder) {
                 let resp = request_interaction_async(run_id, meta, ipc_req.clone(), None).await?;
                 match bp_style {
                     leviath_core::blueprint::InteractionStyle::MultipleChoice
@@ -567,12 +569,12 @@ async fn run_interactive_points_stage_with(
                 return Ok(PointsOutcome::Aborted);
             }
 
-            if !user_text.is_empty() {
-                if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
-                    let tokens = user_text.len() / 4 + 1;
-                    let content = format!("User [{}]: {}", point.name, user_text);
-                    let _ = window.add_to_region("conversation", content, tokens);
-                }
+            if !user_text.is_empty()
+                && let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity)
+            {
+                let tokens = user_text.len() / 4 + 1;
+                let content = format!("User [{}]: {}", point.name, user_text);
+                let _ = window.add_to_region("conversation", content, tokens);
             }
 
             // Deterministic direct-edit: if the selection is an edit option,
@@ -593,13 +595,12 @@ async fn run_interactive_points_stage_with(
                     &point.name,
                     seed,
                 );
-                let edited =
-                    if let (Some(run_id), Some(ref mut meta)) = (&run_id_owned, &mut meta_holder) {
-                        let resp = request_interaction_async(run_id, meta, edit_req, None).await?;
-                        response_as_text(&resp)
-                    } else {
-                        response_as_text(&ask_foreground(&edit_req))
-                    };
+                let edited = if let (Some(run_id), Some(meta)) = (&run_id_owned, &mut meta_holder) {
+                    let resp = request_interaction_async(run_id, meta, edit_req, None).await?;
+                    response_as_text(&resp)
+                } else {
+                    response_as_text(&ask_foreground(&edit_req))
+                };
                 if !edited.is_empty() {
                     if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
                         let content = format!(
@@ -669,7 +670,7 @@ async fn run_interactive_points_stage_with(
         if let Ok(resp) = response {
             if !resp.content.is_empty() {
                 io.on_output(&resp.content).await;
-                if let (Some(run_id), Some(ref m)) = (&run_id_owned, &meta_holder) {
+                if let (Some(run_id), Some(m)) = (&run_id_owned, &meta_holder) {
                     record_stage_output(run_id, m.stage_index, &resp.content);
                 }
             }
@@ -679,7 +680,7 @@ async fn run_interactive_points_stage_with(
                 resp.tokens_used.cached_tokens,
             )
             .await;
-            if let (Some(_), Some(ref m)) = (&run_id_owned, &meta_holder) {
+            if let (Some(_), Some(m)) = (&run_id_owned, &meta_holder) {
                 let token_line = format!(
                     "[Tokens used: {} input, {} output]",
                     resp.tokens_used.prompt_tokens, resp.tokens_used.completion_tokens
@@ -1213,9 +1214,11 @@ mod tests {
         assert_eq!(provider.count_tokens("abcd", "m"), 1);
         assert_eq!(provider.max_context_tokens("m"), 100_000);
         assert_eq!(provider.name(), "mock");
-        assert!(tokio_test_block_on(provider.list_models())
-            .unwrap()
-            .is_empty());
+        assert!(
+            tokio_test_block_on(provider.list_models())
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -1226,9 +1229,11 @@ mod tests {
         assert_eq!(provider.count_tokens("abcd", "m"), 1);
         assert_eq!(provider.max_context_tokens("m"), 100_000);
         assert_eq!(provider.name(), "stream-failing-mock");
-        assert!(tokio_test_block_on(provider.list_models())
-            .unwrap()
-            .is_empty());
+        assert!(
+            tokio_test_block_on(provider.list_models())
+                .unwrap()
+                .is_empty()
+        );
     }
 
     fn tokio_test_block_on<F: std::future::Future>(fut: F) -> F::Output {
@@ -2380,10 +2385,12 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("require an interaction asker"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("require an interaction asker")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -1384,8 +1384,8 @@ mod tests {
     /// that drive a real config load (e.g. `execute_worker()` on a valid
     /// manifest) don't make a real, billed inference request via
     /// `generate_title()`. Shared with `commands/run/foreground.rs` — see
-    /// `crate::config::isolate_config_path_for_test` for the rationale.
-    use crate::config::isolate_config_path_for_test as isolate_config_path;
+    /// `crate::config::with_isolated_config_path_async` for the rationale.
+    use crate::config::with_isolated_config_path_async;
 
     fn make_meta(run_id: &str, num_stages: usize) -> RunMeta {
         RunMeta::new(
@@ -1575,125 +1575,133 @@ mod tests {
         // runs dir unless isolated -- caught missing this guard when a
         // leftover "test-complete-pos" dir turned up in the real
         // ~/.leviath/runs/ after a full-suite run.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-complete-pos");
-        let mut meta = RunMeta::new(
-            "test-complete-pos".into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            3,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: "test-complete-pos".to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 3,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        // Should not panic with positive stages
-        cb.on_complete(2).await;
+        crate::runstate::with_isolated_runs_dir_async("worker-cb-complete-pos", |_d| async move {
+            let mut meta = RunMeta::new(
+                "test-complete-pos".into(),
+                "agent".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                3,
+            );
+            let mut cb = WorkerCallbacks {
+                run_id: "test-complete-pos".to_string(),
+                meta: &mut meta,
+                blueprint_stages_len: 3,
+                tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                taint_global: false,
+                taint_policy: leviath_core::PolicyConfig::default(),
+                context_window: Arc::new(Mutex::new(None)),
+            };
+            // Should not panic with positive stages
+            cb.on_complete(2).await;
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_transition_does_not_panic() {
         // See the comment on `worker_callbacks_on_complete_with_positive_stages`
         // -- `on_transition` also calls `record_stage_log` for real.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-transition");
-        let mut meta = RunMeta::new(
-            "test-trans".into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            2,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: "test-trans".to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 2,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        cb.on_transition("plan", "code", 0).await;
+        crate::runstate::with_isolated_runs_dir_async("worker-cb-transition", |_d| async move {
+            let mut meta = RunMeta::new(
+                "test-trans".into(),
+                "agent".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                2,
+            );
+            let mut cb = WorkerCallbacks {
+                run_id: "test-trans".to_string(),
+                meta: &mut meta,
+                blueprint_stages_len: 2,
+                tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                taint_global: false,
+                taint_policy: leviath_core::PolicyConfig::default(),
+                context_window: Arc::new(Mutex::new(None)),
+            };
+            cb.on_transition("plan", "code", 0).await;
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_cancel_sets_cancelled_and_persists() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-cancel");
-        let mut meta = RunMeta::new(
-            "test-cancel".into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            2,
-        );
-        runstate::create_run(&meta).unwrap();
-        let mut cb = WorkerCallbacks {
-            run_id: "test-cancel".to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 2,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        cb.on_cancel(0).await;
+        crate::runstate::with_isolated_runs_dir_async("worker-cb-cancel", |_d| async move {
+            let mut meta = RunMeta::new(
+                "test-cancel".into(),
+                "agent".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                2,
+            );
+            runstate::create_run(&meta).unwrap();
+            let mut cb = WorkerCallbacks {
+                run_id: "test-cancel".to_string(),
+                meta: &mut meta,
+                blueprint_stages_len: 2,
+                tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                taint_global: false,
+                taint_policy: leviath_core::PolicyConfig::default(),
+                context_window: Arc::new(Mutex::new(None)),
+            };
+            cb.on_cancel(0).await;
 
-        assert_eq!(meta.status, RunStatus::Cancelled);
-        // Persisted to disk as well.
-        let persisted = runstate::read_meta("test-cancel").unwrap();
-        assert_eq!(persisted.status, RunStatus::Cancelled);
+            assert_eq!(meta.status, RunStatus::Cancelled);
+            // Persisted to disk as well.
+            let persisted = runstate::read_meta("test-cancel").unwrap();
+            assert_eq!(persisted.status, RunStatus::Cancelled);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn worker_on_taint_audit_persists_events() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-taint-audit");
-        let mut meta = RunMeta::new(
-            "test-taint-audit".into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        runstate::create_run(&meta).unwrap();
-        let mut cb = WorkerCallbacks {
-            run_id: "test-taint-audit".to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: true,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        let events = vec![leviath_core::taint::GateEvent {
-            timestamp: 0,
-            agent_id: "a".into(),
-            tool_name: "shell".into(),
-            input_mode: leviath_core::taint::InputMode::Traditional,
-            taint_level: leviath_core::TaintLevel::Private,
-            clearance: leviath_core::TaintLevel::Public,
-            allowed: false,
-            decision_source: leviath_core::taint::GateDecisionSource::UserDenied,
-        }];
-        cb.on_taint_audit(0, &events).await;
+        crate::runstate::with_isolated_runs_dir_async("worker-cb-taint-audit", |_d| async move {
+            let mut meta = RunMeta::new(
+                "test-taint-audit".into(),
+                "agent".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                1,
+            );
+            runstate::create_run(&meta).unwrap();
+            let mut cb = WorkerCallbacks {
+                run_id: "test-taint-audit".to_string(),
+                meta: &mut meta,
+                blueprint_stages_len: 1,
+                tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                taint_global: true,
+                taint_policy: leviath_core::PolicyConfig::default(),
+                context_window: Arc::new(Mutex::new(None)),
+            };
+            let events = vec![leviath_core::taint::GateEvent {
+                timestamp: 0,
+                agent_id: "a".into(),
+                tool_name: "shell".into(),
+                input_mode: leviath_core::taint::InputMode::Traditional,
+                taint_level: leviath_core::TaintLevel::Private,
+                clearance: leviath_core::TaintLevel::Public,
+                allowed: false,
+                decision_source: leviath_core::taint::GateDecisionSource::UserDenied,
+            }];
+            cb.on_taint_audit(0, &events).await;
 
-        let path = runstate::stage_dir("test-taint-audit", 0).join("taint_audit.json");
-        assert!(path.exists());
-        let content = std::fs::read_to_string(path).unwrap();
-        assert!(content.contains("shell"));
-        // Trait accessors reflect the configured values.
-        assert!(cb.taint_global_enabled());
+            let path = runstate::stage_dir("test-taint-audit", 0).join("taint_audit.json");
+            assert!(path.exists());
+            let content = std::fs::read_to_string(path).unwrap();
+            assert!(content.contains("shell"));
+            // Trait accessors reflect the configured values.
+            assert!(cb.taint_global_enabled());
+        })
+        .await;
     }
 
     async fn resolve_gate_prompt_with(
@@ -1764,630 +1772,683 @@ mod tests {
 
     #[tokio::test]
     async fn worker_gate_prompt_maps_deny() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-gate-prompt-deny");
-        let res =
-            resolve_gate_prompt_with("gp-deny", false, crate::interaction::ApprovalScope::Once)
-                .await;
-        assert_eq!(res, leviath_runtime::taint::GateResolution::Deny);
+        crate::runstate::with_isolated_runs_dir_async("worker-gate-prompt-deny", |_d| async move {
+            let res =
+                resolve_gate_prompt_with("gp-deny", false, crate::interaction::ApprovalScope::Once)
+                    .await;
+            assert_eq!(res, leviath_runtime::taint::GateResolution::Deny);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn worker_gate_prompt_maps_allow_once_and_session() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-gate-prompt-allow");
-        let once =
-            resolve_gate_prompt_with("gp-once", true, crate::interaction::ApprovalScope::Once)
+        crate::runstate::with_isolated_runs_dir_async(
+            "worker-gate-prompt-allow",
+            |_d| async move {
+                let once = resolve_gate_prompt_with(
+                    "gp-once",
+                    true,
+                    crate::interaction::ApprovalScope::Once,
+                )
                 .await;
-        assert_eq!(once, leviath_runtime::taint::GateResolution::AllowOnce);
-        let session = resolve_gate_prompt_with(
-            "gp-session",
-            true,
-            crate::interaction::ApprovalScope::Session,
+                assert_eq!(once, leviath_runtime::taint::GateResolution::AllowOnce);
+                let session = resolve_gate_prompt_with(
+                    "gp-session",
+                    true,
+                    crate::interaction::ApprovalScope::Session,
+                )
+                .await;
+                assert_eq!(session, leviath_runtime::taint::GateResolution::AlwaysAllow);
+            },
         )
         .await;
-        assert_eq!(session, leviath_runtime::taint::GateResolution::AlwaysAllow);
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_claude_code_warning_does_not_panic() {
         // See the comment on `worker_callbacks_on_complete_with_positive_stages`
         // -- `on_claude_code_warning` also calls `record_stage_log` for real.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("worker-cb-ccw");
-        let mut meta = RunMeta::new(
-            "test-ccw".into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: "test-ccw".to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        cb.on_claude_code_warning(0).await;
+        crate::runstate::with_isolated_runs_dir_async("worker-cb-ccw", |_d| async move {
+            let mut meta = RunMeta::new(
+                "test-ccw".into(),
+                "agent".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                1,
+            );
+            let mut cb = WorkerCallbacks {
+                run_id: "test-ccw".to_string(),
+                meta: &mut meta,
+                blueprint_stages_len: 1,
+                tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                taint_global: false,
+                taint_policy: leviath_core::PolicyConfig::default(),
+                context_window: Arc::new(Mutex::new(None)),
+            };
+            cb.on_claude_code_warning(0).await;
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_provider_missing_returns_true() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_provider_missing_returns_true",
-        );
-        // Use a temp dir for run state
-        let run_id = "test-worker-prov-miss";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                // Use a temp dir for run state
+                let run_id = "test-worker-prov-miss";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        // Write initial stages index
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                // Write initial stages index
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        let result = cb.on_provider_missing("nonexistent", 0).await;
-        // on_provider_missing should return true (abort).
-        assert!(result);
-        assert_eq!(cb.meta.status, RunStatus::Error);
-        assert!(cb.meta.error.is_some());
-        assert!(cb.meta.error.as_ref().unwrap().contains("nonexistent"));
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
+                let result = cb.on_provider_missing("nonexistent", 0).await;
+                // on_provider_missing should return true (abort).
+                assert!(result);
+                assert_eq!(cb.meta.status, RunStatus::Error);
+                assert!(cb.meta.error.is_some());
+                assert!(cb.meta.error.as_ref().unwrap().contains("nonexistent"));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_enter_updates_meta() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_enter_updates_meta",
-        );
-        let run_id = "test-worker-stage-enter";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-enter";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let stages = vec![
-            crate::runstate::StageRecord::new("plan".to_string(), 0),
-            crate::runstate::StageRecord::new("code".to_string(), 1),
-        ];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![
+                    crate::runstate::StageRecord::new("plan".to_string(), 0),
+                    crate::runstate::StageRecord::new("code".to_string(), 1),
+                ];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            2,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 2,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        cb.on_stage_enter("plan", 0, "anthropic", "claude-sonnet-4-6", "")
-            .await;
-        assert_eq!(cb.meta.current_stage, "plan");
-        assert_eq!(cb.meta.stage_index, 0);
-        assert_eq!(cb.meta.status, RunStatus::Running);
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    2,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 2,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
+                cb.on_stage_enter("plan", 0, "anthropic", "claude-sonnet-4-6", "")
+                    .await;
+                assert_eq!(cb.meta.current_stage, "plan");
+                assert_eq!(cb.meta.stage_index, 0);
+                assert_eq!(cb.meta.status, RunStatus::Running);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_enter_with_visit_label() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_enter_with_visit_label",
-        );
-        let run_id = "test-worker-visit-label";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-visit-label";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("code".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("code".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
-        cb.on_stage_enter("code", 0, "anthropic", "claude-sonnet-4-6", " (visit 2)")
-            .await;
-        assert_eq!(cb.meta.current_stage, "code");
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
+                cb.on_stage_enter("code", 0, "anthropic", "claude-sonnet-4-6", " (visit 2)")
+                    .await;
+                assert_eq!(cb.meta.current_stage, "code");
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_error_graph_mode() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_error_graph_mode",
-        );
-        let run_id = "test-worker-stage-err-graph";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-err-graph";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let err = anyhow::anyhow!("test error");
-        let result = cb.on_stage_error("main", 0, &err, true).await;
-        assert_eq!(result, Some(leviath_core::blueprint::StageResult::Error));
+                let err = anyhow::anyhow!("test error");
+                let result = cb.on_stage_error("main", 0, &err, true).await;
+                assert_eq!(result, Some(leviath_core::blueprint::StageResult::Error));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_error_linear_mode() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_error_linear_mode",
-        );
-        let run_id = "test-worker-stage-err-linear";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-err-linear";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let err = anyhow::anyhow!("linear error");
-        let result = cb.on_stage_error("main", 0, &err, false).await;
-        assert!(result.is_none());
-        assert_eq!(cb.meta.status, RunStatus::Error);
-        assert!(cb.meta.error.as_ref().unwrap().contains("linear error"));
+                let err = anyhow::anyhow!("linear error");
+                let result = cb.on_stage_error("main", 0, &err, false).await;
+                assert!(result.is_none());
+                assert_eq!(cb.meta.status, RunStatus::Error);
+                assert!(cb.meta.error.as_ref().unwrap().contains("linear error"));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_result_updates_stages() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_result_updates_stages",
-        );
-        let run_id = "test-worker-stage-result";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        // Create stages dir for output
-        let stage_dir = crate::runstate::stage_dir(run_id, 0);
-        let _ = std::fs::create_dir_all(&stage_dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-result";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+                // Create stages dir for output
+                let stage_dir = crate::runstate::stage_dir(run_id, 0);
+                let _ = std::fs::create_dir_all(&stage_dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let registry = leviath_runtime::ProviderRegistry::new();
-        let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
-        let mut pool = leviath_runtime::AgentPool::new(leviath_core::Blueprint::new(
-            "test".to_string(),
-            "test".to_string(),
-            vec![],
-            leviath_core::ContextLayout::new(vec![], 0),
-        ));
-        let agent_id = pool.spawn_agent(engine.world_mut());
-        let entity = pool.get_agent(&agent_id).unwrap();
+                let registry = leviath_runtime::ProviderRegistry::new();
+                let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
+                let mut pool = leviath_runtime::AgentPool::new(leviath_core::Blueprint::new(
+                    "test".to_string(),
+                    "test".to_string(),
+                    vec![],
+                    leviath_core::ContextLayout::new(vec![], 0),
+                ));
+                let agent_id = pool.spawn_agent(engine.world_mut());
+                let entity = pool.get_agent(&agent_id).unwrap();
 
-        // Test with a response
-        let response = leviath_providers::InferenceResponse {
-            content: "test output".to_string(),
-            tool_calls: vec![],
-            tokens_used: leviath_providers::TokenUsage {
-                prompt_tokens: 100,
-                completion_tokens: 50,
-                total_tokens: 150,
-                cached_tokens: 10,
-                cache_write_tokens: 0,
+                // Test with a response
+                let response = leviath_providers::InferenceResponse {
+                    content: "test output".to_string(),
+                    tool_calls: vec![],
+                    tokens_used: leviath_providers::TokenUsage {
+                        prompt_tokens: 100,
+                        completion_tokens: 50,
+                        total_tokens: 150,
+                        cached_tokens: 10,
+                        cache_write_tokens: 0,
+                    },
+                    finish_reason: leviath_providers::FinishReason::Complete,
+                };
+
+                cb.on_stage_result(
+                    "main",
+                    0,
+                    &leviath_core::blueprint::StageResult::Success,
+                    Some(&response),
+                    &mut engine,
+                    entity,
+                )
+                .await;
+
+                assert_eq!(cb.meta.prompt_tokens, 100);
+                assert_eq!(cb.meta.completion_tokens, 50);
+                assert_eq!(cb.meta.cached_tokens, 10);
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
             },
-            finish_reason: leviath_providers::FinishReason::Complete,
-        };
-
-        cb.on_stage_result(
-            "main",
-            0,
-            &leviath_core::blueprint::StageResult::Success,
-            Some(&response),
-            &mut engine,
-            entity,
         )
         .await;
-
-        assert_eq!(cb.meta.prompt_tokens, 100);
-        assert_eq!(cb.meta.completion_tokens, 50);
-        assert_eq!(cb.meta.cached_tokens, 10);
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_result_no_response() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_result_no_response",
-        );
-        let run_id = "test-worker-stage-result-none";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-result-none";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = RunMeta::new(
-            run_id.into(),
-            "agent".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = RunMeta::new(
+                    run_id.into(),
+                    "agent".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                );
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let registry = leviath_runtime::ProviderRegistry::new();
-        let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
-        let entity = bevy_ecs::prelude::Entity::from_raw(0);
+                let registry = leviath_runtime::ProviderRegistry::new();
+                let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
+                let entity = bevy_ecs::prelude::Entity::from_raw(0);
 
-        // No response
-        cb.on_stage_result(
-            "main",
-            0,
-            &leviath_core::blueprint::StageResult::Success,
-            None,
-            &mut engine,
-            entity,
+                // No response
+                cb.on_stage_result(
+                    "main",
+                    0,
+                    &leviath_core::blueprint::StageResult::Success,
+                    None,
+                    &mut engine,
+                    entity,
+                )
+                .await;
+
+                // Tokens should remain zero
+                assert_eq!(cb.meta.prompt_tokens, 0);
+                assert_eq!(cb.meta.completion_tokens, 0);
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
         )
         .await;
-
-        // Tokens should remain zero
-        assert_eq!(cb.meta.prompt_tokens, 0);
-        assert_eq!(cb.meta.completion_tokens, 0);
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     // ─── on_stage_result with empty content ──────────────────────────────────
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_result_empty_content_skips_context_window() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_result_empty_content_skips_context_window",
-        );
-        let run_id = "test-worker-stage-result-empty-content";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        let stage_dir = crate::runstate::stage_dir(run_id, 0);
-        let _ = std::fs::create_dir_all(&stage_dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-result-empty-content";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+                let stage_dir = crate::runstate::stage_dir(run_id, 0);
+                let _ = std::fs::create_dir_all(&stage_dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = make_meta(run_id, 1);
-        let (mut engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
-        let _ = (pool, agent_id); // keep alive
+                let mut meta = make_meta(run_id, 1);
+                let (mut engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
+                let _ = (pool, agent_id); // keep alive
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // Empty content — the `add_to_region` branch is NOT taken
-        let response = make_response("");
-        cb.on_stage_result(
-            "main",
-            0,
-            &leviath_core::blueprint::StageResult::Success,
-            Some(&response),
-            &mut engine,
-            entity,
+                // Empty content — the `add_to_region` branch is NOT taken
+                let response = make_response("");
+                cb.on_stage_result(
+                    "main",
+                    0,
+                    &leviath_core::blueprint::StageResult::Success,
+                    Some(&response),
+                    &mut engine,
+                    entity,
+                )
+                .await;
+
+                // Token counts still updated even when content is empty
+                assert_eq!(cb.meta.prompt_tokens, 100);
+                assert_eq!(cb.meta.completion_tokens, 50);
+                assert_eq!(cb.meta.cached_tokens, 10);
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
         )
         .await;
-
-        // Token counts still updated even when content is empty
-        assert_eq!(cb.meta.prompt_tokens, 100);
-        assert_eq!(cb.meta.completion_tokens, 50);
-        assert_eq!(cb.meta.cached_tokens, 10);
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     // ─── on_stage_result with non-empty content adds to context window ────────
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_result_non_empty_content_adds_to_window() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_result_non_empty_content_adds_to_window",
-        );
-        let run_id = "test-worker-stage-result-non-empty";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        let stage_dir = crate::runstate::stage_dir(run_id, 0);
-        let _ = std::fs::create_dir_all(&stage_dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-result-non-empty";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+                let stage_dir = crate::runstate::stage_dir(run_id, 0);
+                let _ = std::fs::create_dir_all(&stage_dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = make_meta(run_id, 1);
-        let (mut engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
-        let _ = (pool, agent_id);
+                let mut meta = make_meta(run_id, 1);
+                let (mut engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
+                let _ = (pool, agent_id);
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // Non-empty content — `add_to_region` branch IS taken
-        let response = make_response("This is the assistant's output after completing the task.");
-        cb.on_stage_result(
-            "main",
-            0,
-            &leviath_core::blueprint::StageResult::Success,
-            Some(&response),
-            &mut engine,
-            entity,
+                // Non-empty content — `add_to_region` branch IS taken
+                let response =
+                    make_response("This is the assistant's output after completing the task.");
+                cb.on_stage_result(
+                    "main",
+                    0,
+                    &leviath_core::blueprint::StageResult::Success,
+                    Some(&response),
+                    &mut engine,
+                    entity,
+                )
+                .await;
+
+                assert_eq!(cb.meta.prompt_tokens, 100);
+                assert_eq!(cb.meta.completion_tokens, 50);
+
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
         )
         .await;
-
-        assert_eq!(cb.meta.prompt_tokens, 100);
-        assert_eq!(cb.meta.completion_tokens, 50);
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
     }
 
     // ─── on_post_stage ────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn worker_callbacks_on_post_stage_updates_meta_and_writes_snapshot() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_post_stage_updates_meta_and_writes_snapshot",
-        );
-        let run_id = "test-worker-on-post-stage";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-on-post-stage";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let mut meta = make_meta(run_id, 1);
-        meta.stage_index = 0;
-        // Write initial meta so runstate can read it
-        let _ = crate::runstate::write_meta(&meta);
+                let mut meta = make_meta(run_id, 1);
+                meta.stage_index = 0;
+                // Write initial meta so runstate can read it
+                let _ = crate::runstate::write_meta(&meta);
 
-        let (engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
-        let _ = (pool, agent_id);
+                let (engine, pool, agent_id, entity) = make_engine_with_agent(&mut meta);
+                let _ = (pool, agent_id);
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // Should not panic; updates meta.iteration from AgentState and writes meta
-        cb.on_post_stage(&engine, entity, "main").await;
+                // Should not panic; updates meta.iteration from AgentState and writes meta
+                cb.on_post_stage(&engine, entity, "main").await;
 
-        // Meta should have been written (no panic is the key assertion here)
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                // Meta should have been written (no panic is the key assertion here)
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn worker_callbacks_on_post_stage_without_agent_state() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_post_stage_without_agent_state",
-        );
-        let run_id = "test-worker-on-post-stage-no-state";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-on-post-stage-no-state";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let mut meta = make_meta(run_id, 1);
-        let _ = crate::runstate::write_meta(&meta);
+                let mut meta = make_meta(run_id, 1);
+                let _ = crate::runstate::write_meta(&meta);
 
-        let registry = leviath_runtime::ProviderRegistry::new();
-        let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
-        // Spawn entity WITHOUT AgentState (bare entity) to test the `if let Some` branch
-        let entity = engine.world_mut().spawn(()).id();
+                let registry = leviath_runtime::ProviderRegistry::new();
+                let mut engine = leviath_runtime::AgentEngine::with_providers(registry);
+                // Spawn entity WITHOUT AgentState (bare entity) to test the `if let Some` branch
+                let entity = engine.world_mut().spawn(()).id();
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // on_post_stage with an entity that has no AgentState — should not panic
-        cb.on_post_stage(&engine, entity, "main").await;
+                // on_post_stage with an entity that has no AgentState — should not panic
+                cb.on_post_stage(&engine, entity, "main").await;
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── execute_worker error paths ───────────────────────────────────────────
 
     #[tokio::test]
     async fn execute_worker_fails_with_nonexistent_path() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_worker_fails_with_nonexistent_path",
-        );
-        let run_id = "test-execute-worker-bad-path";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-execute-worker-bad-path";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        // Write meta so execute_worker can read it
-        let meta = make_meta(run_id, 0);
-        let _ = crate::runstate::write_meta(&meta);
+                // Write meta so execute_worker can read it
+                let meta = make_meta(run_id, 0);
+                let _ = crate::runstate::write_meta(&meta);
 
-        let args = WorkerArgs {
-            path: "/nonexistent/path/to/nowhere".to_string(),
-            task: "do something".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                let args = WorkerArgs {
+                    path: "/nonexistent/path/to/nowhere".to_string(),
+                    task: "do something".to_string(),
+                    run_id: run_id.to_string(),
+                    model: None,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                };
 
-        let result = execute_worker(args).await;
-        // Should fail because path doesn't exist
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        let has_manifest_err = err_msg.contains("Could not find") | err_msg.contains("manifest");
-        // Expected manifest error.
-        assert!(has_manifest_err);
+                let result = execute_worker(args).await;
+                // Should fail because path doesn't exist
+                assert!(result.is_err());
+                let err_msg = result.unwrap_err().to_string();
+                let has_manifest_err =
+                    err_msg.contains("Could not find") | err_msg.contains("manifest");
+                // Expected manifest error.
+                assert!(has_manifest_err);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_worker_creates_meta_when_missing() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("execute_worker_creates_meta_when_missing");
-        let run_id = "test-execute-worker-no-meta";
-        // Do NOT pre-write meta — tests the fallback branch in execute_worker
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_worker_creates_meta_when_missing",
+            |_d| async move {
+                let run_id = "test-execute-worker-no-meta";
+                // Do NOT pre-write meta — tests the fallback branch in execute_worker
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        let args = WorkerArgs {
-            path: "/nonexistent/path".to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: Some("claude-sonnet-4-6".to_string()),
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                let args = WorkerArgs {
+                    path: "/nonexistent/path".to_string(),
+                    task: "test task".to_string(),
+                    run_id: run_id.to_string(),
+                    model: Some("claude-sonnet-4-6".to_string()),
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                };
 
-        // Will fail at manifest lookup, but the RunMeta creation fallback is exercised
-        let result = execute_worker(args).await;
-        assert!(result.is_err());
+                // Will fail at manifest lookup, but the RunMeta creation fallback is exercised
+                let result = execute_worker(args).await;
+                assert!(result.is_err());
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_worker_with_valid_manifest_fails_at_inference() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_worker_with_valid_manifest_fails_at_inference",
-        );
-        // Redirect $HOME so Config::load() can't see a real config/API key —
-        // otherwise this would make a real, billed inference call via
-        // generate_title(). See CONFIG_PATH_ENV_LOCK/isolate_config_path above.
-        let _config_guard = isolate_config_path("valid-manifest");
-
-        // Create a temp dir with a valid manifest
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-valid-manifest");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+            |_d| async move {
+                // Redirect $HOME so Config::load() can't see a real config/API key —
+                // otherwise this would make a real, billed inference call via
+                // generate_title(). See CONFIG_PATH_ENV_LOCK/isolate_config_path above.
+                with_isolated_config_path_async("valid-manifest", |_fake_dir| async move {
+                    // Create a temp dir with a valid manifest
+                    let temp_dir = std::env::temp_dir().join("lev-test-worker-valid-manifest");
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    let manifest_content = r#"
 [agent]
 name = "test-worker-agent"
 version = "1.0.0"
@@ -2401,43 +2462,48 @@ max_iterations = 1
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 "#;
-        let manifest_path = temp_dir.join("agent.leviath");
-        std::fs::write(&manifest_path, manifest_content).unwrap();
+                    let manifest_path = temp_dir.join("agent.leviath");
+                    std::fs::write(&manifest_path, manifest_content).unwrap();
 
-        let run_id = "test-execute-worker-valid-manifest";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+                    let run_id = "test-execute-worker-valid-manifest";
+                    let dir = crate::runstate::run_dir(run_id);
+                    let _ = std::fs::create_dir_all(&dir);
 
-        let meta = make_meta(run_id, 1);
-        let _ = crate::runstate::write_meta(&meta);
+                    let meta = make_meta(run_id, 1);
+                    let _ = crate::runstate::write_meta(&meta);
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: true, // tests the yolo → launch_overrides branch
-            allow: vec!["read_file".to_string()], // tests --allow branch
-            ask: vec!["bash".to_string()], // tests --ask branch
-            deny: vec!["write_file".to_string()], // tests --deny branch
-            max_depth: None,
-        };
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "test task".to_string(),
+                        run_id: run_id.to_string(),
+                        model: None,
+                        yolo: true, // tests the yolo → launch_overrides branch
+                        allow: vec!["read_file".to_string()], // tests --allow branch
+                        ask: vec!["bash".to_string()], // tests --ask branch
+                        deny: vec!["write_file".to_string()], // tests --deny branch
+                        max_depth: None,
+                    };
 
-        // This will fail because no real anthropic API key is configured,
-        // but it exercises manifest loading, blueprint parsing, config loading,
-        // provider registry building, engine setup, tool registry init,
-        // launch_overrides population, and stage loop entry (provider missing).
-        let result = execute_worker(args).await;
-        // We expect either an error (no API key / provider not found) or success.
-        // The key is that the code path runs without panicking.
-        let _ = result; // Accept any result
+                    // This will fail because no real anthropic API key is configured,
+                    // but it exercises manifest loading, blueprint parsing, config loading,
+                    // provider registry building, engine setup, tool registry init,
+                    // launch_overrides population, and stage loop entry (provider missing).
+                    let result = execute_worker(args).await;
+                    // We expect either an error (no API key / provider not found) or success.
+                    // The key is that the code path runs without panicking.
+                    let _ = result; // Accept any result
 
-        // Verify meta was written
-        let saved_meta = crate::runstate::read_meta(run_id);
-        saved_meta.expect("Meta should have been written by execute_worker");
+                    // Verify meta was written
+                    let saved_meta = crate::runstate::read_meta(run_id);
+                    saved_meta.expect("Meta should have been written by execute_worker");
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                    let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
+        .await;
     }
 
     // ─── run_worker_inner: read_to_string failure (line 549) ─────────────────
@@ -2450,99 +2516,108 @@ model = "claude-sonnet-4-6"
 
     #[tokio::test]
     async fn run_worker_inner_manifest_is_directory_returns_read_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_manifest_is_directory_returns_read_error",
-        );
-        let pid = std::process::id();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos();
-        let agent_dir = std::env::temp_dir().join(format!("lev-test-manifest-is-dir-{pid}-{now}"));
-        let _ = std::fs::create_dir_all(&agent_dir);
-        // Create agent.leviath as a DIRECTORY (not a file).
-        let manifest_as_dir = agent_dir.join("agent.leviath");
-        let _ = std::fs::create_dir_all(&manifest_as_dir);
+            |_d| async move {
+                let pid = std::process::id();
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos();
+                let agent_dir =
+                    std::env::temp_dir().join(format!("lev-test-manifest-is-dir-{pid}-{now}"));
+                let _ = std::fs::create_dir_all(&agent_dir);
+                // Create agent.leviath as a DIRECTORY (not a file).
+                let manifest_as_dir = agent_dir.join("agent.leviath");
+                let _ = std::fs::create_dir_all(&manifest_as_dir);
 
-        let run_id = format!("test-worker-manifest-dir-{pid}-{now}");
-        let args = WorkerArgs {
-            path: agent_dir.to_string_lossy().to_string(),
-            task: "task".to_string(),
-            run_id: run_id.clone(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                let run_id = format!("test-worker-manifest-dir-{pid}-{now}");
+                let args = WorkerArgs {
+                    path: agent_dir.to_string_lossy().to_string(),
+                    task: "task".to_string(),
+                    run_id: run_id.clone(),
+                    model: None,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                };
 
-        let result = execute_worker(args).await;
-        // Expected read error for directory manifest.
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("Failed to read manifest") | err.contains("directory"));
+                let result = execute_worker(args).await;
+                // Expected read error for directory manifest.
+                assert!(result.is_err());
+                let err = result.unwrap_err().to_string();
+                assert!(err.contains("Failed to read manifest") | err.contains("directory"));
 
-        let _ = std::fs::remove_dir_all(&agent_dir);
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(&agent_dir);
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── run_worker_inner error paths ────────────────────────────────────────
 
     #[tokio::test]
     async fn run_worker_inner_invalid_manifest_toml_returns_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_invalid_manifest_toml_returns_error",
-        );
-        // Covers the parse_manifest error path (parse_manifest fails on bad TOML).
-        // Uses execute_worker (which delegates to run_worker_inner with the real
-        // build_provider_registry named function) to avoid a never-called closure
-        // body in test infrastructure becoming a coverage gap.
-        let _config_guard = isolate_config_path("invalid-manifest-toml");
+            |_d| async move {
+                // Covers the parse_manifest error path (parse_manifest fails on bad TOML).
+                // Uses execute_worker (which delegates to run_worker_inner with the real
+                // build_provider_registry named function) to avoid a never-called closure
+                // body in test infrastructure becoming a coverage gap.
+                with_isolated_config_path_async("invalid-manifest-toml", |_fake_dir| async move {
+                    let temp_dir =
+                        std::env::temp_dir().join("lev-test-worker-invalid-manifest-toml");
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    let invalid_toml = "this is [not valid = toml at all {{{{";
+                    let manifest_path = temp_dir.join("agent.leviath");
+                    std::fs::write(&manifest_path, invalid_toml).unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-invalid-manifest-toml");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let invalid_toml = "this is [not valid = toml at all {{{{";
-        let manifest_path = temp_dir.join("agent.leviath");
-        std::fs::write(&manifest_path, invalid_toml).unwrap();
+                    let run_id = "test-execute-worker-invalid-toml";
 
-        let run_id = "test-execute-worker-invalid-toml";
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "test task".to_string(),
+                        run_id: run_id.to_string(),
+                        model: None,
+                        yolo: false,
+                        allow: vec![],
+                        ask: vec![],
+                        deny: vec![],
+                        max_depth: None,
+                    };
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                    let result = execute_worker(args).await;
+                    result.unwrap_err(); // just verify it errored (message varies by toml version)
 
-        let result = execute_worker(args).await;
-        result.unwrap_err(); // just verify it errored (message varies by toml version)
-
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                    let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn run_worker_inner_invalid_config_toml_returns_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_invalid_config_toml_returns_error",
-        );
-        // Covers the Config::load()? error path.
-        // Uses execute_worker (which calls run_worker_inner with the real
-        // build_provider_registry named function) to avoid a never-called closure
-        // body in test infrastructure becoming a coverage gap.
-        let _config_guard = isolate_config_path("invalid-config-toml");
+            |_d| async move {
+                // Covers the Config::load()? error path.
+                // Uses execute_worker (which calls run_worker_inner with the real
+                // build_provider_registry named function) to avoid a never-called closure
+                // body in test infrastructure becoming a coverage gap.
+                with_isolated_config_path_async("invalid-config-toml", |_fake_dir| async move {
+                    std::fs::write(Config::config_path(), "this is [not valid = toml {{{{")
+                        .unwrap();
 
-        std::fs::write(Config::config_path(), "this is [not valid = toml {{{{").unwrap();
-
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-invalid-config");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+                    let temp_dir = std::env::temp_dir().join("lev-test-worker-invalid-config");
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    let manifest_content = r#"
 [agent]
 name = "test-cfg-fail-agent"
 version = "1.0.0"
@@ -2556,41 +2631,46 @@ max_iterations = 1
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 "#;
-        let manifest_path = temp_dir.join("agent.leviath");
-        std::fs::write(&manifest_path, manifest_content).unwrap();
+                    let manifest_path = temp_dir.join("agent.leviath");
+                    std::fs::write(&manifest_path, manifest_content).unwrap();
 
-        let run_id = "test-execute-worker-invalid-config";
+                    let run_id = "test-execute-worker-invalid-config";
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "test task".to_string(),
+                        run_id: run_id.to_string(),
+                        model: None,
+                        yolo: false,
+                        allow: vec![],
+                        ask: vec![],
+                        deny: vec![],
+                        max_depth: None,
+                    };
 
-        let result = execute_worker(args).await;
-        result.unwrap_err(); // verify it errored (message varies by toml version)
+                    let result = execute_worker(args).await;
+                    result.unwrap_err(); // verify it errored (message varies by toml version)
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                    let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn run_worker_inner_blueprint_validation_failure_returns_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_blueprint_validation_failure_returns_error",
-        );
-        // Parses cleanly, but `entry_stage` names a stage that doesn't exist, so
-        // `blueprint.validate()` fails — covering the validate() map_err/`?`.
-        // This error occurs before provider registration, so no network is hit.
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-validate-fail");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+            |_d| async move {
+                // Parses cleanly, but `entry_stage` names a stage that doesn't exist, so
+                // `blueprint.validate()` fails — covering the validate() map_err/`?`.
+                // This error occurs before provider registration, so no network is hit.
+                let temp_dir = std::env::temp_dir().join("lev-test-worker-validate-fail");
+                let _ = std::fs::create_dir_all(&temp_dir);
+                let manifest_content = r#"
 [agent]
 name = "test-validate-fail-agent"
 version = "1.0.0"
@@ -2601,30 +2681,33 @@ entry_stage = "does-not-exist"
 mode = "autonomous"
 max_iterations = 1
 "#;
-        std::fs::write(temp_dir.join("agent.leviath"), manifest_content).unwrap();
+                std::fs::write(temp_dir.join("agent.leviath"), manifest_content).unwrap();
 
-        let run_id = "test-execute-worker-validate-fail";
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                let run_id = "test-execute-worker-validate-fail";
+                let args = WorkerArgs {
+                    path: temp_dir.to_string_lossy().to_string(),
+                    task: "test task".to_string(),
+                    run_id: run_id.to_string(),
+                    model: None,
+                    yolo: false,
+                    allow: vec![],
+                    ask: vec![],
+                    deny: vec![],
+                    max_depth: None,
+                };
 
-        let result = execute_worker(args).await;
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("blueprint validation failed"),
-            "unexpected error: {err}"
-        );
+                let result = execute_worker(args).await;
+                let err = result.unwrap_err().to_string();
+                assert!(
+                    err.contains("blueprint validation failed"),
+                    "unexpected error: {err}"
+                );
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(&temp_dir);
+            },
+        )
+        .await;
     }
 
     #[test]
@@ -2784,23 +2867,26 @@ max_iterations = 1
 
     #[tokio::test]
     async fn run_worker_inner_with_failing_provider_propagates_error() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_with_failing_provider_propagates_error",
-        );
-        // Covers the `?` on `run_stage_loop` when run_stage_loop returns Err
-        // because the provider always fails.
-        let _config_guard = isolate_config_path("worker-failing-provider");
-        let mut fake_config = Config::default();
-        fake_config.title.enabled = false;
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
+            |_d| async move {
+                // Covers the `?` on `run_stage_loop` when run_stage_loop returns Err
+                // because the provider always fails.
+                with_isolated_config_path_async(
+                    "worker-failing-provider",
+                    |_fake_dir| async move {
+                        let mut fake_config = Config::default();
+                        fake_config.title.enabled = false;
+                        std::fs::write(
+                            Config::config_path(),
+                            toml::to_string(&fake_config).unwrap(),
+                        )
+                        .unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-failing-provider");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+                        let temp_dir =
+                            std::env::temp_dir().join("lev-test-worker-failing-provider");
+                        let _ = std::fs::create_dir_all(&temp_dir);
+                        let manifest_content = r#"
 [agent]
 name = "test-worker-fail-agent"
 version = "1.0.0"
@@ -2814,73 +2900,82 @@ max_iterations = 1
 provider = "failing-mock"
 model = "fail-model"
 "#;
-        let manifest_path = temp_dir.join("agent.leviath");
-        std::fs::write(&manifest_path, manifest_content).unwrap();
+                        let manifest_path = temp_dir.join("agent.leviath");
+                        std::fs::write(&manifest_path, manifest_content).unwrap();
 
-        let run_id = "test-worker-inner-failing-provider";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        let mut meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+                        let run_id = "test-worker-inner-failing-provider";
+                        let dir = crate::runstate::run_dir(run_id);
+                        let _ = std::fs::create_dir_all(&dir);
+                        let mut meta = make_meta(run_id, 1);
+                        crate::runstate::create_run(&meta).unwrap();
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                        let args = WorkerArgs {
+                            path: temp_dir.to_string_lossy().to_string(),
+                            task: "test task".to_string(),
+                            run_id: run_id.to_string(),
+                            model: None,
+                            yolo: false,
+                            allow: vec![],
+                            ask: vec![],
+                            deny: vec![],
+                            max_depth: None,
+                        };
 
-        let result = run_worker_inner(&args, &mut meta, |_config| {
-            let mut registry = leviath_runtime::ProviderRegistry::new();
-            registry.register("failing-mock".to_string(), Arc::new(FailingMockProvider));
-            registry
-        })
+                        let result = run_worker_inner(&args, &mut meta, |_config| {
+                            let mut registry = leviath_runtime::ProviderRegistry::new();
+                            registry.register(
+                                "failing-mock".to_string(),
+                                Arc::new(FailingMockProvider),
+                            );
+                            registry
+                        })
+                        .await;
+
+                        // Expected error from failing provider.
+                        assert!(result.is_err());
+
+                        let _ = std::fs::remove_dir_all(&dir);
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+                    },
+                )
+                .await;
+            },
+        )
         .await;
-
-        // Expected error from failing provider.
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     // ─── run_worker_inner: title None path (line 571) ────────────────────────
 
     #[tokio::test]
     async fn run_worker_inner_title_enabled_but_no_title_provider_skips_title_print() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_title_enabled_but_no_title_provider_skips_title_print",
-        );
-        // Covers the None branch of `if let Some(ref t) = meta.title` (line 571):
-        // config.title.enabled = true, but config.title.provider is set to a name
-        // that is NOT registered in the provider registry. generate_title returns
-        // None → the `println!("Title: {}", t)` line is skipped; meta.title stays None.
-        let _config_guard = isolate_config_path("worker-title-none");
+            |_d| async move {
+                // Covers the None branch of `if let Some(ref t) = meta.title` (line 571):
+                // config.title.enabled = true, but config.title.provider is set to a name
+                // that is NOT registered in the provider registry. generate_title returns
+                // None → the `println!("Title: {}", t)` line is skipped; meta.title stays None.
+                with_isolated_config_path_async("worker-title-none", |_fake_dir| async move {
+                    let mut fake_config = Config::default();
+                    fake_config.title.enabled = true;
+                    fake_config.title.provider = Some("nonexistent-title-prov".to_string());
+                    std::fs::write(
+                        Config::config_path(),
+                        toml::to_string(&fake_config).unwrap(),
+                    )
+                    .unwrap();
 
-        let mut fake_config = Config::default();
-        fake_config.title.enabled = true;
-        fake_config.title.provider = Some("nonexistent-title-prov".to_string());
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
-
-        let pid = std::process::id();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("lev-test-worker-title-none-{pid}-{now}"));
-        let _ = std::fs::create_dir_all(&temp_dir);
-        // Use the "anthropic" provider in the manifest's stage so we register it
-        // below — the title provider ("nonexistent-title-prov") remains absent.
-        let manifest_content = r#"
+                    let pid = std::process::id();
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .subsec_nanos();
+                    let temp_dir = std::env::temp_dir()
+                        .join(format!("lev-test-worker-title-none-{pid}-{now}"));
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    // Use the "anthropic" provider in the manifest's stage so we register it
+                    // below — the title provider ("nonexistent-title-prov") remains absent.
+                    let manifest_content = r#"
 [agent]
 name = "test-title-none-agent"
 version = "1.0.0"
@@ -2894,71 +2989,76 @@ max_iterations = 1
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+                    write_test_agent(&temp_dir, manifest_content);
 
-        let run_id = format!("test-worker-title-none-{pid}-{now}");
-        let dir = crate::runstate::run_dir(&run_id);
-        let _ = std::fs::create_dir_all(&dir);
+                    let run_id = format!("test-worker-title-none-{pid}-{now}");
+                    let dir = crate::runstate::run_dir(&run_id);
+                    let _ = std::fs::create_dir_all(&dir);
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task for title none path".to_string(),
-            run_id: run_id.clone(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "test task for title none path".to_string(),
+                        run_id: run_id.clone(),
+                        model: None,
+                        yolo: false,
+                        allow: vec![],
+                        ask: vec![],
+                        deny: vec![],
+                        max_depth: None,
+                    };
 
-        let mut meta = make_meta(&run_id, 1);
-        let _result = run_worker_inner(&args, &mut meta, |_config| {
-            // Register "anthropic" but NOT "nonexistent-title-prov"
-            let mut registry = leviath_runtime::ProviderRegistry::new();
-            registry.register("anthropic".to_string(), Arc::new(MockProvider::new()));
-            registry
-        })
+                    let mut meta = make_meta(&run_id, 1);
+                    let _result = run_worker_inner(&args, &mut meta, |_config| {
+                        // Register "anthropic" but NOT "nonexistent-title-prov"
+                        let mut registry = leviath_runtime::ProviderRegistry::new();
+                        registry.register("anthropic".to_string(), Arc::new(MockProvider::new()));
+                        registry
+                    })
+                    .await;
+
+                    // generate_title returns None → meta.title stays None
+                    // Title should be None when provider is not registered.
+                    assert!(meta.title.is_none());
+
+                    let _ = std::fs::remove_dir_all(&dir);
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
         .await;
-
-        // generate_title returns None → meta.title stays None
-        // Title should be None when provider is not registered.
-        assert!(meta.title.is_none());
-
-        let _ = std::fs::remove_dir_all(&dir);
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[tokio::test]
     async fn run_worker_inner_with_mock_provider_completes_full_round_trip() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "run_worker_inner_with_mock_provider_completes_full_round_trip",
-        );
-        let _config_guard = isolate_config_path("worker-mock-provider");
-        // A malformed key still exercises the `validate_keys()` warning
-        // branch without being usable as a real credential -- and since the
-        // provider registry is fully mocked below, no real network call can
-        // happen regardless.
-        let mut fake_config = Config::default();
-        fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
-        // Title generation and the stage's own inference must use distinct
-        // registered providers: both draw from the same injected registry,
-        // and a single shared `MockProvider` instance's call-count-based
-        // "return a tool call on the first call" logic would otherwise be
-        // consumed by the title-generation call, leaving the stage's own
-        // first (real) call already past index 0 -- silently skipping the
-        // exec-closure tool-call round trip this test exists to cover.
-        fake_config.title.provider = Some("title-mock".to_string());
-        fake_config.title.model = Some("title-mock-model".to_string());
-        std::fs::write(
-            Config::config_path(),
-            toml::to_string(&fake_config).unwrap(),
-        )
-        .unwrap();
+            |_d| async move {
+                with_isolated_config_path_async("worker-mock-provider", |_fake_dir| async move {
+                    // A malformed key still exercises the `validate_keys()` warning
+                    // branch without being usable as a real credential -- and since the
+                    // provider registry is fully mocked below, no real network call can
+                    // happen regardless.
+                    let mut fake_config = Config::default();
+                    fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
+                    // Title generation and the stage's own inference must use distinct
+                    // registered providers: both draw from the same injected registry,
+                    // and a single shared `MockProvider` instance's call-count-based
+                    // "return a tool call on the first call" logic would otherwise be
+                    // consumed by the title-generation call, leaving the stage's own
+                    // first (real) call already past index 0 -- silently skipping the
+                    // exec-closure tool-call round trip this test exists to cover.
+                    fake_config.title.provider = Some("title-mock".to_string());
+                    fake_config.title.model = Some("title-mock-model".to_string());
+                    std::fs::write(
+                        Config::config_path(),
+                        toml::to_string(&fake_config).unwrap(),
+                    )
+                    .unwrap();
 
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-mock-provider");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+                    let temp_dir = std::env::temp_dir().join("lev-test-worker-mock-provider");
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    let manifest_content = r#"
 [agent]
 name = "test-worker-mock-agent"
 version = "1.0.0"
@@ -2975,40 +3075,45 @@ model = "mock-model"
 [tool_permissions]
 bash = "ask"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+                    write_test_agent(&temp_dir, manifest_content);
 
-        let run_id = "test-worker-mock-provider-round-trip";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        let mut meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+                    let run_id = "test-worker-mock-provider-round-trip";
+                    let dir = crate::runstate::run_dir(run_id);
+                    let _ = std::fs::create_dir_all(&dir);
+                    let mut meta = make_meta(run_id, 1);
+                    crate::runstate::create_run(&meta).unwrap();
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "test task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: true,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "test task".to_string(),
+                        run_id: run_id.to_string(),
+                        model: None,
+                        yolo: true,
+                        allow: vec![],
+                        ask: vec![],
+                        deny: vec![],
+                        max_depth: None,
+                    };
 
-        let result = run_worker_inner(&args, &mut meta, |_config| {
-            let mut registry = leviath_runtime::ProviderRegistry::new();
-            registry.register("anthropic".to_string(), Arc::new(MockProvider::new()));
-            registry.register("title-mock".to_string(), Arc::new(MockProvider::new()));
-            registry
-        })
+                    let result = run_worker_inner(&args, &mut meta, |_config| {
+                        let mut registry = leviath_runtime::ProviderRegistry::new();
+                        registry.register("anthropic".to_string(), Arc::new(MockProvider::new()));
+                        registry.register("title-mock".to_string(), Arc::new(MockProvider::new()));
+                        registry
+                    })
+                    .await;
+
+                    result.expect("expected clean completion from run_worker_inner");
+                    // generate_title should have produced a title via the mock provider.
+                    assert!(meta.title.is_some());
+
+                    let _ = std::fs::remove_dir_all(&dir);
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
         .await;
-
-        result.expect("expected clean completion from run_worker_inner");
-        // generate_title should have produced a title via the mock provider.
-        assert!(meta.title.is_some());
-
-        let _ = std::fs::remove_dir_all(&dir);
-        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[test]
@@ -3023,18 +3128,17 @@ bash = "ask"
 
     #[tokio::test]
     async fn execute_worker_with_yolo_false_and_empty_overrides() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "execute_worker_with_yolo_false_and_empty_overrides",
-        );
-        // Redirect $HOME so Config::load() can't see a real config/API key —
-        // otherwise this would make a real, billed inference call via
-        // generate_title(). See CONFIG_PATH_ENV_LOCK/isolate_config_path above.
-        let _config_guard = isolate_config_path("no-yolo");
-
-        // Valid manifest, yolo=false, no allow/ask/deny
-        let temp_dir = std::env::temp_dir().join("lev-test-worker-no-yolo");
-        let _ = std::fs::create_dir_all(&temp_dir);
-        let manifest_content = r#"
+            |_d| async move {
+                // Redirect $HOME so Config::load() can't see a real config/API key —
+                // otherwise this would make a real, billed inference call via
+                // generate_title(). See CONFIG_PATH_ENV_LOCK/isolate_config_path above.
+                with_isolated_config_path_async("no-yolo", |_fake_dir| async move {
+                    // Valid manifest, yolo=false, no allow/ask/deny
+                    let temp_dir = std::env::temp_dir().join("lev-test-worker-no-yolo");
+                    let _ = std::fs::create_dir_all(&temp_dir);
+                    let manifest_content = r#"
 [agent]
 name = "no-yolo-agent"
 version = "1.0.0"
@@ -3043,29 +3147,34 @@ description = "Test"
 [stages.main]
 mode = "autonomous"
 "#;
-        write_test_agent(&temp_dir, manifest_content);
+                    write_test_agent(&temp_dir, manifest_content);
 
-        let run_id = "test-execute-worker-no-yolo";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+                    let run_id = "test-execute-worker-no-yolo";
+                    let dir = crate::runstate::run_dir(run_id);
+                    let _ = std::fs::create_dir_all(&dir);
 
-        let args = WorkerArgs {
-            path: temp_dir.to_string_lossy().to_string(),
-            task: "minimal task".to_string(),
-            run_id: run_id.to_string(),
-            model: None,
-            yolo: false,
-            allow: vec![],
-            ask: vec![],
-            deny: vec![],
-            max_depth: None,
-        };
+                    let args = WorkerArgs {
+                        path: temp_dir.to_string_lossy().to_string(),
+                        task: "minimal task".to_string(),
+                        run_id: run_id.to_string(),
+                        model: None,
+                        yolo: false,
+                        allow: vec![],
+                        ask: vec![],
+                        deny: vec![],
+                        max_depth: None,
+                    };
 
-        let result = execute_worker(args).await;
-        let _ = result;
+                    let result = execute_worker(args).await;
+                    let _ = result;
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
-        let _ = std::fs::remove_dir_all(&temp_dir);
+                    let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                })
+                .await;
+            },
+        )
+        .await;
     }
 
     // ─── WorkerCallbacks::run_autonomous ─────────────────────────────────────
@@ -3129,174 +3238,189 @@ mode = "autonomous"
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_error_graph_mode_with_full_state() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_error_graph_mode_with_full_state",
-        );
-        let run_id = "test-worker-stage-err-graph2";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        let stage_dir = crate::runstate::stage_dir(run_id, 0);
-        let _ = std::fs::create_dir_all(&stage_dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-err-graph2";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+                let stage_dir = crate::runstate::stage_dir(run_id, 0);
+                let _ = std::fs::create_dir_all(&stage_dir);
 
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = make_meta(run_id, 2);
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 2,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = make_meta(run_id, 2);
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 2,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // graph mode → Some(StageResult::Error) returned; meta NOT set to Error
-        let err = anyhow::anyhow!("graph stage error");
-        let result = cb.on_stage_error("main", 0, &err, true).await;
-        assert_eq!(result, Some(leviath_core::blueprint::StageResult::Error));
-        // In graph mode, meta status is NOT changed to Error (unlike linear)
-        assert_ne!(cb.meta.status, RunStatus::Error);
+                // graph mode → Some(StageResult::Error) returned; meta NOT set to Error
+                let err = anyhow::anyhow!("graph stage error");
+                let result = cb.on_stage_error("main", 0, &err, true).await;
+                assert_eq!(result, Some(leviath_core::blueprint::StageResult::Error));
+                // In graph mode, meta status is NOT changed to Error (unlike linear)
+                assert_ne!(cb.meta.status, RunStatus::Error);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── on_provider_missing: stages index has no entry at stage_idx ─────────
 
     #[tokio::test]
     async fn worker_callbacks_on_provider_missing_empty_stages() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_provider_missing_empty_stages",
-        );
-        let run_id = "test-worker-prov-miss-empty";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-prov-miss-empty";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        // Write empty stages index (stage_idx=0 won't match)
-        let stages: Vec<crate::runstate::StageRecord> = vec![];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                // Write empty stages index (stage_idx=0 won't match)
+                let stages: Vec<crate::runstate::StageRecord> = vec![];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = make_meta(run_id, 0);
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 0,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = make_meta(run_id, 0);
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 0,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let result = cb.on_provider_missing("missing-provider", 0).await;
-        // Should abort run.
-        assert!(result);
-        assert_eq!(cb.meta.status, RunStatus::Error);
+                let result = cb.on_provider_missing("missing-provider", 0).await;
+                // Should abort run.
+                assert!(result);
+                assert_eq!(cb.meta.status, RunStatus::Error);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── on_complete with max stages, checks correct log path ────────────────
 
     #[tokio::test]
     async fn worker_callbacks_on_complete_logs_to_last_stage() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_complete_logs_to_last_stage",
-        );
-        let run_id = "test-worker-complete-log";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
-        // Create the stage log dir for stage 2 (last_stage_idx=2)
-        let stage_dir = crate::runstate::stage_dir(run_id, 2);
-        let _ = std::fs::create_dir_all(&stage_dir);
+            |_d| async move {
+                let run_id = "test-worker-complete-log";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
+                // Create the stage log dir for stage 2 (last_stage_idx=2)
+                let stage_dir = crate::runstate::stage_dir(run_id, 2);
+                let _ = std::fs::create_dir_all(&stage_dir);
 
-        let mut meta = make_meta(run_id, 3);
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 3,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut meta = make_meta(run_id, 3);
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 3,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // Should not panic even with stages > 0
-        cb.on_complete(2).await;
+                // Should not panic even with stages > 0
+                cb.on_complete(2).await;
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── on_stage_enter when stage index is out of bounds ────────────────────
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_enter_out_of_bounds_stage_idx() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_enter_out_of_bounds_stage_idx",
-        );
-        let run_id = "test-worker-stage-enter-oob";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-enter-oob";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        // Only one stage in index but we request idx=5
-        let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
-        let _ = crate::runstate::write_stages_index(run_id, &stages);
+                // Only one stage in index but we request idx=5
+                let stages = vec![crate::runstate::StageRecord::new("main".to_string(), 0)];
+                let _ = crate::runstate::write_stages_index(run_id, &stages);
 
-        let mut meta = make_meta(run_id, 1);
-        let _ = crate::runstate::write_meta(&meta);
+                let mut meta = make_meta(run_id, 1);
+                let _ = crate::runstate::write_meta(&meta);
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 1,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 1,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        // stage_idx=5 but only 1 stage — the `if let Some(r)` guard handles this safely
-        cb.on_stage_enter("extra", 5, "anthropic", "claude-sonnet-4-6", "")
-            .await;
-        assert_eq!(cb.meta.current_stage, "extra");
-        assert_eq!(cb.meta.stage_index, 5);
+                // stage_idx=5 but only 1 stage — the `if let Some(r)` guard handles this safely
+                cb.on_stage_enter("extra", 5, "anthropic", "claude-sonnet-4-6", "")
+                    .await;
+                assert_eq!(cb.meta.current_stage, "extra");
+                assert_eq!(cb.meta.stage_index, 5);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── on_stage_error linear mode when stages idx is out of bounds ──────────
 
     #[tokio::test]
     async fn worker_callbacks_on_stage_error_linear_out_of_bounds() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_callbacks_on_stage_error_linear_out_of_bounds",
-        );
-        let run_id = "test-worker-stage-err-linear-oob";
-        let dir = crate::runstate::run_dir(run_id);
-        let _ = std::fs::create_dir_all(&dir);
+            |_d| async move {
+                let run_id = "test-worker-stage-err-linear-oob";
+                let dir = crate::runstate::run_dir(run_id);
+                let _ = std::fs::create_dir_all(&dir);
 
-        // Empty stages index
-        let _ = crate::runstate::write_stages_index(run_id, &[]);
+                // Empty stages index
+                let _ = crate::runstate::write_stages_index(run_id, &[]);
 
-        let mut meta = make_meta(run_id, 0);
-        let _ = crate::runstate::write_meta(&meta);
+                let mut meta = make_meta(run_id, 0);
+                let _ = crate::runstate::write_meta(&meta);
 
-        let mut cb = WorkerCallbacks {
-            run_id: run_id.to_string(),
-            meta: &mut meta,
-            blueprint_stages_len: 0,
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            taint_global: false,
-            taint_policy: leviath_core::PolicyConfig::default(),
-            context_window: Arc::new(Mutex::new(None)),
-        };
+                let mut cb = WorkerCallbacks {
+                    run_id: run_id.to_string(),
+                    meta: &mut meta,
+                    blueprint_stages_len: 0,
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    taint_global: false,
+                    taint_policy: leviath_core::PolicyConfig::default(),
+                    context_window: Arc::new(Mutex::new(None)),
+                };
 
-        let err = anyhow::anyhow!("oob error");
-        let result = cb.on_stage_error("main", 99, &err, false).await;
-        assert!(result.is_none());
-        assert_eq!(cb.meta.status, RunStatus::Error);
+                let err = anyhow::anyhow!("oob error");
+                let result = cb.on_stage_error("main", 99, &err, false).await;
+                assert!(result.is_none());
+                assert_eq!(cb.meta.status, RunStatus::Error);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            },
+        )
+        .await;
     }
 
     // ─── WorkerInteractionBackend ───────────────────────────────────────────
@@ -3305,82 +3429,93 @@ mode = "autonomous"
 
     #[tokio::test]
     async fn worker_interaction_backend_ask_delegates_to_bg_review() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "worker_interaction_backend_ask_delegates_to_bg_review",
-        );
-        let run_id = "test-worker-backend-ask";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = "test-worker-backend-ask";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::text("ask-1", "the answer");
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::text("ask-1", "the answer");
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let backend = WorkerInteractionBackend {
-            run_id,
-            stage_idx: 0,
-        };
-        let req =
-            crate::interaction::InteractionRequest::free_text("ask-1", "Question?", "main", true);
-        let resp = backend.ask(req).await;
-        assert_eq!(resp.value.as_deref(), Some("the answer"));
+                let backend = WorkerInteractionBackend {
+                    run_id,
+                    stage_idx: 0,
+                };
+                let req = crate::interaction::InteractionRequest::free_text(
+                    "ask-1",
+                    "Question?",
+                    "main",
+                    true,
+                );
+                let resp = backend.ask(req).await;
+                assert_eq!(resp.value.as_deref(), Some("the answer"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[test]
     fn worker_interaction_backend_log_writes_to_stage_log() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "worker_interaction_backend_log_writes_to_stage_log",
+            |_d| {
+                let run_id = "test-worker-backend-log";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let backend = WorkerInteractionBackend {
+                    run_id,
+                    stage_idx: 0,
+                };
+                backend.log("[tool] ask_user_text \u{2192} waiting: hello");
+
+                let log_contents = crate::runstate::tail_stage_log(run_id, 0, 65536);
+                assert!(log_contents.contains("ask_user_text"));
+                assert!(log_contents.contains("hello"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-worker-backend-log";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let backend = WorkerInteractionBackend {
-            run_id,
-            stage_idx: 0,
-        };
-        backend.log("[tool] ask_user_text \u{2192} waiting: hello");
-
-        let log_contents = crate::runstate::tail_stage_log(run_id, 0, 65536);
-        assert!(log_contents.contains("ask_user_text"));
-        assert!(log_contents.contains("hello"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn worker_interaction_backend_on_review_document_persists_artifact_and_output() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "worker_interaction_backend_on_review_document_persists_artifact_and_output",
+            |_d| {
+                let run_id = "test-worker-backend-review-doc";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let backend = WorkerInteractionBackend {
+                    run_id,
+                    stage_idx: 0,
+                };
+                backend.on_review_document("call-42", "My Title", "# Body\ncontent");
+
+                let artifact_path = crate::runstate::stage_dir(run_id, 0)
+                    .join("reviews")
+                    .join("review-call-42.md");
+                let artifact = std::fs::read_to_string(&artifact_path).unwrap();
+                assert_eq!(artifact, "# Body\ncontent");
+
+                let output = crate::runstate::tail_stage_output(run_id, 0, 65536);
+                assert!(output.contains("My Title"));
+                assert!(output.contains("# Body\ncontent"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-worker-backend-review-doc";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let backend = WorkerInteractionBackend {
-            run_id,
-            stage_idx: 0,
-        };
-        backend.on_review_document("call-42", "My Title", "# Body\ncontent");
-
-        let artifact_path = crate::runstate::stage_dir(run_id, 0)
-            .join("reviews")
-            .join("review-call-42.md");
-        let artifact = std::fs::read_to_string(&artifact_path).unwrap();
-        assert_eq!(artifact, "# Body\ncontent");
-
-        let output = crate::runstate::tail_stage_output(run_id, 0, 65536);
-        assert!(output.contains("My Title"));
-        assert!(output.contains("# Body\ncontent"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── dispatch_tool_calls ────────────────────────────────────────────────
@@ -3432,458 +3567,491 @@ mode = "autonomous"
 
     #[tokio::test]
     async fn dispatch_tool_calls_deny_policy_returns_denied_message() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_deny_policy_returns_denied_message",
-        );
-        let run_id = "test-dispatch-deny";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-deny";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("bash".to_string(), ToolPolicy::Deny);
-        state.global_perms = Arc::new(global);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("bash".to_string(), ToolPolicy::Deny);
+                state.global_perms = Arc::new(global);
 
-        let calls = vec![make_tool_call("bash", serde_json::json!({"command": "ls"}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("bash", serde_json::json!({"command": "ls"}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-bash");
-        assert!(out[0].1.contains("[denied]"));
-        assert!(out[0].1.contains("not permitted"));
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-bash");
+                assert!(out[0].1.contains("[denied]"));
+                assert!(out[0].1.contains("not permitted"));
 
-        let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
-        assert!(log.contains("denied"));
+                let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
+                assert!(log.contains("denied"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_allow_builtin_executes_and_logs() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_allow_builtin_executes_and_logs",
-        );
-        let run_id = "test-dispatch-allow-builtin";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-allow-builtin";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut launch = std::collections::HashMap::new();
-        launch.insert("*".to_string(), ToolPolicy::Allow);
-        state.launch_overrides = Arc::new(launch);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut launch = std::collections::HashMap::new();
+                launch.insert("*".to_string(), ToolPolicy::Allow);
+                state.launch_overrides = Arc::new(launch);
 
-        // read_file on a file that doesn't exist still returns a (tool-level)
-        // error string rather than panicking, which is enough to prove the
-        // builtin execution path ran.
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "definitely-not-here.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                // read_file on a file that doesn't exist still returns a (tool-level)
+                // error string rather than panicking, which is enough to prove the
+                // builtin execution path ran.
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "definitely-not-here.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-read_file");
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-read_file");
 
-        let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
-        assert!(log.contains("read_file"));
+                let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
+                assert!(log.contains("read_file"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_result_truncated_when_long() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_result_truncated_when_long",
-        );
-        let run_id = "test-dispatch-truncate";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-truncate";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        // Write a file with content long enough that its read_file result
-        // exceeds 120 chars, exercising the truncation branch of the
-        // activity-log message (the returned tool result itself is never
-        // truncated -- only the short-form log line is).
-        let file_path = dir.join("big.txt");
-        let long_content = "x".repeat(500);
-        std::fs::write(&file_path, &long_content).unwrap();
+                // Write a file with content long enough that its read_file result
+                // exceeds 120 chars, exercising the truncation branch of the
+                // activity-log message (the returned tool result itself is never
+                // truncated -- only the short-form log line is).
+                let file_path = dir.join("big.txt");
+                let long_content = "x".repeat(500);
+                std::fs::write(&file_path, &long_content).unwrap();
 
-        let workdir = dir.clone();
-        let config = Config::default();
-        let tool_registry = ToolRegistry::build(workdir, &config).await;
-        let mut launch = std::collections::HashMap::new();
-        launch.insert("*".to_string(), ToolPolicy::Allow);
-        let state = ToolDispatchState {
-            builtins: tool_registry.builtins.clone(),
-            mcp: tool_registry.mcp.clone(),
-            builtin_names: tool_registry.builtin_names.clone(),
-            launch_overrides: Arc::new(launch),
-            session_allows: Arc::new(Mutex::new(std::collections::HashSet::new())),
-            stage_perms: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            agent_perms: Arc::new(std::collections::HashMap::new()),
-            global_perms: Arc::new(std::collections::HashMap::new()),
-            run_id: Arc::new(run_id.to_string()),
-            stage_idx: Arc::new(Mutex::new(0usize)),
-            stage_name: Arc::new(Mutex::new("main".to_string())),
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            iteration_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            context_window: Arc::new(Mutex::new(None)),
-            file_tracking: None,
-        };
+                let workdir = dir.clone();
+                let config = Config::default();
+                let tool_registry = ToolRegistry::build(workdir, &config).await;
+                let mut launch = std::collections::HashMap::new();
+                launch.insert("*".to_string(), ToolPolicy::Allow);
+                let state = ToolDispatchState {
+                    builtins: tool_registry.builtins.clone(),
+                    mcp: tool_registry.mcp.clone(),
+                    builtin_names: tool_registry.builtin_names.clone(),
+                    launch_overrides: Arc::new(launch),
+                    session_allows: Arc::new(Mutex::new(std::collections::HashSet::new())),
+                    stage_perms: Arc::new(Mutex::new(std::collections::HashMap::new())),
+                    agent_perms: Arc::new(std::collections::HashMap::new()),
+                    global_perms: Arc::new(std::collections::HashMap::new()),
+                    run_id: Arc::new(run_id.to_string()),
+                    stage_idx: Arc::new(Mutex::new(0usize)),
+                    stage_name: Arc::new(Mutex::new("main".to_string())),
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    iteration_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    context_window: Arc::new(Mutex::new(None)),
+                    file_tracking: None,
+                };
 
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "big.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "big.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        // Full (untruncated) result is returned to the model.
-        assert!(out[0].1.contains(&long_content));
+                assert_eq!(out.len(), 1);
+                // Full (untruncated) result is returned to the model.
+                assert!(out[0].1.contains(&long_content));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_session_allow_short_circuits_policy_resolution() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_session_allow_short_circuits_policy_resolution",
-        );
-        let run_id = "test-dispatch-session-allow";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-session-allow";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        // Global policy says Deny, but session_allows already contains the
-        // tool, so it should be treated as Allow regardless.
-        let mut global = std::collections::HashMap::new();
-        global.insert("read_file".to_string(), ToolPolicy::Deny);
-        state.global_perms = Arc::new(global);
-        state
-            .session_allows
-            .lock()
-            .await
-            .insert("read_file".to_string());
+                let mut state = make_dispatch_state(run_id).await;
+                // Global policy says Deny, but session_allows already contains the
+                // tool, so it should be treated as Allow regardless.
+                let mut global = std::collections::HashMap::new();
+                global.insert("read_file".to_string(), ToolPolicy::Deny);
+                state.global_perms = Arc::new(global);
+                state
+                    .session_allows
+                    .lock()
+                    .await
+                    .insert("read_file".to_string());
 
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "definitely-not-here.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "definitely-not-here.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        // Not denied -- session allow overrode the global Deny.
-        assert!(!out[0].1.contains("[denied]"));
+                assert_eq!(out.len(), 1);
+                // Not denied -- session allow overrode the global Deny.
+                assert!(!out[0].1.contains("[denied]"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_approved_executes_tool() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_approved_executes_tool",
-        );
-        let run_id = "test-dispatch-ask-approved";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-ask-approved";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("read_file".to_string(), ToolPolicy::Ask);
-        state.global_perms = Arc::new(global);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("read_file".to_string(), ToolPolicy::Ask);
+                state.global_perms = Arc::new(global);
 
-        // Compute the request id the same way `request_tool_approval_background`
-        // does, so our canned response matches.
-        let tool_name = "read_file";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
+                // Compute the request id the same way `request_tool_approval_background`
+                // does, so our canned response matches.
+                let tool_name = "read_file";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
 
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id_clone,
-                true,
-                crate::interaction::ApprovalScope::Session,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id_clone,
+                        true,
+                        crate::interaction::ApprovalScope::Session,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "definitely-not-here.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "definitely-not-here.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        // Session scope approval should have been recorded.
-        assert!(state.session_allows.lock().await.contains("read_file"));
+                assert_eq!(out.len(), 1);
+                // Session scope approval should have been recorded.
+                assert!(state.session_allows.lock().await.contains("read_file"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_approved_mcp_tool_returns_error_text() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_approved_mcp_tool_returns_error_text",
-        );
-        // Not a builtin name and no MCP server registered -> the MCP
-        // execute() path returns Err, exercising the `Err(e)` arm of the
-        // Ask-branch's MCP dispatch (as opposed to the builtin-execution arm
-        // already covered by `dispatch_tool_calls_ask_approved_executes_tool`).
-        let run_id = "test-dispatch-ask-approved-mcp";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // Not a builtin name and no MCP server registered -> the MCP
+                // execute() path returns Err, exercising the `Err(e)` arm of the
+                // Ask-branch's MCP dispatch (as opposed to the builtin-execution arm
+                // already covered by `dispatch_tool_calls_ask_approved_executes_tool`).
+                let run_id = "test-dispatch-ask-approved-mcp";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("some_mcp_tool".to_string(), ToolPolicy::Ask);
-        state.global_perms = Arc::new(global);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("some_mcp_tool".to_string(), ToolPolicy::Ask);
+                state.global_perms = Arc::new(global);
 
-        let tool_name = "some_mcp_tool";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
+                let tool_name = "some_mcp_tool";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
 
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id_clone,
-                true,
-                crate::interaction::ApprovalScope::Once,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id_clone,
+                        true,
+                        crate::interaction::ApprovalScope::Once,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call("some_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("some_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert!(out[0].1.contains("[error]"));
+                assert_eq!(out.len(), 1);
+                assert!(out[0].1.contains("[error]"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_allow_mcp_tool_returns_error_text() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_allow_mcp_tool_returns_error_text",
-        );
-        // Same as above but via the Allow branch's MCP dispatch (lines
-        // distinct from the Ask branch's identical match).
-        let run_id = "test-dispatch-allow-mcp";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                // Same as above but via the Allow branch's MCP dispatch (lines
+                // distinct from the Ask branch's identical match).
+                let run_id = "test-dispatch-allow-mcp";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut launch = std::collections::HashMap::new();
-        launch.insert("*".to_string(), ToolPolicy::Allow);
-        state.launch_overrides = Arc::new(launch);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut launch = std::collections::HashMap::new();
+                launch.insert("*".to_string(), ToolPolicy::Allow);
+                state.launch_overrides = Arc::new(launch);
 
-        let calls = vec![make_tool_call("some_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("some_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert!(out[0].1.contains("[error]"));
+                assert_eq!(out.len(), 1);
+                assert!(out[0].1.contains("[error]"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_approved_long_result_is_truncated_in_log() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_approved_long_result_is_truncated_in_log",
-        );
-        // The Ask branch's own truncation computation (distinct from the
-        // Allow branch's, covered by `dispatch_tool_calls_result_truncated_when_long`)
-        // had no test driving a long result through an Ask-approved call.
-        let run_id = "test-dispatch-ask-truncate";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // The Ask branch's own truncation computation (distinct from the
+                // Allow branch's, covered by `dispatch_tool_calls_result_truncated_when_long`)
+                // had no test driving a long result through an Ask-approved call.
+                let run_id = "test-dispatch-ask-truncate";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let long_content = "y".repeat(500);
-        std::fs::write(dir.join("big.txt"), &long_content).unwrap();
+                let long_content = "y".repeat(500);
+                std::fs::write(dir.join("big.txt"), &long_content).unwrap();
 
-        let workdir = dir.clone();
-        let config = Config::default();
-        let tool_registry = ToolRegistry::build(workdir, &config).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("read_file".to_string(), ToolPolicy::Ask);
-        let state = ToolDispatchState {
-            builtins: tool_registry.builtins.clone(),
-            mcp: tool_registry.mcp.clone(),
-            builtin_names: tool_registry.builtin_names.clone(),
-            launch_overrides: Arc::new(std::collections::HashMap::new()),
-            session_allows: Arc::new(Mutex::new(std::collections::HashSet::new())),
-            stage_perms: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            agent_perms: Arc::new(std::collections::HashMap::new()),
-            global_perms: Arc::new(global),
-            run_id: Arc::new(run_id.to_string()),
-            stage_idx: Arc::new(Mutex::new(0usize)),
-            stage_name: Arc::new(Mutex::new("main".to_string())),
-            tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            iteration_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            context_window: Arc::new(Mutex::new(None)),
-            file_tracking: None,
-        };
+                let workdir = dir.clone();
+                let config = Config::default();
+                let tool_registry = ToolRegistry::build(workdir, &config).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("read_file".to_string(), ToolPolicy::Ask);
+                let state = ToolDispatchState {
+                    builtins: tool_registry.builtins.clone(),
+                    mcp: tool_registry.mcp.clone(),
+                    builtin_names: tool_registry.builtin_names.clone(),
+                    launch_overrides: Arc::new(std::collections::HashMap::new()),
+                    session_allows: Arc::new(Mutex::new(std::collections::HashSet::new())),
+                    stage_perms: Arc::new(Mutex::new(std::collections::HashMap::new())),
+                    agent_perms: Arc::new(std::collections::HashMap::new()),
+                    global_perms: Arc::new(global),
+                    run_id: Arc::new(run_id.to_string()),
+                    stage_idx: Arc::new(Mutex::new(0usize)),
+                    stage_name: Arc::new(Mutex::new("main".to_string())),
+                    tool_calls_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    iteration_counter: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                    context_window: Arc::new(Mutex::new(None)),
+                    file_tracking: None,
+                };
 
-        let tool_name = "read_file";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
+                let tool_name = "read_file";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
 
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id_clone,
-                true,
-                crate::interaction::ApprovalScope::Once,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id_clone,
+                        true,
+                        crate::interaction::ApprovalScope::Once,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "big.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "big.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        // Full (untruncated) result is returned to the model.
-        assert!(out[0].1.contains(&long_content));
+                assert_eq!(out.len(), 1);
+                // Full (untruncated) result is returned to the model.
+                assert!(out[0].1.contains(&long_content));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_denied_returns_declined_message() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_denied_returns_declined_message",
-        );
-        let run_id = "test-dispatch-ask-denied";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-ask-denied";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("read_file".to_string(), ToolPolicy::Ask);
-        state.global_perms = Arc::new(global);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("read_file".to_string(), ToolPolicy::Ask);
+                state.global_perms = Arc::new(global);
 
-        let tool_name = "read_file";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
+                let tool_name = "read_file";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
 
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id_clone,
-                false,
-                crate::interaction::ApprovalScope::Once,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id_clone,
+                        false,
+                        crate::interaction::ApprovalScope::Once,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call(
-            "read_file",
-            serde_json::json!({"path": "definitely-not-here.txt"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "read_file",
+                    serde_json::json!({"path": "definitely-not-here.txt"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert!(out[0].1.contains("[denied]"));
-        assert!(out[0].1.contains("declined"));
-        assert!(!state.session_allows.lock().await.contains("read_file"));
+                assert_eq!(out.len(), 1);
+                assert!(out[0].1.contains("[denied]"));
+                assert!(out[0].1.contains("declined"));
+                assert!(!state.session_allows.lock().await.contains("read_file"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_dynamic_interaction_short_circuits() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_dynamic_interaction_short_circuits",
-        );
-        let run_id = "test-dispatch-dynamic-interaction";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-dynamic-interaction";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let state = make_dispatch_state(run_id).await;
+                let state = make_dispatch_state(run_id).await;
 
-        // `handle_ask_user_text` (via `dispatch_dynamic_interaction`) never
-        // times out -- it blocks on `request_interaction_bg_review` until a
-        // response is written. Its request id is deterministically
-        // `ask-<tool_call_id>` (see dynamic_interaction.rs), so we can
-        // pre-compute it and answer in the background.
-        let req_id = "ask-call-ask_user_text".to_string();
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-            let resp = crate::interaction::InteractionResponse::text(&req_id, "hi there");
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                // `handle_ask_user_text` (via `dispatch_dynamic_interaction`) never
+                // times out -- it blocks on `request_interaction_bg_review` until a
+                // response is written. Its request id is deterministically
+                // `ask-<tool_call_id>` (see dynamic_interaction.rs), so we can
+                // pre-compute it and answer in the background.
+                let req_id = "ask-call-ask_user_text".to_string();
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                    let resp = crate::interaction::InteractionResponse::text(&req_id, "hi there");
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call(
-            "ask_user_text",
-            serde_json::json!({"prompt": "What is your name?"}),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "ask_user_text",
+                    serde_json::json!({"prompt": "What is your name?"}),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-ask_user_text");
-        assert!(out[0].1.contains("hi there"));
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-ask_user_text");
+                assert!(out[0].1.contains("hi there"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_multiple_calls_preserve_order() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_multiple_calls_preserve_order",
-        );
-        let run_id = "test-dispatch-multi";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-multi";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut global = std::collections::HashMap::new();
-        global.insert("bash".to_string(), ToolPolicy::Deny);
-        global.insert("read_file".to_string(), ToolPolicy::Allow);
-        state.global_perms = Arc::new(global);
+                let mut state = make_dispatch_state(run_id).await;
+                let mut global = std::collections::HashMap::new();
+                global.insert("bash".to_string(), ToolPolicy::Deny);
+                global.insert("read_file".to_string(), ToolPolicy::Allow);
+                state.global_perms = Arc::new(global);
 
-        let calls = vec![
-            make_tool_call("bash", serde_json::json!({"command": "ls"})),
-            make_tool_call("read_file", serde_json::json!({"path": "nope.txt"})),
-        ];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![
+                    make_tool_call("bash", serde_json::json!({"command": "ls"})),
+                    make_tool_call("read_file", serde_json::json!({"path": "nope.txt"})),
+                ];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 2);
-        assert_eq!(out[0].0, "call-bash");
-        assert!(out[0].1.contains("[denied]"));
-        assert_eq!(out[1].0, "call-read_file");
-        assert!(!out[1].1.contains("[denied]"));
+                assert_eq!(out.len(), 2);
+                assert_eq!(out[0].0, "call-bash");
+                assert!(out[0].1.contains("[denied]"));
+                assert_eq!(out[1].0, "call-read_file");
+                assert!(!out[1].1.contains("[denied]"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── MCP Ok(r) arms: lines 132-133, 163-164 ──────────────────────────────
@@ -4002,144 +4170,165 @@ for line in sys.stdin:
 
     #[tokio::test]
     async fn dispatch_tool_calls_allow_mcp_ok_success_returns_text() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_allow_mcp_ok_success_returns_text",
-        );
-        // Covers line 163: `Ok(r) if r.success => r.text`
-        let run_id = "test-dispatch-allow-mcp-ok-success";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // Covers line 163: `Ok(r) if r.success => r.text`
+                let run_id = "test-dispatch-allow-mcp-ok-success";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let state =
-            make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_SUCCESS, ToolPolicy::Allow).await;
+                let state =
+                    make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_SUCCESS, ToolPolicy::Allow)
+                        .await;
 
-        let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-stub_mcp_tool");
-        let has_ok_text = out[0].1.contains("ok result from stub");
-        // Expected success text.
-        assert!(has_ok_text);
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-stub_mcp_tool");
+                let has_ok_text = out[0].1.contains("ok result from stub");
+                // Expected success text.
+                assert!(has_ok_text);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_allow_mcp_ok_error_result_returns_error_prefix() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_allow_mcp_ok_error_result_returns_error_prefix",
-        );
-        // Covers line 164: `Ok(r) => format!("[error] {}", r.text)` (isError: true)
-        let run_id = "test-dispatch-allow-mcp-ok-error-result";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // Covers line 164: `Ok(r) => format!("[error] {}", r.text)` (isError: true)
+                let run_id = "test-dispatch-allow-mcp-ok-error-result";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let state =
-            make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_ERROR_RESULT, ToolPolicy::Allow)
+                let state = make_dispatch_state_with_mcp_tool(
+                    run_id,
+                    MCP_STUB_ERROR_RESULT,
+                    ToolPolicy::Allow,
+                )
                 .await;
 
-        let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-stub_mcp_tool");
-        let has_error_prefix = out[0].1.starts_with("[error]");
-        // Expected [error] prefix.
-        assert!(has_error_prefix);
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-stub_mcp_tool");
+                let has_error_prefix = out[0].1.starts_with("[error]");
+                // Expected [error] prefix.
+                assert!(has_error_prefix);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── Ask branch MCP Ok(r) arms (lines 132-133) ───────────────────────────
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_approved_mcp_ok_success_returns_text() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_approved_mcp_ok_success_returns_text",
-        );
-        // Covers line 132: `Ok(r) if r.success => r.text` in the Ask branch
-        let run_id = "test-dispatch-ask-mcp-ok-success";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // Covers line 132: `Ok(r) if r.success => r.text` in the Ask branch
+                let run_id = "test-dispatch-ask-mcp-ok-success";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let state =
-            make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_SUCCESS, ToolPolicy::Ask).await;
+                let state =
+                    make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_SUCCESS, ToolPolicy::Ask)
+                        .await;
 
-        // Schedule approval response so the Ask branch doesn't block
-        let run_id_clone = run_id.to_string();
-        let tool_name = "stub_mcp_tool";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id,
-                true,
-                crate::interaction::ApprovalScope::Once,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                // Schedule approval response so the Ask branch doesn't block
+                let run_id_clone = run_id.to_string();
+                let tool_name = "stub_mcp_tool";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id,
+                        true,
+                        crate::interaction::ApprovalScope::Once,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        let has_ok_text = out[0].1.contains("ok result from stub");
-        // Expected success text.
-        assert!(has_ok_text);
+                assert_eq!(out.len(), 1);
+                let has_ok_text = out[0].1.contains("ok result from stub");
+                // Expected success text.
+                assert!(has_ok_text);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_tool_calls_ask_approved_mcp_ok_error_result_returns_error_prefix() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_ask_approved_mcp_ok_error_result_returns_error_prefix",
-        );
-        // Covers line 133: `Ok(r) => format!("[error] {}", r.text)` in the Ask branch
-        let run_id = "test-dispatch-ask-mcp-ok-error-result";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let meta = make_meta(run_id, 1);
-        crate::runstate::create_run(&meta).unwrap();
+            |_d| async move {
+                // Covers line 133: `Ok(r) => format!("[error] {}", r.text)` in the Ask branch
+                let run_id = "test-dispatch-ask-mcp-ok-error-result";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                let meta = make_meta(run_id, 1);
+                crate::runstate::create_run(&meta).unwrap();
 
-        let state =
-            make_dispatch_state_with_mcp_tool(run_id, MCP_STUB_ERROR_RESULT, ToolPolicy::Ask).await;
+                let state = make_dispatch_state_with_mcp_tool(
+                    run_id,
+                    MCP_STUB_ERROR_RESULT,
+                    ToolPolicy::Ask,
+                )
+                .await;
 
-        let run_id_clone = run_id.to_string();
-        let tool_name = "stub_mcp_tool";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = crate::interaction::make_interaction_id(hash, 0);
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            let resp = crate::interaction::InteractionResponse::approval(
-                &req_id,
-                true,
-                crate::interaction::ApprovalScope::Once,
-            );
-            crate::interaction::write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                let tool_name = "stub_mcp_tool";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = crate::interaction::make_interaction_id(hash, 0);
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    let resp = crate::interaction::InteractionResponse::approval(
+                        &req_id,
+                        true,
+                        crate::interaction::ApprovalScope::Once,
+                    );
+                    crate::interaction::write_response(&run_id_clone, &resp).ok();
+                });
 
-        let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call("stub_mcp_tool", serde_json::json!({}))];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        let has_error_prefix = out[0].1.starts_with("[error]");
-        // Expected [error] prefix.
-        assert!(has_error_prefix);
+                assert_eq!(out.len(), 1);
+                let has_error_prefix = out[0].1.starts_with("[error]");
+                // Expected [error] prefix.
+                assert!(has_error_prefix);
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── handle_context_tool tests ───────────────────────────────────────────
@@ -5474,34 +5663,37 @@ for line in sys.stdin:
     async fn dispatch_tool_calls_context_tool_routes_to_handler() {
         // A `context_*` tool call is routed to handle_context_tool and logged,
         // covering the `tc.name.starts_with("context_")` branch (lines 76-84).
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_context_tool_routes_to_handler",
-        );
-        let run_id = "test-dispatch-context-tool";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-context-tool";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        state.context_window = make_context_window_with_hashmap("notes");
+                let mut state = make_dispatch_state(run_id).await;
+                state.context_window = make_context_window_with_hashmap("notes");
 
-        let calls = vec![make_tool_call(
-            "context_write",
-            serde_json::json!({ "region": "notes", "key": "k", "content": "v" }),
-        )];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![make_tool_call(
+                    "context_write",
+                    serde_json::json!({ "region": "notes", "key": "k", "content": "v" }),
+                )];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, "call-context_write");
-        let write_result = &out[0].1;
-        assert!(
-            write_result.contains("Stored in 'notes'"),
-            "unexpected result: {write_result}",
-        );
+                assert_eq!(out.len(), 1);
+                assert_eq!(out[0].0, "call-context_write");
+                let write_result = &out[0].1;
+                assert!(
+                    write_result.contains("Stored in 'notes'"),
+                    "unexpected result: {write_result}",
+                );
 
-        let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
-        assert!(log.contains("context_write"));
+                let log = crate::runstate::tail_stage_log(run_id, 0, 65536);
+                assert!(log.contains("context_write"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -5509,61 +5701,63 @@ for line in sys.stdin:
         // With file tracking configured, `read_files` routes to
         // maybe_track_batch_read and other read/write tools route to
         // maybe_track_file, covering the file-tracking block (lines 201-221).
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "dispatch_tool_calls_file_tracking_read_and_batch",
-        );
-        let run_id = "test-dispatch-file-tracking";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-dispatch-file-tracking";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        // Create real files under the dispatch state's workdir (temp_dir).
-        let workdir = std::env::temp_dir();
-        let pid = std::process::id();
-        let single = format!("lev-dispatch-ft-single-{pid}.txt");
-        let batch = format!("lev-dispatch-ft-batch-{pid}.txt");
-        std::fs::write(workdir.join(&single), "single file body").unwrap();
-        std::fs::write(workdir.join(&batch), "batch file body").unwrap();
+                // Create real files under the dispatch state's workdir (temp_dir).
+                let workdir = std::env::temp_dir();
+                let pid = std::process::id();
+                let single = format!("lev-dispatch-ft-single-{pid}.txt");
+                let batch = format!("lev-dispatch-ft-batch-{pid}.txt");
+                std::fs::write(workdir.join(&single), "single file body").unwrap();
+                std::fs::write(workdir.join(&batch), "batch file body").unwrap();
 
-        let mut state = make_dispatch_state(run_id).await;
-        let mut launch = std::collections::HashMap::new();
-        launch.insert("*".to_string(), ToolPolicy::Allow);
-        state.launch_overrides = Arc::new(launch);
-        state.context_window = make_context_window_with_hashmap("files");
-        state.file_tracking = Some(make_file_tracking_config("files", true, true));
+                let mut state = make_dispatch_state(run_id).await;
+                let mut launch = std::collections::HashMap::new();
+                launch.insert("*".to_string(), ToolPolicy::Allow);
+                state.launch_overrides = Arc::new(launch);
+                state.context_window = make_context_window_with_hashmap("files");
+                state.file_tracking = Some(make_file_tracking_config("files", true, true));
 
-        let calls = vec![
-            make_tool_call(
-                "read_files",
-                serde_json::json!({ "paths": [batch.clone()] }),
-            ),
-            make_tool_call("read_file", serde_json::json!({ "path": single.clone() })),
-        ];
-        let out = dispatch_tool_calls(&state, calls).await;
+                let calls = vec![
+                    make_tool_call(
+                        "read_files",
+                        serde_json::json!({ "paths": [batch.clone()] }),
+                    ),
+                    make_tool_call("read_file", serde_json::json!({ "path": single.clone() })),
+                ];
+                let out = dispatch_tool_calls(&state, calls).await;
 
-        assert_eq!(out.len(), 2);
-        // read_files result was replaced with the batch summary.
-        let batch_result = &out[0].1;
-        assert!(
-            batch_result.contains("stored in your system prompt under [files]"),
-            "unexpected batch result: {batch_result}",
-        );
-        // read_file result was replaced with the single-file reference message.
-        let single_result = &out[1].1;
-        assert!(
-            single_result.contains("[files]") && single_result.contains("### ["),
-            "unexpected single result: {single_result}",
-        );
+                assert_eq!(out.len(), 2);
+                // read_files result was replaced with the batch summary.
+                let batch_result = &out[0].1;
+                assert!(
+                    batch_result.contains("stored in your system prompt under [files]"),
+                    "unexpected batch result: {batch_result}",
+                );
+                // read_file result was replaced with the single-file reference message.
+                let single_result = &out[1].1;
+                assert!(
+                    single_result.contains("[files]") && single_result.contains("### ["),
+                    "unexpected single result: {single_result}",
+                );
 
-        // Both files ended up in the HashMap region.
-        let guard = state.context_window.lock().await;
-        let region = guard.as_ref().unwrap().get_region("files").unwrap();
-        assert!(region.get_by_key(&batch).is_some());
-        assert!(region.get_by_key(&single).is_some());
-        drop(guard);
+                // Both files ended up in the HashMap region.
+                let guard = state.context_window.lock().await;
+                let region = guard.as_ref().unwrap().get_region("files").unwrap();
+                assert!(region.get_by_key(&batch).is_some());
+                assert!(region.get_by_key(&single).is_some());
 
-        let _ = std::fs::remove_file(workdir.join(&single));
-        let _ = std::fs::remove_file(workdir.join(&batch));
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_file(workdir.join(&single));
+                let _ = std::fs::remove_file(workdir.join(&batch));
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── handle_context_tool: remaining error / branch coverage ──────────────

--- a/crates/leviath-cli/src/commands/run/worker.rs
+++ b/crates/leviath-cli/src/commands/run/worker.rs
@@ -9,9 +9,10 @@ use tokio::sync::Mutex;
 
 use crate::config::{Config, ToolPolicy};
 use crate::runstate::{self, RunMeta, RunStatus, StageRecord, StageRunStatus};
-use crate::tools::{resolve_policy, ToolRegistry};
+use crate::tools::{ToolRegistry, resolve_policy};
 
-use super::executor::{run_stage_loop, StageCallbacks, StageContext};
+use super::WorkerArgs;
+use super::executor::{StageCallbacks, StageContext, run_stage_loop};
 use super::helpers::{
     build_context_snapshot, generate_title, initialize_context_window, record_stage_log,
     record_stage_output, write_context_snapshot_if_bg,
@@ -19,7 +20,6 @@ use super::helpers::{
 use super::io::{ConsoleIO, RunIO};
 use super::manifest::{find_manifest, parse_manifest};
 use super::session::build_provider_registry_from_config;
-use super::WorkerArgs;
 
 /// Tracks the current stage index for tool-activity logging from the executor closure.
 type CurrentStageIdx = Arc<Mutex<usize>>;
@@ -129,7 +129,7 @@ async fn dispatch_tool_calls(
             }
             ToolPolicy::Ask => {
                 use crate::interaction::{
-                    request_tool_approval_background, ApprovalScope, TOOL_APPROVAL_TIMEOUT,
+                    ApprovalScope, TOOL_APPROVAL_TIMEOUT, request_tool_approval_background,
                 };
                 let (approved, scope) = request_tool_approval_background(
                     &state.run_id,
@@ -579,13 +579,12 @@ async fn maybe_track_file(
 
     // Upsert into the HashMap region
     let mut guard = context_window.lock().await;
-    if let Some(window) = guard.as_mut() {
-        if let Some(region) = window.get_region_mut(&ft.region) {
-            if matches!(region.kind, leviath_core::RegionKind::HashMap { .. }) {
-                let _ = region.upsert_by_key(&path, file_content, tokens);
-                return replacement_msg;
-            }
-        }
+    if let Some(window) = guard.as_mut()
+        && let Some(region) = window.get_region_mut(&ft.region)
+        && matches!(region.kind, leviath_core::RegionKind::HashMap { .. })
+    {
+        let _ = region.upsert_by_key(&path, file_content, tokens);
+        return replacement_msg;
     }
 
     // Region not found or not HashMap — return original result
@@ -680,7 +679,7 @@ impl leviath_runtime::taint::GatePrompt for WorkerGatePrompt {
     ) -> leviath_runtime::taint::GateResolution {
         use super::dynamic_interaction::{gate_block_info, gate_prompt_args, map_gate_approval};
         use crate::interaction::{
-            request_tool_approval_background, ApprovalScope, TOOL_APPROVAL_TIMEOUT,
+            ApprovalScope, TOOL_APPROVAL_TIMEOUT, request_tool_approval_background,
         };
         use leviath_runtime::taint::GateResolution;
 
@@ -935,15 +934,15 @@ impl<'a> StageCallbacks for WorkerCallbacks<'a> {
             self.meta.cache_write_tokens += resp.tokens_used.cache_write_tokens;
 
             // Carry the final response forward so the next stage sees the previous stage's output
-            if !resp.content.is_empty() {
-                if let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity) {
-                    let tokens = resp.content.len() / 4 + 1;
-                    let _ = window.add_to_region(
-                        "conversation",
-                        format!("Assistant ({}): {}", stage_name, resp.content),
-                        tokens,
-                    );
-                }
+            if !resp.content.is_empty()
+                && let Some(mut window) = engine.world_mut().get_mut::<ContextWindow>(entity)
+            {
+                let tokens = resp.content.len() / 4 + 1;
+                let _ = window.add_to_region(
+                    "conversation",
+                    format!("Assistant ({}): {}", stage_name, resp.content),
+                    tokens,
+                );
             }
         }
 
@@ -1113,11 +1112,11 @@ pub(crate) fn post_tool_context_sync(
     };
     if to_entity {
         // shared→entity: merge context tool writes into entity CW
-        if let Some(shared_cw) = guard.as_ref() {
-            if let Some(mut entity_cw) = world.get_mut::<leviath_runtime::ContextWindow>(ent) {
-                entity_cw.regions = shared_cw.regions.clone();
-                entity_cw.current_tokens = shared_cw.current_tokens;
-            }
+        if let Some(shared_cw) = guard.as_ref()
+            && let Some(mut entity_cw) = world.get_mut::<leviath_runtime::ContextWindow>(ent)
+        {
+            entity_cw.regions = shared_cw.regions.clone();
+            entity_cw.current_tokens = shared_cw.current_tokens;
         }
     } else if let Some(entity_cw) = world.get::<leviath_runtime::ContextWindow>(ent) {
         // entity→shared: update shared copy with engine's changes
@@ -5647,11 +5646,13 @@ for line in sys.stdin:
         let guard = cw.lock().await;
         let region = guard.as_ref().unwrap().get_region("files").unwrap();
         // big.txt was truncated; small.txt kept verbatim.
-        assert!(region
-            .get_by_key("big.txt")
-            .unwrap()
-            .content
-            .contains("truncated"));
+        assert!(
+            region
+                .get_by_key("big.txt")
+                .unwrap()
+                .content
+                .contains("truncated")
+        );
         assert_eq!(region.get_by_key("small.txt").unwrap().content, "tiny");
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -374,16 +374,16 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::get;
-    use axum::Router;
     use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
     use crate::config::Config;
-    use crate::runstate::{create_run, RunMeta, RunStatus};
+    use crate::runstate::{RunMeta, RunStatus, create_run};
     use crate::test_support::with_tracing;
 
     fn test_state() -> AppState {
@@ -1499,10 +1499,12 @@ prompt = "Plan the work"
                     .unwrap();
                 let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
                 assert_eq!(result["run_id"].as_str().unwrap(), run_id);
-                assert!(result["output"]
-                    .as_str()
-                    .unwrap()
-                    .contains("stage output here"));
+                assert!(
+                    result["output"]
+                        .as_str()
+                        .unwrap()
+                        .contains("stage output here")
+                );
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -527,167 +527,177 @@ prompt = "Plan the work"
     #[tokio::test]
     async fn spawn_agent_valid_blueprint_creates_run_and_returns_ok() {
         with_tracing(|| {});
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "spawn_agent_valid_blueprint_creates_run_and_returns_ok",
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let bp_name = format!("spawnable-{}", std::process::id());
-        write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
+            |_d| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let bp_name = format!("spawnable-{}", std::process::id());
+                write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
 
-        let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
-        let mut rx = state.event_tx.subscribe();
-        // Pre-broadcast a non-AgentSpawned event so the drain loop below sees
-        // it and exercises the `if let` non-matching branch (line 536 else-path).
-        let _ = state.event_tx.send(ServerEvent::Tokens {
-            agent_id: "pre-event".to_string(),
-            run_id: "pre-event-run".to_string(),
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            cached_tokens: 0,
-            cache_write_tokens: 0,
-        });
-        let app = Router::new()
-            .route("/api/agents", axum::routing::post(spawn_agent))
-            .with_state(state);
+                let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
+                let mut rx = state.event_tx.subscribe();
+                // Pre-broadcast a non-AgentSpawned event so the drain loop below sees
+                // it and exercises the `if let` non-matching branch (line 536 else-path).
+                let _ = state.event_tx.send(ServerEvent::Tokens {
+                    agent_id: "pre-event".to_string(),
+                    run_id: "pre-event-run".to_string(),
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                });
+                let app = Router::new()
+                    .route("/api/agents", axum::routing::post(spawn_agent))
+                    .with_state(state);
 
-        let workdir = tempfile::tempdir().unwrap();
-        let body = serde_json::json!({
-            "blueprint": bp_name,
-            "task": "do the thing",
-            "workdir": workdir.path().to_string_lossy(),
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/agents")
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let workdir = tempfile::tempdir().unwrap();
+                let body = serde_json::json!({
+                    "blueprint": bp_name,
+                    "task": "do the thing",
+                    "workdir": workdir.path().to_string_lossy(),
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/api/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let agent_id = spawn_resp["agent_id"].as_str().unwrap().to_string();
-        let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
-        assert_eq!(agent_id, bp_name);
-        assert!(run_id.contains(&bp_name));
+                let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                let agent_id = spawn_resp["agent_id"].as_str().unwrap().to_string();
+                let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
+                assert_eq!(agent_id, bp_name);
+                assert!(run_id.contains(&bp_name));
 
-        // The run should have been persisted to disk.
-        let meta = runstate::read_meta(&run_id).expect("run meta should exist");
-        assert_eq!(meta.agent_name, bp_name);
+                // The run should have been persisted to disk.
+                let meta = runstate::read_meta(&run_id).expect("run meta should exist");
+                assert_eq!(meta.agent_name, bp_name);
 
-        // Drain all events: the pre-broadcast Tokens event exercises the
-        // `if let ServerEvent::AgentSpawned` else-path; the real AgentSpawned
-        // event exercises the if-branch.
-        let mut spawned_events: Vec<String> = Vec::new();
-        while let Ok(ev) = rx.try_recv() {
-            if let ServerEvent::AgentSpawned { run_id: ev_rid, .. } = ev {
-                spawned_events.push(ev_rid);
-            }
-        }
-        assert_broadcast_agent_spawned(&spawned_events, &run_id);
+                // Drain all events: the pre-broadcast Tokens event exercises the
+                // `if let ServerEvent::AgentSpawned` else-path; the real AgentSpawned
+                // event exercises the if-branch.
+                let mut spawned_events: Vec<String> = Vec::new();
+                while let Ok(ev) = rx.try_recv() {
+                    if let ServerEvent::AgentSpawned { run_id: ev_rid, .. } = ev {
+                        spawned_events.push(ev_rid);
+                    }
+                }
+                assert_broadcast_agent_spawned(&spawned_events, &run_id);
 
-        // Give the (doomed) child process a moment to exit on its own so we
-        // don't leave a zombie process behind, then clean up run state.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                // Give the (doomed) child process a moment to exit on its own so we
+                // don't leave a zombie process behind, then clean up run state.
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn spawn_agent_with_full_options_creates_run() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("spawn_agent_with_full_options_creates_run");
-        let dir = tempfile::tempdir().unwrap();
-        let bp_name = format!("spawnable-full-{}", std::process::id());
-        write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
+        crate::runstate::with_isolated_runs_dir_async(
+            "spawn_agent_with_full_options_creates_run",
+            |_d| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let bp_name = format!("spawnable-full-{}", std::process::id());
+                write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
 
-        let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
-        let app = Router::new()
-            .route("/api/agents", axum::routing::post(spawn_agent))
-            .with_state(state);
+                let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
+                let app = Router::new()
+                    .route("/api/agents", axum::routing::post(spawn_agent))
+                    .with_state(state);
 
-        let workdir = tempfile::tempdir().unwrap();
-        let body = serde_json::json!({
-            "blueprint": bp_name,
-            "task": "do the thing",
-            "workdir": workdir.path().to_string_lossy(),
-            "model": "claude-sonnet-4-6",
-            "yolo": true,
-            "allow": ["read_file"],
-            "max_depth": 2,
-            "metadata": {"k": "v"},
-            "callback_url": "https://example.com/hook",
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/agents")
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let workdir = tempfile::tempdir().unwrap();
+                let body = serde_json::json!({
+                    "blueprint": bp_name,
+                    "task": "do the thing",
+                    "workdir": workdir.path().to_string_lossy(),
+                    "model": "claude-sonnet-4-6",
+                    "yolo": true,
+                    "allow": ["read_file"],
+                    "max_depth": 2,
+                    "metadata": {"k": "v"},
+                    "callback_url": "https://example.com/hook",
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/api/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
-        let meta = runstate::read_meta(&run_id).expect("run meta should exist");
-        assert_eq!(
-            meta.callback_url.as_deref(),
-            Some("https://example.com/hook")
-        );
-        assert_eq!(meta.metadata.get("k").map(|v| v.as_str()), Some("v"));
+                let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
+                let meta = runstate::read_meta(&run_id).expect("run meta should exist");
+                assert_eq!(
+                    meta.callback_url.as_deref(),
+                    Some("https://example.com/hook")
+                );
+                assert_eq!(meta.metadata.get("k").map(|v| v.as_str()), Some("v"));
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn spawn_agent_without_workdir_falls_back_to_current_dir() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "spawn_agent_without_workdir_falls_back_to_current_dir",
-        );
-        // Every other spawn_agent test supplies `workdir` explicitly; this
-        // exercises the `body.workdir.unwrap_or_else(|| current_dir())`
-        // fallback branch specifically.
-        let dir = tempfile::tempdir().unwrap();
-        let bp_name = format!("spawnable-no-workdir-{}", std::process::id());
-        write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
+            |_d| async move {
+                // Every other spawn_agent test supplies `workdir` explicitly; this
+                // exercises the `body.workdir.unwrap_or_else(|| current_dir())`
+                // fallback branch specifically.
+                let dir = tempfile::tempdir().unwrap();
+                let bp_name = format!("spawnable-no-workdir-{}", std::process::id());
+                write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
 
-        let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
-        let app = Router::new()
-            .route("/api/agents", axum::routing::post(spawn_agent))
-            .with_state(state);
+                let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
+                let app = Router::new()
+                    .route("/api/agents", axum::routing::post(spawn_agent))
+                    .with_state(state);
 
-        let body = serde_json::json!({
-            "blueprint": bp_name,
-            "task": "do the thing",
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/agents")
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = serde_json::json!({
+                    "blueprint": bp_name,
+                    "task": "do the thing",
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/api/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
-        let meta = runstate::read_meta(&run_id).expect("run meta should exist");
-        let expected_workdir = std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .expect("current_dir should succeed in test");
-        assert_eq!(meta.workdir, expected_workdir);
+                let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let spawn_resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                let run_id = spawn_resp["run_id"].as_str().unwrap().to_string();
+                let meta = runstate::read_meta(&run_id).expect("run meta should exist");
+                let expected_workdir = std::env::current_dir()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .expect("current_dir should succeed in test");
+                assert_eq!(meta.workdir, expected_workdir);
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -883,19 +893,24 @@ prompt = "Plan the work"
         // a concurrently-running isolated test on another thread could flip
         // the env var between this helper's create_run and open_log_files
         // steps, resolving to two different directories.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("assert_spawn_agent_fails_on");
-        let dir = tempfile::tempdir().unwrap();
-        let bp_name = format!("spawn-fail-{:?}-{}", fail_on as u8, std::process::id());
-        write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
-        let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
-        let workdir = tempfile::tempdir().unwrap();
-        let body = make_spawn_req(&bp_name, workdir.path());
-        let io = MockSpawnAgentIo { fail_on };
+        crate::runstate::with_isolated_runs_dir_async(
+            "assert_spawn_agent_fails_on",
+            |_d| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let bp_name = format!("spawn-fail-{:?}-{}", fail_on as u8, std::process::id());
+                write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
+                let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
+                let workdir = tempfile::tempdir().unwrap();
+                let body = make_spawn_req(&bp_name, workdir.path());
+                let io = MockSpawnAgentIo { fail_on };
 
-        let result = spawn_agent_with(state, body, &io).await;
-        cleanup_runs_with_prefix(&bp_name);
-        let (status, _) = result.expect_err("expected spawn_agent_with to fail");
-        assert_eq!(status, expected_status);
+                let result = spawn_agent_with(state, body, &io).await;
+                cleanup_runs_with_prefix(&bp_name);
+                let (status, _) = result.expect_err("expected spawn_agent_with to fail");
+                assert_eq!(status, expected_status);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -935,31 +950,34 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn spawn_agent_with_no_failure_succeeds_via_mock() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "spawn_agent_with_no_failure_succeeds_via_mock",
-        );
-        // Exercises MockSpawnAgentIo::spawn's `cmd.spawn()` path (FailOn::None
-        // means no mock fails, so the real spawn is called). The spawned
-        // process exits quickly (test harness binary + unknown args).
-        let dir = tempfile::tempdir().unwrap();
-        let bp_name = format!("spawn-mock-ok-{}", std::process::id());
-        write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
-        let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
-        let workdir = tempfile::tempdir().unwrap();
-        let body = make_spawn_req(&bp_name, workdir.path());
-        let io = MockSpawnAgentIo {
-            fail_on: FailOn::None,
-        };
-        let result = spawn_agent_with(state, body, &io).await;
-        let run_id = result
-            .expect("expected spawn_agent_with to succeed")
-            .0
-            .run_id
-            .clone();
-        cleanup_runs_with_prefix(&bp_name);
-        // Give the spawned child a moment to exit cleanly.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            |_d| async move {
+                // Exercises MockSpawnAgentIo::spawn's `cmd.spawn()` path (FailOn::None
+                // means no mock fails, so the real spawn is called). The spawned
+                // process exits quickly (test harness binary + unknown args).
+                let dir = tempfile::tempdir().unwrap();
+                let bp_name = format!("spawn-mock-ok-{}", std::process::id());
+                write_test_blueprint(&dir.path().join(&bp_name), &bp_name);
+                let state = test_state_with_agent_paths(vec![dir.path().to_path_buf()]);
+                let workdir = tempfile::tempdir().unwrap();
+                let body = make_spawn_req(&bp_name, workdir.path());
+                let io = MockSpawnAgentIo {
+                    fail_on: FailOn::None,
+                };
+                let result = spawn_agent_with(state, body, &io).await;
+                let run_id = result
+                    .expect("expected spawn_agent_with to succeed")
+                    .0
+                    .run_id
+                    .clone();
+                cleanup_runs_with_prefix(&bp_name);
+                // Give the spawned child a moment to exit cleanly.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     /// Exercises the `?` error propagation in `MockSpawnAgentIo::parse_manifest`
@@ -991,32 +1009,36 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn list_agents_with_status_filter_running() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("list_agents_with_status_filter_running");
-        let run_id = unique_run_id("list-filter");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::Running;
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "list_agents_with_status_filter_running",
+            |_d| async move {
+                let run_id = unique_run_id("list-filter");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::Running;
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents", get(list_agents))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri("/api/agents?status=running")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-        // The run we created has Running status
-        let found = runs.iter().any(|r| r.run_id == run_id);
-        assert_found_running_run(found);
+                let app = Router::new()
+                    .route("/api/agents", get(list_agents))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri("/api/agents?status=running")
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
+                // The run we created has Running status
+                let found = runs.iter().any(|r| r.run_id == run_id);
+                assert_found_running_run(found);
 
-        // Cleanup
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                // Cleanup
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     fn assert_found_running_run(found: bool) {
@@ -1031,44 +1053,47 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn list_agents_with_status_filter_excludes_others() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "list_agents_with_status_filter_excludes_others",
-        );
-        let run_id = unique_run_id("list-filter-excl");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::Complete;
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("list-filter-excl");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::Complete;
+                create_run(&meta).unwrap();
 
-        // Create a second run with Running status so the filtered list is
-        // non-empty — this makes the map/any closure in the assertion actually
-        // execute, covering the closure body in LLVM's instrumentation.
-        let run_id2 = unique_run_id("list-filter-excl-running");
-        let mut meta2 = make_run(&run_id2);
-        meta2.status = RunStatus::Running;
-        create_run(&meta2).unwrap();
+                // Create a second run with Running status so the filtered list is
+                // non-empty — this makes the map/any closure in the assertion actually
+                // execute, covering the closure body in LLVM's instrumentation.
+                let run_id2 = unique_run_id("list-filter-excl-running");
+                let mut meta2 = make_run(&run_id2);
+                meta2.status = RunStatus::Running;
+                create_run(&meta2).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents", get(list_agents))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri("/api/agents?status=running")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-        // The complete run should not appear in the 'running' filter.
-        let found = runs.iter().any(|r| r.run_id == run_id);
-        assert_complete_run_excluded(found);
-        // The running run should appear.
-        let found2 = runs.iter().any(|r| r.run_id == run_id2);
-        assert_running_run_included(found2);
+                let app = Router::new()
+                    .route("/api/agents", get(list_agents))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri("/api/agents?status=running")
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
+                // The complete run should not appear in the 'running' filter.
+                let found = runs.iter().any(|r| r.run_id == run_id);
+                assert_complete_run_excluded(found);
+                // The running run should appear.
+                let found2 = runs.iter().any(|r| r.run_id == run_id2);
+                assert_running_run_included(found2);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id2));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id2));
+            },
+        )
+        .await;
     }
 
     fn assert_complete_run_excluded(found: bool) {
@@ -1093,29 +1118,34 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn list_agents_multi_status_filter() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("list_agents_multi_status_filter");
-        let run_id = unique_run_id("list-multi");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::Error;
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "list_agents_multi_status_filter",
+            |_d| async move {
+                let run_id = unique_run_id("list-multi");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::Error;
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents", get(list_agents))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri("/api/agents?status=running,error")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-        let found = runs.iter().any(|r| r.run_id == run_id);
-        assert_error_run_included(found);
+                let app = Router::new()
+                    .route("/api/agents", get(list_agents))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri("/api/agents?status=running,error")
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
+                let found = runs.iter().any(|r| r.run_id == run_id);
+                assert_error_run_included(found);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     fn assert_error_run_included(found: bool) {
@@ -1132,28 +1162,32 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn get_agent_existing_run_returns_ok() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("get_agent_existing_run_returns_ok");
-        let run_id = unique_run_id("get-agent");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "get_agent_existing_run_returns_ok",
+            |_d| async move {
+                let run_id = unique_run_id("get-agent");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}", get(get_agent))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let got: RunMeta = serde_json::from_slice(&body).unwrap();
-        assert_eq!(got.run_id, run_id);
+                let app = Router::new()
+                    .route("/api/agents/{id}", get(get_agent))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let got: RunMeta = serde_json::from_slice(&body).unwrap();
+                assert_eq!(got.run_id, run_id);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1173,35 +1207,39 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn agent_children_with_children_found() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_children_with_children_found");
-        let parent_id = unique_run_id("parent");
-        let child_id = unique_run_id("child");
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_children_with_children_found",
+            |_d| async move {
+                let parent_id = unique_run_id("parent");
+                let child_id = unique_run_id("child");
 
-        let parent = make_run(&parent_id);
-        create_run(&parent).unwrap();
+                let parent = make_run(&parent_id);
+                create_run(&parent).unwrap();
 
-        let mut child = make_run(&child_id);
-        child.parent_run_id = Some(parent_id.clone());
-        create_run(&child).unwrap();
+                let mut child = make_run(&child_id);
+                child.parent_run_id = Some(parent_id.clone());
+                create_run(&child).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/children", get(agent_children))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/children", parent_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let children: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-        assert_child_run_appears(children.iter().any(|c| c.run_id == child_id));
+                let app = Router::new()
+                    .route("/api/agents/{id}/children", get(agent_children))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/children", parent_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let children: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
+                assert_child_run_appears(children.iter().any(|c| c.run_id == child_id));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&parent_id));
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&child_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&parent_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&child_id));
+            },
+        )
+        .await;
     }
 
     fn assert_child_run_appears(found: bool) {
@@ -1216,28 +1254,32 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn agent_children_no_children_returns_empty() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_children_no_children_returns_empty");
-        let run_id = unique_run_id("no-children");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_children_no_children_returns_empty",
+            |_d| async move {
+                let run_id = unique_run_id("no-children");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/children", get(agent_children))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/children", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let children: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-        assert_no_self_in_children(&children);
+                let app = Router::new()
+                    .route("/api/agents/{id}/children", get(agent_children))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/children", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let children: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
+                assert_no_self_in_children(&children);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     fn assert_no_self_in_children(children: &[RunMeta]) {
@@ -1257,108 +1299,125 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn agent_context_with_snapshot_returns_ok() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_context_with_snapshot_returns_ok");
-        let run_id = unique_run_id("ctx-snap");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_context_with_snapshot_returns_ok",
+            |_d| async move {
+                let run_id = unique_run_id("ctx-snap");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        // Write a context snapshot
-        let snap = runstate::ContextSnapshot {
-            stage_name: "plan".to_string(),
-            total_tokens: 5000,
-            max_tokens: 200000,
-            regions: vec![],
-        };
-        runstate::write_context_snapshot(&run_id, &snap).unwrap();
+                // Write a context snapshot
+                let snap = runstate::ContextSnapshot {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 5000,
+                    max_tokens: 200000,
+                    regions: vec![],
+                };
+                runstate::write_context_snapshot(&run_id, &snap).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/context", get(agent_context))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/context", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let got: runstate::ContextSnapshot = serde_json::from_slice(&body).unwrap();
-        assert_eq!(got.total_tokens, 5000);
+                let app = Router::new()
+                    .route("/api/agents/{id}/context", get(agent_context))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/context", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let got: runstate::ContextSnapshot = serde_json::from_slice(&body).unwrap();
+                assert_eq!(got.total_tokens, 5000);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn agent_context_no_snapshot_returns_404() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_context_no_snapshot_returns_404");
-        let run_id = unique_run_id("ctx-none");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_context_no_snapshot_returns_404",
+            |_d| async move {
+                let run_id = unique_run_id("ctx-none");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/context", get(agent_context))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/context", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
+                let app = Router::new()
+                    .route("/api/agents/{id}/context", get(agent_context))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/context", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── agent_logs ───────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn agent_logs_existing_run_returns_ok() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_logs_existing_run_returns_ok");
-        let run_id = unique_run_id("logs-ok");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_logs_existing_run_returns_ok",
+            |_d| async move {
+                let run_id = unique_run_id("logs-ok");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        // Write something to output.log
-        let log_path = runstate::run_dir(&run_id).join("output.log");
-        std::fs::write(&log_path, "hello log\n").unwrap();
+                // Write something to output.log
+                let log_path = runstate::run_dir(&run_id).join("output.log");
+                std::fs::write(&log_path, "hello log\n").unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/logs", get(agent_logs))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/logs", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let app = Router::new()
+                    .route("/api/agents/{id}/logs", get(agent_logs))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/logs", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn agent_logs_with_tail_param() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("agent_logs_with_tail_param");
-        let run_id = unique_run_id("logs-tail");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_logs_with_tail_param",
+            |_d| async move {
+                let run_id = unique_run_id("logs-tail");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let log_path = runstate::run_dir(&run_id).join("output.log");
-        std::fs::write(&log_path, "line1\nline2\nline3\n").unwrap();
+                let log_path = runstate::run_dir(&run_id).join("output.log");
+                std::fs::write(&log_path, "line1\nline2\nline3\n").unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/logs", get(agent_logs))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/logs?tail=100", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let app = Router::new()
+                    .route("/api/agents/{id}/logs", get(agent_logs))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/logs?tail=100", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1378,69 +1437,77 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn agent_result_existing_run_no_stages() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_result_existing_run_no_stages");
-        let run_id = unique_run_id("result-no-stages");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::Complete;
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_result_existing_run_no_stages",
+            |_d| async move {
+                let run_id = unique_run_id("result-no-stages");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::Complete;
+                create_run(&meta).unwrap();
 
-        // Write some output.log content
-        let log_path = runstate::run_dir(&run_id).join("output.log");
-        std::fs::write(&log_path, "task complete\n").unwrap();
+                // Write some output.log content
+                let log_path = runstate::run_dir(&run_id).join("output.log");
+                std::fs::write(&log_path, "task complete\n").unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}/result", get(agent_result))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/result", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result["run_id"].as_str().unwrap(), run_id);
-        assert_eq!(result["status"].as_str().unwrap(), "Complete");
+                let app = Router::new()
+                    .route("/api/agents/{id}/result", get(agent_result))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/result", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(result["run_id"].as_str().unwrap(), run_id);
+                assert_eq!(result["status"].as_str().unwrap(), "Complete");
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn agent_result_existing_run_with_stages() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("agent_result_existing_run_with_stages");
-        let run_id = unique_run_id("result-stages");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_result_existing_run_with_stages",
+            |_d| async move {
+                let run_id = unique_run_id("result-stages");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        // Write a stages index and stage output
-        let stages = vec![runstate::StageRecord::new("plan".to_string(), 0)];
-        runstate::write_stages_index(&run_id, &stages).unwrap();
-        runstate::append_stage_output(&run_id, 0, "stage output here");
+                // Write a stages index and stage output
+                let stages = vec![runstate::StageRecord::new("plan".to_string(), 0)];
+                runstate::write_stages_index(&run_id, &stages).unwrap();
+                runstate::append_stage_output(&run_id, 0, "stage output here");
 
-        let app = Router::new()
-            .route("/api/agents/{id}/result", get(agent_result))
-            .with_state(test_state());
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/result", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result["run_id"].as_str().unwrap(), run_id);
-        assert!(result["output"]
-            .as_str()
-            .unwrap()
-            .contains("stage output here"));
+                let app = Router::new()
+                    .route("/api/agents/{id}/result", get(agent_result))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/result", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(result["run_id"].as_str().unwrap(), run_id);
+                assert!(result["output"]
+                    .as_str()
+                    .unwrap()
+                    .contains("stage output here"));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1470,31 +1537,34 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn kill_agent_existing_run_returns_no_content() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "kill_agent_existing_run_returns_no_content",
-        );
-        use axum::routing::delete;
+            |_d| async move {
+                use axum::routing::delete;
 
-        let run_id = unique_run_id("kill-agent");
-        let meta = make_run_with_safe_pid(&run_id);
-        create_run(&meta).unwrap();
+                let run_id = unique_run_id("kill-agent");
+                let meta = make_run_with_safe_pid(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}", delete(kill_agent))
-            .with_state(test_state());
-        let req = Request::builder()
-            .method("DELETE")
-            .uri(format!("/api/agents/{}", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::NO_CONTENT);
+                let app = Router::new()
+                    .route("/api/agents/{id}", delete(kill_agent))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/agents/{}", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::NO_CONTENT);
 
-        // Verify status was updated to Cancelled
-        let updated = runstate::read_meta(&run_id).unwrap();
-        assert_eq!(updated.status, RunStatus::Cancelled);
+                // Verify status was updated to Cancelled
+                let updated = runstate::read_meta(&run_id).unwrap();
+                assert_eq!(updated.status, RunStatus::Cancelled);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1515,38 +1585,43 @@ prompt = "Plan the work"
 
     #[tokio::test]
     async fn kill_agent_cascades_to_children() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("kill_agent_cascades_to_children");
-        use axum::routing::delete;
+        crate::runstate::with_isolated_runs_dir_async(
+            "kill_agent_cascades_to_children",
+            |_d| async move {
+                use axum::routing::delete;
 
-        let parent_id = unique_run_id("kill-parent");
-        let child_id = unique_run_id("kill-child");
+                let parent_id = unique_run_id("kill-parent");
+                let child_id = unique_run_id("kill-child");
 
-        let parent = make_run_with_safe_pid(&parent_id);
-        create_run(&parent).unwrap();
+                let parent = make_run_with_safe_pid(&parent_id);
+                create_run(&parent).unwrap();
 
-        let mut child = make_run_with_safe_pid(&child_id);
-        child.parent_run_id = Some(parent_id.clone());
-        create_run(&child).unwrap();
+                let mut child = make_run_with_safe_pid(&child_id);
+                child.parent_run_id = Some(parent_id.clone());
+                create_run(&child).unwrap();
 
-        let app = Router::new()
-            .route("/api/agents/{id}", delete(kill_agent))
-            .with_state(test_state());
-        let req = Request::builder()
-            .method("DELETE")
-            .uri(format!("/api/agents/{}", parent_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::NO_CONTENT);
+                let app = Router::new()
+                    .route("/api/agents/{id}", delete(kill_agent))
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/agents/{}", parent_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::NO_CONTENT);
 
-        // Both parent and child should be Cancelled
-        let parent_meta = runstate::read_meta(&parent_id).unwrap();
-        let child_meta = runstate::read_meta(&child_id).unwrap();
-        assert_eq!(parent_meta.status, RunStatus::Cancelled);
-        assert_eq!(child_meta.status, RunStatus::Cancelled);
+                // Both parent and child should be Cancelled
+                let parent_meta = runstate::read_meta(&parent_id).unwrap();
+                let child_meta = runstate::read_meta(&child_id).unwrap();
+                assert_eq!(parent_meta.status, RunStatus::Cancelled);
+                assert_eq!(child_meta.status, RunStatus::Cancelled);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&parent_id));
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&child_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&parent_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&child_id));
+            },
+        )
+        .await;
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -215,10 +215,10 @@ pub(super) async fn validate_blueprint(
 mod tests {
     use super::*;
     use crate::test_support::write_test_agent;
+    use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::{get, post};
-    use axum::Router;
     use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
@@ -822,11 +822,13 @@ prompt = "Plan"
             .unwrap();
         let result: ValidateResponse = serde_json::from_slice(&bytes).unwrap();
         assert!(!result.valid);
-        assert!(result
-            .errors
-            .unwrap()
-            .iter()
-            .any(|e| e.contains("entry_stage")));
+        assert!(
+            result
+                .errors
+                .unwrap()
+                .iter()
+                .any(|e| e.contains("entry_stage"))
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -48,10 +48,10 @@ pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::get;
-    use axum::Router;
     use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -170,54 +170,62 @@ mod tests {
 
     #[tokio::test]
     async fn get_interaction_no_pending_returns_404() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("get_interaction_no_pending_returns_404");
-        let run_id = unique_run_id("get-int-none");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "get_interaction_no_pending_returns_404",
+            |_d| async move {
+                let run_id = unique_run_id("get-int-none");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", get(get_interaction));
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
+                let app = Router::new().route("/api/agents/{id}/interaction", get(get_interaction));
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn get_interaction_with_pending_returns_ok() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("get_interaction_with_pending_returns_ok");
-        let run_id = unique_run_id("get-int-ok");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "get_interaction_with_pending_returns_ok",
+            |_d| async move {
+                let run_id = unique_run_id("get-int-ok");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        // Write a pending interaction request
-        let req_val = interaction::InteractionRequest::free_text(
-            "req-001",
-            "What should I do?",
-            "plan",
-            true,
-        );
-        interaction::write_request(&run_id, &req_val).unwrap();
+                // Write a pending interaction request
+                let req_val = interaction::InteractionRequest::free_text(
+                    "req-001",
+                    "What should I do?",
+                    "plan",
+                    true,
+                );
+                interaction::write_request(&run_id, &req_val).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", get(get_interaction));
-        let req = Request::builder()
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(val["id"], "req-001");
+                let app = Router::new().route("/api/agents/{id}/interaction", get(get_interaction));
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(val["id"], "req-001");
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── submit_interaction ───────────────────────────────────────────────────
@@ -238,120 +246,136 @@ mod tests {
 
     #[tokio::test]
     async fn submit_interaction_once_scope_returns_accepted() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "submit_interaction_once_scope_returns_accepted",
-        );
-        let run_id = unique_run_id("submit-once");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("submit-once");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
-        let body = serde_json::json!({
-            "request_id": "req-001",
-            "value": "yes",
-            "approved": true,
-            "scope": "once"
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app =
+                    Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
+                let body = serde_json::json!({
+                    "request_id": "req-001",
+                    "value": "yes",
+                    "approved": true,
+                    "scope": "once"
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn submit_interaction_session_scope_returns_accepted() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "submit_interaction_session_scope_returns_accepted",
-        );
-        let run_id = unique_run_id("submit-session");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("submit-session");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
-        let body = serde_json::json!({
-            "request_id": "req-002",
-            "approved": true,
-            "scope": "session"
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app =
+                    Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
+                let body = serde_json::json!({
+                    "request_id": "req-002",
+                    "approved": true,
+                    "scope": "session"
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn submit_interaction_no_scope_returns_accepted() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "submit_interaction_no_scope_returns_accepted",
-        );
-        let run_id = unique_run_id("submit-noscope");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("submit-noscope");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
-        let body = serde_json::json!({
-            "request_id": "req-003",
-            "value": "do it"
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app =
+                    Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
+                let body = serde_json::json!({
+                    "request_id": "req-003",
+                    "value": "do it"
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn submit_interaction_write_failure_returns_500() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "submit_interaction_write_failure_returns_500",
-        );
-        let run_id = unique_run_id("submit-write-fail");
-        let meta = make_run(&run_id);
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("submit-write-fail");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
 
-        // Force `interaction::write_response`'s `std::fs::write(&tmp, ...)` to
-        // fail with EISDIR by pre-creating a directory at the exact
-        // `response.json.tmp` path it would otherwise write a file to.
-        let tmp_path = interaction::response_path(&run_id).with_extension("json.tmp");
-        std::fs::create_dir_all(&tmp_path).unwrap();
+                // Force `interaction::write_response`'s `std::fs::write(&tmp, ...)` to
+                // fail with EISDIR by pre-creating a directory at the exact
+                // `response.json.tmp` path it would otherwise write a file to.
+                let tmp_path = interaction::response_path(&run_id).with_extension("json.tmp");
+                std::fs::create_dir_all(&tmp_path).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
-        let body = serde_json::json!({"request_id": "req-fail", "approved": true});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(val["error"]
-            .as_str()
-            .unwrap()
-            .contains("Failed to write interaction response"));
+                let app =
+                    Router::new().route("/api/agents/{id}/interaction", post(submit_interaction));
+                let body = serde_json::json!({"request_id": "req-fail", "approved": true});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert!(val["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Failed to write interaction response"));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── send_message ─────────────────────────────────────────────────────────
@@ -372,166 +396,182 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_running_agent_appends_to_log() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("send_message_running_agent_appends_to_log");
-        let run_id = unique_run_id("msg-running");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::Running;
-        create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "send_message_running_agent_appends_to_log",
+            |_d| async move {
+                let run_id = unique_run_id("msg-running");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::Running;
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/message", post(send_message));
-        let body = serde_json::json!({"message": "keep going"});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/message", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app = Router::new().route("/api/agents/{id}/message", post(send_message));
+                let body = serde_json::json!({"message": "keep going"});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/message", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn send_message_waiting_input_with_pending_writes_response() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "send_message_waiting_input_with_pending_writes_response",
-        );
-        let run_id = unique_run_id("msg-waiting");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::WaitingInput;
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("msg-waiting");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::WaitingInput;
+                create_run(&meta).unwrap();
 
-        // Create a pending interaction request
-        let req_val = interaction::InteractionRequest::free_text(
-            "req-wait-001",
-            "What should I do?",
-            "plan",
-            true,
-        );
-        interaction::write_request(&run_id, &req_val).unwrap();
+                // Create a pending interaction request
+                let req_val = interaction::InteractionRequest::free_text(
+                    "req-wait-001",
+                    "What should I do?",
+                    "plan",
+                    true,
+                );
+                interaction::write_request(&run_id, &req_val).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/message", post(send_message));
-        let body = serde_json::json!({"message": "do the thing"});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/message", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app = Router::new().route("/api/agents/{id}/message", post(send_message));
+                let body = serde_json::json!({"message": "do the thing"});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/message", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        // Verify a response was written
-        let response = interaction::take_response(&run_id);
-        assert_response_was_written(&response);
-        assert_eq!(response.unwrap().value.as_deref(), Some("do the thing"));
+                // Verify a response was written
+                let response = interaction::take_response(&run_id);
+                assert_response_was_written(&response);
+                assert_eq!(response.unwrap().value.as_deref(), Some("do the thing"));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn send_message_complete_interactive_with_pending_writes_response() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "send_message_complete_interactive_with_pending_writes_response",
-        );
-        let run_id = unique_run_id("msg-complete-interactive");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::CompleteInteractive;
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("msg-complete-interactive");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::CompleteInteractive;
+                create_run(&meta).unwrap();
 
-        // Create a pending interaction request
-        let req_val = interaction::InteractionRequest::free_text(
-            "req-ci-001",
-            "Optional follow-up?",
-            "result",
-            false,
-        );
-        interaction::write_request(&run_id, &req_val).unwrap();
+                // Create a pending interaction request
+                let req_val = interaction::InteractionRequest::free_text(
+                    "req-ci-001",
+                    "Optional follow-up?",
+                    "result",
+                    false,
+                );
+                interaction::write_request(&run_id, &req_val).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/message", post(send_message));
-        let body = serde_json::json!({"message": "no thanks"});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/message", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app = Router::new().route("/api/agents/{id}/message", post(send_message));
+                let body = serde_json::json!({"message": "no thanks"});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/message", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn send_message_waiting_input_no_pending_appends_to_log() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "send_message_waiting_input_no_pending_appends_to_log",
-        );
-        let run_id = unique_run_id("msg-waiting-nopend");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::WaitingInput;
-        // No pending request written
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("msg-waiting-nopend");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::WaitingInput;
+                // No pending request written
+                create_run(&meta).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/message", post(send_message));
-        let body = serde_json::json!({"message": "hello there"});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/message", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+                let app = Router::new().route("/api/agents/{id}/message", post(send_message));
+                let body = serde_json::json!({"message": "hello there"});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/message", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn send_message_waiting_input_write_failure_returns_500() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "send_message_waiting_input_write_failure_returns_500",
-        );
-        let run_id = unique_run_id("msg-write-fail");
-        let mut meta = make_run(&run_id);
-        meta.status = RunStatus::WaitingInput;
-        create_run(&meta).unwrap();
+            |_d| async move {
+                let run_id = unique_run_id("msg-write-fail");
+                let mut meta = make_run(&run_id);
+                meta.status = RunStatus::WaitingInput;
+                create_run(&meta).unwrap();
 
-        let req_val = interaction::InteractionRequest::free_text(
-            "req-wait-fail",
-            "What should I do?",
-            "plan",
-            true,
-        );
-        interaction::write_request(&run_id, &req_val).unwrap();
+                let req_val = interaction::InteractionRequest::free_text(
+                    "req-wait-fail",
+                    "What should I do?",
+                    "plan",
+                    true,
+                );
+                interaction::write_request(&run_id, &req_val).unwrap();
 
-        // Same EISDIR trick as submit_interaction_write_failure_returns_500,
-        // forcing send_message's own write_response call to fail.
-        let tmp_path = interaction::response_path(&run_id).with_extension("json.tmp");
-        std::fs::create_dir_all(&tmp_path).unwrap();
+                // Same EISDIR trick as submit_interaction_write_failure_returns_500,
+                // forcing send_message's own write_response call to fail.
+                let tmp_path = interaction::response_path(&run_id).with_extension("json.tmp");
+                std::fs::create_dir_all(&tmp_path).unwrap();
 
-        let app = Router::new().route("/api/agents/{id}/message", post(send_message));
-        let body = serde_json::json!({"message": "do the thing"});
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/message", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(val["error"]
-            .as_str()
-            .unwrap()
-            .contains("Failed to write response"));
+                let app = Router::new().route("/api/agents/{id}/message", post(send_message));
+                let body = serde_json::json!({"message": "do the thing"});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/message", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert!(val["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Failed to write response"));
 
-        let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -88,19 +88,19 @@ pub(super) async fn send_message(
     })?;
 
     // Write the message as a pending interaction response if the agent is waiting
-    if meta.status == RunStatus::WaitingInput || meta.status == RunStatus::CompleteInteractive {
-        if let Some(req) = interaction::read_request(&id) {
-            let resp = interaction::InteractionResponse::text(&req.id, &body.message);
-            interaction::write_response(&id, &resp).map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: format!("Failed to write response: {}", e),
-                    }),
-                )
-            })?;
-            return Ok(StatusCode::ACCEPTED);
-        }
+    if (meta.status == RunStatus::WaitingInput || meta.status == RunStatus::CompleteInteractive)
+        && let Some(req) = interaction::read_request(&id)
+    {
+        let resp = interaction::InteractionResponse::text(&req.id, &body.message);
+        interaction::write_response(&id, &resp).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to write response: {}", e),
+                }),
+            )
+        })?;
+        return Ok(StatusCode::ACCEPTED);
     }
 
     // If not waiting, append to the run's output log as a user message
@@ -116,13 +116,13 @@ pub(super) async fn send_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::{get, post};
-    use axum::Router;
     use tower::ServiceExt;
 
-    use crate::runstate::{create_run, RunMeta, RunStatus};
+    use crate::runstate::{RunMeta, RunStatus, create_run};
 
     fn unique_run_id(prefix: &str) -> String {
         use std::time::{SystemTime, UNIX_EPOCH};
@@ -367,10 +367,12 @@ mod tests {
                     .await
                     .unwrap();
                 let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-                assert!(val["error"]
-                    .as_str()
-                    .unwrap()
-                    .contains("Failed to write interaction response"));
+                assert!(
+                    val["error"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Failed to write interaction response")
+                );
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },
@@ -563,10 +565,12 @@ mod tests {
                     .await
                     .unwrap();
                 let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-                assert!(val["error"]
-                    .as_str()
-                    .unwrap()
-                    .contains("Failed to write response"));
+                assert!(
+                    val["error"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Failed to write response")
+                );
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -763,45 +763,49 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_submit_interaction_full_router() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_submit_interaction_full_router");
-        use crate::runstate::{create_run, RunMeta};
+        crate::runstate::with_isolated_runs_dir_async(
+            "test_submit_interaction_full_router",
+            |_d| async move {
+                use crate::runstate::{create_run, RunMeta};
 
-        let run_id = format!(
-            "test-modrs-int-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "test-agent".to_string(),
-            "/path".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-modrs-int-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let meta = RunMeta::new(
+                    run_id.clone(),
+                    "test-agent".to_string(),
+                    "/path".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                create_run(&meta).unwrap();
 
-        let app = full_app();
-        let body = serde_json::json!({
-            "request_id": "req-full-001",
-            "value": "do it",
-            "scope": "once"
-        });
-        let req = Request::builder()
-            .method("POST")
-            .uri(format!("/api/agents/{}/interaction", run_id))
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_string(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+                let app = full_app();
+                let body = serde_json::json!({
+                    "request_id": "req-full-001",
+                    "value": "do it",
+                    "scope": "once"
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/agents/{}/interaction", run_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), StatusCode::ACCEPTED);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── execute() — real server bootstrap ─────────────────────────────────
@@ -825,67 +829,79 @@ prompt = "Run"
 
     #[tokio::test]
     async fn execute_binds_and_serves_with_wildcard_cors() {
-        let _guard = crate::config::isolate_config_path_for_test("serve-mod-wildcard-cors");
-        with_tracing(|| {});
-        // port: 0 lets the OS assign a genuinely free ephemeral port at bind
-        // time; execute_with_shutdown reports the real bound SocketAddr back
-        // via `ready` the instant it's bound, so there's no
-        // probe-bind-drop-rebind gap for another process/test to race into
-        // (that gap is a real, CI-reproducing TOCTOU -- see
-        // execute_with_shutdown's doc comment). Exercises the exact same
-        // production code path execute() does (its own body is just this
-        // call with `ready: None`), so this remains a real end-to-end test
-        // of execute()'s bootstrap logic.
-        let args = ServeArgs {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            cors: "*".to_string(),
-        };
-        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-        let handle = tokio::spawn(execute_with_shutdown(
-            args,
-            Box::pin(std::future::pending()),
-            Some(ready_tx),
-        ));
-        let addr = ready_rx
-            .await
-            .expect("server should report its bound address");
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-wildcard-cors",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                // port: 0 lets the OS assign a genuinely free ephemeral port at bind
+                // time; execute_with_shutdown reports the real bound SocketAddr back
+                // via `ready` the instant it's bound, so there's no
+                // probe-bind-drop-rebind gap for another process/test to race into
+                // (that gap is a real, CI-reproducing TOCTOU -- see
+                // execute_with_shutdown's doc comment). Exercises the exact same
+                // production code path execute() does (its own body is just this
+                // call with `ready: None`), so this remains a real end-to-end test
+                // of execute()'s bootstrap logic.
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: "*".to_string(),
+                };
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let handle = tokio::spawn(execute_with_shutdown(
+                    args,
+                    Box::pin(std::future::pending()),
+                    Some(ready_tx),
+                ));
+                let addr = ready_rx
+                    .await
+                    .expect("server should report its bound address");
 
-        // Sanity-check a real request round trip through the full app.
-        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        stream
-            .write_all(b"GET /api/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
-            .await
-            .unwrap();
-        let mut resp = Vec::new();
-        stream.read_to_end(&mut resp).await.unwrap();
-        let resp_str = String::from_utf8_lossy(&resp);
-        assert_response_ok(&resp_str);
+                // Sanity-check a real request round trip through the full app.
+                let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                stream
+                    .write_all(
+                        b"GET /api/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+                let mut resp = Vec::new();
+                stream.read_to_end(&mut resp).await.unwrap();
+                let resp_str = String::from_utf8_lossy(&resp);
+                assert_response_ok(&resp_str);
 
-        handle.abort();
+                handle.abort();
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_specific_cors_origin_serves() {
-        let _guard = crate::config::isolate_config_path_for_test("serve-mod-specific-cors");
-        let args = ServeArgs {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            cors: "https://example.com".to_string(),
-        };
-        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-        let handle = tokio::spawn(execute_with_shutdown(
-            args,
-            Box::pin(std::future::pending()),
-            Some(ready_tx),
-        ));
-        let addr = ready_rx
-            .await
-            .expect("server should report its bound address");
-        assert!(tokio::net::TcpStream::connect(addr).await.is_ok());
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-specific-cors",
+            |_fake_dir| async move {
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: "https://example.com".to_string(),
+                };
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let handle = tokio::spawn(execute_with_shutdown(
+                    args,
+                    Box::pin(std::future::pending()),
+                    Some(ready_tx),
+                ));
+                let addr = ready_rx
+                    .await
+                    .expect("server should report its bound address");
+                assert!(tokio::net::TcpStream::connect(addr).await.is_ok());
 
-        handle.abort();
+                handle.abort();
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -916,17 +932,22 @@ prompt = "Run"
     /// `LEVIATH_CONFIG_PATH` at a file containing invalid TOML.
     #[tokio::test]
     async fn execute_with_malformed_config_returns_err() {
-        let _guard = crate::config::isolate_config_path_for_test("serve-mod-malformed");
-        // After isolate_config_path_for_test, Config::config_path() returns the temp path.
-        std::fs::write(Config::config_path(), "not valid toml [[[").unwrap();
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-malformed",
+            |_fake_dir| async move {
+                // After isolate_config_path_for_test, Config::config_path() returns the temp path.
+                std::fs::write(Config::config_path(), "not valid toml [[[").unwrap();
 
-        let args = ServeArgs {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            cors: "*".to_string(),
-        };
-        let result = execute(args).await;
-        assert_execute_failed_on_malformed_config(&result);
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: "*".to_string(),
+                };
+                let result = execute(args).await;
+                assert_execute_failed_on_malformed_config(&result);
+            },
+        )
+        .await;
     }
 
     /// Covers the `for warning in cfg.validate_keys()` loop body (lines 32-33)
@@ -935,7 +956,7 @@ prompt = "Run"
     #[tokio::test]
     async fn execute_with_bad_api_key_logs_warning_and_serves() {
         with_tracing(|| {});
-        let guard = crate::config::isolate_config_path_for_test("serve-mod-badkey");
+        crate::config::with_isolated_config_path_async("serve-mod-badkey", |_fake_dir| async move {
         // Write a config with an anthropic key that fails validate_keys().
         std::fs::write(
             Config::config_path(),
@@ -964,7 +985,6 @@ prompt = "Run"
             .await
             .expect("server should report its bound address");
         let connected = tokio::net::TcpStream::connect(addr).await.is_ok();
-        drop(guard);
         assert_connected_with_bad_api_key(connected);
 
         // Trigger graceful shutdown so execute_with_shutdown returns Ok(()).
@@ -974,6 +994,7 @@ prompt = "Run"
             .expect("timed out waiting for execute to return")
             .expect("task panicked");
         assert_execute_returned_ok_after_shutdown(&result);
+    }).await;
     }
 
     /// Covers `TcpListener::bind(addr).await?` error path (line 116 gap) by
@@ -998,35 +1019,40 @@ prompt = "Run"
     /// `execute_with_shutdown` and sending a graceful-shutdown signal.
     #[tokio::test]
     async fn execute_with_shutdown_signal_returns_ok() {
-        let _guard = crate::config::isolate_config_path_for_test("serve-mod-shutdown-signal");
-        let args = ServeArgs {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            cors: "*".to_string(),
-        };
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-shutdown-signal",
+            |_fake_dir| async move {
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: "*".to_string(),
+                };
 
-        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-        let shutdown_fut = async move {
-            let _ = shutdown_rx.await;
-        };
-        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+                let shutdown_fut = async move {
+                    let _ = shutdown_rx.await;
+                };
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
 
-        let handle = tokio::spawn(execute_with_shutdown(
-            args,
-            Box::pin(shutdown_fut),
-            Some(ready_tx),
-        ));
-        ready_rx
-            .await
-            .expect("server should report its bound address");
+                let handle = tokio::spawn(execute_with_shutdown(
+                    args,
+                    Box::pin(shutdown_fut),
+                    Some(ready_tx),
+                ));
+                ready_rx
+                    .await
+                    .expect("server should report its bound address");
 
-        // Send shutdown signal and wait for execute to return Ok.
-        let _ = shutdown_tx.send(());
-        let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("timed out waiting for execute_with_shutdown to return")
-            .expect("task panicked");
-        assert_execute_with_shutdown_returned_ok(&result);
+                // Send shutdown signal and wait for execute to return Ok.
+                let _ = shutdown_tx.send(());
+                let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+                    .await
+                    .expect("timed out waiting for execute_with_shutdown to return")
+                    .expect("task panicked");
+                assert_execute_with_shutdown_returned_ok(&result);
+            },
+        )
+        .await;
     }
 
     /// Covers the `ready: None` fall-through of the `if let Some(ready)` block
@@ -1036,26 +1062,32 @@ prompt = "Run"
     /// is the only path that reaches the block's None continuation.
     #[tokio::test]
     async fn execute_with_shutdown_no_ready_observer_returns_ok() {
-        let _guard = crate::config::isolate_config_path_for_test("serve-mod-no-ready");
-        let args = ServeArgs {
-            port: 0,
-            host: "127.0.0.1".to_string(),
-            cors: "*".to_string(),
-        };
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-no-ready",
+            |_fake_dir| async move {
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: "*".to_string(),
+                };
 
-        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-        let shutdown_fut = async move {
-            let _ = shutdown_rx.await;
-        };
+                let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+                let shutdown_fut = async move {
+                    let _ = shutdown_rx.await;
+                };
 
-        let handle = tokio::spawn(execute_with_shutdown(args, Box::pin(shutdown_fut), None));
-        // Give the server a moment to bind before shutting down.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let _ = shutdown_tx.send(());
-        let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("timed out waiting for execute_with_shutdown to return")
-            .expect("task panicked");
-        assert_execute_with_shutdown_returned_ok(&result);
+                let handle =
+                    tokio::spawn(execute_with_shutdown(args, Box::pin(shutdown_fut), None));
+                // Give the server a moment to bind before shutting down.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let _ = shutdown_tx.send(());
+                let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+                    .await
+                    .expect("timed out waiting for execute_with_shutdown to return")
+                    .expect("task panicked");
+                assert_execute_with_shutdown_returned_ok(&result);
+            },
+        )
+        .await;
     }
 }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -17,8 +17,8 @@ pub use types::{AppState, ServeArgs, ServerEvent};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use axum::routing::{get, post};
 use axum::Router;
+use axum::routing::{get, post};
 use tokio::sync::broadcast;
 use tower_http::cors::{Any, CorsLayer};
 
@@ -766,7 +766,7 @@ prompt = "Run"
         crate::runstate::with_isolated_runs_dir_async(
             "test_submit_interaction_full_router",
             |_d| async move {
-                use crate::runstate::{create_run, RunMeta};
+                use crate::runstate::{RunMeta, create_run};
 
                 let run_id = format!(
                     "test-modrs-int-{}-{}",

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -122,30 +122,29 @@ fn poll_once(
                     result: meta.error.clone(),
                 });
 
-                if let Some(ref url) = meta.callback_url {
-                    if !poll
+                if let Some(ref url) = meta.callback_url
+                    && !poll
                         .callback_fired
                         .get(&meta.run_id)
                         .copied()
                         .unwrap_or(false)
-                    {
-                        poll.callback_fired.insert(meta.run_id.clone(), true);
-                        let payload = serde_json::json!({
-                            "event": "agent_completed",
-                            "run_id": meta.run_id,
-                            "agent_id": meta.agent_name,
-                            "status": status_str,
-                            "result": meta.error,
-                            "metadata": meta.metadata,
-                            "tokens": {
-                                "prompt": meta.prompt_tokens,
-                                "completion": meta.completion_tokens,
-                            }
-                        });
-                        let client = client.clone();
-                        let url = url.clone();
-                        tokio::spawn(fire_webhook(client, url, payload));
-                    }
+                {
+                    poll.callback_fired.insert(meta.run_id.clone(), true);
+                    let payload = serde_json::json!({
+                        "event": "agent_completed",
+                        "run_id": meta.run_id,
+                        "agent_id": meta.agent_name,
+                        "status": status_str,
+                        "result": meta.error,
+                        "metadata": meta.metadata,
+                        "tokens": {
+                            "prompt": meta.prompt_tokens,
+                            "completion": meta.completion_tokens,
+                        }
+                    });
+                    let client = client.clone();
+                    let url = url.clone();
+                    tokio::spawn(fire_webhook(client, url, payload));
                 }
             }
 
@@ -608,7 +607,7 @@ mod tests {
     #[test]
     fn polling_loop_emits_context_update() {
         crate::runstate::with_isolated_runs_dir("polling_loop_emits_context_update", |_d| {
-            use crate::runstate::{create_run, write_context_snapshot, ContextSnapshot, RunMeta};
+            use crate::runstate::{ContextSnapshot, RunMeta, create_run, write_context_snapshot};
 
             let (state, mut rx) = make_test_state();
             let mut poll = PollState {
@@ -682,7 +681,7 @@ mod tests {
             "poll_once_no_context_update_when_tokens_unchanged",
             |_d| {
                 use crate::runstate::{
-                    create_run, write_context_snapshot, ContextSnapshot, RunMeta,
+                    ContextSnapshot, RunMeta, create_run, write_context_snapshot,
                 };
 
                 let (state, mut rx) = make_test_state();
@@ -756,10 +755,10 @@ mod tests {
                 });
                 let mut ctx_updates_for_run = 0u32;
                 while let Ok(ev) = rx.try_recv() {
-                    if let ServerEvent::ContextUpdate { run_id: eid, .. } = &ev {
-                        if eid == &run_id {
-                            ctx_updates_for_run += 1;
-                        }
+                    if let ServerEvent::ContextUpdate { run_id: eid, .. } = &ev
+                        && eid == &run_id
+                    {
+                        ctx_updates_for_run += 1;
                     }
                 }
                 // poll_once emitted 0 ContextUpdates for run_id (unchanged tokens);
@@ -788,7 +787,7 @@ mod tests {
     fn polling_loop_emits_interaction_needed() {
         crate::runstate::with_isolated_runs_dir("polling_loop_emits_interaction_needed", |_d| {
             use crate::interaction::{self, InteractionRequest};
-            use crate::runstate::{create_run, RunMeta};
+            use crate::runstate::{RunMeta, create_run};
 
             let (state, mut rx) = make_test_state();
             let mut poll = PollState {
@@ -908,11 +907,12 @@ mod tests {
         poll_once(&state, &mut poll, &client, &[meta]);
 
         // callback_fired should be recorded immediately...
-        assert!(poll
-            .callback_fired
-            .get("run-webhook-1")
-            .copied()
-            .unwrap_or(false));
+        assert!(
+            poll.callback_fired
+                .get("run-webhook-1")
+                .copied()
+                .unwrap_or(false)
+        );
 
         // ...and the webhook POST should actually be delivered.
         let body = tokio::time::timeout(std::time::Duration::from_secs(5), rx)
@@ -961,11 +961,12 @@ mod tests {
 
         // callback_fired is recorded synchronously, before the (failing)
         // webhook send is even attempted.
-        assert!(poll
-            .callback_fired
-            .get("run-webhook-fail")
-            .copied()
-            .unwrap_or(false));
+        assert!(
+            poll.callback_fired
+                .get("run-webhook-fail")
+                .copied()
+                .unwrap_or(false)
+        );
 
         // Give the spawned task time to attempt the connection and fail.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -1030,11 +1031,12 @@ mod tests {
         meta.touch();
         // First completion: fires the webhook and marks it fired.
         poll_once(&state, &mut poll, &client, std::slice::from_ref(&meta));
-        assert!(poll
-            .callback_fired
-            .get("run-webhook-2")
-            .copied()
-            .unwrap_or(false));
+        assert!(
+            poll.callback_fired
+                .get("run-webhook-2")
+                .copied()
+                .unwrap_or(false)
+        );
 
         // The mock server only accepts a single connection; if poll_once
         // tried to fire the callback again it would either hang or the

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -607,57 +607,57 @@ mod tests {
 
     #[test]
     fn polling_loop_emits_context_update() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("polling_loop_emits_context_update");
-        use crate::runstate::{create_run, write_context_snapshot, ContextSnapshot, RunMeta};
+        crate::runstate::with_isolated_runs_dir("polling_loop_emits_context_update", |_d| {
+            use crate::runstate::{create_run, write_context_snapshot, ContextSnapshot, RunMeta};
 
-        let (state, mut rx) = make_test_state();
-        let mut poll = PollState {
-            last_status: HashMap::new(),
-            last_context_tokens: HashMap::new(),
-            last_pending: HashMap::new(),
-            callback_fired: HashMap::new(),
-        };
-        let client = reqwest::Client::new();
+            let (state, mut rx) = make_test_state();
+            let mut poll = PollState {
+                last_status: HashMap::new(),
+                last_context_tokens: HashMap::new(),
+                last_pending: HashMap::new(),
+                callback_fired: HashMap::new(),
+            };
+            let client = reqwest::Client::new();
 
-        let run_id = format!(
-            "test-poll-ctx-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "agent".into(),
-            "/p".into(),
-            "task".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        create_run(&meta).unwrap();
+            let run_id = format!(
+                "test-poll-ctx-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .subsec_nanos()
+            );
+            let meta = RunMeta::new(
+                run_id.clone(),
+                "agent".into(),
+                "/p".into(),
+                "task".into(),
+                None,
+                "/tmp".into(),
+                1,
+            );
+            create_run(&meta).unwrap();
 
-        let snap = ContextSnapshot {
-            stage_name: "plan".to_string(),
-            total_tokens: 7500,
-            max_tokens: 200000,
-            regions: vec![],
-        };
-        write_context_snapshot(&run_id, &snap).unwrap();
+            let snap = ContextSnapshot {
+                stage_name: "plan".to_string(),
+                total_tokens: 7500,
+                max_tokens: 200000,
+                regions: vec![],
+            };
+            write_context_snapshot(&run_id, &snap).unwrap();
 
-        poll_once(&state, &mut poll, &client, &[meta]);
+            poll_once(&state, &mut poll, &client, &[meta]);
 
-        let mut got_context = false;
-        while let Ok(ev) = rx.try_recv() {
-            if matches!(&ev, ServerEvent::ContextUpdate { run_id: eid, total_tokens, .. } if eid == &run_id && *total_tokens == 7500)
-            {
-                got_context = true;
+            let mut got_context = false;
+            while let Ok(ev) = rx.try_recv() {
+                if matches!(&ev, ServerEvent::ContextUpdate { run_id: eid, total_tokens, .. } if eid == &run_id && *total_tokens == 7500)
+                {
+                    got_context = true;
+                }
             }
-        }
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
-        assert_got_context_update(got_context);
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            assert_got_context_update(got_context);
+        });
     }
 
     fn assert_got_context_update(got_context: bool) {
@@ -678,93 +678,97 @@ mod tests {
     /// ContextUpdate event is emitted on the second call.
     #[test]
     fn poll_once_no_context_update_when_tokens_unchanged() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "poll_once_no_context_update_when_tokens_unchanged",
-        );
-        use crate::runstate::{create_run, write_context_snapshot, ContextSnapshot, RunMeta};
+            |_d| {
+                use crate::runstate::{
+                    create_run, write_context_snapshot, ContextSnapshot, RunMeta,
+                };
 
-        let (state, mut rx) = make_test_state();
-        let mut poll = PollState {
-            last_status: HashMap::new(),
-            last_context_tokens: HashMap::new(),
-            last_pending: HashMap::new(),
-            callback_fired: HashMap::new(),
-        };
-        let client = reqwest::Client::new();
+                let (state, mut rx) = make_test_state();
+                let mut poll = PollState {
+                    last_status: HashMap::new(),
+                    last_context_tokens: HashMap::new(),
+                    last_pending: HashMap::new(),
+                    callback_fired: HashMap::new(),
+                };
+                let client = reqwest::Client::new();
 
-        let run_id = format!(
-            "test-poll-ctx-same-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "agent".into(),
-            "/p".into(),
-            "task".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        create_run(&meta).unwrap();
+                let run_id = format!(
+                    "test-poll-ctx-same-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .subsec_nanos()
+                );
+                let meta = RunMeta::new(
+                    run_id.clone(),
+                    "agent".into(),
+                    "/p".into(),
+                    "task".into(),
+                    None,
+                    "/tmp".into(),
+                    1,
+                );
+                create_run(&meta).unwrap();
 
-        let snap = ContextSnapshot {
-            stage_name: "plan".to_string(),
-            total_tokens: 5000,
-            max_tokens: 200000,
-            regions: vec![],
-        };
-        write_context_snapshot(&run_id, &snap).unwrap();
+                let snap = ContextSnapshot {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 5000,
+                    max_tokens: 200000,
+                    regions: vec![],
+                };
+                write_context_snapshot(&run_id, &snap).unwrap();
 
-        // First call: tokens change (prev = None → 5000), should emit event.
-        poll_once(&state, &mut poll, &client, std::slice::from_ref(&meta));
-        while rx.try_recv().is_ok() {} // drain events
+                // First call: tokens change (prev = None → 5000), should emit event.
+                poll_once(&state, &mut poll, &client, std::slice::from_ref(&meta));
+                while rx.try_recv().is_ok() {} // drain events
 
-        // Second call: tokens unchanged (prev = 5000, current = 5000), no event.
-        poll_once(&state, &mut poll, &client, &[meta]);
+                // Second call: tokens unchanged (prev = 5000, current = 5000), no event.
+                poll_once(&state, &mut poll, &client, &[meta]);
 
-        // Inject events to exercise all branches of the drain loop below:
-        // 1. A non-ContextUpdate (Tokens) so the outer `if let ContextUpdate` fails
-        //    → covers the implicit else-path of the if-let (line 648 col 13).
-        // 2. A ContextUpdate for a different run → outer matches, inner eid!=run_id.
-        // 3. A ContextUpdate for our run → outer matches, inner eid==run_id.
-        // We count only #3 to verify poll_once emitted 0 for run_id (total = 1).
-        let _ = state.event_tx.send(ServerEvent::Tokens {
-            agent_id: "noise-agent".to_string(),
-            run_id: "noise-run".to_string(),
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            cached_tokens: 0,
-            cache_write_tokens: 0,
-        });
-        let _ = state.event_tx.send(ServerEvent::ContextUpdate {
-            agent_id: "other-agent".to_string(),
-            run_id: "other-run-ctx".to_string(),
-            total_tokens: 100,
-            max_tokens: 200000,
-        });
-        let _ = state.event_tx.send(ServerEvent::ContextUpdate {
-            agent_id: "our-agent".to_string(),
-            run_id: run_id.clone(),
-            total_tokens: 9999,
-            max_tokens: 200000,
-        });
-        let mut ctx_updates_for_run = 0u32;
-        while let Ok(ev) = rx.try_recv() {
-            if let ServerEvent::ContextUpdate { run_id: eid, .. } = &ev {
-                if eid == &run_id {
-                    ctx_updates_for_run += 1;
+                // Inject events to exercise all branches of the drain loop below:
+                // 1. A non-ContextUpdate (Tokens) so the outer `if let ContextUpdate` fails
+                //    → covers the implicit else-path of the if-let (line 648 col 13).
+                // 2. A ContextUpdate for a different run → outer matches, inner eid!=run_id.
+                // 3. A ContextUpdate for our run → outer matches, inner eid==run_id.
+                // We count only #3 to verify poll_once emitted 0 for run_id (total = 1).
+                let _ = state.event_tx.send(ServerEvent::Tokens {
+                    agent_id: "noise-agent".to_string(),
+                    run_id: "noise-run".to_string(),
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                });
+                let _ = state.event_tx.send(ServerEvent::ContextUpdate {
+                    agent_id: "other-agent".to_string(),
+                    run_id: "other-run-ctx".to_string(),
+                    total_tokens: 100,
+                    max_tokens: 200000,
+                });
+                let _ = state.event_tx.send(ServerEvent::ContextUpdate {
+                    agent_id: "our-agent".to_string(),
+                    run_id: run_id.clone(),
+                    total_tokens: 9999,
+                    max_tokens: 200000,
+                });
+                let mut ctx_updates_for_run = 0u32;
+                while let Ok(ev) = rx.try_recv() {
+                    if let ServerEvent::ContextUpdate { run_id: eid, .. } = &ev {
+                        if eid == &run_id {
+                            ctx_updates_for_run += 1;
+                        }
+                    }
                 }
-            }
-        }
-        // poll_once emitted 0 ContextUpdates for run_id (unchanged tokens);
-        // we manually injected exactly 1. Total must be exactly 1.
-        assert_ctx_updates_for_run(ctx_updates_for_run);
+                // poll_once emitted 0 ContextUpdates for run_id (unchanged tokens);
+                // we manually injected exactly 1. Total must be exactly 1.
+                assert_ctx_updates_for_run(ctx_updates_for_run);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+                let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            },
+        );
     }
 
     fn assert_ctx_updates_for_run(ctx_updates_for_run: u32) {
@@ -782,52 +786,53 @@ mod tests {
 
     #[test]
     fn polling_loop_emits_interaction_needed() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("polling_loop_emits_interaction_needed");
-        use crate::interaction::{self, InteractionRequest};
-        use crate::runstate::{create_run, RunMeta};
+        crate::runstate::with_isolated_runs_dir("polling_loop_emits_interaction_needed", |_d| {
+            use crate::interaction::{self, InteractionRequest};
+            use crate::runstate::{create_run, RunMeta};
 
-        let (state, mut rx) = make_test_state();
-        let mut poll = PollState {
-            last_status: HashMap::new(),
-            last_context_tokens: HashMap::new(),
-            last_pending: HashMap::new(),
-            callback_fired: HashMap::new(),
-        };
-        let client = reqwest::Client::new();
+            let (state, mut rx) = make_test_state();
+            let mut poll = PollState {
+                last_status: HashMap::new(),
+                last_context_tokens: HashMap::new(),
+                last_pending: HashMap::new(),
+                callback_fired: HashMap::new(),
+            };
+            let client = reqwest::Client::new();
 
-        let run_id = format!(
-            "test-poll-int-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .subsec_nanos()
-        );
-        let meta = RunMeta::new(
-            run_id.clone(),
-            "agent".into(),
-            "/p".into(),
-            "task".into(),
-            None,
-            "/tmp".into(),
-            1,
-        );
-        create_run(&meta).unwrap();
+            let run_id = format!(
+                "test-poll-int-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .subsec_nanos()
+            );
+            let meta = RunMeta::new(
+                run_id.clone(),
+                "agent".into(),
+                "/p".into(),
+                "task".into(),
+                None,
+                "/tmp".into(),
+                1,
+            );
+            create_run(&meta).unwrap();
 
-        let req = InteractionRequest::free_text("req-001", "What next?", "plan", true);
-        interaction::write_request(&run_id, &req).unwrap();
+            let req = InteractionRequest::free_text("req-001", "What next?", "plan", true);
+            interaction::write_request(&run_id, &req).unwrap();
 
-        poll_once(&state, &mut poll, &client, &[meta]);
+            poll_once(&state, &mut poll, &client, &[meta]);
 
-        let mut got_interaction = false;
-        while let Ok(ev) = rx.try_recv() {
-            if matches!(&ev, ServerEvent::InteractionNeeded { run_id: eid, .. } if eid == &run_id) {
-                got_interaction = true;
+            let mut got_interaction = false;
+            while let Ok(ev) = rx.try_recv() {
+                if matches!(&ev, ServerEvent::InteractionNeeded { run_id: eid, .. } if eid == &run_id)
+                {
+                    got_interaction = true;
+                }
             }
-        }
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
-        assert_got_interaction_needed(got_interaction);
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(&run_id));
+            assert_got_interaction_needed(got_interaction);
+        });
     }
 
     fn assert_got_interaction_needed(got_interaction: bool) {

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -238,14 +238,19 @@ mod tests {
 
     #[tokio::test]
     async fn agents_tree_includes_created_run() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("agents_tree_includes_created_run");
-        let run_id = "test-tree-agents-tree-1";
-        let _cleanup = RunCleanup(&[run_id]);
-        let meta = make_meta(run_id, "agent-tree-test", None);
-        runstate::create_run(&meta).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "agents_tree_includes_created_run",
+            |_d| async move {
+                let run_id = "test-tree-agents-tree-1";
+                let _cleanup = RunCleanup(&[run_id]);
+                let meta = make_meta(run_id, "agent-tree-test", None);
+                runstate::create_run(&meta).unwrap();
 
-        let Json(tree) = agents_tree().await;
-        assert!(tree.iter().any(|n| n.run_id == run_id));
+                let Json(tree) = agents_tree().await;
+                assert!(tree.iter().any(|n| n.run_id == run_id));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -260,30 +265,33 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tree_status_returns_tree_with_subtree_totals() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "agent_tree_status_returns_tree_with_subtree_totals",
-        );
-        let run_id = "test-tree-status-root";
-        let child_id = "test-tree-status-child";
-        let _cleanup = RunCleanup(&[run_id, child_id]);
+            |_d| async move {
+                let run_id = "test-tree-status-root";
+                let child_id = "test-tree-status-child";
+                let _cleanup = RunCleanup(&[run_id, child_id]);
 
-        let mut root = make_meta(run_id, "root-agent", None);
-        root.prompt_tokens = 10;
-        root.completion_tokens = 2;
-        runstate::create_run(&root).unwrap();
+                let mut root = make_meta(run_id, "root-agent", None);
+                root.prompt_tokens = 10;
+                root.completion_tokens = 2;
+                runstate::create_run(&root).unwrap();
 
-        let mut child = make_meta(child_id, "child-agent", Some(run_id));
-        child.prompt_tokens = 20;
-        child.completion_tokens = 3;
-        runstate::create_run(&child).unwrap();
+                let mut child = make_meta(child_id, "child-agent", Some(run_id));
+                child.prompt_tokens = 20;
+                child.completion_tokens = 3;
+                runstate::create_run(&child).unwrap();
 
-        let Json(node) = agent_tree_status(AxumPath(run_id.to_string()))
-            .await
-            .unwrap();
-        assert_eq!(node.run_id, run_id);
-        assert_eq!(node.subtree_prompt_tokens, 30);
-        assert_eq!(node.subtree_completion_tokens, 5);
-        assert_eq!(node.children.len(), 1);
-        assert_eq!(node.children[0].run_id, child_id);
+                let Json(node) = agent_tree_status(AxumPath(run_id.to_string()))
+                    .await
+                    .unwrap();
+                assert_eq!(node.run_id, run_id);
+                assert_eq!(node.subtree_prompt_tokens, 30);
+                assert_eq!(node.subtree_completion_tokens, 5);
+                assert_eq!(node.children.len(), 1);
+                assert_eq!(node.children[0].run_id, child_id);
+            },
+        )
+        .await;
     }
 }

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -82,8 +82,8 @@ async fn handle_ws(
 mod tests {
     use super::*;
 
-    use axum::routing::get;
     use axum::Router;
+    use axum::routing::get;
     use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;

--- a/crates/leviath-cli/src/commands/setup.rs
+++ b/crates/leviath-cli/src/commands/setup.rs
@@ -947,29 +947,28 @@ mod tests {
 
     #[test]
     fn run_non_interactive_setup_writes_through_config_path() {
-        let _guard =
-            crate::config::isolate_config_path_for_test("setup-non-interactive-configpath");
+        crate::config::with_isolated_config_path("setup-non-interactive-configpath", |_fake_dir| {
+            let mut config = Config::load().unwrap_or_default();
+            let args = SetupArgs {
+                non_interactive: true,
+                anthropic_key: Some("sk-ant-execute-test".to_string()),
+                openai_key: None,
+                google_key: None,
+                openrouter_key: None,
+                ollama_url: None,
+                default_model: None,
+            };
 
-        let mut config = Config::load().unwrap_or_default();
-        let args = SetupArgs {
-            non_interactive: true,
-            anthropic_key: Some("sk-ant-execute-test".to_string()),
-            openai_key: None,
-            google_key: None,
-            openrouter_key: None,
-            ollama_url: None,
-            default_model: None,
-        };
+            run_non_interactive_setup(&mut config, &args, &Config::config_path()).unwrap();
 
-        run_non_interactive_setup(&mut config, &args, &Config::config_path()).unwrap();
-
-        // Config::load() re-reads via the same (isolated) LEVIATH_CONFIG_PATH,
-        // proving the setup core wrote through Config::config_path().
-        let reloaded = Config::load().unwrap();
-        assert_eq!(
-            reloaded.providers.anthropic_api_key.as_deref(),
-            Some("sk-ant-execute-test")
-        );
+            // Config::load() re-reads via the same (isolated) LEVIATH_CONFIG_PATH,
+            // proving the setup core wrote through Config::config_path().
+            let reloaded = Config::load().unwrap();
+            assert_eq!(
+                reloaded.providers.anthropic_api_key.as_deref(),
+                Some("sk-ant-execute-test")
+            );
+        });
     }
 
     /// Reader factory shared by both `execute_with` tests below: 7 empty lines,
@@ -983,41 +982,45 @@ mod tests {
 
     #[test]
     fn execute_with_non_interactive_applies_flags_and_never_builds_the_reader() {
-        let _guard =
-            crate::config::isolate_config_path_for_test("setup-execute-with-noninteractive");
-        let args = SetupArgs {
-            non_interactive: true,
-            anthropic_key: Some("sk-ant-ew".to_string()),
-            openai_key: None,
-            google_key: None,
-            openrouter_key: None,
-            ollama_url: None,
-            default_model: None,
-        };
-        // `--non-interactive` short-circuits before the reader factory runs.
-        execute_with(&args, seven_blank_lines).unwrap();
-        assert_eq!(
-            Config::load()
-                .unwrap()
-                .providers
-                .anthropic_api_key
-                .as_deref(),
-            Some("sk-ant-ew")
+        crate::config::with_isolated_config_path(
+            "setup-execute-with-noninteractive",
+            |_fake_dir| {
+                let args = SetupArgs {
+                    non_interactive: true,
+                    anthropic_key: Some("sk-ant-ew".to_string()),
+                    openai_key: None,
+                    google_key: None,
+                    openrouter_key: None,
+                    ollama_url: None,
+                    default_model: None,
+                };
+                // `--non-interactive` short-circuits before the reader factory runs.
+                execute_with(&args, seven_blank_lines).unwrap();
+                assert_eq!(
+                    Config::load()
+                        .unwrap()
+                        .providers
+                        .anthropic_api_key
+                        .as_deref(),
+                    Some("sk-ant-ew")
+                );
+            },
         );
     }
 
     #[test]
     fn execute_with_interactive_reads_from_the_injected_factory() {
-        let _guard = crate::config::isolate_config_path_for_test("setup-execute-with-interactive");
-        let args = SetupArgs {
-            non_interactive: false,
-            anthropic_key: None,
-            openai_key: None,
-            google_key: None,
-            openrouter_key: None,
-            ollama_url: None,
-            default_model: None,
-        };
-        execute_with(&args, seven_blank_lines).unwrap();
+        crate::config::with_isolated_config_path("setup-execute-with-interactive", |_fake_dir| {
+            let args = SetupArgs {
+                non_interactive: false,
+                anthropic_key: None,
+                openai_key: None,
+                google_key: None,
+                openrouter_key: None,
+                ollama_url: None,
+                default_model: None,
+            };
+            execute_with(&args, seven_blank_lines).unwrap();
+        });
     }
 }

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -1383,18 +1383,23 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         std::fs::create_dir_all(&tests_dir).unwrap();
 
         // Redirect Config::load() to a file with invalid TOML.
-        let guard = crate::config::isolate_config_path_for_test("test-cmd-config-fail");
-        let bad_config = guard.fake_dir.join("config.toml");
-        std::fs::write(&bad_config, "not valid toml {{{").unwrap();
+        crate::config::with_isolated_config_path_async(
+            "test-cmd-config-fail",
+            |fake_dir| async move {
+                let bad_config = fake_dir.join("config.toml");
+                std::fs::write(&bad_config, "not valid toml {{{").unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false, // triggers Config::load()
-        };
-        let result = execute_with_registry(args, Box::new(build_registry_from_config)).await;
-        drop(guard);
-        assert!(result.is_err());
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false, // triggers Config::load()
+                };
+                let result =
+                    execute_with_registry(args, Box::new(build_registry_from_config)).await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     /// Covers the `parse_manifest(&manifest_content)?` error path
@@ -1801,34 +1806,38 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_all_pass() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-non-dry-run-all-pass");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(
-            project,
-            r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-non-dry-run-all-pass",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(
+                    project,
+                    r#"
 [[test]]
 name = "greeting"
 input = "say hello"
 expect_contains = "world"
 "#,
-        );
+                );
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result = with_tracing(|| {
-            execute_with_registry(
-                args,
-                Box::new(mock_registry_builder("Hello, world!", vec![])),
-            )
-        })
+                let result = with_tracing(|| {
+                    execute_with_registry(
+                        args,
+                        Box::new(mock_registry_builder("Hello, world!", vec![])),
+                    )
+                })
+                .await;
+                assert!(result.is_ok());
+            },
+        )
         .await;
-        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -1854,42 +1863,47 @@ expect_contains = "world"
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_failure_bails_with_count() {
-        let _config_guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "test-rs-non-dry-run-failure-bails-with-count",
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(
-            project,
-            r#"
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(
+                    project,
+                    r#"
 [[test]]
 name = "greeting"
 input = "say hello"
 expect_contains = "world"
 "#,
-        );
+                );
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("goodbye", vec![]))).await;
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("1 test(s) failed"));
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("goodbye", vec![])))
+                        .await;
+                let err = result.unwrap_err().to_string();
+                assert!(err.contains("1 test(s) failed"));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_applies_filter() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-non-dry-run-applies-filter");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(
-            project,
-            r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-non-dry-run-applies-filter",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(
+                    project,
+                    r#"
 [[test]]
 name = "keep_me"
 input = "say hello"
@@ -1900,79 +1914,87 @@ name = "skip_me"
 input = "say hello"
 expect_contains = "unmatchable content"
 "#,
-        );
+                );
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: Some("keep".to_string()),
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: Some("keep".to_string()),
+                    dry_run: false,
+                };
 
-        // "skip_me" would fail (its expectation never matches the mock
-        // response), but the filter excludes it -- only "keep_me" runs, and
-        // it passes, so the whole run succeeds.
-        let result = execute_with_registry(
-            args,
-            Box::new(mock_registry_builder("Hello, world!", vec![])),
+                // "skip_me" would fail (its expectation never matches the mock
+                // response), but the filter excludes it -- only "keep_me" runs, and
+                // it passes, so the whole run succeeds.
+                let result = execute_with_registry(
+                    args,
+                    Box::new(mock_registry_builder("Hello, world!", vec![])),
+                )
+                .await;
+                assert!(result.is_ok());
+            },
         )
         .await;
-        assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_tool_call_assertion() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-non-dry-run-tool-call-assertion");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(
-            project,
-            r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-non-dry-run-tool-call-assertion",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(
+                    project,
+                    r#"
 [[test]]
 name = "tool_test"
 input = "run a command"
 expect_tool_call = "bash"
 "#,
-        );
+                );
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "bash".to_string(),
-            arguments: serde_json::json!({}),
-        }];
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("", tool_calls))).await;
-        assert!(result.is_ok());
+                let tool_calls = vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "bash".to_string(),
+                    arguments: serde_json::json!({}),
+                }];
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("", tool_calls)))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_provider_error_counts_as_failure() {
-        let _config_guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "test-rs-non-dry-run-provider-error-counts-as-failure",
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(
-            project,
-            r#"
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(
+                    project,
+                    r#"
 [[test]]
 name = "no_such_provider"
 input = "hi"
 expect_contains = "x"
 "#,
-        );
-        // Overwrite the manifest with a provider name the mock registry never
-        // registers, so `run_test_case`'s "not configured" error path fires
-        // (the `Err(e)` arm of `execute`'s match, not `Ok(false)`).
-        std::fs::write(
-            project.join("agent.leviath"),
-            r#"
+                );
+                // Overwrite the manifest with a provider name the mock registry never
+                // registers, so `run_test_case`'s "not configured" error path fires
+                // (the `Err(e)` arm of `execute`'s match, not `Ok(false)`).
+                std::fs::write(
+                    project.join("agent.leviath"),
+                    r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -1981,53 +2003,64 @@ description = "test"
 [stages.main]
 model = { provider = "nonexistent-provider", model = "x" }
 "#,
-        )
-        .unwrap();
+                )
+                .unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("irrelevant", vec![])))
+                let result = execute_with_registry(
+                    args,
+                    Box::new(mock_registry_builder("irrelevant", vec![])),
+                )
                 .await;
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("1 test(s) failed"));
+                let err = result.unwrap_err().to_string();
+                assert!(err.contains("1 test(s) failed"));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_non_dry_run_toml_malformed_errors() {
-        let _config_guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "test-rs-non-dry-run-toml-malformed-errors",
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        write_project_with_test_file(project, "not valid {{{ toml");
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                write_project_with_test_file(project, "not valid {{{ toml");
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("irrelevant", vec![])))
+                let result = execute_with_registry(
+                    args,
+                    Box::new(mock_registry_builder("irrelevant", vec![])),
+                )
                 .await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to parse"));
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("Failed to parse"));
+            },
+        )
+        .await;
     }
 
     // ─── rhai script execution path ──────────────────────────────────────────
 
     #[tokio::test]
     async fn execute_with_registry_rhai_script_passes() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-rhai-script-passes");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        let manifest = r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-rhai-script-passes",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                let manifest = r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -2036,29 +2069,34 @@ description = "test"
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 "#;
-        write_test_agent(project, manifest);
-        let tests_dir = project.join("tests");
-        std::fs::create_dir_all(&tests_dir).unwrap();
-        std::fs::write(tests_dir.join("script.rhai"), "true").unwrap();
+                write_test_agent(project, manifest);
+                let tests_dir = project.join("tests");
+                std::fs::create_dir_all(&tests_dir).unwrap();
+                std::fs::write(tests_dir.join("script.rhai"), "true").unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![]))).await;
-        assert!(result.is_ok());
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_rhai_script_returns_false_fails() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-rhai-script-returns-false-fails");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        let manifest = r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-rhai-script-returns-false-fails",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                let manifest = r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -2067,30 +2105,35 @@ description = "test"
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 "#;
-        write_test_agent(project, manifest);
-        let tests_dir = project.join("tests");
-        std::fs::create_dir_all(&tests_dir).unwrap();
-        std::fs::write(tests_dir.join("script.rhai"), "false").unwrap();
+                write_test_agent(project, manifest);
+                let tests_dir = project.join("tests");
+                std::fs::create_dir_all(&tests_dir).unwrap();
+                std::fs::write(tests_dir.join("script.rhai"), "false").unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![]))).await;
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("1 test(s) failed"));
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
+                        .await;
+                let err = result.unwrap_err().to_string();
+                assert!(err.contains("1 test(s) failed"));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_rhai_script_error_fails() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-rhai-script-error-fails");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        let manifest = r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-rhai-script-error-fails",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                let manifest = r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -2099,30 +2142,35 @@ description = "test"
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 "#;
-        write_test_agent(project, manifest);
-        let tests_dir = project.join("tests");
-        std::fs::create_dir_all(&tests_dir).unwrap();
-        std::fs::write(tests_dir.join("script.rhai"), "this is not valid rhai (((").unwrap();
+                write_test_agent(project, manifest);
+                let tests_dir = project.join("tests");
+                std::fs::create_dir_all(&tests_dir).unwrap();
+                std::fs::write(tests_dir.join("script.rhai"), "this is not valid rhai (((")
+                    .unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![]))).await;
-        assert!(result.is_err());
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
+                        .await;
+                assert!(result.is_err());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_rhai_script_non_bool_return_passes() {
-        let _config_guard = crate::config::isolate_config_path_for_test(
+        crate::config::with_isolated_config_path_async(
             "test-rs-rhai-script-non-bool-return-passes",
-        );
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        let manifest = r#"
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                let manifest = r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -2131,31 +2179,36 @@ description = "test"
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 "#;
-        write_test_agent(project, manifest);
-        let tests_dir = project.join("tests");
-        std::fs::create_dir_all(&tests_dir).unwrap();
-        // Returns an integer, not a bool -- exercises the `else` arm of the
-        // `result.as_bool()` match (treated as an automatic pass).
-        std::fs::write(tests_dir.join("script.rhai"), "42").unwrap();
+                write_test_agent(project, manifest);
+                let tests_dir = project.join("tests");
+                std::fs::create_dir_all(&tests_dir).unwrap();
+                // Returns an integer, not a bool -- exercises the `else` arm of the
+                // `result.as_bool()` match (treated as an automatic pass).
+                std::fs::write(tests_dir.join("script.rhai"), "42").unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: None,
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
 
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![]))).await;
-        assert!(result.is_ok());
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn execute_with_registry_rhai_script_filter_excludes_all() {
-        let _config_guard =
-            crate::config::isolate_config_path_for_test("test-rs-rhai-script-filter-excludes-all");
-        let dir = tempfile::tempdir().unwrap();
-        let project = dir.path();
-        let manifest = r#"
+        crate::config::with_isolated_config_path_async(
+            "test-rs-rhai-script-filter-excludes-all",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().unwrap();
+                let project = dir.path();
+                let manifest = r#"
 [agent]
 name = "test-agent"
 version = "0.1.0"
@@ -2164,22 +2217,26 @@ description = "test"
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 "#;
-        write_test_agent(project, manifest);
-        let tests_dir = project.join("tests");
-        std::fs::create_dir_all(&tests_dir).unwrap();
-        std::fs::write(tests_dir.join("script.rhai"), "false").unwrap();
+                write_test_agent(project, manifest);
+                let tests_dir = project.join("tests");
+                std::fs::create_dir_all(&tests_dir).unwrap();
+                std::fs::write(tests_dir.join("script.rhai"), "false").unwrap();
 
-        let args = TestArgs {
-            path: Some(project.to_str().unwrap().to_string()),
-            filter: Some("no-such-script".to_string()),
-            dry_run: false,
-        };
+                let args = TestArgs {
+                    path: Some(project.to_str().unwrap().to_string()),
+                    filter: Some("no-such-script".to_string()),
+                    dry_run: false,
+                };
 
-        // Filter excludes the only script -- 0 total, reports "no test files
-        // found" and succeeds (rather than failing on the script's `false`).
-        let result =
-            execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![]))).await;
-        assert!(result.is_ok());
+                // Filter excludes the only script -- 0 total, reports "no test files
+                // found" and succeeds (rather than failing on the script's `false`).
+                let result =
+                    execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
     }
 
     // ─── build_registry_from_config ──────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -177,10 +177,10 @@ async fn execute_with_registry(
 
             for test_case in &test_file.test {
                 // Apply filter if provided
-                if let Some(ref filter) = args.filter {
-                    if !test_case.name.contains(filter.as_str()) {
-                        continue;
-                    }
+                if let Some(ref filter) = args.filter
+                    && !test_case.name.contains(filter.as_str())
+                {
+                    continue;
                 }
 
                 total += 1;
@@ -229,10 +229,10 @@ async fn execute_with_registry(
                 .unwrap_or("unknown");
 
             // Apply filter if provided
-            if let Some(ref filter) = args.filter {
-                if !file_name.contains(filter.as_str()) {
-                    continue;
-                }
+            if let Some(ref filter) = args.filter
+                && !file_name.contains(filter.as_str())
+            {
+                continue;
             }
 
             total += 1;
@@ -1298,7 +1298,7 @@ max_tokens = 5000
     /// Covers the `ok_or(anyhow!("Blueprint has no stages"))` path.
     #[tokio::test]
     async fn run_test_case_blueprint_with_no_stages_errors() {
-        use leviath_core::{layout::ContextLayout, Blueprint};
+        use leviath_core::{Blueprint, layout::ContextLayout};
         let blueprint = Blueprint::new(
             "no-stages".to_string(),
             "test".to_string(),
@@ -1528,8 +1528,8 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     #[test]
     fn init_test_context_window_no_pinned_region_skips_input() {
         use bevy_ecs::world::World;
-        use leviath_core::layout::ContextLayout;
         use leviath_core::Blueprint;
+        use leviath_core::layout::ContextLayout;
         // Blueprint with no context regions → ContextLayout has no Pinned region.
         let blueprint = Blueprint::new(
             "no-regions".to_string(),
@@ -1855,10 +1855,12 @@ expect_contains = "world"
         };
         let result = execute_with_registry(args, Box::new(build_registry_from_config)).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No agent.leviath found"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No agent.leviath found")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -375,43 +375,22 @@ fn set_dir_permissions_with(
     }
 }
 
-/// Serializes any test, in this file or elsewhere in the crate, that reads
-/// `Config::config_path()`'s default (unset-env) behavior or that
-/// temporarily overrides `LEVIATH_CONFIG_PATH`. This env var is
-/// process-global, so tests in different files/modules that don't share a
-/// lock can race — e.g. a test in `commands/run/worker.rs` redirecting
-/// `LEVIATH_CONFIG_PATH` while this file's `config_path_contains_leviath`
-/// concurrently asserts on the real default path. Declared here (not inside
-/// `mod tests`) so it's reachable crate-wide as `crate::config::CONFIG_PATH_ENV_LOCK`
-/// without needing to expose the whole test module.
-#[cfg(test)]
-pub(crate) static CONFIG_PATH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Serializes any test, anywhere in the crate, that mutates the
-/// process-global `PATH` env var (e.g. to starve editor/clipboard-tool
-/// resolution). Declared here for the same reason as `CONFIG_PATH_ENV_LOCK`
-/// above: a per-file lock (as in `commands/run/session.rs`'s `launch_editor`
-/// tests and `commands/dashboard/helpers.rs`'s clipboard-fallback test) does
-/// not serialize against another file's tests, since each is a distinct Rust
-/// item despite the shared name -- a real (if narrow) cross-file race window.
-#[cfg(test)]
-pub(crate) static PATH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// Serializes any test, anywhere in the crate, that mutates the process's
 /// current working directory (via `std::env::set_current_dir`) or whose
-/// assertions implicitly depend on it. Declared here for the same reason as
-/// `CONFIG_PATH_ENV_LOCK`/`PATH_ENV_LOCK` above: a per-file lock (as in
+/// assertions implicitly depend on it. Declared here (not inside `mod tests`)
+/// so it's reachable crate-wide: a per-file lock (as in
 /// `commands/run/manifest.rs`'s CWD-dependent `find_manifest` tests) would not
-/// serialize against a CWD-mutating test in a different file.
+/// serialize against a CWD-mutating test in a different file. (Env-var
+/// isolation, by contrast, goes through the `temp-env` crate's own global
+/// lock; `set_current_dir` is not an env var, so it keeps this dedicated lock.)
 #[cfg(test)]
 pub(crate) static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// RAII guard that releases [`CWD_LOCK`] and restores the process's
 /// original working directory on drop.
 ///
-/// Wraps the `MutexGuard` inside a private field (mirroring
-/// [`ConfigPathTestGuard`] below) specifically so it can be held across an
-/// `.await` in an async test without tripping clippy's
+/// Wraps the `MutexGuard` inside a private field specifically so it can be held
+/// across an `.await` in an async test without tripping clippy's
 /// `await_holding_lock` lint, which only looks for a directly-visible
 /// `MutexGuard` local -- not one hidden inside a wrapper struct's field.
 /// That's not working around a real risk: each `#[tokio::test]` gets its
@@ -456,7 +435,7 @@ pub(crate) fn isolate_cwd_for_test() -> CwdTestGuard {
 /// Provider API key env vars that `Config::load()` (via `dotenvy::dotenv()`)
 /// loads into the process env regardless of which config file path is used --
 /// so redirecting the config path alone isn't enough; these must be cleared
-/// too by [`isolate_config_path_for_test`].
+/// too by [`config_isolation_vars`].
 #[cfg(test)]
 const PROVIDER_KEY_ENV_VARS: &[&str] = &[
     "ANTHROPIC_API_KEY",
@@ -465,88 +444,69 @@ const PROVIDER_KEY_ENV_VARS: &[&str] = &[
     "OPENROUTER_API_KEY",
 ];
 
-/// RAII guard that restores `LEVIATH_CONFIG_PATH`, `LEVIATH_SKIP_DOTENV`, and
-/// the provider key env vars to their original values, and releases
-/// [`CONFIG_PATH_ENV_LOCK`], on drop.
+/// Create a fresh, empty temp directory to stand in for the config directory.
 #[cfg(test)]
-pub(crate) struct ConfigPathTestGuard {
-    original_config_path: Option<std::ffi::OsString>,
-    original_skip_dotenv: Option<std::ffi::OsString>,
-    original_keys: Vec<(&'static str, Option<std::ffi::OsString>)>,
-    pub(crate) fake_dir: std::path::PathBuf,
-    _lock: std::sync::MutexGuard<'static, ()>,
-}
-
-/// Restore one environment variable to a previously-snapshotted value:
-/// re-set it if it was present, or remove it if it was absent.
-///
-/// Extracted so both arms are exercised by a deterministic unit test
-/// ([`tests::restore_env_var_covers_both_arms`]) regardless of which provider
-/// keys happen to be set in the ambient test environment. Inline, the `Some`
-/// arm was only ever hit when a snapshotted var was actually set — never in a
-/// clean environment (a fresh CI runner, where none of the provider keys are
-/// exported), leaving the `Some` arm permanently uncovered there.
-#[cfg(test)]
-fn restore_env_var(key: &str, value: Option<&std::ffi::OsStr>) {
-    match value {
-        Some(v) => std::env::set_var(key, v),
-        None => std::env::remove_var(key),
-    }
-}
-
-#[cfg(test)]
-impl Drop for ConfigPathTestGuard {
-    fn drop(&mut self) {
-        restore_env_var(
-            "LEVIATH_CONFIG_PATH",
-            self.original_config_path.take().as_deref(),
-        );
-        restore_env_var(
-            "LEVIATH_SKIP_DOTENV",
-            self.original_skip_dotenv.take().as_deref(),
-        );
-        for (key, value) in self.original_keys.drain(..) {
-            restore_env_var(key, value.as_deref());
-        }
-        let _ = std::fs::remove_dir_all(&self.fake_dir);
-    }
-}
-
-/// Points `LEVIATH_CONFIG_PATH` at a nonexistent path inside a fresh temp
-/// directory, sets `LEVIATH_SKIP_DOTENV`, and clears `PROVIDER_KEY_ENV_VARS`,
-/// for the duration of the returned guard -- so `Config::load()` sees no
-/// config file and no real API keys, and falls back to defaults with no
-/// registered providers.
-///
-/// Shared across test modules (e.g. `commands/run/worker.rs`,
-/// `commands/run/foreground.rs`) that need to drive a real `Config::load()`
-/// without risking a real, billed inference call via a real API key found in
-/// `~/.leviath/config.toml` or a repo-root `.env`.
-#[cfg(test)]
-pub(crate) fn isolate_config_path_for_test(unique: &str) -> ConfigPathTestGuard {
-    let lock = CONFIG_PATH_ENV_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let original_config_path = std::env::var_os("LEVIATH_CONFIG_PATH");
-    let original_skip_dotenv = std::env::var_os("LEVIATH_SKIP_DOTENV");
-    let original_keys: Vec<_> = PROVIDER_KEY_ENV_VARS
-        .iter()
-        .map(|&key| (key, std::env::var_os(key)))
-        .collect();
-    for &key in PROVIDER_KEY_ENV_VARS {
-        std::env::remove_var(key);
-    }
-    let fake_dir = std::env::temp_dir().join(format!("lev-fake-config-{}", unique));
+fn make_fake_config_dir(unique: &str) -> std::path::PathBuf {
+    let fake_dir = std::env::temp_dir().join(format!("lev-fake-config-{unique}"));
     let _ = std::fs::create_dir_all(&fake_dir);
-    std::env::set_var("LEVIATH_CONFIG_PATH", fake_dir.join("config.toml"));
-    std::env::set_var("LEVIATH_SKIP_DOTENV", "1");
-    ConfigPathTestGuard {
-        original_config_path,
-        original_skip_dotenv,
-        original_keys,
-        fake_dir,
-        _lock: lock,
+    fake_dir
+}
+
+/// The env overrides that isolate `Config::load()` from the real environment:
+/// point `LEVIATH_CONFIG_PATH` at a nonexistent file in `fake_dir`, set
+/// `LEVIATH_SKIP_DOTENV`, and clear every provider API key (so no real, billed
+/// inference call can be made). Consumed by [`with_isolated_config_path`] and
+/// its async twin, which hand it to `temp_env` for scoped set-and-restore.
+#[cfg(test)]
+fn config_isolation_vars(
+    fake_dir: &std::path::Path,
+) -> Vec<(&'static str, Option<std::ffi::OsString>)> {
+    let mut vars: Vec<(&'static str, Option<std::ffi::OsString>)> = vec![
+        (
+            "LEVIATH_CONFIG_PATH",
+            Some(fake_dir.join("config.toml").into_os_string()),
+        ),
+        ("LEVIATH_SKIP_DOTENV", Some(std::ffi::OsString::from("1"))),
+    ];
+    for &key in PROVIDER_KEY_ENV_VARS {
+        vars.push((key, None));
     }
+    vars
+}
+
+/// Runs `f` with `Config::load()` isolated from the real environment (see
+/// [`config_isolation_vars`]), passing it the fake config directory so tests
+/// that need to plant a `config.toml` can. `temp_env::with_vars` sets the
+/// overrides, runs the closure, and restores the prior values afterwards --
+/// serialized process-wide against every other temp-env test, so no hand-rolled
+/// lock is needed. The closure-scoped form (not an RAII guard) is required
+/// because edition 2024 makes `set_var` `unsafe`, which the crate forbids.
+#[cfg(test)]
+pub(crate) fn with_isolated_config_path<R>(
+    unique: &str,
+    f: impl FnOnce(&std::path::Path) -> R,
+) -> R {
+    let fake_dir = make_fake_config_dir(unique);
+    let result = temp_env::with_vars(config_isolation_vars(&fake_dir), || f(&fake_dir));
+    let _ = std::fs::remove_dir_all(&fake_dir);
+    result
+}
+
+/// Async counterpart of [`with_isolated_config_path`] for `#[tokio::test]`s.
+/// The isolation env vars stay in place across every `.await` in `fut`.
+#[cfg(test)]
+pub(crate) async fn with_isolated_config_path_async<R, Fut>(
+    unique: &str,
+    f: impl FnOnce(std::path::PathBuf) -> Fut,
+) -> R
+where
+    Fut: std::future::Future<Output = R>,
+{
+    let fake_dir = make_fake_config_dir(unique);
+    let result =
+        temp_env::async_with_vars(config_isolation_vars(&fake_dir), f(fake_dir.clone())).await;
+    let _ = std::fs::remove_dir_all(&fake_dir);
+    result
 }
 
 #[cfg(test)]
@@ -554,128 +514,27 @@ mod tests {
     use super::*;
     use crate::test_support::with_tracing;
 
-    // ─── restore_env_var ─────────────────────────────────────────────────────
-
-    /// Exercises both arms of [`restore_env_var`] deterministically, so its
-    /// `Some` arm is covered even in a clean environment where none of the
-    /// provider keys the guards snapshot are set (the state on a fresh CI
-    /// runner). Uses a dedicated sentinel key no other code reads, and holds
-    /// `CONFIG_PATH_ENV_LOCK` to serialize with the crate's other
-    /// env-mutating tests.
-    #[test]
-    fn restore_env_var_covers_both_arms() {
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let key = "LEVIATH_TEST_RESTORE_ENV_VAR_SENTINEL";
-        let original = std::env::var_os(key);
-
-        // `Some` arm: the var is (re)set to the given value.
-        restore_env_var(key, Some(std::ffi::OsStr::new("sentinel-value")));
-        assert_eq!(
-            std::env::var_os(key).as_deref(),
-            Some(std::ffi::OsStr::new("sentinel-value"))
-        );
-
-        // `None` arm: the var is removed.
-        restore_env_var(key, None);
-        assert!(std::env::var_os(key).is_none());
-
-        // Leave the ambient environment exactly as we found it.
-        restore_env_var(key, original.as_deref());
-    }
-
     // ─── leviath_home_dir ────────────────────────────────────────────────────
-
-    /// Restores `LEVIATH_HOME` to its pre-test value (or removes it if it
-    /// wasn't set), shared by every `leviath_home_dir_*` test below.
-    ///
-    /// A single shared implementation -- rather than each test inlining its
-    /// own copy of this match -- matters for coverage, not just brevity:
-    /// `original` is `None` in every test that doesn't deliberately seed a
-    /// sentinel first (realistic dev/CI environments never have
-    /// `LEVIATH_HOME` set), so a test-private copy of this restore logic
-    /// would leave its own `Some(v) => set_var(...)` arm permanently
-    /// uncovered -- `cargo-llvm-cov` counts coverage per exact source
-    /// location, so one test hitting the `Some` arm of a *different*
-    /// test's textually-identical-looking copy doesn't cover this one.
-    /// Routing every test through one shared function means any test that
-    /// happens to pass `Some(..)` (see
-    /// `leviath_home_dir_restore_preserves_previously_set_home`) covers the
-    /// `Some` arm for all callers at once.
-    fn restore_leviath_home(original: Option<std::ffi::OsString>) {
-        unsafe {
-            match original {
-                Some(v) => std::env::set_var("LEVIATH_HOME", v),
-                None => std::env::remove_var("LEVIATH_HOME"),
-            }
-        }
-    }
 
     #[test]
     fn leviath_home_dir_uses_override_when_set() {
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let original = std::env::var_os("LEVIATH_HOME");
-        unsafe {
-            std::env::set_var("LEVIATH_HOME", "/tmp/leviath-home-override-test");
-        }
-        let result = leviath_home_dir();
-        restore_leviath_home(original);
-        assert_eq!(
-            result,
-            Some(std::path::PathBuf::from("/tmp/leviath-home-override-test"))
+        temp_env::with_var(
+            "LEVIATH_HOME",
+            Some("/tmp/leviath-home-override-test"),
+            || {
+                assert_eq!(
+                    leviath_home_dir(),
+                    Some(std::path::PathBuf::from("/tmp/leviath-home-override-test"))
+                );
+            },
         );
     }
 
     #[test]
     fn leviath_home_dir_falls_back_to_dirs_home_dir_when_unset() {
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let original = std::env::var_os("LEVIATH_HOME");
-        unsafe {
-            std::env::remove_var("LEVIATH_HOME");
-        }
-        let result = leviath_home_dir();
-        restore_leviath_home(original);
-        assert_eq!(result, dirs::home_dir());
-    }
-
-    /// Covers `restore_leviath_home`'s `Some(v) => set_var(...)` arm, which
-    /// the two tests above never reach (both start from a realistic unset
-    /// `LEVIATH_HOME`): seeds a sentinel *before* capturing `original`, so
-    /// the shared restore step has something real to put back.
-    #[test]
-    fn leviath_home_dir_restore_preserves_previously_set_home() {
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        unsafe {
-            std::env::set_var("LEVIATH_HOME", "/tmp/leviath-home-original-sentinel");
-        }
-        let original = std::env::var_os("LEVIATH_HOME");
-        unsafe {
-            std::env::set_var("LEVIATH_HOME", "/tmp/leviath-home-override-test-2");
-        }
-        let result = leviath_home_dir();
-        restore_leviath_home(original);
-        assert_eq!(
-            result,
-            Some(std::path::PathBuf::from(
-                "/tmp/leviath-home-override-test-2"
-            ))
-        );
-        assert_eq!(
-            std::env::var_os("LEVIATH_HOME"),
-            Some(std::ffi::OsString::from(
-                "/tmp/leviath-home-original-sentinel"
-            ))
-        );
-        unsafe {
-            std::env::remove_var("LEVIATH_HOME");
-        }
+        temp_env::with_var_unset("LEVIATH_HOME", || {
+            assert_eq!(leviath_home_dir(), dirs::home_dir());
+        });
     }
 
     // ─── load_from_path / save_to_path (path-parameterized for testability) ─
@@ -707,26 +566,20 @@ mod tests {
         // in `load_from_path` has only ever been exercised on its `true`
         // (field absent, fall back to env) arm elsewhere in this file --
         // never on the `false` (field already set from the TOML file, skip
-        // the env lookup) arm. Hold the shared lock while clearing these
-        // process-global env vars so a concurrently-running test elsewhere
-        // in the crate can't be mid-set when we read them.
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let saved: Vec<_> = PROVIDER_KEY_ENV_VARS
+        // the env lookup) arm. `temp_env::with_vars` clears these process-global
+        // env vars for the closure (and serializes against every other temp-env
+        // test), so no concurrently-running test can be mid-set when we read.
+        let unset: Vec<(&str, Option<&str>)> = PROVIDER_KEY_ENV_VARS
             .iter()
             .chain(["OLLAMA_HOST"].iter())
-            .map(|&key| (key, std::env::var_os(key)))
+            .map(|&key| (key, None))
             .collect();
-        for &(key, _) in &saved {
-            std::env::remove_var(key);
-        }
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        std::fs::write(
-            &path,
-            r#"
+        temp_env::with_vars(unset, || {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("config.toml");
+            std::fs::write(
+                &path,
+                r#"
 default_provider = "anthropic"
 openrouter_api_key = "sk-or-existing"
 ollama_base_url = "http://existing-ollama:11434"
@@ -738,32 +591,29 @@ anthropic_api_key = "sk-ant-existing"
 openai_api_key = "sk-openai-existing"
 google_api_key = "AIza-existing"
 "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
+            let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
 
-        for (key, original) in saved {
-            restore_env_var(key, original.as_deref());
-        }
-
-        assert_eq!(
-            config.providers.anthropic_api_key.as_deref(),
-            Some("sk-ant-existing")
-        );
-        assert_eq!(
-            config.providers.openai_api_key.as_deref(),
-            Some("sk-openai-existing")
-        );
-        assert_eq!(
-            config.providers.google_api_key.as_deref(),
-            Some("AIza-existing")
-        );
-        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or-existing"));
-        assert_eq!(
-            config.ollama_base_url.as_deref(),
-            Some("http://existing-ollama:11434")
-        );
+            assert_eq!(
+                config.providers.anthropic_api_key.as_deref(),
+                Some("sk-ant-existing")
+            );
+            assert_eq!(
+                config.providers.openai_api_key.as_deref(),
+                Some("sk-openai-existing")
+            );
+            assert_eq!(
+                config.providers.google_api_key.as_deref(),
+                Some("AIza-existing")
+            );
+            assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or-existing"));
+            assert_eq!(
+                config.ollama_base_url.as_deref(),
+                Some("http://existing-ollama:11434")
+            );
+        });
     }
 
     #[test]
@@ -869,16 +719,17 @@ google_api_key = "AIza-existing"
         // wrapper itself (every other test calls `save_to_path` directly),
         // using `LEVIATH_CONFIG_PATH` to redirect the "real" path to a
         // tempdir instead of the developer's actual `~/.leviath/config.toml`.
-        let _guard = isolate_config_path_for_test("save-wrapper");
-        let config = Config {
-            default_provider: "openai".to_string(),
-            ..Config::default()
-        };
+        with_isolated_config_path("save-wrapper", |_fake_dir| {
+            let config = Config {
+                default_provider: "openai".to_string(),
+                ..Config::default()
+            };
 
-        with_tracing(|| config.save()).unwrap();
+            with_tracing(|| config.save()).unwrap();
 
-        let loaded = with_tracing(|| Config::load_from_path(&Config::config_path())).unwrap();
-        assert_eq!(loaded.default_provider, "openai");
+            let loaded = with_tracing(|| Config::load_from_path(&Config::config_path())).unwrap();
+            assert_eq!(loaded.default_provider, "openai");
+        });
     }
 
     #[test]
@@ -887,12 +738,13 @@ google_api_key = "AIza-existing"
         // or a well-formed one, so `load()`'s `?` on `load_from_path(...)`
         // has never actually propagated an `Err`. Writing malformed TOML to
         // the guard's redirected `LEVIATH_CONFIG_PATH` forces that.
-        let guard = isolate_config_path_for_test("load-malformed");
-        std::fs::write(guard.fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
+        with_isolated_config_path("load-malformed", |fake_dir| {
+            std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
 
-        let result = Config::load();
+            let result = Config::load();
 
-        assert!(result.is_err());
+            assert!(result.is_err());
+        });
     }
 
     // ─── check_permissions_at ────────────────────────────────────────────
@@ -1329,61 +1181,15 @@ max_output_tokens = 2048
 
     #[test]
     fn config_path_contains_leviath() {
-        // LEVIATH_CONFIG_PATH is process-global — hold the shared lock so a
-        // concurrently-running test elsewhere in the crate (e.g.
-        // commands/run/worker.rs's isolate_config_path) can't be mid-override
-        // when we read the real default here.
-        let _lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let path = Config::config_path();
-        assert!(path.to_str().unwrap().contains(".leviath"));
-        assert!(path.to_str().unwrap().ends_with("config.toml"));
-    }
-
-    #[test]
-    fn config_path_test_guard_drop_restores_previous_env_values() {
-        // Every other user of `isolate_config_path_for_test` starts from an
-        // *unset* `LEVIATH_CONFIG_PATH`/`LEVIATH_SKIP_DOTENV`, so the guard's
-        // `Drop` always takes the `None => remove_var(..)` arm. This test
-        // seeds both vars with sentinel values first, so `Drop` must take the
-        // `Some(path) => set_var(..)` arm instead, restoring them rather than
-        // removing them. The lock is held continuously (by the guard itself)
-        // so no concurrently-running test elsewhere in the crate can
-        // observe or clobber the sentinel values in between.
-        let lock = CONFIG_PATH_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        std::env::set_var("LEVIATH_CONFIG_PATH", "/sentinel/config-path");
-        std::env::set_var("LEVIATH_SKIP_DOTENV", "sentinel-value");
-
-        let original_config_path = std::env::var_os("LEVIATH_CONFIG_PATH");
-        let original_skip_dotenv = std::env::var_os("LEVIATH_SKIP_DOTENV");
-        let fake_dir =
-            std::env::temp_dir().join("lev-fake-config-drop-restore-previous-values-test");
-        let _ = std::fs::create_dir_all(&fake_dir);
-        std::env::set_var("LEVIATH_CONFIG_PATH", fake_dir.join("config.toml"));
-        std::env::set_var("LEVIATH_SKIP_DOTENV", "1");
-        let guard = ConfigPathTestGuard {
-            original_config_path,
-            original_skip_dotenv,
-            original_keys: vec![],
-            fake_dir: fake_dir.clone(),
-            _lock: lock,
-        };
-
-        drop(guard);
-
-        assert_eq!(
-            std::env::var("LEVIATH_CONFIG_PATH").unwrap(),
-            "/sentinel/config-path"
-        );
-        assert_eq!(
-            std::env::var("LEVIATH_SKIP_DOTENV").unwrap(),
-            "sentinel-value"
-        );
-        std::env::remove_var("LEVIATH_CONFIG_PATH");
-        std::env::remove_var("LEVIATH_SKIP_DOTENV");
+        // Force `LEVIATH_CONFIG_PATH` unset (via `temp_env::with_var_unset`,
+        // which also serializes against every other temp-env test) so
+        // `config_path()` resolves to the real default, not a concurrently-set
+        // override.
+        temp_env::with_var_unset("LEVIATH_CONFIG_PATH", || {
+            let path = Config::config_path();
+            assert!(path.to_str().unwrap().contains(".leviath"));
+            assert!(path.to_str().unwrap().ends_with("config.toml"));
+        });
     }
 
     // ─── Config save/load roundtrip ────────────────────────────────────────

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -242,20 +242,18 @@ impl Config {
     /// Validate API key formats and return warnings for suspicious keys.
     pub fn validate_keys(&self) -> Vec<String> {
         let mut warnings = Vec::new();
-        if let Some(ref key) = self.providers.anthropic_api_key {
-            if !key.starts_with("sk-ant-") {
-                warnings.push(
-                    "Anthropic API key doesn't start with 'sk-ant-' — verify it's correct"
-                        .to_string(),
-                );
-            }
+        if let Some(ref key) = self.providers.anthropic_api_key
+            && !key.starts_with("sk-ant-")
+        {
+            warnings.push(
+                "Anthropic API key doesn't start with 'sk-ant-' — verify it's correct".to_string(),
+            );
         }
-        if let Some(ref key) = self.providers.openai_api_key {
-            if !key.starts_with("sk-") {
-                warnings.push(
-                    "OpenAI API key doesn't start with 'sk-' — verify it's correct".to_string(),
-                );
-            }
+        if let Some(ref key) = self.providers.openai_api_key
+            && !key.starts_with("sk-")
+        {
+            warnings
+                .push("OpenAI API key doesn't start with 'sk-' — verify it's correct".to_string());
         }
         warnings
     }
@@ -693,10 +691,12 @@ google_api_key = "AIza-existing"
         let result = Config::default().save_to_path(&path);
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to write config"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to write config")
+        );
     }
 
     #[test]
@@ -707,10 +707,12 @@ google_api_key = "AIza-existing"
         let path = blocking_file.join("config.toml");
         let result = Config::default().save_to_path(&path);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to create config directory"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to create config directory")
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -283,16 +283,17 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_models_variant_is_routed() {
-        let guard = crate::config::isolate_config_path_for_test("dispatch-models");
-        let args = commands::models::ModelsArgs {
-            command: commands::models::ModelsCommand::List(commands::models::ListArgs {
-                provider: None,
-                remote: false,
-            }),
-        };
-        let result = dispatch(Commands::Models(args), &MockRisky).await;
-        drop(guard);
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async("dispatch-models", |_fake_dir| async move {
+            let args = commands::models::ModelsArgs {
+                command: commands::models::ModelsCommand::List(commands::models::ListArgs {
+                    provider: None,
+                    remote: false,
+                }),
+            };
+            let result = dispatch(Commands::Models(args), &MockRisky).await;
+            assert!(result.is_ok());
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/interaction.rs
+++ b/crates/leviath-cli/src/interaction.rs
@@ -21,7 +21,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use crate::runstate::{run_dir, write_meta, RunMeta, RunStatus};
+use crate::runstate::{RunMeta, RunStatus, run_dir, write_meta};
 
 // ─── Value types (re-exported from `leviath-core`) ────────────
 //
@@ -30,8 +30,8 @@ use crate::runstate::{run_dir, write_meta, RunMeta, RunStatus};
 // them without depending on the CLI. Re-exported here so `crate::interaction::*`
 // paths resolve.
 pub use leviath_core::interaction::{
-    make_interaction_id, response_approved, response_as_choice, response_as_text, ApprovalScope,
-    BodyFormat, InteractionKind, InteractionRequest, InteractionResponse,
+    ApprovalScope, BodyFormat, InteractionKind, InteractionRequest, InteractionResponse,
+    make_interaction_id, response_approved, response_as_choice, response_as_text,
 };
 
 // ─── File paths ─────────────────────────────────────────────────────────────
@@ -142,10 +142,10 @@ fn poll_step(run_id: &str, req_id: &str, started: Instant, timeout: Option<Durat
         return PollStep::Answer(resp);
     }
 
-    if let Some(t) = timeout {
-        if started.elapsed() >= t {
-            return PollStep::TimedOut;
-        }
+    if let Some(t) = timeout
+        && started.elapsed() >= t
+    {
+        return PollStep::TimedOut;
     }
 
     PollStep::KeepWaiting
@@ -435,10 +435,11 @@ pub fn request_interaction_from_reader(
                     return InteractionResponse::choice(&req.id, 0);
                 }
                 let s = input.trim();
-                if let Ok(n) = s.parse::<usize>() {
-                    if n >= 1 && n <= req.options.len() {
-                        return InteractionResponse::choice(&req.id, n - 1);
-                    }
+                if let Ok(n) = s.parse::<usize>()
+                    && n >= 1
+                    && n <= req.options.len()
+                {
+                    return InteractionResponse::choice(&req.id, n - 1);
                 }
                 println!("Please enter a number between 1 and {}.", req.options.len());
             }

--- a/crates/leviath-cli/src/interaction.rs
+++ b/crates/leviath-cli/src/interaction.rs
@@ -532,27 +532,27 @@ mod tests {
 
     #[test]
     fn poll_step_answer_when_matching_response() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("poll_step_answer_when_matching_response");
-        let run_id = "poll-step-answer";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("poll_step_answer_when_matching_response", |_d| {
+            let run_id = "poll-step-answer";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        write_response(run_id, &InteractionResponse::text("req-A", "the answer")).unwrap();
+            write_response(run_id, &InteractionResponse::text("req-A", "the answer")).unwrap();
 
-        let (tag, resp) = poll_step(
-            run_id,
-            "req-A",
-            Instant::now(),
-            Some(Duration::from_secs(60)),
-        )
-        .parts();
-        assert_eq!(tag, "answer");
-        assert_eq!(resp.unwrap().value.as_deref(), Some("the answer"));
-        // The response file was consumed by take_response.
-        assert!(take_response(run_id).is_none());
+            let (tag, resp) = poll_step(
+                run_id,
+                "req-A",
+                Instant::now(),
+                Some(Duration::from_secs(60)),
+            )
+            .parts();
+            assert_eq!(tag, "answer");
+            assert_eq!(resp.unwrap().value.as_deref(), Some("the answer"));
+            // The response file was consumed by take_response.
+            assert!(take_response(run_id).is_none());
 
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[test]
@@ -560,249 +560,269 @@ mod tests {
         // An empty `request_id` short-circuits the staleness check (the
         // `!resp.request_id.is_empty()` operand is false), so the response is
         // accepted even though it doesn't equal `req_id`.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "poll_step_answer_when_response_has_empty_request_id",
+            |_d| {
+                let run_id = "poll-step-answer-empty-id";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                write_response(run_id, &InteractionResponse::text("", "empty-id answer")).unwrap();
+
+                let (tag, resp) = poll_step(
+                    run_id,
+                    "req-A",
+                    Instant::now(),
+                    Some(Duration::from_secs(60)),
+                )
+                .parts();
+                assert_eq!(tag, "answer");
+                assert_eq!(resp.unwrap().value.as_deref(), Some("empty-id answer"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "poll-step-answer-empty-id";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        write_response(run_id, &InteractionResponse::text("", "empty-id answer")).unwrap();
-
-        let (tag, resp) = poll_step(
-            run_id,
-            "req-A",
-            Instant::now(),
-            Some(Duration::from_secs(60)),
-        )
-        .parts();
-        assert_eq!(tag, "answer");
-        assert_eq!(resp.unwrap().value.as_deref(), Some("empty-id answer"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn poll_step_keep_waiting_when_stale_response() {
         // A response whose request_id differs is stale: discarded (consumed off
         // disk) and reported as KeepWaiting.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "poll_step_keep_waiting_when_stale_response",
+            |_d| {
+                let run_id = "poll-step-stale";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                write_response(run_id, &InteractionResponse::text("other-req", "stale")).unwrap();
+
+                let (tag, resp) = poll_step(
+                    run_id,
+                    "req-A",
+                    Instant::now(),
+                    Some(Duration::from_secs(60)),
+                )
+                .parts();
+                assert_eq!(tag, "keep_waiting");
+                assert!(resp.is_none());
+                // The stale response was consumed, so a follow-up poll sees nothing.
+                assert!(take_response(run_id).is_none());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "poll-step-stale";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        write_response(run_id, &InteractionResponse::text("other-req", "stale")).unwrap();
-
-        let (tag, resp) = poll_step(
-            run_id,
-            "req-A",
-            Instant::now(),
-            Some(Duration::from_secs(60)),
-        )
-        .parts();
-        assert_eq!(tag, "keep_waiting");
-        assert!(resp.is_none());
-        // The stale response was consumed, so a follow-up poll sees nothing.
-        assert!(take_response(run_id).is_none());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn poll_step_keep_waiting_when_no_response_and_timeout_not_elapsed() {
         // No response on disk and the timeout hasn't elapsed → keep waiting.
         // Covers the `started.elapsed() >= t` FALSE branch.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "poll_step_keep_waiting_when_no_response_and_timeout_not_elapsed",
+            |_d| {
+                let run_id = "poll-step-no-response";
+                // Deliberately no dir/file: take_response returns None.
+                let (tag, resp) = poll_step(
+                    run_id,
+                    "req-A",
+                    Instant::now(),
+                    Some(Duration::from_secs(60)),
+                )
+                .parts();
+                assert_eq!(tag, "keep_waiting");
+                assert!(resp.is_none());
+            },
         );
-        let run_id = "poll-step-no-response";
-        // Deliberately no dir/file: take_response returns None.
-        let (tag, resp) = poll_step(
-            run_id,
-            "req-A",
-            Instant::now(),
-            Some(Duration::from_secs(60)),
-        )
-        .parts();
-        assert_eq!(tag, "keep_waiting");
-        assert!(resp.is_none());
     }
 
     #[test]
     fn poll_step_keep_waiting_when_no_response_and_no_timeout() {
         // `timeout == None` (wait indefinitely) with no response → keep waiting;
         // covers the `if let Some(t) = timeout` None arm.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "poll_step_keep_waiting_when_no_response_and_no_timeout",
+            |_d| {
+                let run_id = "poll-step-no-timeout";
+                let (tag, _resp) = poll_step(run_id, "req-A", Instant::now(), None).parts();
+                assert_eq!(tag, "keep_waiting");
+            },
         );
-        let run_id = "poll-step-no-timeout";
-        let (tag, _resp) = poll_step(run_id, "req-A", Instant::now(), None).parts();
-        assert_eq!(tag, "keep_waiting");
     }
 
     #[test]
     fn poll_step_timed_out_when_elapsed() {
         // No response and `started` far enough in the past that
         // `started.elapsed() >= timeout` is deterministically true — no sleeping.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("poll_step_timed_out_when_elapsed");
-        let run_id = "poll-step-timeout";
-        let timeout = Duration::from_millis(50);
-        let started = Instant::now() - Duration::from_millis(500);
-        let (tag, resp) = poll_step(run_id, "req-A", started, Some(timeout)).parts();
-        assert_eq!(tag, "timed_out");
-        assert!(resp.is_none());
+        crate::runstate::with_isolated_runs_dir("poll_step_timed_out_when_elapsed", |_d| {
+            let run_id = "poll-step-timeout";
+            let timeout = Duration::from_millis(50);
+            let started = Instant::now() - Duration::from_millis(500);
+            let (tag, resp) = poll_step(run_id, "req-A", started, Some(timeout)).parts();
+            assert_eq!(tag, "timed_out");
+            assert!(resp.is_none());
+        });
     }
 
     // ─── File I/O roundtrip (write_request, read_request, etc.) ────────────
 
     #[test]
     fn test_write_and_read_request() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_write_and_read_request");
-        let run_id = "test-interaction-rw-req";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_and_read_request", |_d| {
+            let run_id = "test-interaction-rw-req";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
-        write_request(run_id, &req).unwrap();
+            let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
+            write_request(run_id, &req).unwrap();
 
-        let back = read_request(run_id);
-        assert!(back.is_some());
-        let back = back.unwrap();
-        assert_eq!(back.id, "rw1");
-        assert_eq!(back.prompt, "What now?");
-        assert_eq!(back.kind, InteractionKind::FreeText);
+            let back = read_request(run_id);
+            assert!(back.is_some());
+            let back = back.unwrap();
+            assert_eq!(back.id, "rw1");
+            assert_eq!(back.prompt, "What now?");
+            assert_eq!(back.kind, InteractionKind::FreeText);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_request_rename_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_write_request_rename_fails_when_target_is_a_directory",
+            |_d| {
+                let run_id = "test-write-request-target-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // Pre-create the target path as a directory: the tmp-file write
+                // succeeds, but `fs::rename` onto an existing directory fails,
+                // exercising `write_request`'s rename `?`.
+                std::fs::create_dir_all(pending_path(run_id)).unwrap();
+
+                let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
+                let result = write_request(run_id, &req);
+                assert!(result.is_err());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-write-request-target-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Pre-create the target path as a directory: the tmp-file write
-        // succeeds, but `fs::rename` onto an existing directory fails,
-        // exercising `write_request`'s rename `?`.
-        std::fs::create_dir_all(pending_path(run_id)).unwrap();
-
-        let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
-        let result = write_request(run_id, &req);
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_write_request_tmp_write_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_write_request_tmp_write_fails_when_target_is_a_directory",
+            |_d| {
+                let run_id = "test-write-request-tmp-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // Pre-create the *tmp* path (not the final path, covered by
+                // `test_write_request_rename_fails_when_target_is_a_directory` above)
+                // as a directory: `std::fs::write(&tmp, &json)` itself fails with
+                // EISDIR before `fs::rename` is ever reached, exercising
+                // `write_request`'s tmp-file-write `?` -- a distinct branch from the
+                // rename failure, since a well-formed JSON body is never itself
+                // capable of making `serde_json::to_string_pretty` fail.
+                std::fs::create_dir_all(pending_path(run_id).with_extension("json.tmp")).unwrap();
+
+                let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
+                let result = write_request(run_id, &req);
+                assert!(result.is_err());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-write-request-tmp-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Pre-create the *tmp* path (not the final path, covered by
-        // `test_write_request_rename_fails_when_target_is_a_directory` above)
-        // as a directory: `std::fs::write(&tmp, &json)` itself fails with
-        // EISDIR before `fs::rename` is ever reached, exercising
-        // `write_request`'s tmp-file-write `?` -- a distinct branch from the
-        // rename failure, since a well-formed JSON body is never itself
-        // capable of making `serde_json::to_string_pretty` fail.
-        std::fs::create_dir_all(pending_path(run_id).with_extension("json.tmp")).unwrap();
-
-        let req = InteractionRequest::free_text("rw1", "What now?", "plan", true);
-        let result = write_request(run_id, &req);
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_write_and_read_response() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_write_and_read_response");
-        let run_id = "test-interaction-rw-resp";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_and_read_response", |_d| {
+            let run_id = "test-interaction-rw-resp";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let resp = InteractionResponse::text("rw2", "my answer");
-        write_response(run_id, &resp).unwrap();
+            let resp = InteractionResponse::text("rw2", "my answer");
+            write_response(run_id, &resp).unwrap();
 
-        let back = take_response(run_id);
-        assert!(back.is_some());
-        let back = back.unwrap();
-        assert_eq!(back.request_id, "rw2");
-        assert_eq!(back.value.as_deref(), Some("my answer"));
+            let back = take_response(run_id);
+            assert!(back.is_some());
+            let back = back.unwrap();
+            assert_eq!(back.request_id, "rw2");
+            assert_eq!(back.value.as_deref(), Some("my answer"));
 
-        // take_response should have removed the file
-        assert!(take_response(run_id).is_none());
+            // take_response should have removed the file
+            assert!(take_response(run_id).is_none());
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_response_rename_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_write_response_rename_fails_when_target_is_a_directory",
+            |_d| {
+                let run_id = "test-write-response-target-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // Pre-create the target path as a directory: the tmp-file write
+                // succeeds, but `fs::rename` onto an existing directory fails,
+                // exercising `write_response`'s rename `?`.
+                std::fs::create_dir_all(response_path(run_id)).unwrap();
+
+                let resp = InteractionResponse::text("rw2", "my answer");
+                let result = write_response(run_id, &resp);
+                assert!(result.is_err());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-write-response-target-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Pre-create the target path as a directory: the tmp-file write
-        // succeeds, but `fs::rename` onto an existing directory fails,
-        // exercising `write_response`'s rename `?`.
-        std::fs::create_dir_all(response_path(run_id)).unwrap();
-
-        let resp = InteractionResponse::text("rw2", "my answer");
-        let result = write_response(run_id, &resp);
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_write_response_tmp_write_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_write_response_tmp_write_fails_when_target_is_a_directory",
+            |_d| {
+                let run_id = "test-write-response-tmp-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // See `test_write_request_tmp_write_fails_when_target_is_a_directory`
+                // -- same distinction, for `write_response`'s own tmp-file write.
+                std::fs::create_dir_all(response_path(run_id).with_extension("json.tmp")).unwrap();
+
+                let resp = InteractionResponse::text("rw2", "my answer");
+                let result = write_response(run_id, &resp);
+                assert!(result.is_err());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-write-response-tmp-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // See `test_write_request_tmp_write_fails_when_target_is_a_directory`
-        // -- same distinction, for `write_response`'s own tmp-file write.
-        std::fs::create_dir_all(response_path(run_id).with_extension("json.tmp")).unwrap();
-
-        let resp = InteractionResponse::text("rw2", "my answer");
-        let result = write_response(run_id, &resp);
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_clear_interaction() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_clear_interaction");
-        let run_id = "test-interaction-clear";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_clear_interaction", |_d| {
+            let run_id = "test-interaction-clear";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::free_text("c1", "prompt", "stage", true);
-        write_request(run_id, &req).unwrap();
-        let resp = InteractionResponse::text("c1", "answer");
-        write_response(run_id, &resp).unwrap();
+            let req = InteractionRequest::free_text("c1", "prompt", "stage", true);
+            write_request(run_id, &req).unwrap();
+            let resp = InteractionResponse::text("c1", "answer");
+            write_response(run_id, &resp).unwrap();
 
-        assert!(pending_path(run_id).exists());
-        assert!(response_path(run_id).exists());
+            assert!(pending_path(run_id).exists());
+            assert!(response_path(run_id).exists());
 
-        clear_interaction(run_id);
+            clear_interaction(run_id);
 
-        assert!(!pending_path(run_id).exists());
-        assert!(!response_path(run_id).exists());
+            assert!(!pending_path(run_id).exists());
+            assert!(!response_path(run_id).exists());
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
@@ -835,129 +855,132 @@ mod tests {
 
     #[test]
     fn test_write_read_request_tool_approval() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_write_read_request_tool_approval");
-        let run_id = "test-interaction-rw-ta";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_read_request_tool_approval", |_d| {
+            let run_id = "test-interaction-rw-ta";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::tool_approval(
-            "ta1",
-            "bash",
-            serde_json::json!({"command": "rm -rf /", "cwd": "/tmp"}),
-            "code",
-        );
-        write_request(run_id, &req).unwrap();
+            let req = InteractionRequest::tool_approval(
+                "ta1",
+                "bash",
+                serde_json::json!({"command": "rm -rf /", "cwd": "/tmp"}),
+                "code",
+            );
+            write_request(run_id, &req).unwrap();
 
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.kind, InteractionKind::ToolApproval);
-        assert_eq!(back.tool_name.as_deref(), Some("bash"));
-        assert!(back.tool_arguments.is_some());
-        assert_eq!(back.options.len(), 3);
+            let back = read_request(run_id).unwrap();
+            assert_eq!(back.kind, InteractionKind::ToolApproval);
+            assert_eq!(back.tool_name.as_deref(), Some("bash"));
+            assert!(back.tool_arguments.is_some());
+            assert_eq!(back.options.len(), 3);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_read_request_multiple_choice() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_write_read_request_multiple_choice");
-        let run_id = "test-interaction-rw-mc";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_read_request_multiple_choice", |_d| {
+            let run_id = "test-interaction-rw-mc";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::multiple_choice(
-            "mc1",
-            "Pick approach",
-            vec!["Fast".into(), "Thorough".into(), "Cancel".into()],
-            "plan",
-        );
-        write_request(run_id, &req).unwrap();
+            let req = InteractionRequest::multiple_choice(
+                "mc1",
+                "Pick approach",
+                vec!["Fast".into(), "Thorough".into(), "Cancel".into()],
+                "plan",
+            );
+            write_request(run_id, &req).unwrap();
 
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.kind, InteractionKind::MultipleChoice);
-        assert_eq!(back.options.len(), 3);
-        assert_eq!(back.options[0], "Fast");
+            let back = read_request(run_id).unwrap();
+            assert_eq!(back.kind, InteractionKind::MultipleChoice);
+            assert_eq!(back.options.len(), 3);
+            assert_eq!(back.options[0], "Fast");
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_read_request_confirm() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_write_read_request_confirm");
-        let run_id = "test-interaction-rw-confirm";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_read_request_confirm", |_d| {
+            let run_id = "test-interaction-rw-confirm";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::confirm("cf1", "Deploy to prod?", "deploy");
-        write_request(run_id, &req).unwrap();
+            let req = InteractionRequest::confirm("cf1", "Deploy to prod?", "deploy");
+            write_request(run_id, &req).unwrap();
 
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.kind, InteractionKind::Confirm);
-        assert_eq!(back.options, vec!["Yes", "No"]);
+            let back = read_request(run_id).unwrap();
+            assert_eq!(back.kind, InteractionKind::Confirm);
+            assert_eq!(back.options, vec!["Yes", "No"]);
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_read_request_review() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_write_read_request_review");
-        let run_id = "test-interaction-rw-review";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_read_request_review", |_d| {
+            let run_id = "test-interaction-rw-review";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::review(
-            "rev1",
-            "Architecture Review",
-            "# Architecture\n\n- Component A\n- Component B",
-            "plan",
-        );
-        write_request(run_id, &req).unwrap();
+            let req = InteractionRequest::review(
+                "rev1",
+                "Architecture Review",
+                "# Architecture\n\n- Component A\n- Component B",
+                "plan",
+            );
+            write_request(run_id, &req).unwrap();
 
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.body_format, BodyFormat::Markdown);
-        assert!(back.body.as_deref().unwrap().contains("Component A"));
+            let back = read_request(run_id).unwrap();
+            assert_eq!(back.body_format, BodyFormat::Markdown);
+            assert!(back.body.as_deref().unwrap().contains("Component A"));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     // ─── write_response/take_response approval ────────────────────────────
 
     #[test]
     fn test_write_take_response_approval() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_write_take_response_approval");
-        let run_id = "test-interaction-rw-approval";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_take_response_approval", |_d| {
+            let run_id = "test-interaction-rw-approval";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let resp = InteractionResponse::approval("ap1", true, ApprovalScope::Session);
-        write_response(run_id, &resp).unwrap();
+            let resp = InteractionResponse::approval("ap1", true, ApprovalScope::Session);
+            write_response(run_id, &resp).unwrap();
 
-        let back = take_response(run_id).unwrap();
-        assert_eq!(back.approved, Some(true));
-        assert_eq!(back.scope, Some(ApprovalScope::Session));
+            let back = take_response(run_id).unwrap();
+            assert_eq!(back.approved, Some(true));
+            assert_eq!(back.scope, Some(ApprovalScope::Session));
 
-        // Should be consumed
-        assert!(take_response(run_id).is_none());
+            // Should be consumed
+            assert!(take_response(run_id).is_none());
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     #[test]
     fn test_write_take_response_choice() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test("test_write_take_response_choice");
-        let run_id = "test-interaction-rw-choice";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_take_response_choice", |_d| {
+            let run_id = "test-interaction-rw-choice";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let resp = InteractionResponse::choice("ch1", 2);
-        write_response(run_id, &resp).unwrap();
+            let resp = InteractionResponse::choice("ch1", 2);
+            write_response(run_id, &resp).unwrap();
 
-        let back = take_response(run_id).unwrap();
-        assert_eq!(back.choice_index, Some(2));
+            let back = take_response(run_id).unwrap();
+            assert_eq!(back.choice_index, Some(2));
 
-        let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+            let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+        });
     }
 
     // ─── clear_interaction on nonexistent is safe ─────────────────────────
@@ -971,131 +994,141 @@ mod tests {
 
     #[test]
     fn test_write_read_response_choice_roundtrip() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_write_read_response_choice_roundtrip");
-        let run_id = "test-interaction-rw-choice-rt";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir(
+            "test_write_read_response_choice_roundtrip",
+            |_d| {
+                let run_id = "test-interaction-rw-choice-rt";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let resp = InteractionResponse::choice("ch-rt", 1);
-        write_response(run_id, &resp).unwrap();
+                let resp = InteractionResponse::choice("ch-rt", 1);
+                write_response(run_id, &resp).unwrap();
 
-        let back = take_response(run_id).unwrap();
-        assert_eq!(back.request_id, "ch-rt");
-        assert_eq!(back.choice_index, Some(1));
-        assert!(back.value.is_none());
+                let back = take_response(run_id).unwrap();
+                assert_eq!(back.request_id, "ch-rt");
+                assert_eq!(back.choice_index, Some(1));
+                assert!(back.value.is_none());
 
-        let _ = std::fs::remove_dir_all(dir);
+                let _ = std::fs::remove_dir_all(dir);
+            },
+        );
     }
 
     // ─── clear_interaction after only writing request ─────────────────────
 
     #[test]
     fn test_clear_interaction_only_request() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_clear_interaction_only_request");
-        let run_id = "test-interaction-clear-req-only";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_clear_interaction_only_request", |_d| {
+            let run_id = "test-interaction-clear-req-only";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req = InteractionRequest::free_text("cr1", "prompt", "stage", true);
-        write_request(run_id, &req).unwrap();
-        assert!(pending_path(run_id).exists());
+            let req = InteractionRequest::free_text("cr1", "prompt", "stage", true);
+            write_request(run_id, &req).unwrap();
+            assert!(pending_path(run_id).exists());
 
-        clear_interaction(run_id);
-        assert!(!pending_path(run_id).exists());
-        assert!(!response_path(run_id).exists());
+            clear_interaction(run_id);
+            assert!(!pending_path(run_id).exists());
+            assert!(!response_path(run_id).exists());
 
-        let _ = std::fs::remove_dir_all(dir);
+            let _ = std::fs::remove_dir_all(dir);
+        });
     }
 
     // ─── read_request returns None for corrupted JSON ─────────────────────
 
     #[test]
     fn test_read_request_corrupted_json_returns_none() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_read_request_corrupted_json_returns_none",
+            |_d| {
+                let run_id = "test-interaction-corrupt-req";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                std::fs::write(pending_path(run_id), "not valid json {{{").unwrap();
+                assert!(read_request(run_id).is_none());
+
+                let _ = std::fs::remove_dir_all(dir);
+            },
         );
-        let run_id = "test-interaction-corrupt-req";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        std::fs::write(pending_path(run_id), "not valid json {{{").unwrap();
-        assert!(read_request(run_id).is_none());
-
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     // ─── take_response returns None for corrupted JSON ────────────────────
 
     #[test]
     fn test_take_response_corrupted_json_returns_none() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_take_response_corrupted_json_returns_none",
+            |_d| {
+                let run_id = "test-interaction-corrupt-resp";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                std::fs::write(response_path(run_id), "garbage").unwrap();
+                assert!(take_response(run_id).is_none());
+
+                let _ = std::fs::remove_dir_all(dir);
+            },
         );
-        let run_id = "test-interaction-corrupt-resp";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        std::fs::write(response_path(run_id), "garbage").unwrap();
-        assert!(take_response(run_id).is_none());
-
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     // ─── request_id matching in write/read ─────────────────────────────────
 
     #[test]
     fn test_request_id_preserved_through_write_read() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_id_preserved_through_write_read",
+            |_d| {
+                let run_id = "test-interaction-reqid";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let req = InteractionRequest::tool_approval(
+                    "unique-req-42",
+                    "write_file",
+                    serde_json::json!({"path": "/tmp/foo"}),
+                    "code",
+                );
+                write_request(run_id, &req).unwrap();
+
+                let back = read_request(run_id).unwrap();
+                assert_eq!(back.id, "unique-req-42");
+
+                // Write response with matching request_id
+                let resp =
+                    InteractionResponse::approval("unique-req-42", true, ApprovalScope::Once);
+                write_response(run_id, &resp).unwrap();
+
+                let back_resp = take_response(run_id).unwrap();
+                assert_eq!(back_resp.request_id, "unique-req-42");
+
+                let _ = std::fs::remove_dir_all(dir);
+            },
         );
-        let run_id = "test-interaction-reqid";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let req = InteractionRequest::tool_approval(
-            "unique-req-42",
-            "write_file",
-            serde_json::json!({"path": "/tmp/foo"}),
-            "code",
-        );
-        write_request(run_id, &req).unwrap();
-
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.id, "unique-req-42");
-
-        // Write response with matching request_id
-        let resp = InteractionResponse::approval("unique-req-42", true, ApprovalScope::Once);
-        write_response(run_id, &resp).unwrap();
-
-        let back_resp = take_response(run_id).unwrap();
-        assert_eq!(back_resp.request_id, "unique-req-42");
-
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     // ─── Multiple write_request overwrites previous ───────────────────────
 
     #[test]
     fn test_write_request_overwrites_previous() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_write_request_overwrites_previous");
-        let run_id = "test-interaction-overwrite";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_write_request_overwrites_previous", |_d| {
+            let run_id = "test-interaction-overwrite";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let req1 = InteractionRequest::free_text("first", "First?", "stage", true);
-        write_request(run_id, &req1).unwrap();
+            let req1 = InteractionRequest::free_text("first", "First?", "stage", true);
+            write_request(run_id, &req1).unwrap();
 
-        let req2 = InteractionRequest::free_text("second", "Second?", "stage", true);
-        write_request(run_id, &req2).unwrap();
+            let req2 = InteractionRequest::free_text("second", "Second?", "stage", true);
+            write_request(run_id, &req2).unwrap();
 
-        let back = read_request(run_id).unwrap();
-        assert_eq!(back.id, "second");
-        assert_eq!(back.prompt, "Second?");
+            let back = read_request(run_id).unwrap();
+            assert_eq!(back.id, "second");
+            assert_eq!(back.prompt, "Second?");
 
-        let _ = std::fs::remove_dir_all(dir);
+            let _ = std::fs::remove_dir_all(dir);
+        });
     }
 
     // ─── request_interaction (synchronous) ───────────────────────────────
@@ -1103,770 +1136,849 @@ mod tests {
 
     #[test]
     fn test_request_interaction_sync_success() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_request_interaction_sync_success");
-        let run_id = "test-sync-request-ok";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_request_interaction_sync_success", |_d| {
+            let run_id = "test-sync-request-ok";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        // Create meta.json so write_meta succeeds
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+            // Create meta.json so write_meta succeeds
+            let mut meta = crate::runstate::RunMeta::new(
+                run_id.to_string(),
+                "agent".to_string(),
+                "/tmp/agent.toml".to_string(),
+                "task".to_string(),
+                None,
+                "/tmp".to_string(),
+                1,
+            );
+            crate::runstate::create_run(&meta).unwrap();
 
-        let req_id = "sync-req-1".to_string();
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
+            let req_id = "sync-req-1".to_string();
+            let run_id_clone = run_id.to_string();
+            let req_id_clone = req_id.clone();
 
-        // Spawn thread that writes the response after 150ms
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(150));
-            let resp = InteractionResponse::text(&req_id_clone, "the answer");
-            write_response(&run_id_clone, &resp).ok();
+            // Spawn thread that writes the response after 150ms
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                let resp = InteractionResponse::text(&req_id_clone, "the answer");
+                write_response(&run_id_clone, &resp).ok();
+            });
+
+            let req = InteractionRequest::free_text(&req_id, "What?", "plan", true);
+            let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
+            assert!(result.is_ok());
+            let resp = result.unwrap();
+            assert_eq!(resp.value.as_deref(), Some("the answer"));
+
+            let _ = std::fs::remove_dir_all(&dir);
         });
-
-        let req = InteractionRequest::free_text(&req_id, "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
-        assert!(result.is_ok());
-        let resp = result.unwrap();
-        assert_eq!(resp.value.as_deref(), Some("the answer"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_request_interaction_sync_no_timeout_waits_indefinitely_for_response() {
         // `timeout: None` means the poll loop never checks elapsed time — cover
         // that branch explicitly so it isn't left to the `Some(t)` tests.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_no_timeout_waits_indefinitely_for_response",
+            |_d| {
+                let run_id = "test-sync-request-no-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
+
+                let req_id = "sync-no-timeout-1".to_string();
+                let run_id_clone = run_id.to_string();
+                let req_id_clone = req_id.clone();
+
+                // Spawn thread that writes the response after a couple of poll cycles.
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(150));
+                    let resp = InteractionResponse::text(&req_id_clone, "no-timeout answer");
+                    write_response(&run_id_clone, &resp).ok();
+                });
+
+                let req = InteractionRequest::free_text(&req_id, "What?", "plan", true);
+                let result = request_interaction(run_id, &mut meta, req, None);
+                assert!(result.is_ok());
+                let resp = result.unwrap();
+                assert_eq!(resp.value.as_deref(), Some("no-timeout answer"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-sync-request-no-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
-
-        let req_id = "sync-no-timeout-1".to_string();
-        let run_id_clone = run_id.to_string();
-        let req_id_clone = req_id.clone();
-
-        // Spawn thread that writes the response after a couple of poll cycles.
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(150));
-            let resp = InteractionResponse::text(&req_id_clone, "no-timeout answer");
-            write_response(&run_id_clone, &resp).ok();
-        });
-
-        let req = InteractionRequest::free_text(&req_id, "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, None);
-        assert!(result.is_ok());
-        let resp = result.unwrap();
-        assert_eq!(resp.value.as_deref(), Some("no-timeout answer"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_request_interaction_sync_timeout() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_request_interaction_sync_timeout");
-        let run_id = "test-sync-request-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir("test_request_interaction_sync_timeout", |_d| {
+            let run_id = "test-sync-request-timeout";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+            let mut meta = crate::runstate::RunMeta::new(
+                run_id.to_string(),
+                "agent".to_string(),
+                "/tmp/agent.toml".to_string(),
+                "task".to_string(),
+                None,
+                "/tmp".to_string(),
+                1,
+            );
+            crate::runstate::create_run(&meta).unwrap();
 
-        let req = InteractionRequest::free_text("sync-timeout", "What?", "plan", true);
-        // Timeout of 200ms — no response will be written
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_millis(200)));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("timed out"));
+            let req = InteractionRequest::free_text("sync-timeout", "What?", "plan", true);
+            // Timeout of 200ms — no response will be written
+            let result =
+                request_interaction(run_id, &mut meta, req, Some(Duration::from_millis(200)));
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("timed out"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[test]
     fn test_request_interaction_sync_not_required_status() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_not_required_status",
+            |_d| {
+                let run_id = "test-sync-request-not-required";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
+
+                let run_id_clone = run_id.to_string();
+                // Spawn thread that writes the response immediately
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(150));
+                    let resp = InteractionResponse::text("not-req-1", "ok");
+                    write_response(&run_id_clone, &resp).ok();
+                });
+
+                // required: false → CompleteInteractive status branch
+                let req = InteractionRequest::free_text("not-req-1", "Optional?", "plan", false);
+                let result =
+                    request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
+                assert!(result.is_ok());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-sync-request-not-required";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
-
-        let run_id_clone = run_id.to_string();
-        // Spawn thread that writes the response immediately
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(150));
-            let resp = InteractionResponse::text("not-req-1", "ok");
-            write_response(&run_id_clone, &resp).ok();
-        });
-
-        // required: false → CompleteInteractive status branch
-        let req = InteractionRequest::free_text("not-req-1", "Optional?", "plan", false);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
-        assert!(result.is_ok());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_request_interaction_sync_stale_response_then_correct() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_stale_response_then_correct",
+            |_d| {
+                let run_id = "test-sync-stale-then-correct";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
+
+                let run_id_clone = run_id.to_string();
+                // Write a stale response first (different request_id), then the correct one
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(120));
+                    // Stale response
+                    let stale = InteractionResponse::text("other-req", "stale answer");
+                    write_response(&run_id_clone, &stale).ok();
+                    // Give time for it to be consumed, then write correct one
+                    std::thread::sleep(std::time::Duration::from_millis(150));
+                    let correct = InteractionResponse::text("target-req", "correct answer");
+                    write_response(&run_id_clone, &correct).ok();
+                });
+
+                let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
+                let result =
+                    request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
+                assert!(result.is_ok());
+                let resp = result.unwrap();
+                assert_eq!(resp.value.as_deref(), Some("correct answer"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-sync-stale-then-correct";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
-
-        let run_id_clone = run_id.to_string();
-        // Write a stale response first (different request_id), then the correct one
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(120));
-            // Stale response
-            let stale = InteractionResponse::text("other-req", "stale answer");
-            write_response(&run_id_clone, &stale).ok();
-            // Give time for it to be consumed, then write correct one
-            std::thread::sleep(std::time::Duration::from_millis(150));
-            let correct = InteractionResponse::text("target-req", "correct answer");
-            write_response(&run_id_clone, &correct).ok();
-        });
-
-        let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
-        assert!(result.is_ok());
-        let resp = result.unwrap();
-        assert_eq!(resp.value.as_deref(), Some("correct answer"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_request_interaction_sync_write_request_fails_when_run_dir_missing() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_write_request_fails_when_run_dir_missing",
-        );
-        let run_id = "test-sync-request-no-dir";
-        // Deliberately skip creating the run directory, so `write_request`'s
-        // tmp-file write fails immediately, exercising this function's own
-        // `write_request(...)?` propagation.
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
+            |_d| {
+                let run_id = "test-sync-request-no-dir";
+                // Deliberately skip creating the run directory, so `write_request`'s
+                // tmp-file write fails immediately, exercising this function's own
+                // `write_request(...)?` propagation.
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
 
-        let req = InteractionRequest::free_text("no-dir-req", "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
-        assert!(result.is_err());
+                let req = InteractionRequest::free_text("no-dir-req", "What?", "plan", true);
+                let result =
+                    request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
+                assert!(result.is_err());
+            },
+        );
     }
 
     #[test]
     fn test_request_interaction_sync_write_meta_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_write_meta_fails_when_target_is_a_directory",
+            |_d| {
+                let run_id = "test-sync-request-meta-target-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // Pre-create meta.json as a directory: write_request succeeds (it
+                // touches a different filename), but the subsequent `write_meta`'s
+                // rename onto "meta.json" fails, exercising this function's own
+                // `write_meta(...)?` propagation.
+                std::fs::create_dir_all(dir.join("meta.json")).unwrap();
+
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+
+                let req = InteractionRequest::free_text("meta-fail-req", "What?", "plan", true);
+                let result =
+                    request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
+                assert!(result.is_err());
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-sync-request-meta-target-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Pre-create meta.json as a directory: write_request succeeds (it
-        // touches a different filename), but the subsequent `write_meta`'s
-        // rename onto "meta.json" fails, exercising this function's own
-        // `write_meta(...)?` propagation.
-        std::fs::create_dir_all(dir.join("meta.json")).unwrap();
-
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-
-        let req = InteractionRequest::free_text("meta-fail-req", "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_secs(5)));
-        assert!(result.is_err());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── request_interaction_async ────────────────────────────────────────
 
     #[tokio::test]
     async fn test_request_interaction_async_success() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_request_interaction_async_success");
-        let run_id = "test-async-request-ok";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "test_request_interaction_async_success",
+            |_d| async move {
+                let run_id = "test-async-request-ok";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::text("async-req-1", "async answer");
-            write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp = InteractionResponse::text("async-req-1", "async answer");
+                    write_response(&run_id_clone, &resp).ok();
+                });
 
-        let req = InteractionRequest::free_text("async-req-1", "Async?", "plan", true);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5))).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().value.as_deref(), Some("async answer"));
+                let req = InteractionRequest::free_text("async-req-1", "Async?", "plan", true);
+                let result =
+                    request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5)))
+                        .await;
+                assert!(result.is_ok());
+                assert_eq!(result.unwrap().value.as_deref(), Some("async answer"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_async_timeout() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_request_interaction_async_timeout");
-        let run_id = "test-async-request-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        crate::runstate::with_isolated_runs_dir_async(
+            "test_request_interaction_async_timeout",
+            |_d| async move {
+                let run_id = "test-async-request-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let req = InteractionRequest::free_text("async-timeout", "Async?", "plan", true);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_millis(200)))
+                let req = InteractionRequest::free_text("async-timeout", "Async?", "plan", true);
+                let result = request_interaction_async(
+                    run_id,
+                    &mut meta,
+                    req,
+                    Some(Duration::from_millis(200)),
+                )
                 .await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("timed out"));
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("timed out"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_async_not_required() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_async_not_required",
-        );
-        let run_id = "test-async-request-not-req";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-async-request-not-req";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::text("async-not-req", "ok");
-            write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp = InteractionResponse::text("async-not-req", "ok");
+                    write_response(&run_id_clone, &resp).ok();
+                });
 
-        // required: false → CompleteInteractive status branch
-        let req = InteractionRequest::free_text("async-not-req", "Optional?", "plan", false);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5))).await;
-        assert!(result.is_ok());
+                // required: false → CompleteInteractive status branch
+                let req =
+                    InteractionRequest::free_text("async-not-req", "Optional?", "plan", false);
+                let result =
+                    request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5)))
+                        .await;
+                assert!(result.is_ok());
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_async_write_meta_fails_when_target_is_a_directory() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_async_write_meta_fails_when_target_is_a_directory",
-        );
-        let run_id = "test-async-request-meta-target-is-dir";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Pre-create meta.json as a directory: write_request succeeds (it
-        // touches a different filename), but the subsequent `write_meta`'s
-        // rename onto "meta.json" fails, exercising this function's own
-        // `write_meta(...)?` propagation.
-        std::fs::create_dir_all(dir.join("meta.json")).unwrap();
+            |_d| async move {
+                let run_id = "test-async-request-meta-target-is-dir";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // Pre-create meta.json as a directory: write_request succeeds (it
+                // touches a different filename), but the subsequent `write_meta`'s
+                // rename onto "meta.json" fails, exercising this function's own
+                // `write_meta(...)?` propagation.
+                std::fs::create_dir_all(dir.join("meta.json")).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
 
-        let req = InteractionRequest::free_text("async-meta-fail-req", "What?", "plan", true);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5))).await;
-        assert!(result.is_err());
+                let req =
+                    InteractionRequest::free_text("async-meta-fail-req", "What?", "plan", true);
+                let result =
+                    request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5)))
+                        .await;
+                assert!(result.is_err());
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_async_stale_then_correct() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_async_stale_then_correct",
-        );
-        let run_id = "test-async-stale-then-correct";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-async-stale-then-correct";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(120)).await;
-            // Stale response
-            let stale = InteractionResponse::text("wrong-id", "stale");
-            write_response(&run_id_clone, &stale).ok();
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            // Correct response
-            let correct = InteractionResponse::text("async-stale-target", "correct");
-            write_response(&run_id_clone, &correct).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(120)).await;
+                    // Stale response
+                    let stale = InteractionResponse::text("wrong-id", "stale");
+                    write_response(&run_id_clone, &stale).ok();
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    // Correct response
+                    let correct = InteractionResponse::text("async-stale-target", "correct");
+                    write_response(&run_id_clone, &correct).ok();
+                });
 
-        let req = InteractionRequest::free_text("async-stale-target", "Async?", "plan", true);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5))).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().value.as_deref(), Some("correct"));
+                let req =
+                    InteractionRequest::free_text("async-stale-target", "Async?", "plan", true);
+                let result =
+                    request_interaction_async(run_id, &mut meta, req, Some(Duration::from_secs(5)))
+                        .await;
+                assert!(result.is_ok());
+                assert_eq!(result.unwrap().value.as_deref(), Some("correct"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── request_interaction_bg_review ────────────────────────────────────
 
     #[tokio::test]
     async fn test_request_interaction_bg_review_responds() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_bg_review_responds",
-        );
-        let run_id = "test-bg-review-ok";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-bg-review-ok";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        // Create meta so the meta-update path succeeds
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                // Create meta so the meta-update path succeeds
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::text("bg-rev-1", "reviewed");
-            write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp = InteractionResponse::text("bg-rev-1", "reviewed");
+                    write_response(&run_id_clone, &resp).ok();
+                });
 
-        let req =
-            InteractionRequest::review("bg-rev-1", "Review this", "# Plan\n\nDetails here", "plan");
-        let resp = request_interaction_bg_review(run_id, req).await;
-        assert_eq!(resp.value.as_deref(), Some("reviewed"));
-        assert_eq!(resp.request_id, "bg-rev-1");
+                let req = InteractionRequest::review(
+                    "bg-rev-1",
+                    "Review this",
+                    "# Plan\n\nDetails here",
+                    "plan",
+                );
+                let resp = request_interaction_bg_review(run_id, req).await;
+                assert_eq!(resp.value.as_deref(), Some("reviewed"));
+                assert_eq!(resp.request_id, "bg-rev-1");
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_bg_review_no_meta() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_bg_review_no_meta",
-        );
-        // bg_review should work even when meta.json doesn't exist
-        let run_id = "test-bg-review-no-meta";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        // No meta.json created
+            |_d| async move {
+                // bg_review should work even when meta.json doesn't exist
+                let run_id = "test-bg-review-no-meta";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+                // No meta.json created
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::text("bg-rev-no-meta", "answer");
-            write_response(&run_id_clone, &resp).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp = InteractionResponse::text("bg-rev-no-meta", "answer");
+                    write_response(&run_id_clone, &resp).ok();
+                });
 
-        let req = InteractionRequest::free_text("bg-rev-no-meta", "Review?", "plan", true);
-        let resp = request_interaction_bg_review(run_id, req).await;
-        assert_eq!(resp.request_id, "bg-rev-no-meta");
+                let req = InteractionRequest::free_text("bg-rev-no-meta", "Review?", "plan", true);
+                let resp = request_interaction_bg_review(run_id, req).await;
+                assert_eq!(resp.request_id, "bg-rev-no-meta");
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_interaction_bg_review_stale_then_correct() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_bg_review_stale_then_correct",
-        );
-        let run_id = "test-bg-review-stale";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-bg-review-stale";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let run_id_clone = run_id.to_string();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(120)).await;
-            // Stale response
-            let stale = InteractionResponse::text("wrong", "stale");
-            write_response(&run_id_clone, &stale).ok();
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            // Correct response
-            let correct = InteractionResponse::text("bg-rev-target", "ok");
-            write_response(&run_id_clone, &correct).ok();
-        });
+                let run_id_clone = run_id.to_string();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(120)).await;
+                    // Stale response
+                    let stale = InteractionResponse::text("wrong", "stale");
+                    write_response(&run_id_clone, &stale).ok();
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    // Correct response
+                    let correct = InteractionResponse::text("bg-rev-target", "ok");
+                    write_response(&run_id_clone, &correct).ok();
+                });
 
-        let req = InteractionRequest::free_text("bg-rev-target", "Review?", "plan", true);
-        let resp = request_interaction_bg_review(run_id, req).await;
-        assert_eq!(resp.value.as_deref(), Some("ok"));
+                let req = InteractionRequest::free_text("bg-rev-target", "Review?", "plan", true);
+                let resp = request_interaction_bg_review(run_id, req).await;
+                assert_eq!(resp.value.as_deref(), Some("ok"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── request_tool_approval_background ────────────────────────────────
 
     #[tokio::test]
     async fn test_request_tool_approval_background_approved() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_approved",
-        );
-        let run_id = "test-tool-approval-bg-ok";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-bg-ok";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        // Calculate the expected request ID (same hash as the function uses)
-        let tool_name = "bash";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = make_interaction_id(hash, 0);
+                // Calculate the expected request ID (same hash as the function uses)
+                let tool_name = "bash";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = make_interaction_id(hash, 0);
 
-        let resp_path = response_path(run_id);
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::approval(&req_id_clone, true, ApprovalScope::Once);
-            let json = serde_json::to_string_pretty(&resp).unwrap();
-            std::fs::write(&resp_path, json).ok();
-        });
+                let resp_path = response_path(run_id);
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp =
+                        InteractionResponse::approval(&req_id_clone, true, ApprovalScope::Once);
+                    let json = serde_json::to_string_pretty(&resp).unwrap();
+                    std::fs::write(&resp_path, json).ok();
+                });
 
-        let args = serde_json::json!({"command": "ls"});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            tool_name,
-            &args,
-            "code",
-            Duration::from_secs(10),
+                let args = serde_json::json!({"command": "ls"});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    tool_name,
+                    &args,
+                    "code",
+                    Duration::from_secs(10),
+                )
+                .await;
+                assert!(approved);
+                assert_eq!(scope, ApprovalScope::Once);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(approved);
-        assert_eq!(scope, ApprovalScope::Once);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_denied() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_denied",
-        );
-        let run_id = "test-tool-approval-bg-denied";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-bg-denied";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        // No meta.json — exercises the else branch
-        let tool_name = "write_file";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = make_interaction_id(hash, 0);
+                // No meta.json — exercises the else branch
+                let tool_name = "write_file";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = make_interaction_id(hash, 0);
 
-        let resp_path = response_path(run_id);
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::approval(&req_id_clone, false, ApprovalScope::Once);
-            let json = serde_json::to_string_pretty(&resp).unwrap();
-            std::fs::write(&resp_path, json).ok();
-        });
+                let resp_path = response_path(run_id);
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp =
+                        InteractionResponse::approval(&req_id_clone, false, ApprovalScope::Once);
+                    let json = serde_json::to_string_pretty(&resp).unwrap();
+                    std::fs::write(&resp_path, json).ok();
+                });
 
-        let args = serde_json::json!({"path": "/tmp/f.txt"});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            tool_name,
-            &args,
-            "code",
-            Duration::from_secs(10),
+                let args = serde_json::json!({"path": "/tmp/f.txt"});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    tool_name,
+                    &args,
+                    "code",
+                    Duration::from_secs(10),
+                )
+                .await;
+                assert!(!approved);
+                assert_eq!(scope, ApprovalScope::Once);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(!approved);
-        assert_eq!(scope, ApprovalScope::Once);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_session_scope() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_session_scope",
-        );
-        let run_id = "test-tool-approval-bg-session";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-bg-session";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        let tool_name = "edit_file";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = make_interaction_id(hash, 0);
+                let tool_name = "edit_file";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = make_interaction_id(hash, 0);
 
-        // Capture the response path NOW (before spawning) so the spawned task
-        // doesn't re-read LEVIATH_RUNS_DIR at execution time — a concurrent test
-        // in commands/run/mod.rs temporarily sets LEVIATH_RUNS_DIR to a
-        // read-only dir, which would silently break write_response.
-        let resp_path = response_path(run_id);
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(150)).await;
-            let resp = InteractionResponse::approval(&req_id_clone, true, ApprovalScope::Session);
-            let json = serde_json::to_string_pretty(&resp).unwrap();
-            std::fs::write(&resp_path, json).ok();
-        });
+                // Capture the response path NOW (before spawning) so the spawned task
+                // doesn't re-read LEVIATH_RUNS_DIR at execution time — a concurrent test
+                // in commands/run/mod.rs temporarily sets LEVIATH_RUNS_DIR to a
+                // read-only dir, which would silently break write_response.
+                let resp_path = response_path(run_id);
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let resp =
+                        InteractionResponse::approval(&req_id_clone, true, ApprovalScope::Session);
+                    let json = serde_json::to_string_pretty(&resp).unwrap();
+                    std::fs::write(&resp_path, json).ok();
+                });
 
-        let args = serde_json::json!({});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            tool_name,
-            &args,
-            "impl",
-            Duration::from_secs(10),
+                let args = serde_json::json!({});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    tool_name,
+                    &args,
+                    "impl",
+                    Duration::from_secs(10),
+                )
+                .await;
+                assert!(approved);
+                assert_eq!(scope, ApprovalScope::Session);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(approved);
-        assert_eq!(scope, ApprovalScope::Session);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_stale_then_correct() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_stale_then_correct",
-        );
-        let run_id = "test-tool-approval-bg-stale";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-bg-stale";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let tool_name = "bash";
-        let hash = tool_name
-            .bytes()
-            .fold(0usize, |a, b| a.wrapping_add(b as usize));
-        let req_id = make_interaction_id(hash, 0);
+                let tool_name = "bash";
+                let hash = tool_name
+                    .bytes()
+                    .fold(0usize, |a, b| a.wrapping_add(b as usize));
+                let req_id = make_interaction_id(hash, 0);
 
-        let resp_path = response_path(run_id);
-        let req_id_clone = req_id.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(120)).await;
-            // Write a stale response first
-            let stale = InteractionResponse::approval("wrong-id", true, ApprovalScope::Once);
-            let json = serde_json::to_string_pretty(&stale).unwrap();
-            std::fs::write(&resp_path, json).ok();
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            // Write the correct response
-            let correct = InteractionResponse::approval(&req_id_clone, false, ApprovalScope::Once);
-            let json = serde_json::to_string_pretty(&correct).unwrap();
-            std::fs::write(&resp_path, json).ok();
-        });
+                let resp_path = response_path(run_id);
+                let req_id_clone = req_id.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(120)).await;
+                    // Write a stale response first
+                    let stale =
+                        InteractionResponse::approval("wrong-id", true, ApprovalScope::Once);
+                    let json = serde_json::to_string_pretty(&stale).unwrap();
+                    std::fs::write(&resp_path, json).ok();
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    // Write the correct response
+                    let correct =
+                        InteractionResponse::approval(&req_id_clone, false, ApprovalScope::Once);
+                    let json = serde_json::to_string_pretty(&correct).unwrap();
+                    std::fs::write(&resp_path, json).ok();
+                });
 
-        let args = serde_json::json!({"command": "rm -rf"});
-        let (approved, _scope) = request_tool_approval_background(
-            run_id,
-            tool_name,
-            &args,
-            "code",
-            Duration::from_secs(10),
+                let args = serde_json::json!({"command": "rm -rf"});
+                let (approved, _scope) = request_tool_approval_background(
+                    run_id,
+                    tool_name,
+                    &args,
+                    "code",
+                    Duration::from_secs(10),
+                )
+                .await;
+                assert!(!approved);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(!approved);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_timeout_auto_denies() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_timeout_auto_denies",
-        );
-        let run_id = "test-tool-approval-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        // No responder — the short timeout should fire the auto-deny path.
-        let args = serde_json::json!({"command": "rm -rf /"});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            "bash",
-            &args,
-            "code",
-            Duration::from_millis(150),
+                // No responder — the short timeout should fire the auto-deny path.
+                let args = serde_json::json!({"command": "rm -rf /"});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    "bash",
+                    &args,
+                    "code",
+                    Duration::from_millis(150),
+                )
+                .await;
+                assert!(!approved);
+                assert_eq!(scope, ApprovalScope::Once);
+
+                // Status should be restored to Running (not left stuck WaitingInput).
+                let meta_after = crate::runstate::read_meta(run_id).unwrap();
+                assert_eq!(meta_after.status, RunStatus::Running);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(!approved);
-        assert_eq!(scope, ApprovalScope::Once);
-
-        // Status should be restored to Running (not left stuck WaitingInput).
-        let meta_after = crate::runstate::read_meta(run_id).unwrap();
-        assert_eq!(meta_after.status, RunStatus::Running);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_timeout_with_no_meta_file() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_timeout_with_no_meta_file",
-        );
-        let run_id = "test-tool-approval-timeout-no-meta";
-        let dir = crate::runstate::run_dir(run_id);
-        // Deliberately skip `create_run` — no meta.json ever exists, so every
-        // `read_meta` call (including the one on the timeout path) fails,
-        // exercising the `if let Ok(...)` else arm at the timeout branch.
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-timeout-no-meta";
+                let dir = crate::runstate::run_dir(run_id);
+                // Deliberately skip `create_run` — no meta.json ever exists, so every
+                // `read_meta` call (including the one on the timeout path) fails,
+                // exercising the `if let Ok(...)` else arm at the timeout branch.
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let args = serde_json::json!({"command": "rm -rf /"});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            "bash",
-            &args,
-            "code",
-            Duration::from_millis(150),
+                let args = serde_json::json!({"command": "rm -rf /"});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    "bash",
+                    &args,
+                    "code",
+                    Duration::from_millis(150),
+                )
+                .await;
+                assert!(!approved);
+                assert_eq!(scope, ApprovalScope::Once);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        assert!(!approved);
-        assert_eq!(scope, ApprovalScope::Once);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── Deterministic loop-arm coverage (pre-written stale response) ──────
@@ -1883,108 +1995,121 @@ mod tests {
 
     #[test]
     fn test_request_interaction_sync_stale_prewritten_then_timeout_is_deterministic() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir(
             "test_request_interaction_sync_stale_prewritten_then_timeout_is_deterministic",
+            |_d| {
+                let run_id = "test-sync-stale-prewritten-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
+
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
+
+                write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
+
+                let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
+                let result =
+                    request_interaction(run_id, &mut meta, req, Some(Duration::from_millis(50)));
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("timed out"));
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         );
-        let run_id = "test-sync-stale-prewritten-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
-
-        write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
-
-        let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
-        let result = request_interaction(run_id, &mut meta, req, Some(Duration::from_millis(50)));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("timed out"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn test_request_interaction_async_stale_prewritten_then_timeout_is_deterministic() {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_async_stale_prewritten_then_timeout_is_deterministic",
-        );
-        let run_id = "test-async-stale-prewritten-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-async-stale-prewritten-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let mut meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let mut meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
+                write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
 
-        let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
-        let result =
-            request_interaction_async(run_id, &mut meta, req, Some(Duration::from_millis(50)))
+                let req = InteractionRequest::free_text("target-req", "What?", "plan", true);
+                let result = request_interaction_async(
+                    run_id,
+                    &mut meta,
+                    req,
+                    Some(Duration::from_millis(50)),
+                )
                 .await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("timed out"));
+                assert!(result.is_err());
+                assert!(result.unwrap_err().to_string().contains("timed out"));
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_request_tool_approval_background_stale_prewritten_then_timeout_is_deterministic()
     {
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_tool_approval_background_stale_prewritten_then_timeout_is_deterministic",
-        );
-        let run_id = "test-tool-approval-stale-prewritten-timeout";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-tool-approval-stale-prewritten-timeout";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        // Stale approval (different request_id) is discarded on the first poll.
-        write_response(
-            run_id,
-            &InteractionResponse::approval("stale-id", true, ApprovalScope::Session),
-        )
-        .unwrap();
+                // Stale approval (different request_id) is discarded on the first poll.
+                write_response(
+                    run_id,
+                    &InteractionResponse::approval("stale-id", true, ApprovalScope::Session),
+                )
+                .unwrap();
 
-        let args = serde_json::json!({"command": "ls"});
-        let (approved, scope) = request_tool_approval_background(
-            run_id,
-            "bash",
-            &args,
-            "code",
-            Duration::from_millis(50),
+                let args = serde_json::json!({"command": "ls"});
+                let (approved, scope) = request_tool_approval_background(
+                    run_id,
+                    "bash",
+                    &args,
+                    "code",
+                    Duration::from_millis(50),
+                )
+                .await;
+                // Stale response ignored → falls through to the timeout auto-deny.
+                assert!(!approved);
+                assert_eq!(scope, ApprovalScope::Once);
+
+                let _ = std::fs::remove_dir_all(&dir);
+            },
         )
         .await;
-        // Stale response ignored → falls through to the timeout auto-deny.
-        assert!(!approved);
-        assert_eq!(scope, ApprovalScope::Once);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -1997,48 +2122,52 @@ mod tests {
         // The file disappears exactly when the worker's poll took the stale one
         // and continued — i.e. exercised the KeepWaiting arm — so ordering is
         // guaranteed regardless of scheduling.
-        let _guard = crate::runstate::isolate_runs_dir_for_test(
+        crate::runstate::with_isolated_runs_dir_async(
             "test_request_interaction_bg_review_keep_waiting_arm_is_deterministic",
-        );
-        let run_id = "test-bg-review-keepwaiting-det";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+            |_d| async move {
+                let run_id = "test-bg-review-keepwaiting-det";
+                let dir = crate::runstate::run_dir(run_id);
+                std::fs::create_dir_all(&dir).unwrap();
 
-        let meta = crate::runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/tmp/agent.toml".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        crate::runstate::create_run(&meta).unwrap();
+                let meta = crate::runstate::RunMeta::new(
+                    run_id.to_string(),
+                    "agent".to_string(),
+                    "/tmp/agent.toml".to_string(),
+                    "task".to_string(),
+                    None,
+                    "/tmp".to_string(),
+                    1,
+                );
+                crate::runstate::create_run(&meta).unwrap();
 
-        // Stale response present before the first poll → guaranteed KeepWaiting.
-        write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
-        // Capture the response path now so the responder doesn't re-resolve
-        // LEVIATH_RUNS_DIR later (mirrors the tool-approval tests' guard).
-        let resp_path = response_path(run_id);
+                // Stale response present before the first poll → guaranteed KeepWaiting.
+                write_response(run_id, &InteractionResponse::text("stale-id", "stale")).unwrap();
+                // Capture the response path now so the responder doesn't re-resolve
+                // LEVIATH_RUNS_DIR later (mirrors the tool-approval tests' guard).
+                let resp_path = response_path(run_id);
 
-        let resp_path_responder = resp_path.clone();
-        tokio::spawn(async move {
-            // Wait until the worker consumes the stale response (file vanishes),
-            // which only happens on the KeepWaiting/continue path.
-            while resp_path_responder.exists() {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-            let correct = InteractionResponse::text("bg-rev-det", "final answer");
-            let json = serde_json::to_string_pretty(&correct).unwrap();
-            std::fs::write(&resp_path_responder, json).ok();
-        });
+                let resp_path_responder = resp_path.clone();
+                tokio::spawn(async move {
+                    // Wait until the worker consumes the stale response (file vanishes),
+                    // which only happens on the KeepWaiting/continue path.
+                    while resp_path_responder.exists() {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    let correct = InteractionResponse::text("bg-rev-det", "final answer");
+                    let json = serde_json::to_string_pretty(&correct).unwrap();
+                    std::fs::write(&resp_path_responder, json).ok();
+                });
 
-        let req = InteractionRequest::review("bg-rev-det", "Review", "# Plan\n\nDetails", "plan");
-        let resp = request_interaction_bg_review(run_id, req).await;
-        assert_eq!(resp.value.as_deref(), Some("final answer"));
-        assert_eq!(resp.request_id, "bg-rev-det");
+                let req =
+                    InteractionRequest::review("bg-rev-det", "Review", "# Plan\n\nDetails", "plan");
+                let resp = request_interaction_bg_review(run_id, req).await;
+                assert_eq!(resp.value.as_deref(), Some("final answer"));
+                assert_eq!(resp.request_id, "bg-rev-det");
 
-        let _ = std::fs::remove_dir_all(&dir);
+                let _ = std::fs::remove_dir_all(&dir);
+            },
+        )
+        .await;
     }
 
     // ─── request_interaction_from_reader (mocked stdin) ────────────────────
@@ -2101,18 +2230,19 @@ mod tests {
 
     #[test]
     fn test_edit_text_request_ipc_roundtrip() {
-        let _guard =
-            crate::runstate::isolate_runs_dir_for_test("test_edit_text_request_ipc_roundtrip");
-        let run_id = "edit-ipc-run";
-        let dir = crate::runstate::run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        let req = InteractionRequest::edit_text("er1", "Edit the plan", "plan", "line 1\nline 2");
-        write_request(run_id, &req).unwrap();
-        let back = read_request(run_id).expect("request should round-trip");
-        assert_eq!(back.kind, InteractionKind::EditText);
-        assert_eq!(back.body.as_deref(), Some("line 1\nline 2"));
-        assert_eq!(back.id, "er1");
-        let _ = std::fs::remove_dir_all(&dir);
+        crate::runstate::with_isolated_runs_dir("test_edit_text_request_ipc_roundtrip", |_d| {
+            let run_id = "edit-ipc-run";
+            let dir = crate::runstate::run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
+            let req =
+                InteractionRequest::edit_text("er1", "Edit the plan", "plan", "line 1\nline 2");
+            write_request(run_id, &req).unwrap();
+            let back = read_request(run_id).expect("request should round-trip");
+            assert_eq!(back.kind, InteractionKind::EditText);
+            assert_eq!(back.body.as_deref(), Some("line 1\nline 2"));
+            assert_eq!(back.id, "er1");
+            let _ = std::fs::remove_dir_all(&dir);
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -12,16 +12,16 @@ use std::fs::File;
 use std::io;
 
 use clap::Parser;
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
 use crossterm::ExecutableCommand;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use tracing::info;
 
 use leviath_cli::commands;
 use leviath_cli::commands::dashboard::{CrosstermEventSource, DashboardArgs, TerminalSetup};
-use leviath_cli::dispatch::{dispatch, Commands, RiskyExecutors};
+use leviath_cli::dispatch::{Commands, RiskyExecutors, dispatch};
 
 /// Leviath CLI - Agent framework with structured context windows
 #[derive(Parser)]

--- a/crates/leviath-cli/src/render.rs
+++ b/crates/leviath-cli/src/render.rs
@@ -336,7 +336,7 @@ impl Renderer {
                         Some(None) | None => "● ".to_string(),
                     };
                     // Increment ordered list counter
-                    if let Some(Some(ref mut n)) = self.list_stack.last_mut() {
+                    if let Some(Some(n)) = self.list_stack.last_mut() {
                         *n += 1;
                     }
                     self.current_spans.push(Span::styled(
@@ -355,11 +355,7 @@ impl Renderer {
                     self.code_lang = match kind {
                         CodeBlockKind::Fenced(lang) => {
                             let s = lang.into_string();
-                            if s.is_empty() {
-                                None
-                            } else {
-                                Some(s)
-                            }
+                            if s.is_empty() { None } else { Some(s) }
                         }
                         CodeBlockKind::Indented => None,
                     };

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -363,112 +363,75 @@ pub fn tail_stage_log(run_id: &str, stage_idx: usize, max_bytes: u64) -> String 
     tail_file(&stage_dir(run_id, stage_idx).join("logs.log"), max_bytes)
 }
 
-/// Serializes any test, anywhere in the crate, that reads `runs_dir()`'s or
-/// `dashboard_log_path()`'s default (unset-env) behavior, or that mutates
-/// `LEVIATH_RUNS_DIR`/`LEVIATH_DASHBOARD_LOG_PATH`. Both env vars are
-/// process-global, so tests in different files that don't share a lock can
-/// race -- e.g. a test isolating run state via [`isolate_runs_dir_for_test`]
-/// while another, unlocked test asserts on the real home-directory fallback.
-/// Declared here (not inside `mod tests`) so it's reachable crate-wide as
-/// `crate::runstate::RUNS_DIR_ENV_LOCK`, mirroring `config.rs`'s
-/// `CONFIG_PATH_ENV_LOCK`.
-#[cfg(test)]
-pub(crate) static RUNS_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Restores an env var to a previously-captured value: `Some` re-sets it,
-/// `None` removes it. Shared by [`RunsDirTestGuard::drop`] and the handful
-/// of tests in `mod tests` that temporarily override `LEVIATH_RUNS_DIR`/
-/// `LEVIATH_DASHBOARD_LOG_PATH` to exercise the real (env-reading) fallback
-/// path directly, so both the "was set" and "was unset" arms are exercised
-/// through one shared, directly-tested implementation instead of leaving
-/// either arm's coverage dependent on incidental test-scheduling timing.
-#[cfg(test)]
-pub(crate) fn restore_env_var(key: &str, prev: Option<std::ffi::OsString>) {
-    // Non-generic (single monomorphization) so both match arms are attributed
-    // to one instantiation and fully covered by `restore_env_var_handles_both_some_and_none`.
-    match prev {
-        Some(v) => unsafe { std::env::set_var(key, v) },
-        None => unsafe { std::env::remove_var(key) },
-    }
-}
-
-/// RAII guard that restores `LEVIATH_RUNS_DIR` and
-/// `LEVIATH_DASHBOARD_LOG_PATH` to their original values, removes the
-/// isolated temp directory, and releases [`RUNS_DIR_ENV_LOCK`], on drop.
-#[cfg(test)]
-pub(crate) struct RunsDirTestGuard {
-    original_runs_dir: Option<std::ffi::OsString>,
-    original_dashboard_log_path: Option<std::ffi::OsString>,
-    base_dir: std::path::PathBuf,
-    _lock: std::sync::MutexGuard<'static, ()>,
-}
-
-#[cfg(test)]
-impl Drop for RunsDirTestGuard {
-    fn drop(&mut self) {
-        restore_env_var("LEVIATH_RUNS_DIR", self.original_runs_dir.take());
-        restore_env_var(
-            "LEVIATH_DASHBOARD_LOG_PATH",
-            self.original_dashboard_log_path.take(),
-        );
-        let _ = std::fs::remove_dir_all(&self.base_dir);
-    }
-}
-
-/// Points `LEVIATH_RUNS_DIR` and `LEVIATH_DASHBOARD_LOG_PATH` at fresh paths
-/// inside a temp directory, for the duration of the returned guard, so tests
-/// that create real run/agent/dashboard-log state (`create_run`,
-/// `write_meta`, `append_stage_output`, `append_dashboard_log`, `list_runs`,
-/// ...) never touch the real `~/.leviath/runs/` or `~/.leviath/dashboard.log`.
+/// Build the isolated base directory for a run-state test and create its
+/// `runs/` subdir. Returned so the caller's closure can plant fixtures under it.
 ///
-/// This matters more than it looks: those are the exact files `lev dash`/
-/// `lev serve` read from. Without this guard, tests writing real fixture
-/// entries (`agent_name: "test"`, `workdir: "/tmp"`, etc.) straight into the
-/// user's actual runs directory can leave orphans behind: most get cleaned up
-/// by each test's own `remove_dir_all` at the end, but a test process killed
-/// mid-run (e.g. Ctrl+C on a hung test) never reaches that cleanup, so the
-/// entries stay behind permanently, showing up as orphaned "waiting" agents in
-/// the user's real dashboard.
+/// Rooted under `~/.leviath-test/rs-<hash>` rather than `std::env::temp_dir()`:
+/// some dashboard render tests display a real on-disk path inside a fixed-width
+/// terminal area and assert on a substring near its *end*, and macOS's real
+/// temp dir (`/var/folders/xy/.../T/`) is long enough to push realistic paths
+/// past the render width and truncate the asserted suffix. `unique` is hashed
+/// short for the same reason (test names run 60+ chars). `.leviath-test` is a
+/// sibling of `.leviath`, never read by `lev dash`/`lev serve`, so even if a
+/// killed test process skips cleanup it can't leak into the real dashboard.
 #[cfg(test)]
-pub(crate) fn isolate_runs_dir_for_test(unique: &str) -> RunsDirTestGuard {
-    let lock = RUNS_DIR_ENV_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let original_runs_dir = std::env::var_os("LEVIATH_RUNS_DIR");
-    let original_dashboard_log_path = std::env::var_os("LEVIATH_DASHBOARD_LOG_PATH");
-    // Keep the temp path short and hash `unique` down rather than embedding
-    // it verbatim: some dashboard render tests display a real on-disk path
-    // (e.g. stage_dir(...).join("output.log")) inside a fixed-width
-    // terminal area and assert on a substring near the *end* of that path.
-    // Test function names here can run 60+ characters.
+fn make_runs_base_dir(unique: &str) -> std::path::PathBuf {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     unique.hash(&mut hasher);
     let short = format!("{:x}", hasher.finish() & 0xffff_ffff);
-    // Rooted under the home dir (NOT std::env::temp_dir()) so the render
-    // code's existing `~`-shortening of displayed paths still applies --
-    // macOS's real temp dir is itself ~50 chars (`/var/folders/xy/.../T/`),
-    // which alone was enough to push realistic paths past the same render
-    // width and truncate away the asserted-on suffix. `.leviath-test` is a
-    // sibling of `.leviath`, never read by `lev dash`/`lev serve`, so this
-    // still can't leak into the user's real dashboard even if a killed test
-    // process skips this guard's own Drop-time cleanup.
     let base_dir = dirs::home_dir()
         .unwrap_or_default()
         .join(".leviath-test")
         .join(format!("rs-{short}"));
-    let runs_dir = base_dir.join("runs");
-    let _ = std::fs::create_dir_all(&runs_dir);
-    unsafe {
-        std::env::set_var("LEVIATH_RUNS_DIR", &runs_dir);
-        std::env::set_var("LEVIATH_DASHBOARD_LOG_PATH", base_dir.join("dashboard.log"));
-    }
-    RunsDirTestGuard {
-        original_runs_dir,
-        original_dashboard_log_path,
-        base_dir,
-        _lock: lock,
-    }
+    let _ = std::fs::create_dir_all(base_dir.join("runs"));
+    base_dir
+}
+
+/// The env overrides that point run-state I/O at `base_dir` instead of the
+/// real `~/.leviath/`. Handed to `temp_env` for scoped set-and-restore.
+#[cfg(test)]
+fn runs_dir_isolation_vars(
+    base_dir: &std::path::Path,
+) -> [(&'static str, Option<std::ffi::OsString>); 2] {
+    [
+        (
+            "LEVIATH_RUNS_DIR",
+            Some(base_dir.join("runs").into_os_string()),
+        ),
+        (
+            "LEVIATH_DASHBOARD_LOG_PATH",
+            Some(base_dir.join("dashboard.log").into_os_string()),
+        ),
+    ]
+}
+
+/// Runs `f` with `LEVIATH_RUNS_DIR`/`LEVIATH_DASHBOARD_LOG_PATH` pointed at a
+/// fresh isolated temp directory (passed to `f`), restoring them afterwards.
+/// Closure-scoped (not an RAII guard) because edition 2024 makes `set_var`
+/// `unsafe`, which the crate forbids; `temp_env` serializes it process-wide.
+#[cfg(test)]
+pub(crate) fn with_isolated_runs_dir<R>(unique: &str, f: impl FnOnce(&std::path::Path) -> R) -> R {
+    let base_dir = make_runs_base_dir(unique);
+    let result = temp_env::with_vars(runs_dir_isolation_vars(&base_dir), || f(&base_dir));
+    let _ = std::fs::remove_dir_all(&base_dir);
+    result
+}
+
+/// Async counterpart of [`with_isolated_runs_dir`] for `#[tokio::test]`s.
+#[cfg(test)]
+pub(crate) async fn with_isolated_runs_dir_async<R, Fut>(
+    unique: &str,
+    f: impl FnOnce(std::path::PathBuf) -> Fut,
+) -> R
+where
+    Fut: std::future::Future<Output = R>,
+{
+    let base_dir = make_runs_base_dir(unique);
+    let result =
+        temp_env::async_with_vars(runs_dir_isolation_vars(&base_dir), f(base_dir.clone())).await;
+    let _ = std::fs::remove_dir_all(&base_dir);
+    result
 }
 
 #[cfg(test)]
@@ -796,57 +759,60 @@ mod tests {
         // Isolated via `isolate_runs_dir_for_test` so write_meta/read_meta
         // never touch the real ~/.leviath/runs/ -- the temp dir is removed
         // automatically when `_guard` drops, so no manual cleanup needed.
-        let _guard = isolate_runs_dir_for_test("write-and-read-meta-roundtrip");
-        let meta = RunMeta::new(
-            "test-roundtrip-unit".into(),
-            "test-agent".into(),
-            "/agents/test".into(),
-            "unit test".into(),
-            Some("model-x".into()),
-            "/tmp".into(),
-            2,
-        );
+        with_isolated_runs_dir("write-and-read-meta-roundtrip", |_d| {
+            let meta = RunMeta::new(
+                "test-roundtrip-unit".into(),
+                "test-agent".into(),
+                "/agents/test".into(),
+                "unit test".into(),
+                Some("model-x".into()),
+                "/tmp".into(),
+                2,
+            );
 
-        create_run(&meta).unwrap();
-        let back = read_meta(&meta.run_id).unwrap();
-        assert_eq!(back.run_id, "test-roundtrip-unit");
-        assert_eq!(back.agent_name, "test-agent");
-        assert_eq!(back.task, "unit test");
-        assert_eq!(back.model.as_deref(), Some("model-x"));
+            create_run(&meta).unwrap();
+            let back = read_meta(&meta.run_id).unwrap();
+            assert_eq!(back.run_id, "test-roundtrip-unit");
+            assert_eq!(back.agent_name, "test-agent");
+            assert_eq!(back.task, "unit test");
+            assert_eq!(back.model.as_deref(), Some("model-x"));
+        });
     }
 
     #[test]
     fn read_meta_returns_err_on_corrupted_json() {
         // Exercises `read_meta_from`'s `serde_json::from_str(&json)?` Err
         // arm: a `meta.json` that exists but doesn't parse as a `RunMeta`.
-        let _guard = isolate_runs_dir_for_test("read-meta-returns-err-on-corrupted-json");
-        let run_id = "corrupted-meta-run";
-        let dir = run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("meta.json"), "not valid json").unwrap();
+        with_isolated_runs_dir("read-meta-returns-err-on-corrupted-json", |_d| {
+            let run_id = "corrupted-meta-run";
+            let dir = run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("meta.json"), "not valid json").unwrap();
 
-        let result = read_meta(run_id);
-        assert!(result.is_err());
+            let result = read_meta(run_id);
+            assert!(result.is_err());
+        });
     }
 
     // ─── write_stages_index / read_stages_index roundtrip ───────────────────
 
     #[test]
     fn write_and_read_stages_index_roundtrip() {
-        let _guard = isolate_runs_dir_for_test("write-and-read-stages-index-roundtrip");
-        let run_id = "test-stages-idx-unit";
-        let dir = run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        with_isolated_runs_dir("write-and-read-stages-index-roundtrip", |_d| {
+            let run_id = "test-stages-idx-unit";
+            let dir = run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let stages = vec![
-            StageRecord::new("init".into(), 0),
-            StageRecord::new("process".into(), 1),
-        ];
-        write_stages_index(run_id, &stages).unwrap();
-        let back = read_stages_index(run_id);
-        assert_eq!(back.len(), 2);
-        assert_eq!(back[0].name, "init");
-        assert_eq!(back[1].name, "process");
+            let stages = vec![
+                StageRecord::new("init".into(), 0),
+                StageRecord::new("process".into(), 1),
+            ];
+            write_stages_index(run_id, &stages).unwrap();
+            let back = read_stages_index(run_id);
+            assert_eq!(back.len(), 2);
+            assert_eq!(back[0].name, "init");
+            assert_eq!(back[1].name, "process");
+        });
     }
 
     #[test]
@@ -859,21 +825,22 @@ mod tests {
 
     #[test]
     fn write_and_read_context_snapshot_roundtrip() {
-        let _guard = isolate_runs_dir_for_test("write-and-read-context-snapshot-roundtrip");
-        let run_id = "test-ctx-snap-unit";
-        let dir = run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
+        with_isolated_runs_dir("write-and-read-context-snapshot-roundtrip", |_d| {
+            let run_id = "test-ctx-snap-unit";
+            let dir = run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
 
-        let snap = ContextSnapshot {
-            stage_name: "test".into(),
-            total_tokens: 42,
-            max_tokens: 8192,
-            regions: vec![],
-        };
-        write_context_snapshot(run_id, &snap).unwrap();
-        let back = read_context_snapshot(run_id).unwrap();
-        assert_eq!(back.stage_name, "test");
-        assert_eq!(back.total_tokens, 42);
+            let snap = ContextSnapshot {
+                stage_name: "test".into(),
+                total_tokens: 42,
+                max_tokens: 8192,
+                regions: vec![],
+            };
+            write_context_snapshot(run_id, &snap).unwrap();
+            let back = read_context_snapshot(run_id).unwrap();
+            assert_eq!(back.stage_name, "test");
+            assert_eq!(back.total_tokens, 42);
+        });
     }
 
     #[test]
@@ -892,41 +859,44 @@ mod tests {
 
     #[test]
     fn append_and_tail_stage_output() {
-        let _guard = isolate_runs_dir_for_test("append-and-tail-stage-output");
-        let run_id = "test-stage-output-unit";
-        append_stage_output(run_id, 0, "line 1");
-        append_stage_output(run_id, 0, "line 2");
-        let output = tail_stage_output(run_id, 0, 4096);
-        assert!(output.contains("line 1"));
-        assert!(output.contains("line 2"));
+        with_isolated_runs_dir("append-and-tail-stage-output", |_d| {
+            let run_id = "test-stage-output-unit";
+            append_stage_output(run_id, 0, "line 1");
+            append_stage_output(run_id, 0, "line 2");
+            let output = tail_stage_output(run_id, 0, 4096);
+            assert!(output.contains("line 1"));
+            assert!(output.contains("line 2"));
+        });
     }
 
     #[test]
     fn append_and_tail_stage_log() {
-        let _guard = isolate_runs_dir_for_test("append-and-tail-stage-log");
-        let run_id = "test-stage-log-unit";
-        append_stage_log(run_id, 0, "event A");
-        append_stage_log(run_id, 0, "event B");
-        let log = tail_stage_log(run_id, 0, 4096);
-        assert!(log.contains("event A"));
-        assert!(log.contains("event B"));
+        with_isolated_runs_dir("append-and-tail-stage-log", |_d| {
+            let run_id = "test-stage-log-unit";
+            append_stage_log(run_id, 0, "event A");
+            append_stage_log(run_id, 0, "event B");
+            let log = tail_stage_log(run_id, 0, 4096);
+            assert!(log.contains("event A"));
+            assert!(log.contains("event B"));
+        });
     }
 
     // ─── write/read stage context ───────────────────────────────────────────
 
     #[test]
     fn write_and_read_stage_context_roundtrip() {
-        let _guard = isolate_runs_dir_for_test("write-and-read-stage-context-roundtrip");
-        let run_id = "test-stage-ctx-unit";
-        let snap = ContextSnapshot {
-            stage_name: "stage-0".into(),
-            total_tokens: 100,
-            max_tokens: 4096,
-            regions: vec![],
-        };
-        write_stage_context(run_id, 0, &snap).unwrap();
-        let back = read_stage_context(run_id, 0).unwrap();
-        assert_eq!(back.stage_name, "stage-0");
+        with_isolated_runs_dir("write-and-read-stage-context-roundtrip", |_d| {
+            let run_id = "test-stage-ctx-unit";
+            let snap = ContextSnapshot {
+                stage_name: "stage-0".into(),
+                total_tokens: 100,
+                max_tokens: 4096,
+                regions: vec![],
+            };
+            write_stage_context(run_id, 0, &snap).unwrap();
+            let back = read_stage_context(run_id, 0).unwrap();
+            assert_eq!(back.stage_name, "stage-0");
+        });
     }
 
     #[test]
@@ -938,9 +908,10 @@ mod tests {
 
     #[test]
     fn append_dashboard_log_creates_log_file() {
-        let _guard = isolate_runs_dir_for_test("append-dashboard-log-creates-log-file");
-        append_dashboard_log("coverage-test-message");
-        assert!(dashboard_log_path().exists());
+        with_isolated_runs_dir("append-dashboard-log-creates-log-file", |_d| {
+            append_dashboard_log("coverage-test-message");
+            assert!(dashboard_log_path().exists());
+        });
     }
 
     #[test]
@@ -950,11 +921,12 @@ mod tests {
         // opening it for append fails with `IsADirectory` -- the function
         // must swallow this silently (best-effort logging) rather than
         // panic.
-        let _guard = isolate_runs_dir_for_test("append-dashboard-log-open-failure");
-        let path = dashboard_log_path();
-        std::fs::create_dir_all(&path).unwrap();
-        append_dashboard_log("this should not panic");
-        assert!(path.is_dir());
+        with_isolated_runs_dir("append-dashboard-log-open-failure", |_d| {
+            let path = dashboard_log_path();
+            std::fs::create_dir_all(&path).unwrap();
+            append_dashboard_log("this should not panic");
+            assert!(path.is_dir());
+        });
     }
 
     #[test]
@@ -962,54 +934,28 @@ mod tests {
         // Every other test resolves `dashboard_log_path()` to a path with a
         // real parent component, leaving the `if let Some(parent) = ...`
         // pattern's `None` arm (root paths like "/" have no parent) never
-        // exercised. Locks `RUNS_DIR_ENV_LOCK` directly (not
-        // `isolate_runs_dir_for_test`, whose fixed `base_dir.join(...)`
-        // path always has a parent) so the override can point at "/".
-        let _lock = RUNS_DIR_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = std::env::var_os("LEVIATH_DASHBOARD_LOG_PATH");
-        unsafe { std::env::set_var("LEVIATH_DASHBOARD_LOG_PATH", "/") };
-        assert!(dashboard_log_path().parent().is_none());
-        append_dashboard_log("this should not panic even with no parent");
-        restore_env_var("LEVIATH_DASHBOARD_LOG_PATH", prev);
+        // exercised. `temp_env::with_var` points the override at "/" for the
+        // closure's duration (serialized process-wide, then restored).
+        temp_env::with_var("LEVIATH_DASHBOARD_LOG_PATH", Some("/"), || {
+            assert!(dashboard_log_path().parent().is_none());
+            append_dashboard_log("this should not panic even with no parent");
+        });
     }
 
     // ─── dashboard_log_path ────────────────────────────────────────────────
 
-    // `restore_env_var` (used below) is defined alongside `RunsDirTestGuard`
-    // in the parent module, since `RunsDirTestGuard::drop` shares it too --
-    // see its doc comment for why both the `Some` and `None` arms are
-    // exercised directly by the test below rather than by the "real" call
-    // sites, whose `prev` depends on incidental test-scheduling timing.
-
-    #[test]
-    fn restore_env_var_handles_both_some_and_none() {
-        let key = "LEVIATH_COVERAGE_RESTORE_ENV_VAR_TEST";
-        restore_env_var(key, Some(std::ffi::OsString::from("value")));
-        assert_eq!(std::env::var(key).as_deref(), Ok("value"));
-        restore_env_var(key, None);
-        assert!(std::env::var(key).is_err());
-    }
-
     #[test]
     fn dashboard_log_path_structure() {
         // Exercises the real (env-reading) `dashboard_log_path()` on its
-        // fallback branch, so -- like `runs_dir_structure` below -- this
-        // must hold `RUNS_DIR_ENV_LOCK` and force both env vars unset:
-        // `isolate_runs_dir_for_test` (used by many other tests) sets
-        // `LEVIATH_DASHBOARD_LOG_PATH` process-wide, and without the lock a
-        // concurrently-running isolated test would make this assertion
-        // race and intermittently fail.
-        let _lock = RUNS_DIR_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = std::env::var_os("LEVIATH_DASHBOARD_LOG_PATH");
-        unsafe { std::env::remove_var("LEVIATH_DASHBOARD_LOG_PATH") };
-        let path = dashboard_log_path();
-        assert!(path.to_str().unwrap().contains(".leviath"));
-        assert!(path.to_str().unwrap().ends_with("dashboard.log"));
-        restore_env_var("LEVIATH_DASHBOARD_LOG_PATH", prev);
+        // fallback branch, so -- like `runs_dir_structure` below -- it forces
+        // `LEVIATH_DASHBOARD_LOG_PATH` unset via `temp_env::with_var_unset`,
+        // which also serializes against every other temp-env test so a
+        // concurrently-isolated test can't race this assertion.
+        temp_env::with_var_unset("LEVIATH_DASHBOARD_LOG_PATH", || {
+            let path = dashboard_log_path();
+            assert!(path.to_str().unwrap().contains(".leviath"));
+            assert!(path.to_str().unwrap().ends_with("dashboard.log"));
+        });
     }
 
     // ─── runs_dir / run_dir ────────────────────────────────────────────────
@@ -1018,15 +964,11 @@ mod tests {
     fn runs_dir_structure() {
         // See the comment on `dashboard_log_path_structure` above -- same
         // race, same fix, for `LEVIATH_RUNS_DIR`.
-        let _lock = RUNS_DIR_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = std::env::var_os("LEVIATH_RUNS_DIR");
-        unsafe { std::env::remove_var("LEVIATH_RUNS_DIR") };
-        let path = runs_dir();
-        assert!(path.to_str().unwrap().contains(".leviath"));
-        assert!(path.to_str().unwrap().ends_with("runs"));
-        restore_env_var("LEVIATH_RUNS_DIR", prev);
+        temp_env::with_var_unset("LEVIATH_RUNS_DIR", || {
+            let path = runs_dir();
+            assert!(path.to_str().unwrap().contains(".leviath"));
+            assert!(path.to_str().unwrap().ends_with("runs"));
+        });
     }
 
     #[test]
@@ -1065,35 +1007,25 @@ mod tests {
         assert!(path.to_str().unwrap().contains("my-run-123"));
     }
 
-    // ─── isolate_runs_dir_for_test ──────────────────────────────────────────
+    // ─── with_isolated_runs_dir ─────────────────────────────────────────────
 
     #[test]
-    fn isolate_runs_dir_for_test_points_at_temp_dir_and_restores_on_drop() {
-        // Deliberately does NOT snapshot "the env var value before" from
-        // outside any lock and compare against it after -- `isolate_runs_dir_for_test`
-        // only holds `RUNS_DIR_ENV_LOCK` for its own scope, so a naive
-        // before/after comparison races a concurrently-running isolated test
-        // on another thread (observed: `left: None, right: Some(".../rs-.../runs")`
-        // when another guard's value leaked into "before" or "after" this
-        // guard's own window). Instead assert the guard's own path is live
-        // only inside its scope and gone afterward -- a property that holds
-        // no matter what other threads are doing, since no other test can
-        // legitimately produce this exact hash-derived path.
-        let guard_runs_dir;
-        let guard_log_path;
-        {
-            let guard = isolate_runs_dir_for_test("guard-self-test");
-            guard_runs_dir = guard.base_dir.join("runs");
-            guard_log_path = guard.base_dir.join("dashboard.log");
-            assert_eq!(runs_dir(), guard_runs_dir);
+    fn with_isolated_runs_dir_points_at_temp_dir_and_cleans_up_after() {
+        // Deliberately avoids a racy before/after ambient comparison (a
+        // concurrently-isolated test could own `LEVIATH_RUNS_DIR` just before
+        // or after this closure's temp-env window): instead assert the helper's
+        // own hash-derived path is live *inside* the closure and removed
+        // afterward -- a property no other test can perturb, since none
+        // produces this exact path.
+        let inside = with_isolated_runs_dir("helper-self-test", |base_dir| {
+            let expected = base_dir.join("runs");
+            assert_eq!(runs_dir(), expected);
             assert!(runs_dir().exists());
-            assert_eq!(dashboard_log_path(), guard_log_path);
-        }
-        // Guard dropped: env vars must no longer point at the (now-removed)
-        // temp dir this guard created.
-        assert_ne!(runs_dir(), guard_runs_dir);
-        assert_ne!(dashboard_log_path(), guard_log_path);
-        assert!(!guard_runs_dir.exists());
+            assert_eq!(dashboard_log_path(), base_dir.join("dashboard.log"));
+            expected
+        });
+        // Closure returned: the temp dir the helper created is gone.
+        assert!(!inside.exists());
     }
 
     // ─── tail_file edge cases ──────────────────────────────────────────────
@@ -1244,56 +1176,58 @@ mod tests {
 
     #[test]
     fn append_stage_output_multiple_stages() {
-        let _guard = isolate_runs_dir_for_test("append-stage-output-multiple-stages");
-        let run_id = "test-multi-stage-out";
-        append_stage_output(run_id, 0, "stage 0 output");
-        append_stage_output(run_id, 1, "stage 1 output");
-        append_stage_output(run_id, 2, "stage 2 output");
+        with_isolated_runs_dir("append-stage-output-multiple-stages", |_d| {
+            let run_id = "test-multi-stage-out";
+            append_stage_output(run_id, 0, "stage 0 output");
+            append_stage_output(run_id, 1, "stage 1 output");
+            append_stage_output(run_id, 2, "stage 2 output");
 
-        let out0 = tail_stage_output(run_id, 0, 4096);
-        let out1 = tail_stage_output(run_id, 1, 4096);
-        let out2 = tail_stage_output(run_id, 2, 4096);
+            let out0 = tail_stage_output(run_id, 0, 4096);
+            let out1 = tail_stage_output(run_id, 1, 4096);
+            let out2 = tail_stage_output(run_id, 2, 4096);
 
-        assert!(out0.contains("stage 0 output"));
-        assert!(out1.contains("stage 1 output"));
-        assert!(out2.contains("stage 2 output"));
-        // Verify no cross-contamination
-        assert!(!out0.contains("stage 1 output"));
+            assert!(out0.contains("stage 0 output"));
+            assert!(out1.contains("stage 1 output"));
+            assert!(out2.contains("stage 2 output"));
+            // Verify no cross-contamination
+            assert!(!out0.contains("stage 1 output"));
+        });
     }
 
     // ─── list_runs ─────────────────────────────────────────────────────────
 
     #[test]
     fn list_runs_returns_sorted() {
-        let _guard = isolate_runs_dir_for_test("list-runs-returns-sorted");
-        let meta1 = RunMeta::new(
-            "test-list-run-a".into(),
-            "agent".into(),
-            "/p".into(),
-            "task a".into(),
-            None,
-            "/w".into(),
-            1,
-        );
-        let meta2 = RunMeta::new(
-            "test-list-run-b".into(),
-            "agent".into(),
-            "/p".into(),
-            "task b".into(),
-            None,
-            "/w".into(),
-            1,
-        );
+        with_isolated_runs_dir("list-runs-returns-sorted", |_d| {
+            let meta1 = RunMeta::new(
+                "test-list-run-a".into(),
+                "agent".into(),
+                "/p".into(),
+                "task a".into(),
+                None,
+                "/w".into(),
+                1,
+            );
+            let meta2 = RunMeta::new(
+                "test-list-run-b".into(),
+                "agent".into(),
+                "/p".into(),
+                "task b".into(),
+                None,
+                "/w".into(),
+                1,
+            );
 
-        let _ = create_run(&meta1);
-        // Small delay to ensure different timestamps
-        let _ = create_run(&meta2);
+            let _ = create_run(&meta1);
+            // Small delay to ensure different timestamps
+            let _ = create_run(&meta2);
 
-        let runs = list_runs();
-        // Both should appear in the list
-        let ids: Vec<&str> = runs.iter().map(|r| r.run_id.as_str()).collect();
-        assert!(ids.contains(&"test-list-run-a"));
-        assert!(ids.contains(&"test-list-run-b"));
+            let runs = list_runs();
+            // Both should appear in the list
+            let ids: Vec<&str> = runs.iter().map(|r| r.run_id.as_str()).collect();
+            assert!(ids.contains(&"test-list-run-a"));
+            assert!(ids.contains(&"test-list-run-b"));
+        });
     }
 
     // ─── tail_stage_log / tail_stage_output empty ──────────────────────────
@@ -1341,51 +1275,44 @@ mod tests {
         // When `output.log` already exists as a *directory*, `OpenOptions::open`
         // fails and the write is silently skipped (the `if let Ok(file)` false
         // path). Making the target a directory fails the open on every platform.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("append_stage_output_open_failure");
-        let run_id = "append-out-openfail";
-        ensure_stage_dir(run_id, 0);
-        std::fs::create_dir_all(stage_dir(run_id, 0).join("output.log")).unwrap();
-        append_stage_output(run_id, 0, "ignored"); // must not panic
+        crate::runstate::with_isolated_runs_dir("append_stage_output_open_failure", |_d| {
+            let run_id = "append-out-openfail";
+            ensure_stage_dir(run_id, 0);
+            std::fs::create_dir_all(stage_dir(run_id, 0).join("output.log")).unwrap();
+            append_stage_output(run_id, 0, "ignored"); // must not panic
+        });
     }
 
     #[test]
     fn append_stage_log_open_failure_is_silently_skipped() {
         // Same as above for `logs.log` in `append_stage_log`.
-        let _guard = crate::runstate::isolate_runs_dir_for_test("append_stage_log_open_failure");
-        let run_id = "append-log-openfail";
-        ensure_stage_dir(run_id, 0);
-        std::fs::create_dir_all(stage_dir(run_id, 0).join("logs.log")).unwrap();
-        append_stage_log(run_id, 0, "ignored"); // must not panic
+        crate::runstate::with_isolated_runs_dir("append_stage_log_open_failure", |_d| {
+            let run_id = "append-log-openfail";
+            ensure_stage_dir(run_id, 0);
+            std::fs::create_dir_all(stage_dir(run_id, 0).join("logs.log")).unwrap();
+            append_stage_log(run_id, 0, "ignored"); // must not panic
+        });
     }
 
     // ─── runs_dir / list_runs edge cases ────────────────────────────────────
 
     #[test]
     fn runs_dir_with_override_set_returns_override() {
-        let _lock = RUNS_DIR_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmpdir = tempfile::tempdir().unwrap();
-        let prev = std::env::var_os("LEVIATH_RUNS_DIR");
-        unsafe { std::env::set_var("LEVIATH_RUNS_DIR", tmpdir.path()) };
-        let dir = runs_dir();
-        assert_eq!(dir, tmpdir.path());
-        restore_env_var("LEVIATH_RUNS_DIR", prev);
+        temp_env::with_var("LEVIATH_RUNS_DIR", Some(tmpdir.path()), || {
+            assert_eq!(runs_dir(), tmpdir.path());
+        });
     }
 
     #[test]
     fn runs_dir_without_override_falls_back_to_home() {
-        let _lock = RUNS_DIR_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = std::env::var_os("LEVIATH_RUNS_DIR");
-        unsafe { std::env::remove_var("LEVIATH_RUNS_DIR") };
-        let dir = runs_dir();
-        #[cfg(unix)]
-        assert!(dir.ends_with(".leviath/runs"));
-        #[cfg(windows)]
-        assert!(dir.ends_with(".leviath\\runs"));
-        restore_env_var("LEVIATH_RUNS_DIR", prev);
+        temp_env::with_var_unset("LEVIATH_RUNS_DIR", || {
+            let dir = runs_dir();
+            #[cfg(unix)]
+            assert!(dir.ends_with(".leviath/runs"));
+            #[cfg(windows)]
+            assert!(dir.ends_with(".leviath\\runs"));
+        });
     }
 
     #[test]
@@ -1394,9 +1321,10 @@ mod tests {
         // empty runs dir (not "the real dir, which we hope has no entry with
         // this exact bogus id") -- can assert real emptiness instead of just
         // absence of one specific id.
-        let _guard = isolate_runs_dir_for_test("list-runs-empty-when-runs-dir-missing-or-empty");
-        let runs = list_runs();
-        assert!(runs.is_empty());
+        with_isolated_runs_dir("list-runs-empty-when-runs-dir-missing-or-empty", |_d| {
+            let runs = list_runs();
+            assert!(runs.is_empty());
+        });
     }
 
     #[test]
@@ -1441,13 +1369,14 @@ mod tests {
         // tail_log() itself (as opposed to tail_file(), which every other
         // test here calls directly) had zero coverage -- it's a one-line
         // wrapper joining run_dir(run_id) with "output.log".
-        let _guard = isolate_runs_dir_for_test("tail-log-reads-output-log-for-run-id");
-        let run_id = "test-tail-log-run";
-        let dir = run_dir(run_id);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("output.log"), "hello from output.log").unwrap();
+        with_isolated_runs_dir("tail-log-reads-output-log-for-run-id", |_d| {
+            let run_id = "test-tail-log-run";
+            let dir = run_dir(run_id);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("output.log"), "hello from output.log").unwrap();
 
-        assert_eq!(tail_log(run_id, 1024), "hello from output.log");
+            assert_eq!(tail_log(run_id, 1024), "hello from output.log");
+        });
     }
 
     #[cfg(unix)]
@@ -1729,10 +1658,11 @@ mod tests {
     #[test]
     fn append_dashboard_log_writes_message() {
         // Exercises the create_dir_all branch and writeln! branch via a unique marker.
-        let _guard = isolate_runs_dir_for_test("append-dashboard-log-writes-message");
-        let unique = format!("cov-dashboard-log-{}", std::process::id());
-        append_dashboard_log(&unique);
-        let content = std::fs::read_to_string(dashboard_log_path()).unwrap_or_default();
-        assert!(content.contains(&unique));
+        with_isolated_runs_dir("append-dashboard-log-writes-message", |_d| {
+            let unique = format!("cov-dashboard-log-{}", std::process::id());
+            append_dashboard_log(&unique);
+            let content = std::fs::read_to_string(dashboard_log_path()).unwrap_or_default();
+            assert!(content.contains(&unique));
+        });
     }
 }

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -213,10 +213,10 @@ fn list_runs_in_dir(dir: PathBuf) -> Vec<RunMeta> {
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for entry in entries.filter_map(|e| e.ok()) {
             let meta_path = entry.path().join("meta.json");
-            if let Ok(json) = std::fs::read_to_string(&meta_path) {
-                if let Ok(meta) = serde_json::from_str::<RunMeta>(&json) {
-                    runs.push(meta);
-                }
+            if let Ok(json) = std::fs::read_to_string(&meta_path)
+                && let Ok(meta) = serde_json::from_str::<RunMeta>(&json)
+            {
+                runs.push(meta);
             }
         }
     }

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -296,7 +296,7 @@ impl SubAgentExecutor {
                     return format!(
                         "[error] Blueprint '{}' not found. Register it first.",
                         blueprint_name
-                    )
+                    );
                 }
             }
         };
@@ -960,19 +960,21 @@ mod subagent_tests {
         // Parent tracks the child (so the dashboard tree shows it).
         let children = eng.world().get::<SubAgentChildren>(root_entity).unwrap();
         assert!(children.children.contains(&child_entity));
-        assert!(eng
-            .world()
-            .get::<AgentState>(root_entity)
-            .unwrap()
-            .spawned_children_ids
-            .contains(&child_id));
+        assert!(
+            eng.world()
+                .get::<AgentState>(root_entity)
+                .unwrap()
+                .spawned_children_ids
+                .contains(&child_id)
+        );
         // Seed landed in the pinned region.
         let window = eng.world().get::<ContextWindow>(child_entity).unwrap();
         let sys = window.get_region("system").unwrap();
-        assert!(sys
-            .content
-            .iter()
-            .any(|e| e.content.contains("work item context")));
+        assert!(
+            sys.content
+                .iter()
+                .any(|e| e.content.contains("work item context"))
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/tests/cli_dispatch.rs
+++ b/crates/leviath-cli/tests/cli_dispatch.rs
@@ -237,13 +237,14 @@ fn add_subcommand_installs_from_local_directory_and_exits_zero() {
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(tmp
-        .path()
-        .join(".leviath")
-        .join("agents")
-        .join("coder")
-        .join("agent.leviath")
-        .exists());
+    assert!(
+        tmp.path()
+            .join(".leviath")
+            .join("agents")
+            .join("coder")
+            .join("agent.leviath")
+            .exists()
+    );
 }
 
 // ─── remove ──────────────────────────────────────────────────────────────

--- a/crates/leviath-core/Cargo.toml
+++ b/crates/leviath-core/Cargo.toml
@@ -13,3 +13,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -135,13 +135,13 @@ impl Blueprint {
             self.stages.iter().map(|s| s.name.as_str()).collect();
 
         // Entry stage must exist if set
-        if let Some(ref entry) = self.entry_stage {
-            if !stage_names.contains(entry.as_str()) {
-                return Err(ValidationError::Graph(format!(
-                    "entry_stage '{}' does not match any defined stage",
-                    entry
-                )));
-            }
+        if let Some(entry) = &self.entry_stage
+            && !stage_names.contains(entry.as_str())
+        {
+            return Err(ValidationError::Graph(format!(
+                "entry_stage '{}' does not match any defined stage",
+                entry
+            )));
         }
 
         // Fan-out stages reference a worker source + optional merge stage. These
@@ -173,7 +173,7 @@ impl Blueprint {
                             return Err(ValidationError::Stage {
                                 stage: stage.name.clone(),
                                 message: format!("fan_out worker_stage '{}' does not exist", ws),
-                            })
+                            });
                         }
                         Some(target) if !target.allow_as_worker => {
                             return Err(ValidationError::Stage {
@@ -182,18 +182,18 @@ impl Blueprint {
                                     "fan_out worker_stage '{}' must set allow_as_worker = true",
                                     ws
                                 ),
-                            })
+                            });
                         }
                         Some(_) => {}
                     }
                 }
-                if let Some(ms) = &config.merge_stage {
-                    if !stage_names.contains(ms.as_str()) {
-                        return Err(ValidationError::Stage {
-                            stage: stage.name.clone(),
-                            message: format!("fan_out merge_stage '{}' does not exist", ms),
-                        });
-                    }
+                if let Some(ms) = &config.merge_stage
+                    && !stage_names.contains(ms.as_str())
+                {
+                    return Err(ValidationError::Stage {
+                        stage: stage.name.clone(),
+                        message: format!("fan_out merge_stage '{}' does not exist", ms),
+                    });
                 }
             }
         }
@@ -310,14 +310,13 @@ impl Blueprint {
                 }
                 // If all targets are exhaustible (already visited + have max_revisits),
                 // the stage will eventually have zero available edges → terminal
-                let all_exhaustible = transitions.keys().all(|target| {
+                transitions.keys().all(|target| {
                     self.stages
                         .iter()
                         .find(|s| s.name == *target)
                         .map(|s| s.max_revisits.is_some())
                         .unwrap_or(false)
-                });
-                all_exhaustible
+                })
             }
         }
     }

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -681,36 +681,35 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     }
 
     // Parse file tracking config: [context.file_tracking]
-    if let Some(context_table) = parsed.get("context").and_then(|v| v.as_table()) {
-        if let Some(ft_table) = context_table
+    if let Some(context_table) = parsed.get("context").and_then(|v| v.as_table())
+        && let Some(ft_table) = context_table
             .get("file_tracking")
             .and_then(|v| v.as_table())
-        {
-            let region = ft_table
-                .get("region")
-                .and_then(|v| v.as_str())
-                .unwrap_or("files")
-                .to_string();
-            let track_reads = ft_table
-                .get("track_reads")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            let track_writes = ft_table
-                .get("track_writes")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            let max_file_tokens = ft_table
-                .get("max_file_tokens")
-                .and_then(|v| v.as_integer())
-                .map(|v| v as usize);
+    {
+        let region = ft_table
+            .get("region")
+            .and_then(|v| v.as_str())
+            .unwrap_or("files")
+            .to_string();
+        let track_reads = ft_table
+            .get("track_reads")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let track_writes = ft_table
+            .get("track_writes")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        let max_file_tokens = ft_table
+            .get("max_file_tokens")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize);
 
-            blueprint.file_tracking = Some(crate::FileTrackingConfig {
-                region,
-                track_reads,
-                track_writes,
-                max_file_tokens,
-            });
-        }
+        blueprint.file_tracking = Some(crate::FileTrackingConfig {
+            region,
+            track_reads,
+            track_writes,
+            max_file_tokens,
+        });
     }
 
     Ok(blueprint)
@@ -1673,10 +1672,12 @@ mode = "autonomous"
 "#;
         let result = parse_manifest(toml);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Missing [agent] section"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing [agent] section")
+        );
     }
 
     #[test]
@@ -1848,10 +1849,12 @@ mode = "autonomous"
         let transitions = plan.transitions.as_ref().unwrap();
 
         // plan stage should route errors to error_recovery, like implement/review do.
-        assert!(transitions
-            .get("error_recovery")
-            .map(|e| e.condition == crate::blueprint::TransitionCondition::Error)
-            .unwrap_or(false));
+        assert!(
+            transitions
+                .get("error_recovery")
+                .map(|e| e.condition == crate::blueprint::TransitionCondition::Error)
+                .unwrap_or(false)
+        );
 
         // allow_complete lets the model respond DONE (e.g. when the user
         // chose "Abort") instead of being forced into 'implement' or 'plan'.
@@ -1910,10 +1913,12 @@ mode = "autonomous"
             .as_ref()
             .expect("review stage must declare transitions");
         // review stage should route errors to error_recovery, like implement does.
-        assert!(transitions
-            .get("error_recovery")
-            .map(|e| e.condition == crate::blueprint::TransitionCondition::Error)
-            .unwrap_or(false));
+        assert!(
+            transitions
+                .get("error_recovery")
+                .map(|e| e.condition == crate::blueprint::TransitionCondition::Error)
+                .unwrap_or(false)
+        );
     }
 
     #[test]
@@ -1935,17 +1940,22 @@ mode = "autonomous"
 
         let plan = bp.find_stage("plan").unwrap();
         assert!(plan.available_tools.contains(&"ask_user_text".to_string()));
-        assert!(plan
-            .available_tools
-            .contains(&"ask_user_choice".to_string()));
+        assert!(
+            plan.available_tools
+                .contains(&"ask_user_choice".to_string())
+        );
 
         let implement = bp.find_stage("implement").unwrap();
-        assert!(implement
-            .available_tools
-            .contains(&"ask_user_text".to_string()));
-        assert!(implement
-            .available_tools
-            .contains(&"ask_user_confirm".to_string()));
+        assert!(
+            implement
+                .available_tools
+                .contains(&"ask_user_text".to_string())
+        );
+        assert!(
+            implement
+                .available_tools
+                .contains(&"ask_user_confirm".to_string())
+        );
     }
 
     // ─── Production-code branch coverage: optional field None-paths ──────────

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -1736,7 +1736,7 @@ mod tests {
         // include the extra tokens from the 2 ToolResult entries.
         assert_eq!(removed.content, "assistant");
         assert_eq!(removed.tokens, 100 + 30 + 20); // 150
-                                                   // Only the user message remains
+        // Only the user message remains
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.content[0].content, "user msg");
         assert_eq!(region.current_tokens, 10);

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -36,11 +36,7 @@ impl TaintLevel {
 
     /// Returns the maximum of two taint levels.
     pub fn max(self, other: TaintLevel) -> TaintLevel {
-        if self >= other {
-            self
-        } else {
-            other
-        }
+        if self >= other { self } else { other }
     }
 
     /// Parse a taint level from a string (case-insensitive).

--- a/crates/leviath-mcp/Cargo.toml
+++ b/crates/leviath-mcp/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -1175,12 +1175,12 @@ for line in sys.stdin:
         let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
         client.child.kill().await.expect("kill should succeed");
         let _ = client.child.wait().await; // reap so the pipe's read end is fully gone
-                                           // Empirically, a *tiny* buffered write's subsequent flush() doesn't
-                                           // reliably surface EPIPE immediately after reaping on this platform
-                                           // (unlike a >8KB write, which bypasses BufWriter's buffer and hits
-                                           // the OS directly in write_all() itself -- see the write_all tests
-                                           // below, which are deterministic). A short delay lets the kernel
-                                           // fully settle the closed pipe state before flush() is attempted.
+        // Empirically, a *tiny* buffered write's subsequent flush() doesn't
+        // reliably surface EPIPE immediately after reaping on this platform
+        // (unlike a >8KB write, which bypasses BufWriter's buffer and hits
+        // the OS directly in write_all() itself -- see the write_all tests
+        // below, which are deterministic). A short delay lets the kernel
+        // fully settle the closed pipe state before flush() is attempted.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         client
     }

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -546,9 +546,11 @@ for line in sys.stdin:
             .execute_on("server1", "echo", serde_json::json!({}))
             .await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("tool execution failed"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("tool execution failed")
+        );
     }
 }

--- a/crates/leviath-package/Cargo.toml
+++ b/crates/leviath-package/Cargo.toml
@@ -22,3 +22,6 @@ dirs = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -3,8 +3,8 @@
 //! Creates `.leviath-bundle` files which are tar.gz archives containing
 //! the agent manifest, definition, scripts, and documentation.
 
-use flate2::write::GzEncoder;
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -435,10 +435,12 @@ mod tests {
         let bundler = AgentBundler::new();
         let result = bundler.bundle_to_file(&project, &output);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to write bundle"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to write bundle")
+        );
     }
 
     // The tar-append error arm ("Failed to add ...") is exercised OS-agnostically
@@ -664,10 +666,12 @@ mod tests {
         });
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to read directory"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to read directory")
+        );
     }
 
     // ─── add_directory_to_tar: strip_prefix failure (direct unit test) ──
@@ -694,10 +698,12 @@ mod tests {
             bundler.add_directory_to_tar(&mut tar, project, unrelated.path(), &|p| fs::read_dir(p));
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to compute relative path"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to compute relative path")
+        );
     }
 
     // ─── write_bundle: tar/gzip finalize failure paths ──────────────────
@@ -732,10 +738,12 @@ mod tests {
         let result = bundler.write_bundle(dir.path(), &mut sink, &|p| fs::read_dir(p));
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to finalize tar archive"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to finalize tar archive")
+        );
     }
 
     /// A `Write` sink that succeeds exactly once (letting the gzip header
@@ -769,10 +777,12 @@ mod tests {
         let result = bundler.write_bundle(dir.path(), &mut sink, &|p| fs::read_dir(p));
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to finalize gzip"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to finalize gzip")
+        );
     }
 
     // Neither `tar::Builder::into_inner` nor `GzEncoder::finish` ever calls

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -248,8 +248,8 @@ impl Default for AgentInstaller {
 mod tests {
     use super::*;
     use crate::test_support::with_tracing;
-    use flate2::write::GzEncoder;
     use flate2::Compression;
+    use flate2::write::GzEncoder;
 
     /// Create a minimal tar.gz bundle with an agent.leviath manifest.
     fn make_bundle(name: &str, version: &str, description: &str) -> Vec<u8> {
@@ -499,9 +499,10 @@ description = "{}"
         let err = installer
             .install_from_bytes("blocked", &bundle)
             .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to create install directory"));
+        assert!(
+            err.to_string()
+                .contains("Failed to create install directory")
+        );
     }
 
     #[test]
@@ -541,9 +542,11 @@ description = "{}"
         let result = installer.uninstall("not-a-dir");
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to remove agent"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to remove agent")
+        );
     }
 }

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -28,3 +28,6 @@ bytes = "1"
 [dev-dependencies]
 # test-util enables tokio::time::pause so retry/backoff tests run instantly
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -2155,10 +2155,12 @@ mod tests {
         };
         let result = provider.infer(request).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .starts_with("Request failed:"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Request failed:")
+        );
     }
 
     #[tokio::test]
@@ -2199,10 +2201,12 @@ mod tests {
         };
         let result = provider.list_models().await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .starts_with("Request failed:"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Request failed:")
+        );
     }
 
     // ─── parse_sse_event: message_delta without usage ─────────────────────

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -627,10 +627,12 @@ mod tests {
     fn test_parse_malformed_json() {
         let result = parse_claude_response("not valid json at all");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .starts_with("Invalid response:"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Invalid response:")
+        );
     }
 
     #[test]
@@ -1293,9 +1295,10 @@ mod tests {
             .await
             .expect("stream should yield an item")
             .expect_err("expected a read error from invalid UTF-8");
-        assert!(err
-            .to_string()
-            .contains("Failed to read Claude Code output"));
+        assert!(
+            err.to_string()
+                .contains("Failed to read Claude Code output")
+        );
         let _ = std::fs::remove_file(&script);
     }
 }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -1,7 +1,7 @@
 //! Google Gemini provider implementation (via OpenAI-compatible endpoint).
 
 use crate::openai_compat::{
-    build_openai_request_body, parse_openai_response, send_chat_request, OpenAiSseStream,
+    OpenAiSseStream, build_openai_request_body, parse_openai_response, send_chat_request,
 };
 #[cfg(test)]
 use crate::provider::FinishReason;
@@ -434,9 +434,11 @@ mod tests {
             request_timeout_secs: None,
         };
         let provider = GeminiProvider::with_config(config);
-        assert!(provider
-            .base_url
-            .contains("generativelanguage.googleapis.com"));
+        assert!(
+            provider
+                .base_url
+                .contains("generativelanguage.googleapis.com")
+        );
     }
 
     #[test]
@@ -703,11 +705,13 @@ mod tests {
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
         let result = provider.infer_stream(simple_request()).await;
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Request failed:"));
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Request failed:")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -33,9 +33,9 @@ pub use ollama::OllamaProvider;
 pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use provider::{
-    build_http_client, check_http_response, parse_openai_finish_reason, ContentBlock, FinishReason,
-    InferenceRequest, InferenceResponse, Message, MessageContent, ModelCapabilities, ModelInfo,
-    Provider, ProviderConfig, ProviderError, RateLimitConfig, Result, StreamChunk, SystemBlock,
-    TokenUsage, Tool, ToolCall, ToolCallDelta,
+    ContentBlock, FinishReason, InferenceRequest, InferenceResponse, Message, MessageContent,
+    ModelCapabilities, ModelInfo, Provider, ProviderConfig, ProviderError, RateLimitConfig, Result,
+    StreamChunk, SystemBlock, TokenUsage, Tool, ToolCall, ToolCallDelta, build_http_client,
+    check_http_response, parse_openai_finish_reason,
 };
 pub use rate_limit::RateLimiter;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -1296,11 +1296,13 @@ mod tests {
             extra: serde_json::Value::Null,
         };
         let result = provider.infer_stream(request).await;
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Request failed:"));
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Request failed:")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -1,7 +1,7 @@
 //! OpenAI provider implementation.
 
 use crate::openai_compat::{
-    build_openai_request_body, parse_openai_response, send_chat_request, OpenAiSseStream,
+    OpenAiSseStream, build_openai_request_body, parse_openai_response, send_chat_request,
 };
 #[cfg(test)]
 use crate::provider::FinishReason;
@@ -785,11 +785,13 @@ mod tests {
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
         let result = provider.infer_stream(simple_request()).await;
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Request failed:"));
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Request failed:")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -4,9 +4,9 @@
 //! OpenAI Chat Completions format.
 
 use crate::provider::{
-    check_http_response, parse_openai_finish_reason, ContentBlock, InferenceRequest,
-    InferenceResponse, MessageContent, ProviderError, Result, StreamChunk, TokenUsage, ToolCall,
-    ToolCallDelta,
+    ContentBlock, InferenceRequest, InferenceResponse, MessageContent, ProviderError, Result,
+    StreamChunk, TokenUsage, ToolCall, ToolCallDelta, check_http_response,
+    parse_openai_finish_reason,
 };
 use crate::rate_limit::RateLimiter;
 use futures_core::Stream;

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -3,7 +3,7 @@
 //! OpenRouter provides access to multiple models through a unified API.
 //! Uses OpenAI-compatible format with additional headers.
 
-use crate::openai_compat::{parse_openai_response, send_chat_request, OpenAiSseStream};
+use crate::openai_compat::{OpenAiSseStream, parse_openai_response, send_chat_request};
 use crate::provider::{
     InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider, ProviderConfig,
     ProviderError, Result, StreamChunk,
@@ -904,11 +904,13 @@ mod tests {
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
         let result = provider.infer_stream(simple_request()).await;
-        assert!(result
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Request failed:"));
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Request failed:")
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -21,3 +21,6 @@ async-trait = "0.1"
 
 [dev-dependencies]
 async-trait = "0.1"
+
+[lints]
+workspace = true

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -3,8 +3,8 @@
 use bevy_ecs::prelude::*;
 use leviath_core::Region;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Agent execution state component.
 ///
@@ -285,25 +285,24 @@ impl ContextWindow {
             let mut evicted_any = false;
 
             for region in &mut self.regions {
-                if matches!(region.kind, RegionKind::Temporary) {
-                    if let Some(entry) = region.remove_oldest() {
-                        let freed = entry.tokens;
-                        self.current_tokens -= freed;
-                        evicted_any = true;
+                if matches!(region.kind, RegionKind::Temporary)
+                    && let Some(entry) = region.remove_oldest()
+                {
+                    let freed = entry.tokens;
+                    self.current_tokens -= freed;
+                    evicted_any = true;
 
-                        tracing::debug!(
-                            region = %region.name,
-                            tokens_freed = freed,
-                            "Evicted temporary region entry (oldest first)"
-                        );
+                    tracing::debug!(
+                        region = %region.name,
+                        tokens_freed = freed,
+                        "Evicted temporary region entry (oldest first)"
+                    );
 
-                        if self.max_tokens.saturating_sub(self.current_tokens) >= target_free_tokens
-                        {
-                            return Ok(EvictionResult {
-                                tokens_freed: initial_tokens - self.current_tokens,
-                                needs_compaction: Vec::new(),
-                            });
-                        }
+                    if self.max_tokens.saturating_sub(self.current_tokens) >= target_free_tokens {
+                        return Ok(EvictionResult {
+                            tokens_freed: initial_tokens - self.current_tokens,
+                            needs_compaction: Vec::new(),
+                        });
                     }
                 }
             }
@@ -1630,12 +1629,16 @@ mod tests {
 
         let summary = window.taint_summary();
         assert_eq!(summary.len(), 2);
-        assert!(summary
-            .iter()
-            .any(|(name, level)| name == "conv" && *level == leviath_core::TaintLevel::Private));
-        assert!(summary
-            .iter()
-            .any(|(name, level)| name == "tools" && *level == leviath_core::TaintLevel::Public));
+        assert!(
+            summary
+                .iter()
+                .any(|(name, level)| name == "conv" && *level == leviath_core::TaintLevel::Private)
+        );
+        assert!(
+            summary
+                .iter()
+                .any(|(name, level)| name == "tools" && *level == leviath_core::TaintLevel::Public)
+        );
     }
 
     #[test]
@@ -1730,10 +1733,12 @@ mod tests {
             }
         }
         // The assistant text should still be present
-        assert!(assembled
-            .messages
-            .iter()
-            .any(|m| m.role == "assistant" && m.content.as_text().contains("read that file")));
+        assert!(
+            assembled
+                .messages
+                .iter()
+                .any(|m| m.role == "assistant" && m.content.as_text().contains("read that file"))
+        );
     }
 
     #[test]
@@ -1976,10 +1981,12 @@ mod tests {
             }
         }
         // The assistant text should still be present
-        assert!(assembled
-            .messages
-            .iter()
-            .any(|m| m.role == "assistant" && m.content.as_text().contains("do both")));
+        assert!(
+            assembled
+                .messages
+                .iter()
+                .any(|m| m.role == "assistant" && m.content.as_text().contains("do both"))
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -100,8 +100,8 @@ mod tests {
     use crate::{AgentEngine, AgentPool, ContextWindow, ProviderRegistry};
     use bevy_ecs::prelude::Entity;
     use leviath_core::{
-        blueprint::ModelConfig, layout::RegionDefinition, Blueprint, ContextLayout,
-        EvictionStrategy, RegionKind, Stage,
+        Blueprint, ContextLayout, EvictionStrategy, RegionKind, Stage, blueprint::ModelConfig,
+        layout::RegionDefinition,
     };
 
     fn blueprint_with(regions: Vec<RegionDefinition>) -> Blueprint {
@@ -141,12 +141,14 @@ mod tests {
 
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         // Task seeded into the explicitly-named "task" pinned region.
-        assert!(window
-            .get_region("task")
-            .unwrap()
-            .content
-            .iter()
-            .any(|e| e.content.contains("do the thing")));
+        assert!(
+            window
+                .get_region("task")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("do the thing"))
+        );
         // Blueprint-declared tool_results / conversation are not duplicated.
         assert_eq!(
             window
@@ -182,12 +184,14 @@ mod tests {
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         assert!(window.get_region("tool_results").is_some());
         assert!(window.get_region("conversation").is_some());
-        assert!(window
-            .get_region("system")
-            .unwrap()
-            .content
-            .iter()
-            .any(|e| e.content.contains("seed task")));
+        assert!(
+            window
+                .get_region("system")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("seed task"))
+        );
     }
 
     #[test]
@@ -227,12 +231,14 @@ mod tests {
         // The non-pinned "task" region is left empty...
         assert!(window.get_region("task").unwrap().content.is_empty());
         // ...and the seed lands in the first pinned region instead.
-        assert!(window
-            .get_region("system")
-            .unwrap()
-            .content
-            .iter()
-            .any(|e| e.content.contains("fallback seed")));
+        assert!(
+            window
+                .get_region("system")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("fallback seed"))
+        );
     }
 
     #[test]
@@ -259,12 +265,14 @@ mod tests {
 
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         assert_eq!(window.regions.len(), 2);
-        assert!(window
-            .get_region("system")
-            .unwrap()
-            .content
-            .iter()
-            .any(|e| e.content.contains("carried content")));
+        assert!(
+            window
+                .get_region("system")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("carried content"))
+        );
         assert!(window.get_region("scratch").unwrap().content.is_empty());
         // Token total recomputed from the surviving content.
         assert_eq!(window.current_tokens, window.calculate_tokens());

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -12,8 +12,8 @@
 
 use async_trait::async_trait;
 
-use leviath_core::interaction::{response_approved, response_as_choice, response_as_text};
 use leviath_core::interaction::{ApprovalScope, InteractionRequest, InteractionResponse};
+use leviath_core::interaction::{response_approved, response_as_choice, response_as_text};
 
 // ─── Shared taint-gate prompt helpers ──────────────────────────────────────
 // Used by both the worker (IPC) and foreground (stdin) GatePrompt impls so the

--- a/crates/leviath-runtime/src/engine.rs
+++ b/crates/leviath-runtime/src/engine.rs
@@ -853,14 +853,14 @@ impl AgentEngine {
     /// Extracted so both the sequential loop and the concurrent shared driver
     /// run identical logic under their respective borrows/guards.
     fn loop_check_cancelled(&mut self, entity: Entity, iteration: usize) -> bool {
-        if let Some(token) = self.world.get::<CancellationToken>(entity) {
-            if token.is_cancelled() {
-                tracing::info!(iteration, "Inference loop cancelled");
-                if let Some(mut state) = self.world.get_mut::<AgentState>(entity) {
-                    state.status = AgentStatus::Cancelled;
-                }
-                return true;
+        if let Some(token) = self.world.get::<CancellationToken>(entity)
+            && token.is_cancelled()
+        {
+            tracing::info!(iteration, "Inference loop cancelled");
+            if let Some(mut state) = self.world.get_mut::<AgentState>(entity) {
+                state.status = AgentStatus::Cancelled;
             }
+            return true;
         }
         false
     }
@@ -1013,13 +1013,13 @@ impl AgentEngine {
                 .unwrap_or_default();
 
             // Apply max_result_tokens truncation from routing config
-            if let Some(routing) = tool_result_routing.as_ref() {
-                if let Some(max_tokens) = routing.max_result_tokens {
-                    let max_chars = max_tokens * 4;
-                    if result_text.len() > max_chars {
-                        result_text = truncate_on_char_boundary(&result_text, max_chars);
-                        result_text.push_str("\n[...truncated]");
-                    }
+            if let Some(routing) = tool_result_routing.as_ref()
+                && let Some(max_tokens) = routing.max_result_tokens
+            {
+                let max_chars = max_tokens * 4;
+                if result_text.len() > max_chars {
+                    result_text = truncate_on_char_boundary(&result_text, max_chars);
+                    result_text.push_str("\n[...truncated]");
                 }
             }
 
@@ -2878,12 +2878,14 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().content, "mock response");
         // The handle is still usable after the loop (guard was released).
-        assert!(handle
-            .read()
-            .await
-            .world()
-            .get::<AgentState>(entity)
-            .is_some());
+        assert!(
+            handle
+                .read()
+                .await
+                .world()
+                .get::<AgentState>(entity)
+                .is_some()
+        );
     }
 
     /// A provider whose `infer` always fails — used to drive the loop's network
@@ -4201,10 +4203,11 @@ mod tests {
         // Tool results now go to "conversation" as typed entries
         let w = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = w.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. })));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. }))
+        );
     }
 
     #[tokio::test]
@@ -4296,10 +4299,11 @@ mod tests {
         // Tool results now go to "conversation" as typed entries
         let w = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = w.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. })));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. }))
+        );
     }
 
     #[tokio::test]
@@ -4396,10 +4400,11 @@ mod tests {
         // Tool results now go to "conversation" as typed entries
         let w = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = w.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. })));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { .. }))
+        );
     }
 
     #[test]
@@ -5463,10 +5468,12 @@ mod tests {
         assert!(!tool_results_text(&engine, entity).contains("[blocked]"));
         // The allow was audited.
         let allow_once = leviath_core::taint::GateDecisionSource::UserAllowOnce;
-        assert!(engine
-            .taint_audit_log(entity)
-            .iter()
-            .any(|e| e.allowed && e.decision_source == allow_once));
+        assert!(
+            engine
+                .taint_audit_log(entity)
+                .iter()
+                .any(|e| e.allowed && e.decision_source == allow_once)
+        );
     }
 
     #[tokio::test]
@@ -5477,10 +5484,12 @@ mod tests {
         assert!(executed.lock().unwrap().contains(&"shell".to_string()));
         // Audited as an always-allow decision.
         let always_allow = leviath_core::taint::GateDecisionSource::UserAlwaysAllow;
-        assert!(engine
-            .taint_audit_log(entity)
-            .iter()
-            .any(|e| e.allowed && e.decision_source == always_allow));
+        assert!(
+            engine
+                .taint_audit_log(entity)
+                .iter()
+                .any(|e| e.allowed && e.decision_source == always_allow)
+        );
         // The tool's clearance was raised to Private for the rest of the run.
         let cls = engine
             .taint_gates
@@ -5565,10 +5574,12 @@ mod tests {
         assert!(executed.lock().unwrap().contains(&"shell".to_string()));
         let allowlist_rule =
             leviath_core::taint::GateDecisionSource::AllowlistRule { rule_index: 0 };
-        assert!(engine
-            .taint_audit_log(entity)
-            .iter()
-            .any(|e| e.allowed && e.decision_source == allowlist_rule));
+        assert!(
+            engine
+                .taint_audit_log(entity)
+                .iter()
+                .any(|e| e.allowed && e.decision_source == allowlist_rule)
+        );
     }
 
     #[test]
@@ -5598,12 +5609,14 @@ mod tests {
             })
             .id();
         // No taint tracking yet → overall_taint is None.
-        assert!(engine
-            .world()
-            .get::<ContextWindow>(entity)
-            .unwrap()
-            .overall_taint()
-            .is_none());
+        assert!(
+            engine
+                .world()
+                .get::<ContextWindow>(entity)
+                .unwrap()
+                .overall_taint()
+                .is_none()
+        );
         engine.enable_entity_taint_tracking(entity);
         // Now tracking is on → overall_taint reports (Public with no tainted data).
         assert_eq!(

--- a/crates/leviath-runtime/src/graph.rs
+++ b/crates/leviath-runtime/src/graph.rs
@@ -75,33 +75,31 @@ pub async fn resolve_transition(
             }
 
             // Step 1: Error condition — auto-transition if error occurred
-            if *stage_result == StageResult::Error {
-                if let Some((_name, edge)) = available
+            if *stage_result == StageResult::Error
+                && let Some((_name, edge)) = available
                     .iter()
                     .find(|(_, e)| e.condition == TransitionCondition::Error)
-                {
-                    let target_idx = blueprint
-                        .stages
-                        .iter()
-                        .position(|s| s.name == edge.target)
-                        .unwrap_or(0);
-                    return Some(((*edge).clone(), target_idx));
-                }
+            {
+                let target_idx = blueprint
+                    .stages
+                    .iter()
+                    .position(|s| s.name == edge.target)
+                    .unwrap_or(0);
+                return Some(((*edge).clone(), target_idx));
             }
 
             // Step 2: MaxIterations condition — auto-transition
-            if *stage_result == StageResult::MaxIterations {
-                if let Some((_name, edge)) = available
+            if *stage_result == StageResult::MaxIterations
+                && let Some((_name, edge)) = available
                     .iter()
                     .find(|(_, e)| e.condition == TransitionCondition::MaxIterations)
-                {
-                    let target_idx = blueprint
-                        .stages
-                        .iter()
-                        .position(|s| s.name == edge.target)
-                        .unwrap_or(0);
-                    return Some(((*edge).clone(), target_idx));
-                }
+            {
+                let target_idx = blueprint
+                    .stages
+                    .iter()
+                    .position(|s| s.name == edge.target)
+                    .unwrap_or(0);
+                return Some(((*edge).clone(), target_idx));
             }
 
             // Step 3: Filter to only always/llm_choice edges for LLM prompt
@@ -1985,14 +1983,17 @@ mod tests {
 
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("concise summary of the conversation")));
-        assert!(!conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("raw conversation content")));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("concise summary of the conversation"))
+        );
+        assert!(
+            !conv
+                .content
+                .iter()
+                .any(|e| e.content.contains("raw conversation content"))
+        );
     }
 
     // ─── apply_compact_transform: provider infer() errors ────────────────────
@@ -2024,10 +2025,11 @@ mod tests {
 
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("raw conversation content")));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("raw conversation content"))
+        );
     }
 
     // ─── apply_edge_transform: Custom with non-empty compact + no explicit prompt ─
@@ -2704,10 +2706,11 @@ mod tests {
 
         let window = engine.world().get::<ContextWindow>(entity).unwrap();
         let conv = window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content == "preserved content"));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content == "preserved content")
+        );
     }
 
     // ─── resolve_transition: multiple LlmChoice edges, provider returns no match

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -31,11 +31,11 @@ pub use components::{
     TaskAssignment, ToolResultRoutingComponent,
 };
 pub use engine::{
-    run_inference_loop_shared, AgentEngine, EngineHandle, ProviderRegistry, ToolExecutorDyn,
-    ToolResultsFuture,
+    AgentEngine, EngineHandle, ProviderRegistry, ToolExecutorDyn, ToolResultsFuture,
+    run_inference_loop_shared,
 };
 pub use pool::AgentPool;
-pub use provider_creds::{build_provider_registry, ProviderCreds};
+pub use provider_creds::{ProviderCreds, build_provider_registry};
 pub use run_io::RunIO;
 pub use scheduler::TaskScheduler;
 pub use spawn::spawn_child_agent;

--- a/crates/leviath-runtime/src/pool.rs
+++ b/crates/leviath-runtime/src/pool.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::test_support::with_tracing;
     use leviath_core::blueprint::ModelConfig;
     use leviath_core::{
-        layout::RegionDefinition, region::RegionKind, Blueprint, ContextLayout, Stage,
+        Blueprint, ContextLayout, Stage, layout::RegionDefinition, region::RegionKind,
     };
 
     fn create_test_blueprint() -> Blueprint {

--- a/crates/leviath-runtime/src/repetition.rs
+++ b/crates/leviath-runtime/src/repetition.rs
@@ -159,12 +159,16 @@ mod tests {
         };
         let mut detector = RepetitionDetector::new(config);
 
-        assert!(detector
-            .record_call("read_file", r#"{"path":"src/main.rs"}"#)
-            .is_none());
-        assert!(detector
-            .record_call("read_file", r#"{"path":"src/main.rs"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"src/main.rs"}"#)
+                .is_none()
+        );
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"src/main.rs"}"#)
+                .is_none()
+        );
 
         let nudge = detector.record_call("read_file", r#"{"path":"src/main.rs"}"#);
         assert!(nudge.is_some());
@@ -182,17 +186,23 @@ mod tests {
         detector.record_call("read_file", r#"{"path":"foo.py"}"#);
 
         // Productive call resets
-        assert!(detector
-            .record_call("write_file", r#"{"path":"foo.py","content":"x"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("write_file", r#"{"path":"foo.py","content":"x"}"#)
+                .is_none()
+        );
 
         // Read again — counter should be back to 1
-        assert!(detector
-            .record_call("read_file", r#"{"path":"foo.py"}"#)
-            .is_none());
-        assert!(detector
-            .record_call("read_file", r#"{"path":"foo.py"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"foo.py"}"#)
+                .is_none()
+        );
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"foo.py"}"#)
+                .is_none()
+        );
 
         // Third read triggers nudge again
         let nudge = detector.record_call("read_file", r#"{"path":"foo.py"}"#);
@@ -210,9 +220,11 @@ mod tests {
 
         // 5 different read-only calls
         for i in 0..4 {
-            assert!(detector
-                .record_call("read_file", &format!(r#"{{"path":"file{i}.rs"}}"#))
-                .is_none());
+            assert!(
+                detector
+                    .record_call("read_file", &format!(r#"{{"path":"file{i}.rs"}}"#))
+                    .is_none()
+            );
         }
         let nudge = detector.record_call("list_dir", r#"{"path":"src/"}"#);
         assert!(nudge.is_some());
@@ -223,15 +235,21 @@ mod tests {
     fn test_different_arguments_dont_trigger_repeat() {
         let mut detector = RepetitionDetector::with_defaults();
 
-        assert!(detector
-            .record_call("read_file", r#"{"path":"a.rs"}"#)
-            .is_none());
-        assert!(detector
-            .record_call("read_file", r#"{"path":"b.rs"}"#)
-            .is_none());
-        assert!(detector
-            .record_call("read_file", r#"{"path":"c.rs"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"a.rs"}"#)
+                .is_none()
+        );
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"b.rs"}"#)
+                .is_none()
+        );
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"c.rs"}"#)
+                .is_none()
+        );
         // No nudge — all different args
     }
 
@@ -244,9 +262,11 @@ mod tests {
         };
         let mut detector = RepetitionDetector::new(config);
 
-        assert!(detector
-            .record_call("read_file", r#"{"path":"x.rs"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"x.rs"}"#)
+                .is_none()
+        );
         let nudge = detector.record_call("read_file", r#"{"path":"x.rs"}"#);
         assert!(nudge.is_some());
     }
@@ -260,12 +280,16 @@ mod tests {
         };
         let mut detector = RepetitionDetector::new(config);
 
-        assert!(detector
-            .record_call("read_file", r#"{"path":"x.rs"}"#)
-            .is_none());
-        assert!(detector
-            .record_call("read_file", r#"{"path":"x.rs"}"#)
-            .is_none());
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"x.rs"}"#)
+                .is_none()
+        );
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"x.rs"}"#)
+                .is_none()
+        );
     }
 
     #[test]
@@ -285,9 +309,11 @@ mod tests {
         detector.record_call("read_file", r#"{"path":"c.rs"}"#);
         detector.record_call("read_file", r#"{"path":"d.rs"}"#);
         // Only 2 in streak after reset, so no nudge
-        assert!(detector
-            .record_call("list_dir", r#"{"path":"src/"}"#)
-            .is_some()); // 3 = threshold
+        assert!(
+            detector
+                .record_call("list_dir", r#"{"path":"src/"}"#)
+                .is_some()
+        ); // 3 = threshold
     }
 
     #[test]
@@ -304,8 +330,10 @@ mod tests {
         // Unknown tool: not readonly, not productive — doesn't increment or reset streak
         detector.record_call("some_other_tool", r#"{}"#);
         // Streak is still 2
-        assert!(detector
-            .record_call("read_file", r#"{"path":"c.rs"}"#)
-            .is_some()); // 3 = threshold
+        assert!(
+            detector
+                .record_call("read_file", r#"{"path":"c.rs"}"#)
+                .is_some()
+        ); // 3 = threshold
     }
 }

--- a/crates/leviath-runtime/src/run_io.rs
+++ b/crates/leviath-runtime/src/run_io.rs
@@ -6,9 +6,9 @@
 //! `leviath-cli`.
 
 use async_trait::async_trait;
+use leviath_core::Stage;
 use leviath_core::blueprint::StageResult;
 use leviath_core::run_meta::RegionSnapshot;
-use leviath_core::Stage;
 
 /// Abstraction over I/O for the stage executor.
 #[async_trait]

--- a/crates/leviath-runtime/src/spawn.rs
+++ b/crates/leviath-runtime/src/spawn.rs
@@ -131,8 +131,8 @@ mod tests {
         ProviderRegistry, SubAgentChildren,
     };
     use leviath_core::{
-        blueprint::ModelConfig, layout::RegionDefinition, Blueprint, ContextLayout, RegionKind,
-        Stage,
+        Blueprint, ContextLayout, RegionKind, Stage, blueprint::ModelConfig,
+        layout::RegionDefinition,
     };
     use std::sync::Arc;
     use tokio::sync::RwLock;
@@ -200,20 +200,22 @@ mod tests {
         let children = eng.world().get::<SubAgentChildren>(root_entity).unwrap();
         assert!(children.children.contains(&child_entity));
         assert_eq!(children.max_child_depth, 3);
-        assert!(eng
-            .world()
-            .get::<AgentState>(root_entity)
-            .unwrap()
-            .spawned_children_ids
-            .contains(&child_id));
+        assert!(
+            eng.world()
+                .get::<AgentState>(root_entity)
+                .unwrap()
+                .spawned_children_ids
+                .contains(&child_id)
+        );
 
         // Seed landed in the pinned region.
         let window = eng.world().get::<ContextWindow>(child_entity).unwrap();
         let sys = window.get_region("system").unwrap();
-        assert!(sys
-            .content
-            .iter()
-            .any(|e| e.content.contains("work item context")));
+        assert!(
+            sys.content
+                .iter()
+                .any(|e| e.content.contains("work item context"))
+        );
         // Default conversation region was auto-added.
         assert!(window.get_region("conversation").is_some());
     }

--- a/crates/leviath-runtime/src/systems.rs
+++ b/crates/leviath-runtime/src/systems.rs
@@ -296,12 +296,12 @@ pub fn cascade_kill_system(
     // Pass 2: cancel each child
     let mut cancel_query = queries.p1();
     for child_entity in to_cancel {
-        if let Ok((mut state, token)) = cancel_query.get_mut(child_entity) {
-            if !matches!(state.status, AgentStatus::Cancelled) {
-                token.cancel();
-                state.status = AgentStatus::Cancelled;
-                tracing::info!(agent_id = %state.agent_id, "Cascade-cancelled child agent");
-            }
+        if let Ok((mut state, token)) = cancel_query.get_mut(child_entity)
+            && !matches!(state.status, AgentStatus::Cancelled)
+        {
+            token.cancel();
+            state.status = AgentStatus::Cancelled;
+            tracing::info!(agent_id = %state.agent_id, "Cascade-cancelled child agent");
         }
     }
 }
@@ -337,8 +337,8 @@ pub fn stage_gating_system(mut query: Query<&mut AgentState>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::with_tracing;
     use crate::AgentMessage;
+    use crate::test_support::with_tracing;
     use leviath_core::{EvictionStrategy, Region, RegionKind};
 
     #[test]
@@ -983,10 +983,11 @@ mod tests {
 
         let parent_window = world.get::<ContextWindow>(parent_entity).unwrap();
         let conv = parent_window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("error") && e.content.contains("something went wrong")));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("error") && e.content.contains("something went wrong"))
+        );
     }
 
     #[test]
@@ -1085,10 +1086,11 @@ mod tests {
 
         let window = world.get::<ContextWindow>(entity).unwrap();
         let conv = window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("Hello from user")));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("Hello from user"))
+        );
     }
 
     #[test]
@@ -1161,10 +1163,11 @@ mod tests {
 
         let window = world.get::<ContextWindow>(entity).unwrap();
         let conv = window.get_region("conversation").unwrap();
-        assert!(conv
-            .content
-            .iter()
-            .any(|e| e.content.contains("Test message")));
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("Test message"))
+        );
     }
 
     // ─── child_completion with despawned parent entity ────────────────────

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -5,8 +5,8 @@
 //! level (determined by input mode) against the tool's clearance level.
 
 use leviath_core::taint::{
-    builtin_tool_classification, GateDecision, GateDecisionSource, GateEvent, InputMode,
-    SecurityConfig, TaintLevel, ToolClassification,
+    GateDecision, GateDecisionSource, GateEvent, InputMode, SecurityConfig, TaintLevel,
+    ToolClassification, builtin_tool_classification,
 };
 use std::collections::HashMap;
 
@@ -336,19 +336,19 @@ impl TaintGate {
         }
 
         // Check scripted rules
-        if let Some(checker) = script_checker {
-            if let Some(script_name) = checker(tool_name, target, taint) {
-                self.log_event(
-                    agent_id,
-                    tool_name,
-                    InputMode::Traditional,
-                    taint,
-                    clearance,
-                    true,
-                    GateDecisionSource::ScriptedRule { script_name },
-                );
-                return GateDecision::Allowed;
-            }
+        if let Some(checker) = script_checker
+            && let Some(script_name) = checker(tool_name, target, taint)
+        {
+            self.log_event(
+                agent_id,
+                tool_name,
+                InputMode::Traditional,
+                taint,
+                clearance,
+                true,
+                GateDecisionSource::ScriptedRule { script_name },
+            );
+            return GateDecision::Allowed;
         }
 
         decision
@@ -1283,16 +1283,22 @@ mod tests {
 
     #[test]
     fn filter_error_display() {
-        assert!(FilterError::RegionNotFound("r".into())
-            .to_string()
-            .contains("region not found"));
-        assert!(FilterError::TaintNotEnabled("r".into())
-            .to_string()
-            .contains("Taint tracking not enabled"));
+        assert!(
+            FilterError::RegionNotFound("r".into())
+                .to_string()
+                .contains("region not found")
+        );
+        assert!(
+            FilterError::TaintNotEnabled("r".into())
+                .to_string()
+                .contains("Taint tracking not enabled")
+        );
         assert!(FilterError::FilterDisabled.to_string().contains("disabled"));
-        assert!(FilterError::FreeformNotEnabled
-            .to_string()
-            .contains("Freeform"));
+        assert!(
+            FilterError::FreeformNotEnabled
+                .to_string()
+                .contains("Freeform")
+        );
     }
 
     // ─── DegradationEngine ──────────────────────────────────────────────────

--- a/crates/leviath-runtime/tests/context_management.rs
+++ b/crates/leviath-runtime/tests/context_management.rs
@@ -125,9 +125,11 @@ fn test_schema_validation_mermaid() {
 
     // Valid mermaid should pass
     assert!(schema.validate("graph TD\n  A --> B").is_ok());
-    assert!(schema
-        .validate("sequenceDiagram\n  Alice->>Bob: Hello")
-        .is_ok());
+    assert!(
+        schema
+            .validate("sequenceDiagram\n  Alice->>Bob: Hello")
+            .is_ok()
+    );
 
     // Invalid mermaid should fail
     assert!(schema.validate("just plain text").is_err());
@@ -206,15 +208,19 @@ fn test_context_window_add_to_region() {
     window.add_region(region);
 
     // Add content to existing region
-    assert!(window
-        .add_to_region("system", "Hello".to_string(), 10)
-        .is_ok());
+    assert!(
+        window
+            .add_to_region("system", "Hello".to_string(), 10)
+            .is_ok()
+    );
     assert_eq!(window.current_tokens, 10);
 
     // Add content to non-existent region should fail
-    assert!(window
-        .add_to_region("nonexistent", "test".to_string(), 5)
-        .is_err());
+    assert!(
+        window
+            .add_to_region("nonexistent", "test".to_string(), 5)
+            .is_err()
+    );
 }
 
 #[test]
@@ -505,9 +511,11 @@ fn test_child_completion_notifies_parent() {
 
     // Simulate what child_completion_system does: inject result into parent
     let parent_state = world.get::<AgentState>(parent).unwrap();
-    assert!(parent_state
-        .spawned_children_ids
-        .contains(&"child-01".to_string()));
+    assert!(
+        parent_state
+            .spawned_children_ids
+            .contains(&"child-01".to_string())
+    );
     assert_eq!(parent_state.pending_wait, Some("child-01".to_string()));
 
     // After processing, parent should have the child removed and pending_wait cleared
@@ -578,23 +586,23 @@ async fn test_file_tracking_sync_assembly_integration() {
     // 3. Simulate file tracking: upsert into shared CW's HashMap region
     {
         let mut guard = shared_cw.lock().await;
-        if let Some(window) = guard.as_mut() {
-            if let Some(region) = window.get_region_mut("files") {
-                region
-                    .upsert_by_key(
-                        "src/main.py",
-                        "def main():\n    print('hello')".to_string(),
-                        10,
-                    )
-                    .unwrap();
-                region
-                    .upsert_by_key(
-                        "src/utils.py",
-                        "def helper():\n    return 42".to_string(),
-                        8,
-                    )
-                    .unwrap();
-            }
+        if let Some(window) = guard.as_mut()
+            && let Some(region) = window.get_region_mut("files")
+        {
+            region
+                .upsert_by_key(
+                    "src/main.py",
+                    "def main():\n    print('hello')".to_string(),
+                    10,
+                )
+                .unwrap();
+            region
+                .upsert_by_key(
+                    "src/utils.py",
+                    "def helper():\n    return 42".to_string(),
+                    8,
+                )
+                .unwrap();
         }
     }
 

--- a/crates/leviath-scripting/Cargo.toml
+++ b/crates/leviath-scripting/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rhai = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/leviath-scripting/src/engine.rs
+++ b/crates/leviath-scripting/src/engine.rs
@@ -150,9 +150,11 @@ mod tests {
         let script = r#"is_mermaid(content)"#;
 
         assert!(engine.validate(script, "graph TD\n  A --> B").unwrap());
-        assert!(engine
-            .validate(script, "sequenceDiagram\n  Alice->>Bob: Hello")
-            .unwrap());
+        assert!(
+            engine
+                .validate(script, "sequenceDiagram\n  Alice->>Bob: Hello")
+                .unwrap()
+        );
         assert!(!engine.validate(script, "just text").unwrap());
     }
 
@@ -237,10 +239,12 @@ mod tests {
         let script = "this is not valid rhai {{{";
         let result = engine.transform(script, input);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .starts_with("Script execution failed:"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Script execution failed:")
+        );
     }
 
     #[test]
@@ -274,10 +278,12 @@ mod tests {
 
         let result = engine.execute("undefined_function_call()", &mut scope);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .starts_with("Script execution failed:"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Script execution failed:")
+        );
     }
 
     #[test]

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -14,3 +14,6 @@ nix = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 tracing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
+nix = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -1,14 +1,16 @@
 //! Platform/OS-specific system calls for Leviath, isolated behind one
 //! cross-platform API.
 //!
-//! Every raw `libc` call, `#[cfg(unix)]`/`#[cfg(windows)]` branch, and
-//! platform permission/signal/TTY primitive used anywhere in the workspace
-//! lives here — nowhere else. Callers use the plain functions re-exported at
-//! the crate root and never write a `#[cfg]` of their own.
+//! Every `#[cfg(unix)]`/`#[cfg(windows)]` branch and platform
+//! permission/signal/TTY primitive used anywhere in the workspace lives here —
+//! nowhere else. The unavoidable OS-level `unsafe` is delegated to audited
+//! crates (`nix`) and safe std APIs, so this crate itself contains no `unsafe`.
+//! Callers use the plain functions re-exported at the crate root and never
+//! write a `#[cfg]` of their own.
 //!
 //! ## Why this crate exists
 //!
-//! 1. **De-duplication.** The `setsid`/`pre_exec` detach, `libc::kill`, and
+//! 1. **De-duplication.** The `process_group` detach, `nix`-based `kill`, and
 //!    `Permissions::from_mode(0o600)` logic each has exactly one implementation
 //!    here, rather than being spread across call sites in `leviath-cli`.
 //! 2. **Per-OS coverage correctness.** Because all platform code is gathered
@@ -17,9 +19,9 @@
 //!    compiled, so the coverage tool never sees them as gaps. The
 //!    Linux-visible code paths are all reachable from real unit tests.
 //! 3. **Testability.** Every function in this crate is exercised by real unit
-//!    tests — the syscalls here are either safe to call under test (`setsid`
-//!    fails harmlessly, `kill` on a nonexistent pid returns `ESRCH`, `chmod` on
-//!    a tempfile) or split behind an injected seam ([`tty::osc52_write_via`]
+//!    tests — the syscalls here are either safe to call under test (`kill` on a
+//!    nonexistent pid returns `ESRCH`, `chmod` on a tempfile) or split behind an
+//!    injected seam ([`tty::osc52_write_via`]
 //!    takes the tty opener + sink; `perms`' hardening op is a `fn` pointer). The
 //!    only genuinely-untestable real-I/O leaves (opening `/dev/tty`, writing the
 //!    real `stdout()`) are composed in the CLI binary, not here — so this crate

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -23,7 +23,7 @@ pub(crate) fn terminate(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
-    use nix::sys::signal::{kill, Signal};
+    use nix::sys::signal::{Signal, kill};
     use nix::unistd::Pid;
     // Best-effort: any error (e.g. `ESRCH` when the process has already exited)
     // is intentionally ignored.

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -5,31 +5,17 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
-/// The `pre_exec` hook installed by [`configure_detached`]: start a new session
-/// so the child is detached from the controlling terminal.
+/// Put the spawned child into its own process group so it is detached from the
+/// launching terminal's foreground group and outlives that terminal closing.
 ///
-/// `setsid()` fails harmlessly if the caller is already a process-group leader;
-/// its return value is intentionally ignored. This is a free function (rather
-/// than an inline closure) precisely so it can be called directly in a unit
-/// test — covering the real `setsid` call in-process — while ALSO being usable
-/// as a `pre_exec` hook in production, where it runs in the forked child.
-pub(crate) fn new_session() -> io::Result<()> {
-    // SAFETY: `setsid()` is async-signal-safe and has no preconditions beyond
-    // the usual POSIX constraints.
-    unsafe {
-        libc::setsid();
-    }
-    Ok(())
-}
-
-/// Install [`new_session`] as `cmd`'s `pre_exec` hook.
+/// This uses the safe, stable [`CommandExt::process_group`] instead of a
+/// `pre_exec` + `setsid()` hook: both call sites redirect the child's stdio to
+/// files/null and spawn fire-and-forget (the child is reparented to init), so a
+/// fresh process group delivers the same "survives the terminal" behaviour with
+/// no `unsafe` FFI. This only configures `cmd`; nothing runs until `spawn()`.
 pub(crate) fn configure_detached(cmd: &mut Command) {
     use std::os::unix::process::CommandExt;
-    // SAFETY: `new_session` only calls the async-signal-safe `setsid()`, which
-    // is valid to run in the pre_exec child between fork and exec.
-    unsafe {
-        cmd.pre_exec(new_session);
-    }
+    cmd.process_group(0);
 }
 
 /// Send `SIGTERM` to `pid`, guarding against the `kill(0, …)` process-group case.
@@ -37,11 +23,11 @@ pub(crate) fn terminate(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
-    // SAFETY: `kill()` with a positive pid and a standard signal number has no
-    // memory-safety preconditions; errors (e.g. ESRCH) are intentionally ignored.
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGTERM);
-    }
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+    // Best-effort: any error (e.g. `ESRCH` when the process has already exited)
+    // is intentionally ignored.
+    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
     true
 }
 
@@ -103,7 +89,9 @@ mod tests {
         set_mode(&path, 0o644).unwrap();
 
         fn always_fails(_: &Path, _: u32) -> io::Result<()> {
-            Err(io::Error::from_raw_os_error(libc::EPERM))
+            Err(io::Error::from_raw_os_error(
+                nix::errno::Errno::EPERM as i32,
+            ))
         }
 
         let result = ensure_private_with(&path, 0o600, always_fails);
@@ -127,16 +115,9 @@ mod tests {
     }
 
     #[test]
-    fn new_session_returns_ok() {
-        // Runs the real setsid() in-process; it may fail harmlessly if we are
-        // already a process-group leader, but always returns Ok.
-        assert!(new_session().is_ok());
-    }
-
-    #[test]
-    fn configure_detached_installs_hook_without_spawning() {
-        // Registering the pre_exec hook must not fork/exec or panic; the hook
-        // only runs on a later spawn(), which this test deliberately omits.
+    fn configure_detached_sets_process_group_without_spawning() {
+        // Configuring the process group must not fork/exec or panic; it only
+        // takes effect on a later spawn(), which this test deliberately omits.
         let mut cmd = Command::new("true");
         configure_detached(&mut cmd);
     }

--- a/crates/leviath-sys/src/tty.rs
+++ b/crates/leviath-sys/src/tty.rs
@@ -65,10 +65,11 @@ pub fn osc52_write_via(
     stdout_fallback: &mut dyn Write,
 ) -> bool {
     let osc = osc52_sequence(text);
-    if let Ok(mut tty) = open_tty() {
-        if tty.write_all(osc.as_bytes()).is_ok() && tty.flush().is_ok() {
-            return true;
-        }
+    if let Ok(mut tty) = open_tty()
+        && tty.write_all(osc.as_bytes()).is_ok()
+        && tty.flush().is_ok()
+    {
+        return true;
     }
     // Fallback: write to stdout. Report the real outcome so callers can show an
     // error when even this fails.

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = { workspace = true }

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -16,3 +16,6 @@ tokio = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 temp-env = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1699,10 +1699,6 @@ mod tests {
 
     // ── detect_shell ──────────────────────────────────────────────────────
 
-    // Serialize tests that read or write $SHELL to prevent races.
-    #[cfg(not(windows))]
-    static SHELL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// Windows' `detect_shell()` branch is a plain, unconditional constant
     /// return (no env/filesystem dependence to inject) -- the
     /// platform-agnostic `detect_shell_returns_valid_shell` test below
@@ -1718,8 +1714,9 @@ mod tests {
 
     #[test]
     fn detect_shell_returns_valid_shell() {
-        #[cfg(not(windows))]
-        let _g = SHELL_ENV_LOCK.lock().unwrap();
+        // Pure reader: `detect_shell()` always returns a non-empty shell (and the
+        // "-c" flag on non-Windows) regardless of $SHELL, so it is robust to a
+        // concurrent temp-env writer and needs no serialization of its own.
         let (shell, flag) = BuiltinTools::detect_shell();
         assert!(!shell.is_empty());
         assert!(!flag.is_empty());
@@ -1729,19 +1726,16 @@ mod tests {
 
     /// Forces `detect_shell()` to exercise the real `shell_exists` closure by
     /// temporarily setting $SHELL to an unrecognized path, causing the candidate
-    /// loop (and the closure) to be reached.
+    /// loop (and the closure) to be reached. `temp_env::with_var` sets the var,
+    /// runs the closure, and restores it -- serialized against every other
+    /// temp-env test process-wide, so no hand-rolled lock is needed.
     #[cfg(not(windows))]
     #[test]
     fn detect_shell_queries_real_filesystem_for_unrecognized_shell() {
-        let _g = SHELL_ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::set_var("SHELL", "/opt/not-a-recognized-shell");
-        }
-        let (shell, flag) = BuiltinTools::detect_shell();
-        // Restore: set SHELL to the found shell (always a valid shell on Unix)
-        unsafe {
-            std::env::set_var("SHELL", shell);
-        }
+        let (shell, flag) =
+            temp_env::with_var("SHELL", Some("/opt/not-a-recognized-shell"), || {
+                BuiltinTools::detect_shell()
+            });
         assert_eq!(flag, "-c");
         assert!([
             "/bin/bash",

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -3,12 +3,12 @@
 //! Provides file system and shell tools sandboxed to a working directory.
 
 use leviath_providers::Tool;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tokio::process::Command;
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 
 /// Context for tool execution — defines the sandbox root.
 pub struct ToolContext {
@@ -736,11 +736,11 @@ impl BuiltinTools {
         env_shell: Option<String>,
         shell_exists: &dyn Fn(&str) -> bool,
     ) -> (&'static str, &'static str) {
-        if let Some(shell) = env_shell {
-            if shell.ends_with("/zsh") || shell.ends_with("/bash") || shell.ends_with("/sh") {
-                let shell: &'static str = Box::leak(shell.into_boxed_str());
-                return (shell, "-c");
-            }
+        if let Some(shell) = env_shell
+            && (shell.ends_with("/zsh") || shell.ends_with("/bash") || shell.ends_with("/sh"))
+        {
+            let shell: &'static str = Box::leak(shell.into_boxed_str());
+            return (shell, "-c");
         }
         for &shell in &[
             "/bin/bash",
@@ -1178,10 +1178,12 @@ mod tests {
         )));
         let result = tools.resolve("../../etc/passwd");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("escapes the working directory"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("escapes the working directory")
+        );
     }
 
     #[tokio::test]
@@ -1737,14 +1739,16 @@ mod tests {
                 BuiltinTools::detect_shell()
             });
         assert_eq!(flag, "-c");
-        assert!([
-            "/bin/bash",
-            "/usr/bin/bash",
-            "/bin/zsh",
-            "/usr/bin/zsh",
-            "/bin/sh"
-        ]
-        .contains(&shell));
+        assert!(
+            [
+                "/bin/bash",
+                "/usr/bin/bash",
+                "/bin/zsh",
+                "/usr/bin/zsh",
+                "/bin/sh"
+            ]
+            .contains(&shell)
+        );
     }
 
     // ── detect_shell_impl() — inject env and filesystem for full branch coverage ──

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [[bin]]
@@ -22,3 +22,6 @@ tempfile = "3"
 # hook is a mandatory part of getting the project working locally rather
 # than a manual, easy-to-forget `git config core.hooksPath` step.
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
+
+[lints]
+workspace = true

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -290,12 +290,16 @@ mod tests {
         run_with(&m, CoverageMode::All).unwrap();
         let calls = m.calls.borrow();
         assert_eq!(calls.len(), 2, "one gate call per non-xtask package");
-        assert!(calls
-            .iter()
-            .any(|a| has_pair(a, "--package", "leviath-core")));
-        assert!(calls
-            .iter()
-            .any(|a| has_pair(a, "--package", "leviath-cli")));
+        assert!(
+            calls
+                .iter()
+                .any(|a| has_pair(a, "--package", "leviath-core"))
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|a| has_pair(a, "--package", "leviath-cli"))
+        );
         assert!(!calls.iter().any(|a| has_pair(a, "--package", "xtask")));
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -161,9 +161,11 @@ mod tests {
             anyhow::bail!("simulated coverage failure")
         });
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("simulated coverage failure"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("simulated coverage failure")
+        );
     }
 }


### PR DESCRIPTION
## What & why

Leviath had 49 `unsafe` sites. This removes **all** of them from our own code and makes new `unsafe` a hard compile error, so the invariant can't regress.

Split into three reviewable commits:

1. **`refactor(sys)`** — the only 3 real FFI blocks (in `leviath-sys`):
   - `libc::setsid` + `pre_exec` → std's safe `Command::process_group(0)`
   - `libc::kill` → `nix::sys::signal::kill` (safe)
   - swaps the `libc` dep for `nix`
2. **`test(cli,tools)`** — routes all ~360 test env-var sites through the `temp-env` crate's scoped closures (encapsulate the unsafe, auto-restore). The two shared RAII guards (`isolate_config_path_for_test`, `isolate_runs_dir_for_test`) become `with_isolated_*` closures; async tests use `async_with_vars`. Deletes all hand-rolled per-variable env locks/guards. temp-env's single process-wide lock removes the cross-file dual-lock races the per-family locks papered over.
3. **`chore(lint)`** — `[workspace.lints.rust] unsafe_code = "forbid"` + `[lints] workspace = true` in all 10 crates, and upgrades the workspace to **edition 2024** (the change that makes `set_var`/`remove_var` `unsafe fn` — the motivation for #2). `cargo fix --edition` handled match-ergonomics; edition-2024 let-chains let clippy collapse a batch of nested `if let` guards.

## The honest scope of "zero unsafe"

`forbid(unsafe_code)` certifies zero `unsafe` **in our crates**. The OS's unavoidable syscall `unsafe` now lives in audited dependencies (`nix`, `temp-env`), never hand-written by us — the idiomatic posture. `forbid` (not `deny`) can't be re-enabled by a local `#[allow]`, and it's caught by the existing clippy/test/doc CI jobs and the pre-commit hook, so **no new CI job was added**.

## Behavioral note
`process_group(0)` puts detached child processes in a new process group rather than a new session (setsid). Both `configure_detached` call sites already redirect stdio and spawn fire-and-forget, so this is practically equivalent for "survives the launching terminal." It does **not** change the in-process (ECS) multi-agent model — only how already-spawned `lev` child processes are detached.

## Verification (local, edition 2024)
- Builds; **2041 leviath-cli tests + all 24 suites pass**
- clippy `-D warnings`, `cargo fmt --check`, rustdoc `-D warnings`: clean
- `cargo xtask coverage`: **all 9 packages at 100%**
- Final grep: zero `unsafe` keywords in `crates/`/`xtask/`; the lint verified to reject a probe `unsafe` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)