### PR TITLE
fix(cli): honor agent-level tool permissions + add bounded [limits] defaults

### DIFF
--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -88,6 +88,47 @@ pub struct Config {
     /// opts *in* by setting `taint_tracking = true` in its own `[security]`.
     #[serde(default)]
     pub taint_tracking: bool,
+
+    /// Runtime resource limits (inference concurrency + iteration caps).
+    #[serde(default)]
+    pub limits: LimitsConfig,
+}
+
+fn default_max_concurrent_inferences() -> Option<usize> {
+    Some(8)
+}
+
+fn default_default_max_iterations() -> Option<usize> {
+    Some(50)
+}
+
+/// Runtime resource limits with safe defaults baked in.
+///
+/// Both fields default to a bounded value so a fresh install can't accidentally
+/// run unbounded inference concurrency or an unbounded agent loop. Set a field
+/// explicitly in `[limits]` to raise or lower it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LimitsConfig {
+    /// Global fallback cap on concurrent inference requests for any model
+    /// without its own per-model pool entry. Defaults to `Some(8)`; omit or set
+    /// a large number to effectively unbound it.
+    #[serde(default = "default_max_concurrent_inferences")]
+    pub max_concurrent_inferences: Option<usize>,
+
+    /// Fallback `max_iterations` applied to a stage that does not set its own,
+    /// so an agent can't loop forever with no completion signal. Defaults to
+    /// `Some(50)`. A stage's explicit `max_iterations` always wins.
+    #[serde(default = "default_default_max_iterations")]
+    pub default_max_iterations: Option<usize>,
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_inferences: default_max_concurrent_inferences(),
+            default_max_iterations: default_default_max_iterations(),
+        }
+    }
 }
 
 /// Provider configuration.
@@ -123,6 +164,7 @@ impl Default for Config {
             title: TitleConfig::default(),
             request_timeout_secs: None,
             taint_tracking: false,
+            limits: LimitsConfig::default(),
         }
     }
 }
@@ -540,6 +582,50 @@ mod tests {
         std::fs::write(&path, toml::to_string_pretty(&original).unwrap()).unwrap();
         let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
         assert_eq!(config.default_provider, "openai");
+    }
+
+    #[test]
+    fn limits_default_to_bounded_values() {
+        let limits = LimitsConfig::default();
+        assert_eq!(limits.max_concurrent_inferences, Some(8));
+        assert_eq!(limits.default_max_iterations, Some(50));
+        // And the top-level Config carries the same defaults.
+        assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
+    }
+
+    /// A valid full config-file body with the `[limits]` section removed, so
+    /// tests can simulate a config written before the section existed (robust to
+    /// unrelated fields being added). `[limits]` serializes as the final section.
+    #[cfg(test)]
+    fn config_toml_without_limits() -> String {
+        let full = toml::to_string_pretty(&Config::default()).unwrap();
+        format!("{}\n", full.split("[limits]").next().unwrap().trim_end())
+    }
+
+    #[test]
+    fn limits_absent_section_uses_defaults() {
+        // A config file with no `[limits]` table still gets the bounded defaults.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, config_toml_without_limits()).unwrap();
+        let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
+        assert_eq!(config.limits.max_concurrent_inferences, Some(8));
+        assert_eq!(config.limits.default_max_iterations, Some(50));
+    }
+
+    #[test]
+    fn limits_partial_section_fills_the_other_default() {
+        // Setting only one field leaves the other at its per-field serde default.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let body = format!(
+            "{}\n[limits]\nmax_concurrent_inferences = 3\n",
+            config_toml_without_limits()
+        );
+        std::fs::write(&path, body).unwrap();
+        let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
+        assert_eq!(config.limits.max_concurrent_inferences, Some(3));
+        assert_eq!(config.limits.default_max_iterations, Some(50));
     }
 
     #[test]
@@ -1448,12 +1534,18 @@ anthropic_api_key = "sk-ant-test-key"
             },
             request_timeout_secs: None,
             taint_tracking: false,
+            limits: LimitsConfig {
+                max_concurrent_inferences: Some(4),
+                default_max_iterations: Some(99),
+            },
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
 
         assert_eq!(deserialized.default_provider, "anthropic");
+        assert_eq!(deserialized.limits.max_concurrent_inferences, Some(4));
+        assert_eq!(deserialized.limits.default_max_iterations, Some(99));
         assert_eq!(
             deserialized.providers.anthropic_api_key.as_deref(),
             Some("sk-ant-key")

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -109,10 +109,15 @@ pub fn build_host(
 ) -> WorldHost {
     let hub = InteractionHub::new();
     let tool_service = Arc::new(CliToolService::new());
+    // The configured global fallback bounds concurrent inference for any model
+    // without its own per-model pool entry (defaults to a small cap so a fresh
+    // install can't fan out unbounded requests against provider rate limits).
+    let pool_config =
+        InferencePoolConfig::new().with_default(config.limits.max_concurrent_inferences);
     let mut world = PipelineWorld::new(
         providers,
         tool_service.clone(),
-        InferencePoolConfig::new(),
+        pool_config,
         runs_dir.clone(),
         runtime,
     );

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -153,6 +153,7 @@ fn build_tool_state(
     entry_stage: &str,
     entry_index: usize,
     stage_perms_by_index: Vec<HashMap<String, String>>,
+    agent_perms: HashMap<String, String>,
     launch_overrides: HashMap<String, crate::config::ToolPolicy>,
     subagent: Option<SubAgentHandle>,
 ) -> Arc<AgentToolState> {
@@ -168,7 +169,7 @@ fn build_tool_state(
         session_allows: Arc::new(Mutex::new(HashSet::new())),
         stage_perms: Arc::new(StdMutex::new(entry_perms)),
         stage_perms_by_index: Arc::new(stage_perms_by_index),
-        agent_perms: Arc::new(HashMap::new()),
+        agent_perms: Arc::new(agent_perms),
         global_perms: Arc::new(config.tool_permissions.clone()),
         interaction: hub.backend_for(run_id),
         stage_name: Arc::new(StdMutex::new(entry_stage.to_string())),
@@ -203,6 +204,15 @@ pub fn build_agent(
     // A request-level `--max-depth` overrides the blueprint's sub-agent depth cap.
     if let Some(md) = args.max_depth {
         blueprint.max_child_depth = Some(md);
+    }
+    // Apply the config's `default_max_iterations` to any stage that doesn't set
+    // its own, so an agent can't loop forever with no completion signal
+    // (`enforce_max_iterations` treats `None`/0 as unbounded). A stage's explicit
+    // `max_iterations` always wins.
+    if let Some(default_max) = config.limits.default_max_iterations {
+        for stage in &mut blueprint.stages {
+            stage.max_iterations.get_or_insert(default_max);
+        }
     }
 
     // 2. Per-agent built-in tools (over the agent's workdir).
@@ -268,6 +278,11 @@ pub fn build_agent(
         .iter()
         .position(|s| s.name == entry_stage)
         .unwrap_or(0);
+    // Agent-level tool permissions (the manifest's top-level `[tool_permissions]`,
+    // recorded in blueprint metadata). Populates the tool state's agent-level
+    // policy layer (between stage and global in `resolve_policy`), which was
+    // previously always empty.
+    let agent_perms = blueprint.agent_tool_permissions();
     let model_label = stages
         .first()
         .map(|s| format!("{}/{}", s.provider_name, s.model));
@@ -346,6 +361,7 @@ pub fn build_agent(
         &entry_stage,
         entry_index,
         stage_perms_by_index,
+        agent_perms,
         launch_overrides,
         Some(subagent),
     );
@@ -708,6 +724,150 @@ mod tests {
         )()
         .await;
         assert!(!out[0].1.contains("[denied]"));
+    }
+
+    #[tokio::test]
+    async fn build_agent_honors_agent_level_tool_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        // A top-level `[tool_permissions]` block denying a builtin — no stage
+        // perms, no launch overrides, no global config deny. Only the agent-level
+        // layer can produce the deny, so this proves it is wired through.
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"perm\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [tool_permissions]\nread_file = \"deny\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let out = leviath_runtime::pipeline::ToolService::exec_for(
+            cli.as_ref(),
+            entity,
+            vec![leviath_providers::ToolCall {
+                id: "c1".to_string(),
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({"path": "/no/such/file"}),
+            }],
+        )()
+        .await;
+        assert!(
+            out[0].1.contains("[denied]"),
+            "agent-level deny should block read_file"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_agent_applies_default_max_iterations_only_when_stage_omits_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        // Two stages: one omits max_iterations, one sets it explicitly to 3.
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"iters\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [stages.capped]\nmax_iterations = 3\n\
+             model = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        // A non-default cap so the assertion can't accidentally match the built-in.
+        let config = Config {
+            limits: crate::config::LimitsConfig {
+                default_max_iterations: Some(42),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &config,
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let bp = world
+            .world()
+            .get::<leviath_runtime::pipeline::AgentBlueprint>(entity)
+            .expect("blueprint");
+        let by_name = |n: &str| {
+            bp.0.stages
+                .iter()
+                .find(|s| s.name == n)
+                .unwrap()
+                .max_iterations
+        };
+        // The stage that omitted it inherits the config default …
+        assert_eq!(by_name("main"), Some(42));
+        // … while an explicit per-stage cap is left untouched.
+        assert_eq!(by_name("capped"), Some(3));
+    }
+
+    #[tokio::test]
+    async fn build_agent_leaves_max_iterations_unset_when_config_default_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"nolimit\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        // `None` disables the config default entirely — the stage stays uncapped.
+        let config = Config {
+            limits: crate::config::LimitsConfig {
+                default_max_iterations: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &config,
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let bp = world
+            .world()
+            .get::<leviath_runtime::pipeline::AgentBlueprint>(entity)
+            .expect("blueprint");
+        assert_eq!(bp.0.stages[0].max_iterations, None);
     }
 
     #[tokio::test]

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -90,6 +90,24 @@ impl Blueprint {
         }
     }
 
+    /// Agent-level tool permissions, keyed by tool name.
+    ///
+    /// The manifest parser records a top-level `[tool_permissions]` block as
+    /// `tool_perm:<tool>` → policy-string entries in [`Self::metadata`]. This
+    /// projects them back into a tool-keyed map for the runtime's agent-level
+    /// permission layer. Non-`tool_perm:` keys and non-string values are ignored.
+    pub fn agent_tool_permissions(&self) -> HashMap<String, String> {
+        self.metadata
+            .iter()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.strip_prefix("tool_perm:")?.to_string(),
+                    v.as_str()?.to_string(),
+                ))
+            })
+            .collect()
+    }
+
     /// Add tool filters to this blueprint.
     pub fn with_tools(mut self, tools: Vec<ToolFilter>) -> Self {
         self.tools = tools;
@@ -1049,6 +1067,29 @@ mod tests {
         assert_eq!(bp.tools.len(), 1);
         assert_eq!(bp.transforms.len(), 1);
         assert_eq!(bp.version, "2.0.0");
+    }
+
+    #[test]
+    fn agent_tool_permissions_projects_only_string_tool_perm_entries() {
+        let stages = vec![Stage::new("plan".to_string(), make_model())];
+        let mut bp = Blueprint::new("t".into(), "d".into(), stages, make_layout());
+        // A well-formed tool_perm string entry — included.
+        bp.metadata.insert(
+            "tool_perm:bash".to_string(),
+            serde_json::Value::String("deny".to_string()),
+        );
+        // A non-`tool_perm:` key — skipped (strip_prefix returns None).
+        bp.metadata
+            .insert("title".to_string(), serde_json::Value::String("x".into()));
+        // A tool_perm key whose value isn't a string — skipped (as_str is None).
+        bp.metadata
+            .insert("tool_perm:weird".to_string(), serde_json::Value::Bool(true));
+
+        let perms = bp.agent_tool_permissions();
+        assert_eq!(perms.get("bash").map(String::as_str), Some("deny"));
+        assert!(!perms.contains_key("title"));
+        assert!(!perms.contains_key("weird"));
+        assert_eq!(perms.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What

Three v1 correctness gaps in how a spawned agent's limits are resolved.

### Agent-level `[tool_permissions]` were ignored
A manifest's top-level `[tool_permissions]` block is parsed into blueprint metadata (`tool_perm:<tool>` entries), but `build_tool_state` hardcoded an **empty** `agent_perms` map — so those permissions silently did nothing. Stage-level `[stages.x.tool_permissions]` *were* honored, an easy-to-miss asymmetry (e.g. a parallel-fixer relying on an agent-level `read_files = "allow"` would fall through to `Ask`).

Fix: add `Blueprint::agent_tool_permissions()` in `leviath-core` (projects the `tool_perm:<tool>` metadata back into a tool-keyed map; non-`tool_perm` keys and non-string values ignored) and feed it into the tool state's agent-level policy layer. Precedence is unchanged: launch → stage → **agent** → global → built-in default.

The extraction lives in core so all three branches (match, non-prefixed key, non-string value) are unit-testable by direct `Blueprint` construction — the manifest only ever produces string `tool_perm` entries, so doing it inline in `spawn.rs` would have left dead, uncoverable branches.

### Unbounded inference concurrency + unbounded agent loops
New `[limits]` config section with bounded defaults so a fresh install is safe:

```toml
[limits]
max_concurrent_inferences = 8   # global fallback pool cap (was unbounded)
default_max_iterations = 50      # applied to any stage that omits its own cap
```

- `max_concurrent_inferences` → the world's `InferencePoolConfig` default in `daemon/setup.rs`.
- `default_max_iterations` → applied in `build_agent` to any stage without an explicit `max_iterations` (which `enforce_max_iterations` otherwise treats as uncapped → infinite loop). An explicit per-stage value always wins.

Both fields have per-field serde defaults, so an existing config file with no `[limits]` section — or a partial one — still gets the bounded values.

## Tests
- leviath-core: `agent_tool_permissions_projects_only_string_tool_perm_entries` (all three branches).
- leviath-cli: agent-level deny is enforced end-to-end via `exec_for`; `default_max_iterations` applied only when a stage omits it (and left `None` when the config default is `None`); `[limits]` defaults present/absent/partial round-trip.
- `cargo xtask coverage --package leviath-core` and `--package leviath-cli` both 100%. Full `cargo test -p leviath-core -p leviath-cli` green; clippy + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)