### PR TITLE
feat(runtime): write a portable run archive (run.lvr) as runs progress

### DIFF
--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -37,9 +37,45 @@ pub struct PersistJob {
 
 /// The single-lane persistence worker: writes each [`PersistJob`]'s files under
 /// `runs_dir`, one at a time, until the job channel closes (world shutdown).
+///
+/// It also owns this daemon's run-ownership identity — a stable per-machine id
+/// (`<runs_dir>/../machine-id`, created once) and a per-process `world_id` — which
+/// it stamps into every run's portable archive so a run copied to another machine
+/// is unambiguously attributable (see [`leviath_core::run_archive`]).
 pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<PersistJob>) {
+    let machine_id = load_or_create_machine_id(&runs_dir);
+    let world_id = generate_id();
     while let Some(job) = jobs.recv().await {
-        write_snapshot(&runs_dir, &job).await;
+        write_snapshot(&runs_dir, &job, &machine_id, &world_id).await;
+    }
+}
+
+/// A short opaque id derived from the current time + pid. Not cryptographic — it
+/// only needs to distinguish concurrent daemons/runs on a shared filesystem.
+fn generate_id() -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::time::SystemTime::now().hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// This machine's stable id, persisted at `<runs_dir>/../machine-id` (next to the
+/// leviath home) and created once. Falls back to a fresh (unpersisted) id if the
+/// file can't be written.
+fn load_or_create_machine_id(runs_dir: &Path) -> String {
+    let path = runs_dir.parent().unwrap_or(runs_dir).join("machine-id");
+    let existing = std::fs::read_to_string(&path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    match existing {
+        Some(id) => id,
+        None => {
+            let id = generate_id();
+            let _ = std::fs::write(&path, &id);
+            id
+        }
     }
 }
 
@@ -47,12 +83,13 @@ pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<P
 /// each via a temp file + atomic rename. Best-effort: logs and returns on any
 /// error. Serialization is infallible for these plain serde structs, so a
 /// serialize error is a bug rather than a runtime condition (`.expect`).
-async fn write_snapshot(runs_dir: &Path, job: &PersistJob) {
+async fn write_snapshot(runs_dir: &Path, job: &PersistJob, machine_id: &str, world_id: &str) {
     let dir = runs_dir.join(&job.run_id);
     if let Err(e) = tokio::fs::create_dir_all(&dir).await {
         tracing::warn!(run_id = %job.run_id, error = %e, "persistence: create run dir failed");
         return;
     }
+    append_run_archive(&dir, job, machine_id, world_id).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
     write_bytes_atomic(&dir.join("meta.json"), meta_json.as_bytes(), &job.run_id).await;
     let ctx_json =
@@ -87,6 +124,61 @@ async fn write_snapshot(runs_dir: &Path, job: &PersistJob) {
             &job.run_id,
         )
         .await;
+    }
+}
+
+/// Append this snapshot to the run's portable archive (`<run_dir>/run.lvr`).
+///
+/// The first write for a run lays down the archive preamble + a `Header` (the
+/// run's identity + metadata); every write (including the first) appends a
+/// `Checkpoint` carrying the full metadata + context window, so the archive
+/// always folds to the run's latest resumable state. Best-effort — a failed
+/// write is logged and swallowed like the rest of the persistence lane.
+///
+/// (Context is carried in full per checkpoint for now; storing it as a
+/// [`run_archive::ContextDiff`] between checkpoints is a follow-up efficiency.)
+async fn append_run_archive(dir: &Path, job: &PersistJob, machine_id: &str, world_id: &str) {
+    use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+
+    let path = dir.join("run.lvr");
+    let is_new = !tokio::fs::try_exists(&path).await.unwrap_or(false);
+
+    // Encode into a buffer via the sync codec, then append in one async write.
+    let mut buf: Vec<u8> = Vec::new();
+    if is_new {
+        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION)
+            .expect("writing to a Vec never fails");
+        let header = RunRecord::Header {
+            identity: RunIdentity {
+                run_id: job.run_id.clone(),
+                machine_id: machine_id.to_string(),
+                world_id: world_id.to_string(),
+                created_at: job.meta.started_at,
+            },
+            meta: Box::new(job.meta.clone()),
+        };
+        run_archive::write_record(&mut buf, &header).expect("writing to a Vec never fails");
+    }
+    let checkpoint = RunRecord::Checkpoint {
+        meta: Box::new(job.meta.clone()),
+        context: job.context.clone(),
+        at: job.meta.updated_at,
+    };
+    run_archive::write_record(&mut buf, &checkpoint).expect("writing to a Vec never fails");
+
+    match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await
+    {
+        Ok(mut file) => {
+            let _ = file.write_all(&buf).await;
+            let _ = file.flush().await;
+        }
+        Err(e) => {
+            tracing::warn!(run_id = %job.run_id, error = %e, "persistence: run archive append failed");
+        }
     }
 }
 
@@ -185,6 +277,109 @@ mod tests {
         assert!(!run_dir.join("meta.json.tmp").exists());
     }
 
+    fn job(run_id: &str) -> PersistJob {
+        PersistJob {
+            run_id: run_id.to_string(),
+            meta: meta(run_id),
+            context: context(),
+            stages: vec![],
+            output_appends: vec![],
+            log_appends: vec![],
+            taint_audit: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_snapshot_creates_a_readable_run_archive() {
+        use leviath_core::run_archive::{RunRecord, fold, read_archive};
+        let dir = tempfile::tempdir().unwrap();
+        write_snapshot(dir.path(), &job("run-1"), "machine-x", "world-y").await;
+
+        let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
+        let (version, records) = read_archive(&mut bytes.as_slice()).unwrap();
+        assert_eq!(version, leviath_core::run_archive::RUN_ARCHIVE_VERSION);
+        // First write lays down a Header then a Checkpoint.
+        assert!(
+            records
+                .iter()
+                .any(|r| matches!(r, RunRecord::Header { .. }))
+        );
+        assert!(
+            records
+                .iter()
+                .any(|r| matches!(r, RunRecord::Checkpoint { .. }))
+        );
+        // The archive folds to the run's identity + state.
+        let folded = fold(&records).unwrap();
+        assert_eq!(folded.identity.run_id, "run-1");
+        assert_eq!(folded.identity.machine_id, "machine-x");
+        assert_eq!(folded.identity.world_id, "world-y");
+        assert_eq!(folded.meta.run_id, "run-1");
+    }
+
+    #[tokio::test]
+    async fn run_archive_appends_a_checkpoint_per_write_with_one_header() {
+        use leviath_core::run_archive::{RunRecord, read_archive};
+        let dir = tempfile::tempdir().unwrap();
+        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
+        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
+
+        let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
+        let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
+        let headers = records
+            .iter()
+            .filter(|r| matches!(r, RunRecord::Header { .. }))
+            .count();
+        let checkpoints = records
+            .iter()
+            .filter(|r| matches!(r, RunRecord::Checkpoint { .. }))
+            .count();
+        assert_eq!(headers, 1, "header only written once");
+        assert_eq!(checkpoints, 2, "a checkpoint per write");
+    }
+
+    #[tokio::test]
+    async fn run_archive_open_failure_is_swallowed() {
+        // Pre-create `run.lvr` as a directory so opening it for append fails; the
+        // best-effort archive write must not panic (and the rest still runs).
+        let dir = tempfile::tempdir().unwrap();
+        let run_dir = dir.path().join("run-1");
+        std::fs::create_dir_all(run_dir.join("run.lvr")).unwrap();
+        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
+        // meta.json still written despite the archive failure.
+        assert!(run_dir.join("meta.json").exists());
+    }
+
+    #[test]
+    fn machine_id_is_persisted_and_reused() {
+        let dir = tempfile::tempdir().unwrap();
+        let runs = dir.path().join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        let first = load_or_create_machine_id(&runs);
+        assert!(!first.is_empty());
+        // A second call returns the same persisted id.
+        assert_eq!(load_or_create_machine_id(&runs), first);
+        // It lives next to the runs dir.
+        assert!(dir.path().join("machine-id").exists());
+    }
+
+    #[test]
+    fn machine_id_regenerates_when_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let runs = dir.path().join("runs");
+        std::fs::create_dir_all(&runs).unwrap();
+        std::fs::write(dir.path().join("machine-id"), "   \n").unwrap();
+        let id = load_or_create_machine_id(&runs);
+        assert!(!id.is_empty());
+    }
+
+    #[test]
+    fn generate_id_is_sixteen_hex_chars() {
+        let id = generate_id();
+        assert_eq!(id.len(), 16);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
     #[tokio::test]
     async fn worker_writes_stages_index_and_appends_output_and_logs() {
         let dir = tempfile::tempdir().unwrap();
@@ -199,6 +394,8 @@ mod tests {
                 log_appends: vec![(0, "[tool] list_dir: .".to_string())],
                 taint_audit: None,
             },
+            "machine-test",
+            "world-test",
         )
         .await;
 
@@ -227,6 +424,8 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: Some((2, r#"[{"tool_name":"shell"}]"#.to_string())),
             },
+            "machine-test",
+            "world-test",
         )
         .await;
         let audit =
@@ -248,6 +447,8 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
             },
+            "machine-test",
+            "world-test",
         )
         .await;
         // No stages.json, no stages dir when there's nothing to write.
@@ -281,6 +482,8 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
             },
+            "machine-test",
+            "world-test",
         )
         .await;
     }
@@ -305,6 +508,8 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
             },
+            "machine-test",
+            "world-test",
         )
         .await;
 
@@ -333,6 +538,8 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
             },
+            "machine-test",
+            "world-test",
         )
         .await;
 


### PR DESCRIPTION
## What

Wires the run-archive format (PR #56, `leviath-core::run_archive`) into the daemon's persistence lane, so **every run is now encapsulated in a single portable `run.lvr` file** alongside its `meta.json`/`context.json`.

### Ownership identity
The persistence worker computes this daemon's run-ownership identity once:
- a **stable per-machine id** persisted at `<runs_dir>/../machine-id` (created on first run), and
- a **per-process `world_id`**.

Both are stamped into every archive's `Header`, so a run copied between machines — or hosted on a shared filesystem by multiple daemons that might otherwise collide on `run_id` — is unambiguously attributable. (This is the groundwork for the future cross-machine migration direction: `OwnershipChanged` records can hand a run to a new owner.)

### Writing
On each snapshot, `write_snapshot` appends to `<run_dir>/run.lvr`:
- the **first** write lays down the archive preamble + a `Header` (identity + metadata);
- **every** write appends a `Checkpoint` (full metadata + context window),

so the archive always `fold()`s to the run's latest resumable state. Best-effort and swallowed on error, matching the rest of the lane.

## Scope / follow-ups
- Context is carried **in full per checkpoint** for now; encoding it as a `run_archive::ContextDiff` between checkpoints (the efficiency win the format already supports) is a fast-follow.
- **Reload-from-archive / demand paging** (unload idle+terminal agents, page back in) is the next step — see `docs/design/agent-paging.md`.

## Tests
Archive is created and `read_archive`+`fold` round-trip to the run's identity/state; a checkpoint is appended per write with exactly one header; open-failure is swallowed (meta.json still written); machine-id is persisted+reused (and regenerated from an empty file); `generate_id` shape. `cargo test -p leviath-runtime` green; clippy + rustdoc clean. Runtime whole-file coverage verified on CI (local macOS under-reports — the documented phantom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)