### PR TITLE
feat(providers): exact API token counting + Gemini per-model caps (closes #41)

### DIFF
--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1327,7 +1327,7 @@ mod tests {
             ))
         }
 
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len() / 4
         }
 
@@ -1654,7 +1654,7 @@ mod tests {
             models: vec![],
             fail: false,
         };
-        assert_eq!(provider.count_tokens("abcd", "mock-model"), 1);
+        assert_eq!(provider.count_tokens("abcd", "mock-model").await, 1);
         assert_eq!(provider.max_context_tokens("mock-model"), 100_000);
         assert_eq!(provider.name(), "mock");
         let _ = provider.capabilities("mock-model");

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -1152,7 +1152,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             })
         }
 
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len()
         }
 
@@ -1193,7 +1193,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             })
         }
 
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len()
         }
 
@@ -1227,7 +1227,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             ))
         }
 
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len()
         }
 
@@ -1720,11 +1720,11 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         assert!(err.contains("not configured"));
     }
 
-    #[test]
-    fn no_temperature_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn no_temperature_provider_metadata_is_exercised() {
         let p = NoTemperatureProvider;
         assert_eq!(p.name(), "no-temperature");
-        assert_eq!(p.count_tokens("abcd", "m"), 4);
+        assert_eq!(p.count_tokens("abcd", "m").await, 4);
         assert_eq!(p.max_context_tokens("m"), 8192);
     }
 
@@ -2335,10 +2335,10 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     // ─── ErrorProvider trivial trait methods ─────────────────────────────────
 
-    #[test]
-    fn error_provider_trivial_trait_methods() {
+    #[tokio::test]
+    async fn error_provider_trivial_trait_methods() {
         let provider = ErrorProvider;
-        assert_eq!(provider.count_tokens("hello", "any-model"), 5);
+        assert_eq!(provider.count_tokens("hello", "any-model").await, 5);
         assert_eq!(provider.max_context_tokens("any-model"), 8192);
         assert_eq!(provider.name(), "error-provider");
         let caps = provider.capabilities("any-model");
@@ -2347,13 +2347,13 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     // ─── MockProvider trivial trait methods ──────────────────────────────────
 
-    #[test]
-    fn mock_provider_trivial_trait_methods() {
+    #[tokio::test]
+    async fn mock_provider_trivial_trait_methods() {
         let provider = MockProvider {
             content: "x".to_string(),
             tool_calls: vec![],
         };
-        assert_eq!(provider.count_tokens("hello", "any-model"), 5);
+        assert_eq!(provider.count_tokens("hello", "any-model").await, 5);
         assert_eq!(provider.max_context_tokens("any-model"), 8192);
         assert_eq!(provider.name(), "mock");
     }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -136,6 +136,16 @@ pub struct LimitsConfig {
     /// `Some(50)`. A stage's explicit `max_iterations` always wins.
     #[serde(default = "default_default_max_iterations")]
     pub default_max_iterations: Option<usize>,
+
+    /// Opt-in exact pre-inference token budgeting. When `true`, each agent
+    /// inference is preceded by an exact token count of the assembled request
+    /// (via the provider's `count_tokens`, which uses a remote endpoint for
+    /// Anthropic/Gemini and a local heuristic otherwise) and is rejected before
+    /// sending if it would exceed the model's context window. Off by default:
+    /// normal budgeting uses cheap local estimates, and this adds a network
+    /// round-trip per inference for providers with a remote count endpoint.
+    #[serde(default)]
+    pub exact_token_counting: bool,
 }
 
 impl Default for LimitsConfig {
@@ -143,6 +153,7 @@ impl Default for LimitsConfig {
         Self {
             max_concurrent_inferences: default_max_concurrent_inferences(),
             default_max_iterations: default_default_max_iterations(),
+            exact_token_counting: false,
         }
     }
 }
@@ -650,8 +661,25 @@ mod tests {
         let limits = LimitsConfig::default();
         assert_eq!(limits.max_concurrent_inferences, Some(8));
         assert_eq!(limits.default_max_iterations, Some(50));
+        // Exact token counting is opt-in, off by default.
+        assert!(!limits.exact_token_counting);
         // And the top-level Config carries the same defaults.
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
+    }
+
+    #[test]
+    fn exact_token_counting_parses_when_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let body = format!(
+            "{}\n[limits]\nexact_token_counting = true\n",
+            config_toml_without_limits()
+        );
+        std::fs::write(&path, body).unwrap();
+        let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
+        assert!(config.limits.exact_token_counting);
+        // The other fields still fall back to their per-field defaults.
+        assert_eq!(config.limits.max_concurrent_inferences, Some(8));
     }
 
     /// A valid full config-file body with the `[limits]` section removed, so
@@ -1682,6 +1710,7 @@ anthropic_api_key = "sk-ant-test-key"
             limits: LimitsConfig {
                 max_concurrent_inferences: Some(4),
                 default_max_iterations: Some(99),
+                exact_token_counting: false,
             },
             batch_tool_hint: true,
         };

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -279,7 +279,7 @@ mod tests {
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("test".to_string()))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -488,12 +488,12 @@ mod tests {
         assert!(err.contains("no worker source"));
     }
 
-    #[test]
-    fn fake_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn fake_provider_metadata_is_exercised() {
         use leviath_providers::Provider;
         let p = FakeProvider;
         assert_eq!(p.name(), "fake");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -357,7 +357,7 @@ mod tests {
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("t".to_string()))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -1068,7 +1068,7 @@ mod tests {
         use leviath_providers::Provider;
         let p = FakeProvider;
         assert_eq!(p.name(), "fake");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -121,6 +121,8 @@ pub fn build_host(
         runs_dir.clone(),
         runtime,
     );
+    // Opt-in accurate pre-inference budget guard (off by default).
+    world.set_exact_token_counting(config.limits.exact_token_counting);
     // Share the hub with the tick loop so a blocked agent's open prompt is
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());
@@ -239,7 +241,7 @@ mod tests {
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("test".to_string()))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -319,7 +321,7 @@ mod tests {
         use leviath_providers::Provider;
         let p = FakeProvider;
         assert_eq!(p.name(), "fake");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -445,7 +445,7 @@ mod tests {
                 "test provider".to_string(),
             ))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -987,7 +987,7 @@ mod tests {
     async fn fake_provider_methods_are_exercised() {
         let p = FakeProvider;
         assert_eq!(p.name(), "fake");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -272,6 +272,38 @@ impl AnthropicProvider {
         }
     }
 
+    /// Call Anthropic's exact `/messages/count_tokens` endpoint for `text`.
+    ///
+    /// Wraps the text as a single user message (the endpoint counts structured
+    /// message input). Returns the reported `input_tokens`, or an error the
+    /// caller turns into a heuristic fallback. Does not consume the inference
+    /// rate limiter — counting is a cheap, best-effort side call.
+    async fn count_tokens_remote(&self, text: &str, model: &str) -> Result<usize> {
+        let url = format!("{}/messages/count_tokens", self.base_url);
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": text }],
+        });
+        let response = self
+            .apply_headers(self.client.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let response = crate::provider::check_http_response(response, None).await?;
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        value
+            .get("input_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+            .ok_or_else(|| {
+                ProviderError::InvalidResponse("count_tokens missing input_tokens".to_string())
+            })
+    }
+
     /// Build the request body for the Anthropic API.
     fn build_request_body(&self, request: &InferenceRequest) -> serde_json::Value {
         // Anthropic allows at most 4 `cache_control` blocks per request, counted
@@ -661,9 +693,19 @@ impl Provider for AnthropicProvider {
         Ok(Box::pin(stream))
     }
 
-    fn count_tokens(&self, text: &str, _model: &str) -> usize {
-        // Anthropic-specific: ~3.5 chars per token (more efficient than GPT)
-        (text.len() as f32 / 3.5) as usize
+    async fn count_tokens(&self, text: &str, model: &str) -> usize {
+        // Prefer the exact `/messages/count_tokens` endpoint; fall back to the
+        // ~3.5 chars/token heuristic on any error (network, non-2xx, parse).
+        match self.count_tokens_remote(text, model).await {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "Anthropic count_tokens endpoint failed; using heuristic"
+                );
+                crate::tokenizer::count_tokens(text, model)
+            }
+        }
     }
 
     fn max_context_tokens(&self, model: &str) -> usize {
@@ -1560,28 +1602,92 @@ mod tests {
 
     // ── Additional coverage tests ──────────────────────────────────────────
 
-    #[test]
-    fn test_count_tokens_basic() {
-        let provider = AnthropicProvider::new("test-key".to_string());
-        let tokens = provider.count_tokens("Hello, world!", "claude-sonnet-4-6");
+    /// Build a provider whose count-token endpoint is unreachable, so
+    /// `count_tokens` deterministically falls back to the local heuristic
+    /// without any real network call.
+    fn heuristic_only_provider() -> AnthropicProvider {
+        AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: "http://127.0.0.1:19997".to_string(),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_basic() {
+        let provider = heuristic_only_provider();
+        let tokens = provider
+            .count_tokens("Hello, world!", "claude-sonnet-4-6")
+            .await;
         assert!(tokens > 0);
         // ~3.5 chars per token → 13 chars ≈ 3-4 tokens
         assert!(tokens < 10);
     }
 
-    #[test]
-    fn test_count_tokens_empty() {
-        let provider = AnthropicProvider::new("test-key".to_string());
-        let tokens = provider.count_tokens("", "claude-sonnet-4-6");
+    #[tokio::test]
+    async fn test_count_tokens_empty() {
+        let provider = heuristic_only_provider();
+        let tokens = provider.count_tokens("", "claude-sonnet-4-6").await;
         assert_eq!(tokens, 0);
     }
 
-    #[test]
-    fn test_count_tokens_long_string() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+    #[tokio::test]
+    async fn test_count_tokens_long_string() {
+        let provider = heuristic_only_provider();
         let text = "a".repeat(3500);
-        let tokens = provider.count_tokens(&text, "claude-sonnet-4-6");
-        assert_eq!(tokens, 1000); // 3500 / 3.5 = 1000
+        let tokens = provider.count_tokens(&text, "claude-sonnet-4-6").await;
+        assert_eq!(tokens, 1000); // heuristic fallback: 3500 / 3.5 = 1000
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_uses_exact_endpoint() {
+        // The endpoint's `input_tokens` wins over the heuristic when reachable.
+        let url = spawn_mock_server(200, "OK", br#"{"input_tokens": 42}"#).await;
+        let provider = AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: url,
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+        };
+        let tokens = provider.count_tokens("anything", "claude-sonnet-4-6").await;
+        assert_eq!(tokens, 42);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_error_status() {
+        // A 500 from the endpoint → heuristic fallback (7 chars / 3.5 = 2).
+        let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
+        let provider = AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: url,
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+        };
+        let tokens = provider.count_tokens("1234567", "claude-sonnet-4-6").await;
+        assert_eq!(tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_missing_field() {
+        // 200 but no `input_tokens` → heuristic fallback (7 chars / 3.5 = 2).
+        let url = spawn_mock_server(200, "OK", br#"{"unexpected": true}"#).await;
+        let provider = AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: url,
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+        };
+        let tokens = provider.count_tokens("1234567", "claude-sonnet-4-6").await;
+        assert_eq!(tokens, 2);
     }
 
     #[test]

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -1675,6 +1675,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_count_tokens_falls_back_on_malformed_json() {
+        // 200 but a non-JSON body → InvalidResponse on parse → heuristic (7/3.5 = 2).
+        let url = spawn_mock_server(200, "OK", b"not json").await;
+        let provider = AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: url,
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+        };
+        let tokens = provider.count_tokens("1234567", "claude-sonnet-4-6").await;
+        assert_eq!(tokens, 2);
+    }
+
+    #[tokio::test]
     async fn test_count_tokens_falls_back_on_missing_field() {
         // 200 but no `input_tokens` → heuristic fallback (7 chars / 3.5 = 2).
         let url = spawn_mock_server(200, "OK", br#"{"unexpected": true}"#).await;

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -437,8 +437,9 @@ impl Provider for ClaudeCodeProvider {
         .await
     }
 
-    fn count_tokens(&self, text: &str, _model: &str) -> usize {
-        // ~3.5 characters per token heuristic (same as Anthropic provider)
+    async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        // Subprocess transport with no token-count endpoint; ~3.5 chars/token
+        // heuristic (same as the Anthropic provider's fallback).
         (text.len() as f64 / 3.5).ceil() as usize
     }
 
@@ -605,12 +606,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn count_tokens_uses_the_character_heuristic() {
+    #[tokio::test]
+    async fn count_tokens_uses_the_character_heuristic() {
         let provider = ClaudeCodeProvider::new();
-        assert_eq!(provider.count_tokens("", "claude-sonnet-4-6"), 0);
+        assert_eq!(provider.count_tokens("", "claude-sonnet-4-6").await, 0);
         assert_eq!(
-            provider.count_tokens(&"a".repeat(350), "claude-sonnet-4-6"),
+            provider
+                .count_tokens(&"a".repeat(350), "claude-sonnet-4-6")
+                .await,
             100
         );
     }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -15,6 +15,35 @@ use futures_core::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
 
+/// Gemini model family, classified from a model id, used to pick per-family
+/// capability defaults. Values are identical across families today; the split
+/// exists so a family's limits can diverge without reworking the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeminiFamily {
+    /// Cost-efficient, high-volume variants (`*-flash-lite`).
+    FlashLite,
+    /// Reasoning-first pro variants (`*-pro*`).
+    Pro,
+    /// Standard flash variants (`*-flash*`, excluding flash-lite).
+    Flash,
+    /// Anything else / future models.
+    Other,
+}
+
+impl GeminiFamily {
+    fn classify(model: &str) -> Self {
+        if model.contains("flash-lite") {
+            GeminiFamily::FlashLite
+        } else if model.contains("pro") {
+            GeminiFamily::Pro
+        } else if model.contains("flash") {
+            GeminiFamily::Flash
+        } else {
+            GeminiFamily::Other
+        }
+    }
+}
+
 /// Google Gemini provider using the OpenAI-compatible endpoint.
 pub struct GeminiProvider {
     /// HTTP client
@@ -75,27 +104,83 @@ impl GeminiProvider {
         }
     }
 
-    /// Return built-in capability defaults for a model.
+    /// Return built-in capability defaults for a model, by family.
     ///
-    /// Current model families (all share 1M context, 65K output, full tool/streaming support):
+    /// Current model families all share 1M context / 65K output / full
+    /// tool+streaming support, so the values are identical today. The per-family
+    /// branching exists so a family can diverge (e.g. a smaller flash-lite output
+    /// cap, or a future `supports_thinking` flag) without another refactor.
+    /// `list_models` fetches the *authoritative* per-model limits from the native
+    /// API; this is the offline default used for the sync `capabilities()` path.
     /// - gemini-3.5-flash (latest flash, near-Pro intelligence)
     /// - gemini-3.1-pro-preview (latest pro, reasoning-first)
     /// - gemini-3-flash (complex multimodal/agentic)
     /// - gemini-3.1-flash-lite (cost-efficient, high-volume)
-    ///
-    /// All Gemini models currently expose identical capabilities via the
-    /// OpenAI-compatible endpoint, so a single default covers all families.
-    /// When ModelCapabilities gains a `supports_thinking` field, split the
-    /// flash-lite variants into their own branch.
-    fn builtin_capabilities(&self, _model: &str) -> ModelCapabilities {
+    fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
+        // All families currently share these values; the match keeps them
+        // labelled by family so any one can be adjusted independently (the arms
+        // are intentionally identical today — divergence-readiness scaffolding).
+        #[allow(clippy::match_same_arms)]
+        let (max_context_tokens, max_output_tokens) = match GeminiFamily::classify(model) {
+            GeminiFamily::FlashLite => (1_048_576, 65_535),
+            GeminiFamily::Pro => (1_048_576, 65_535),
+            GeminiFamily::Flash => (1_048_576, 65_535),
+            GeminiFamily::Other => (1_048_576, 65_535),
+        };
         ModelCapabilities {
             supports_temperature: true,
             supports_streaming: true,
             supports_tools: true,
             supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 65_535,
+            max_context_tokens,
+            max_output_tokens,
         }
+    }
+
+    /// Derive the native Gemini API base (`.../v1beta`) from the OpenAI-compatible
+    /// base (`.../v1beta/openai`). Native-only endpoints (`:countTokens`, the
+    /// per-model `models` listing) live under the former. Returns `None` when the
+    /// configured base doesn't follow the `/openai` convention (e.g. a custom
+    /// proxy), so callers fall back rather than guessing a wrong URL.
+    fn native_base(&self) -> Option<String> {
+        self.base_url.strip_suffix("/openai").map(|s| s.to_string())
+    }
+
+    /// Call Gemini's exact native `:countTokens` endpoint for `text`.
+    ///
+    /// Wraps the text as a single user content part. Returns the reported
+    /// `totalTokens`, or an error the caller turns into a heuristic fallback.
+    async fn count_tokens_remote(&self, text: &str, model: &str) -> Result<usize> {
+        let native = self.native_base().ok_or_else(|| {
+            ProviderError::Other(
+                "non-standard base_url; native countTokens unavailable".to_string(),
+            )
+        })?;
+        let url = format!("{}/models/{}:countTokens", native, model);
+        let body = serde_json::json!({
+            "contents": [{ "role": "user", "parts": [{ "text": text }] }],
+        });
+        let response = self
+            .client
+            .post(&url)
+            .header("x-goog-api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let response = crate::provider::check_http_response(response, None).await?;
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        value
+            .get("totalTokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+            .ok_or_else(|| {
+                ProviderError::InvalidResponse("countTokens missing totalTokens".to_string())
+            })
     }
 }
 
@@ -172,8 +257,19 @@ impl Provider for GeminiProvider {
         Ok(Box::pin(stream))
     }
 
-    fn count_tokens(&self, text: &str, model: &str) -> usize {
-        crate::tokenizer::count_tokens(text, model)
+    async fn count_tokens(&self, text: &str, model: &str) -> usize {
+        // Prefer Gemini's exact native `:countTokens` endpoint; fall back to the
+        // local heuristic on any error (network, non-2xx, parse, non-standard base).
+        match self.count_tokens_remote(text, model).await {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "Gemini countTokens endpoint failed; using heuristic"
+                );
+                crate::tokenizer::count_tokens(text, model)
+            }
+        }
     }
 
     fn max_context_tokens(&self, model: &str) -> usize {
@@ -193,6 +289,71 @@ impl Provider for GeminiProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        // Prefer the native `/v1beta/models` listing: unlike the OpenAI-compat
+        // `/models`, it returns real per-model `inputTokenLimit`/`outputTokenLimit`.
+        // Fall back to the compat listing (with builtin caps) when the base URL
+        // isn't the standard `.../openai` form.
+        match self.native_base() {
+            Some(native) => self.list_models_native(&native).await,
+            None => self.list_models_compat().await,
+        }
+    }
+}
+
+impl GeminiProvider {
+    /// Native `/v1beta/models` listing with authoritative per-model token limits.
+    async fn list_models_native(&self, native_base: &str) -> Result<Vec<ModelInfo>> {
+        let response = self
+            .client
+            .get(format!("{}/models", native_base))
+            .header("x-goog-api-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let response = crate::provider::check_http_response(response, None).await?;
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+
+        let models = body
+            .get("models")
+            .and_then(|d| d.as_array())
+            .ok_or_else(|| {
+                ProviderError::InvalidResponse("No models field in models response".to_string())
+            })?
+            .iter()
+            .filter_map(|item| {
+                // `name` is like "models/gemini-3.5-flash"; the id drops the prefix.
+                let name = item.get("name")?.as_str()?;
+                let id = name.strip_prefix("models/").unwrap_or(name).to_string();
+                // Start from the family defaults, then override with the API's
+                // authoritative limits where present.
+                let mut capabilities = self.capabilities(&id);
+                if let Some(ctx) = item.get("inputTokenLimit").and_then(|v| v.as_u64()) {
+                    capabilities.max_context_tokens = ctx as usize;
+                }
+                if let Some(out) = item.get("outputTokenLimit").and_then(|v| v.as_u64()) {
+                    capabilities.max_output_tokens = out as usize;
+                }
+                Some(ModelInfo {
+                    id,
+                    display_name: item
+                        .get("displayName")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    provider: "google".into(),
+                    capabilities,
+                })
+            })
+            .collect();
+
+        Ok(models)
+    }
+
+    /// OpenAI-compat `/models` listing (no per-model token limits) used only when
+    /// the configured base URL isn't the standard native-derivable form.
+    async fn list_models_compat(&self) -> Result<Vec<ModelInfo>> {
         let response = self
             .client
             .get(format!("{}/models", self.base_url))
@@ -200,19 +361,7 @@ impl Provider for GeminiProvider {
             .send()
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
-
+        let response = crate::provider::check_http_response(response, None).await?;
         let body: serde_json::Value = response
             .json()
             .await
@@ -468,18 +617,60 @@ mod tests {
         assert!(provider.rate_limiter.is_some());
     }
 
-    #[test]
-    fn test_count_tokens_uses_tiktoken() {
-        let provider = GeminiProvider::new("key".to_string());
-        let tokens = provider.count_tokens("Hello, world!", "gemini-3.5-flash");
-        assert!(tokens > 0);
+    /// Provider whose native base is a non-standard URL (no `/openai` suffix),
+    /// so `count_tokens` skips the endpoint and uses the local heuristic.
+    fn heuristic_only_provider() -> GeminiProvider {
+        GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: "http://127.0.0.1:19997".to_string(),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        }
     }
 
-    #[test]
-    fn test_count_tokens_empty() {
-        let provider = GeminiProvider::new("key".to_string());
-        let tokens = provider.count_tokens("", "gemini-3.5-flash");
+    #[tokio::test]
+    async fn test_count_tokens_heuristic_fallback() {
+        let provider = heuristic_only_provider();
+        // 8 chars / 4 = 2 (gemini heuristic branch)
+        let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_empty() {
+        let provider = heuristic_only_provider();
+        let tokens = provider.count_tokens("", "gemini-3.5-flash").await;
         assert_eq!(tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_uses_exact_endpoint() {
+        let base = spawn_mock_server(200, "OK", br#"{"totalTokens": 99}"#).await;
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        let tokens = provider.count_tokens("anything", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 99);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_error_status() {
+        let base = spawn_mock_server(500, "Internal Server Error", b"boom").await;
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        // 8 chars / 4 = 2 (heuristic fallback)
+        let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 2);
     }
 
     #[test]
@@ -747,10 +938,106 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_models_non_success_body_read_error_falls_back_to_unknown_error() {
+    async fn list_models_non_success_body_read_error_falls_back_to_status() {
+        // A truncated body makes reading the error text fail; `check_http_response`
+        // still reports the status (falling back to the reqwest error string).
         let url = spawn_mock_server_truncated_body(500, "Internal Server Error").await;
         let provider = provider_with_url(url);
         let err = provider.list_models().await.unwrap_err();
-        assert!(err.to_string().contains("unknown error"));
+        assert!(err.to_string().contains("500"));
+    }
+
+    // ─── Native models listing (real per-model token limits) ──────────────
+
+    /// Provider whose base ends in `/openai`, so `native_base()` resolves and
+    /// `list_models` takes the native path.
+    fn native_provider_with_base(base: &str) -> GeminiProvider {
+        GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_models_native_uses_real_token_limits() {
+        // `name` carries the "models/" prefix; the API returns authoritative
+        // per-model limits that override the builtin family defaults.
+        let body = br#"{"models":[
+            {"name":"models/gemini-3.5-flash","displayName":"Flash","inputTokenLimit":2000000,"outputTokenLimit":8192}
+        ]}"#;
+        let base = spawn_mock_server(200, "OK", body).await;
+        let provider = native_provider_with_base(&base);
+        let models = provider.list_models().await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gemini-3.5-flash");
+        assert_eq!(models[0].display_name.as_deref(), Some("Flash"));
+        assert_eq!(models[0].capabilities.max_context_tokens, 2_000_000);
+        assert_eq!(models[0].capabilities.max_output_tokens, 8192);
+    }
+
+    #[tokio::test]
+    async fn list_models_native_falls_back_to_builtin_when_limits_absent() {
+        // No limit fields → builtin family defaults are kept.
+        let body = br#"{"models":[{"name":"models/gemini-3.1-pro-preview"}]}"#;
+        let base = spawn_mock_server(200, "OK", body).await;
+        let provider = native_provider_with_base(&base);
+        let models = provider.list_models().await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gemini-3.1-pro-preview");
+        assert_eq!(models[0].capabilities.max_context_tokens, 1_048_576);
+        assert_eq!(models[0].capabilities.max_output_tokens, 65_535);
+    }
+
+    #[tokio::test]
+    async fn list_models_native_missing_models_field_errors() {
+        let base = spawn_mock_server(200, "OK", b"{}").await;
+        let provider = native_provider_with_base(&base);
+        let err = provider.list_models().await.unwrap_err();
+        assert!(err.to_string().contains("Invalid response:"));
+    }
+
+    #[tokio::test]
+    async fn list_models_native_skips_entries_without_name() {
+        let body = br#"{"models":[{"no_name":true},{"name":"models/gemini-3-flash"}]}"#;
+        let base = spawn_mock_server(200, "OK", body).await;
+        let provider = native_provider_with_base(&base);
+        let models = provider.list_models().await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gemini-3-flash");
+    }
+
+    #[test]
+    fn native_base_strips_openai_suffix() {
+        let provider = GeminiProvider::new("k".to_string());
+        assert_eq!(
+            provider.native_base().as_deref(),
+            Some("https://generativelanguage.googleapis.com/v1beta")
+        );
+    }
+
+    #[test]
+    fn native_base_none_for_nonstandard_url() {
+        let provider = provider_with_url("http://proxy.local/custom".to_string());
+        assert!(provider.native_base().is_none());
+    }
+
+    #[test]
+    fn gemini_family_classification() {
+        assert_eq!(
+            GeminiFamily::classify("gemini-3.1-flash-lite"),
+            GeminiFamily::FlashLite
+        );
+        assert_eq!(
+            GeminiFamily::classify("gemini-3.1-pro-preview"),
+            GeminiFamily::Pro
+        );
+        assert_eq!(
+            GeminiFamily::classify("gemini-3.5-flash"),
+            GeminiFamily::Flash
+        );
+        assert_eq!(GeminiFamily::classify("gemini-future"), GeminiFamily::Other);
     }
 }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -326,7 +326,10 @@ impl GeminiProvider {
             .filter_map(|item| {
                 // `name` is like "models/gemini-3.5-flash"; the id drops the prefix.
                 let name = item.get("name")?.as_str()?;
-                let id = name.strip_prefix("models/").unwrap_or(name).to_string();
+                let id = match name.strip_prefix("models/") {
+                    Some(rest) => rest.to_string(),
+                    None => name.to_string(),
+                };
                 // Start from the family defaults, then override with the API's
                 // authoritative limits where present.
                 let mut capabilities = self.capabilities(&id);
@@ -673,6 +676,49 @@ mod tests {
         assert_eq!(tokens, 2);
     }
 
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_connection_error() {
+        // Base ends in `/openai` so `native_base` resolves, but the port is dead:
+        // the POST fails at send() → RequestFailed → heuristic fallback.
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: "http://127.0.0.1:19997/openai".to_string(),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_malformed_json() {
+        let base = spawn_mock_server(200, "OK", b"not json").await;
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_tokens_falls_back_on_missing_total_tokens() {
+        let base = spawn_mock_server(200, "OK", br#"{"unexpected": true}"#).await;
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
+        assert_eq!(tokens, 2);
+    }
+
     #[test]
     fn test_capabilities_override_takes_precedence() {
         let mut overrides = HashMap::new();
@@ -992,6 +1038,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_models_native_id_without_models_prefix_is_used_verbatim() {
+        // A `name` lacking the "models/" prefix is used as-is (unwrap_or branch).
+        let body = br#"{"models":[{"name":"gemini-bare","inputTokenLimit":500000}]}"#;
+        let base = spawn_mock_server(200, "OK", body).await;
+        let provider = native_provider_with_base(&base);
+        let models = provider.list_models().await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gemini-bare");
+        assert_eq!(models[0].capabilities.max_context_tokens, 500_000);
+    }
+
+    #[tokio::test]
+    async fn list_models_native_connection_error() {
+        // `/openai` base resolves native, dead port → RequestFailed.
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: "http://127.0.0.1:19997/openai".to_string(),
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+        };
+        let err = provider.list_models().await.unwrap_err();
+        assert!(err.to_string().contains("Request failed:"));
+    }
+
+    #[tokio::test]
+    async fn list_models_native_malformed_json_errors() {
+        let base = spawn_mock_server(200, "OK", b"not json").await;
+        let provider = native_provider_with_base(&base);
+        let err = provider.list_models().await.unwrap_err();
+        assert!(err.to_string().contains("Invalid response:"));
+    }
+
+    #[tokio::test]
+    async fn list_models_native_non_success_status_errors() {
+        // A non-2xx from the native endpoint propagates via check_http_response.
+        let base = spawn_mock_server(401, "Unauthorized", b"bad key").await;
+        let provider = native_provider_with_base(&base);
+        let err = provider.list_models().await.unwrap_err();
+        assert!(err.to_string().contains("401"));
+    }
+
+    #[tokio::test]
     async fn list_models_native_missing_models_field_errors() {
         let base = spawn_mock_server(200, "OK", b"{}").await;
         let provider = native_provider_with_base(&base);
@@ -1001,7 +1090,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_models_native_skips_entries_without_name() {
-        let body = br#"{"models":[{"no_name":true},{"name":"models/gemini-3-flash"}]}"#;
+        // First entry has no `name` (get None), second's `name` is a non-string
+        // (as_str None) — both filtered out; only the valid third survives.
+        let body =
+            br#"{"models":[{"no_name":true},{"name":123},{"name":"models/gemini-3-flash"}]}"#;
         let base = spawn_mock_server(200, "OK", body).await;
         let provider = native_provider_with_base(&base);
         let models = provider.list_models().await.unwrap();

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -394,8 +394,8 @@ impl Provider for OllamaProvider {
         Ok(Box::pin(stream))
     }
 
-    fn count_tokens(&self, text: &str, _model: &str) -> usize {
-        // Approximate counting (model-dependent)
+    async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        // Ollama exposes no token-count endpoint; approximate locally.
         text.len() / 4
     }
 
@@ -708,19 +708,19 @@ mod tests {
         assert_eq!(caps.max_context_tokens, 131_072);
     }
 
-    #[test]
-    fn test_count_tokens() {
+    #[tokio::test]
+    async fn test_count_tokens() {
         let provider = OllamaProvider::new();
-        let tokens = provider.count_tokens("Hello, world!", "llama3");
+        let tokens = provider.count_tokens("Hello, world!", "llama3").await;
         assert!(tokens > 0);
         // len / 4 = 13 / 4 = 3
         assert_eq!(tokens, 3);
     }
 
-    #[test]
-    fn test_count_tokens_empty() {
+    #[tokio::test]
+    async fn test_count_tokens_empty() {
         let provider = OllamaProvider::new();
-        assert_eq!(provider.count_tokens("", "llama3"), 0);
+        assert_eq!(provider.count_tokens("", "llama3").await, 0);
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -196,7 +196,8 @@ impl Provider for OpenAIProvider {
         Ok(Box::pin(stream))
     }
 
-    fn count_tokens(&self, text: &str, model: &str) -> usize {
+    async fn count_tokens(&self, text: &str, model: &str) -> usize {
+        // tiktoken is exact for OpenAI models and runs locally — no network call.
         crate::tokenizer::count_tokens(text, model)
     }
 
@@ -514,18 +515,18 @@ mod tests {
         assert_eq!(provider.base_url, "https://custom.openai.com");
     }
 
-    #[test]
-    fn test_count_tokens_uses_tiktoken() {
+    #[tokio::test]
+    async fn test_count_tokens_uses_tiktoken() {
         let provider = OpenAIProvider::new("key".to_string());
-        let tokens = provider.count_tokens("Hello, world!", "gpt-5.4-mini");
+        let tokens = provider.count_tokens("Hello, world!", "gpt-5.4-mini").await;
         assert!(tokens > 0);
         assert!(tokens < 20);
     }
 
-    #[test]
-    fn test_count_tokens_empty() {
+    #[tokio::test]
+    async fn test_count_tokens_empty() {
         let provider = OpenAIProvider::new("key".to_string());
-        let tokens = provider.count_tokens("", "gpt-5.4-mini");
+        let tokens = provider.count_tokens("", "gpt-5.4-mini").await;
         assert_eq!(tokens, 0);
     }
 

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -233,8 +233,9 @@ impl Provider for OpenRouterProvider {
         Ok(Box::pin(stream))
     }
 
-    fn count_tokens(&self, text: &str, _model: &str) -> usize {
-        // Approximate counting (provider-specific tokenizers not available)
+    async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        // OpenRouter fronts many models and exposes no token-count endpoint;
+        // approximate locally (provider-specific tokenizers not available).
         text.len() / 4
     }
 
@@ -623,17 +624,17 @@ mod tests {
         assert_eq!(provider.name(), "openrouter");
     }
 
-    #[test]
-    fn test_count_tokens() {
+    #[tokio::test]
+    async fn test_count_tokens() {
         let provider = OpenRouterProvider::new("key".to_string());
-        let tokens = provider.count_tokens("Hello, world!", "any-model");
+        let tokens = provider.count_tokens("Hello, world!", "any-model").await;
         assert_eq!(tokens, 3); // 13 / 4 = 3
     }
 
-    #[test]
-    fn test_count_tokens_empty() {
+    #[tokio::test]
+    async fn test_count_tokens_empty() {
         let provider = OpenRouterProvider::new("key".to_string());
-        assert_eq!(provider.count_tokens("", "any-model"), 0);
+        assert_eq!(provider.count_tokens("", "any-model").await, 0);
     }
 
     #[test]

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -478,7 +478,15 @@ pub trait Provider: Send + Sync {
     }
 
     /// Count tokens in the given text for this provider's models.
-    fn count_tokens(&self, text: &str, model: &str) -> usize;
+    ///
+    /// Providers with an exact remote token-count endpoint (Anthropic, Gemini)
+    /// call it here and fall back to a local heuristic on any error, so this is
+    /// infallible. Providers without such an endpoint (OpenAI via tiktoken,
+    /// OpenRouter, Ollama, Claude Code) compute locally and never `.await` on
+    /// the network. Because an implementation may perform a network round-trip,
+    /// do **not** call this on a hot per-entry accounting path; use it for
+    /// bounded, request-level checks.
+    async fn count_tokens(&self, text: &str, model: &str) -> usize;
 
     /// Get the maximum context tokens for a model.
     fn max_context_tokens(&self, model: &str) -> usize;
@@ -867,7 +875,7 @@ mod tests {
             })
         }
 
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len()
         }
 
@@ -917,10 +925,10 @@ mod tests {
         assert!(models.is_empty());
     }
 
-    #[test]
-    fn minimal_provider_trait_accessors() {
+    #[tokio::test]
+    async fn minimal_provider_trait_accessors() {
         let provider = MinimalProvider;
-        assert_eq!(provider.count_tokens("hello", "any"), 5);
+        assert_eq!(provider.count_tokens("hello", "any").await, 5);
         assert_eq!(provider.max_context_tokens("any"), 1000);
         assert_eq!(provider.name(), "minimal");
         assert_eq!(

--- a/crates/leviath-providers/src/tokenizer.rs
+++ b/crates/leviath-providers/src/tokenizer.rs
@@ -8,12 +8,21 @@ use tiktoken_rs::get_bpe_from_model;
 /// Count tokens in text for a specific model.
 ///
 /// Uses tiktoken for OpenAI/GPT models, approximate counting for others.
+///
+/// This is the offline/heuristic path. Providers with an exact remote
+/// token-count endpoint (Anthropic, Gemini) call it only as the fallback when
+/// that endpoint is unavailable; see each provider's `count_tokens`.
 pub fn count_tokens(text: &str, model: &str) -> usize {
     if model.starts_with("gpt-") || model.starts_with("o3-") || model.starts_with("o4-") {
         count_tokens_tiktoken(text, model)
     } else if model.starts_with("claude-") {
         // Anthropic: ~3.5 chars per token (no official Rust tokenizer)
         approximate_count_anthropic(text)
+    } else if model.starts_with("gemini-") {
+        // Gemini: no official Rust tokenizer; ~4 chars per token (SentencePiece,
+        // close to GPT for English). Kept as its own branch so the ratio can be
+        // tuned independently of the generic fallback.
+        approximate_count_gemini(text)
     } else {
         approximate_count(text)
     }
@@ -29,6 +38,11 @@ fn count_tokens_tiktoken(text: &str, model: &str) -> usize {
 /// Approximate token count for Anthropic models (~3.5 chars per token).
 fn approximate_count_anthropic(text: &str) -> usize {
     (text.len() as f32 / 3.5).ceil() as usize
+}
+
+/// Approximate token count for Gemini models (~4 chars per token).
+fn approximate_count_gemini(text: &str) -> usize {
+    text.len().div_ceil(4)
 }
 
 /// Approximate token count based on character length.
@@ -132,6 +146,14 @@ mod tests {
         // "Hello" = 5 chars, 5/3.5 = 1.43, ceil = 2
         let count = count_tokens("Hello", "claude-sonnet-4-6");
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_gemini_model_uses_gemini_approx() {
+        // "12345678" = 8 chars, 8/4 = 2 tokens (gemini branch, not tiktoken)
+        assert_eq!(count_tokens("12345678", "gemini-3.5-flash"), 2);
+        // 9 chars / 4 = 2.25 → ceil = 3
+        assert_eq!(count_tokens("123456789", "gemini-3.1-pro-preview"), 3);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -127,7 +127,7 @@ mod tests {
                 None => Err(ProviderError::Other("exhausted".to_string())),
             }
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -200,13 +200,13 @@ mod tests {
         run_compaction_job(job(provider, vec!["a"]), tx, wake).await;
     }
 
-    #[test]
-    fn script_metadata_is_exercised() {
+    #[tokio::test]
+    async fn script_metadata_is_exercised() {
         let p = Script {
             out: Mutex::new(std::collections::VecDeque::new()),
         };
         assert_eq!(p.name(), "script");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -539,7 +539,7 @@ mod tests {
                 finish_reason: FinishReason::Complete,
             })
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -608,6 +608,7 @@ mod tests {
             content_summary_outcomes: cs_tx,
             wake: Arc::new(Notify::new()),
             runtime: Handle::current(),
+            exact_token_counting: false,
         });
         (world, cs_rx)
     }
@@ -618,14 +619,14 @@ mod tests {
         s.run(world);
     }
 
-    #[test]
-    fn fake_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn fake_provider_metadata_is_exercised() {
         let p = FakeProvider {
             reply: String::new(),
             fail: false,
         };
         assert_eq!(p.name(), "fake");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -914,7 +914,7 @@ mod tests {
                 .pop_front()
                 .ok_or_else(|| ProviderError::Other("exhausted".to_string()))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -1905,7 +1905,7 @@ mod tests {
             responses: Mutex::new(std::collections::VecDeque::new()),
         };
         assert_eq!(p.name(), "script");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
         let req = InferenceRequest {

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -408,16 +408,9 @@ mod tests {
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
         let err = outcome.result.expect_err("should be rejected");
-        assert!(
-            matches!(
-                err,
-                ProviderError::TokenLimitExceeded {
-                    used: 950,
-                    max: 1000
-                }
-            ),
-            "got: {err}"
-        );
+        // Assert on the Display string (branch-free) rather than `matches!`,
+        // whose non-matching arm would be an uncovered region.
+        assert_eq!(err.to_string(), "Token limit exceeded: 950 > 1000");
     }
 
     #[tokio::test]
@@ -437,6 +430,16 @@ mod tests {
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
         assert_eq!(outcome.result.expect("should succeed").content, "ok");
+    }
+
+    #[tokio::test]
+    async fn counter_provider_metadata_is_exercised() {
+        // Keep the Counter mock's non-`infer` trait methods measured.
+        let p = Counter { count: 5, max: 10 };
+        assert_eq!(p.name(), "counter");
+        assert_eq!(p.max_context_tokens("m"), 10);
+        assert_eq!(p.count_tokens("t", "m").await, 5);
+        assert!(p.capabilities("m").supports_streaming);
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -70,6 +70,33 @@ pub struct InferenceJob {
     /// The per-model pool permit, held for the whole request and released when
     /// the job finishes.
     pub permit: InferencePermit,
+    /// When set, count the assembled request's tokens exactly (via the
+    /// provider's `count_tokens`, which uses a remote endpoint where available)
+    /// before calling `infer`, and fail early if it would exceed the model's
+    /// context window. Off by default — the runtime's cheap `len/4` estimates
+    /// drive normal budgeting; this is the opt-in accurate guard.
+    pub exact_token_counting: bool,
+}
+
+/// Flatten a request into the text whose tokens we count for the budget guard:
+/// system blocks, every message's textual content, and each tool's name +
+/// description + JSON schema. This mirrors what the provider sends closely enough
+/// for a context-window check (exact per-message/role overhead is the provider's
+/// to add; the bulk is this text).
+fn flatten_request_text(request: &InferenceRequest) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for block in &request.system {
+        parts.push(block.text.clone());
+    }
+    for msg in &request.messages {
+        parts.push(msg.content.as_text());
+    }
+    for tool in &request.tools {
+        parts.push(tool.name.clone());
+        parts.push(tool.description.clone());
+        parts.push(tool.parameters.to_string());
+    }
+    parts.join("\n")
 }
 
 /// The completed result of an [`InferenceJob`], applied on a later tick by the
@@ -98,7 +125,26 @@ pub async fn run_inference_job(
         provider,
         request,
         permit,
+        exact_token_counting,
     } = job;
+    // Opt-in accurate pre-flight budget guard: count the assembled request
+    // exactly (remote endpoint where the provider has one, heuristic otherwise)
+    // and refuse a request that would overflow the model's context window,
+    // rather than sending it and letting the provider reject it after the fact.
+    if exact_token_counting {
+        let text = flatten_request_text(&request);
+        let used = provider.count_tokens(&text, &request.model).await;
+        let max = provider.max_context_tokens(&request.model);
+        if used.saturating_add(request.max_tokens) > max {
+            drop(permit);
+            let _ = results.send(InferenceOutcome {
+                entity,
+                result: Err(ProviderError::TokenLimitExceeded { used, max }),
+            });
+            wake.notify_one();
+            return;
+        }
+    }
     // Retry transient failures (connection reset, timeout, 429, 5xx) with
     // exponential backoff, holding the permit across the backoff; a permanent
     // error fails immediately. The whole thing is bounded by `job_timeout` so a
@@ -180,7 +226,7 @@ mod tests {
                 Fixed::Err(m) => Err(ProviderError::Other(m.clone())),
             }
         }
-        fn count_tokens(&self, _text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, _text: &str, _model: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _model: &str) -> usize {
@@ -201,6 +247,7 @@ mod tests {
             provider,
             request: test_request(),
             permit: pools.try_acquire("m").expect("free pool"),
+            exact_token_counting: false,
         }
     }
 
@@ -222,6 +269,7 @@ mod tests {
             provider,
             request: test_request(),
             permit,
+            exact_token_counting: false,
         };
         let (tx, mut rx) = mpsc::unbounded_channel();
         let policy = RetryPolicy {
@@ -272,13 +320,151 @@ mod tests {
         assert!(outcome.result.is_err());
     }
 
+    /// A provider with a fixed `count_tokens` result and context window, used to
+    /// drive the opt-in pre-inference budget guard. `infer` always succeeds.
+    struct Counter {
+        count: usize,
+        max: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Counter {
+        async fn infer(
+            &self,
+            _req: InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            Ok(response("ok"))
+        }
+        async fn count_tokens(&self, _text: &str, _model: &str) -> usize {
+            self.count
+        }
+        fn max_context_tokens(&self, _model: &str) -> usize {
+            self.max
+        }
+        fn name(&self) -> &str {
+            "counter"
+        }
+        fn capabilities(&self, _model: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    fn counting_job(provider: Arc<dyn Provider>, exact: bool) -> InferenceJob {
+        let pools = InferencePools::new(InferencePoolConfig::new());
+        InferenceJob {
+            entity: Entity::from_raw(7),
+            provider,
+            request: test_request(), // max_tokens: 100
+            permit: pools.try_acquire("m").expect("free pool"),
+            exact_token_counting: exact,
+        }
+    }
+
     #[test]
-    fn fixed_provider_metadata_is_exercised() {
+    fn flatten_request_text_includes_system_messages_and_tools() {
+        use leviath_providers::{SystemBlock, Tool};
+        let req = InferenceRequest {
+            system: vec![SystemBlock {
+                text: "sys".to_string(),
+                cache_hint: leviath_core::CacheHint::Never,
+            }],
+            messages: vec![leviath_providers::Message {
+                role: "user".to_string(),
+                content: "hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "m".to_string(),
+            max_tokens: 10,
+            temperature: 0.0,
+            tools: vec![Tool {
+                name: "search".to_string(),
+                description: "find things".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }],
+            extra: serde_json::Value::Null,
+        };
+        let text = flatten_request_text(&req);
+        assert!(text.contains("sys"));
+        assert!(text.contains("hello"));
+        assert!(text.contains("search"));
+        assert!(text.contains("find things"));
+        assert!(text.contains("object"));
+    }
+
+    #[tokio::test]
+    async fn guard_rejects_request_over_context_window() {
+        // count(950) + max_tokens(100) = 1050 > context(1000) ⇒ rejected pre-flight.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let provider = Arc::new(Counter {
+            count: 950,
+            max: 1000,
+        });
+        run_inference_job(
+            counting_job(provider, true),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        let err = outcome.result.expect_err("should be rejected");
+        assert!(
+            matches!(
+                err,
+                ProviderError::TokenLimitExceeded {
+                    used: 950,
+                    max: 1000
+                }
+            ),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_allows_request_within_context_window() {
+        // count(800) + 100 = 900 ≤ 1000 ⇒ proceeds to infer.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let provider = Arc::new(Counter {
+            count: 800,
+            max: 1000,
+        });
+        run_inference_job(
+            counting_job(provider, true),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert_eq!(outcome.result.expect("should succeed").content, "ok");
+    }
+
+    #[tokio::test]
+    async fn guard_off_skips_the_count_and_proceeds() {
+        // Even wildly over budget, with the flag off the guard never runs.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let provider = Arc::new(Counter {
+            count: 1_000_000,
+            max: 1000,
+        });
+        run_inference_job(
+            counting_job(provider, false),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert_eq!(outcome.result.expect("should succeed").content, "ok");
+    }
+
+    #[tokio::test]
+    async fn fixed_provider_metadata_is_exercised() {
         // Covers the mock's non-`infer` trait methods (the pipeline resolves
         // these off the provider elsewhere; here we just keep them measured).
         let p = Fixed::Ok(response("x"));
         assert_eq!(p.name(), "fixed");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }
@@ -332,7 +518,7 @@ mod tests {
                 None => Err(ProviderError::Other("exhausted".to_string())),
             }
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -426,14 +612,14 @@ mod tests {
         assert_eq!(*provider.calls.lock().unwrap(), 1); // no retry on a permanent error
     }
 
-    #[test]
-    fn scripted_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn scripted_provider_metadata_is_exercised() {
         let p = Scripted {
             steps: std::sync::Mutex::new(std::collections::VecDeque::new()),
             calls: std::sync::Mutex::new(0),
         };
         assert_eq!(p.name(), "scripted");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -101,6 +101,10 @@ pub struct InferenceStage {
     pub wake: Arc<Notify>,
     /// Runtime the worker tasks are spawned onto.
     pub runtime: Handle,
+    /// Opt-in: perform an exact pre-inference token count and reject requests
+    /// that would overflow the model's context window (see
+    /// [`InferenceJob::exact_token_counting`]). Off by default.
+    pub exact_token_counting: bool,
 }
 
 /// Truncate `text` to at most `max_chars` characters, never splitting a
@@ -231,6 +235,7 @@ pub fn dispatch_inference(
                 provider,
                 request,
                 permit,
+                exact_token_counting: stage.exact_token_counting,
             };
             stage.runtime.spawn(run_inference_job(
                 job,
@@ -2761,6 +2766,9 @@ pub fn dispatch_transition_choice(
             provider,
             request,
             permit,
+            // Routing responses are tiny (≤256 tokens) and always fit; skip the
+            // extra count call for them.
+            exact_token_counting: false,
         };
         stage.runtime.spawn(run_inference_job(
             job,
@@ -2935,7 +2943,7 @@ mod tests {
                 finish_reason: leviath_providers::FinishReason::Complete,
             })
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -3091,15 +3099,15 @@ mod tests {
         assert_eq!(req.temperature, 0.0); // model doesn't support temperature
     }
 
-    #[test]
-    fn cfg_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn cfg_provider_metadata_is_exercised() {
         // Keep the mock's non-`infer`/`capabilities` trait methods measured.
         let p = Cfg {
             supports_temperature: true,
             max_output: 1,
         };
         assert_eq!(p.name(), "cfg");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
     }
 
@@ -3122,6 +3130,7 @@ mod tests {
             content_summary_outcomes: cstx,
             wake: Arc::new(Notify::new()),
             runtime: Handle::current(),
+            exact_token_counting: false,
         });
         (world, rx)
     }

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -58,7 +58,7 @@ mod tests {
         ) -> Result<InferenceResponse, ProviderError> {
             Err(ProviderError::ApiError("stub".to_string()))
         }
-        fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
             text.len()
         }
         fn max_context_tokens(&self, _model: &str) -> usize {
@@ -97,7 +97,7 @@ mod tests {
     async fn stub_provider_methods_are_exercised() {
         let p = StubProvider;
         assert_eq!(p.name(), "stub");
-        assert_eq!(p.count_tokens("abcd", "m"), 4);
+        assert_eq!(p.count_tokens("abcd", "m").await, 4);
         assert_eq!(p.max_context_tokens("m"), 8192);
         let _ = p.capabilities("m");
         let request = InferenceRequest {

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -227,12 +227,12 @@ impl PipelineWorld {
     /// world — see [`crate::inference_bridge::InferenceJob::exact_token_counting`].
     /// Call once at startup when the run config requests it, before serving.
     pub fn set_exact_token_counting(&mut self, enabled: bool) {
-        if let Some(mut stage) = self
-            .world
-            .get_resource_mut::<crate::pipeline::InferenceStage>()
-        {
-            stage.exact_token_counting = enabled;
-        }
+        // `InferenceStage` is inserted by every `PipelineWorld::new` path, so it
+        // is a hard invariant here — `resource_mut` (which panics if absent) is
+        // correct and keeps this branch-free.
+        self.world
+            .resource_mut::<crate::pipeline::InferenceStage>()
+            .exact_token_counting = enabled;
     }
 
     /// Install the shared interaction hub as a world resource and attach this

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -116,6 +116,7 @@ impl PipelineWorld {
             content_summary_outcomes: cs_tx,
             wake: wake.clone(),
             runtime,
+            exact_token_counting: false,
         });
         world.insert_resource(crate::context_transform::ContentSummaryResults(cs_rx));
         world.insert_resource(crate::interaction_points::InteractionPointStage {
@@ -220,6 +221,18 @@ impl PipelineWorld {
     /// Read-only access to the underlying ECS world.
     pub fn world(&self) -> &World {
         &self.world
+    }
+
+    /// Enable (or disable) the opt-in exact pre-inference budget guard for this
+    /// world — see [`crate::inference_bridge::InferenceJob::exact_token_counting`].
+    /// Call once at startup when the run config requests it, before serving.
+    pub fn set_exact_token_counting(&mut self, enabled: bool) {
+        if let Some(mut stage) = self
+            .world
+            .get_resource_mut::<crate::pipeline::InferenceStage>()
+        {
+            stage.exact_token_counting = enabled;
+        }
     }
 
     /// Install the shared interaction hub as a world resource and attach this
@@ -530,7 +543,7 @@ mod tests {
             let next = self.responses.lock().unwrap().pop_front();
             next.ok_or_else(|| ProviderError::Other("script exhausted".to_string()))
         }
-        fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
             1
         }
         fn max_context_tokens(&self, _m: &str) -> usize {
@@ -680,6 +693,25 @@ mod tests {
             std::env::temp_dir(),
             Handle::current(),
         )
+    }
+
+    #[tokio::test]
+    async fn set_exact_token_counting_toggles_the_stage_flag() {
+        let mut world = build_world(ProviderRegistry::new());
+        // Default is off.
+        assert!(
+            !world
+                .world()
+                .resource::<crate::pipeline::InferenceStage>()
+                .exact_token_counting
+        );
+        world.set_exact_token_counting(true);
+        assert!(
+            world
+                .world()
+                .resource::<crate::pipeline::InferenceStage>()
+                .exact_token_counting
+        );
     }
 
     #[tokio::test]
@@ -875,14 +907,14 @@ mod tests {
         assert!(err.is_err());
     }
 
-    #[test]
-    fn script_provider_metadata_is_exercised() {
+    #[tokio::test]
+    async fn script_provider_metadata_is_exercised() {
         // Keep the mock's non-`infer`/`capabilities` methods measured.
         let p = Script {
             responses: Mutex::new(std::collections::VecDeque::new()),
         };
         assert_eq!(p.name(), "script");
-        assert_eq!(p.count_tokens("t", "m"), 1);
+        assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
     }


### PR DESCRIPTION
## Summary

Closes #41. Token-counting accuracy was uneven: only OpenAI reached a real tokenizer (tiktoken); Anthropic/Gemini/OpenRouter/Ollama used char heuristics, Gemini even fell to the generic `len/4` branch, and Gemini returned identical `ModelCapabilities` for every model.

**Key finding that shaped the design:** `Provider::count_tokens` was effectively dead code — the runtime's budget/compaction accounting uses inline `content.len() / 4 + 1` at ~20 sites and never called it. `capabilities()`, by contrast, *is* live (drives `build_request`'s output cap + temperature and `lev models`). There is no offline Rust tokenizer for Claude/Gemini, so exact counts require the providers' remote endpoints.

## Exact API token counting

- `Provider::count_tokens` is now `async` and exact-where-possible, **infallible** (each impl falls back to its local heuristic on any error).
- **Anthropic** → `POST /v1/messages/count_tokens` (parses `input_tokens`). **Gemini** → native `:countTokens` (native base derived by stripping `/openai` from the OpenAI-compat base; parses `totalTokens`). **OpenAI** keeps tiktoken; **OpenRouter/Ollama/Claude-Code** keep heuristics (no endpoint exists). `tokenizer.rs` gained a Gemini branch.
- Because the endpoint is a network call, it does **not** replace the runtime's cheap per-entry `len/4` estimates. Instead a new **opt-in** pre-inference budget guard in `run_inference_job` counts the assembled request exactly and rejects it early with `TokenLimitExceeded` if it would overflow the model's context window. Gated by `[limits] exact_token_counting` (default `false`), threaded via `InferenceStage` → `PipelineWorld::set_exact_token_counting` (wired in the daemon world builder). The routing/transition lane always passes `false`.

## Gemini per-model capabilities

- `builtin_capabilities` now branches by model family (divergence-ready; values are identical today, so an explicit `#[allow(clippy::match_same_arms)]` documents the intent).
- `list_models` now queries the native `/v1beta/models` endpoint for real per-model `inputTokenLimit`/`outputTokenLimit` (the OpenAI-compat `/models` returns neither); falls back to the compat listing for non-standard base URLs.

## Tests & verification

- Async ripple: all provider impls and ~12 test mocks updated to `async count_tokens`.
- New unit tests: count endpoints (success + fallback on error/missing-field), the guard (over/under/off), request flattening, native model listing (real limits + missing-field fallback + skip-without-name), `native_base` derivation, family classification, and the `[limits] exact_token_counting` config flag.
- **Live-tested against the real Anthropic API:** `count_tokens` returned a real value (42 tokens for a ~100-byte mixed English+code message, vs. the 31 the char heuristic guesses — the endpoint correctly counts per-message framing/overhead), and an invalid key degraded gracefully to the heuristic. Gemini's endpoints could not be live-tested (no Google API key available); they follow the same reusable HTTP/fallback pattern and are unit-tested against mock servers.

Local gates all green: `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo doc -D warnings`, full `cargo test --workspace`, ast-grep suppression scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)