### PR TITLE
feat(cli): view a run's context-window history (CLI + HTTP)

### DIFF
--- a/crates/leviath-cli/src/commands/context.rs
+++ b/crates/leviath-cli/src/commands/context.rs
@@ -1,0 +1,247 @@
+//! `lev context <run-id>` — show a run's context-window history.
+//!
+//! Replays the run's portable archive (`run.lvr`) into the sequence of context
+//! windows over time (one per recorded checkpoint/step) and prints them, so you
+//! can inspect what the agent's memory looked like at each stage and point —
+//! for debugging or auditing. Read-only; sources everything from disk.
+
+use clap::Args;
+use leviath_core::run_archive::RunPoint;
+
+/// Arguments for `lev context`.
+#[derive(Args, Debug)]
+pub struct ContextArgs {
+    /// The run id whose context-window history to show.
+    pub run_id: String,
+    /// Print the full history as JSON instead of a human-readable summary.
+    #[arg(long)]
+    pub json: bool,
+    /// Include each region's entry contents (not just per-region summaries).
+    #[arg(long)]
+    pub full: bool,
+}
+
+/// Execute `lev context`.
+pub async fn execute(args: ContextArgs) -> anyhow::Result<()> {
+    let history = crate::runstate::context_history(&args.run_id);
+    if history.is_empty() {
+        anyhow::bail!(
+            "no context history for run '{}' (no readable run.lvr archive)",
+            args.run_id
+        );
+    }
+    let out = render(&args.run_id, &history, args.json, args.full);
+    print!("{out}");
+    Ok(())
+}
+
+/// Render the history to a string (pure, so it's directly testable).
+fn render(run_id: &str, history: &[RunPoint], json: bool, full: bool) -> String {
+    if json {
+        // RunPoint is Serialize; a plain array is the machine-readable form.
+        return format!(
+            "{}\n",
+            serde_json::to_string_pretty(history).expect("RunPoint history always serializes")
+        );
+    }
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Context history for run '{run_id}' ({} point{}):\n\n",
+        history.len(),
+        if history.len() == 1 { "" } else { "s" }
+    ));
+    for (i, point) in history.iter().enumerate() {
+        out.push_str(&format!(
+            "[{}] {}  stage={}  iter={}  status={}  tokens={}/{}\n",
+            i + 1,
+            format_time(point.at),
+            point.context.stage_name,
+            point.meta.iteration,
+            point.meta.status,
+            point.context.total_tokens,
+            point.context.max_tokens,
+        ));
+        for region in &point.context.regions {
+            out.push_str(&format!(
+                "      region {} ({}) — {} tok, {} entr{}\n",
+                region.name,
+                region.kind,
+                region.current_tokens,
+                region.entries.len(),
+                if region.entries.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                },
+            ));
+            if full {
+                for entry in &region.entries {
+                    for line in entry.content.lines() {
+                        out.push_str(&format!("          {line}\n"));
+                    }
+                }
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Format a unix timestamp as a local `YYYY-MM-DD HH:MM:SS`, or the raw seconds
+/// if it's out of range.
+fn format_time(secs: i64) -> String {
+    match chrono::DateTime::from_timestamp(secs, 0) {
+        Some(dt) => dt
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string(),
+        None => secs.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta};
+
+    fn point(stage: &str, tokens: usize, entries: Vec<&str>) -> RunPoint {
+        RunPoint {
+            meta: RunMeta::new(
+                "run-x".to_string(),
+                "coder".to_string(),
+                "/agents/coder".to_string(),
+                "task".to_string(),
+                None,
+                "/work".to_string(),
+                2,
+            ),
+            context: ContextSnapshot {
+                stage_name: stage.to_string(),
+                total_tokens: tokens,
+                max_tokens: 1000,
+                regions: vec![RegionSnapshot {
+                    name: "conv".to_string(),
+                    kind: "clearable".to_string(),
+                    current_tokens: tokens,
+                    max_tokens: 1000,
+                    entries: entries
+                        .into_iter()
+                        .map(|c| RegionEntrySnapshot {
+                            content: c.to_string(),
+                            tokens: 1,
+                            kind: leviath_core::region::EntryKind::Text,
+                            metadata: None,
+                            key: None,
+                        })
+                        .collect(),
+                }],
+            },
+            at: 0,
+        }
+    }
+
+    #[test]
+    fn render_human_lists_each_point_and_region() {
+        let history = vec![
+            point("plan", 1, vec!["hi"]),
+            point("implement", 3, vec!["a", "b"]),
+        ];
+        let out = render("run-x", &history, false, false);
+        assert!(out.contains("Context history for run 'run-x' (2 points)"));
+        assert!(out.contains("[1]") && out.contains("stage=plan"));
+        assert!(out.contains("[2]") && out.contains("stage=implement"));
+        assert!(out.contains("region conv (clearable)"));
+        // Summary mode doesn't dump entry contents.
+        assert!(!out.contains("          hi"));
+    }
+
+    #[test]
+    fn render_full_includes_entry_contents() {
+        let history = vec![point("plan", 1, vec!["secret line"])];
+        let out = render("run-x", &history, false, true);
+        assert!(out.contains("secret line"));
+        // Singular "point" / "entry" wording.
+        assert!(out.contains("(1 point)"));
+        assert!(out.contains("1 entry"));
+    }
+
+    #[test]
+    fn render_json_is_a_parseable_array() {
+        let history = vec![point("plan", 1, vec!["hi"])];
+        let out = render("run-x", &history, true, false);
+        let parsed: Vec<RunPoint> = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].context.stage_name, "plan");
+    }
+
+    #[test]
+    fn format_time_handles_valid_and_out_of_range() {
+        // A fixed timestamp (2023-11-14 UTC) formats as a date-time string.
+        let formatted = format_time(1_700_000_000);
+        assert!(formatted.contains('-') && formatted.contains(':'));
+        // i64::MAX is out of DateTime range → falls back to the raw number.
+        assert_eq!(format_time(i64::MAX), i64::MAX.to_string());
+    }
+
+    #[test]
+    fn execute_prints_history_for_a_run_with_an_archive() {
+        crate::runstate::with_isolated_runs_dir("context-execute-ok", |_d| {
+            use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+            let run_id = "ctx-exec-run";
+            std::fs::create_dir_all(crate::runstate::run_dir(run_id)).unwrap();
+            let mut buf = Vec::new();
+            run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::Header {
+                    identity: RunIdentity {
+                        run_id: run_id.to_string(),
+                        machine_id: "m".to_string(),
+                        world_id: "w".to_string(),
+                        created_at: 0,
+                    },
+                    meta: Box::new(RunMeta::new(
+                        run_id.to_string(),
+                        "a".to_string(),
+                        "/p".to_string(),
+                        "t".to_string(),
+                        None,
+                        "/w".to_string(),
+                        1,
+                    )),
+                },
+            )
+            .unwrap();
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::ContextCheckpoint {
+                    snapshot: ContextSnapshot {
+                        stage_name: "plan".to_string(),
+                        total_tokens: 1,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: 1,
+                },
+            )
+            .unwrap();
+            std::fs::write(crate::runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+
+            // Present archive → the success path (render + print) runs and returns Ok.
+            let args = ContextArgs {
+                run_id: run_id.to_string(),
+                json: true,
+                full: false,
+            };
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            assert!(rt.block_on(execute(args)).is_ok());
+            // Missing archive → the error path.
+            let missing = ContextArgs {
+                run_id: "no-archive-run".to_string(),
+                json: false,
+                full: false,
+            };
+            assert!(rt.block_on(execute(missing)).is_err());
+        });
+    }
+}

--- a/crates/leviath-cli/src/commands/mod.rs
+++ b/crates/leviath-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command implementations.
 
 pub mod add;
+pub mod context;
 pub mod create;
 pub mod ctl;
 pub mod daemon;

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -137,6 +137,21 @@ pub(super) async fn agent_context(
         })
 }
 
+pub(super) async fn agent_context_history(
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<Vec<leviath_core::run_archive::RunPoint>>, (StatusCode, Json<ErrorResponse>)> {
+    let history = runstate::context_history(&id);
+    if history.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("No context history for run '{}'", id),
+            }),
+        ));
+    }
+    Ok(Json(history))
+}
+
 pub(super) async fn agent_logs(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<LogsQuery>,
@@ -751,6 +766,102 @@ prompt = "Plan the work"
                     .with_state(test_state());
                 let req = Request::builder()
                     .uri(format!("/api/agents/{}/context", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// Write a minimal `run.lvr` (Header + one ContextCheckpoint) for `run_id`.
+    fn write_archive_fixture(run_id: &str) {
+        use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+        let mut buf = Vec::new();
+        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::Header {
+                identity: RunIdentity {
+                    run_id: run_id.to_string(),
+                    machine_id: "m".to_string(),
+                    world_id: "w".to_string(),
+                    created_at: 0,
+                },
+                meta: Box::new(make_run(run_id)),
+            },
+        )
+        .unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::ContextCheckpoint {
+                snapshot: runstate::ContextSnapshot {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 7,
+                    max_tokens: 100,
+                    regions: vec![],
+                },
+                at: 1,
+            },
+        )
+        .unwrap();
+        std::fs::write(runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+    }
+
+    #[tokio::test]
+    async fn agent_context_history_returns_ok() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_context_history_returns_ok",
+            |_d| async move {
+                let run_id = unique_run_id("ctx-hist");
+                create_run(&make_run(&run_id)).unwrap();
+                write_archive_fixture(&run_id);
+
+                let app = Router::new()
+                    .route(
+                        "/api/agents/{id}/context/history",
+                        get(agent_context_history),
+                    )
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/context/history", run_id))
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let got: Vec<leviath_core::run_archive::RunPoint> =
+                    serde_json::from_slice(&body).unwrap();
+                assert_eq!(got.len(), 1);
+                assert_eq!(got[0].context.stage_name, "plan");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_context_history_no_archive_returns_404() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_context_history_no_archive_returns_404",
+            |_d| async move {
+                let run_id = unique_run_id("ctx-hist-none");
+                create_run(&make_run(&run_id)).unwrap();
+
+                let app = Router::new()
+                    .route(
+                        "/api/agents/{id}/context/history",
+                        get(agent_context_history),
+                    )
+                    .with_state(test_state());
+                let req = Request::builder()
+                    .uri(format!("/api/agents/{}/context/history", run_id))
                     .body(Body::empty())
                     .unwrap();
                 let resp = app.oneshot(req).await.unwrap();

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -155,6 +155,10 @@ async fn execute_with_shutdown(
         )
         .route("/api/agents/{id}/children", get(agents::agent_children))
         .route("/api/agents/{id}/context", get(agents::agent_context))
+        .route(
+            "/api/agents/{id}/context/history",
+            get(agents::agent_context_history),
+        )
         .route("/api/agents/{id}/logs", get(agents::agent_logs))
         .route("/api/agents/{id}/result", get(agents::agent_result))
         .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
@@ -335,6 +339,10 @@ mod tests {
             .route("/api/agents/{id}", get(agents::get_agent))
             .route("/api/agents/{id}/children", get(agents::agent_children))
             .route("/api/agents/{id}/context", get(agents::agent_context))
+            .route(
+                "/api/agents/{id}/context/history",
+                get(agents::agent_context_history),
+            )
             .route("/api/agents/{id}/logs", get(agents::agent_logs))
             .route("/api/agents/{id}/result", get(agents::agent_result))
             .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
@@ -649,6 +657,10 @@ model = "claude-sonnet-4-6"
             )
             .route("/api/agents/{id}/children", get(agents::agent_children))
             .route("/api/agents/{id}/context", get(agents::agent_context))
+            .route(
+                "/api/agents/{id}/context/history",
+                get(agents::agent_context_history),
+            )
             .route("/api/agents/{id}/logs", get(agents::agent_logs))
             .route("/api/agents/{id}/result", get(agents::agent_result))
             .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -77,6 +77,9 @@ pub enum Commands {
 
     /// Run the shared-world daemon in the foreground
     Daemon(commands::daemon::DaemonArgs),
+
+    /// Show a run's context-window history (from its run.lvr archive)
+    Context(commands::context::ContextArgs),
 }
 
 /// The subset of commands whose real execution performs I/O that a unit test
@@ -132,6 +135,7 @@ pub async fn dispatch(command: Commands, ex: &impl RiskyExecutors) -> anyhow::Re
         Commands::Policy(args) => commands::policy::execute(args).await,
         Commands::Serve(args) => ex.serve(args).await,
         Commands::Daemon(args) => ex.daemon(args).await,
+        Commands::Context(args) => commands::context::execute(args).await,
     }
 }
 
@@ -362,6 +366,18 @@ mod tests {
                 .to_string(),
         };
         let result = dispatch(Commands::Validate(args), &MockRisky).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_context_variant_is_routed() {
+        // A run with no archive → the command errors (routing is exercised).
+        let args = commands::context::ContextArgs {
+            run_id: "no-such-run-xyzzy".to_string(),
+            json: false,
+            full: false,
+        };
+        let result = dispatch(Commands::Context(args), &MockRisky).await;
         assert!(result.is_err());
     }
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -57,6 +57,24 @@ pub fn read_context_snapshot(run_id: &str) -> Option<ContextSnapshot> {
     serde_json::from_str(&json).ok()
 }
 
+/// Read + parse a run's portable archive (`<run_dir>/run.lvr`), returning its
+/// records, or `None` if the archive is missing or unreadable.
+pub fn read_run_archive(run_id: &str) -> Option<Vec<leviath_core::run_archive::RunRecord>> {
+    let path = run_dir(run_id).join("run.lvr");
+    let bytes = std::fs::read(&path).ok()?;
+    leviath_core::run_archive::read_archive(&mut bytes.as_slice())
+        .ok()
+        .map(|(_version, records)| records)
+}
+
+/// A run's context-window history: the full window (+ metadata) at each recorded
+/// point over time, oldest first. Empty when there's no readable archive.
+pub fn context_history(run_id: &str) -> Vec<leviath_core::run_archive::RunPoint> {
+    read_run_archive(run_id)
+        .map(|records| leviath_core::run_archive::replay_points(&records))
+        .unwrap_or_default()
+}
+
 fn now_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -873,6 +891,74 @@ mod tests {
     #[test]
     fn read_context_snapshot_missing_returns_none() {
         assert!(read_context_snapshot("nonexistent-ctx-run").is_none());
+    }
+
+    #[test]
+    fn read_run_archive_roundtrips_and_context_history_replays() {
+        with_isolated_runs_dir("read-run-archive-roundtrip", |_d| {
+            use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+            let run_id = "archive-unit";
+            std::fs::create_dir_all(run_dir(run_id)).unwrap();
+            let mut buf = Vec::new();
+            run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+            let meta = RunMeta::new(
+                run_id.to_string(),
+                "a".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::Header {
+                    identity: RunIdentity {
+                        run_id: run_id.to_string(),
+                        machine_id: "m".to_string(),
+                        world_id: "w".to_string(),
+                        created_at: 0,
+                    },
+                    meta: Box::new(meta),
+                },
+            )
+            .unwrap();
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::ContextCheckpoint {
+                    snapshot: ContextSnapshot {
+                        stage_name: "plan".to_string(),
+                        total_tokens: 3,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: 1,
+                },
+            )
+            .unwrap();
+            std::fs::write(run_dir(run_id).join("run.lvr"), &buf).unwrap();
+
+            let records = read_run_archive(run_id).expect("archive read");
+            assert_eq!(records.len(), 2);
+            let history = context_history(run_id);
+            assert_eq!(history.len(), 1);
+            assert_eq!(history[0].context.stage_name, "plan");
+        });
+    }
+
+    #[test]
+    fn read_run_archive_missing_or_corrupt_returns_none() {
+        with_isolated_runs_dir("read-run-archive-corrupt", |_d| {
+            // Missing archive.
+            assert!(read_run_archive("no-such-archive-run").is_none());
+            assert!(context_history("no-such-archive-run").is_empty());
+            // Corrupt archive (bad magic) → None, not a panic.
+            let run_id = "corrupt-archive-unit";
+            std::fs::create_dir_all(run_dir(run_id)).unwrap();
+            std::fs::write(run_dir(run_id).join("run.lvr"), b"not an archive").unwrap();
+            assert!(read_run_archive(run_id).is_none());
+            assert!(context_history(run_id).is_empty());
+        });
     }
 
     // ─── stage_dir / append_stage_output / append_stage_log ─────────────────

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -507,7 +507,7 @@ pub fn fold(records: &[RunRecord]) -> Option<FoldedRun> {
 
 /// A run's context window at one recorded point in time, with the metadata
 /// (stage, iteration, status, …) in effect then. Produced by [`replay_points`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunPoint {
     /// The run metadata at this point.
     pub meta: RunMeta,


### PR DESCRIPTION
## What

Surfaces the run archive's **context-window history** (`run_archive::replay_points`, from #59) so you can inspect what an agent's memory looked like **at each stage and point over time** — for debugging/auditing. Two of the three viewing surfaces the run format was built for (the dashboard TUI is the follow-up).

### Shared readers (`runstate`)
- `read_run_archive(run_id)` — parse `<run_dir>/run.lvr` into records (None if missing/corrupt)
- `context_history(run_id)` — replay it into the sequence of `RunPoint`s (window + metadata per point)

### CLI — `lev context <run-id>`
Prints the per-point history: timestamp, stage, iteration, status, token usage, and per-region summaries.
- `--full` dumps each region's entry contents
- `--json` emits the machine-readable array

```
Context history for run 'sw-eng-a1b2' (3 points):

[1] 2026-07-22 05:31:02  stage=plan  iter=0  status=Running  tokens=1240/200000
      region task (pinned) — 40 tok, 1 entry
      region plan (clearable) — 1200 tok, 3 entries
...
```

### HTTP — `GET /api/agents/{id}/context/history`
Returns the history as JSON; 404 when there's no archive. Registered in the production router + both test routers; inherits the bearer-token auth + CORS layers automatically.

`RunPoint` is now `Serialize`/`Deserialize` for the JSON surfaces.

## Tests
CLI render (human / `--full` / `--json`), `format_time`, and `execute` (present + missing archive); runstate readers (roundtrip + missing/corrupt); HTTP handler (200 + 404). leviath-core + leviath-cli at 100% coverage; clippy + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)