### PR TITLE
feat: retry transient inference errors (closes #14)

### DIFF
--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -37,6 +37,46 @@ pub enum ProviderError {
     Other(String),
 }
 
+impl ProviderError {
+    /// Whether this failure is worth retrying — a transient network or
+    /// server-side issue (connection reset, timeout, 429, 5xx / "overloaded")
+    /// — as opposed to a permanent one (auth, invalid request, token limit)
+    /// that would just fail again.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            // Network-level failures: connection reset, timeout, DNS, TLS.
+            ProviderError::RequestFailed(_) => true,
+            // 429 — back off and retry.
+            ProviderError::RateLimitExceeded => true,
+            // We only have the message, so match the common server-side (5xx)
+            // signals — including Anthropic's 529 "overloaded". 4xx client
+            // errors carry none of these and stay permanent.
+            ProviderError::ApiError(msg) => {
+                let m = msg.to_ascii_lowercase();
+                [
+                    "500",
+                    "502",
+                    "503",
+                    "504",
+                    "529",
+                    "overloaded",
+                    "internal server error",
+                    "bad gateway",
+                    "service unavailable",
+                    "gateway timeout",
+                ]
+                .iter()
+                .any(|s| m.contains(s))
+            }
+            // A malformed response, an over-limit request, or an unknown error
+            // won't be fixed by retrying.
+            ProviderError::InvalidResponse(_)
+            | ProviderError::TokenLimitExceeded { .. }
+            | ProviderError::Other(_) => false,
+        }
+    }
+}
+
 /// Capabilities supported by a model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelCapabilities {
@@ -527,6 +567,24 @@ mod stream_once {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_error_is_transient_classification() {
+        // Network + rate-limit + 5xx / overloaded ⇒ retry.
+        assert!(ProviderError::RequestFailed("connection reset".into()).is_transient());
+        assert!(ProviderError::RateLimitExceeded.is_transient());
+        assert!(ProviderError::ApiError("HTTP 503 Service Unavailable".into()).is_transient());
+        assert!(ProviderError::ApiError("500 internal server error".into()).is_transient());
+        assert!(ProviderError::ApiError("529 overloaded".into()).is_transient());
+        assert!(ProviderError::ApiError("502 Bad Gateway".into()).is_transient());
+        assert!(ProviderError::ApiError("504 gateway timeout".into()).is_transient());
+        // 4xx client errors + malformed / limit / unknown ⇒ permanent.
+        assert!(!ProviderError::ApiError("401 unauthorized".into()).is_transient());
+        assert!(!ProviderError::ApiError("400 bad request".into()).is_transient());
+        assert!(!ProviderError::InvalidResponse("garbage".into()).is_transient());
+        assert!(!ProviderError::TokenLimitExceeded { used: 9, max: 8 }.is_transient());
+        assert!(!ProviderError::Other("mystery".into()).is_transient());
+    }
 
     // ─── ProviderError Display ──────────────────────────────────────────────
 

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -14,6 +14,7 @@
 //! one per agent — that is what keeps CPU bounded by work, not by agent count.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use bevy_ecs::entity::Entity;
 use leviath_providers::{InferenceRequest, InferenceResponse, Provider, ProviderError};
@@ -21,6 +22,30 @@ use tokio::sync::Notify;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::inference_pool::InferencePermit;
+
+/// How a transient inference failure is retried before the agent is failed.
+///
+/// Transient errors (see [`ProviderError::is_transient`]) are retried with
+/// exponential backoff; a permanent error (auth, invalid request, token limit)
+/// fails immediately. This keeps a passing network blip from marking a stage
+/// `error` and carrying its half-finished work forward.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    /// Total attempts including the first (e.g. `4` = one try + three retries).
+    pub max_attempts: u32,
+    /// Base backoff; the retry after attempt `n` waits `base_delay * 2^(n-1)`
+    /// (so 1s, 2s, 4s, … for a 1s base).
+    pub base_delay: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 4,
+            base_delay: Duration::from_secs(1),
+        }
+    }
+}
 
 /// A unit of inference work the dispatch system hands to the worker pool.
 pub struct InferenceJob {
@@ -54,6 +79,7 @@ pub async fn run_inference_job(
     job: InferenceJob,
     results: UnboundedSender<InferenceOutcome>,
     wake: Arc<Notify>,
+    retry: RetryPolicy,
 ) {
     let InferenceJob {
         entity,
@@ -61,7 +87,20 @@ pub async fn run_inference_job(
         request,
         permit,
     } = job;
-    let result = provider.infer(request).await;
+    // Retry transient failures (connection reset, timeout, 429, 5xx) with
+    // exponential backoff, holding the permit across the backoff; a permanent
+    // error fails immediately.
+    let mut attempt = 1u32;
+    let result = loop {
+        match provider.infer(request.clone()).await {
+            Ok(response) => break Ok(response),
+            Err(e) if e.is_transient() && attempt < retry.max_attempts => {
+                tokio::time::sleep(retry.base_delay * 2u32.pow(attempt - 1)).await;
+                attempt += 1;
+            }
+            Err(e) => break Err(e),
+        }
+    };
     drop(permit); // free the pool slot before the collect system runs
     let _ = results.send(InferenceOutcome { entity, result });
     wake.notify_one();
@@ -146,7 +185,13 @@ mod tests {
     async fn run_job_reports_ok_and_wakes() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let wake = Arc::new(Notify::new());
-        run_inference_job(job(Arc::new(Fixed::Ok(response("hi")))), tx, wake.clone()).await;
+        run_inference_job(
+            job(Arc::new(Fixed::Ok(response("hi")))),
+            tx,
+            wake.clone(),
+            RetryPolicy::default(),
+        )
+        .await;
 
         let outcome = rx.try_recv().expect("outcome sent");
         assert_eq!(outcome.entity, Entity::from_raw(7));
@@ -160,7 +205,7 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let wake = Arc::new(Notify::new());
         let err = Arc::new(Fixed::Err("boom".to_string()));
-        run_inference_job(job(err), tx, wake).await;
+        run_inference_job(job(err), tx, wake, RetryPolicy::default()).await;
 
         let outcome = rx.try_recv().expect("outcome sent");
         assert!(outcome.result.is_err());
@@ -183,6 +228,145 @@ mod tests {
         drop(rx); // world shutting down: nobody to receive
         let wake = Arc::new(Notify::new());
         // Must not panic even though the send fails.
-        run_inference_job(job(Arc::new(Fixed::Ok(response("x")))), tx, wake).await;
+        run_inference_job(
+            job(Arc::new(Fixed::Ok(response("x")))),
+            tx,
+            wake,
+            RetryPolicy::default(),
+        )
+        .await;
+    }
+
+    // ── retry behavior ──
+
+    enum Step {
+        Ok(String),
+        Transient,
+        Permanent,
+    }
+
+    /// A provider that plays a scripted sequence of results and counts calls.
+    struct Scripted {
+        steps: std::sync::Mutex<std::collections::VecDeque<Step>>,
+        calls: std::sync::Mutex<u32>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Scripted {
+        async fn infer(
+            &self,
+            _req: InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            *self.calls.lock().unwrap() += 1;
+            match self.steps.lock().unwrap().pop_front() {
+                Some(Step::Ok(t)) => Ok(response(&t)),
+                Some(Step::Transient) => Err(ProviderError::RateLimitExceeded),
+                Some(Step::Permanent) => Err(ProviderError::Other("permanent".to_string())),
+                None => Err(ProviderError::Other("exhausted".to_string())),
+            }
+        }
+        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            100_000
+        }
+        fn name(&self) -> &str {
+            "scripted"
+        }
+        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    fn no_delay(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            base_delay: Duration::ZERO,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_job_retries_transient_then_succeeds() {
+        let provider = Arc::new(Scripted {
+            steps: std::sync::Mutex::new(
+                vec![
+                    Step::Transient,
+                    Step::Transient,
+                    Step::Ok("done".to_string()),
+                ]
+                .into(),
+            ),
+            calls: std::sync::Mutex::new(0),
+        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            job(provider.clone()),
+            tx,
+            Arc::new(Notify::new()),
+            no_delay(4),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert_eq!(outcome.result.unwrap().content, "done");
+        assert_eq!(*provider.calls.lock().unwrap(), 3); // two retries then success
+    }
+
+    #[tokio::test]
+    async fn run_job_gives_up_after_max_attempts() {
+        let provider = Arc::new(Scripted {
+            steps: std::sync::Mutex::new(
+                vec![
+                    Step::Transient,
+                    Step::Transient,
+                    Step::Transient,
+                    Step::Transient,
+                ]
+                .into(),
+            ),
+            calls: std::sync::Mutex::new(0),
+        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            job(provider.clone()),
+            tx,
+            Arc::new(Notify::new()),
+            no_delay(3),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert!(outcome.result.is_err());
+        assert_eq!(*provider.calls.lock().unwrap(), 3); // exhausted the 3 attempts
+    }
+
+    #[tokio::test]
+    async fn run_job_does_not_retry_a_permanent_error() {
+        let provider = Arc::new(Scripted {
+            steps: std::sync::Mutex::new(vec![Step::Permanent, Step::Ok("x".to_string())].into()),
+            calls: std::sync::Mutex::new(0),
+        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            job(provider.clone()),
+            tx,
+            Arc::new(Notify::new()),
+            no_delay(4),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert!(outcome.result.is_err());
+        assert_eq!(*provider.calls.lock().unwrap(), 1); // no retry on a permanent error
+    }
+
+    #[test]
+    fn scripted_provider_metadata_is_exercised() {
+        let p = Scripted {
+            steps: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            calls: std::sync::Mutex::new(0),
+        };
+        assert_eq!(p.name(), "scripted");
+        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.max_context_tokens("m"), 100_000);
+        let _ = p.capabilities("m");
     }
 }

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -40,7 +40,7 @@ pub use components::{
     InferenceResult, MessageInbox, ParentRef, SubAgentChildren, ToolResultRoutingComponent,
 };
 pub use fanout::{FanOutSpawner, FanOutSpawnerRes, WorkItem, parse_work_items};
-pub use inference_bridge::{InferenceJob, InferenceOutcome, run_inference_job};
+pub use inference_bridge::{InferenceJob, InferenceOutcome, RetryPolicy, run_inference_job};
 pub use inference_pool::{InferencePermit, InferencePoolConfig, InferencePools};
 pub use provider_creds::{ProviderCreds, build_provider_registry};
 pub use providers::ProviderRegistry;

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -202,6 +202,7 @@ pub fn dispatch_inference(
                 job,
                 stage.outcomes.clone(),
                 stage.wake.clone(),
+                crate::inference_bridge::RetryPolicy::default(),
             ));
             par_commands.command_scope(|mut commands| {
                 commands
@@ -2603,6 +2604,7 @@ pub fn dispatch_transition_choice(
             job,
             stage.transition_outcomes.clone(),
             stage.wake.clone(),
+            crate::inference_bridge::RetryPolicy::default(),
         ));
         commands
             .entity(entity)


### PR DESCRIPTION
Closes #14. Transient API failures during a stage (connection reset, timeout, 429, 5xx) marked the stage `error` and transitioned along error edges — carrying half-finished work forward and skipping required regions the interrupted agent never filled. Retry them instead.

- **`ProviderError::is_transient()`** classifies retryable failures: `RequestFailed` (network), `RateLimitExceeded` (429), and `ApiError` whose message carries a 5xx / "overloaded" (529) signal. Auth/4xx, invalid response, token-limit, and unknown errors stay permanent.
- **`run_inference_job` takes a `RetryPolicy`** (default: 4 attempts, 1s/2s/4s exponential backoff) and retries transient failures with the pool permit held, failing immediately on a permanent error. Both inference dispatch sites (agent turn + transition-choice) pass the default.

Tests cover the classifier (every variant) and the retry loop (recover-after-retries, give-up-at-max, no-retry-on-permanent) with zero-delay policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)