### PR TITLE
fix(agent-client): shell $SHELL fallback (#79) + default cwd to launch dir (#80)

### DIFF
--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -92,6 +92,7 @@ pub async fn serve_over<R, W>(
     control: ControlClient,
     args: AgentClientArgs,
     runs_dir: PathBuf,
+    default_cwd: String,
 ) -> anyhow::Result<()>
 where
     R: AsyncBufRead + Send + 'static,
@@ -113,6 +114,7 @@ where
         session: None,
         next_request_id: 0,
         io_alive: true,
+        default_cwd,
     };
     server.run(&mut reader).await;
     Ok(())
@@ -151,6 +153,11 @@ struct Server {
     session: Option<ActiveSession>,
     /// Monotonic id source for agent→client requests.
     next_request_id: i64,
+    /// Working directory to use when a `session/new` omits (or empties) `cwd` —
+    /// the directory `lev agent-client` was launched from. Without this the
+    /// agent's workdir was an empty string, so it ran in the daemon's directory
+    /// rather than the caller's.
+    default_cwd: String,
     /// Whether the output stream is still writable. Output is best-effort: a
     /// failed write means the client is gone, so this flips to `false` and the
     /// server winds down rather than propagating an error per write site (which
@@ -273,13 +280,21 @@ impl Server {
                 "session/new supplied MCP servers; ignoring in favour of the blueprint's own"
             );
         }
-        match resolve_blueprint(self.args.agent.as_deref(), &params.cwd) {
+        // An absent/empty `cwd` falls back to the directory `lev agent-client`
+        // was launched from, so the agent's tools operate there rather than in
+        // the daemon's working directory.
+        let cwd = if params.cwd.trim().is_empty() {
+            self.default_cwd.clone()
+        } else {
+            params.cwd
+        };
+        match resolve_blueprint(self.args.agent.as_deref(), &cwd) {
             Ok(blueprint) => {
                 let session_id = new_session_id(&blueprint.agent_name);
                 self.session = Some(ActiveSession {
                     session_id: session_id.clone(),
                     blueprint,
-                    cwd: params.cwd,
+                    cwd,
                     run_id: None,
                 });
                 self.write(&JsonRpcMessage::response(

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -23,6 +23,10 @@ use tokio::task::JoinHandle;
 /// its on-disk output.
 const RUN_ID: &str = "coder-test-run";
 
+/// The default working directory the harness gives the server, standing in for
+/// the directory `lev agent-client` was launched from.
+const HARNESS_DEFAULT_CWD: &str = "/harness-launch-dir";
+
 /// Aborts a background task when the harness is dropped.
 struct AbortOnDrop(JoinHandle<()>);
 impl Drop for AbortOnDrop {
@@ -128,6 +132,7 @@ impl Harness {
                 control,
                 args,
                 runs_path,
+                HARNESS_DEFAULT_CWD.to_string(),
             )
             .await;
         });
@@ -448,6 +453,7 @@ async fn output_failing_mid_turn_ends_the_turn() {
             control,
             args,
             runs.path().to_path_buf(),
+            HARNESS_DEFAULT_CWD.to_string(),
         ),
     )
     .await;
@@ -473,6 +479,7 @@ async fn a_broken_output_stream_winds_the_server_down() {
             control,
             AgentClientArgs::default(),
             runs,
+            HARNESS_DEFAULT_CWD.to_string(),
         ),
     )
     .await;
@@ -531,6 +538,41 @@ async fn session_new_opens_a_session_and_returns_its_id() {
             .starts_with("coder")
     );
     drop(bp);
+    h.close_input().await;
+}
+
+#[tokio::test]
+async fn empty_cwd_defaults_to_the_launch_directory() {
+    // Regression for #80: a `session/new` with an empty `cwd` must give the
+    // spawned agent the directory `lev agent-client` was launched from (the
+    // harness's default), not an empty workdir that runs in the daemon's dir.
+    let captured = Arc::new(std::sync::Mutex::new(None));
+    let cap = captured.clone();
+    let daemon = ScriptedDaemon::new(vec![completed("complete")], move |req| match req {
+        ControlRequest::Spawn { args } => {
+            *cap.lock().unwrap() = Some(args.workdir.clone());
+            ControlResponse::Spawned {
+                run_id: RUN_ID.to_string(),
+            }
+        }
+        _ => ControlResponse::Ok { ok: true },
+    });
+    let (_bp, args) = blueprint_args();
+    let mut h = Harness::start(daemon, args);
+    h.send(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}"#)
+        .await;
+    let _ = h.recv().await;
+    // Empty cwd → falls back to the launch directory.
+    h.send(r#"{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":""}}"#)
+        .await;
+    let _ = h.recv().await;
+    h.send(r#"{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"go"}]}}"#)
+        .await;
+    let _ = h.recv_until(is_result).await;
+    assert_eq!(
+        captured.lock().unwrap().as_deref(),
+        Some(HARNESS_DEFAULT_CWD)
+    );
     h.close_input().await;
 }
 
@@ -1140,7 +1182,15 @@ async fn an_unreachable_daemon_makes_a_prompt_refuse() {
     let runs_dir = tempfile::tempdir().unwrap();
     let runs_path = runs_dir.path().to_path_buf();
     let server = tokio::spawn(async move {
-        let _ = serve_over(BufReader::new(server_in), server_out, bad, args, runs_path).await;
+        let _ = serve_over(
+            BufReader::new(server_in),
+            server_out,
+            bad,
+            args,
+            runs_path,
+            HARNESS_DEFAULT_CWD.to_string(),
+        )
+        .await;
     });
     let mut h = Harness {
         to_server,

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -108,12 +108,18 @@ impl RiskyExecutors for RealExecutors {
         // (`agent_client::serve_over`) is fully unit-tested over an in-memory
         // duplex; only the real stdio + socket wiring lives here.
         ensure_daemon_running().await?;
+        // The directory `lev agent-client` was launched from is the default
+        // working dir for sessions whose `session/new` omits `cwd`.
+        let default_cwd = std::env::current_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
         commands::agent_client::serve_over(
             tokio::io::BufReader::new(tokio::io::stdin()),
             tokio::io::stdout(),
             control_client()?,
             args,
             leviath_cli::runstate::runs_dir(),
+            default_cwd,
         )
         .await
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -776,7 +776,12 @@ impl BuiltinTools {
     ) -> (&'static str, &'static str) {
         if let Some(shell) = env_shell
             && (shell.ends_with("/zsh") || shell.ends_with("/bash") || shell.ends_with("/sh"))
+            && shell_exists(&shell)
         {
+            // Only trust `$SHELL` when it actually exists — a stale or
+            // sandbox-missing `$SHELL` (e.g. `/bin/zsh` in an environment that
+            // doesn't ship it) otherwise made every shell call fail to spawn.
+            // When it's missing, fall through to the known-path fallback list.
             let shell: &'static str = Box::leak(shell.into_boxed_str());
             return (shell, "-c");
         }
@@ -1810,8 +1815,11 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn detect_shell_impl_returns_zsh_from_env() {
+        // `$SHELL` is trusted only when it exists on disk.
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/zsh".to_string()), &|_| false);
+            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/zsh".to_string()), &|s| {
+                s == "/usr/local/bin/zsh"
+            });
         assert_eq!(shell, "/usr/local/bin/zsh");
         assert_eq!(flag, "-c");
     }
@@ -1820,7 +1828,9 @@ mod tests {
     #[test]
     fn detect_shell_impl_returns_bash_from_env() {
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/bash".to_string()), &|_| false);
+            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/bash".to_string()), &|s| {
+                s == "/usr/local/bin/bash"
+            });
         assert_eq!(shell, "/usr/local/bin/bash");
         assert_eq!(flag, "-c");
     }
@@ -1829,8 +1839,23 @@ mod tests {
     #[test]
     fn detect_shell_impl_returns_sh_from_env() {
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/bin/sh".to_string()), &|_| false);
+            BuiltinTools::detect_shell_impl(Some("/usr/bin/sh".to_string()), &|s| {
+                s == "/usr/bin/sh"
+            });
         assert_eq!(shell, "/usr/bin/sh");
+        assert_eq!(flag, "-c");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn detect_shell_impl_falls_back_when_env_shell_is_missing() {
+        // Regression for #79: `$SHELL` is a recognized shell name but does not
+        // exist on disk (a stale or sandbox-missing `/bin/zsh`). It must NOT be
+        // returned — fall through to an available fallback instead of failing
+        // every shell call with "No such file or directory".
+        let (shell, flag) =
+            BuiltinTools::detect_shell_impl(Some("/bin/zsh".to_string()), &|s| s == "/bin/sh");
+        assert_eq!(shell, "/bin/sh");
         assert_eq!(flag, "-c");
     }
 


### PR DESCRIPTION
Closes #79, closes #80.

## #79 — shell tool fails when `$SHELL` doesn't exist
`detect_shell_impl` trusted `$SHELL` whenever it *looked* like a shell (ends with `/zsh`, `/bash`, `/sh`) **without checking it exists**. A stale or sandbox-missing `$SHELL` (e.g. `/bin/zsh` in an environment that doesn't ship it) made every shell call fail with `Failed to spawn shell '/bin/zsh': No such file or directory`.

**Fix:** trust `$SHELL` only when it exists on disk; otherwise fall through to the known-path fallback list (`/bin/bash`, `/bin/zsh`, `/bin/sh`, …). Reproduced (returns the nonexistent shell) and **verified live**: with `SHELL=/nonexistent/zsh` the shell tool now falls back and runs the command.

## #80 — agent workdir defaults to empty string via ACP
`lev agent-client` used whatever `cwd` the client sent in `session/new`; an empty/absent `cwd` produced `"workdir": ""`, so the agent ran in the **daemon's** directory — reading unrelated files and writing outputs in the wrong place.

**Fix:** `serve_over` takes a `default_cwd` — the directory `lev agent-client` was launched from (`std::env::current_dir()`, wired in `main.rs`) — used when `session/new` omits/empties `cwd`. A client that supplies `cwd` still wins. **Verified live:** an empty-cwd session now runs in the launch directory.

## `main.rs`
Touches the coverage-excluded bin entrypoint to capture the launch cwd (`allow-main-rs-change` label applied).

## Testing
New: `detect_shell_impl_falls_back_when_env_shell_is_missing` (tools), `empty_cwd_defaults_to_the_launch_directory` (agent-client). 100% coverage retained on `leviath-tools` and `leviath-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)