### PR TITLE
fix(providers): deliver system prompts + tool history on OpenAI-compat APIs

### DIFF
--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -153,16 +153,10 @@ impl OllamaProvider {
 
     /// Build request body for the Ollama API.
     fn build_request_body(&self, request: &InferenceRequest) -> serde_json::Value {
-        let messages: Vec<serde_json::Value> = request
-            .messages
-            .iter()
-            .map(|msg| {
-                serde_json::json!({
-                    "role": msg.role,
-                    "content": msg.content,
-                })
-            })
-            .collect();
+        // System blocks prepended + tool_use/tool_result history converted to
+        // OpenAI format (Ollama speaks the OpenAI chat shape). Previously the
+        // system prompt was dropped and blocks were serialized as raw JSON.
+        let messages = crate::openai_compat::openai_messages(request);
 
         let caps = self.capabilities(&request.model);
         let options = if caps.supports_temperature {
@@ -933,6 +927,84 @@ mod tests {
         let temp = body["options"]["temperature"].as_f64().unwrap();
         assert!((temp - 0.8).abs() < 0.001);
         assert_eq!(body["options"]["num_predict"], 512);
+    }
+
+    #[test]
+    fn test_build_request_body_prepends_system_blocks() {
+        let provider = OllamaProvider::new();
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "You are a local assistant.".to_string(),
+                cache_hint: leviath_core::CacheHint::Never,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: "llama3-8b".to_string(),
+            max_tokens: 512,
+            temperature: 0.8,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        // The system block is delivered as the first message rather than dropped.
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "You are a local assistant.");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn test_build_request_body_serializes_tool_history() {
+        let provider = OllamaProvider::new();
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![
+                crate::provider::Message {
+                    role: "assistant".to_string(),
+                    content: crate::provider::MessageContent::Blocks(vec![
+                        crate::provider::ContentBlock::ToolUse {
+                            id: "call_1".to_string(),
+                            name: "list_files".to_string(),
+                            input: serde_json::json!({ "dir": "." }),
+                        },
+                    ]),
+                    cache_breakpoint: false,
+                },
+                crate::provider::Message {
+                    role: "user".to_string(),
+                    content: crate::provider::MessageContent::Blocks(vec![
+                        crate::provider::ContentBlock::ToolResult {
+                            tool_use_id: "call_1".to_string(),
+                            content: "a.txt\nb.txt".to_string(),
+                            is_error: false,
+                        },
+                    ]),
+                    cache_breakpoint: false,
+                },
+            ],
+            model: "llama3-8b".to_string(),
+            max_tokens: 512,
+            temperature: 0.8,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        // Tool call round-trips as an assistant `tool_calls` message …
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(
+            messages[0]["tool_calls"][0]["function"]["name"],
+            "list_files"
+        );
+        // … and the result as a `tool`-role message, not raw block JSON.
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(messages[1]["content"], "a.txt\nb.txt");
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -83,97 +83,92 @@ pub async fn send_chat_request(
 }
 
 /// Build the JSON request body for the OpenAI Chat Completions API.
-pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Value {
-    let mut messages: Vec<serde_json::Value> = Vec::new();
+/// Convert one message's content into one or more OpenAI-format messages. A
+/// [`MessageContent::Blocks`] message carrying tool calls/results expands to
+/// several (an assistant `tool_calls` message, or one `tool`-role message per
+/// result), so tool history round-trips correctly on OpenAI-compatible APIs
+/// instead of being serialized raw in Anthropic block form.
+pub fn message_to_openai(role: &str, content: &MessageContent) -> Vec<serde_json::Value> {
+    match content {
+        MessageContent::Text(text) => {
+            vec![serde_json::json!({ "role": role, "content": text })]
+        }
+        MessageContent::Blocks(blocks) => {
+            let text_parts: Vec<&str> = blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            let tool_results: Vec<(&str, &str)> = blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => Some((tool_use_id.as_str(), content.as_str())),
+                    _ => None,
+                })
+                .collect();
+            let tool_calls: Vec<serde_json::Value> = blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::ToolUse { id, name, input } => Some(serde_json::json!({
+                        "id": id,
+                        "type": "function",
+                        "function": { "name": name, "arguments": input.to_string() }
+                    })),
+                    _ => None,
+                })
+                .collect();
 
-    // Prepend system blocks as system-role messages
-    for block in &request.system {
-        messages.push(serde_json::json!({
-            "role": "system",
-            "content": block.text,
-        }));
-    }
-
-    // Convert conversation messages to OpenAI format
-    for msg in &request.messages {
-        match &msg.content {
-            MessageContent::Text(text) => {
-                messages.push(serde_json::json!({
-                    "role": msg.role,
-                    "content": text,
-                }));
-            }
-            MessageContent::Blocks(blocks) => {
-                // Separate text, tool_use, and tool_result blocks
-                let text_parts: Vec<&str> = blocks
+            if !tool_calls.is_empty() {
+                let content = text_parts.join("");
+                let mut msg_json = serde_json::json!({
+                    "role": "assistant",
+                    "tool_calls": tool_calls,
+                });
+                if !content.is_empty() {
+                    msg_json["content"] = serde_json::Value::String(content);
+                }
+                vec![msg_json]
+            } else if !tool_results.is_empty() {
+                tool_results
                     .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::Text { text } => Some(text.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                // Extract (tool_use_id, content) directly; the filter_map's
-                // `None` arm also runs for non-ToolResult blocks, so there is
-                // no unreachable match arm.
-                let tool_results: Vec<(&str, &str)> = blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::ToolResult {
-                            tool_use_id,
-                            content,
-                            ..
-                        } => Some((tool_use_id.as_str(), content.as_str())),
-                        _ => None,
-                    })
-                    .collect();
-                // Build OpenAI tool_calls directly from the ToolUse blocks. The
-                // filter_map's `None` arm also runs for non-ToolUse blocks, so
-                // there is no unreachable match arm.
-                let tool_calls: Vec<serde_json::Value> = blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::ToolUse { id, name, input } => Some(serde_json::json!({
-                            "id": id,
-                            "type": "function",
-                            "function": {
-                                "name": name,
-                                "arguments": input.to_string(),
-                            }
-                        })),
-                        _ => None,
-                    })
-                    .collect();
-
-                if !tool_calls.is_empty() {
-                    // Assistant message with tool calls
-                    let content = text_parts.join("");
-                    let mut msg_json = serde_json::json!({
-                        "role": "assistant",
-                        "tool_calls": tool_calls,
-                    });
-                    if !content.is_empty() {
-                        msg_json["content"] = serde_json::Value::String(content);
-                    }
-                    messages.push(msg_json);
-                } else if !tool_results.is_empty() {
-                    // Each tool result becomes a separate "tool" role message
-                    for (tool_use_id, content) in &tool_results {
-                        messages.push(serde_json::json!({
+                    .map(|(tool_use_id, content)| {
+                        serde_json::json!({
                             "role": "tool",
                             "tool_call_id": tool_use_id,
                             "content": content,
-                        }));
-                    }
-                } else {
-                    // Text-only blocks
-                    messages.push(serde_json::json!({
-                        "role": msg.role,
-                        "content": text_parts.join(""),
-                    }));
-                }
+                        })
+                    })
+                    .collect()
+            } else {
+                vec![serde_json::json!({ "role": role, "content": text_parts.join("") })]
             }
         }
     }
+}
+
+/// The full OpenAI-format message array for a request: `request.system` blocks
+/// prepended as `system`-role messages, then each conversation message
+/// converted via [`message_to_openai`]. Reused by every OpenAI-compatible
+/// provider so system prompts and tool history are handled uniformly.
+pub fn openai_messages(request: &InferenceRequest) -> Vec<serde_json::Value> {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    for block in &request.system {
+        messages.push(serde_json::json!({ "role": "system", "content": block.text }));
+    }
+    for msg in &request.messages {
+        messages.extend(message_to_openai(&msg.role, &msg.content));
+    }
+    messages
+}
+
+pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Value {
+    let messages = openai_messages(request);
 
     let mut body = serde_json::json!({
         "model": request.model,

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -82,28 +82,37 @@ impl OpenRouterProvider {
         let is_anthropic = request.model.contains("claude");
         let mut breakpoint_count = 0usize;
 
-        let messages: Vec<serde_json::Value> = request
-            .messages
-            .iter()
-            .map(|msg| {
-                if is_anthropic && msg.cache_breakpoint && breakpoint_count < 4 {
+        let mut messages: Vec<serde_json::Value> = Vec::new();
+        // System blocks first (previously dropped).
+        for block in &request.system {
+            messages.push(serde_json::json!({ "role": "system", "content": block.text }));
+        }
+        for msg in &request.messages {
+            match &msg.content {
+                // A cache-breakpointed text turn (Anthropic-via-OpenRouter) keeps
+                // its ephemeral cache_control wrapper.
+                crate::provider::MessageContent::Text(text)
+                    if is_anthropic && msg.cache_breakpoint && breakpoint_count < 4 =>
+                {
                     breakpoint_count += 1;
-                    serde_json::json!({
+                    messages.push(serde_json::json!({
                         "role": msg.role,
                         "content": [{
                             "type": "text",
-                            "text": msg.content,
+                            "text": text,
                             "cache_control": { "type": "ephemeral" }
                         }],
-                    })
-                } else {
-                    serde_json::json!({
-                        "role": msg.role,
-                        "content": msg.content,
-                    })
+                    }));
                 }
-            })
-            .collect();
+                // Everything else — including tool_use/tool_result block history —
+                // goes through the OpenAI-format conversion so it round-trips on
+                // non-Anthropic models instead of being sent as raw block JSON.
+                _ => messages.extend(crate::openai_compat::message_to_openai(
+                    &msg.role,
+                    &msg.content,
+                )),
+            }
+        }
 
         let caps = self.capabilities(&request.model);
         let mut body = if caps.supports_temperature {
@@ -223,8 +232,11 @@ impl Provider for OpenRouterProvider {
         text.len() / 4
     }
 
-    fn max_context_tokens(&self, _model: &str) -> usize {
-        128_000
+    fn max_context_tokens(&self, model: &str) -> usize {
+        // Delegate to the per-model capabilities table rather than a flat 128K,
+        // which badly under-budgeted large-context models (Llama-4 ~10M, several
+        // ~1M) and over-budgeted small ones.
+        self.capabilities(model).max_context_tokens
     }
 
     fn name(&self) -> &str {
@@ -496,6 +508,86 @@ mod tests {
         assert_eq!(body["model"], "anthropic/claude-sonnet-4");
     }
 
+    #[test]
+    fn test_build_request_body_prepends_system_blocks() {
+        let provider = OpenRouterProvider::new("test-key".to_string());
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "You are a helpful assistant.".to_string(),
+                cache_hint: leviath_core::CacheHint::Never,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "openai/gpt-4o".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        // System block is delivered as the first message, not dropped.
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "You are a helpful assistant.");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_build_request_body_serializes_tool_history() {
+        let provider = OpenRouterProvider::new("test-key".to_string());
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![
+                crate::provider::Message {
+                    role: "assistant".to_string(),
+                    content: crate::provider::MessageContent::Blocks(vec![
+                        crate::provider::ContentBlock::ToolUse {
+                            id: "call_1".to_string(),
+                            name: "get_weather".to_string(),
+                            input: serde_json::json!({ "city": "Paris" }),
+                        },
+                    ]),
+                    cache_breakpoint: false,
+                },
+                crate::provider::Message {
+                    role: "user".to_string(),
+                    content: crate::provider::MessageContent::Blocks(vec![
+                        crate::provider::ContentBlock::ToolResult {
+                            tool_use_id: "call_1".to_string(),
+                            content: "sunny".to_string(),
+                            is_error: false,
+                        },
+                    ]),
+                    cache_breakpoint: false,
+                },
+            ],
+            model: "openai/gpt-4o".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+        };
+
+        let body = provider.build_request_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        // Tool call → assistant message with an OpenAI `tool_calls` array.
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(
+            messages[0]["tool_calls"][0]["function"]["name"],
+            "get_weather"
+        );
+        // Tool result → a `tool`-role message keyed by the call id.
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(messages[1]["content"], "sunny");
+    }
+
     // ── Additional coverage tests ──────────────────────────────────────────
 
     #[test]
@@ -520,7 +612,17 @@ mod tests {
     #[test]
     fn test_max_context_tokens() {
         let provider = OpenRouterProvider::new("key".to_string());
+        // Unknown model ⇒ the conservative fallback.
         assert_eq!(provider.max_context_tokens("any-model"), 128_000);
+        // A known large-context model reports its real size (not a flat 128K) —
+        // it now delegates to the per-model capabilities table.
+        assert_eq!(
+            provider.max_context_tokens("meta-llama/llama-4-scout"),
+            provider
+                .capabilities("meta-llama/llama-4-scout")
+                .max_context_tokens
+        );
+        assert!(provider.max_context_tokens("meta-llama/llama-4-scout") > 128_000);
     }
 
     #[test]

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -54,6 +54,12 @@ impl ProviderError {
             ProviderError::ApiError(msg) => {
                 let m = msg.to_ascii_lowercase();
                 [
+                    // Rate limiting (a provider that maps 429 to ApiError rather
+                    // than RateLimitExceeded, e.g. Ollama).
+                    "429",
+                    "too many requests",
+                    "rate limit",
+                    // Server-side 5xx (and Anthropic's 529 "overloaded").
                     "500",
                     "502",
                     "503",
@@ -574,6 +580,8 @@ mod tests {
         assert!(ProviderError::RequestFailed("connection reset".into()).is_transient());
         assert!(ProviderError::RateLimitExceeded.is_transient());
         assert!(ProviderError::ApiError("HTTP 503 Service Unavailable".into()).is_transient());
+        assert!(ProviderError::ApiError("HTTP 429 Too Many Requests".into()).is_transient());
+        assert!(ProviderError::ApiError("rate limit exceeded".into()).is_transient());
         assert!(ProviderError::ApiError("500 internal server error".into()).is_transient());
         assert!(ProviderError::ApiError("529 overloaded".into()).is_transient());
         assert!(ProviderError::ApiError("502 Bad Gateway".into()).is_transient());


### PR DESCRIPTION
## What

Fixes two request-construction gaps in the OpenRouter and Ollama providers that made them unusable for real agent loops, plus two smaller correctness fixes.

### System prompt was dropped
Both providers ignored `request.system` entirely — the agent's system prompt never reached the model. They now prepend system blocks as `system`-role messages.

### Tool history was malformed
Both serialized `MessageContent::Blocks` as raw Anthropic-tagged JSON (`{"type":"tool_use",...}`) inside a `content` string, which OpenAI-shaped backends can't parse. Multi-turn tool conversations were broken.

Extracted `message_to_openai` / `openai_messages` in `openai_compat` (the logic already lived in `build_openai_request_body`) and reuse them from both providers:
- tool calls → an assistant `tool_calls` array
- each tool result → a `tool`-role message keyed by `tool_call_id`
- OpenRouter preserves its per-turn ephemeral `cache_control` wrapper for Anthropic text turns (prompt caching unaffected).

### Smaller fixes
- `ProviderError::is_transient()` now classifies `429` / `too many requests` / `rate limit` API errors as transient (they were being treated as fatal, so rate limits weren't retried).
- OpenRouter `max_context_tokens` now derives from the per-model capabilities table instead of a hardcoded `128_000` (large-context models like Llama 4 Scout were being truncated).

## Tests
Added system-prompt-delivery and multi-turn tool-history serialization tests to both `openrouter` and `ollama`; updated the `is_transient` and OpenRouter `max_context_tokens` tests. `cargo test -p leviath-providers` green (484 passing). Coverage verified via CI (local macOS under-reports these files — the documented multi-instantiation phantom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)