### PR TITLE
feat(providers): pass [model.parameters] through to the request body

### DIFF
--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -390,6 +390,12 @@ impl AnthropicProvider {
             body["tools"] = serde_json::Value::Array(tools);
         }
 
+        // Pass through extra model parameters (top_p, top_k, stop_sequences, …).
+        crate::openai_compat::merge_extra_params(
+            body.as_object_mut()
+                .expect("an Anthropic request body is always a JSON object"),
+            &request.extra,
+        );
         body
     }
 
@@ -1043,6 +1049,27 @@ mod tests {
         assert_eq!(system[0]["text"], "You are helpful.");
         assert!(system[0].get("cache_control").is_some());
         assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_build_request_body_passes_through_extra_params() {
+        let provider = AnthropicProvider::new("test-key".to_string());
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::json!({ "top_p": 0.9, "top_k": 40 }),
+        };
+        let body = provider.build_request_body(&request);
+        assert_eq!(body["top_p"], serde_json::json!(0.9));
+        assert_eq!(body["top_k"], serde_json::json!(40));
     }
 
     #[test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -194,6 +194,14 @@ impl OllamaProvider {
             body["tools"] = serde_json::Value::Array(tools);
         }
 
+        // Pass through extra model parameters (top_p, top_k, stop, seed, …).
+        // Ollama's sampling knobs live under `options`, so merge there.
+        crate::openai_compat::merge_extra_params(
+            body.get_mut("options")
+                .and_then(|v| v.as_object_mut())
+                .expect("ollama request body always has an `options` object"),
+            &request.extra,
+        );
         body
     }
 
@@ -927,6 +935,28 @@ mod tests {
         let temp = body["options"]["temperature"].as_f64().unwrap();
         assert!((temp - 0.8).abs() < 0.001);
         assert_eq!(body["options"]["num_predict"], 512);
+    }
+
+    #[test]
+    fn test_build_request_body_passes_extra_params_into_options() {
+        let provider = OllamaProvider::new();
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: "llama3-8b".to_string(),
+            max_tokens: 512,
+            temperature: 0.8,
+            tools: vec![],
+            extra: serde_json::json!({ "top_k": 40, "top_p": 0.95 }),
+        };
+        let body = provider.build_request_body(&request);
+        // Ollama's sampling knobs live under `options`.
+        assert_eq!(body["options"]["top_k"], serde_json::json!(40));
+        assert_eq!(body["options"]["top_p"], serde_json::json!(0.95));
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -195,7 +195,28 @@ pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Valu
         body["tools"] = serde_json::Value::Array(tools);
     }
 
+    merge_extra_params(
+        body.as_object_mut()
+            .expect("an OpenAI request body is always a JSON object"),
+        &request.extra,
+    );
     body
+}
+
+/// Merge a request's pass-through `extra` params (the manifest's
+/// `[model.parameters]` beyond temperature/max_output_tokens — `top_p`, `stop`,
+/// `seed`, `frequency_penalty`, …) into an OpenAI-shaped request `target`.
+/// A non-object `extra` (e.g. `Null` when none are set) is a no-op, and keys the
+/// builder already set are not overwritten (explicit request fields win).
+pub fn merge_extra_params(
+    target: &mut serde_json::Map<String, serde_json::Value>,
+    extra: &serde_json::Value,
+) {
+    if let serde_json::Value::Object(params) = extra {
+        for (key, value) in params {
+            target.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
 }
 
 /// Parse a Chat Completions response body into an `InferenceResponse`.
@@ -500,6 +521,41 @@ mod tests {
             tools: vec![],
             extra: serde_json::json!({}),
         }
+    }
+
+    // ─── merge_extra_params ─────────────────────────────────────────────────
+
+    #[test]
+    fn merge_extra_params_adds_object_keys_without_overwriting() {
+        let mut target = serde_json::Map::new();
+        target.insert("temperature".to_string(), serde_json::json!(0.5));
+        merge_extra_params(
+            &mut target,
+            &serde_json::json!({ "top_p": 0.9, "temperature": 0.1, "seed": 7 }),
+        );
+        // New keys added …
+        assert_eq!(target["top_p"], serde_json::json!(0.9));
+        assert_eq!(target["seed"], serde_json::json!(7));
+        // … but an existing key (an explicit request field) is not overwritten.
+        assert_eq!(target["temperature"], serde_json::json!(0.5));
+    }
+
+    #[test]
+    fn merge_extra_params_ignores_non_object_extra() {
+        let mut target = serde_json::Map::new();
+        target.insert("a".to_string(), serde_json::json!(1));
+        merge_extra_params(&mut target, &serde_json::Value::Null);
+        merge_extra_params(&mut target, &serde_json::json!("string"));
+        assert_eq!(target.len(), 1);
+    }
+
+    #[test]
+    fn build_openai_request_body_passes_through_extra_params() {
+        let mut req = sample_request();
+        req.extra = serde_json::json!({ "top_p": 0.8, "stop": ["END"] });
+        let body = build_openai_request_body(&req);
+        assert_eq!(body["top_p"], serde_json::json!(0.8));
+        assert_eq!(body["stop"], serde_json::json!(["END"]));
     }
 
     // ─── build_openai_request_body ──────────────────────────────────────────

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -148,6 +148,12 @@ impl OpenRouterProvider {
             body["tools"] = serde_json::Value::Array(tools);
         }
 
+        // Pass through extra model parameters (top_p, stop, seed, …).
+        crate::openai_compat::merge_extra_params(
+            body.as_object_mut()
+                .expect("an OpenRouter request body is always a JSON object"),
+            &request.extra,
+        );
         body
     }
 }
@@ -506,6 +512,27 @@ mod tests {
 
         let body = provider.build_request_body(&request);
         assert_eq!(body["model"], "anthropic/claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_build_request_body_passes_through_extra_params() {
+        let provider = OpenRouterProvider::new("test-key".to_string());
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "openai/gpt-4o".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::json!({ "top_p": 0.9, "seed": 3 }),
+        };
+        let body = provider.build_request_body(&request);
+        assert_eq!(body["top_p"], serde_json::json!(0.9));
+        assert_eq!(body["seed"], serde_json::json!(3));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -104,12 +104,17 @@ pub struct EvictionResult {
 /// Set on the agent entity before each stage to override default inference
 /// parameters like temperature and max output tokens. When absent, defaults
 /// are used (temperature 0.7, max output 4096).
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Default)]
 pub struct InferenceConfig {
     /// Temperature override. If None, uses 0.7 (or 0.0 if model doesn't support it).
     pub temperature: Option<f32>,
     /// Max output tokens override. If None, caps at model's max_output_tokens capability.
     pub max_output_tokens: Option<usize>,
+    /// Extra provider parameters from `[stages.<name>.model.parameters]` beyond
+    /// `temperature`/`max_output_tokens` (e.g. `top_p`, `stop`, `seed`,
+    /// `frequency_penalty`). Passed through to the provider request so models can
+    /// be tuned from the manifest. Empty when none are set.
+    pub extra_params: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Per-entity tool result routing configuration.

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -474,6 +474,7 @@ mod tests {
             inference_config: InferenceConfig {
                 temperature: None,
                 max_output_tokens: None,
+                extra_params: Default::default(),
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -910,6 +910,7 @@ mod tests {
             inference_config: crate::components::InferenceConfig {
                 temperature: None,
                 max_output_tokens: None,
+                extra_params: Default::default(),
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -143,6 +143,13 @@ fn build_request(
         0.0
     };
 
+    // Pass through any extra model parameters (top_p, stop, seed, …) so the
+    // provider can apply them; `Null` when there are none.
+    let extra = match config.map(|c| &c.extra_params) {
+        Some(params) if !params.is_empty() => serde_json::Value::Object(params.clone()),
+        _ => serde_json::Value::Null,
+    };
+
     InferenceRequest {
         system: assembled.system_blocks,
         messages: assembled.messages,
@@ -150,7 +157,7 @@ fn build_request(
         max_tokens,
         temperature,
         tools: filtered_tools,
-        extra: serde_json::Value::Null,
+        extra,
     }
 }
 
@@ -2297,6 +2304,16 @@ fn stage_setup_from(stage: &leviath_core::Stage) -> StageSetup {
         .get("temperature")
         .and_then(|v| v.as_f64())
         .map(|t| t as f32);
+    // Every other model parameter (top_p, stop, seed, frequency_penalty, …) is
+    // passed through to the provider verbatim; only temperature/max_output_tokens
+    // are consumed specially above.
+    let extra_params: serde_json::Map<String, serde_json::Value> = stage
+        .model
+        .parameters
+        .iter()
+        .filter(|(k, _)| k.as_str() != "temperature" && k.as_str() != "max_output_tokens")
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     let max_output_tokens = stage
         .model
         .parameters
@@ -2326,6 +2343,7 @@ fn stage_setup_from(stage: &leviath_core::Stage) -> StageSetup {
         inference_config: InferenceConfig {
             temperature,
             max_output_tokens,
+            extra_params,
         },
         routing: stage.tool_result_routing.clone(),
         accepts_messages: stage.accepts_messages,
@@ -2844,6 +2862,7 @@ mod tests {
         let cfg = InferenceConfig {
             temperature: Some(0.1),
             max_output_tokens: Some(42),
+            extra_params: Default::default(),
         };
         let si = stage(
             "m",
@@ -2855,6 +2874,21 @@ mod tests {
         assert_eq!(req.tools[0].name, "keep");
         assert_eq!(req.max_tokens, 42); // config output cap wins
         assert_eq!(req.temperature, 0.1); // config temperature
+        assert_eq!(req.extra, serde_json::Value::Null); // no extra params → Null
+    }
+
+    #[test]
+    fn build_request_passes_through_extra_params() {
+        let mut extra_params = serde_json::Map::new();
+        extra_params.insert("top_p".to_string(), serde_json::json!(0.9));
+        let cfg = InferenceConfig {
+            temperature: None,
+            max_output_tokens: None,
+            extra_params,
+        };
+        let si = stage("m", vec![], None);
+        let req = build_request(&window(), Some(&cfg), &si, &provider(true, 500));
+        assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
     }
 
     #[test]
@@ -4616,6 +4650,7 @@ mod tests {
             inference_config: InferenceConfig {
                 temperature: None,
                 max_output_tokens: None,
+                extra_params: Default::default(),
             },
             routing: None,
             accepts_messages: true,
@@ -4922,6 +4957,7 @@ mod tests {
         s.inference_config = InferenceConfig {
             temperature: Some(0.3),
             max_output_tokens: Some(99),
+            extra_params: Default::default(),
         };
         s.accepts_messages = false;
         let mut world = World::new();
@@ -5198,6 +5234,34 @@ mod tests {
         let mut s3 = stage_named("fan", None, false, None);
         s3.mode = fanout("   ");
         assert_eq!(stage_setup_from(&s3).system_prompt, None);
+    }
+
+    #[test]
+    fn stage_setup_from_collects_extra_model_parameters() {
+        let mut s = stage_named("plan", None, false, None);
+        // temperature/max_output_tokens are consumed specially; everything else
+        // is collected as pass-through extra_params.
+        s.model
+            .parameters
+            .insert("temperature".to_string(), serde_json::json!(0.3));
+        s.model
+            .parameters
+            .insert("max_output_tokens".to_string(), serde_json::json!(256));
+        s.model
+            .parameters
+            .insert("top_p".to_string(), serde_json::json!(0.9));
+        s.model
+            .parameters
+            .insert("seed".to_string(), serde_json::json!(11));
+
+        let setup = stage_setup_from(&s);
+        assert_eq!(setup.inference_config.temperature, Some(0.3));
+        assert_eq!(setup.inference_config.max_output_tokens, Some(256));
+        let extra = &setup.inference_config.extra_params;
+        assert_eq!(extra.len(), 2);
+        assert_eq!(extra["top_p"], serde_json::json!(0.9));
+        assert_eq!(extra["seed"], serde_json::json!(11));
+        assert!(!extra.contains_key("temperature"));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -110,6 +110,7 @@ mod tests {
             inference_config: InferenceConfig {
                 temperature: temp,
                 max_output_tokens: None,
+                extra_params: Default::default(),
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -573,6 +573,7 @@ mod tests {
             inference_config: InferenceConfig {
                 temperature: None,
                 max_output_tokens: None,
+                extra_params: Default::default(),
             },
             routing: None,
             accepts_messages: true,


### PR DESCRIPTION
## What

A stage's `[model.parameters]` beyond `temperature`/`max_output_tokens` (`top_p`, `stop`, `seed`, `frequency_penalty`, `top_k`, …) were parsed into the blueprint but **dropped at request-build time** — `InferenceRequest.extra` was always `Null` and no provider read it, so those knobs did nothing.

Now they flow end-to-end:
- `stage_setup_from` collects every param except temperature/max_output_tokens into `InferenceConfig.extra_params`.
- `build_request` forwards them as `InferenceRequest.extra` (`Null` when there are none).
- Each provider merges them into its wire body: **top-level** for OpenAI / OpenRouter / Anthropic; **under `options`** for Ollama (its sampling knobs live there). Explicit request fields (model, temperature, …) are never overwritten.

```toml
[stages.plan.model.parameters]
temperature = 0.3
top_p = 0.9
seed = 42
```

**Gemini** is intentionally left untouched — its `generationConfig` uses different camelCase parameter names, so a raw merge would send invalid keys. Documented as a limitation.

## Tests
- `merge_extra_params` unit tests (object merge, no-overwrite, non-object no-op).
- Per-provider pass-through tests (OpenAI/OpenRouter/Anthropic top-level; Ollama under `options`).
- Pipeline: `stage_setup_from` collects extras (excluding temp/max), and `build_request` forwards them (plus the `Null`-when-empty path).

Full `cargo test -p leviath-runtime -p leviath-providers` green; clippy + rustdoc clean. Whole-file coverage for runtime/providers verified on CI (local macOS under-reports — the documented phantom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)