### PR TITLE
feat(daemon): persist + restore fan-out state so an interrupted merge resumes

### DIFF
--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -74,12 +74,41 @@ pub fn reload_persisted_agents(
         }
     }
     // Second pass: every run is now an entity, so rebuild the parent→children
-    // tree deterministically from the persisted links (no heuristics).
+    // tree deterministically from the persisted links (no heuristics), then
+    // resume any parent that was parked mid fan-out.
     relink_tree(world, &reloaded);
+    restore_fan_outs(world, &reloaded, runs_dir);
     reloaded
         .into_iter()
         .map(|(meta, entity)| (meta.run_id, entity))
         .collect()
+}
+
+/// Rebuild `FanOutWaiting` for any reloaded parent that was parked mid fan-out
+/// (a `<run_dir>/fanout.json` is present), so its split/merge resumes rather than
+/// hanging. Active workers are re-linked by run-id via the reloaded run→entity
+/// map; a worker that didn't reload is recorded as a failure so the merge still
+/// completes. A malformed/absent file is skipped.
+fn restore_fan_outs(world: &mut PipelineWorld, reloaded: &[(RunMeta, Entity)], runs_dir: &Path) {
+    let by_run_id: std::collections::HashMap<&str, Entity> = reloaded
+        .iter()
+        .map(|(m, e)| (m.run_id.as_str(), *e))
+        .collect();
+    for (meta, entity) in reloaded {
+        let path = runs_dir.join(&meta.run_id).join("fanout.json");
+        let Some(state) = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<leviath_runtime::fanout::FanOutState>(&s).ok())
+        else {
+            continue;
+        };
+        leviath_runtime::fanout::restore_fan_out_waiting(
+            world.world_mut(),
+            *entity,
+            state,
+            &|rid| by_run_id.get(rid).copied(),
+        );
+    }
 }
 
 /// Rebuild `ParentRef` / `SubAgentChildren` on the freshly reloaded entities from
@@ -441,6 +470,86 @@ mod tests {
         let totals = world.world().get::<TokenTotals>(*entity).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
+    }
+
+    #[tokio::test]
+    async fn resumes_a_parent_parked_mid_fan_out() {
+        use leviath_core::blueprint::{FanOutConfig, WorkerFailurePolicy};
+        use leviath_runtime::fanout::{FanOutState, FanOutWaiting};
+
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+
+        // A parent parked mid fan-out: a valid fanout.json alongside its meta.
+        write_run(
+            runs.path(),
+            "parent-fo",
+            mpath,
+            RunStatus::WaitingInput,
+            None,
+        );
+        let state = FanOutState {
+            config: FanOutConfig {
+                worker_agent: None,
+                worker_stage: Some("w".to_string()),
+                worker_query: None,
+                merge_stage: None,
+                max_workers: 1,
+                on_worker_failure: WorkerFailurePolicy::Continue,
+                split_prompt: "s".to_string(),
+            },
+            max_workers: 1,
+            pending: vec![],
+            // One in-flight worker, referenced by the run-id of another reloaded
+            // run so the resolver maps it back to an entity on restore.
+            active: vec![("item-1".to_string(), "worker-fo".to_string())],
+            summaries: vec![],
+            failures: vec![],
+        };
+        std::fs::write(
+            runs.path().join("parent-fo").join("fanout.json"),
+            serde_json::to_string(&state).unwrap(),
+        )
+        .unwrap();
+        // The referenced worker run, so the active worker re-links to a real entity.
+        write_run(runs.path(), "worker-fo", mpath, RunStatus::Running, None);
+
+        // A run with a malformed fanout.json → skipped (no FanOutWaiting).
+        write_run(runs.path(), "bad-fo", mpath, RunStatus::WaitingInput, None);
+        std::fs::write(runs.path().join("bad-fo").join("fanout.json"), b"garbage").unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+        let by_id: std::collections::HashMap<_, _> =
+            restored.iter().map(|(r, e)| (r.clone(), *e)).collect();
+
+        // The parent's fan-out waiting state was rebuilt; the malformed one wasn't.
+        assert!(
+            world
+                .world()
+                .get::<FanOutWaiting>(by_id["parent-fo"])
+                .is_some()
+        );
+        assert!(
+            world
+                .world()
+                .get::<FanOutWaiting>(by_id["bad-fo"])
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -31,7 +31,7 @@ use crate::pipeline::{AgentBlueprint, ProcessResponse, ResolveTransition, StageC
 const DEFAULT_FANOUT_DEPTH: usize = 3;
 
 /// One unit of work produced by a fan-out split.
-#[derive(serde::Deserialize, Debug, Clone, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 pub struct WorkItem {
     /// Stable id (used to label the worker in the consolidated report).
     #[serde(default)]
@@ -76,17 +76,96 @@ pub trait FanOutSpawner: Send + Sync {
 #[derive(Resource, Clone)]
 pub struct FanOutSpawnerRes(pub Arc<dyn FanOutSpawner>);
 
+/// A currently-running fan-out worker: its work-item id, its live entity, and
+/// its run-id (kept so the waiting state can be persisted/restored without a
+/// cross-entity lookup — see [`FanOutState`]).
+struct ActiveWorker {
+    item_id: String,
+    entity: Entity,
+    run_id: String,
+}
+
 /// A parent parked while its fan-out workers run. Holds the not-yet-started
-/// `pending` items, the currently-`active` `(item_id, worker)` pairs, and the
-/// accumulated worker results.
+/// `pending` items, the currently-`active` workers, and the accumulated results.
 #[derive(Component)]
 pub struct FanOutWaiting {
     config: FanOutConfig,
     max_workers: usize,
     pending: VecDeque<WorkItem>,
-    active: Vec<(String, Entity)>,
+    active: Vec<ActiveWorker>,
     summaries: Vec<(String, String)>,
     failures: Vec<(String, String)>,
+}
+
+/// The serializable form of [`FanOutWaiting`], written to `<run_dir>/fanout.json`
+/// so a parent interrupted mid-split resumes its merge after a restart. `active`
+/// carries worker **run-ids** (not entities); recovery maps them back to the
+/// reloaded worker entities.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FanOutState {
+    /// The fan-out configuration.
+    pub config: FanOutConfig,
+    /// The concurrency cap.
+    pub max_workers: usize,
+    /// Work items not yet started.
+    pub pending: Vec<WorkItem>,
+    /// In-flight workers as `(item_id, run_id)`.
+    pub active: Vec<(String, String)>,
+    /// Completed worker results as `(item_id, summary)`.
+    pub summaries: Vec<(String, String)>,
+    /// Failed worker results as `(item_id, message)`.
+    pub failures: Vec<(String, String)>,
+}
+
+impl FanOutWaiting {
+    /// Project to the serializable [`FanOutState`] (workers by run-id).
+    pub(crate) fn to_state(&self) -> FanOutState {
+        FanOutState {
+            config: self.config.clone(),
+            max_workers: self.max_workers,
+            pending: self.pending.iter().cloned().collect(),
+            active: self
+                .active
+                .iter()
+                .map(|w| (w.item_id.clone(), w.run_id.clone()))
+                .collect(),
+            summaries: self.summaries.clone(),
+            failures: self.failures.clone(),
+        }
+    }
+}
+
+/// Rebuild a parent's [`FanOutWaiting`] from a persisted [`FanOutState`] and
+/// insert it, mapping each active worker's run-id back to its reloaded entity
+/// via `resolve`. Workers whose entity didn't reload are treated as failures so
+/// the merge still completes rather than waiting forever. Used by restart
+/// recovery to resume an interrupted fan-out.
+pub fn restore_fan_out_waiting(
+    world: &mut World,
+    parent: Entity,
+    state: FanOutState,
+    resolve: &dyn Fn(&str) -> Option<Entity>,
+) {
+    let mut active = Vec::new();
+    let mut failures = state.failures;
+    for (item_id, run_id) in state.active {
+        match resolve(&run_id) {
+            Some(entity) => active.push(ActiveWorker {
+                item_id,
+                entity,
+                run_id,
+            }),
+            None => failures.push((item_id, "worker did not reload after restart".to_string())),
+        }
+    }
+    world.entity_mut(parent).insert(FanOutWaiting {
+        config: state.config,
+        max_workers: state.max_workers,
+        pending: state.pending.into_iter().collect(),
+        active,
+        summaries: state.summaries,
+        failures,
+    });
 }
 
 /// Fan-out split system (exclusive): for each `ProcessResponse` agent whose
@@ -171,11 +250,11 @@ pub fn fan_out_collect(world: &mut World) {
 
         // 1. Reap workers that have reached a terminal state.
         let mut still_active = Vec::with_capacity(w.active.len());
-        for (id, worker) in std::mem::take(&mut w.active) {
-            match worker_terminal_result(world, worker) {
-                Some(Ok(content)) => w.summaries.push((id, content)),
-                Some(Err(message)) => w.failures.push((id, message)),
-                None => still_active.push((id, worker)),
+        for aw in std::mem::take(&mut w.active) {
+            match worker_terminal_result(world, aw.entity) {
+                Some(Ok(content)) => w.summaries.push((aw.item_id, content)),
+                Some(Err(message)) => w.failures.push((aw.item_id, message)),
+                None => still_active.push(aw),
             }
         }
         w.active = still_active;
@@ -186,7 +265,18 @@ pub fn fan_out_collect(world: &mut World) {
                 break;
             };
             match start_worker(world, parent, &w.config, &item) {
-                Ok(child) => w.active.push((item.id, child)),
+                Ok(child) => {
+                    // Capture the worker's run-id so the waiting state persists.
+                    let run_id = world
+                        .get::<crate::persistence::RunMetadata>(child)
+                        .map(|m| m.run_id.clone())
+                        .unwrap_or_default();
+                    w.active.push(ActiveWorker {
+                        item_id: item.id,
+                        entity: child,
+                        run_id,
+                    });
+                }
                 Err(message) => w.failures.push((item.id, message)),
             }
         }
@@ -732,6 +822,58 @@ mod tests {
         fan_out_collect(&mut world);
         assert!(world.get::<FanOutWaiting>(e).is_none());
         assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    }
+
+    #[test]
+    fn fan_out_state_roundtrips_and_unresolved_workers_become_failures() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 2, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"},{"id":"b"}]"#,
+        );
+        fan_out_split(&mut world);
+        fan_out_collect(&mut world); // starts both workers → active
+
+        // Projecting to the serializable state captures each worker's run-id.
+        let state = world.get::<FanOutWaiting>(e).unwrap().to_state();
+        assert_eq!(state.active.len(), 2);
+        assert!(state.active.iter().all(|(_id, run_id)| !run_id.is_empty()));
+
+        // Restore onto a fresh parent, resolving run-ids back to entities.
+        let by_run: std::collections::HashMap<String, Entity> = world
+            .get::<SubAgentChildren>(e)
+            .unwrap()
+            .children
+            .iter()
+            .filter_map(|&c| {
+                world
+                    .get::<crate::persistence::RunMetadata>(c)
+                    .map(|m| (m.run_id.clone(), c))
+            })
+            .collect();
+        let fresh = world.spawn_empty().id();
+        restore_fan_out_waiting(&mut world, fresh, state.clone(), &|rid| {
+            by_run.get(rid).copied()
+        });
+        assert_eq!(
+            world
+                .get::<FanOutWaiting>(fresh)
+                .unwrap()
+                .to_state()
+                .active
+                .len(),
+            2
+        );
+
+        // A resolver that can't map the workers → they become failures, so the
+        // merge still completes rather than waiting forever.
+        let orphaned = world.spawn_empty().id();
+        restore_fan_out_waiting(&mut world, orphaned, state, &|_| None);
+        let s = world.get::<FanOutWaiting>(orphaned).unwrap().to_state();
+        assert!(s.active.is_empty());
+        assert_eq!(s.failures.len(), 2);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -33,6 +33,11 @@ pub struct PersistJob {
     /// `(stage_index, serialized GateEvent log)` to write to
     /// `stages/<idx>/taint_audit.json`. `None` ⇒ no audit to persist.
     pub taint_audit: Option<(usize, String)>,
+    /// Serialized [`FanOutState`](crate::fanout::FanOutState) for a parent parked
+    /// mid fan-out, written to `fanout.json` so the split/merge resumes after a
+    /// restart. `None` ⇒ the agent isn't waiting on a fan-out (any stale file is
+    /// removed).
+    pub fanout: Option<String>,
 }
 
 /// The single-lane persistence worker: writes each [`PersistJob`]'s files under
@@ -136,6 +141,15 @@ async fn write_snapshot(
             &job.run_id,
         )
         .await;
+    }
+    // Fan-out waiting state (whole-file), or remove any stale file once the
+    // parent is no longer parked on a fan-out.
+    let fanout_path = dir.join("fanout.json");
+    match &job.fanout {
+        Some(json) => write_bytes_atomic(&fanout_path, json.as_bytes(), &job.run_id).await,
+        None => {
+            let _ = tokio::fs::remove_file(&fanout_path).await;
+        }
     }
 }
 
@@ -307,6 +321,7 @@ mod tests {
             output_appends: vec![],
             log_appends: vec![],
             taint_audit: None,
+            fanout: None,
         })
         .unwrap();
         drop(tx); // close so the worker loop ends
@@ -331,6 +346,7 @@ mod tests {
             output_appends: vec![],
             log_appends: vec![],
             taint_audit: None,
+            fanout: None,
         }
     }
 
@@ -455,6 +471,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_snapshot_writes_then_removes_fanout_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run-1").join("fanout.json");
+        // A job carrying fan-out state writes fanout.json.
+        let mut fo_job = job("run-1");
+        fo_job.fanout = Some(r#"{"resume":"me"}"#.to_string());
+        write_snapshot(dir.path(), &fo_job, "m", "w", None).await;
+        assert!(path.exists());
+        // A later job without fan-out state removes the now-stale file.
+        write_snapshot(dir.path(), &job("run-1"), "m", "w", Some(&fo_job.context)).await;
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
     async fn run_archive_open_failure_is_swallowed() {
         // Pre-create `run.lvr` as a directory so opening it for append fails; the
         // best-effort archive write must not panic (and the rest still runs).
@@ -509,6 +539,7 @@ mod tests {
                 output_appends: vec![(0, "the plan".to_string())],
                 log_appends: vec![(0, "[tool] list_dir: .".to_string())],
                 taint_audit: None,
+                fanout: None,
             },
             "machine-test",
             "world-test",
@@ -540,6 +571,7 @@ mod tests {
                 output_appends: vec![],
                 log_appends: vec![],
                 taint_audit: Some((2, r#"[{"tool_name":"shell"}]"#.to_string())),
+                fanout: None,
             },
             "machine-test",
             "world-test",
@@ -564,6 +596,7 @@ mod tests {
                 output_appends: vec![],
                 log_appends: vec![],
                 taint_audit: None,
+                fanout: None,
             },
             "machine-test",
             "world-test",
@@ -600,6 +633,7 @@ mod tests {
                 output_appends: vec![],
                 log_appends: vec![],
                 taint_audit: None,
+                fanout: None,
             },
             "machine-test",
             "world-test",
@@ -627,6 +661,7 @@ mod tests {
                 output_appends: vec![],
                 log_appends: vec![],
                 taint_audit: None,
+                fanout: None,
             },
             "machine-test",
             "world-test",
@@ -658,6 +693,7 @@ mod tests {
                 output_appends: vec![],
                 log_appends: vec![],
                 taint_audit: None,
+                fanout: None,
             },
             "machine-test",
             "world-test",

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -1474,6 +1474,7 @@ pub fn dispatch_persistence(
         Option<&crate::taint::TaintGate>,
         Option<&crate::components::ParentRef>,
         Option<&crate::components::SubAgentChildren>,
+        Option<&crate::fanout::FanOutWaiting>,
     )>,
     stage: Res<PersistenceStage>,
 ) {
@@ -1489,6 +1490,7 @@ pub fn dispatch_persistence(
         taint_gate,
         parent_ref,
         children,
+        fan_out_waiting,
     ) in agents.iter_mut()
     {
         let now = chrono::Utc::now().timestamp();
@@ -1534,6 +1536,11 @@ pub fn dispatch_persistence(
                     .expect("GateEvent slice always serializes"),
             )
         });
+        // A parent parked mid fan-out: persist its waiting state so the
+        // split/merge resumes after a restart (removed once it's no longer
+        // waiting — see the writer).
+        let fanout = fan_out_waiting
+            .map(|w| serde_json::to_string(&w.to_state()).expect("FanOutState always serializes"));
         let _ = stage.0.send(PersistJob {
             run_id: md.run_id.clone(),
             meta,
@@ -1542,6 +1549,7 @@ pub fn dispatch_persistence(
             output_appends,
             log_appends,
             taint_audit,
+            fanout,
         });
     }
 }
@@ -3389,6 +3397,48 @@ mod tests {
         assert_eq!(job.meta.children, vec!["kid-1".to_string()]);
         assert_eq!(job.meta.depth, 3);
         assert_eq!(job.meta.max_child_depth, 6);
+    }
+
+    #[test]
+    fn dispatch_persistence_serializes_fan_out_waiting() {
+        use leviath_core::blueprint::{FanOutConfig, WorkerFailurePolicy};
+        let (mut world, mut rx) = world_with_persistence();
+        let e = world
+            .spawn((
+                run_metadata(),
+                agent_state(),
+                conv_window(),
+                StageCursor { index: 0 },
+                TokenTotals::default(),
+                PersistWatermark::default(),
+            ))
+            .id();
+        // Attach a (minimal) FanOutWaiting via the public restore path.
+        crate::fanout::restore_fan_out_waiting(
+            &mut world,
+            e,
+            crate::fanout::FanOutState {
+                config: FanOutConfig {
+                    worker_agent: None,
+                    worker_stage: Some("w".to_string()),
+                    worker_query: None,
+                    merge_stage: None,
+                    max_workers: 1,
+                    on_worker_failure: WorkerFailurePolicy::Continue,
+                    split_prompt: "s".to_string(),
+                },
+                max_workers: 1,
+                pending: vec![],
+                active: vec![],
+                summaries: vec![],
+                failures: vec![],
+            },
+            &|_| None,
+        );
+
+        run_dispatch_persistence(&mut world);
+        let job = rx.try_recv().expect("job sent");
+        assert!(job.fanout.is_some(), "fan-out waiting state persisted");
     }
 
     #[test]


### PR DESCRIPTION
## What

A parent parked mid fan-out (in `FanOutWaiting`) was lost on restart. #50 rebuilt the sub-agent **tree**, but `FanOutWaiting` itself — which holds the split/merge state — is un-serializable (`Vec<(String, Entity)>`) and was never persisted, so a reloaded parent never resumed its merge (it hung, or its stage completed without the worker results).

This makes the fan-out state a **stored fact** that restart rebuilds — the last of the deterministic-resume gaps.

### How
- **Serializable form**: `FanOutState` keys active workers by **run-id** (not `Entity`). `FanOutWaiting.active` now carries each worker's run-id (captured when the worker starts), so `to_state()` needs no cross-entity lookup at persist time. `restore_fan_out_waiting()` rebuilds the component, mapping run-ids back to entities via a resolver.
- **Persist**: `dispatch_persistence` serializes a parent's `FanOutWaiting` into `PersistJob.fanout`; the persistence worker writes `<run_dir>/fanout.json` — and **removes** it once the parent is no longer waiting, so a stale file can't mis-fire.
- **Restore**: recovery rebuilds `FanOutWaiting` from `fanout.json` after the tree is relinked, re-linking active workers by run-id. A worker that didn't reload becomes a **failure** so the merge still completes rather than waiting forever.

## Tests
`to_state`/`restore` round-trip + unresolved-worker→failure; `dispatch_persistence` serializing the state; the writer's write-then-remove of `fanout.json`; recovery rebuilding it (valid + malformed archive skipped). leviath-cli at 100% coverage; clippy + rustdoc clean; runtime whole-file coverage verified on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)