### PR TITLE
fix(serve): require a bearer token on the API server

### DIFF
--- a/crates/leviath-cli/src/commands/serve/auth.rs
+++ b/crates/leviath-cli/src/commands/serve/auth.rs
@@ -1,0 +1,184 @@
+//! Bearer-token authentication for the API server.
+//!
+//! The API can spawn tool-/shell-executing agents, so it must never run
+//! unauthenticated. [`resolve_token`] refuses to start the server unless a token
+//! is configured (via `--token` or `LEVIATH_API_TOKEN`), and [`require_auth`] is
+//! a middleware that rejects any request without a matching token. Clients send
+//! it as `Authorization: Bearer <token>`; WebSocket clients (browsers can't set
+//! request headers on a WS upgrade) may instead pass `?token=<token>`.
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{StatusCode, header::AUTHORIZATION};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// Resolve the API token from `--token` (`arg`) or the `LEVIATH_API_TOKEN`
+/// environment variable. Returns an error — refusing to start — when neither is
+/// set, so an unauthenticated agent-spawning API can never be launched.
+pub(super) fn resolve_token(arg: Option<&str>) -> anyhow::Result<String> {
+    if let Some(t) = arg.map(str::trim).filter(|t| !t.is_empty()) {
+        return Ok(t.to_string());
+    }
+    if let Ok(env) = std::env::var("LEVIATH_API_TOKEN") {
+        let t = env.trim().to_string();
+        if !t.is_empty() {
+            return Ok(t);
+        }
+    }
+    anyhow::bail!(
+        "refusing to start an unauthenticated API server: it can spawn \
+         tool-executing agents. Set a token with `--token <token>` or the \
+         LEVIATH_API_TOKEN environment variable. Clients send it as \
+         `Authorization: Bearer <token>` (or `?token=<token>` for WebSockets)."
+    )
+}
+
+/// Constant-time string equality, so a wrong token can't be recovered by timing.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// The token a request presents: `Authorization: Bearer <token>`, else the
+/// `token` query parameter (for WebSocket clients that can't set headers).
+fn presented_token(req: &Request) -> Option<String> {
+    if let Some(bearer) = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+    {
+        return Some(bearer.trim().to_string());
+    }
+    req.uri()
+        .query()
+        .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("token=")))
+        .map(|t| t.to_string())
+}
+
+/// Middleware: allow the request through only when it presents the expected
+/// token; otherwise respond `401 Unauthorized`.
+pub(super) async fn require_auth(
+    State(expected): State<Arc<String>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    match presented_token(&req) {
+        Some(token) if constant_time_eq(&token, &expected) => next.run(req).await,
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            "unauthorized: missing or invalid API token",
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request as HttpRequest;
+
+    fn req(auth: Option<&str>, query: Option<&str>) -> Request {
+        let uri = match query {
+            Some(q) => format!("http://x/api/agents?{q}"),
+            None => "http://x/api/agents".to_string(),
+        };
+        let mut b = HttpRequest::builder().uri(uri);
+        if let Some(a) = auth {
+            b = b.header(AUTHORIZATION, a);
+        }
+        b.body(Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn resolve_token_prefers_arg_then_env_then_errors() {
+        assert_eq!(resolve_token(Some("from-arg")).unwrap(), "from-arg");
+        assert_eq!(resolve_token(Some("  spaced  ")).unwrap(), "spaced");
+        // Blank arg falls through to env.
+        temp_env::with_var("LEVIATH_API_TOKEN", Some("from-env"), || {
+            assert_eq!(resolve_token(Some("   ")).unwrap(), "from-env");
+            assert_eq!(resolve_token(None).unwrap(), "from-env");
+        });
+        // Blank env is treated as unset.
+        temp_env::with_var("LEVIATH_API_TOKEN", Some("  "), || {
+            assert!(resolve_token(None).is_err());
+        });
+        temp_env::with_var("LEVIATH_API_TOKEN", None::<&str>, || {
+            assert!(resolve_token(None).is_err());
+        });
+    }
+
+    #[test]
+    fn constant_time_eq_matches_std_equality() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd")); // length mismatch
+        assert!(constant_time_eq("", ""));
+    }
+
+    #[test]
+    fn presented_token_reads_header_then_query() {
+        assert_eq!(
+            presented_token(&req(Some("Bearer tok123"), None)).as_deref(),
+            Some("tok123")
+        );
+        // Non-bearer header ⇒ falls to query.
+        assert_eq!(
+            presented_token(&req(Some("Basic x"), Some("token=qtok"))).as_deref(),
+            Some("qtok")
+        );
+        assert_eq!(
+            presented_token(&req(None, Some("foo=1&token=qtok"))).as_deref(),
+            Some("qtok")
+        );
+        assert!(presented_token(&req(None, None)).is_none());
+        // A different key that ends in "token" isn't mistaken for it.
+        assert!(presented_token(&req(None, Some("mytoken=x"))).is_none());
+    }
+
+    #[tokio::test]
+    async fn require_auth_allows_valid_and_rejects_invalid() {
+        use axum::routing::get;
+        use axum::{Router, middleware};
+        use tower::ServiceExt;
+
+        let expected = Arc::new("secret".to_string());
+        let app: Router = Router::new()
+            .route("/api/agents", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(expected, require_auth));
+
+        // Valid bearer token ⇒ 200.
+        let ok = app
+            .clone()
+            .oneshot(req(Some("Bearer secret"), None))
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::OK);
+
+        // Valid via query param ⇒ 200.
+        let okq = app
+            .clone()
+            .oneshot(req(None, Some("token=secret")))
+            .await
+            .unwrap();
+        assert_eq!(okq.status(), StatusCode::OK);
+
+        // Missing token ⇒ 401.
+        let missing = app.clone().oneshot(req(None, None)).await.unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        // Wrong token ⇒ 401.
+        let wrong = app.oneshot(req(Some("Bearer nope"), None)).await.unwrap();
+        assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -4,6 +4,7 @@
 //! HTTP. No web UI — the frontend lives in a separate repo.
 
 mod agents;
+mod auth;
 mod blueprints;
 mod config;
 mod interactions;
@@ -72,6 +73,17 @@ async fn execute_with_shutdown(
     shutdown: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
     ready: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
 ) -> anyhow::Result<()> {
+    // Resolve the API token before binding — refuse to start unauthenticated.
+    let auth_token = std::sync::Arc::new(auth::resolve_token(args.token.as_deref())?);
+    // The API can spawn tool-executing agents; loudly warn if bound off-host.
+    if args.host != "127.0.0.1" && args.host != "localhost" && args.host != "::1" {
+        tracing::warn!(
+            host = %args.host,
+            "serving the agent API on a non-local address — anyone who can reach \
+             this host and holds the token can spawn agents"
+        );
+    }
+
     let cfg = Config::load()?;
     for warning in cfg.validate_keys() {
         tracing::warn!("{}", warning);
@@ -159,6 +171,12 @@ async fn execute_with_shutdown(
         // WebSocket
         .route("/ws", get(websocket::ws_global))
         .route("/ws/agents/{id}", get(websocket::ws_agent))
+        // Require a valid token on every route; CORS stays outermost so browser
+        // preflight (OPTIONS) is answered before the auth check.
+        .layer(axum::middleware::from_fn_with_state(
+            auth_token,
+            auth::require_auth,
+        ))
         .layer(cors)
         .with_state(state);
 
@@ -745,6 +763,7 @@ prompt = "Run"
             port: 3000,
             host: "127.0.0.1".to_string(),
             cors: "*".to_string(),
+            token: Some("test-token".to_string()),
         };
         assert_eq!(args.port, 3000);
         assert_eq!(args.host, "127.0.0.1");
@@ -839,6 +858,7 @@ prompt = "Run"
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     cors: "*".to_string(),
+                    token: Some("test-token".to_string()),
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(execute_with_shutdown(
@@ -856,7 +876,8 @@ prompt = "Run"
                 use tokio::io::{AsyncReadExt, AsyncWriteExt};
                 stream
                     .write_all(
-                        b"GET /api/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                        b"GET /api/config HTTP/1.1\r\nHost: localhost\r\n\
+                          Authorization: Bearer test-token\r\nConnection: close\r\n\r\n",
                     )
                     .await
                     .unwrap();
@@ -864,6 +885,21 @@ prompt = "Run"
                 stream.read_to_end(&mut resp).await.unwrap();
                 let resp_str = String::from_utf8_lossy(&resp);
                 assert_response_ok(&resp_str);
+
+                // Without the token the same request is rejected.
+                let mut unauth = tokio::net::TcpStream::connect(addr).await.unwrap();
+                unauth
+                    .write_all(
+                        b"GET /api/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+                let mut resp2 = Vec::new();
+                unauth.read_to_end(&mut resp2).await.unwrap();
+                assert!(
+                    String::from_utf8_lossy(&resp2).starts_with("HTTP/1.1 401"),
+                    "unauthenticated request should be 401"
+                );
 
                 handle.abort();
             },
@@ -880,6 +916,7 @@ prompt = "Run"
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     cors: "https://example.com".to_string(),
+                    token: Some("test-token".to_string()),
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(execute_with_shutdown(
@@ -907,6 +944,7 @@ prompt = "Run"
             port: 0,
             host: "not a valid host".to_string(),
             cors: "*".to_string(),
+            token: Some("test-token".to_string()),
         };
         let result = execute(args, no_daemon_control()).await;
         assert!(result.is_err());
@@ -937,6 +975,7 @@ prompt = "Run"
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     cors: "*".to_string(),
+                    token: Some("test-token".to_string()),
                 };
                 let result = execute(args, no_daemon_control()).await;
                 assert_execute_failed_on_malformed_config(&result);
@@ -963,6 +1002,7 @@ prompt = "Run"
             port: 0,
             host: "127.0.0.1".to_string(),
             cors: "*".to_string(),
+            token: Some("test-token".to_string()),
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1005,9 +1045,26 @@ prompt = "Run"
             port: 8080,
             host: "192.0.2.1".to_string(),
             cors: "*".to_string(),
+            token: Some("test-token".to_string()),
         };
         let result = execute(args, no_daemon_control()).await;
         assert_execute_failed_on_port_in_use(&result);
+    }
+
+    #[tokio::test]
+    async fn execute_refuses_to_start_without_a_token() {
+        // No --token and no LEVIATH_API_TOKEN ⇒ the server won't start.
+        temp_env::async_with_vars([("LEVIATH_API_TOKEN", None::<&str>)], async {
+            let args = ServeArgs {
+                port: 0,
+                host: "127.0.0.1".to_string(),
+                cors: "*".to_string(),
+                token: None,
+            };
+            let result = execute(args, no_daemon_control()).await;
+            assert!(result.is_err(), "must refuse to start unauthenticated");
+        })
+        .await;
     }
 
     /// Covers `axum::serve(...).await?` Ok path (lines 117, 119) by running
@@ -1021,6 +1078,7 @@ prompt = "Run"
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     cors: "*".to_string(),
+                    token: Some("test-token".to_string()),
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1065,6 +1123,7 @@ prompt = "Run"
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     cors: "*".to_string(),
+                    token: Some("test-token".to_string()),
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -25,6 +25,12 @@ pub struct ServeArgs {
     /// Allow CORS from origin (default: *)
     #[arg(long, default_value = "*")]
     pub cors: String,
+
+    /// API token clients must present (`Authorization: Bearer <token>`, or
+    /// `?token=` for WebSockets). Overrides the LEVIATH_API_TOKEN env var; the
+    /// server refuses to start if neither is set.
+    #[arg(long)]
+    pub token: Option<String>,
 }
 
 // ─── Shared state ────────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -263,6 +263,7 @@ mod tests {
             port: 0,
             host: "127.0.0.1".to_string(),
             cors: "*".to_string(),
+            token: Some("test-token".to_string()),
         };
         let result = dispatch(Commands::Serve(args), &MockRisky).await;
         assert!(result.is_ok());


### PR DESCRIPTION
**v1 blocker (1 of 2).** `lev serve` was fully unauthenticated — anyone reaching the port could `POST /api/agents` to spawn a tool-executing agent, or CRUD blueprints on disk; with CORS `*`, a visited web page could hit those routes.

- Refuses to start without a token (`--token` / `LEVIATH_API_TOKEN`) — secure by default, no auto-generated secret.
- `require_auth` middleware rejects requests lacking a matching token (401, constant-time compare). `Authorization: Bearer <token>`, or `?token=` for WebSockets. CORS stays outermost so preflight works. Warns on non-local bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)