### PR TITLE
feat(run-archive): store context as diffs + a queryable context history

### DIFF
--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -243,6 +243,18 @@ pub enum RunRecord {
         /// Unix seconds.
         at: i64,
     },
+    /// A step forward: the updated metadata plus a *diff* of the context window
+    /// since the previous point. This is the compact per-tick record the writer
+    /// emits between full checkpoints — meta is small, and the context (the bulk)
+    /// is carried as a [`ContextDelta`] rather than a full snapshot.
+    Progress {
+        /// The run metadata as of this step.
+        meta: Box<RunMeta>,
+        /// The context change since the previous recorded point.
+        delta: ContextDelta,
+        /// Unix seconds.
+        at: i64,
+    },
 }
 
 // ─── context diffing ────────────────────────────────────────────────────────
@@ -484,9 +496,95 @@ pub fn fold(records: &[RunRecord]) -> Option<FoldedRun> {
                 folded.meta = (**meta).clone();
                 folded.context = context.clone();
             }
+            RunRecord::Progress { meta, delta, .. } => {
+                folded.meta = (**meta).clone();
+                apply_delta(&mut folded.context, delta);
+            }
         }
     }
     Some(folded)
+}
+
+/// A run's context window at one recorded point in time, with the metadata
+/// (stage, iteration, status, …) in effect then. Produced by [`replay_points`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct RunPoint {
+    /// The run metadata at this point.
+    pub meta: RunMeta,
+    /// The full context window at this point.
+    pub context: ContextSnapshot,
+    /// Unix seconds this point was recorded.
+    pub at: i64,
+}
+
+/// Replay a run journal into the sequence of context-window snapshots over time,
+/// one [`RunPoint`] per record that changes the context (a checkpoint, diff, or
+/// progress step). This is what the context-history views (TUI/CLI/API) consume
+/// to show the window "at each stage and point". Returns an empty vec if the
+/// records don't start with a [`RunRecord::Header`].
+pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
+    let mut iter = records.iter();
+    let mut meta = match iter.next() {
+        Some(RunRecord::Header { meta, .. }) => (**meta).clone(),
+        _ => return Vec::new(),
+    };
+    let mut context = ContextSnapshot {
+        stage_name: String::new(),
+        total_tokens: 0,
+        max_tokens: 0,
+        regions: Vec::new(),
+    };
+    let mut points = Vec::new();
+    for record in iter {
+        match record {
+            RunRecord::Header { meta: m, .. } => meta = (**m).clone(),
+            RunRecord::StatusChanged { status, .. } => meta.status = status.clone(),
+            RunRecord::ContextCheckpoint { snapshot, at } => {
+                context = snapshot.clone();
+                points.push(RunPoint {
+                    meta: meta.clone(),
+                    context: context.clone(),
+                    at: *at,
+                });
+            }
+            RunRecord::ContextDiff { delta, at } => {
+                apply_delta(&mut context, delta);
+                points.push(RunPoint {
+                    meta: meta.clone(),
+                    context: context.clone(),
+                    at: *at,
+                });
+            }
+            RunRecord::Checkpoint {
+                meta: m,
+                context: c,
+                at,
+            } => {
+                meta = (**m).clone();
+                context = c.clone();
+                points.push(RunPoint {
+                    meta: meta.clone(),
+                    context: context.clone(),
+                    at: *at,
+                });
+            }
+            RunRecord::Progress { meta: m, delta, at } => {
+                meta = (**m).clone();
+                apply_delta(&mut context, delta);
+                points.push(RunPoint {
+                    meta: meta.clone(),
+                    context: context.clone(),
+                    at: *at,
+                });
+            }
+            // Non-context records don't add a timeline point.
+            RunRecord::OwnershipChanged { .. }
+            | RunRecord::Inference { .. }
+            | RunRecord::ToolBatch { .. }
+            | RunRecord::Message { .. } => {}
+        }
+    }
+    points
 }
 
 #[cfg(test)]
@@ -765,6 +863,20 @@ mod tests {
                 context: snapshot("plan", vec![region("conv", vec![entry("hi", 1)])]),
                 at: 108,
             },
+            RunRecord::Progress {
+                meta: Box::new(meta()),
+                delta: ContextDelta {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("step", 2)],
+                        current_tokens: 3,
+                    }],
+                },
+                at: 109,
+            },
         ]
     }
 
@@ -942,11 +1054,11 @@ mod tests {
         // One inbound message recorded.
         assert_eq!(folded.messages.len(), 1);
         assert_eq!(folded.messages[0].content, "another");
-        // The Checkpoint is the last context-affecting record, so the folded
-        // window matches its snapshot (the earlier diff was superseded).
+        // The Progress step is the last context-affecting record: it layers its
+        // append diff onto the preceding Checkpoint's window (hi + step).
         assert_eq!(folded.context.regions[0].name, "conv");
-        assert_eq!(folded.context.regions[0].entries.len(), 1);
-        // Status came from the Checkpoint's meta (Starting), after StatusChanged.
+        assert_eq!(folded.context.regions[0].entries.len(), 2);
+        assert_eq!(folded.context.total_tokens, 3);
         assert_eq!(folded.meta.run_id, "run-1");
     }
 
@@ -998,5 +1110,173 @@ mod tests {
         let folded = fold(&records).unwrap();
         assert_eq!(folded.identity.machine_id, "machine-c");
         assert_eq!(folded.meta.status, RunStatus::Running);
+    }
+
+    #[test]
+    fn fold_progress_applies_meta_and_context_diff() {
+        let mut advanced = meta();
+        advanced.status = RunStatus::Running;
+        advanced.iteration = 5;
+        let records = vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 1,
+            },
+            RunRecord::Progress {
+                meta: Box::new(advanced),
+                delta: ContextDelta {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("there", 2)],
+                        current_tokens: 3,
+                    }],
+                },
+                at: 2,
+            },
+        ];
+        let folded = fold(&records).unwrap();
+        assert_eq!(folded.meta.iteration, 5);
+        assert_eq!(folded.meta.status, RunStatus::Running);
+        assert_eq!(folded.context.regions[0].entries.len(), 2);
+    }
+
+    // ── replay_points (context-window history) ──
+
+    #[test]
+    fn replay_points_requires_a_header() {
+        assert!(replay_points(&[]).is_empty());
+        assert!(
+            replay_points(&[RunRecord::Message {
+                message: MessageRecord {
+                    role: "user".to_string(),
+                    content: "x".to_string(),
+                },
+                at: 1,
+            }])
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn replay_points_emits_a_snapshot_per_context_change() {
+        // Header (no point) → checkpoint (point 1) → status (no point, but tracked)
+        // → progress diff (point 2). Non-context records don't add points.
+        let mut running = meta();
+        running.status = RunStatus::Running;
+        let records = vec![
+            header(),
+            RunRecord::Inference {
+                stage: "plan".to_string(),
+                iteration: 0,
+                request: InferenceRequestRecord {
+                    model: "m".to_string(),
+                    system: vec![],
+                    messages: vec![],
+                    tool_names: vec![],
+                    temperature: 0.7,
+                    max_tokens: 10,
+                },
+                response: InferenceResponseRecord {
+                    content: "ok".to_string(),
+                    tool_calls: vec![],
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                },
+                at: 1,
+            },
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 2,
+            },
+            RunRecord::StatusChanged {
+                status: RunStatus::Running,
+                at: 3,
+            },
+            RunRecord::Progress {
+                meta: Box::new(running),
+                delta: ContextDelta {
+                    stage_name: "implement".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("more", 2)],
+                        current_tokens: 3,
+                    }],
+                },
+                at: 4,
+            },
+        ];
+        let points = replay_points(&records);
+        assert_eq!(points.len(), 2, "one point per context change");
+        // First point: the checkpoint window.
+        assert_eq!(points[0].at, 2);
+        assert_eq!(points[0].context.regions[0].entries.len(), 1);
+        // Second point: the progress diff layered on, with the running status
+        // carried from the StatusChanged + the progress meta.
+        assert_eq!(points[1].at, 4);
+        assert_eq!(points[1].context.regions[0].entries.len(), 2);
+        assert_eq!(points[1].context.stage_name, "implement");
+        assert_eq!(points[1].meta.status, RunStatus::Running);
+    }
+
+    #[test]
+    fn replay_points_handles_context_diff_and_a_later_header() {
+        // A standalone ContextDiff is a point; a second Header refreshes meta
+        // without adding a point.
+        let mut relabeled = meta();
+        relabeled.agent_name = "renamed".to_string();
+        let records = vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 1,
+            },
+            RunRecord::Header {
+                identity: identity(),
+                meta: Box::new(relabeled),
+            },
+            RunRecord::ContextDiff {
+                delta: ContextDelta {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("more", 2)],
+                        current_tokens: 3,
+                    }],
+                },
+                at: 2,
+            },
+        ];
+        let points = replay_points(&records);
+        assert_eq!(points.len(), 2); // checkpoint + diff (header adds no point)
+        assert_eq!(points[1].context.regions[0].entries.len(), 2);
+        // The later Header's meta is in effect at the diff point.
+        assert_eq!(points[1].meta.agent_name, "renamed");
+    }
+
+    #[test]
+    fn replay_points_over_a_full_checkpoint() {
+        // A `Checkpoint` (full meta+context) is also a point.
+        let records = vec![
+            header(),
+            RunRecord::Checkpoint {
+                meta: Box::new(meta()),
+                context: snapshot("review", vec![region("conv", vec![entry("x", 4)])]),
+                at: 9,
+            },
+        ];
+        let points = replay_points(&records);
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].context.stage_name, "review");
+        assert_eq!(points[0].context.regions[0].entries[0].tokens, 4);
     }
 }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -45,8 +45,14 @@ pub struct PersistJob {
 pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<PersistJob>) {
     let machine_id = load_or_create_machine_id(&runs_dir);
     let world_id = generate_id();
+    // The last context window archived per run, so the next write can be stored
+    // as a compact diff rather than a full snapshot.
+    let mut last_context: std::collections::HashMap<String, ContextSnapshot> =
+        std::collections::HashMap::new();
     while let Some(job) = jobs.recv().await {
-        write_snapshot(&runs_dir, &job, &machine_id, &world_id).await;
+        let prev = last_context.get(&job.run_id);
+        write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev).await;
+        last_context.insert(job.run_id.clone(), job.context.clone());
     }
 }
 
@@ -83,13 +89,19 @@ fn load_or_create_machine_id(runs_dir: &Path) -> String {
 /// each via a temp file + atomic rename. Best-effort: logs and returns on any
 /// error. Serialization is infallible for these plain serde structs, so a
 /// serialize error is a bug rather than a runtime condition (`.expect`).
-async fn write_snapshot(runs_dir: &Path, job: &PersistJob, machine_id: &str, world_id: &str) {
+async fn write_snapshot(
+    runs_dir: &Path,
+    job: &PersistJob,
+    machine_id: &str,
+    world_id: &str,
+    prev_context: Option<&ContextSnapshot>,
+) {
     let dir = runs_dir.join(&job.run_id);
     if let Err(e) = tokio::fs::create_dir_all(&dir).await {
         tracing::warn!(run_id = %job.run_id, error = %e, "persistence: create run dir failed");
         return;
     }
-    append_run_archive(&dir, job, machine_id, world_id).await;
+    append_run_archive(&dir, job, machine_id, world_id, prev_context).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
     write_bytes_atomic(&dir.join("meta.json"), meta_json.as_bytes(), &job.run_id).await;
     let ctx_json =
@@ -129,42 +141,75 @@ async fn write_snapshot(runs_dir: &Path, job: &PersistJob, machine_id: &str, wor
 
 /// Append this snapshot to the run's portable archive (`<run_dir>/run.lvr`).
 ///
-/// The first write for a run lays down the archive preamble + a `Header` (the
-/// run's identity + metadata); every write (including the first) appends a
-/// `Checkpoint` carrying the full metadata + context window, so the archive
-/// always folds to the run's latest resumable state. Best-effort — a failed
-/// write is logged and swallowed like the rest of the persistence lane.
+/// The context window (the bulk) is stored as a diff between writes:
+/// - **new archive** (file absent): preamble + a `Header` (identity + metadata)
+///   + a full `ContextCheckpoint` the diffs rebase on;
+/// - **resumed** (file present, but this worker has no prior context for the run
+///   — e.g. after a daemon restart): an `OwnershipChanged` recording this
+///   world/machine took over + a fresh `ContextCheckpoint` re-anchor;
+/// - **ongoing** (a prior context is known): a compact `Progress` step carrying
+///   the updated metadata + a `ContextDiff` since the previous point.
 ///
-/// (Context is carried in full per checkpoint for now; storing it as a
-/// [`run_archive::ContextDiff`] between checkpoints is a follow-up efficiency.)
-async fn append_run_archive(dir: &Path, job: &PersistJob, machine_id: &str, world_id: &str) {
+/// The archive always folds to the run's latest resumable state. Best-effort —
+/// a failed write is logged and swallowed like the rest of the persistence lane.
+async fn append_run_archive(
+    dir: &Path,
+    job: &PersistJob,
+    machine_id: &str,
+    world_id: &str,
+    prev_context: Option<&ContextSnapshot>,
+) {
     use leviath_core::run_archive::{self, RunIdentity, RunRecord};
 
     let path = dir.join("run.lvr");
-    let is_new = !tokio::fs::try_exists(&path).await.unwrap_or(false);
+    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
+    let at = job.meta.updated_at;
 
     // Encode into a buffer via the sync codec, then append in one async write.
     let mut buf: Vec<u8> = Vec::new();
-    if is_new {
-        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION)
-            .expect("writing to a Vec never fails");
-        let header = RunRecord::Header {
-            identity: RunIdentity {
-                run_id: job.run_id.clone(),
-                machine_id: machine_id.to_string(),
-                world_id: world_id.to_string(),
-                created_at: job.meta.started_at,
-            },
-            meta: Box::new(job.meta.clone()),
-        };
-        run_archive::write_record(&mut buf, &header).expect("writing to a Vec never fails");
+    match prev_context {
+        // A known prior context → the compact per-step record.
+        Some(prev) => {
+            let progress = RunRecord::Progress {
+                meta: Box::new(job.meta.clone()),
+                delta: run_archive::diff_context(prev, &job.context),
+                at,
+            };
+            run_archive::write_record(&mut buf, &progress).expect("writing to a Vec never fails");
+        }
+        // No prior context this process.
+        None => {
+            if file_exists {
+                // Resumed run: record the ownership handoff to this world.
+                let owned = RunRecord::OwnershipChanged {
+                    machine_id: machine_id.to_string(),
+                    world_id: world_id.to_string(),
+                    at,
+                };
+                run_archive::write_record(&mut buf, &owned).expect("writing to a Vec never fails");
+            } else {
+                // Brand-new archive: preamble + Header.
+                run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION)
+                    .expect("writing to a Vec never fails");
+                let header = RunRecord::Header {
+                    identity: RunIdentity {
+                        run_id: job.run_id.clone(),
+                        machine_id: machine_id.to_string(),
+                        world_id: world_id.to_string(),
+                        created_at: job.meta.started_at,
+                    },
+                    meta: Box::new(job.meta.clone()),
+                };
+                run_archive::write_record(&mut buf, &header).expect("writing to a Vec never fails");
+            }
+            // Either way, anchor with a full context snapshot the diffs rebase on.
+            let checkpoint = RunRecord::ContextCheckpoint {
+                snapshot: job.context.clone(),
+                at,
+            };
+            run_archive::write_record(&mut buf, &checkpoint).expect("writing to a Vec never fails");
+        }
     }
-    let checkpoint = RunRecord::Checkpoint {
-        meta: Box::new(job.meta.clone()),
-        context: job.context.clone(),
-        at: job.meta.updated_at,
-    };
-    run_archive::write_record(&mut buf, &checkpoint).expect("writing to a Vec never fails");
 
     match tokio::fs::OpenOptions::new()
         .create(true)
@@ -289,16 +334,45 @@ mod tests {
         }
     }
 
+    /// A job whose context window has one region with the given entries (for
+    /// exercising context diffs across writes).
+    fn job_with_context(run_id: &str, entries: usize) -> PersistJob {
+        let ctx = ContextSnapshot {
+            stage_name: "s".to_string(),
+            total_tokens: entries,
+            max_tokens: 100,
+            regions: vec![leviath_core::run_meta::RegionSnapshot {
+                name: "conv".to_string(),
+                kind: "clearable".to_string(),
+                current_tokens: entries,
+                max_tokens: 100,
+                entries: (0..entries)
+                    .map(|i| leviath_core::run_meta::RegionEntrySnapshot {
+                        content: format!("line {i}"),
+                        tokens: 1,
+                        kind: leviath_core::region::EntryKind::Text,
+                        metadata: None,
+                        key: None,
+                    })
+                    .collect(),
+            }],
+        };
+        PersistJob {
+            context: ctx,
+            ..job(run_id)
+        }
+    }
+
     #[tokio::test]
     async fn write_snapshot_creates_a_readable_run_archive() {
         use leviath_core::run_archive::{RunRecord, fold, read_archive};
         let dir = tempfile::tempdir().unwrap();
-        write_snapshot(dir.path(), &job("run-1"), "machine-x", "world-y").await;
+        write_snapshot(dir.path(), &job("run-1"), "machine-x", "world-y", None).await;
 
         let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
         let (version, records) = read_archive(&mut bytes.as_slice()).unwrap();
         assert_eq!(version, leviath_core::run_archive::RUN_ARCHIVE_VERSION);
-        // First write lays down a Header then a Checkpoint.
+        // A brand-new archive: a Header then a full ContextCheckpoint.
         assert!(
             records
                 .iter()
@@ -307,7 +381,7 @@ mod tests {
         assert!(
             records
                 .iter()
-                .any(|r| matches!(r, RunRecord::Checkpoint { .. }))
+                .any(|r| matches!(r, RunRecord::ContextCheckpoint { .. }))
         );
         // The archive folds to the run's identity + state.
         let folded = fold(&records).unwrap();
@@ -318,24 +392,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_archive_appends_a_checkpoint_per_write_with_one_header() {
-        use leviath_core::run_archive::{RunRecord, read_archive};
+    async fn run_archive_stores_subsequent_writes_as_progress_diffs() {
+        use leviath_core::run_archive::{RunRecord, read_archive, replay_points};
         let dir = tempfile::tempdir().unwrap();
-        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
-        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
+        let first = job_with_context("run-1", 1);
+        let second = job_with_context("run-1", 3); // grew by 2 entries
+        write_snapshot(dir.path(), &first, "m", "w", None).await;
+        write_snapshot(dir.path(), &second, "m", "w", Some(&first.context)).await;
 
         let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
         let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
-        let headers = records
+        let count = |pred: fn(&RunRecord) -> bool| records.iter().filter(|r| pred(r)).count();
+        assert_eq!(count(|r| matches!(r, RunRecord::Header { .. })), 1);
+        assert_eq!(
+            count(|r| matches!(r, RunRecord::ContextCheckpoint { .. })),
+            1
+        );
+        assert_eq!(
+            count(|r| matches!(r, RunRecord::Progress { .. })),
+            1,
+            "the second write is a compact Progress diff, not a full checkpoint"
+        );
+        // Replaying yields the growing window at each point (1 entry → 3).
+        let points = replay_points(&records);
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].context.regions[0].entries.len(), 1);
+        assert_eq!(points[1].context.regions[0].entries.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn run_archive_records_ownership_handoff_on_resume() {
+        use leviath_core::run_archive::{RunRecord, read_archive};
+        let dir = tempfile::tempdir().unwrap();
+        // First process writes the archive.
+        write_snapshot(dir.path(), &job("run-1"), "m1", "w1", None).await;
+        // A "restarted" worker (no prior context) writes to the existing archive:
+        // it records an ownership handoff + a fresh context re-anchor, not a Header.
+        write_snapshot(dir.path(), &job("run-1"), "m2", "w2", None).await;
+
+        let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
+        let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
+        assert_eq!(
+            records
+                .iter()
+                .filter(|r| matches!(r, RunRecord::Header { .. }))
+                .count(),
+            1,
+            "no second Header on resume"
+        );
+        let owned = records
             .iter()
-            .filter(|r| matches!(r, RunRecord::Header { .. }))
-            .count();
-        let checkpoints = records
-            .iter()
-            .filter(|r| matches!(r, RunRecord::Checkpoint { .. }))
-            .count();
-        assert_eq!(headers, 1, "header only written once");
-        assert_eq!(checkpoints, 2, "a checkpoint per write");
+            .find_map(|r| match r {
+                RunRecord::OwnershipChanged {
+                    machine_id,
+                    world_id,
+                    ..
+                } => Some((machine_id.clone(), world_id.clone())),
+                _ => None,
+            })
+            .expect("ownership handoff recorded");
+        assert_eq!(owned, ("m2".to_string(), "w2".to_string()));
     }
 
     #[tokio::test]
@@ -345,7 +461,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let run_dir = dir.path().join("run-1");
         std::fs::create_dir_all(run_dir.join("run.lvr")).unwrap();
-        write_snapshot(dir.path(), &job("run-1"), "m", "w").await;
+        write_snapshot(dir.path(), &job("run-1"), "m", "w", None).await;
         // meta.json still written despite the archive failure.
         assert!(run_dir.join("meta.json").exists());
     }
@@ -396,6 +512,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
 
@@ -426,6 +543,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
         let audit =
@@ -449,6 +567,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
         // No stages.json, no stages dir when there's nothing to write.
@@ -484,6 +603,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
     }
@@ -510,6 +630,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
 
@@ -540,6 +661,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
         )
         .await;
 


### PR DESCRIPTION
## What

Two additions to the run archive, building on the live writer (#58) — the efficiency win the format was designed for, plus the query API the viewing surfaces need.

### 1. Context stored as diffs (efficiency)
The writer previously appended a full context snapshot (`Checkpoint`) every persist tick. The context window is a run's bulk, so it now stores **diffs** between snapshots:
- **new archive** → `Header` + a full `ContextCheckpoint` (the diffs rebase on it)
- **ongoing** → a compact `Progress` step: updated metadata + a `ContextDiff` since the previous point
- **resumed by a different daemon** (worker has no prior context but the file exists — e.g. after a restart) → an `OwnershipChanged` handoff + a fresh `ContextCheckpoint` re-anchor

The persistence worker tracks the last context per run to compute each diff.

### 2. Queryable context history
New `run_archive::replay_points(records) -> Vec<RunPoint>` replays a journal into the **full context window (+ metadata) at each recorded point** over time. This is what the context-history views (TUI/CLI/HTTP, next PR) consume to show the window "at each stage and point". Adds a `Progress` record type and a `fold` arm for it.

## Tests
- Core: `replay_points` (per-context-change points, diff application, checkpoints, later-header meta, header-required); `Progress` fold + codec round-trip. 100% coverage.
- Writer: the three record paths — new archive (`Header`+`ContextCheckpoint`), ongoing (`Progress` diff, verified by replaying to the grown window), and resume (`OwnershipChanged`, no second header) — plus open-failure swallowed. Runtime whole-file coverage on CI.

Follow-up (next PR): surface `replay_points` in `lev context <run-id>`, the dashboard, and `GET /api/agents/{id}/context/history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)