### PR TITLE
feat(daemon): persist the sub-agent tree so restart rebuilds it exactly

### DIFF
--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -43,9 +43,9 @@ pub fn reload_persisted_agents(
     now_secs: i64,
     subagent_tx: &UnboundedSender<SubAgentOp>,
 ) -> Vec<(String, Entity)> {
-    let mut restored = Vec::new();
+    let mut reloaded: Vec<(RunMeta, Entity)> = Vec::new();
     let Ok(dir_entries) = std::fs::read_dir(runs_dir) else {
-        return restored; // no runs dir yet — nothing to recover
+        return Vec::new(); // no runs dir yet — nothing to recover
     };
     for dir_entry in dir_entries.flatten() {
         let run_dir = dir_entry.path();
@@ -67,13 +67,72 @@ pub fn reload_persisted_agents(
             now_secs,
             subagent_tx,
         ) {
-            Ok(entity) => restored.push((meta.run_id.clone(), entity)),
+            Ok(entity) => reloaded.push((meta, entity)),
             Err(e) => {
                 tracing::warn!(run_id = %meta.run_id, error = %e, "skipping un-reloadable run");
             }
         }
     }
-    restored
+    // Second pass: every run is now an entity, so rebuild the parent→children
+    // tree deterministically from the persisted links (no heuristics).
+    relink_tree(world, &reloaded);
+    reloaded
+        .into_iter()
+        .map(|(meta, entity)| (meta.run_id, entity))
+        .collect()
+}
+
+/// Rebuild `ParentRef` / `SubAgentChildren` on the freshly reloaded entities from
+/// their persisted `parent_run_id` / `children` links, so a restarted daemon
+/// resumes the exact sub-agent tree (a waiting parent holds for its children;
+/// children aren't orphaned). Links whose counterpart didn't reload are logged
+/// and skipped. Idempotent: existing components are overwritten, not duplicated.
+fn relink_tree(world: &mut PipelineWorld, reloaded: &[(RunMeta, Entity)]) {
+    use leviath_runtime::components::{AgentState, ParentRef, SubAgentChildren};
+
+    let by_run_id: std::collections::HashMap<&str, Entity> = reloaded
+        .iter()
+        .map(|(m, e)| (m.run_id.as_str(), *e))
+        .collect();
+    let w = world.world_mut();
+    for (meta, entity) in reloaded {
+        // Child → parent edge.
+        if let Some(parent_id) = &meta.parent_run_id {
+            match by_run_id.get(parent_id.as_str()) {
+                Some(&parent_entity) => {
+                    w.entity_mut(*entity).insert(ParentRef {
+                        parent_entity,
+                        parent_agent_id: parent_id.clone(),
+                        depth: meta.depth,
+                    });
+                }
+                None => tracing::warn!(
+                    run_id = %meta.run_id, parent = %parent_id,
+                    "parent run did not reload; leaving child unlinked"
+                ),
+            }
+        }
+        // Parent → children edge (skip any child that didn't reload).
+        if !meta.children.is_empty() {
+            let children: Vec<Entity> = meta
+                .children
+                .iter()
+                .filter_map(|cid| by_run_id.get(cid.as_str()).copied())
+                .collect();
+            if !children.is_empty() {
+                w.entity_mut(*entity).insert(SubAgentChildren {
+                    children,
+                    max_child_depth: meta.max_child_depth,
+                });
+            }
+            // Keep the serializable child list consistent with the rebuilt
+            // component so the next snapshot re-persists the same tree. A reloaded
+            // agent always carries `AgentState`.
+            w.get_mut::<AgentState>(*entity)
+                .expect("a reloaded agent always has AgentState")
+                .spawned_children_ids = meta.children.clone();
+        }
+    }
 }
 
 /// Read + parse `<run_dir>/meta.json`, returning `None` if it is missing or
@@ -240,6 +299,33 @@ mod tests {
         status: RunStatus,
         context: Option<&ContextSnapshot>,
     ) {
+        write_run_tree(
+            runs_dir,
+            run_id,
+            agent_path,
+            status,
+            context,
+            None,
+            &[],
+            0,
+            0,
+        );
+    }
+
+    /// Like [`write_run`], but with explicit tree links so recovery's re-linking
+    /// pass can be exercised.
+    #[allow(clippy::too_many_arguments)]
+    fn write_run_tree(
+        runs_dir: &Path,
+        run_id: &str,
+        agent_path: &str,
+        status: RunStatus,
+        context: Option<&ContextSnapshot>,
+        parent_run_id: Option<&str>,
+        children: &[&str],
+        depth: usize,
+        max_child_depth: usize,
+    ) {
         let dir = runs_dir.join(run_id);
         std::fs::create_dir_all(&dir).unwrap();
         let meta = RunMeta {
@@ -266,7 +352,10 @@ mod tests {
             title: Some("Resume Me".to_string()),
             metadata: std::collections::HashMap::new(),
             callback_url: Some("http://cb".to_string()),
-            parent_run_id: None,
+            parent_run_id: parent_run_id.map(str::to_string),
+            children: children.iter().map(|s| s.to_string()).collect(),
+            depth,
+            max_child_depth,
         };
         std::fs::write(dir.join("meta.json"), serde_json::to_string(&meta).unwrap()).unwrap();
         if let Some(ctx) = context {
@@ -352,6 +441,174 @@ mod tests {
         let totals = world.world().get::<TokenTotals>(*entity).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
+    }
+
+    #[tokio::test]
+    async fn rebuilds_parent_child_tree_on_reload() {
+        use leviath_runtime::components::{ParentRef, SubAgentChildren};
+
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+
+        // A parent with two children + a child that records its parent + depth.
+        write_run_tree(
+            runs.path(),
+            "parent",
+            mpath,
+            RunStatus::WaitingInput,
+            None,
+            None,
+            &["child-a", "child-b"],
+            0,
+            4,
+        );
+        write_run_tree(
+            runs.path(),
+            "child-a",
+            mpath,
+            RunStatus::Running,
+            None,
+            Some("parent"),
+            &[],
+            1,
+            0,
+        );
+        write_run_tree(
+            runs.path(),
+            "child-b",
+            mpath,
+            RunStatus::Running,
+            None,
+            Some("parent"),
+            &[],
+            1,
+            0,
+        );
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+        assert_eq!(restored.len(), 3);
+        let by_id: std::collections::HashMap<_, _> =
+            restored.iter().map(|(r, e)| (r.clone(), *e)).collect();
+        let parent = by_id["parent"];
+        let child_a = by_id["child-a"];
+        let child_b = by_id["child-b"];
+
+        // Parent's SubAgentChildren rebuilt with both children + the depth cap.
+        let kids = world.world().get::<SubAgentChildren>(parent).unwrap();
+        assert_eq!(kids.max_child_depth, 4);
+        assert_eq!(kids.children.len(), 2);
+        assert!(kids.children.contains(&child_a) && kids.children.contains(&child_b));
+        // Each child's ParentRef points back at the parent, at its stored depth.
+        let pr = world.world().get::<ParentRef>(child_a).unwrap();
+        assert_eq!(pr.parent_entity, parent);
+        assert_eq!(pr.parent_agent_id, "parent");
+        assert_eq!(pr.depth, 1);
+        // The serializable child list is kept in sync for the next snapshot.
+        let state = world
+            .world()
+            .get::<leviath_runtime::components::AgentState>(parent)
+            .unwrap();
+        assert_eq!(state.spawned_children_ids, vec!["child-a", "child-b"]);
+    }
+
+    #[tokio::test]
+    async fn relink_skips_children_and_parents_that_did_not_reload() {
+        use leviath_runtime::components::{ParentRef, SubAgentChildren};
+
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+
+        // Parent lists a child that is terminal (won't reload) → no SubAgentChildren.
+        write_run_tree(
+            runs.path(),
+            "lonely-parent",
+            mpath,
+            RunStatus::WaitingInput,
+            None,
+            None,
+            &["gone-child"],
+            0,
+            2,
+        );
+        write_run_tree(
+            runs.path(),
+            "gone-child",
+            mpath,
+            RunStatus::Complete, // terminal → skipped by recovery
+            None,
+            Some("lonely-parent"),
+            &[],
+            1,
+            0,
+        );
+        // Child whose parent is terminal (won't reload) → left unlinked.
+        write_run_tree(
+            runs.path(),
+            "orphan",
+            mpath,
+            RunStatus::Running,
+            None,
+            Some("gone-parent"),
+            &[],
+            1,
+            0,
+        );
+        write_run_tree(
+            runs.path(),
+            "gone-parent",
+            mpath,
+            RunStatus::Error,
+            None,
+            None,
+            &["orphan"],
+            0,
+            2,
+        );
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+        // Only the two non-terminal runs reload.
+        assert_eq!(restored.len(), 2);
+        let by_id: std::collections::HashMap<_, _> =
+            restored.iter().map(|(r, e)| (r.clone(), *e)).collect();
+        // Parent listed a child that didn't reload → no SubAgentChildren attached.
+        assert!(
+            world
+                .world()
+                .get::<SubAgentChildren>(by_id["lonely-parent"])
+                .is_none()
+        );
+        // Orphan's parent didn't reload → no ParentRef attached.
+        assert!(world.world().get::<ParentRef>(by_id["orphan"]).is_none());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -414,6 +414,9 @@ mod tests {
             metadata: Default::default(),
             callback_url: None,
             parent_run_id: None,
+            children: Vec::new(),
+            depth: 0,
+            max_child_depth: 0,
         };
         std::fs::write(
             run_dir.join("meta.json"),

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -85,6 +85,19 @@ pub struct RunMeta {
     /// Links sub-agent runs to their parent run.
     #[serde(default)]
     pub parent_run_id: Option<String>,
+    /// Run-ids of this agent's direct sub-agents (sub-agent-tool spawns and
+    /// fan-out workers). Persisted so the daemon can rebuild the exact
+    /// parent→children tree on restart rather than reload children as orphans.
+    #[serde(default)]
+    pub children: Vec<String>,
+    /// This agent's depth in the sub-agent tree (0 for a top-level run).
+    /// Persisted so a reloaded child enforces its remaining spawn-depth budget.
+    #[serde(default)]
+    pub depth: usize,
+    /// The sub-agent depth cap this agent imposes on its own children
+    /// (0 when it has none). Restores `SubAgentChildren::max_child_depth`.
+    #[serde(default)]
+    pub max_child_depth: usize,
 }
 
 impl RunMeta {
@@ -123,6 +136,9 @@ impl RunMeta {
             metadata: HashMap::new(),
             callback_url: None,
             parent_run_id: None,
+            children: Vec::new(),
+            depth: 0,
+            max_child_depth: 0,
         }
     }
 
@@ -271,6 +287,9 @@ mod tests {
         assert!(m.metadata.is_empty());
         assert!(m.callback_url.is_none());
         assert!(m.parent_run_id.is_none());
+        assert!(m.children.is_empty());
+        assert_eq!(m.depth, 0);
+        assert_eq!(m.max_child_depth, 0);
         assert!(m.current_stage.is_empty());
         assert_eq!(m.started_at, m.updated_at);
     }
@@ -289,12 +308,23 @@ mod tests {
         m.status = RunStatus::Running;
         m.metadata.insert("k".to_string(), "v".to_string());
         m.title = Some("A title".to_string());
+        m.parent_run_id = Some("parent-1".to_string());
+        m.children = vec!["child-a".to_string(), "child-b".to_string()];
+        m.depth = 2;
+        m.max_child_depth = 5;
         let json = serde_json::to_string(&m).unwrap();
         let back: RunMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(back.run_id, m.run_id);
         assert_eq!(back.status, RunStatus::Running);
         assert_eq!(back.metadata.get("k").map(String::as_str), Some("v"));
         assert_eq!(back.title.as_deref(), Some("A title"));
+        assert_eq!(back.parent_run_id.as_deref(), Some("parent-1"));
+        assert_eq!(
+            back.children,
+            vec!["child-a".to_string(), "child-b".to_string()]
+        );
+        assert_eq!(back.depth, 2);
+        assert_eq!(back.max_child_depth, 5);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -283,6 +283,19 @@ fn start_worker(
             });
         }
     }
+    // Record the worker's run-id on the parent's serializable state so the tree
+    // (fan-out workers included) is persisted for a deterministic restart rebuild.
+    // A freshly spawned worker always has run metadata; its parent always has state.
+    let worker_id = world
+        .get::<crate::persistence::RunMetadata>(child)
+        .expect("a fan-out worker always has run metadata")
+        .run_id
+        .clone();
+    world
+        .get_mut::<AgentState>(parent)
+        .expect("a fan-out parent always has AgentState")
+        .spawned_children_ids
+        .push(worker_id);
     // Seed the worker's context from the parent per any declared blueprint
     // context transform (when a fan-out worker runs a different blueprint).
     crate::context_transform::apply_context_transforms(world, parent, child);
@@ -394,15 +407,33 @@ mod tests {
                 return Err(format!("spawn refused for '{item_id}'"));
             }
             Ok(world
-                .spawn(AgentState {
-                    agent_id: format!("worker-{item_id}"),
-                    current_stage: "w".to_string(),
-                    iteration: 0,
-                    status: AgentStatus::Active,
-                    spawned_children_ids: vec![],
-                    pending_wait: None,
-                    accepts_messages: true,
-                })
+                .spawn((
+                    AgentState {
+                        agent_id: format!("worker-{item_id}"),
+                        current_stage: "w".to_string(),
+                        iteration: 0,
+                        status: AgentStatus::Active,
+                        spawned_children_ids: vec![],
+                        pending_wait: None,
+                        accepts_messages: true,
+                    },
+                    // A real worker carries run metadata (attached by build_agent);
+                    // mirror that so the parent can record the worker's run-id.
+                    crate::persistence::RunMetadata {
+                        run_id: format!("run-{item_id}"),
+                        agent_name: "worker".to_string(),
+                        agent_path: String::new(),
+                        task: String::new(),
+                        model: None,
+                        workdir: String::new(),
+                        num_stages: 1,
+                        started_at: 0,
+                        parent_run_id: None,
+                        metadata: std::collections::HashMap::new(),
+                        callback_url: None,
+                        title: None,
+                    },
+                ))
                 .id())
         }
     }

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -614,6 +614,14 @@ impl WorldHost {
                 });
             }
         }
+        // Record the child's run-id on the parent's serializable state so the
+        // tree is persisted (and restart can rebuild `SubAgentChildren`). A
+        // spawning parent always carries `AgentState`.
+        world
+            .get_mut::<crate::components::AgentState>(parent)
+            .expect("a spawning parent always has AgentState")
+            .spawned_children_ids
+            .push(run_id.clone());
         // Seed the child's context from the parent per any declared blueprint
         // context transform (planner→coder region mapping, etc.).
         crate::context_transform::apply_context_transforms(world, parent, child);

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -149,6 +149,8 @@ pub fn build_run_meta(
     totals: &TokenTotals,
     stage_index: usize,
     now_secs: i64,
+    depth: usize,
+    max_child_depth: usize,
 ) -> RunMeta {
     RunMeta {
         run_id: md.run_id.clone(),
@@ -178,6 +180,10 @@ pub fn build_run_meta(
         metadata: md.metadata.clone(),
         callback_url: md.callback_url.clone(),
         parent_run_id: md.parent_run_id.clone(),
+        // The tree links, so restart can rebuild the exact parent→children graph.
+        children: state.spawned_children_ids.clone(),
+        depth,
+        max_child_depth,
     }
 }
 
@@ -302,7 +308,9 @@ mod tests {
             cache_write_tokens: 5,
             tool_calls: 7,
         };
-        let meta = build_run_meta(&md, &state(AgentStatus::Active), &totals, 1, 2000);
+        let mut st = state(AgentStatus::Active);
+        st.spawned_children_ids = vec!["child-a".to_string(), "child-b".to_string()];
+        let meta = build_run_meta(&md, &st, &totals, 1, 2000, 1, 4);
 
         assert_eq!(meta.run_id, "run-1");
         assert_eq!(meta.status, RunStatus::Running);
@@ -314,6 +322,13 @@ mod tests {
         assert_eq!(meta.updated_at, 2000);
         assert_eq!(meta.parent_run_id.as_deref(), Some("parent"));
         assert!(meta.error.is_none());
+        // The tree links are carried through from the agent's live state.
+        assert_eq!(
+            meta.children,
+            vec!["child-a".to_string(), "child-b".to_string()]
+        );
+        assert_eq!(meta.depth, 1);
+        assert_eq!(meta.max_child_depth, 4);
     }
 
     #[test]
@@ -326,6 +341,8 @@ mod tests {
             &TokenTotals::default(),
             2,
             3000,
+            0,
+            0,
         );
         assert_eq!(meta.status, RunStatus::Error);
         assert_eq!(meta.error.as_deref(), Some("boom"));

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -1465,11 +1465,24 @@ pub fn dispatch_persistence(
         Option<&mut StageLedger>,
         Option<&mut StageIoBuffer>,
         Option<&crate::taint::TaintGate>,
+        Option<&crate::components::ParentRef>,
+        Option<&crate::components::SubAgentChildren>,
     )>,
     stage: Res<PersistenceStage>,
 ) {
-    for (md, state, window, cursor, totals, mut watermark, mut ledger, buffer, taint_gate) in
-        agents.iter_mut()
+    for (
+        md,
+        state,
+        window,
+        cursor,
+        totals,
+        mut watermark,
+        mut ledger,
+        buffer,
+        taint_gate,
+        parent_ref,
+        children,
+    ) in agents.iter_mut()
     {
         let now = chrono::Utc::now().timestamp();
 
@@ -1499,7 +1512,10 @@ pub fn dispatch_persistence(
             watermark.last = Some(current);
         }
 
-        let meta = build_run_meta(md, state, totals, cursor.index, now);
+        // Tree links, for a deterministic restart-time rebuild of the graph.
+        let depth = parent_ref.map(|p| p.depth).unwrap_or(0);
+        let max_child_depth = children.map(|c| c.max_child_depth).unwrap_or(0);
+        let meta = build_run_meta(md, state, totals, cursor.index, now, depth, max_child_depth);
         let context = build_context_snapshot(window, &state.current_stage);
         let stages = ledger.as_deref().map(|l| l.0.clone()).unwrap_or_default();
         // Persist the taint gate's audit log (per-stage) when it has events, so
@@ -3305,6 +3321,40 @@ mod tests {
         assert_eq!(job.log_appends, vec![(0, "[tool] x: y".to_string())]);
         // The buffer was drained in place.
         assert!(world.get::<StageIoBuffer>(e).unwrap().output.is_empty());
+    }
+
+    #[test]
+    fn dispatch_persistence_records_tree_links() {
+        use crate::components::{ParentRef, SubAgentChildren};
+        let (mut world, mut rx) = world_with_persistence();
+        let child = world.spawn_empty().id();
+        let mut state = agent_state();
+        state.spawned_children_ids = vec!["kid-1".to_string()];
+        world.spawn((
+            run_metadata(),
+            state,
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            ParentRef {
+                parent_entity: child,
+                parent_agent_id: "p".to_string(),
+                depth: 3,
+            },
+            SubAgentChildren {
+                children: vec![child],
+                max_child_depth: 6,
+            },
+        ));
+
+        run_dispatch_persistence(&mut world);
+
+        let job = rx.try_recv().expect("job sent");
+        // The persisted meta carries the tree links for a deterministic restore.
+        assert_eq!(job.meta.children, vec!["kid-1".to_string()]);
+        assert_eq!(job.meta.depth, 3);
+        assert_eq!(job.meta.max_child_depth, 6);
     }
 
     #[test]

--- a/docs/design/agent-paging.md
+++ b/docs/design/agent-paging.md
@@ -1,0 +1,108 @@
+# Agent paging + deterministic tree persistence
+
+Status: **proposed** (v1). Author: daemon-lifecycle work, 2026-07.
+
+## Problem
+
+The daemon is one `PipelineWorld` hosting every agent. Two lifecycle gaps make
+it unfit for a long-running v1 daemon:
+
+1. **Sub-agent trees are lost on restart.** Only a child's `parent_run_id`
+   string is persisted. The ECS links (`ParentRef`, `SubAgentChildren`,
+   `FanOutWaiting`) are never rebuilt on reload, so a reloaded parent proceeds
+   as if its children finished (the `requires_children` gate is a no-op without
+   `SubAgentChildren`), and children reload as orphan roots whose results are
+   never collected. Fan-out parents never resume their split/merge.
+
+2. **Terminal agents are never reaped.** `WorldHost::by_run_id` / `emitted` /
+   `emitted_interactions` and the ECS entities themselves grow monotonically —
+   nothing is ever despawned in production. A daemon that runs for days leaks
+   every agent it has ever run.
+
+## Direction (from product owner)
+
+- The parent↔child relationship must be **deterministically stored**, not
+  reconstructed by heuristic. Restore rebuilds the exact tree from disk.
+- An agent should live **in memory only while it is actively being processed or
+  viewed**. When it is quiescent (terminal, or idle/waiting with no imminent
+  work) its state lives in a file and it is **unloaded**; it is **reloaded on
+  demand** when something needs it (a view request, an inbound message, a child
+  completing that its parent must observe).
+
+This is demand-paging for agents. The existing persistence (`meta.json` +
+`context.json`) and recovery (`recovery::reload_one` = `build_agent` +
+`restore_agent`) are already a working "load from disk" path — reused as the
+page-in mechanism. Unload is its inverse: flush, despawn, erase host maps.
+
+## Phasing
+
+### Phase A — deterministic tree persistence + exact restore
+
+Make the tree a stored fact and rebuild it precisely on startup recovery.
+
+**Persist** (new `meta.json` fields on `RunMeta`, all `#[serde(default)]` so old
+runs load):
+- `children: Vec<String>` — the run-ids of this agent's direct sub-agents.
+- `depth: usize` — this agent's depth in the tree (0 for a root).
+- `max_child_depth: usize` — the sub-agent depth cap carried on
+  `SubAgentChildren`.
+
+Populated from live components at snapshot time: `children` from the parent's
+`SubAgentChildren` (each child entity → its `RunMetadata.run_id`); `depth` /
+`max_child_depth` from the agent's `ParentRef` / `SubAgentChildren`. (Equivalent
+alternative: populate `AgentState.spawned_children_ids` — currently a dead
+always-empty field — at `spawn_child` / fan-out `start_worker`, and copy it into
+`RunMeta.children` in `build_run_meta`.)
+
+**Restore** (two-pass in `recovery`):
+1. Reload every persisted agent (existing loop), building `run_id → Entity`.
+2. Re-link: for each child with a `parent_run_id` present in the map, insert
+   `ParentRef { parent_entity, parent_agent_id, depth }`; for each parent,
+   rebuild `SubAgentChildren { children, max_child_depth }` from its persisted
+   `children`. A `parent_run_id` / child whose counterpart is absent is logged
+   and left unlinked (never silently proceeds as "done").
+
+**Fan-out** (`FanOutWaiting` is not serializable): persist a serializable
+`FanOutState { pending, active_run_ids, summaries, failures, merge_stage }` and
+rebuild `FanOutWaiting` after run-ids are mapped to entities, so an interrupted
+split/merge resumes deterministically. (May land as A2 if A1 ships the
+sub-agent-tool tree first.)
+
+Outcome: no orphans, no silent-proceed, no heuristics — restart resumes the
+exact tree.
+
+### Phase B — unload terminal agents + reload-on-demand
+
+- When an agent is terminal (`Complete`/`Error`/`Cancelled`), its final snapshot
+  is flushed and its terminal state has been emitted once, **unload** it:
+  `world.despawn(entity)` and erase its `by_run_id` / `emitted` /
+  `emitted_interactions` entries. Disk history is untouched.
+- Any host operation that targets a run-id not in `by_run_id` (a dashboard/API
+  view, a `send_message`, a `cancel`) first **pages it in** via `reload_one`
+  from disk, then proceeds. A miss that isn't on disk is a genuine 404.
+- A parent waiting on children must be paged in when a child terminal event
+  needs to wake it — the Phase-A tree links tell us which parent to reload.
+
+Outcome: memory is bounded by the number of *active/viewed* agents, not the
+total ever run.
+
+### Phase C (fast-follow) — page out idle/waiting agents
+
+Extend unload to non-terminal but quiescent agents (parked on a human
+interaction, or a parent blocked on long-running children): flush + despawn, and
+page back in on the waking event (interaction response, child completion,
+inbound message). This realizes "in memory only while actively processed or
+viewed" fully. Deferred from the v1 cut so Phases A/B can land and bound memory
+first.
+
+## Invariants / risks
+
+- **Never lose the merge.** A parent must not transition past `requires_children`
+  or a fan-out merge unless its children's results are accounted for — enforced
+  by rebuilding the gate components before the schedule runs post-recovery.
+- **Unload ordering.** A child may only be reaped once no live ancestor still
+  queries it (parent terminal, or past its wait). Reaping walks `ParentRef`.
+- **Page-in races.** Reload-on-demand must be serialized against the tick loop
+  (host owns the world; page-in happens between ticks, like spawn/reload today).
+- **Idempotent restore.** Re-linking checks for existing components so a
+  double-recovery can't duplicate children.


### PR DESCRIPTION
## What

A restarted daemon reloaded every persisted agent as an independent root. The ECS tree links (`ParentRef`, `SubAgentChildren`) were never rebuilt, so:
- a waiting parent proceeded **as if its children had finished** (the `requires_children` gate is a no-op without `SubAgentChildren`), and
- children reloaded as **orphan roots** whose results were never collected back into the parent.

This makes the parent↔child relationship a **deterministically stored fact** and rebuilds the exact tree on restart — no heuristics.

## How

- **Persist the links** in `meta.json` (all `#[serde(default)]`, so pre-existing runs load unchanged):
  - `children` — direct sub-agent run-ids
  - `depth` — this agent's depth in the tree
  - `max_child_depth` — the depth cap it imposes on its children
- **Populate** `AgentState.spawned_children_ids` (previously a dead, always-empty field) at both spawn sites — host `spawn_child` and fan-out `start_worker` — and copy it into the snapshot in `build_run_meta` (with `depth`/`max_child_depth` read from the live `ParentRef`/`SubAgentChildren` in `dispatch_persistence`).
- **Restore** with a second recovery pass: once every run is mapped to an entity, rebuild `ParentRef` + `SubAgentChildren` from the persisted links. A link whose counterpart didn't reload (e.g. a terminal child) is logged and skipped — never silently treated as "done". Re-linking is idempotent.

## Scope / follow-up

Fan-out's `FanOutWaiting` merge state is not serializable; this PR restores the sub-agent tree and stops orphaning fan-out workers (so `cancel_tree` and re-linking work), but a parent interrupted **mid-split** does not yet resume its merge. That, plus terminal-agent unloading and full demand-paging, is captured in the new `docs/design/agent-paging.md` (Phases A2 / B / C).

## Tests
- `run_meta` round-trip covers the new fields; `build_run_meta` and `dispatch_persistence` carry the tree links (new `dispatch_persistence_records_tree_links`).
- Recovery: `rebuilds_parent_child_tree_on_reload` (full parent + two children) and `relink_skips_children_and_parents_that_did_not_reload` (both missing-counterpart branches).
- Fan-out test spawner now attaches `RunMetadata` to workers, mirroring production.
- leviath-core + leviath-cli at 100% local coverage; clippy + rustdoc clean; full `cargo test -p leviath-runtime` green. Runtime whole-file coverage verified on CI (local macOS under-reports it — the documented phantom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)