### PR TITLE
refactor: cut unwired taint modes, Custom transform, and Rhai placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Message a running agent from the terminal or dashboard — input is injected bet
 </td>
 <td width="33%" valign="top">
 
-**🛡️ Taint-Tracked Data Flow (In Progress)**
+**🛡️ Taint-Tracked Data Flow**
 
 A deterministic sensitivity model (Public / Internal / Private) tags every context region — set by the runtime, never by model output. Tools declare a direction and clearance, so an outbound call carrying data above its level is blocked before it fires — returned as `[blocked]`, or, in the daemon, surfaced as an *allow once / allow for this session / deny* prompt — and taint recovers automatically as entries evict. Configure it with an opt-in `[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool with `lev policy test`.
 

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -996,9 +996,6 @@ pub enum ContentTransform {
 
     /// Extract specific fields
     Extract { fields: Vec<String> },
-
-    /// Custom transformation
-    Custom { function: String },
 }
 
 #[cfg(test)]

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -37,7 +37,6 @@ pub use region::{
     SerializedToolCall,
 };
 pub use taint::{
-    FilterInput, FilterMode, FilterOperation, GateDecision, GateDecisionSource, GateEvent,
-    InputMode, PointerRef, RegionTaint, SecurityConfig, TaintLevel, ToolClassification,
-    ToolDirection,
+    GateDecision, GateDecisionSource, GateEvent, RegionTaint, SecurityConfig, TaintLevel,
+    ToolClassification, ToolDirection,
 };

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -734,25 +734,6 @@ fn parse_security_config(security_table: &toml::value::Table) -> crate::Security
     {
         sc.taint_tracking = tt;
     }
-    if let Some(pm) = security_table.get("pointer_mode").and_then(|v| v.as_bool()) {
-        sc.pointer_mode = pm;
-    }
-    if let Some(fm_val) = security_table.get("filter_mode") {
-        if let Some(fm_str) = fm_val.as_str() {
-            sc.filter_mode = crate::FilterMode::from_str_loose(fm_str);
-        } else if let Some(false) = fm_val.as_bool() {
-            sc.filter_mode = None;
-        }
-    }
-    if let Some(deg_arr) = security_table.get("degradation").and_then(|v| v.as_array()) {
-        let modes: Vec<crate::InputMode> = deg_arr
-            .iter()
-            .filter_map(|v| v.as_str().and_then(crate::InputMode::from_str_loose))
-            .collect();
-        if !modes.is_empty() {
-            sc.degradation = modes;
-        }
-    }
     sc
 }
 
@@ -1428,6 +1409,23 @@ mode = "autonomous"
     }
 
     #[test]
+    fn parse_manifest_security_block_without_taint_tracking_defaults_true() {
+        // A present `[security]` block that omits `taint_tracking` keeps the
+        // default (true) — block presence implies intent to configure security.
+        let toml = r#"
+[agent]
+name = "sec-default"
+
+[security]
+
+[stages.main]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert!(bp.security.as_ref().unwrap().taint_tracking);
+    }
+
+    #[test]
     fn parse_manifest_no_security_is_none() {
         let toml = r#"
 [agent]
@@ -2050,19 +2048,10 @@ name = "security-test"
 
 [security]
 taint_tracking = true
-pointer_mode = true
-filter_mode = "structured"
-degradation = ["pointer", "filter", "traditional"]
 "#;
         let bp = parse_manifest(toml).unwrap();
         let sc = bp.security.as_ref().unwrap();
         assert!(sc.taint_tracking);
-        assert!(sc.pointer_mode);
-        assert_eq!(sc.filter_mode, Some(crate::FilterMode::Structured));
-        assert_eq!(sc.degradation.len(), 3);
-        assert_eq!(sc.degradation[0], crate::InputMode::Pointer);
-        assert_eq!(sc.degradation[1], crate::InputMode::Filter);
-        assert_eq!(sc.degradation[2], crate::InputMode::Traditional);
     }
 
     #[test]
@@ -2080,20 +2069,6 @@ taint_tracking = false
     }
 
     #[test]
-    fn parse_manifest_security_filter_mode_false() {
-        let toml = r#"
-[agent]
-name = "no-filter"
-
-[security]
-filter_mode = false
-"#;
-        let bp = parse_manifest(toml).unwrap();
-        let sc = bp.security.as_ref().unwrap();
-        assert!(sc.filter_mode.is_none());
-    }
-
-    #[test]
     fn parse_manifest_no_security_section() {
         let toml = r#"
 [agent]
@@ -2101,35 +2076,6 @@ name = "no-security"
 "#;
         let bp = parse_manifest(toml).unwrap();
         assert!(bp.security.is_none());
-    }
-
-    #[test]
-    fn parse_manifest_security_freeform_filter() {
-        let toml = r#"
-[agent]
-name = "freeform-test"
-
-[security]
-filter_mode = "freeform"
-"#;
-        let bp = parse_manifest(toml).unwrap();
-        let sc = bp.security.as_ref().unwrap();
-        assert_eq!(sc.filter_mode, Some(crate::FilterMode::Freeform));
-    }
-
-    #[test]
-    fn parse_manifest_security_partial_degradation() {
-        let toml = r#"
-[agent]
-name = "partial-deg"
-
-[security]
-degradation = ["traditional"]
-"#;
-        let bp = parse_manifest(toml).unwrap();
-        let sc = bp.security.as_ref().unwrap();
-        assert_eq!(sc.degradation.len(), 1);
-        assert_eq!(sc.degradation[0], crate::InputMode::Traditional);
     }
 
     /// Agent-level tool_permissions with a non-string value — the inner
@@ -2624,79 +2570,25 @@ write_file = 123
     }
 
     #[test]
-    fn parse_manifest_security_all_branches() {
-        // Agent-level [security]: pointer_mode, filter_mode = false (→ None),
-        // and a non-empty degradation list. Stage-level [security]: a string
-        // filter_mode. Together these exercise every branch of
-        // parse_security_config.
+    fn parse_manifest_security_agent_and_stage() {
+        // Both an agent-level [security] and a stage-level override parse,
+        // exercising both call sites of parse_security_config.
         let toml = r#"
 [agent]
-name = "sec-all-branches"
+name = "sec-branches"
 
 [security]
 taint_tracking = false
-pointer_mode = true
-filter_mode = false
-degradation = ["pointer", "filter", "not-a-real-mode"]
 
 [stages.a]
 mode = "autonomous"
 
 [stages.a.security]
-filter_mode = "structured"
-
-[stages.b]
-mode = "autonomous"
-
-[stages.c]
-mode = "autonomous"
-
-[stages.c.security]
-filter_mode = true
+taint_tracking = true
 "#;
         let bp = parse_manifest(toml).unwrap();
-        let agent_sec = bp.security.as_ref().unwrap();
-        assert!(!agent_sec.taint_tracking);
-        assert!(agent_sec.pointer_mode);
-        // filter_mode = false → explicitly disabled.
-        assert!(agent_sec.filter_mode.is_none());
-        // Only the two recognized degradation modes survive.
-        assert_eq!(
-            agent_sec.degradation,
-            vec![crate::InputMode::Pointer, crate::InputMode::Filter]
-        );
-
+        assert!(!bp.security.as_ref().unwrap().taint_tracking);
         let stage_a = bp.find_stage("a").unwrap();
-        let a_sec = stage_a.security.as_ref().unwrap();
-        assert_eq!(a_sec.filter_mode, Some(crate::FilterMode::Structured));
-
-        // Stage c: filter_mode = true (a non-`false` bool) matches neither the
-        // string arm nor the `Some(false)` arm, leaving filter_mode untouched.
-        let stage_c = bp.find_stage("c").unwrap();
-        let c_sec = stage_c.security.as_ref().unwrap();
-        assert_eq!(
-            c_sec.filter_mode,
-            crate::SecurityConfig::default().filter_mode
-        );
-    }
-
-    #[test]
-    fn parse_manifest_security_empty_degradation_keeps_default() {
-        // A degradation list with no recognized modes leaves `modes` empty, so
-        // the `if !modes.is_empty()` assignment is skipped and the default is
-        // retained.
-        let toml = r#"
-[agent]
-name = "sec-empty-deg"
-
-[security]
-degradation = ["nonsense", "also-bad"]
-"#;
-        let bp = parse_manifest(toml).unwrap();
-        let sec = bp.security.as_ref().unwrap();
-        assert_eq!(
-            sec.degradation,
-            crate::SecurityConfig::default().degradation
-        );
+        assert!(stage_a.security.as_ref().unwrap().taint_tracking);
     }
 }

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -261,187 +261,17 @@ impl Default for RegionTaint {
     }
 }
 
-/// Input mode for tool invocations — determines taint checking precision.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum InputMode {
-    /// Pointer mode: reference specific content by ID or offset range.
-    /// Taint checked per-reference. Experimental.
-    Pointer,
-    /// Filter mode: delegate to a scoped sub-agent from a single region.
-    /// Taint checked per source region.
-    Filter,
-    /// Traditional mode: LLM generates tool inputs directly.
-    /// Taint checked against entire context (max across all regions).
-    Traditional,
-}
-
-impl InputMode {
-    /// Parse from a string (case-insensitive).
-    pub fn from_str_loose(s: &str) -> Option<InputMode> {
-        match s.to_lowercase().as_str() {
-            "pointer" => Some(InputMode::Pointer),
-            "filter" => Some(InputMode::Filter),
-            "traditional" => Some(InputMode::Traditional),
-            _ => None,
-        }
-    }
-
-    /// Returns the string representation.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            InputMode::Pointer => "pointer",
-            InputMode::Filter => "filter",
-            InputMode::Traditional => "traditional",
-        }
-    }
-}
-
-impl fmt::Display for InputMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Pointer reference — how an LLM references specific content in a region.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PointerRef {
-    /// Reference a content chunk by its runtime-assigned ID.
-    ChunkId {
-        /// Region containing the chunk.
-        region: String,
-        /// Runtime-assigned chunk identifier.
-        chunk_id: String,
-    },
-    /// Reference a byte/line range within a region.
-    OffsetRange {
-        /// Region containing the content.
-        region: String,
-        /// Start entry index (inclusive).
-        start: usize,
-        /// End entry index (exclusive).
-        end: usize,
-    },
-}
-
-/// Filter operation for scoped sub-agent invocation (structured mode).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FilterOperation {
-    /// Condense content into key points.
-    Summarize,
-    /// Pull specific information by type.
-    Extract {
-        /// What to extract (e.g., "dates", "names", "facts").
-        extract_type: String,
-    },
-    /// Reformat content.
-    Format {
-        /// Target format (e.g., "email", "report", "bullet_points").
-        output_format: String,
-    },
-    /// Generate new content based on region context.
-    Compose {
-        /// Target audience or style.
-        target_audience: Option<String>,
-    },
-    /// Translate to a specified language.
-    Translate {
-        /// Target language.
-        language: String,
-    },
-    /// Custom operation defined by blueprint.
-    Custom {
-        /// Operation name.
-        name: String,
-        /// Additional parameters.
-        params: HashMap<String, String>,
-    },
-}
-
-use std::collections::HashMap;
-
-impl FilterOperation {
-    /// Returns the operation name as a string.
-    pub fn name(&self) -> &str {
-        match self {
-            FilterOperation::Summarize => "summarize",
-            FilterOperation::Extract { .. } => "extract",
-            FilterOperation::Format { .. } => "format",
-            FilterOperation::Compose { .. } => "compose",
-            FilterOperation::Translate { .. } => "translate",
-            FilterOperation::Custom { name, .. } => name,
-        }
-    }
-}
-
-/// Filter mode configuration.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FilterMode {
-    /// Template-based filter prompts (default, deterministic).
-    #[default]
-    Structured,
-    /// Natural language filter instructions (opt-in, more flexible).
-    Freeform,
-}
-
-impl FilterMode {
-    /// Parse from a string.
-    pub fn from_str_loose(s: &str) -> Option<FilterMode> {
-        match s.to_lowercase().as_str() {
-            "structured" => Some(FilterMode::Structured),
-            "freeform" => Some(FilterMode::Freeform),
-            _ => None,
-        }
-    }
-}
-
-/// Filter input specification for a tool invocation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FilterInput {
-    /// Source region to scope the sub-agent to.
-    pub source_region: String,
-    /// Operation to apply.
-    pub operation: FilterOperation,
-    /// Optional output format hint.
-    pub output_format: Option<String>,
-}
-
 /// Security configuration for taint tracking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecurityConfig {
     /// Whether taint tracking is enabled.
     pub taint_tracking: bool,
-    /// Whether pointer mode is enabled (experimental).
-    pub pointer_mode: bool,
-    /// Filter mode setting. None = disabled.
-    pub filter_mode: Option<FilterMode>,
-    /// Degradation path — fallback order when higher-precision modes fail.
-    pub degradation: Vec<InputMode>,
-}
-
-impl SecurityConfig {
-    /// Check if a given input mode is available per this config.
-    pub fn mode_available(&self, mode: &InputMode) -> bool {
-        match mode {
-            InputMode::Pointer => self.pointer_mode,
-            InputMode::Filter => self.filter_mode.is_some(),
-            InputMode::Traditional => true, // always available
-        }
-    }
-
-    /// Get the next fallback mode in the degradation path after the given mode.
-    pub fn next_fallback(&self, current: &InputMode) -> Option<&InputMode> {
-        let pos = self.degradation.iter().position(|m| m == current)?;
-        self.degradation.get(pos + 1)
-    }
 }
 
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self {
             taint_tracking: true,
-            pointer_mode: false,
-            filter_mode: None,
-            degradation: vec![InputMode::Traditional],
         }
     }
 }
@@ -476,7 +306,6 @@ pub fn resolve_security(
     }
     SecurityConfig {
         taint_tracking: global,
-        ..SecurityConfig::default()
     }
 }
 
@@ -527,8 +356,6 @@ pub struct GateEvent {
     pub agent_id: String,
     /// Tool being invoked.
     pub tool_name: String,
-    /// Input mode used.
-    pub input_mode: InputMode,
     /// Taint level at time of check.
     pub taint_level: TaintLevel,
     /// Tool's clearance level.
@@ -908,221 +735,22 @@ mod tests {
         assert_eq!(back.entry_count(), 2);
     }
 
-    // ─── InputMode ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn input_mode_from_str_loose() {
-        assert_eq!(
-            InputMode::from_str_loose("pointer"),
-            Some(InputMode::Pointer)
-        );
-        assert_eq!(InputMode::from_str_loose("FILTER"), Some(InputMode::Filter));
-        assert_eq!(
-            InputMode::from_str_loose("Traditional"),
-            Some(InputMode::Traditional)
-        );
-        assert_eq!(InputMode::from_str_loose("nope"), None);
-    }
-
-    #[test]
-    fn input_mode_display() {
-        assert_eq!(format!("{}", InputMode::Pointer), "pointer");
-        assert_eq!(format!("{}", InputMode::Filter), "filter");
-        assert_eq!(format!("{}", InputMode::Traditional), "traditional");
-    }
-
-    #[test]
-    fn input_mode_serde_roundtrip() {
-        for mode in [
-            InputMode::Pointer,
-            InputMode::Filter,
-            InputMode::Traditional,
-        ] {
-            let json = serde_json::to_string(&mode).unwrap();
-            let back: InputMode = serde_json::from_str(&json).unwrap();
-            assert_eq!(mode, back);
-        }
-    }
-
-    // ─── PointerRef ─────────────────────────────────────────────────────────
-
-    #[test]
-    fn pointer_ref_chunk_id() {
-        let pr = PointerRef::ChunkId {
-            region: "research".into(),
-            chunk_id: "abc123".into(),
-        };
-        let json = serde_json::to_string(&pr).unwrap();
-        let back: PointerRef = serde_json::from_str(&json).unwrap();
-        assert_eq!(pr, back);
-    }
-
-    #[test]
-    fn pointer_ref_offset_range() {
-        let pr = PointerRef::OffsetRange {
-            region: "data".into(),
-            start: 0,
-            end: 5,
-        };
-        let json = serde_json::to_string(&pr).unwrap();
-        let back: PointerRef = serde_json::from_str(&json).unwrap();
-        assert_eq!(pr, back);
-    }
-
-    // ─── FilterOperation ────────────────────────────────────────────────────
-
-    #[test]
-    fn filter_operation_names() {
-        assert_eq!(FilterOperation::Summarize.name(), "summarize");
-        assert_eq!(
-            FilterOperation::Extract {
-                extract_type: "dates".into()
-            }
-            .name(),
-            "extract"
-        );
-        assert_eq!(
-            FilterOperation::Format {
-                output_format: "email".into()
-            }
-            .name(),
-            "format"
-        );
-        assert_eq!(
-            FilterOperation::Compose {
-                target_audience: None
-            }
-            .name(),
-            "compose"
-        );
-        assert_eq!(
-            FilterOperation::Translate {
-                language: "es".into()
-            }
-            .name(),
-            "translate"
-        );
-        assert_eq!(
-            FilterOperation::Custom {
-                name: "my_op".into(),
-                params: HashMap::new(),
-            }
-            .name(),
-            "my_op"
-        );
-    }
-
-    #[test]
-    fn filter_operation_serde_roundtrip() {
-        let op = FilterOperation::Extract {
-            extract_type: "names".into(),
-        };
-        let json = serde_json::to_string(&op).unwrap();
-        let back: FilterOperation = serde_json::from_str(&json).unwrap();
-        assert_eq!(op, back);
-    }
-
-    // ─── FilterMode ─────────────────────────────────────────────────────────
-
-    #[test]
-    fn filter_mode_from_str_loose() {
-        assert_eq!(
-            FilterMode::from_str_loose("structured"),
-            Some(FilterMode::Structured)
-        );
-        assert_eq!(
-            FilterMode::from_str_loose("FREEFORM"),
-            Some(FilterMode::Freeform)
-        );
-        assert_eq!(FilterMode::from_str_loose("nope"), None);
-    }
-
-    #[test]
-    fn filter_mode_default() {
-        assert_eq!(FilterMode::default(), FilterMode::Structured);
-    }
-
-    // ─── FilterInput ────────────────────────────────────────────────────────
-
-    #[test]
-    fn filter_input_serde_roundtrip() {
-        let fi = FilterInput {
-            source_region: "research".into(),
-            operation: FilterOperation::Summarize,
-            output_format: Some("email".into()),
-        };
-        let json = serde_json::to_string(&fi).unwrap();
-        let back: FilterInput = serde_json::from_str(&json).unwrap();
-        assert_eq!(fi, back);
-    }
-
     // ─── SecurityConfig ─────────────────────────────────────────────────────
 
     #[test]
     fn security_config_default() {
         let sc = SecurityConfig::default();
         assert!(sc.taint_tracking);
-        assert!(!sc.pointer_mode);
-        assert!(sc.filter_mode.is_none());
-        assert_eq!(sc.degradation, vec![InputMode::Traditional]);
-    }
-
-    #[test]
-    fn security_config_mode_available() {
-        let sc = SecurityConfig {
-            taint_tracking: true,
-            pointer_mode: true,
-            filter_mode: Some(FilterMode::Structured),
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-        };
-        assert!(sc.mode_available(&InputMode::Pointer));
-        assert!(sc.mode_available(&InputMode::Filter));
-        assert!(sc.mode_available(&InputMode::Traditional));
-
-        let sc2 = SecurityConfig::default();
-        assert!(!sc2.mode_available(&InputMode::Pointer));
-        assert!(!sc2.mode_available(&InputMode::Filter));
-        assert!(sc2.mode_available(&InputMode::Traditional));
-    }
-
-    #[test]
-    fn security_config_next_fallback() {
-        let sc = SecurityConfig {
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-        assert_eq!(
-            sc.next_fallback(&InputMode::Pointer),
-            Some(&InputMode::Filter)
-        );
-        assert_eq!(
-            sc.next_fallback(&InputMode::Filter),
-            Some(&InputMode::Traditional)
-        );
-        assert_eq!(sc.next_fallback(&InputMode::Traditional), None);
     }
 
     #[test]
     fn security_config_serde_roundtrip() {
         let sc = SecurityConfig {
-            taint_tracking: true,
-            pointer_mode: true,
-            filter_mode: Some(FilterMode::Freeform),
-            degradation: vec![InputMode::Pointer, InputMode::Traditional],
+            taint_tracking: false,
         };
         let json = serde_json::to_string(&sc).unwrap();
         let back: SecurityConfig = serde_json::from_str(&json).unwrap();
-        assert!(back.taint_tracking);
-        assert!(back.pointer_mode);
-        assert_eq!(back.filter_mode, Some(FilterMode::Freeform));
+        assert!(!back.taint_tracking);
     }
 
     // ─── GateDecision ───────────────────────────────────────────────────────
@@ -1152,7 +780,6 @@ mod tests {
             timestamp: 1234567890,
             agent_id: "agent-1".into(),
             tool_name: "send_email".into(),
-            input_mode: InputMode::Traditional,
             taint_level: TaintLevel::Private,
             clearance: TaintLevel::Public,
             allowed: false,
@@ -1274,7 +901,6 @@ mod tests {
     fn sec(taint: bool) -> SecurityConfig {
         SecurityConfig {
             taint_tracking: taint,
-            ..SecurityConfig::default()
         }
     }
 
@@ -1350,36 +976,5 @@ mod tests {
         // An out-of-range index is a no-op.
         rt.remove_at(99);
         assert_eq!(rt.entry_count(), 2);
-    }
-
-    #[test]
-    fn test_security_config_next_fallback() {
-        let config = SecurityConfig {
-            taint_tracking: true,
-            pointer_mode: true,
-            filter_mode: None,
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-        };
-        assert_eq!(
-            config.next_fallback(&InputMode::Pointer),
-            Some(&InputMode::Filter)
-        );
-        assert_eq!(
-            config.next_fallback(&InputMode::Filter),
-            Some(&InputMode::Traditional)
-        );
-        // The last mode in the path has no fallback.
-        assert_eq!(config.next_fallback(&InputMode::Traditional), None);
-
-        // A mode absent from the degradation path has no fallback.
-        let cfg2 = SecurityConfig {
-            degradation: vec![InputMode::Traditional],
-            ..SecurityConfig::default()
-        };
-        assert_eq!(cfg2.next_fallback(&InputMode::Pointer), None);
     }
 }

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -93,12 +93,10 @@ fn apply_content_transform(content: &str, transform: &Option<ContentTransform>) 
     match transform {
         None | Some(ContentTransform::Direct) => content.to_string(),
         Some(ContentTransform::Extract { fields }) => extract_fields(content, fields),
-        // Summarize (LLM) and Custom (Rhai) need async/scripting infra that isn't
-        // available at spawn time; fall back to a direct copy so the data still
-        // transfers. (Follow-up: route through the compaction / script lanes.)
-        Some(ContentTransform::Summarize) | Some(ContentTransform::Custom { .. }) => {
-            content.to_string()
-        }
+        // Summarize needs an async LLM call that isn't available at spawn time;
+        // fall back to a direct copy so the data still transfers. (Follow-up:
+        // route through the compaction lane — tracked separately.)
+        Some(ContentTransform::Summarize) => content.to_string(),
     }
 }
 
@@ -177,15 +175,6 @@ mod tests {
         );
         assert_eq!(
             apply_content_transform("x", &Some(ContentTransform::Summarize)),
-            "x"
-        );
-        assert_eq!(
-            apply_content_transform(
-                "x",
-                &Some(ContentTransform::Custom {
-                    function: "f".to_string()
-                })
-            ),
             "x"
         );
         let out = apply_content_transform(

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -280,7 +280,6 @@ mod tests {
     fn gate() -> TaintGate {
         TaintGate::new(SecurityConfig {
             taint_tracking: true,
-            ..Default::default()
         })
     }
 

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -3847,7 +3847,6 @@ mod tests {
     fn enabled_gate() -> crate::taint::TaintGate {
         crate::taint::TaintGate::new(leviath_core::SecurityConfig {
             taint_tracking: true,
-            ..Default::default()
         })
     }
 

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -1,12 +1,12 @@
 //! Taint gate checking for tool execution.
 //!
 //! Implements the gate check logic that runs before outbound tool calls.
-//! When taint tracking is enabled, the gate compares the relevant taint
-//! level (determined by input mode) against the tool's clearance level.
+//! When taint tracking is enabled, the gate compares the context window's
+//! overall taint level against the tool's clearance level.
 
 use leviath_core::taint::{
-    GateDecision, GateDecisionSource, GateEvent, InputMode, SecurityConfig, TaintLevel,
-    ToolClassification, builtin_tool_classification,
+    GateDecision, GateDecisionSource, GateEvent, SecurityConfig, TaintLevel, ToolClassification,
+    builtin_tool_classification,
 };
 use std::collections::HashMap;
 
@@ -68,7 +68,6 @@ impl TaintGate {
         Self {
             config: SecurityConfig {
                 taint_tracking: false,
-                ..SecurityConfig::default()
             },
             tool_overrides: HashMap::new(),
             audit_log: Vec::new(),
@@ -116,7 +115,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 TaintLevel::Public,
                 TaintLevel::Public,
                 true,
@@ -132,7 +130,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 TaintLevel::Public,
                 classification.clearance,
                 true,
@@ -148,7 +145,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 taint,
                 classification.clearance,
                 true,
@@ -167,7 +163,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 taint,
                 classification.clearance,
                 false,
@@ -178,115 +173,6 @@ impl TaintGate {
                 taint_level: taint,
                 clearance: classification.clearance,
                 source_regions,
-                tool_name: tool_name.to_string(),
-            }
-        }
-    }
-
-    /// Check the gate for a pointer-mode tool invocation.
-    ///
-    /// In pointer mode, only the taint of the referenced content is checked.
-    pub fn check_pointer(
-        &mut self,
-        agent_id: &str,
-        tool_name: &str,
-        reference_taint: TaintLevel,
-    ) -> GateDecision {
-        if !self.config.taint_tracking {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Pointer,
-                TaintLevel::Public,
-                TaintLevel::Public,
-                true,
-                GateDecisionSource::TaintDisabled,
-            );
-            return GateDecision::Allowed;
-        }
-
-        let classification = self.tool_classification(tool_name);
-
-        if !classification.is_outbound() || classification.check_clearance(reference_taint) {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Pointer,
-                reference_taint,
-                classification.clearance,
-                true,
-                GateDecisionSource::AutoAllow,
-            );
-            GateDecision::Allowed
-        } else {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Pointer,
-                reference_taint,
-                classification.clearance,
-                false,
-                GateDecisionSource::AutoBlock,
-            );
-            GateDecision::Blocked {
-                taint_level: reference_taint,
-                clearance: classification.clearance,
-                source_regions: vec![],
-                tool_name: tool_name.to_string(),
-            }
-        }
-    }
-
-    /// Check the gate for a filter-mode tool invocation.
-    ///
-    /// In filter mode, the taint of the source region is checked.
-    pub fn check_filter(
-        &mut self,
-        agent_id: &str,
-        tool_name: &str,
-        source_region_taint: TaintLevel,
-        source_region_name: &str,
-    ) -> GateDecision {
-        if !self.config.taint_tracking {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Filter,
-                TaintLevel::Public,
-                TaintLevel::Public,
-                true,
-                GateDecisionSource::TaintDisabled,
-            );
-            return GateDecision::Allowed;
-        }
-
-        let classification = self.tool_classification(tool_name);
-
-        if !classification.is_outbound() || classification.check_clearance(source_region_taint) {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Filter,
-                source_region_taint,
-                classification.clearance,
-                true,
-                GateDecisionSource::AutoAllow,
-            );
-            GateDecision::Allowed
-        } else {
-            self.log_event(
-                agent_id,
-                tool_name,
-                InputMode::Filter,
-                source_region_taint,
-                classification.clearance,
-                false,
-                GateDecisionSource::AutoBlock,
-            );
-            GateDecision::Blocked {
-                taint_level: source_region_taint,
-                clearance: classification.clearance,
-                source_regions: vec![source_region_name.to_string()],
                 tool_name: tool_name.to_string(),
             }
         }
@@ -326,7 +212,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 taint,
                 clearance,
                 true,
@@ -344,7 +229,6 @@ impl TaintGate {
             self.log_event(
                 agent_id,
                 tool_name,
-                InputMode::Traditional,
                 taint,
                 clearance,
                 true,
@@ -361,14 +245,11 @@ impl TaintGate {
         &mut self,
         agent_id: &str,
         tool_name: &str,
-        input_mode: InputMode,
         taint: TaintLevel,
         clearance: TaintLevel,
         source: GateDecisionSource,
     ) {
-        self.log_event(
-            agent_id, tool_name, input_mode, taint, clearance, true, source,
-        );
+        self.log_event(agent_id, tool_name, taint, clearance, true, source);
     }
 
     /// Record a deny decision (the user or a default policy denied the call).
@@ -376,14 +257,11 @@ impl TaintGate {
         &mut self,
         agent_id: &str,
         tool_name: &str,
-        input_mode: InputMode,
         taint: TaintLevel,
         clearance: TaintLevel,
         source: GateDecisionSource,
     ) {
-        self.log_event(
-            agent_id, tool_name, input_mode, taint, clearance, false, source,
-        );
+        self.log_event(agent_id, tool_name, taint, clearance, false, source);
     }
 
     /// Apply the user's resolution of a blocked outbound call: record the
@@ -407,7 +285,6 @@ impl TaintGate {
                 self.record_allow(
                     agent_id,
                     tool_name,
-                    InputMode::Traditional,
                     taint,
                     clearance,
                     GateDecisionSource::UserAllowOnce,
@@ -418,7 +295,6 @@ impl TaintGate {
                 self.record_allow(
                     agent_id,
                     tool_name,
-                    InputMode::Traditional,
                     taint,
                     clearance,
                     GateDecisionSource::UserAlwaysAllow,
@@ -432,7 +308,6 @@ impl TaintGate {
                 self.record_deny(
                     agent_id,
                     tool_name,
-                    InputMode::Traditional,
                     taint,
                     clearance,
                     GateDecisionSource::UserDenied,
@@ -454,17 +329,11 @@ impl TaintGate {
         &self.audit_log
     }
 
-    /// Clear the audit log.
-    pub fn clear_audit_log(&mut self) {
-        self.audit_log.clear();
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn log_event(
         &mut self,
         agent_id: &str,
         tool_name: &str,
-        input_mode: InputMode,
         taint_level: TaintLevel,
         clearance: TaintLevel,
         allowed: bool,
@@ -474,303 +343,11 @@ impl TaintGate {
             timestamp: chrono::Utc::now().timestamp(),
             agent_id: agent_id.to_string(),
             tool_name: tool_name.to_string(),
-            input_mode,
             taint_level,
             clearance,
             allowed,
             decision_source,
         });
-    }
-}
-
-/// Pointer reference resolver — resolves PointerRef to actual content
-/// and its taint level from a ContextWindow.
-#[derive(Debug)]
-pub struct PointerResolver;
-
-/// Result of resolving a pointer reference.
-#[derive(Debug, Clone)]
-pub struct ResolvedPointer {
-    /// The resolved content.
-    pub content: String,
-    /// The taint level of the resolved content.
-    pub taint_level: TaintLevel,
-}
-
-/// Error when resolving a pointer reference.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PointerError {
-    /// Region not found.
-    RegionNotFound(String),
-    /// Chunk ID not found in region.
-    ChunkNotFound { region: String, chunk_id: String },
-    /// Offset range out of bounds.
-    OffsetOutOfBounds {
-        region: String,
-        start: usize,
-        end: usize,
-    },
-    /// Taint tracking not enabled on region.
-    TaintNotEnabled(String),
-}
-
-impl std::fmt::Display for PointerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PointerError::RegionNotFound(r) => write!(f, "Region not found: {}", r),
-            PointerError::ChunkNotFound { region, chunk_id } => {
-                write!(f, "Chunk '{}' not found in region '{}'", chunk_id, region)
-            }
-            PointerError::OffsetOutOfBounds { region, start, end } => {
-                write!(
-                    f,
-                    "Offset range {}..{} out of bounds in region '{}'",
-                    start, end, region
-                )
-            }
-            PointerError::TaintNotEnabled(r) => {
-                write!(f, "Taint tracking not enabled on region '{}'", r)
-            }
-        }
-    }
-}
-
-impl PointerResolver {
-    /// Resolve a PointerRef against a ContextWindow.
-    pub fn resolve(
-        window: &ContextWindow,
-        pointer: &leviath_core::taint::PointerRef,
-    ) -> Result<ResolvedPointer, PointerError> {
-        use leviath_core::taint::PointerRef;
-
-        match pointer {
-            PointerRef::ChunkId { region, chunk_id } => {
-                let reg = window
-                    .get_region(region)
-                    .ok_or_else(|| PointerError::RegionNotFound(region.clone()))?;
-
-                // Chunk IDs are entry metadata with "chunk_id" key
-                let (idx, entry) = reg
-                    .content
-                    .iter()
-                    .enumerate()
-                    .find(|(_, e)| {
-                        e.metadata
-                            .as_ref()
-                            .and_then(|m| m.get("chunk_id"))
-                            .and_then(|v| v.as_str())
-                            == Some(chunk_id.as_str())
-                    })
-                    .ok_or_else(|| PointerError::ChunkNotFound {
-                        region: region.clone(),
-                        chunk_id: chunk_id.clone(),
-                    })?;
-
-                let taint = reg
-                    .taint
-                    .as_ref()
-                    .ok_or_else(|| PointerError::TaintNotEnabled(region.clone()))?
-                    .entry_taint(idx)
-                    .unwrap_or(TaintLevel::Public);
-
-                Ok(ResolvedPointer {
-                    content: entry.content.clone(),
-                    taint_level: taint,
-                })
-            }
-            PointerRef::OffsetRange { region, start, end } => {
-                let reg = window
-                    .get_region(region)
-                    .ok_or_else(|| PointerError::RegionNotFound(region.clone()))?;
-
-                if *start >= reg.content.len() || *end > reg.content.len() || start >= end {
-                    return Err(PointerError::OffsetOutOfBounds {
-                        region: region.clone(),
-                        start: *start,
-                        end: *end,
-                    });
-                }
-
-                let content: String = reg.content[*start..*end]
-                    .iter()
-                    .map(|e| e.content.as_str())
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let taint = reg
-                    .taint
-                    .as_ref()
-                    .ok_or_else(|| PointerError::TaintNotEnabled(region.clone()))?
-                    .range_taint(*start, *end);
-
-                Ok(ResolvedPointer {
-                    content,
-                    taint_level: taint,
-                })
-            }
-        }
-    }
-}
-
-/// Filter input resolver — resolves a FilterInput against a ContextWindow.
-///
-/// In a full system, this would spawn a scoped sub-agent. Here we provide
-/// the resolution logic that determines the taint level and validates the
-/// filter configuration.
-#[derive(Debug)]
-pub struct FilterResolver;
-
-/// Result of resolving a filter input.
-#[derive(Debug, Clone)]
-pub struct ResolvedFilter {
-    /// Content from the source region (for the sub-agent to process).
-    pub source_content: String,
-    /// Taint level of the source region (output inherits this).
-    pub taint_level: TaintLevel,
-    /// The filter operation to apply.
-    pub operation: leviath_core::taint::FilterOperation,
-}
-
-/// Error when resolving a filter input.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FilterError {
-    /// Source region not found.
-    RegionNotFound(String),
-    /// Taint tracking not enabled on source region.
-    TaintNotEnabled(String),
-    /// Filter mode is disabled.
-    FilterDisabled,
-    /// Freeform mode not enabled (user tried freeform but config says structured).
-    FreeformNotEnabled,
-}
-
-impl std::fmt::Display for FilterError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FilterError::RegionNotFound(r) => write!(f, "Source region not found: {}", r),
-            FilterError::TaintNotEnabled(r) => {
-                write!(f, "Taint tracking not enabled on region '{}'", r)
-            }
-            FilterError::FilterDisabled => write!(f, "Filter mode is disabled"),
-            FilterError::FreeformNotEnabled => {
-                write!(
-                    f,
-                    "Freeform filter mode not enabled (config says structured)"
-                )
-            }
-        }
-    }
-}
-
-impl FilterResolver {
-    /// Resolve a FilterInput against a ContextWindow.
-    pub fn resolve(
-        window: &ContextWindow,
-        filter: &leviath_core::taint::FilterInput,
-        config: &SecurityConfig,
-    ) -> Result<ResolvedFilter, FilterError> {
-        // Check filter mode is enabled
-        if config.filter_mode.is_none() {
-            return Err(FilterError::FilterDisabled);
-        }
-
-        let region = window
-            .get_region(&filter.source_region)
-            .ok_or_else(|| FilterError::RegionNotFound(filter.source_region.clone()))?;
-
-        let taint = region
-            .taint_level()
-            .ok_or_else(|| FilterError::TaintNotEnabled(filter.source_region.clone()))?;
-
-        let source_content: String = region
-            .content
-            .iter()
-            .map(|e| e.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        Ok(ResolvedFilter {
-            source_content,
-            taint_level: taint,
-            operation: filter.operation.clone(),
-        })
-    }
-}
-
-/// Degradation engine — manages fallback when a higher-precision input mode fails.
-#[derive(Debug)]
-pub struct DegradationEngine;
-
-/// Error produced by the degradation engine.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DegradationError {
-    /// The current mode failed and no fallback is configured.
-    NoFallback { current_mode: InputMode },
-    /// All modes in the degradation path have been exhausted.
-    AllModesExhausted,
-    /// A specific mode error with message.
-    ModeError { mode: InputMode, message: String },
-}
-
-impl std::fmt::Display for DegradationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DegradationError::NoFallback { current_mode } => {
-                write!(
-                    f,
-                    "Input mode '{}' failed: no fallback configured in degradation path",
-                    current_mode
-                )
-            }
-            DegradationError::AllModesExhausted => {
-                write!(f, "All input modes in degradation path have been exhausted")
-            }
-            DegradationError::ModeError { mode, message } => {
-                write!(f, "Input mode '{}' failed: {}", mode, message)
-            }
-        }
-    }
-}
-
-impl DegradationEngine {
-    /// Get the next mode to try after the given mode fails.
-    /// Returns a descriptive error message for the user alongside the next mode.
-    pub fn degrade(
-        config: &SecurityConfig,
-        current_mode: &InputMode,
-    ) -> Result<(InputMode, String), DegradationError> {
-        match config.next_fallback(current_mode) {
-            Some(next) => {
-                let message = format!(
-                    "Input mode '{}' failed. Degrading to '{}' mode per configured degradation path.",
-                    current_mode, next
-                );
-                Ok((next.clone(), message))
-            }
-            None => Err(DegradationError::NoFallback {
-                current_mode: current_mode.clone(),
-            }),
-        }
-    }
-
-    /// Run through the full degradation path, returning the first available mode.
-    pub fn first_available(config: &SecurityConfig) -> Option<InputMode> {
-        config
-            .degradation
-            .iter()
-            .find(|mode| config.mode_available(mode))
-            .cloned()
-    }
-
-    /// Validate that the degradation path is valid (all modes are available).
-    /// Returns modes in the path that are not available.
-    pub fn validate_path(config: &SecurityConfig) -> Vec<InputMode> {
-        config
-            .degradation
-            .iter()
-            .filter(|mode| !config.mode_available(mode))
-            .cloned()
-            .collect()
     }
 }
 
@@ -890,64 +467,6 @@ mod tests {
     }
 
     #[test]
-    fn gate_pointer_mode_allows_clean_reference() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_pointer("agent-1", "shell", TaintLevel::Public);
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
-    fn gate_pointer_mode_blocks_tainted_reference() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_pointer("agent-1", "shell", TaintLevel::Internal);
-        assert!(!decision.is_allowed());
-    }
-
-    #[test]
-    fn gate_pointer_mode_non_outbound_allows() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_pointer("agent-1", "read_file", TaintLevel::Private);
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
-    fn gate_filter_mode_allows_clean_region() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_filter("agent-1", "shell", TaintLevel::Public, "research");
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
-    fn gate_filter_mode_blocks_tainted_region() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_filter("agent-1", "shell", TaintLevel::Private, "conversation");
-        assert!(!decision.is_allowed());
-        assert_eq!(
-            decision,
-            GateDecision::Blocked {
-                taint_level: TaintLevel::Private,
-                clearance: TaintLevel::Public,
-                source_regions: vec!["conversation".to_string()],
-                tool_name: "shell".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn gate_filter_mode_disabled_allows() {
-        let mut gate = TaintGate::disabled();
-        let decision = gate.check_filter("agent-1", "shell", TaintLevel::Private, "conversation");
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
-    fn gate_pointer_mode_disabled_allows() {
-        let mut gate = TaintGate::disabled();
-        let decision = gate.check_pointer("agent-1", "shell", TaintLevel::Private);
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
     fn gate_audit_log_records_events() {
         let mut gate = TaintGate::new(SecurityConfig::default());
         let window = make_window_with_taint(TaintLevel::Public);
@@ -961,22 +480,11 @@ mod tests {
     }
 
     #[test]
-    fn gate_clear_audit_log() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let window = make_window_with_taint(TaintLevel::Public);
-        gate.check_traditional("agent-1", "shell", &window);
-        assert_eq!(gate.audit_log().len(), 1);
-        gate.clear_audit_log();
-        assert_eq!(gate.audit_log().len(), 0);
-    }
-
-    #[test]
     fn gate_record_allow() {
         let mut gate = TaintGate::new(SecurityConfig::default());
         gate.record_allow(
             "agent-1",
             "shell",
-            InputMode::Traditional,
             TaintLevel::Private,
             TaintLevel::Public,
             GateDecisionSource::UserAllowOnce,
@@ -1012,418 +520,10 @@ mod tests {
     fn gate_new_and_config() {
         let config = SecurityConfig {
             taint_tracking: true,
-            pointer_mode: true,
-            ..SecurityConfig::default()
         };
         let gate = TaintGate::new(config.clone());
         assert!(gate.is_enabled());
-        assert!(gate.config().pointer_mode);
-    }
-
-    // ─── PointerResolver ────────────────────────────────────────────────────
-
-    fn make_window_with_chunks() -> ContextWindow {
-        let mut window = ContextWindow::new(10000);
-        let mut region =
-            Region::new("research".to_string(), RegionKind::Temporary, 5000).with_taint_tracking();
-
-        // Add entries with chunk_id metadata
-        region
-            .add_entry_with_metadata(
-                "public search results".to_string(),
-                10,
-                serde_json::json!({"chunk_id": "chunk-1"}),
-            )
-            .unwrap();
-        // Manually track taint (add_entry_with_metadata tracks as Public)
-
-        region
-            .add_entry_with_metadata(
-                "private calendar data".to_string(),
-                10,
-                serde_json::json!({"chunk_id": "chunk-2"}),
-            )
-            .unwrap();
-
-        // Override taint for second entry.
-        // First entry is Public (default from add_entry_with_metadata); remove
-        // both Public entries and re-add with correct taints.
-        let taint = region
-            .taint
-            .as_mut()
-            .expect("region was created with taint tracking");
-        taint.clear();
-        taint.add_entry(TaintLevel::Public);
-        taint.add_entry(TaintLevel::Private);
-
-        window.add_region(region);
-        window
-    }
-
-    #[test]
-    fn pointer_resolve_chunk_id_public() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::ChunkId {
-            region: "research".into(),
-            chunk_id: "chunk-1".into(),
-        };
-        let result = PointerResolver::resolve(&window, &pointer).unwrap();
-        assert_eq!(result.content, "public search results");
-        assert_eq!(result.taint_level, TaintLevel::Public);
-    }
-
-    #[test]
-    fn pointer_resolve_chunk_id_private() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::ChunkId {
-            region: "research".into(),
-            chunk_id: "chunk-2".into(),
-        };
-        let result = PointerResolver::resolve(&window, &pointer).unwrap();
-        assert_eq!(result.content, "private calendar data");
-        assert_eq!(result.taint_level, TaintLevel::Private);
-    }
-
-    #[test]
-    fn pointer_resolve_chunk_not_found() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::ChunkId {
-            region: "research".into(),
-            chunk_id: "nonexistent".into(),
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(
-            err,
-            PointerError::ChunkNotFound {
-                region: "research".into(),
-                chunk_id: "nonexistent".into()
-            }
-        );
-    }
-
-    #[test]
-    fn pointer_resolve_region_not_found() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::ChunkId {
-            region: "nope".into(),
-            chunk_id: "chunk-1".into(),
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(err, PointerError::RegionNotFound("nope".into()));
-    }
-
-    #[test]
-    fn pointer_resolve_offset_range() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 0,
-            end: 1,
-        };
-        let result = PointerResolver::resolve(&window, &pointer).unwrap();
-        assert_eq!(result.content, "public search results");
-        assert_eq!(result.taint_level, TaintLevel::Public);
-    }
-
-    #[test]
-    fn pointer_resolve_offset_range_multi() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 0,
-            end: 2,
-        };
-        let result = PointerResolver::resolve(&window, &pointer).unwrap();
-        assert!(result.content.contains("public search results"));
-        assert!(result.content.contains("private calendar data"));
-        assert_eq!(result.taint_level, TaintLevel::Private);
-    }
-
-    #[test]
-    fn pointer_resolve_offset_out_of_bounds() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 5,
-            end: 10,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(
-            err,
-            PointerError::OffsetOutOfBounds {
-                region: "research".into(),
-                start: 5,
-                end: 10
-            }
-        );
-    }
-
-    #[test]
-    fn pointer_resolve_taint_not_enabled() {
-        let mut window = ContextWindow::new(10000);
-        let mut region = Region::new("data".to_string(), RegionKind::Temporary, 5000);
-        region
-            .add_entry_with_metadata(
-                "content".to_string(),
-                10,
-                serde_json::json!({"chunk_id": "c1"}),
-            )
-            .unwrap();
-        window.add_region(region);
-
-        let pointer = leviath_core::taint::PointerRef::ChunkId {
-            region: "data".into(),
-            chunk_id: "c1".into(),
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(err, PointerError::TaintNotEnabled("data".into()));
-    }
-
-    #[test]
-    fn pointer_error_display() {
-        let err = PointerError::RegionNotFound("test".into());
-        assert!(err.to_string().contains("Region not found"));
-
-        let err = PointerError::ChunkNotFound {
-            region: "r".into(),
-            chunk_id: "c".into(),
-        };
-        assert!(err.to_string().contains("Chunk"));
-
-        let err = PointerError::OffsetOutOfBounds {
-            region: "r".into(),
-            start: 1,
-            end: 5,
-        };
-        assert!(err.to_string().contains("out of bounds"));
-
-        let err = PointerError::TaintNotEnabled("r".into());
-        assert!(err.to_string().contains("Taint tracking not enabled"));
-    }
-
-    // ─── FilterResolver ─────────────────────────────────────────────────────
-
-    #[test]
-    fn filter_resolve_success() {
-        let mut window = ContextWindow::new(10000);
-        let mut region =
-            Region::new("research".to_string(), RegionKind::Temporary, 5000).with_taint_tracking();
-        region
-            .add_tainted_entry("fact 1".to_string(), 5, TaintLevel::Public)
-            .unwrap();
-        region
-            .add_tainted_entry("fact 2".to_string(), 5, TaintLevel::Public)
-            .unwrap();
-        window.add_region(region);
-
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "research".into(),
-            operation: leviath_core::taint::FilterOperation::Summarize,
-            output_format: None,
-        };
-
-        let result = FilterResolver::resolve(&window, &filter, &config).unwrap();
-        assert!(result.source_content.contains("fact 1"));
-        assert!(result.source_content.contains("fact 2"));
-        assert_eq!(result.taint_level, TaintLevel::Public);
-    }
-
-    #[test]
-    fn filter_resolve_disabled() {
-        let window = ContextWindow::new(10000);
-        let config = SecurityConfig::default(); // filter_mode is None
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "research".into(),
-            operation: leviath_core::taint::FilterOperation::Summarize,
-            output_format: None,
-        };
-
-        let err = FilterResolver::resolve(&window, &filter, &config).unwrap_err();
-        assert_eq!(err, FilterError::FilterDisabled);
-    }
-
-    #[test]
-    fn filter_resolve_region_not_found() {
-        let window = ContextWindow::new(10000);
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "nope".into(),
-            operation: leviath_core::taint::FilterOperation::Summarize,
-            output_format: None,
-        };
-
-        let err = FilterResolver::resolve(&window, &filter, &config).unwrap_err();
-        assert_eq!(err, FilterError::RegionNotFound("nope".into()));
-    }
-
-    #[test]
-    fn filter_resolve_taint_not_enabled() {
-        let mut window = ContextWindow::new(10000);
-        let region = Region::new("data".to_string(), RegionKind::Temporary, 5000);
-        window.add_region(region);
-
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "data".into(),
-            operation: leviath_core::taint::FilterOperation::Summarize,
-            output_format: None,
-        };
-
-        let err = FilterResolver::resolve(&window, &filter, &config).unwrap_err();
-        assert_eq!(err, FilterError::TaintNotEnabled("data".into()));
-    }
-
-    #[test]
-    fn filter_error_display() {
-        assert!(
-            FilterError::RegionNotFound("r".into())
-                .to_string()
-                .contains("region not found")
-        );
-        assert!(
-            FilterError::TaintNotEnabled("r".into())
-                .to_string()
-                .contains("Taint tracking not enabled")
-        );
-        assert!(FilterError::FilterDisabled.to_string().contains("disabled"));
-        assert!(
-            FilterError::FreeformNotEnabled
-                .to_string()
-                .contains("Freeform")
-        );
-    }
-
-    // ─── DegradationEngine ──────────────────────────────────────────────────
-
-    #[test]
-    fn degradation_full_path() {
-        let config = SecurityConfig {
-            pointer_mode: true,
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-
-        let (next, msg) = DegradationEngine::degrade(&config, &InputMode::Pointer).unwrap();
-        assert_eq!(next, InputMode::Filter);
-        assert!(msg.contains("Degrading to 'filter'"));
-
-        let (next2, _) = DegradationEngine::degrade(&config, &InputMode::Filter).unwrap();
-        assert_eq!(next2, InputMode::Traditional);
-
-        let err = DegradationEngine::degrade(&config, &InputMode::Traditional).unwrap_err();
-        assert_eq!(
-            err,
-            DegradationError::NoFallback {
-                current_mode: InputMode::Traditional
-            }
-        );
-    }
-
-    #[test]
-    fn degradation_skip_filter() {
-        let config = SecurityConfig {
-            pointer_mode: true,
-            degradation: vec![InputMode::Pointer, InputMode::Traditional],
-            ..SecurityConfig::default()
-        };
-
-        let (next, _) = DegradationEngine::degrade(&config, &InputMode::Pointer).unwrap();
-        assert_eq!(next, InputMode::Traditional);
-    }
-
-    #[test]
-    fn degradation_strict_single_mode() {
-        let config = SecurityConfig {
-            pointer_mode: true,
-            degradation: vec![InputMode::Pointer],
-            ..SecurityConfig::default()
-        };
-
-        let err = DegradationEngine::degrade(&config, &InputMode::Pointer).unwrap_err();
-        assert_eq!(
-            err,
-            DegradationError::NoFallback {
-                current_mode: InputMode::Pointer
-            }
-        );
-    }
-
-    #[test]
-    fn degradation_first_available() {
-        let config = SecurityConfig {
-            pointer_mode: true,
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-        assert_eq!(
-            DegradationEngine::first_available(&config),
-            Some(InputMode::Pointer)
-        );
-
-        let config2 = SecurityConfig {
-            degradation: vec![InputMode::Pointer, InputMode::Traditional],
-            ..SecurityConfig::default()
-        };
-        // pointer_mode is false, so first available is Traditional
-        assert_eq!(
-            DegradationEngine::first_available(&config2),
-            Some(InputMode::Traditional)
-        );
-    }
-
-    #[test]
-    fn degradation_validate_path() {
-        let config = SecurityConfig {
-            pointer_mode: false,
-            filter_mode: None,
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-        let unavailable = DegradationEngine::validate_path(&config);
-        assert!(unavailable.contains(&InputMode::Pointer));
-        assert!(unavailable.contains(&InputMode::Filter));
-        assert!(!unavailable.contains(&InputMode::Traditional));
-    }
-
-    #[test]
-    fn degradation_error_display() {
-        let err = DegradationError::NoFallback {
-            current_mode: InputMode::Pointer,
-        };
-        assert!(err.to_string().contains("no fallback"));
-
-        let err = DegradationError::AllModesExhausted;
-        assert!(err.to_string().contains("exhausted"));
-
-        let err = DegradationError::ModeError {
-            mode: InputMode::Filter,
-            message: "sub-agent failed".into(),
-        };
-        assert!(err.to_string().contains("sub-agent failed"));
+        assert!(gate.config().taint_tracking);
     }
 
     // ─── Policy-aware gate check ────────────────────────────────────────────
@@ -1543,256 +643,6 @@ mod tests {
         assert!(!decision2.is_allowed());
     }
 
-    // ─── Additional PointerResolver edge-case tests ────────────────────────
-
-    #[test]
-    fn pointer_resolve_offset_range_start_equals_end() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 1,
-            end: 1,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(
-            err,
-            PointerError::OffsetOutOfBounds {
-                region: "research".into(),
-                start: 1,
-                end: 1
-            }
-        );
-    }
-
-    #[test]
-    fn pointer_resolve_offset_range_start_greater_than_end() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 1,
-            end: 0,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(
-            err,
-            PointerError::OffsetOutOfBounds {
-                region: "research".into(),
-                start: 1,
-                end: 0
-            }
-        );
-    }
-
-    #[test]
-    fn pointer_resolve_offset_range_end_exceeds_len() {
-        let window = make_window_with_chunks();
-        // Window has 2 entries, so end=3 is out of bounds
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "research".into(),
-            start: 0,
-            end: 3,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(
-            err,
-            PointerError::OffsetOutOfBounds {
-                region: "research".into(),
-                start: 0,
-                end: 3
-            }
-        );
-    }
-
-    #[test]
-    fn pointer_resolve_offset_region_not_found() {
-        let window = make_window_with_chunks();
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "missing".into(),
-            start: 0,
-            end: 1,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(err, PointerError::RegionNotFound("missing".into()));
-    }
-
-    #[test]
-    fn pointer_resolve_offset_range_taint_not_enabled() {
-        let mut window = ContextWindow::new(10000);
-        let mut region = Region::new("data".to_string(), RegionKind::Temporary, 5000);
-        region.add_entry("entry1".to_string(), 10).unwrap();
-        region.add_entry("entry2".to_string(), 10).unwrap();
-        window.add_region(region);
-
-        let pointer = leviath_core::taint::PointerRef::OffsetRange {
-            region: "data".into(),
-            start: 0,
-            end: 1,
-        };
-        let err = PointerResolver::resolve(&window, &pointer).unwrap_err();
-        assert_eq!(err, PointerError::TaintNotEnabled("data".into()));
-    }
-
-    // ─── Additional FilterResolver tests ───────────────────────────────────
-
-    #[test]
-    fn filter_resolve_with_private_taint() {
-        let mut window = ContextWindow::new(10000);
-        let mut region =
-            Region::new("emails".to_string(), RegionKind::Temporary, 5000).with_taint_tracking();
-        region
-            .add_tainted_entry("email content".to_string(), 10, TaintLevel::Private)
-            .unwrap();
-        window.add_region(region);
-
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "emails".into(),
-            operation: leviath_core::taint::FilterOperation::Extract {
-                extract_type: "subject".into(),
-            },
-            output_format: Some("json".into()),
-        };
-
-        let result = FilterResolver::resolve(&window, &filter, &config).unwrap();
-        assert!(result.source_content.contains("email content"));
-        assert_eq!(result.taint_level, TaintLevel::Private);
-        assert_eq!(result.operation.name(), "extract");
-    }
-
-    #[test]
-    fn filter_resolve_with_mixed_taint_entries() {
-        let mut window = ContextWindow::new(10000);
-        let mut region =
-            Region::new("mixed".to_string(), RegionKind::Temporary, 5000).with_taint_tracking();
-        region
-            .add_tainted_entry("public data".to_string(), 5, TaintLevel::Public)
-            .unwrap();
-        region
-            .add_tainted_entry("internal data".to_string(), 5, TaintLevel::Internal)
-            .unwrap();
-        region
-            .add_tainted_entry("private data".to_string(), 5, TaintLevel::Private)
-            .unwrap();
-        window.add_region(region);
-
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "mixed".into(),
-            operation: leviath_core::taint::FilterOperation::Summarize,
-            output_format: None,
-        };
-
-        let result = FilterResolver::resolve(&window, &filter, &config).unwrap();
-        // Region taint should be max across entries
-        assert_eq!(result.taint_level, TaintLevel::Private);
-        assert!(result.source_content.contains("public data"));
-        assert!(result.source_content.contains("private data"));
-    }
-
-    #[test]
-    fn filter_resolve_with_freeform_mode() {
-        let mut window = ContextWindow::new(10000);
-        let mut region =
-            Region::new("data".to_string(), RegionKind::Temporary, 5000).with_taint_tracking();
-        region
-            .add_tainted_entry("content".to_string(), 5, TaintLevel::Public)
-            .unwrap();
-        window.add_region(region);
-
-        let config = SecurityConfig {
-            filter_mode: Some(leviath_core::FilterMode::Freeform),
-            ..SecurityConfig::default()
-        };
-        let filter = leviath_core::taint::FilterInput {
-            source_region: "data".into(),
-            operation: leviath_core::taint::FilterOperation::Custom {
-                name: "my_filter".into(),
-                params: Default::default(),
-            },
-            output_format: None,
-        };
-
-        let result = FilterResolver::resolve(&window, &filter, &config).unwrap();
-        assert_eq!(result.taint_level, TaintLevel::Public);
-        assert_eq!(result.operation.name(), "my_filter");
-    }
-
-    // ─── Additional DegradationEngine tests ────────────────────────────────
-
-    #[test]
-    fn degradation_empty_path() {
-        let config = SecurityConfig {
-            degradation: vec![],
-            ..SecurityConfig::default()
-        };
-        let err = DegradationEngine::degrade(&config, &InputMode::Traditional).unwrap_err();
-        assert_eq!(
-            err,
-            DegradationError::NoFallback {
-                current_mode: InputMode::Traditional
-            }
-        );
-    }
-
-    #[test]
-    fn degradation_first_available_empty_path() {
-        let config = SecurityConfig {
-            degradation: vec![],
-            ..SecurityConfig::default()
-        };
-        assert_eq!(DegradationEngine::first_available(&config), None);
-    }
-
-    #[test]
-    fn degradation_first_available_skips_unavailable() {
-        let config = SecurityConfig {
-            pointer_mode: false,
-            filter_mode: None,
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-        // Pointer and Filter are unavailable, so Traditional is first available
-        assert_eq!(
-            DegradationEngine::first_available(&config),
-            Some(InputMode::Traditional)
-        );
-    }
-
-    #[test]
-    fn degradation_validate_path_all_available() {
-        let config = SecurityConfig {
-            pointer_mode: true,
-            filter_mode: Some(leviath_core::FilterMode::Structured),
-            degradation: vec![
-                InputMode::Pointer,
-                InputMode::Filter,
-                InputMode::Traditional,
-            ],
-            ..SecurityConfig::default()
-        };
-        let unavailable = DegradationEngine::validate_path(&config);
-        assert!(unavailable.is_empty());
-    }
-
-    #[test]
-    fn degradation_validate_path_empty() {
-        let config = SecurityConfig {
-            degradation: vec![],
-            ..SecurityConfig::default()
-        };
-        assert!(DegradationEngine::validate_path(&config).is_empty());
-    }
-
     // ─── Additional TaintGate tests ────────────────────────────────────────
 
     #[test]
@@ -1814,31 +664,6 @@ mod tests {
     }
 
     #[test]
-    fn gate_pointer_mode_blocks_with_internal_taint() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_pointer("agent-1", "shell", TaintLevel::Private);
-        assert!(!decision.is_allowed());
-        // Pointer mode reports empty source regions.
-        assert_eq!(
-            decision,
-            GateDecision::Blocked {
-                taint_level: TaintLevel::Private,
-                clearance: TaintLevel::Public,
-                source_regions: vec![],
-                tool_name: "shell".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn gate_filter_mode_non_outbound_allows() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision =
-            gate.check_filter("agent-1", "read_file", TaintLevel::Private, "conversation");
-        assert!(decision.is_allowed());
-    }
-
-    #[test]
     fn gate_audit_log_records_blocked_events() {
         let mut gate = TaintGate::new(SecurityConfig::default());
         let window = make_window_with_taint(TaintLevel::Private);
@@ -1848,28 +673,11 @@ mod tests {
         assert!(!gate.audit_log()[0].allowed);
         assert_eq!(gate.audit_log()[0].tool_name, "shell");
         assert_eq!(gate.audit_log()[0].taint_level, TaintLevel::Private);
-        assert_eq!(gate.audit_log()[0].input_mode, InputMode::Traditional);
         // A clearance block is an automatic decision, not a user denial: the
         // user's choice (if any) is logged later by `apply_resolution`.
         assert_eq!(
             gate.audit_log()[0].decision_source,
             GateDecisionSource::AutoBlock,
-        );
-    }
-
-    #[test]
-    fn gate_check_filter_blocked_includes_source_region_name() {
-        let mut gate = TaintGate::new(SecurityConfig::default());
-        let decision = gate.check_filter("agent-1", "shell", TaintLevel::Internal, "emails");
-        assert!(!decision.is_allowed());
-        assert_eq!(
-            decision,
-            GateDecision::Blocked {
-                taint_level: TaintLevel::Internal,
-                clearance: TaintLevel::Public,
-                source_regions: vec!["emails".to_string()],
-                tool_name: "shell".to_string(),
-            }
         );
     }
 

--- a/crates/leviath-scripting/src/engine.rs
+++ b/crates/leviath-scripting/src/engine.rs
@@ -179,28 +179,6 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_modified() {
-        let engine = ScriptEngine::new();
-        let script = r#"
-            let modified = extract_modified(content);
-            modified.len() > 0
-        "#;
-        let content = "file1.txt\nmodified: file2.txt\nfile3.txt";
-        assert!(engine.validate(script, content).unwrap());
-    }
-
-    #[test]
-    fn test_summarize() {
-        let engine = ScriptEngine::new();
-        let script = r#"
-            let summary = summarize(content, 10);
-            summary.len() <= 50
-        "#;
-        let long_text = "a".repeat(1000);
-        assert!(engine.validate(script, &long_text).unwrap());
-    }
-
-    #[test]
     fn test_sandbox_limits() {
         let engine = ScriptEngine::new();
         // Test operation limit by creating an infinite loop

--- a/crates/leviath-scripting/src/functions.rs
+++ b/crates/leviath-scripting/src/functions.rs
@@ -57,34 +57,6 @@ pub fn register_functions(engine: &mut Engine) {
     });
 
     engine.register_fn("is_empty", |text: &str| -> bool { text.trim().is_empty() });
-
-    // Summarization placeholder (requires LLM provider, not available in scripting layer)
-    // Users should implement this at the application level
-    engine.register_fn("summarize", |text: &str, max_tokens: i64| -> String {
-        // Simple truncation as placeholder
-        let target_chars = (max_tokens * 4) as usize;
-        if text.len() <= target_chars {
-            text.to_string()
-        } else {
-            format!("{}...", &text[..target_chars])
-        }
-    });
-
-    // Extract modified files/content
-    // This is a placeholder - real implementation would parse structured data
-    engine.register_fn("extract_modified", |content: &str| -> rhai::Array {
-        // Look for lines starting with common markers
-        content
-            .lines()
-            .filter(|line| {
-                line.starts_with("modified:")
-                    || line.starts_with("changed:")
-                    || line.starts_with("updated:")
-                    || line.starts_with("M ")
-            })
-            .map(|line| rhai::Dynamic::from(line.to_string()))
-            .collect()
-    });
 }
 
 #[cfg(test)]
@@ -337,51 +309,5 @@ mod tests {
         let e = engine();
         let result: bool = e.eval(r#"is_empty("hi")"#).unwrap();
         assert!(!result);
-    }
-
-    // --- summarize ---
-
-    #[test]
-    fn summarize_short_text_unchanged() {
-        let e = engine();
-        let result: String = e.eval(r#"summarize("hello", 100)"#).unwrap();
-        assert_eq!(result, "hello");
-    }
-
-    #[test]
-    fn summarize_long_text_truncated() {
-        let e = engine();
-        // max_tokens=2 => target_chars=8, "hello world" is 11 chars => truncated
-        let result: String = e.eval(r#"summarize("hello world", 2)"#).unwrap();
-        assert!(result.ends_with("..."));
-        assert!(result.len() < "hello world".len() + 3);
-    }
-
-    // --- extract_modified ---
-
-    #[test]
-    fn extract_modified_finds_markers() {
-        let e = engine();
-        let result: rhai::Array = e
-            .eval(r#"extract_modified("modified: a.rs\nother line\nchanged: b.rs\nM c.rs")"#)
-            .unwrap();
-        assert_eq!(result.len(), 3);
-    }
-
-    #[test]
-    fn extract_modified_no_matches() {
-        let e = engine();
-        let result: rhai::Array = e
-            .eval(r#"extract_modified("no markers here\njust text")"#)
-            .unwrap();
-        assert_eq!(result.len(), 0);
-    }
-
-    #[test]
-    fn extract_modified_updated_marker() {
-        let e = engine();
-        let result: rhai::Array = e.eval(r#"extract_modified("updated: file.txt")"#).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].clone_cast::<String>(), "updated: file.txt");
     }
 }


### PR DESCRIPTION
Removes designed-but-unwired / unfinishable features we decided not to build (net **-1858 lines**), so the tree stops carrying and 100%-testing dead scaffolding.

- **Taint gate → traditional-only.** Only `check_traditional` was ever wired. Deletes `check_pointer`/`check_filter`/`clear_audit_log` + the `PointerResolver`/`FilterResolver`/`DegradationEngine` subsystems (runtime), `PointerRef`/`FilterInput`/`FilterOperation`/`FilterMode`/`InputMode` + `SecurityConfig.{pointer_mode,filter_mode,degradation}` + `mode_available`/`next_fallback` (core), the `GateEvent.input_mode` field, and their manifest parsing. The shipped traditional gate + interactive prompt + allowlist + Rhai rules are untouched.
- **Remove `ContentTransform::Custom`** (runtime has no scripting dep by design; no callers, no `.rhai` files). `Summarize` stays — a follow-up implements it for real.
- **Remove the dead Rhai `summarize`/`extract_modified` placeholders** (sandbox has no provider/async by design; zero callers).
- **README:** drop "(In Progress)" from the taint card.

All packages green at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)