### PR TITLE
feat(dashboard): browse a run's context-window history in the TUI

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -218,6 +218,7 @@ impl Dashboard {
                     self.detail_view = false;
                     self.detail_scroll = 0;
                     self.review_scroll = 0;
+                    self.reset_context_history();
                 }
             }
             // Stage tab navigation
@@ -273,7 +274,13 @@ impl Dashboard {
             KeyCode::Char('c') => {
                 self.stage_content_mode = StageContentMode::Context;
                 self.detail_scroll = 0;
+                // `c` shows the live current window; leave any history browsing.
+                self.reset_context_history();
             }
+            // Browse the run's archived context-window history in the Context
+            // view: `,` = earlier point, `.` = later (past the newest → live).
+            KeyCode::Char(',') => self.step_context_history(-1),
+            KeyCode::Char('.') => self.step_context_history(1),
             KeyCode::Char('i') => {
                 // Respond to a pending interaction, or send a mid-run message to
                 // any active agent that accepts them — same key, same input area.
@@ -2363,6 +2370,70 @@ mod tests {
         assert!(!dash.search_mode);
         assert!(dash.search_query.is_empty());
         assert_eq!(dash.search_match_idx, 0);
+    }
+
+    /// A dashboard in detail view that is browsing a (fake) history point, for
+    /// the reset-to-live key tests.
+    fn browsing_detail_dashboard() -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.context_history = vec![leviath_core::run_archive::RunPoint {
+            meta: leviath_core::run_meta::RunMeta::new(
+                "run-1".to_string(),
+                "a".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            ),
+            context: leviath_core::run_meta::ContextSnapshot {
+                stage_name: "s".to_string(),
+                total_tokens: 0,
+                max_tokens: 100,
+                regions: vec![],
+            },
+            at: 0,
+        }];
+        dash.context_history_idx = Some(0);
+        dash
+    }
+
+    #[test]
+    fn detail_view_comma_and_period_route_to_history_step() {
+        // With no archive on disk, stepping is a no-op — this exercises the
+        // `,`/`.` routing arms without needing a run.lvr fixture.
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent(
+            "run-no-archive",
+            AgentDisplayStatus::Active,
+        ));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.handle_key(key(KeyCode::Char(',')));
+        dash.handle_key(key(KeyCode::Char('.')));
+        assert_eq!(dash.context_history_idx, None);
+    }
+
+    #[test]
+    fn detail_view_c_returns_to_live_context() {
+        let mut dash = browsing_detail_dashboard();
+        dash.handle_key(key(KeyCode::Char('c')));
+        assert_eq!(dash.stage_content_mode, StageContentMode::Context);
+        assert_eq!(dash.context_history_idx, None); // back to live
+        assert!(dash.context_history.is_empty());
+    }
+
+    #[test]
+    fn detail_view_esc_resets_context_history() {
+        let mut dash = browsing_detail_dashboard();
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(!dash.detail_view);
+        assert_eq!(dash.context_history_idx, None);
+        assert!(dash.context_history.is_empty());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -35,9 +35,18 @@ impl Dashboard {
         ctx_area: Rect,
         agent: &DashboardAgent,
     ) {
-        // Use per-stage context if available, else fall back to global snapshot
-        let snap_opt = runstate::read_stage_context(&agent.id, self.selected_stage)
+        // When browsing archived history, show that point; else the live window.
+        let snap_opt = self
+            .browsed_context_point()
+            .map(|p| p.context.clone())
+            .or_else(|| runstate::read_stage_context(&agent.id, self.selected_stage))
             .or_else(|| agent.context_snapshot.clone());
+
+        // The card title shows the browsed history position (or a plain " ctx ").
+        let title = match self.context_history_idx {
+            Some(i) => format!(" ctx {}/{} ", i + 1, self.context_history.len()),
+            None => " ctx ".to_string(),
+        };
 
         // Constrain context card to at most 60 cols, left-aligned
         let card_w = ctx_area.width.min(64);
@@ -106,7 +115,7 @@ impl Dashboard {
             frame.render_widget(
                 Paragraph::new(vec![bar_line, info_line]).block(
                     Block::default()
-                        .title(Span::styled(" ctx ", Style::default().fg(C_DIM)))
+                        .title(Span::styled(title.clone(), Style::default().fg(C_DIM)))
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
                         .border_style(Style::default().fg(C_BORDER)),
@@ -121,7 +130,7 @@ impl Dashboard {
                 )))
                 .block(
                     Block::default()
-                        .title(Span::styled(" ctx ", Style::default().fg(C_DIM)))
+                        .title(Span::styled(title.clone(), Style::default().fg(C_DIM)))
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
                         .border_style(Style::default().fg(C_BORDER)),
@@ -405,7 +414,12 @@ impl Dashboard {
     }
 
     fn build_context_lines(&self, agent: &DashboardAgent, render_width: u16) -> Vec<Line<'static>> {
-        let snap_opt = runstate::read_stage_context(&agent.id, self.selected_stage)
+        // When browsing the run's archived context history, show that point's
+        // window; otherwise the live current window for the selected stage.
+        let snap_opt = self
+            .browsed_context_point()
+            .map(|p| p.context.clone())
+            .or_else(|| runstate::read_stage_context(&agent.id, self.selected_stage))
             .or_else(|| agent.context_snapshot.clone());
         if let Some(snap) = snap_opt {
             let mut lines: Vec<Line> = Vec::new();
@@ -1949,6 +1963,75 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+    }
+
+    /// A one-point context history for the browsing render tests.
+    fn one_point_history(
+        context: runstate::ContextSnapshot,
+    ) -> Vec<leviath_core::run_archive::RunPoint> {
+        vec![leviath_core::run_archive::RunPoint {
+            meta: leviath_core::run_meta::RunMeta::new(
+                "r".to_string(),
+                "a".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            ),
+            context,
+            at: 1,
+        }]
+    }
+
+    #[test]
+    fn render_context_bar_shows_history_position_when_browsing() {
+        let backend = TestBackend::new(120, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let agent = make_test_agent("run-hist-bar", AgentDisplayStatus::Active);
+        dash.context_history = one_point_history(make_context_snapshot(1000, 8000));
+        dash.context_history_idx = Some(0);
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 80, 5);
+                dash.render_context_bar(f, area, &agent);
+            })
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            text.contains("ctx 1/1"),
+            "history position in title: {text}"
+        );
+    }
+
+    #[test]
+    fn build_context_lines_uses_browsed_history_point() {
+        let mut dash = make_test_dashboard();
+        // No live snapshot on the agent → the browsed point is the only source.
+        let agent = make_test_agent("run-hist-lines-xyzzy", AgentDisplayStatus::Active);
+        dash.context_history = one_point_history(runstate::ContextSnapshot {
+            stage_name: "browsed-stage".to_string(),
+            total_tokens: 42,
+            max_tokens: 100,
+            regions: vec![runstate::RegionSnapshot {
+                name: "hist-region".to_string(),
+                kind: "pinned".to_string(),
+                current_tokens: 42,
+                max_tokens: 100,
+                entries: vec![],
+            }],
+        });
+        dash.context_history_idx = Some(0);
+        let lines = dash.build_context_lines(&agent, 80);
+        let text: String = lines.iter().map(|l| format!("{l:?}")).collect();
+        assert!(text.contains("hist-region"), "browsed region rendered");
     }
 
     // ─── render_content_pane: Context mode with is_run_state (disk fallback)

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -38,6 +38,13 @@ pub(crate) struct Dashboard {
     pub(super) selected_stage: usize,
     /// Whether the content pane shows Output or Logs — global across all stage tabs.
     pub(super) stage_content_mode: StageContentMode,
+    /// The selected run's context-window history (from its `run.lvr` archive),
+    /// loaded lazily when the user starts browsing it in the Context view. Empty
+    /// until then, and cleared when the browsed run changes.
+    pub(super) context_history: Vec<leviath_core::run_archive::RunPoint>,
+    /// Which historical context point is being viewed: `None` = the live current
+    /// window (the default), `Some(i)` = archived point `i` in `context_history`.
+    pub(super) context_history_idx: Option<usize>,
     /// True after the first sync completes; suppresses startup toasts for pre-existing state.
     pub(super) initial_sync_done: bool,
     /// Monotonic tick counter for animations (spinner, toast timeouts)
@@ -127,6 +134,8 @@ impl Dashboard {
             choice_selected: 0,
             selected_stage: 0,
             stage_content_mode: StageContentMode::Output,
+            context_history: Vec::new(),
+            context_history_idx: None,
             initial_sync_done: false,
             tick_count: 0,
             toasts: Vec::new(),
@@ -271,6 +280,56 @@ impl Dashboard {
 
     pub(super) fn selected_agent_raw_idx(&self) -> Option<usize> {
         self.display_indices.get(self.selected).copied()
+    }
+
+    /// Leave context-history browsing and go back to the live current window.
+    pub(super) fn reset_context_history(&mut self) {
+        self.context_history.clear();
+        self.context_history_idx = None;
+    }
+
+    /// Step through the selected run's archived context-window history in the
+    /// Context view: `delta > 0` moves to a later point, `delta < 0` to an
+    /// earlier one. The history is (re)loaded from the run's `run.lvr` archive
+    /// on each step; stepping past the newest point returns to the live window.
+    /// No-op if the run has no archived history.
+    pub(super) fn step_context_history(&mut self, delta: isize) {
+        let Some(run_id) = self.selected_agent().map(|a| a.id.clone()) else {
+            return;
+        };
+        let history = runstate::context_history(&run_id);
+        if history.is_empty() {
+            self.reset_context_history();
+            return;
+        }
+        let last = (history.len() - 1) as isize;
+        let new_idx = match self.context_history_idx {
+            // From the live window, a backward step enters at the newest point;
+            // a forward step stays live.
+            None => (delta < 0).then_some(last),
+            Some(i) => {
+                let target = i as isize + delta;
+                if target < 0 {
+                    Some(0)
+                } else if target > last {
+                    None // past the newest recorded point → live window
+                } else {
+                    Some(target)
+                }
+            }
+        };
+        self.context_history = history;
+        self.context_history_idx = new_idx.map(|i| i as usize);
+        self.stage_content_mode = StageContentMode::Context;
+        self.detail_scroll = 0;
+    }
+
+    /// The context snapshot to render in the Context view: the selected archived
+    /// history point when browsing, else `None` (callers fall back to the live
+    /// current window).
+    pub(super) fn browsed_context_point(&self) -> Option<&leviath_core::run_archive::RunPoint> {
+        self.context_history_idx
+            .and_then(|i| self.context_history.get(i))
     }
 
     pub(super) fn add_log(&mut self, msg: String) {
@@ -790,6 +849,112 @@ mod tests {
         assert_eq!(dash.agents[dash.display_indices[0]].id, "run-2"); // Active
         assert_eq!(dash.agents[dash.display_indices[1]].id, "run-3"); // Waiting
         assert_eq!(dash.agents[dash.display_indices[2]].id, "run-1"); // Complete
+    }
+
+    /// Write a `run.lvr` for `run_id` with `points` context checkpoints.
+    fn write_history_archive(run_id: &str, points: usize) {
+        use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+        std::fs::create_dir_all(runstate::run_dir(run_id)).unwrap();
+        let mut buf = Vec::new();
+        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::Header {
+                identity: RunIdentity {
+                    run_id: run_id.to_string(),
+                    machine_id: "m".to_string(),
+                    world_id: "w".to_string(),
+                    created_at: 0,
+                },
+                meta: Box::new(leviath_core::run_meta::RunMeta::new(
+                    run_id.to_string(),
+                    "a".to_string(),
+                    "/p".to_string(),
+                    "t".to_string(),
+                    None,
+                    "/w".to_string(),
+                    1,
+                )),
+            },
+        )
+        .unwrap();
+        for i in 0..points {
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::ContextCheckpoint {
+                    snapshot: runstate::ContextSnapshot {
+                        stage_name: format!("stage{i}"),
+                        total_tokens: i,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: i as i64,
+                },
+            )
+            .unwrap();
+        }
+        std::fs::write(runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+    }
+
+    #[test]
+    fn step_context_history_browses_then_returns_to_live() {
+        crate::runstate::with_isolated_runs_dir("dash-ctx-hist-browse", |_d| {
+            write_history_archive("run-h", 2);
+            let mut dash = make_test_dashboard();
+            dash.agents
+                .push(make_test_agent("run-h", AgentDisplayStatus::Active));
+            dash.update_display_indices();
+            dash.selected = 0;
+
+            assert_eq!(dash.context_history_idx, None);
+            assert!(dash.browsed_context_point().is_none());
+
+            // Back from live → newest point (index 1 of 2).
+            dash.step_context_history(-1);
+            assert_eq!(dash.context_history_idx, Some(1));
+            assert_eq!(dash.stage_content_mode, StageContentMode::Context);
+            assert!(dash.browsed_context_point().is_some());
+
+            // Back → index 0, then clamped at 0.
+            dash.step_context_history(-1);
+            assert_eq!(dash.context_history_idx, Some(0));
+            dash.step_context_history(-1);
+            assert_eq!(dash.context_history_idx, Some(0));
+
+            // Forward → index 1, then past newest → live.
+            dash.step_context_history(1);
+            assert_eq!(dash.context_history_idx, Some(1));
+            dash.step_context_history(1);
+            assert_eq!(dash.context_history_idx, None);
+            // Forward from live stays live.
+            dash.step_context_history(1);
+            assert_eq!(dash.context_history_idx, None);
+
+            // reset clears the cache + index.
+            dash.step_context_history(-1);
+            dash.reset_context_history();
+            assert_eq!(dash.context_history_idx, None);
+            assert!(dash.context_history.is_empty());
+        });
+    }
+
+    #[test]
+    fn step_context_history_noop_without_agent_or_archive() {
+        // No selected agent → no-op.
+        let mut dash = make_test_dashboard();
+        dash.step_context_history(-1);
+        assert_eq!(dash.context_history_idx, None);
+
+        // Agent whose run has no archive → resets to live.
+        crate::runstate::with_isolated_runs_dir("dash-ctx-hist-none", |_d| {
+            dash.agents
+                .push(make_test_agent("run-none", AgentDisplayStatus::Active));
+            dash.update_display_indices();
+            dash.selected = 0;
+            dash.step_context_history(-1);
+            assert_eq!(dash.context_history_idx, None);
+            assert!(dash.context_history.is_empty());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the context-viewing surfaces: the dashboard's **Context** detail pane can now step through a run's **archived context-window history** (from `run.lvr`), not just the live current window. (CLI `lev context` + `GET .../context/history` landed in #60.)

- `,` / `.` — step to an earlier / later recorded point; stepping past the newest point returns to the **live** window.
- `c` — return to the live context view (leaves history browsing).
- The context card title shows the browsed position: `ctx i/N`.
- History is reloaded from the archive on each step and cleared when leaving the run's detail view (Esc), so browsing never shows a stale or wrong run's window.

Reuses the existing `StageContentMode::Context` (no new mode/exhaustive-match churn); `build_context_lines` / `render_context_bar` source from the browsed point when one is selected.

## Tests
- Step logic: enter-from-live, clamp at oldest, return-to-live past newest, no-agent / no-archive no-ops.
- Render: browsed-point source (`build_context_lines`) and the `ctx i/N` title (`render_context_bar`).
- Input: `,`/`.` routing, and `c` / Esc resetting to live.

leviath-cli at 100% coverage; clippy + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)