### PR TITLE
fix(taint): don't force taint on unconfigured agents; --yolo waives gate prompts

### DIFF
--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -258,10 +258,19 @@ pub fn build_agent(
     let num_stages = blueprint.stages.len();
     let compaction = blueprint.compaction_config.clone();
     let max_child_depth = blueprint.max_child_depth.unwrap_or(DEFAULT_SUBAGENT_DEPTH);
-    // Taint gate: opt-in via the blueprint's `[security]` block. When on, the
-    // agent's outbound tool calls are gated against its context taint + the policy
-    // allowlist; when absent/off no gate is attached (zero enforcement overhead).
-    let security = blueprint.security.clone().unwrap_or_default();
+    // Taint gate: opt-in via the blueprint's `[security]` block, else the global
+    // config's `taint_tracking`, else off. Cascading through
+    // `resolve_security` (rather than `unwrap_or_default`, which forced taint on
+    // for every agent because `SecurityConfig::default()` is taint-on) means a
+    // blueprint with no `[security]` block correctly inherits the global setting
+    // — off by default. When on, the agent's outbound tool calls are gated
+    // against its context taint + the policy allowlist; when off no gate is
+    // attached (zero enforcement overhead).
+    let security = leviath_core::taint::resolve_security(
+        config.taint_tracking,
+        blueprint.security.as_ref(),
+        None,
+    );
     let tool_sensitivities: Option<HashMap<String, leviath_core::TaintLevel>> =
         security.taint_tracking.then(|| {
             let gate = leviath_runtime::TaintGate::new(security.clone());
@@ -335,6 +344,12 @@ pub fn build_agent(
                 leviath_runtime::TaintGate::new(security.clone()),
                 leviath_runtime::pipeline::ToolSensitivities(sensitivities),
             ));
+            // `--yolo` means run unattended: waive taint-gate prompts (the
+            // tool-policy wildcard below doesn't cover them), so a headless run
+            // never blocks on a gate no one can answer.
+            if args.yolo {
+                entity_mut.insert(leviath_runtime::components::GateAutoApprove);
+            }
             // `Option`'s iterator enables tracking without a dead "no window" arm
             // (a freshly spawned agent always carries a ContextWindow).
             entity_mut
@@ -636,6 +651,88 @@ mod tests {
                 .unwrap()
                 .overall_taint()
                 .is_some()
+        );
+        // Without `--yolo`, the gate stays interactive: no auto-approve marker.
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::components::GateAutoApprove>(entity)
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn build_agent_yolo_attaches_gate_auto_approve_when_taint_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"sec\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [security]\ntaint_tracking = true\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mut args = spawn_args(&manifest.to_string_lossy());
+        args.yolo = true;
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &args,
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+        // Taint on + `--yolo` ⇒ gate is auto-approved (marker attached) so a
+        // headless run never blocks on a gate prompt.
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::components::GateAutoApprove>(entity)
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn build_agent_no_security_block_leaves_taint_off_by_default() {
+        // Bug regression: a blueprint with no `[security]` block and a default
+        // (taint-off) global config must NOT attach the taint gate — previously
+        // `unwrap_or_default()` forced it on for every agent.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"plain\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(), // taint_tracking defaults to false
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::TaintGate>(entity)
+                .is_none(),
+            "no [security] block + global off ⇒ no taint gate"
         );
     }
 

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -270,6 +270,13 @@ pub struct SecurityConfig {
 
 impl Default for SecurityConfig {
     fn default() -> Self {
+        // A present `[security]` block (even empty) means "configure security",
+        // so the struct default is taint-on; a manifest with no block at all
+        // yields `None`, which callers must resolve through
+        // [`resolve_security`]/[`resolve_taint_enabled`] (default off). Do NOT
+        // use `unwrap_or_default()` on an optional agent/global config — that
+        // conflates "no block" with "empty block" and forces taint on
+        // everywhere; cascade through the global setting instead.
         Self {
             taint_tracking: true,
         }

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -68,6 +68,19 @@ pub struct SubAgentChildren {
 #[derive(Component, Debug, Clone)]
 pub struct AwaitingInteraction;
 
+/// Marker: auto-approve this agent's taint-gate blocks instead of raising a
+/// gate prompt.
+///
+/// Set when an agent is launched with `--yolo` (approve everything, run
+/// unattended). The taint gate raises a `MultipleChoice` interaction that the
+/// tool-policy `--yolo` wildcard does not cover, so without this a headless run
+/// — e.g. one driven over the Agent Client Protocol, where no human can answer —
+/// would block forever on a gate no one resolves. When present,
+/// [`dispatch_tools`](crate::pipeline::dispatch_tools) skips the gate check for
+/// this agent (taint tracking still records for audit; enforcement is waived).
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct GateAutoApprove;
+
 /// Status of an agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum AgentStatus {

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -563,6 +563,7 @@ pub fn dispatch_tools(
             Option<&ToolSensitivities>,
             Option<&mut crate::taint::TaintGate>,
             Option<&crate::gate_prompt::GateResolved>,
+            Option<&crate::components::GateAutoApprove>,
         ),
         With<ReadyForTools>,
     >,
@@ -581,9 +582,21 @@ pub fn dispatch_tools(
     // gate-prompt lane are wired (the daemon); otherwise blocks are returned as
     // `[blocked]` immediately, preserving the headless/non-interactive behavior.
     let interactive = hub.as_ref().zip(gate_stage.as_ref());
-    for (entity, state, result, mut window, routing, sensitivities, mut gate, resolved) in
-        agents.iter_mut()
+    for (
+        entity,
+        state,
+        result,
+        mut window,
+        routing,
+        sensitivities,
+        mut gate,
+        resolved,
+        auto_gate,
+    ) in agents.iter_mut()
     {
+        // `--yolo`: waive taint-gate enforcement so a headless run never blocks
+        // on a gate prompt no one can answer (taint tracking still records).
+        let auto_approve_gates = auto_gate.is_some();
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled — don't start new work
         }
@@ -623,7 +636,7 @@ pub fn dispatch_tools(
                     continue;
                 }
             }
-            if let Some(gate) = gate.as_deref_mut() {
+            if let Some(gate) = gate.as_deref_mut().filter(|_| !auto_approve_gates) {
                 let decision = gate.check_with_policy(
                     &state.agent_id,
                     &c.name,
@@ -4060,6 +4073,46 @@ mod tests {
         assert!(world.get::<crate::gate_prompt::GateResolved>(e).is_some());
         assert!(world.get::<ReadyForTools>(e).is_none());
         assert!(world.get::<AwaitingTools>(e).is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_tools_auto_approves_a_gate_block_under_yolo() {
+        // Same blocked + interactive scenario as above, but the agent carries
+        // `GateAutoApprove` (set by `--yolo`): the gate is waived, so the call
+        // dispatches to the lane instead of raising a prompt no one can answer.
+        let (jtx, mut jrx) = mpsc::unbounded_channel();
+        let (gtx, _grx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        world.insert_resource(crate::interaction_hub::InteractionHub::new());
+        world.insert_resource(crate::gate_prompt::GatePromptStage {
+            outcomes: gtx,
+            wake: std::sync::Arc::new(tokio::sync::Notify::new()),
+            runtime: tokio::runtime::Handle::current(),
+        });
+        let e = world
+            .spawn((
+                agent_state(),
+                infer_with(vec![tc("c_shell", "shell")]),
+                tainted_conv_window(),
+                ReadyForTools,
+                enabled_gate(),
+                crate::components::GateAutoApprove,
+            ))
+            .id();
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+        // No gate prompt was raised; the call went to the lane.
+        assert!(
+            world
+                .get::<crate::gate_prompt::AwaitingGatePrompt>(e)
+                .is_none()
+        );
+        assert!(world.get::<AwaitingTools>(e).is_some());
+        assert!(world.get::<ReadyForTools>(e).is_none());
+        assert_eq!(jrx.try_recv().expect("job enqueued").entity, e);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #76.

Two bugs combined to hang headless (ACP / Gas City) runs on a taint gate that `--yolo` couldn't clear. **Reproduced live over the Agent Client Protocol** before fixing: a read→shell flow raised *"Tool 'shell' would send Internal-level data over a channel cleared only for Public. Allow it?"* and `--yolo` hung forever (agent stuck `waiting`, host sees permanently busy).

## Bug 1 — taint tracking enabled even when unconfigured

`daemon/spawn.rs` used `blueprint.security.clone().unwrap_or_default()`, and `SecurityConfig::default()` is **taint-on** (a present `[security]` block means "configure security"). So a blueprint with **no** `[security]` block, under a global config with taint **off**, still got taint tracking — the global setting was never consulted. Proven directly: an unconfigured blueprint produced a `taint_audit.json` and gate evaluations.

**Fix:** resolve via `taint::resolve_security(config.taint_tracking, blueprint.security.as_ref(), None)` — no block cascades to the global setting (off by default). The struct default stays taint-on to preserve the "present `[security]` block ⇒ intent" semantics (used by the manifest parser and gate tests).

## Bug 2 — `--yolo` didn't cover taint gates

`--yolo` inserts a `*` tool-policy allow, which auto-approves `ToolApproval` interactions but **not** the taint gate's `MultipleChoice` prompt. So a taint-gated agent blocked indefinitely on a gate no headless host can answer.

**Fix:** a `GateAutoApprove` marker component, set at spawn when `--yolo`, makes `dispatch_tools` waive the gate check for that agent. Taint tracking still records for audit; only enforcement is waived — matching `--yolo`'s "run unattended" intent, and covering **all** `--yolo` paths (run/serve/agent-client), not just ACP.

## Testing

- New: `dispatch_tools_auto_approves_a_gate_block_under_yolo` (runtime), `build_agent_yolo_attaches_gate_auto_approve_when_taint_on` + `build_agent_no_security_block_leaves_taint_off_by_default` (cli), plus a no-yolo absence assertion.
- **100% coverage** retained on `leviath-core`, `leviath-runtime`, `leviath-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)