### PR TITLE
feat(daemon): unload terminal agents from memory (demand paging, phase 1)

### DIFF
--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -373,6 +373,9 @@ impl WorldHost {
             .iter()
             .map(|(k, &v)| (k.clone(), v))
             .collect();
+        // Terminal agents to unload from memory this pass (their disk state is
+        // preserved and still viewable). Collected during the loop, reaped after.
+        let mut to_reap: Vec<(String, Entity)> = Vec::new();
         for (run_id, entity) in pairs {
             let Some(state) = self.world.world().get::<AgentState>(entity) else {
                 continue; // reaped between registration and now
@@ -481,15 +484,30 @@ impl WorldHost {
                 });
             }
 
-            if cur.terminal && prev.as_ref().map(|e| e.terminal) != Some(true) {
+            let was_terminal = prev.as_ref().map(|e| e.terminal) == Some(true);
+            if cur.terminal && !was_terminal {
                 let _ = self.events.send(WorldEvent::Completed {
                     run_id: run_id.clone(),
                     agent_id: agent_id.clone(),
                     status: status.to_string(),
                 });
             }
+            // Unload a terminal agent once its terminal state has been emitted (a
+            // prior pass already saw it terminal, so the event went out and the
+            // persistence lane captured it) and no live parent still needs it.
+            if cur.terminal && was_terminal && self.no_live_parent(entity) {
+                to_reap.push((run_id.clone(), entity));
+            }
 
             self.emitted.insert(run_id, cur);
+        }
+
+        // Reap: despawn the entity and erase its host-map entries. Iterating a
+        // snapshot of `by_run_id` above means removing here is safe.
+        for (run_id, entity) in to_reap {
+            self.world.world_mut().despawn(entity);
+            self.by_run_id.remove(&run_id);
+            self.emitted.remove(&run_id);
         }
 
         for (agent_id, request) in self.interactions.pending() {
@@ -500,6 +518,24 @@ impl WorldHost {
                     request,
                 });
             }
+        }
+    }
+
+    /// Whether a terminal agent is safe to unload: it has no **live** parent that
+    /// might still be waiting on it. True for a root (no `ParentRef`), or when its
+    /// parent has been despawned or is itself terminal; false while a non-terminal
+    /// parent could still be gating on this child.
+    fn no_live_parent(&self, entity: Entity) -> bool {
+        let world = self.world.world();
+        match world.get::<crate::components::ParentRef>(entity) {
+            None => true,
+            Some(parent_ref) => match world.get::<AgentState>(parent_ref.parent_entity) {
+                None => true,
+                Some(state) => matches!(
+                    state.status,
+                    AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
+                ),
+            },
         }
     }
 
@@ -1510,6 +1546,105 @@ mod tests {
                 .collect::<Vec<_>>()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn emit_events_unloads_terminal_agents_when_safe() {
+        let mut host = host_with(vec![]);
+
+        // A terminal root: emitted on the first pass, unloaded on the second.
+        let root = {
+            let mut s = agent_state("root");
+            s.status = AgentStatus::Complete;
+            host.world.world_mut().spawn(s).id()
+        };
+        host.register("root", root);
+        host.emit_events();
+        assert!(
+            host.live_entity("root").is_some(),
+            "not reaped on the first terminal pass (event must go out first)"
+        );
+        host.emit_events();
+        assert!(host.live_entity("root").is_none(), "reaped after emit");
+        assert!(
+            host.world.world().get::<AgentState>(root).is_none(),
+            "entity despawned"
+        );
+
+        // A terminal child under a LIVE (Active) parent is deferred.
+        let parent = host.world.world_mut().spawn(agent_state("parent")).id();
+        host.register("parent", parent);
+        let child = {
+            let mut s = agent_state("child");
+            s.status = AgentStatus::Complete;
+            host.world
+                .world_mut()
+                .spawn((
+                    s,
+                    ParentRef {
+                        parent_entity: parent,
+                        parent_agent_id: "parent".to_string(),
+                        depth: 1,
+                    },
+                ))
+                .id()
+        };
+        host.register("child", child);
+        host.emit_events();
+        host.emit_events();
+        assert!(
+            host.live_entity("child").is_some(),
+            "not reaped while its parent is live"
+        );
+
+        // Once the parent is terminal, the child becomes reapable.
+        host.world
+            .world_mut()
+            .get_mut::<AgentState>(parent)
+            .unwrap()
+            .status = AgentStatus::Complete;
+        host.emit_events();
+        host.emit_events();
+        assert!(
+            host.live_entity("child").is_none(),
+            "reaped once its parent is terminal"
+        );
+
+        // A terminal child whose parent entity was despawned is also reapable.
+        let ghost = host.world.world_mut().spawn_empty().id();
+        host.world.world_mut().despawn(ghost);
+        let orphan = {
+            let mut s = agent_state("orphan");
+            s.status = AgentStatus::Complete;
+            host.world
+                .world_mut()
+                .spawn((
+                    s,
+                    ParentRef {
+                        parent_entity: ghost,
+                        parent_agent_id: "gone".to_string(),
+                        depth: 1,
+                    },
+                ))
+                .id()
+        };
+        host.register("orphan", orphan);
+        host.emit_events();
+        host.emit_events();
+        assert!(
+            host.live_entity("orphan").is_none(),
+            "reaped: parent entity despawned"
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_events_does_not_reap_non_terminal_agents() {
+        let mut host = host_with(vec![]);
+        let active = host.world.world_mut().spawn(agent_state("active")).id();
+        host.register("active", active);
+        host.emit_events();
+        host.emit_events();
+        assert!(host.live_entity("active").is_some());
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -57,8 +57,25 @@ pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<P
     while let Some(job) = jobs.recv().await {
         let prev = last_context.get(&job.run_id);
         write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev).await;
-        last_context.insert(job.run_id.clone(), job.context.clone());
+        // Drop a fully-terminal run's cached context (it won't be written again),
+        // so the map stays bounded by the set of *live* runs rather than every
+        // run the daemon has ever seen.
+        if is_terminal_run(&job.meta.status) {
+            last_context.remove(&job.run_id);
+        } else {
+            last_context.insert(job.run_id.clone(), job.context.clone());
+        }
     }
+}
+
+/// Whether a run status is fully terminal (no further snapshots expected).
+/// `CompleteInteractive` is excluded — such an agent stays live for follow-up.
+fn is_terminal_run(status: &leviath_core::run_meta::RunStatus) -> bool {
+    use leviath_core::run_meta::RunStatus;
+    matches!(
+        status,
+        RunStatus::Complete | RunStatus::Error | RunStatus::Cancelled
+    )
 }
 
 /// A short opaque id derived from the current time + pid. Not cryptographic — it
@@ -468,6 +485,30 @@ mod tests {
             })
             .expect("ownership handoff recorded");
         assert_eq!(owned, ("m2".to_string(), "w2".to_string()));
+    }
+
+    #[test]
+    fn is_terminal_run_classifies_statuses() {
+        use leviath_core::run_meta::RunStatus;
+        assert!(is_terminal_run(&RunStatus::Complete));
+        assert!(is_terminal_run(&RunStatus::Error));
+        assert!(is_terminal_run(&RunStatus::Cancelled));
+        assert!(!is_terminal_run(&RunStatus::Running));
+        assert!(!is_terminal_run(&RunStatus::CompleteInteractive));
+    }
+
+    #[tokio::test]
+    async fn worker_drops_terminal_runs_from_the_context_cache() {
+        // A terminal job exercises the cache-cleanup branch; the run is still
+        // written. (Non-terminal jobs exercise the insert branch elsewhere.)
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut terminal = job("run-term");
+        terminal.meta.status = leviath_core::run_meta::RunStatus::Complete;
+        tx.send(terminal).unwrap();
+        drop(tx);
+        persistence_worker(dir.path().to_path_buf(), rx).await;
+        assert!(dir.path().join("run-term").join("meta.json").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

The daemon never reaped completed agents: their ECS entities and the host's `by_run_id` / `emitted` maps grew for **every run it ever hosted** — an unbounded memory leak for a long-lived daemon (the audit's Concern B).

Now a terminal agent (`Complete` / `Error` / `Cancelled`) is **unloaded from memory** once:
1. its terminal state has been **emitted** (a prior `emit_events` pass saw it terminal, so the `Completed` event went out and the persistence lane captured it), and
2. **no live parent** still needs it (it's a root, or its parent is itself terminal / despawned).

Unloading despawns the entity and erases its `by_run_id` / `emitted` entries.

### Why it's safe
Every **viewing** surface reads run state from **disk**, not the live host, so completed runs still show everywhere:
- Dashboard: `sync_from_run_state` → `list_runs`
- HTTP: `list_agents` → `list_runs`, `get_agent` → `read_meta`
- `lev context`: reads `run.lvr`

`lev ps` (the live in-memory list) now shows only running agents — its intent. So **memory is bounded by the set of live runs**, and everything else lives on disk, paged back only when viewed — the "in memory only while active" model.

Also drops a terminal run's cached context from the persistence worker's `last_context` map (added with context diffing in #59) so that map stays bounded by live runs too.

## Scope / follow-up
This unloads **terminal** agents. Reload-on-demand for **idle** (non-terminal, parked) agents — which needs a cli→runtime reload seam — is the fast-follow (`docs/design/agent-paging.md`, phase C).

## Tests
`no_live_parent` across all arms (root / terminal parent / despawned parent / live parent → deferred); a terminal agent is reaped only after its state is emitted (not on the first terminal pass); non-terminal agents are never reaped; the persistence worker's terminal-cache cleanup (`is_terminal_run` + the drop branch). Runtime whole-file coverage verified on CI (local macOS under-reports — the documented phantom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)