### PR TITLE
feat(taint): record a YoloAutoApprove audit entry when --yolo waives a gate

### DIFF
--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -392,6 +392,10 @@ pub enum GateDecisionSource {
     UserDenied,
     /// Taint tracking is disabled — automatic allow.
     TaintDisabled,
+    /// Auto-approved by `--yolo`: the gate would have blocked, but the agent
+    /// runs unattended so enforcement is waived. Recorded (rather than silently
+    /// skipped) so the audit trail still shows the over-cleared call.
+    YoloAutoApprove,
 }
 
 /// Built-in tool classification defaults per the plan.

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -76,8 +76,11 @@ pub struct AwaitingInteraction;
 /// tool-policy `--yolo` wildcard does not cover, so without this a headless run
 /// — e.g. one driven over the Agent Client Protocol, where no human can answer —
 /// would block forever on a gate no one resolves. When present,
-/// [`dispatch_tools`](crate::pipeline::dispatch_tools) skips the gate check for
-/// this agent (taint tracking still records for audit; enforcement is waived).
+/// [`dispatch_tools`](crate::pipeline::dispatch_tools) still evaluates the gate
+/// (so an over-cleared call is recorded in the audit trail as
+/// [`YoloAutoApprove`](leviath_core::taint::GateDecisionSource::YoloAutoApprove))
+/// but auto-approves the call instead of raising a prompt — enforcement is
+/// waived, accountability is kept.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct GateAutoApprove;
 

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -636,7 +636,7 @@ pub fn dispatch_tools(
                     continue;
                 }
             }
-            if let Some(gate) = gate.as_deref_mut().filter(|_| !auto_approve_gates) {
+            if let Some(gate) = gate.as_deref_mut() {
                 let decision = gate.check_with_policy(
                     &state.agent_id,
                     &c.name,
@@ -646,21 +646,38 @@ pub fn dispatch_tools(
                     script_checker,
                 );
                 if !decision.is_allowed() {
-                    match (interactive, decision.blocked_levels()) {
-                        (Some(_), Some((taint, clearance))) => {
-                            pending_prompts.push((
-                                c.tool_id.clone(),
-                                c.name.clone(),
-                                taint,
-                                clearance,
-                            ));
+                    if auto_approve_gates {
+                        // `--yolo`: waive enforcement but record the override in
+                        // the audit trail (rather than skipping the gate), so the
+                        // over-cleared call is still accounted for. Fall through
+                        // to dispatch the call.
+                        let (taint, clearance) = decision
+                            .blocked_levels()
+                            .expect("a non-Allowed GateDecision is always Blocked");
+                        gate.record_allow(
+                            &state.agent_id,
+                            &c.name,
+                            taint,
+                            clearance,
+                            leviath_core::taint::GateDecisionSource::YoloAutoApprove,
+                        );
+                    } else {
+                        match (interactive, decision.blocked_levels()) {
+                            (Some(_), Some((taint, clearance))) => {
+                                pending_prompts.push((
+                                    c.tool_id.clone(),
+                                    c.name.clone(),
+                                    taint,
+                                    clearance,
+                                ));
+                            }
+                            _ => {
+                                context_results
+                                    .push((c.tool_id.clone(), taint_block_message(&decision)));
+                            }
                         }
-                        _ => {
-                            context_results
-                                .push((c.tool_id.clone(), taint_block_message(&decision)));
-                        }
+                        continue;
                     }
-                    continue;
                 }
             }
             lane_calls.push(leviath_providers::ToolCall {
@@ -4113,6 +4130,23 @@ mod tests {
         assert!(world.get::<AwaitingTools>(e).is_some());
         assert!(world.get::<ReadyForTools>(e).is_none());
         assert_eq!(jrx.try_recv().expect("job enqueued").entity, e);
+        // The waived block is still recorded in the audit trail. Evaluate the
+        // predicate first so the assert message stays static (a call in the
+        // message only runs on failure and would read as uncovered).
+        let recorded_yolo_override = world
+            .get::<crate::taint::TaintGate>(e)
+            .unwrap()
+            .audit_log()
+            .iter()
+            .any(|ev| {
+                ev.allowed
+                    && ev.decision_source
+                        == leviath_core::taint::GateDecisionSource::YoloAutoApprove
+            });
+        assert!(
+            recorded_yolo_override,
+            "expected a YoloAutoApprove audit entry"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #76.

When `--yolo` waives a taint gate (via the `GateAutoApprove` marker added in #76/#77), it previously **skipped the gate check entirely**, so the over-cleared calls it let through left **no audit trail** — `taint_audit.json` had no record of them.

This changes `dispatch_tools` to still **evaluate** the gate under `--yolo` and, for a call that would have blocked, record it via `record_allow(.., GateDecisionSource::YoloAutoApprove)` before dispatching. So enforcement is still waived (no prompt, no hang), but every call `--yolo` allowed through is accounted for in the audit log.

- New `GateDecisionSource::YoloAutoApprove` variant (serialized into `taint_audit.json`).
- The dispatch test now asserts a `YoloAutoApprove` audit entry is recorded.
- No behavior change to blocking or non-`--yolo` paths.
- 100% coverage retained (`leviath-core`, `leviath-runtime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)