### PR TITLE
feat(regions): structured context regions with seed sources (#84, #13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ toml = { version = "0.8", features = ["preserve_order"] }
 anyhow = "1.0"
 chrono = "0.4"
 rhai = { version = "1.20", features = ["sync"] }
+glob = "0.3"
 tiktoken-rs = "0.5"
 async-trait = "0.1"
 futures = "0.3"

--- a/crates/leviath-agent-client/src/lib.rs
+++ b/crates/leviath-agent-client/src/lib.rs
@@ -28,7 +28,10 @@
 pub mod mapping;
 pub mod protocol;
 
-pub use mapping::{flatten_prompt, is_permission_request, permission_request, stop_reason_for};
+pub use mapping::{
+    flatten_prompt, is_permission_request, parse_region_markers, permission_request,
+    stop_reason_for,
+};
 pub use protocol::{
     AgentCapabilities, AgentInfo, ClientCapabilities, ContentBlock, EmbeddedResource,
     InitializeParams, InitializeResult, JsonRpcError, JsonRpcMessage, MAX_FRAME_BYTES,

--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -59,6 +59,78 @@ pub fn flatten_prompt(blocks: &[ContentBlock]) -> String {
     parts.join("\n\n").trim().to_string()
 }
 
+/// Parse `---region:<name>---` markers out of a flattened prompt into a
+/// name→content map.
+///
+/// A line that is exactly `---region:<name>---` (after trimming) opens a region
+/// block; its content runs until the next `---region:...---` marker, an
+/// `---end-regions---` line, or the end of the text. Any text before the first
+/// marker becomes the `task` region. With **no** markers at all, the whole text
+/// is returned as `{ "task": text }` — the exact pre-feature behavior, so hosts
+/// that don't use markers are unaffected.
+///
+/// Region bodies are trimmed; empty blocks are dropped. Pure — no I/O.
+pub fn parse_region_markers(text: &str) -> std::collections::HashMap<String, String> {
+    use std::collections::HashMap;
+
+    let marker_name = |line: &str| -> Option<String> {
+        let t = line.trim();
+        t.strip_prefix("---region:")
+            .and_then(|rest| rest.strip_suffix("---"))
+            .map(|n| n.trim().to_string())
+    };
+
+    let mut out = HashMap::new();
+    // Current region name (None = the leading "task" block) and its accumulated
+    // lines. `ended` becomes true after `---end-regions---`.
+    let mut current: Option<String> = None;
+    let mut buf: Vec<&str> = Vec::new();
+    let mut ended = false;
+    let mut saw_marker = false;
+
+    let flush = |name: &Option<String>, buf: &mut Vec<&str>, out: &mut HashMap<String, String>| {
+        let body = buf.join("\n");
+        let body = body.trim();
+        if !body.is_empty() {
+            let key = name.clone().unwrap_or_else(|| "task".to_string());
+            out.insert(key, body.to_string());
+        }
+        buf.clear();
+    };
+
+    for line in text.lines() {
+        if ended {
+            break;
+        }
+        if line.trim() == "---end-regions---" {
+            flush(&current, &mut buf, &mut out);
+            ended = true;
+            continue;
+        }
+        if let Some(name) = marker_name(line) {
+            flush(&current, &mut buf, &mut out);
+            current = Some(name);
+            saw_marker = true;
+            continue;
+        }
+        buf.push(line);
+    }
+    if !ended {
+        flush(&current, &mut buf, &mut out);
+    }
+
+    if !saw_marker {
+        // No markers: preserve exact legacy behavior (whole text → task).
+        let mut out = HashMap::new();
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            out.insert("task".to_string(), trimmed.to_string());
+        }
+        return out;
+    }
+    out
+}
+
 /// The stop reason to report for a run that has reached `status`.
 ///
 /// `Error` maps to `refusal` rather than inventing a failure code: the protocol
@@ -190,6 +262,57 @@ mod tests {
             body: None,
             body_format: Default::default(),
         }
+    }
+
+    // ─── parse_region_markers ────────────────────────────────────────────────
+
+    #[test]
+    fn markers_absent_puts_whole_text_in_task() {
+        let out = parse_region_markers("just do the thing");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out.get("task").map(String::as_str),
+            Some("just do the thing")
+        );
+    }
+
+    #[test]
+    fn markers_absent_empty_text_yields_empty_map() {
+        assert!(parse_region_markers("   \n  ").is_empty());
+    }
+
+    #[test]
+    fn leading_text_before_first_marker_becomes_task() {
+        let text = "build a parser\n---region:criteria---\nfocus on safety";
+        let out = parse_region_markers(text);
+        assert_eq!(out.get("task").map(String::as_str), Some("build a parser"));
+        assert_eq!(
+            out.get("criteria").map(String::as_str),
+            Some("focus on safety")
+        );
+    }
+
+    #[test]
+    fn multiple_regions_and_end_marker_with_trailing_text_dropped() {
+        let text = "\
+---region:task---
+build it
+---region:criteria---
+be careful
+---end-regions---
+this trailing text is ignored";
+        let out = parse_region_markers(text);
+        assert_eq!(out.get("task").map(String::as_str), Some("build it"));
+        assert_eq!(out.get("criteria").map(String::as_str), Some("be careful"));
+        assert_eq!(out.len(), 2, "trailing text after end marker is dropped");
+    }
+
+    #[test]
+    fn empty_region_blocks_are_dropped() {
+        let text = "---region:task---\nreal\n---region:empty---\n   \n";
+        let out = parse_region_markers(text);
+        assert_eq!(out.get("task").map(String::as_str), Some("real"));
+        assert!(!out.contains_key("empty"));
     }
 
     // ─── flatten_prompt ──────────────────────────────────────────────────────

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rhai = { workspace = true }
+glob = { workspace = true }
 dirs = "6.0.0"
 chrono = { workspace = true }
 bevy_ecs = { workspace = true }

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -40,7 +40,7 @@ use leviath_agent_client::{
     PROTOCOL_VERSION, PromptCapabilities, RequestPermissionResult, SessionCancelParams,
     SessionNewParams, SessionNewResult, SessionPromptParams, SessionPromptResult, SessionUpdate,
     SessionUpdateParams, StopReason, error_codes, flatten_prompt, is_permission_request,
-    permission_request,
+    parse_region_markers, permission_request,
 };
 use leviath_core::interaction::{ApprovalScope, InteractionRequest, InteractionResponse};
 use leviath_core::run_meta::RunStatus;
@@ -333,8 +333,8 @@ impl Server {
         let params: SessionPromptParams = params
             .and_then(|p| serde_json::from_value(p).ok())
             .unwrap_or_default();
-        let task = flatten_prompt(&params.prompt);
-        if task.is_empty() {
+        let text = flatten_prompt(&params.prompt);
+        if text.is_empty() {
             self.write(&JsonRpcMessage::error_response(
                 id,
                 error_codes::INVALID_PARAMS,
@@ -343,7 +343,11 @@ impl Server {
             .await;
             return;
         }
-        let stop_reason = self.run_turn(reader, task).await;
+        // Parse `---region:<name>---` markers; with none, the whole text is the
+        // `task` region (back-compat).
+        let regions = parse_region_markers(&text);
+        let task = regions.get("task").cloned().unwrap_or_default();
+        let stop_reason = self.run_turn(reader, task, regions).await;
         self.write(&JsonRpcMessage::response(
             id,
             &SessionPromptResult { stop_reason },
@@ -367,7 +371,12 @@ impl Server {
 
     /// Drive one prompt turn: spawn (or message) the agent, then translate the
     /// daemon's events and the run's output until it goes terminal or parks.
-    async fn run_turn(&mut self, reader: &mut BoxReader, task: String) -> StopReason {
+    async fn run_turn(
+        &mut self,
+        reader: &mut BoxReader,
+        task: String,
+        regions: std::collections::HashMap<String, String>,
+    ) -> StopReason {
         // Subscribe before spawning so no event between spawn and subscribe is
         // missed. An unreachable daemon ends the turn as a refusal.
         let Ok(mut stream) = self.control.subscribe().await else {
@@ -380,7 +389,7 @@ impl Server {
             .expect("session present")
             .session_id
             .clone();
-        let run_id = match self.start_run(task).await {
+        let run_id = match self.start_run(task, regions).await {
             RunStart::Ready(run_id) => run_id,
             // The agent already finished and won't take another message — the
             // turn is simply over, not a failure.
@@ -465,7 +474,13 @@ impl Server {
     }
 
     /// Spawn the agent on the first prompt, or deliver a message on later ones.
-    async fn start_run(&mut self, task: String) -> RunStart {
+    /// `regions` seeds named caller-input regions on the first (spawning) prompt;
+    /// on later prompts the text is delivered as a message and `regions` is unused.
+    async fn start_run(
+        &mut self,
+        task: String,
+        regions: std::collections::HashMap<String, String>,
+    ) -> RunStart {
         let existing = self
             .session
             .as_ref()
@@ -492,7 +507,8 @@ impl Server {
             }
             None => {
                 let session = self.session.as_ref().expect("session present");
-                let spawn = spawn_args(&session.blueprint, &task, &session.cwd, &self.args);
+                let spawn =
+                    spawn_args(&session.blueprint, &task, &session.cwd, &self.args, regions);
                 match self.control.spawn(spawn).await {
                     Ok(ControlResponse::Spawned { run_id }) => {
                         self.session.as_mut().expect("session present").run_id =

--- a/crates/leviath-cli/src/commands/agent_client/session.rs
+++ b/crates/leviath-cli/src/commands/agent_client/session.rs
@@ -60,11 +60,13 @@ pub(super) fn spawn_args(
     task: &str,
     cwd: &str,
     args: &AgentClientArgs,
+    regions: std::collections::HashMap<String, String>,
 ) -> SpawnArgs {
     SpawnArgs {
         run_id: new_run_id(&blueprint.agent_name),
         blueprint_path: blueprint.manifest_path.to_string_lossy().to_string(),
         task: task.to_string(),
+        regions,
         model: None,
         workdir: cwd.to_string(),
         metadata: Default::default(),
@@ -144,12 +146,18 @@ prompt = "Plan the work"
             allow: vec!["bash".to_string()],
             max_depth: Some(2),
         };
-        let spawn = spawn_args(&resolved, "do the thing", "/work", &args);
+        let regions =
+            std::collections::HashMap::from([("criteria".to_string(), "be safe".to_string())]);
+        let spawn = spawn_args(&resolved, "do the thing", "/work", &args, regions);
         assert_eq!(
             spawn.blueprint_path,
             resolved.manifest_path.to_string_lossy()
         );
         assert_eq!(spawn.task, "do the thing");
+        assert_eq!(
+            spawn.regions.get("criteria").map(String::as_str),
+            Some("be safe")
+        );
         assert_eq!(spawn.workdir, "/work");
         assert!(spawn.model.is_none());
         assert!(spawn.yolo);

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -9,6 +9,8 @@
 pub mod manifest;
 pub mod session;
 
+use std::collections::HashMap;
+
 use clap::Args;
 
 // Re-export the provider-registry builders used by the daemon setup.
@@ -43,4 +45,171 @@ pub struct RunArgs {
     /// Override the blueprint's max sub-agent tree depth.
     #[arg(long)]
     pub max_depth: Option<usize>,
+
+    /// Dynamic per-region seed flags (`--<region> <text|@file>`), collected by an
+    /// argv pre-scan in the binary since region names are blueprint-defined.
+    /// clap skips this field; it is populated after parsing.
+    #[arg(skip)]
+    pub regions: HashMap<String, String>,
+}
+
+/// The `run` subcommand's own long flags — everything NOT in this set is treated
+/// as a dynamic `--<region>` seed flag by [`extract_region_flags`].
+const KNOWN_RUN_FLAGS: &[&str] = &[
+    "task",
+    "model",
+    "yolo",
+    "allow",
+    "max-depth",
+    "verbose",
+    "help",
+    "version",
+];
+
+/// Pre-scan a full argv (program name first) for dynamic `--<region>` flags on
+/// the `run` subcommand, since region names are blueprint-defined and clap can't
+/// declare them. Returns `(argv_for_clap, region_flags)`: a `--<name>` (or
+/// `--<name>=<value>`) whose `<name>` is not a known `run` flag is pulled out
+/// (with its value) into the map; every other token passes through untouched.
+///
+/// A no-`=` region flag consumes the following token as its value. If argv has
+/// no `run` subcommand token, nothing is extracted (the returned argv equals the
+/// input). Pure — no environment or I/O — so it is unit-testable in isolation.
+pub fn extract_region_flags(argv: Vec<String>) -> (Vec<String>, HashMap<String, String>) {
+    // Locate the subcommand: the first bareword (non-`-`) token after the program
+    // name. Only activate when it is `run`.
+    let sub_pos = argv
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, t)| !t.starts_with('-'))
+        .map(|(i, _)| i);
+    let Some(sub_pos) = sub_pos else {
+        return (argv, HashMap::new());
+    };
+    if argv[sub_pos] != "run" {
+        return (argv, HashMap::new());
+    }
+
+    let mut out: Vec<String> = argv[..=sub_pos].to_vec();
+    let mut regions = HashMap::new();
+    let mut i = sub_pos + 1;
+    while i < argv.len() {
+        let token = &argv[i];
+        if let Some(name) = token.strip_prefix("--") {
+            // Split an `=`-joined value if present.
+            let (name, inline) = match name.split_once('=') {
+                Some((n, v)) => (n, Some(v.to_string())),
+                None => (name, None),
+            };
+            if !name.is_empty() && !KNOWN_RUN_FLAGS.contains(&name) {
+                let value = match inline {
+                    Some(v) => v,
+                    None => {
+                        // Consume the next token as the value, if any.
+                        i += 1;
+                        argv.get(i).cloned().unwrap_or_default()
+                    }
+                };
+                regions.insert(name.to_string(), value);
+                i += 1;
+                continue;
+            }
+        }
+        out.push(token.clone());
+        i += 1;
+    }
+    (out, regions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn extracts_dynamic_region_flags_and_preserves_known_ones() {
+        let (out, regions) = extract_region_flags(argv(&[
+            "lev",
+            "run",
+            "agents/reviewer",
+            "--task",
+            "review it",
+            "--files",
+            "@src/main.rs",
+            "--review-criteria",
+            "@policy.md",
+            "--yolo",
+        ]));
+        // Known flags + positional pass through to clap.
+        assert_eq!(
+            out,
+            argv(&[
+                "lev",
+                "run",
+                "agents/reviewer",
+                "--task",
+                "review it",
+                "--yolo",
+            ])
+        );
+        assert_eq!(
+            regions.get("files").map(String::as_str),
+            Some("@src/main.rs")
+        );
+        assert_eq!(
+            regions.get("review-criteria").map(String::as_str),
+            Some("@policy.md")
+        );
+    }
+
+    #[test]
+    fn extracts_equals_joined_region_flag() {
+        let (out, regions) = extract_region_flags(argv(&["lev", "run", "a", "--criteria=be safe"]));
+        assert_eq!(out, argv(&["lev", "run", "a"]));
+        assert_eq!(regions.get("criteria").map(String::as_str), Some("be safe"));
+    }
+
+    #[test]
+    fn no_region_flags_leaves_argv_unchanged() {
+        let input = argv(&["lev", "run", "a", "--task", "t"]);
+        let (out, regions) = extract_region_flags(input.clone());
+        assert_eq!(out, input);
+        assert!(regions.is_empty());
+    }
+
+    #[test]
+    fn non_run_subcommand_is_untouched() {
+        // A dynamic-looking flag on another subcommand is left for clap to reject.
+        let input = argv(&["lev", "ps", "--weird", "x"]);
+        let (out, regions) = extract_region_flags(input.clone());
+        assert_eq!(out, input);
+        assert!(regions.is_empty());
+    }
+
+    #[test]
+    fn no_subcommand_token_is_untouched() {
+        // Only flags, no bareword subcommand → nothing extracted.
+        let input = argv(&["lev", "--verbose"]);
+        let (out, regions) = extract_region_flags(input.clone());
+        assert_eq!(out, input);
+        assert!(regions.is_empty());
+    }
+
+    #[test]
+    fn trailing_region_flag_without_value_maps_to_empty() {
+        // A dynamic flag at the very end with no following value → empty string.
+        let (out, regions) = extract_region_flags(argv(&["lev", "run", "a", "--spec"]));
+        assert_eq!(out, argv(&["lev", "run", "a"]));
+        assert_eq!(regions.get("spec").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn global_verbose_before_run_still_activates() {
+        let (_out, regions) = extract_region_flags(argv(&["lev", "-v", "run", "a", "--spec", "x"]));
+        assert_eq!(regions.get("spec").map(String::as_str), Some("x"));
+    }
 }

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -65,6 +65,25 @@ fn resolve_task_with(
     )
 }
 
+/// Resolve one CLI region-flag value: `@path` reads (and trims) that file's
+/// contents; anything else is literal text. Unlike `--task`, the `@` is an
+/// explicit file marker, so a missing `@file` is an error (the user meant a
+/// file), not a literal fallback.
+pub fn read_region_value(raw: &str) -> anyhow::Result<String> {
+    match raw.strip_prefix('@') {
+        Some(path) => {
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("Failed to read region file '{}': {}", path, e))?;
+            let trimmed = content.trim().to_string();
+            if trimmed.is_empty() {
+                anyhow::bail!("Region file '{}' is empty.", path);
+            }
+            Ok(trimmed)
+        }
+        None => Ok(raw.to_string()),
+    }
+}
+
 /// Same as [`resolve_task_with`], but with the editor launch itself injected
 /// too — lets tests deterministically exercise `launch_editor`'s error
 /// propagating out of `resolve_task_with` (the `result?` a few lines down)
@@ -408,6 +427,42 @@ mod tests {
     #[should_panic(expected = "expected Ok, got Err(boom)")]
     fn assert_launch_ok_panics_when_err() {
         assert_launch_ok(&Err(anyhow::anyhow!("boom")));
+    }
+
+    // ─── read_region_value ────────────────────────────────────────────────
+
+    #[test]
+    fn read_region_value_literal_passthrough() {
+        assert_eq!(read_region_value("just text").unwrap(), "just text");
+    }
+
+    #[test]
+    fn read_region_value_at_path_reads_and_trims() {
+        let dir = std::env::temp_dir().join("lev-test-region-value");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("r.md");
+        std::fs::write(&file, "  hello region  \n").unwrap();
+        let raw = format!("@{}", file.to_string_lossy());
+        assert_eq!(read_region_value(&raw).unwrap(), "hello region");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_region_value_at_missing_file_errors() {
+        let err = read_region_value("@/no/such/region/file.md").unwrap_err();
+        assert!(err.to_string().contains("Failed to read region file"));
+    }
+
+    #[test]
+    fn read_region_value_at_empty_file_errors() {
+        let dir = std::env::temp_dir().join("lev-test-region-empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("empty.md");
+        std::fs::write(&file, "   \n").unwrap();
+        let raw = format!("@{}", file.to_string_lossy());
+        let err = read_region_value(&raw).unwrap_err();
+        assert!(err.to_string().contains("is empty"));
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ─── platform_default_editors ─────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -46,6 +46,7 @@ pub(super) async fn spawn_agent(
         run_id,
         blueprint_path: manifest_path.to_string_lossy().to_string(),
         task: body.task.clone(),
+        regions: body.regions.clone(),
         model: body.model.clone(),
         workdir,
         metadata: body.metadata.clone(),

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -166,6 +166,9 @@ pub(super) struct SpawnAgentReq {
     #[serde(default)]
     pub(super) allow: Vec<String>,
     pub(super) workdir: Option<String>,
+    /// Literal seed content for named caller-input regions, keyed by region name.
+    #[serde(default)]
+    pub(super) regions: HashMap<String, String>,
     #[serde(default)]
     pub(super) metadata: HashMap<String, String>,
     pub(super) callback_url: Option<String>,

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -3,15 +3,26 @@
 //! `lev run` (and reusable by other clients). The socket-path resolution + connect
 //! live in the binary; these cores are unit-testable against a fake socket server.
 
+use std::collections::HashMap;
+
 use anyhow::bail;
+use leviath_core::layout::RegionSeed;
 use leviath_runtime::control_socket::{ControlClient, ControlResponse};
 use leviath_runtime::host::SpawnArgs;
 
 use crate::commands::run::manifest::find_manifest;
+use crate::commands::run::session::read_region_value;
 use crate::runstate::new_run_id;
 
 /// Resolve the local inputs of a spawn request: find the manifest, mint a run id
-/// from the agent's directory name, and record the working directory.
+/// from the agent's directory name, record the working directory, and resolve
+/// any dynamic `--<region>` flags (raw values, `@path` or literal) against the
+/// blueprint's declared caller-input regions.
+///
+/// `regions` maps a flag name to its raw value. An unknown region name (one the
+/// blueprint doesn't read as caller input) is a hard error here — fast, local
+/// typo protection before the daemon is contacted.
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_spawn_args(
     path: &str,
     task: &str,
@@ -20,6 +31,7 @@ pub fn resolve_spawn_args(
     yolo: bool,
     allow: Vec<String>,
     max_depth: Option<usize>,
+    regions: HashMap<String, String>,
 ) -> anyhow::Result<SpawnArgs> {
     let manifest = find_manifest(path)?;
     let agent_name = manifest
@@ -27,10 +39,46 @@ pub fn resolve_spawn_args(
         .and_then(|p| p.file_name())
         .and_then(|n| n.to_str())
         .unwrap_or("agent");
+
+    // Validate + resolve region flags against the blueprint's caller-input regions.
+    let resolved_regions = if regions.is_empty() {
+        HashMap::new()
+    } else {
+        let content = std::fs::read_to_string(&manifest)
+            .map_err(|e| anyhow::anyhow!("read manifest '{}': {e}", manifest.display()))?;
+        let blueprint = leviath_core::manifest::parse_manifest(&content)
+            .map_err(|e| anyhow::anyhow!("parse manifest: {e}"))?;
+        let declared: Vec<String> = blueprint
+            .context_layout
+            .regions
+            .iter()
+            .filter_map(|r| match &r.seed {
+                Some(RegionSeed::CallerInput { name }) => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        let mut out = HashMap::new();
+        for (name, raw) in regions {
+            if !declared.contains(&name) {
+                bail!(
+                    "unknown region '--{name}'; this agent's caller-input regions are: {}",
+                    if declared.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        declared.join(", ")
+                    }
+                );
+            }
+            out.insert(name, read_region_value(&raw)?);
+        }
+        out
+    };
+
     Ok(SpawnArgs {
         run_id: new_run_id(agent_name),
         blueprint_path: manifest.to_string_lossy().to_string(),
         task: task.to_string(),
+        regions: resolved_regions,
         model,
         workdir: workdir.to_string(),
         metadata: Default::default(),
@@ -92,6 +140,7 @@ mod tests {
             false,
             Vec::new(),
             None,
+            HashMap::new(),
         )
         .unwrap();
         assert!(args.run_id.contains("my-agent"));
@@ -111,9 +160,200 @@ mod tests {
                 "/work",
                 false,
                 Vec::new(),
-                None
+                None,
+                HashMap::new(),
             )
             .is_err()
+        );
+    }
+
+    /// Write a manifest declaring a `criteria` caller-input region, returning its
+    /// path.
+    fn write_region_manifest(dir: &std::path::Path) -> std::path::PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("agent.leviath"),
+            r#"
+[agent]
+name = "reviewer"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }
+criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#,
+        )
+        .unwrap();
+        dir.join("agent.leviath")
+    }
+
+    #[test]
+    fn resolve_spawn_args_resolves_declared_region_and_reads_at_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_region_manifest(&dir.path().join("reviewer"));
+        let policy = dir.path().join("policy.md");
+        std::fs::write(&policy, "  focus on safety  ").unwrap();
+
+        let regions = HashMap::from([(
+            "criteria".to_string(),
+            format!("@{}", policy.to_string_lossy()),
+        )]);
+        let args = resolve_spawn_args(
+            manifest.to_str().unwrap(),
+            "review it",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap();
+        // `@path` was read and trimmed.
+        assert_eq!(
+            args.regions.get("criteria").map(String::as_str),
+            Some("focus on safety")
+        );
+    }
+
+    #[test]
+    fn resolve_spawn_args_unknown_region_reports_none_when_no_caller_inputs() {
+        // A blueprint with zero caller-input regions: the error lists "(none)".
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("noinput");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(
+            agent_dir.join("agent.leviath"),
+            r#"
+[agent]
+name = "noinput"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+data = { kind = "pinned", max_tokens = 2000 }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#,
+        )
+        .unwrap();
+        let manifest = agent_dir.join("agent.leviath");
+        let regions = HashMap::from([("foo".to_string(), "x".to_string())]);
+        let err = resolve_spawn_args(
+            manifest.to_str().unwrap(),
+            "t",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("(none)"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_spawn_args_manifest_read_error_surfaces() {
+        // `find_manifest` accepts a dir whose `agent.leviath` merely *exists*; when
+        // that entry is itself a directory, the client-side read fails (EISDIR).
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("dirmanifest");
+        std::fs::create_dir_all(agent_dir.join("agent.leviath")).unwrap();
+        let regions = HashMap::from([("x".to_string(), "y".to_string())]);
+        let err = resolve_spawn_args(
+            agent_dir.to_str().unwrap(),
+            "t",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("read manifest"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_spawn_args_manifest_parse_error_surfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("badtoml");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(
+            agent_dir.join("agent.leviath"),
+            "this is : not = valid toml [[[",
+        )
+        .unwrap();
+        let regions = HashMap::from([("x".to_string(), "y".to_string())]);
+        let err = resolve_spawn_args(
+            agent_dir.join("agent.leviath").to_str().unwrap(),
+            "t",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("parse manifest"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_spawn_args_region_value_bad_file_errors() {
+        // A declared region whose `@file` value can't be read → the error from
+        // read_region_value propagates out of resolve_spawn_args.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_region_manifest(&dir.path().join("reviewer"));
+        let regions = HashMap::from([("criteria".to_string(), "@/no/such/file.md".to_string())]);
+        let err = resolve_spawn_args(
+            manifest.to_str().unwrap(),
+            "review it",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to read region file"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_spawn_args_rejects_unknown_region_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_region_manifest(&dir.path().join("reviewer"));
+        let regions = HashMap::from([("bogus".to_string(), "x".to_string())]);
+        let err = resolve_spawn_args(
+            manifest.to_str().unwrap(),
+            "review it",
+            None,
+            "/work",
+            false,
+            Vec::new(),
+            None,
+            regions,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown region '--bogus'"),
+            "got: {err}"
         );
     }
 

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -72,6 +72,8 @@ impl FanOutSpawner for DaemonFanOutSpawner {
             false,
             Vec::new(),
             None,
+            // Fan-out workers get their split of the parent task via `task`.
+            std::collections::HashMap::new(),
         )
         .map_err(|e| format!("resolve worker blueprint: {e}"))?;
         // Nest the worker under its fan-out parent in the run tree.
@@ -332,6 +334,7 @@ mod tests {
             run_id: "parent".to_string(),
             blueprint_path: manifest_path.to_string(),
             task: "parent task".to_string(),
+            regions: HashMap::new(),
             model: None,
             workdir: std::env::temp_dir().to_string_lossy().to_string(),
             metadata: HashMap::new(),

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -4,7 +4,9 @@
 //! (the reloaded agent is `ReadyToInfer`), rather than being lost.
 //!
 //! For each `<runs_dir>/<run_id>/meta.json` whose status is non-terminal, this
-//! loads the blueprint (via [`build_agent`], reusing the spawn path), restores the
+//! loads the blueprint (via [`build_agent_for_reload`], reusing the spawn path),
+//! which skips the required-at-spawn region gate since the window is restored
+//! from a snapshot; restores the
 //! persisted context / stage / iteration / token totals via
 //! [`leviath_runtime::restore::restore_agent`], and preserves the original run
 //! metadata. Anything unreadable or un-reloadable is skipped (logged), never fatal.
@@ -36,7 +38,7 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::Config;
-use crate::daemon::spawn::build_agent;
+use crate::daemon::spawn::build_agent_for_reload;
 use crate::daemon::tool_service::CliToolService;
 
 /// Reload every non-terminal persisted run under `runs_dir`, returning the
@@ -256,6 +258,10 @@ fn reload_one(
         run_id: meta.run_id.clone(),
         blueprint_path: meta.agent_path.clone(),
         task: meta.task.clone(),
+        // Region seed content isn't replayed on reload: the window is restored
+        // from the persisted context snapshot after build_agent, so re-seeding
+        // would be redundant (and could double up content).
+        regions: Default::default(),
         model: meta.model.clone(),
         workdir: meta.workdir.clone(),
         metadata: meta.metadata.clone(),
@@ -267,7 +273,7 @@ fn reload_one(
         max_depth: None,
         parent_run_id: meta.parent_run_id.clone(),
     };
-    let entity = build_agent(
+    let entity = build_agent_for_reload(
         world.world_mut(),
         tool_service,
         config,

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -296,10 +296,11 @@ mod tests {
         .unwrap();
         let (reply, rx) = oneshot::channel();
         host.handle(ControlOp::Spawn {
-            args: SpawnArgs {
+            args: Box::new(SpawnArgs {
                 run_id: "run-s".to_string(),
                 blueprint_path: manifest.to_string_lossy().to_string(),
                 task: "t".to_string(),
+                regions: Default::default(),
                 model: None,
                 workdir: std::env::temp_dir().to_string_lossy().to_string(),
                 metadata: Default::default(),
@@ -308,7 +309,7 @@ mod tests {
                 allow: Vec::new(),
                 max_depth: None,
                 parent_run_id: None,
-            },
+            }),
             reply,
         });
         assert_eq!(rx.await.unwrap(), Ok("run-s".to_string()));
@@ -369,10 +370,11 @@ mod tests {
         // Drive a Spawn control op through the host.
         let (reply, rx) = oneshot::channel();
         host.handle(ControlOp::Spawn {
-            args: SpawnArgs {
+            args: Box::new(SpawnArgs {
                 run_id: "run-1".to_string(),
                 blueprint_path: manifest.to_string_lossy().to_string(),
                 task: "do it".to_string(),
+                regions: Default::default(),
                 model: None,
                 workdir: std::env::temp_dir().to_string_lossy().to_string(),
                 metadata: Default::default(),
@@ -381,7 +383,7 @@ mod tests {
                 allow: Vec::new(),
                 max_depth: None,
                 parent_run_id: None,
-            },
+            }),
             reply,
         });
         assert_eq!(rx.await.unwrap(), Ok("run-1".to_string()));

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -22,7 +22,7 @@ use leviath_runtime::host::{SpawnArgs, SubAgentOp};
 use leviath_runtime::interaction_hub::InteractionHub;
 use leviath_runtime::persistence::{RunMetadata, TokenTotals};
 use leviath_runtime::pipeline::{
-    CompactionSettings, PersistWatermark, Providers, ResolvedStage, spawn_agent,
+    CompactionSettings, PersistWatermark, Providers, ResolvedStage, spawn_agent_seeded,
 };
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::UnboundedSender;
@@ -186,10 +186,158 @@ fn build_tool_state(
     })
 }
 
+/// Resolve every region's initial content from its blueprint-declared
+/// [`RegionSeed`] plus the caller-provided values on `args`, into a
+/// name→content map ready for [`spawn_agent_seeded`].
+///
+/// The caller map is `{ "task": args.task } ∪ args.regions` (a `regions["task"]`
+/// wins). Then:
+/// - `CallerInput { name }` pulls from the caller map; if the region is
+///   `required` and the value is missing/blank this returns `Err` — the
+///   required-at-spawn gate, before any inference.
+/// - `Files` / `Glob` read workdir files; `Literal` is verbatim; `Rhai` runs a
+///   workdir script whose `String` return seeds the region.
+/// - Any caller key (other than `task`) that isn't a declared `CallerInput`
+///   region is rejected (typo protection, mirrors the CLI-side check).
+fn resolve_seeds(
+    blueprint: &Blueprint,
+    args: &SpawnArgs,
+    workdir: &str,
+) -> Result<HashMap<String, String>, String> {
+    use leviath_core::layout::RegionSeed;
+
+    // The effective caller-supplied values: task text plus any named regions.
+    let mut caller: HashMap<String, String> = HashMap::new();
+    caller.insert("task".to_string(), args.task.clone());
+    for (k, v) in &args.regions {
+        caller.insert(k.clone(), v.clone());
+    }
+
+    // Unknown caller keys are tolerated here (silently unused): the CLI already
+    // rejects typos client-side in `resolve_spawn_args`, and an ACP host sending
+    // a stray `---region:...---` marker shouldn't fail the whole turn over it.
+
+    let base = std::path::Path::new(workdir);
+    let mut seeds: HashMap<String, String> = HashMap::new();
+
+    for region in &blueprint.context_layout.regions {
+        let Some(seed) = &region.seed else { continue };
+        match seed {
+            RegionSeed::CallerInput { name } => {
+                let value = caller.get(name).map(|s| s.as_str()).unwrap_or("");
+                if value.trim().is_empty() {
+                    if region.required {
+                        return Err(region.required_message.clone().unwrap_or_else(|| {
+                            format!(
+                                "required region '{}' was not provided; supply it via \
+                                 --{name} <text|@file> (CLI), a ---region:{name}--- block \
+                                 (ACP), or the API `regions` field",
+                                region.name
+                            )
+                        }));
+                    }
+                    // Optional and unprovided — leave the region empty.
+                    continue;
+                }
+                seeds.insert(region.name.clone(), value.to_string());
+            }
+            RegionSeed::Literal { text } => {
+                seeds.insert(region.name.clone(), text.clone());
+            }
+            RegionSeed::Files { paths } => {
+                let content = read_and_concat(
+                    &region.name,
+                    paths.iter().map(|p| base.join(p)),
+                    region.required,
+                )?;
+                if let Some(content) = content {
+                    seeds.insert(region.name.clone(), content);
+                }
+            }
+            RegionSeed::Glob { pattern } => {
+                let full = base.join(pattern);
+                let full = full.to_string_lossy();
+                let matches = glob::glob(&full)
+                    .map_err(|e| format!("region '{}': bad glob '{pattern}': {e}", region.name))?;
+                let paths: Vec<std::path::PathBuf> = matches.filter_map(|m| m.ok()).collect();
+                let content = read_and_concat(&region.name, paths.into_iter(), region.required)?;
+                match content {
+                    Some(content) => {
+                        seeds.insert(region.name.clone(), content);
+                    }
+                    None if region.required => {
+                        return Err(format!(
+                            "required region '{}': glob '{pattern}' matched no files",
+                            region.name
+                        ));
+                    }
+                    None => {}
+                }
+            }
+            RegionSeed::Rhai { script } => {
+                let path = base.join(script);
+                let src = std::fs::read_to_string(&path).map_err(|e| {
+                    format!(
+                        "region '{}': read rhai seed '{}': {e}",
+                        region.name,
+                        path.display()
+                    )
+                })?;
+                let mut input = rhai::Map::new();
+                input.insert("task".into(), rhai::Dynamic::from(args.task.clone()));
+                input.insert("workdir".into(), rhai::Dynamic::from(workdir.to_string()));
+                let out = leviath_scripting::ScriptEngine::new()
+                    .transform(&src, input)
+                    .map_err(|e| format!("region '{}': rhai seed failed: {e}", region.name))?;
+                if !out.trim().is_empty() {
+                    seeds.insert(region.name.clone(), out);
+                } else if region.required {
+                    return Err(format!(
+                        "required region '{}': rhai seed '{script}' returned empty",
+                        region.name
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(seeds)
+}
+
+/// Read each file and concatenate with `--- <path> ---` headers. Returns
+/// `Ok(None)` when the list is empty; a missing/unreadable file is an error only
+/// when `required`, else it is skipped.
+fn read_and_concat(
+    region: &str,
+    paths: impl Iterator<Item = std::path::PathBuf>,
+    required: bool,
+) -> Result<Option<String>, String> {
+    let mut parts: Vec<String> = Vec::new();
+    for path in paths {
+        match std::fs::read_to_string(&path) {
+            Ok(text) => parts.push(format!("--- {} ---\n{}", path.display(), text)),
+            Err(e) => {
+                if required {
+                    return Err(format!(
+                        "region '{region}': read seed file '{}': {e}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+    Ok((!parts.is_empty()).then(|| parts.join("\n\n")))
+}
+
 /// Load the blueprint at `args.blueprint_path`, spawn the agent into `world`,
 /// register its tool state, and return the new entity. Operates on the raw ECS
 /// [`World`] so it is callable both from the host's spawner (via
 /// `PipelineWorld::world_mut`) and from a fan-out world-system.
+///
+/// Enforces the required-at-spawn region gate — a fresh spawn whose required
+/// caller-input regions weren't provided fails here. Use
+/// [`build_agent_for_reload`] on the recovery path, where the window is restored
+/// from a snapshot afterward and the gate must not re-fire.
 #[allow(clippy::too_many_arguments)]
 pub fn build_agent(
     world: &mut World,
@@ -201,6 +349,62 @@ pub fn build_agent(
     args: &SpawnArgs,
     now_secs: i64,
     subagent_tx: UnboundedSender<SubAgentOp>,
+) -> Result<Entity, String> {
+    build_agent_inner(
+        world,
+        tool_service,
+        config,
+        shared_mcp,
+        mcp_tool_defs,
+        hub,
+        args,
+        now_secs,
+        subagent_tx,
+        true,
+    )
+}
+
+/// Like [`build_agent`], but skips the required-at-spawn region gate — used by
+/// restart recovery, which reloads a run that already passed the gate when first
+/// spawned and whose context window is restored from a snapshot after this call.
+#[allow(clippy::too_many_arguments)]
+pub fn build_agent_for_reload(
+    world: &mut World,
+    tool_service: &CliToolService,
+    config: &Config,
+    shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
+    mcp_tool_defs: &[Tool],
+    hub: &InteractionHub,
+    args: &SpawnArgs,
+    now_secs: i64,
+    subagent_tx: UnboundedSender<SubAgentOp>,
+) -> Result<Entity, String> {
+    build_agent_inner(
+        world,
+        tool_service,
+        config,
+        shared_mcp,
+        mcp_tool_defs,
+        hub,
+        args,
+        now_secs,
+        subagent_tx,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_agent_inner(
+    world: &mut World,
+    tool_service: &CliToolService,
+    config: &Config,
+    shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
+    mcp_tool_defs: &[Tool],
+    hub: &InteractionHub,
+    args: &SpawnArgs,
+    now_secs: i64,
+    subagent_tx: UnboundedSender<SubAgentOp>,
+    enforce_seeds: bool,
 ) -> Result<Entity, String> {
     // 1. Load the blueprint (the client resolves the manifest path).
     let content = std::fs::read_to_string(&args.blueprint_path)
@@ -305,17 +509,28 @@ pub fn build_agent(
         .first()
         .map(|s| format!("{}/{}", s.provider_name, s.model));
 
-    // 5. Spawn the agent.
-    let entity = spawn_agent(
+    // 5. Resolve region seeds (caller input + blueprint-declared sources) into
+    // concrete content. On a fresh spawn (`enforce_seeds`), required caller-input
+    // regions that weren't provided fail here — before any inference, so no
+    // tokens are spent. On reload the window is restored from a snapshot after
+    // this, so seeding is skipped entirely.
+    let seeds = if enforce_seeds {
+        resolve_seeds(&blueprint, args, &args.workdir)?
+    } else {
+        HashMap::new()
+    };
+
+    // 6. Spawn the agent.
+    let entity = spawn_agent_seeded(
         world,
         args.run_id.clone(),
         blueprint,
-        &args.task,
+        &seeds,
         stages,
         config.batch_tool_hint,
     )?;
 
-    // 6. Attach run metadata / token totals / persistence watermark (+ optional
+    // 7. Attach run metadata / token totals / persistence watermark (+ optional
     // compaction settings).
     let metadata = RunMetadata {
         run_id: args.run_id.clone(),
@@ -366,7 +581,7 @@ pub fn build_agent(
         });
     }
 
-    // 7. Register the per-agent tool state.
+    // 8. Register the per-agent tool state.
     // Launch overrides: `--yolo` allows every tool (`*` wildcard); `--allow X`
     // allows tool `X` outright.
     let mut launch_overrides: HashMap<String, crate::config::ToolPolicy> = HashMap::new();
@@ -600,6 +815,7 @@ mod tests {
             run_id: "run-x".to_string(),
             blueprint_path: path.to_string(),
             task: "do the thing".to_string(),
+            regions: HashMap::new(),
             model: None,
             workdir: std::env::temp_dir().to_string_lossy().to_string(),
             metadata: HashMap::new(),
@@ -666,6 +882,40 @@ mod tests {
                 .get::<leviath_runtime::components::GateAutoApprove>(entity)
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn build_agent_errors_when_required_caller_region_missing() {
+        // A required caller-input region that the request doesn't provide makes
+        // build_agent fail (via resolve_seeds) before spawning — no inference.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"needs\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [context.regions]\n\
+             spec = { kind = \"pinned\", max_tokens = 2000, seed = \"input\", required = true }\n\
+             conversation = { kind = \"sliding_window\", max_items = 20, max_tokens = 10000 }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        // spawn_args() provides only the task, not the required `spec` region.
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .unwrap_err();
+        assert!(err.contains("spec"), "got: {err}");
     }
 
     #[tokio::test]
@@ -1240,5 +1490,254 @@ system_prompt = "be brief"
         )
         .unwrap_err();
         assert!(err.contains("parse manifest"));
+    }
+
+    // ─── resolve_seeds ────────────────────────────────────────────────────────
+
+    fn bp(regions_toml: &str) -> Blueprint {
+        let toml = format!(
+            r#"
+[agent]
+name = "seedy"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+{regions_toml}
+conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
+"#
+        );
+        leviath_core::manifest::parse_manifest(&toml).unwrap()
+    }
+
+    fn args_with(task: &str, regions: HashMap<String, String>, workdir: &str) -> SpawnArgs {
+        SpawnArgs {
+            run_id: "r".to_string(),
+            blueprint_path: "/bp".to_string(),
+            task: task.to_string(),
+            regions,
+            model: None,
+            workdir: workdir.to_string(),
+            metadata: HashMap::new(),
+            callback_url: None,
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            parent_run_id: None,
+        }
+    }
+
+    #[test]
+    fn resolve_seeds_fills_task_and_caller_input() {
+        let bp = bp(
+            r#"task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }
+criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }"#,
+        );
+        let args = args_with(
+            "build it",
+            HashMap::from([("criteria".to_string(), "be safe".to_string())]),
+            "/tmp",
+        );
+        let seeds = resolve_seeds(&bp, &args, "/tmp").unwrap();
+        assert_eq!(seeds.get("task").map(String::as_str), Some("build it"));
+        assert_eq!(seeds.get("criteria").map(String::as_str), Some("be safe"));
+    }
+
+    #[test]
+    fn resolve_seeds_required_caller_input_missing_is_error() {
+        let bp =
+            bp(r#"spec = { kind = "pinned", max_tokens = 2000, seed = "input", required = true }"#);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let err = resolve_seeds(&bp, &args, "/tmp").unwrap_err();
+        assert!(err.contains("spec"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_seeds_optional_caller_input_missing_is_omitted() {
+        let bp = bp(r#"notes = { kind = "pinned", max_tokens = 2000, seed = "input" }"#);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seeds = resolve_seeds(&bp, &args, "/tmp").unwrap();
+        assert!(!seeds.contains_key("notes"));
+    }
+
+    #[test]
+    fn resolve_seeds_literal_and_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "alpha").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "beta").unwrap();
+        let bp = bp(
+            r#"lit = { kind = "pinned", max_tokens = 500, seed = { literal = "hello" } }
+docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"] } }"#,
+        );
+        let args = args_with("t", HashMap::new(), &dir.path().to_string_lossy());
+        let seeds = resolve_seeds(&bp, &args, &dir.path().to_string_lossy()).unwrap();
+        assert_eq!(seeds.get("lit").map(String::as_str), Some("hello"));
+        let docs = seeds.get("docs").unwrap();
+        assert!(docs.contains("alpha") && docs.contains("beta"));
+    }
+
+    #[test]
+    fn resolve_seeds_glob_concatenates_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("specs")).unwrap();
+        std::fs::write(dir.path().join("specs/one.md"), "spec one").unwrap();
+        std::fs::write(dir.path().join("specs/two.md"), "spec two").unwrap();
+        let bp =
+            bp(r#"specs = { kind = "pinned", max_tokens = 4000, seed = { glob = "specs/*.md" } }"#);
+        let wd = dir.path().to_string_lossy().to_string();
+        let args = args_with("t", HashMap::new(), &wd);
+        let seeds = resolve_seeds(&bp, &args, &wd).unwrap();
+        let specs = seeds.get("specs").unwrap();
+        assert!(specs.contains("spec one") && specs.contains("spec two"));
+    }
+
+    #[test]
+    fn resolve_seeds_rhai_runs_script() {
+        let dir = tempfile::tempdir().unwrap();
+        // A script that returns the task text uppercased-ish via concatenation.
+        std::fs::write(
+            dir.path().join("init.rhai"),
+            r#""seeded: " + input["task"]"#,
+        )
+        .unwrap();
+        let bp = bp(
+            r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "init.rhai" } }"#,
+        );
+        let wd = dir.path().to_string_lossy().to_string();
+        let args = args_with("hello", HashMap::new(), &wd);
+        let seeds = resolve_seeds(&bp, &args, &wd).unwrap();
+        assert_eq!(
+            seeds.get("scripted").map(String::as_str),
+            Some("seeded: hello")
+        );
+    }
+
+    #[test]
+    fn resolve_seeds_files_required_missing_errors_optional_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        // Required + a missing file → error.
+        let req = bp(
+            r#"docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["missing.txt"] }, required = true }"#,
+        );
+        let args = args_with("t", HashMap::new(), &wd);
+        let err = resolve_seeds(&req, &args, &wd).unwrap_err();
+        assert!(err.contains("missing.txt"), "got: {err}");
+        // Optional + a missing file → the region is simply omitted.
+        let opt = bp(
+            r#"docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["missing.txt"] } }"#,
+        );
+        let seeds = resolve_seeds(&opt, &args, &wd).unwrap();
+        assert!(!seeds.contains_key("docs"));
+    }
+
+    #[test]
+    fn resolve_seeds_glob_no_match_required_errors_optional_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let args = args_with("t", HashMap::new(), &wd);
+        // Required glob with no matches → error.
+        let req = bp(
+            r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "none/*.md" }, required = true }"#,
+        );
+        let err = resolve_seeds(&req, &args, &wd).unwrap_err();
+        assert!(err.contains("matched no files"), "got: {err}");
+        // Optional glob with no matches → region omitted.
+        let opt =
+            bp(r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "none/*.md" } }"#);
+        let seeds = resolve_seeds(&opt, &args, &wd).unwrap();
+        assert!(!seeds.contains_key("specs"));
+    }
+
+    #[test]
+    fn resolve_seeds_bad_glob_pattern_errors() {
+        // An unclosed `[` is an invalid glob pattern → `glob::glob` returns Err.
+        let dir = tempfile::tempdir().unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let bp = bp(r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "[" } }"#);
+        let args = args_with("t", HashMap::new(), &wd);
+        let err = resolve_seeds(&bp, &args, &wd).unwrap_err();
+        assert!(err.contains("bad glob"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_seeds_rhai_script_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // A script that calls an undefined function → runtime error.
+        std::fs::write(dir.path().join("boom.rhai"), "undefined_func()").unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let bp = bp(
+            r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "boom.rhai" } }"#,
+        );
+        let args = args_with("t", HashMap::new(), &wd);
+        let err = resolve_seeds(&bp, &args, &wd).unwrap_err();
+        assert!(err.contains("rhai seed failed"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_seeds_glob_matching_directory_required_errors() {
+        // A required glob that matches a directory entry → reading it as a file
+        // fails, so read_and_concat returns Err and resolve_seeds propagates it.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let bp = bp(
+            r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "sub*" }, required = true }"#,
+        );
+        let args = args_with("t", HashMap::new(), &wd);
+        let err = resolve_seeds(&bp, &args, &wd).unwrap_err();
+        assert!(err.contains("read seed file"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_seeds_rhai_read_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let bp = bp(
+            r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "nope.rhai" } }"#,
+        );
+        let args = args_with("t", HashMap::new(), &wd);
+        let err = resolve_seeds(&bp, &args, &wd).unwrap_err();
+        assert!(err.contains("read rhai seed"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_seeds_rhai_empty_required_errors_optional_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        // A script returning an empty string.
+        std::fs::write(dir.path().join("empty.rhai"), r#""""#).unwrap();
+        let wd = dir.path().to_string_lossy().to_string();
+        let args = args_with("t", HashMap::new(), &wd);
+        let req = bp(
+            r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "empty.rhai" }, required = true }"#,
+        );
+        let err = resolve_seeds(&req, &args, &wd).unwrap_err();
+        assert!(err.contains("returned empty"), "got: {err}");
+        // Optional + empty → region omitted (no error).
+        let opt = bp(
+            r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "empty.rhai" } }"#,
+        );
+        let seeds = resolve_seeds(&opt, &args, &wd).unwrap();
+        assert!(!seeds.contains_key("scripted"));
+    }
+
+    #[test]
+    fn resolve_seeds_tolerates_unknown_caller_region() {
+        // Unknown caller keys are silently unused (CLI validates client-side;
+        // ACP stray markers must not fail the spawn).
+        let bp = bp(r#"task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }"#);
+        let args = args_with(
+            "t",
+            HashMap::from([("ghost".to_string(), "x".to_string())]),
+            "/tmp",
+        );
+        let seeds = resolve_seeds(&bp, &args, "/tmp").unwrap();
+        assert_eq!(seeds.get("task").map(String::as_str), Some("t"));
+        assert!(!seeds.contains_key("ghost"));
     }
 }

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -89,6 +89,8 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
         false,
         Vec::new(),
         child_max_depth,
+        // Sub-agents receive their whole task via `full_task`; no region flags.
+        std::collections::HashMap::new(),
     ) {
         Ok(a) => a,
         Err(e) => return format!("[error] cannot spawn '{blueprint}': {e}"),

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -127,6 +127,18 @@ pub trait RiskyExecutors {
     async fn mcp(&self, args: commands::mcp::McpArgs) -> anyhow::Result<()>;
 }
 
+/// Inject argv-prescanned dynamic `--<region>` seed flags into a parsed
+/// `run` command. A no-op for every other subcommand. Kept here (a tested lib
+/// seam) so the bin entrypoint's post-parse wiring stays branch-free.
+pub fn apply_region_flags(
+    command: &mut Commands,
+    regions: std::collections::HashMap<String, String>,
+) {
+    if let Commands::Run(args) = command {
+        args.regions = regions;
+    }
+}
+
 /// Route a parsed subcommand to its executor. Safe commands are called
 /// directly (and are exercised through `dispatch()` by the tests below); the
 /// I/O-risky ones go through `ex` (see [`RiskyExecutors`]).
@@ -209,6 +221,24 @@ mod tests {
             name: "unused".to_string(),
             template: "software-engineer".to_string(),
         }
+    }
+
+    // ─── apply_region_flags ──────────────────────────────────────────────────
+
+    #[test]
+    fn apply_region_flags_populates_run_and_noops_other_commands() {
+        let mut run = Commands::Run(commands::run::RunArgs::default());
+        let flags = std::collections::HashMap::from([("criteria".to_string(), "safe".to_string())]);
+        apply_region_flags(&mut run, flags);
+        assert!(
+            matches!(&run, Commands::Run(a) if a.regions.get("criteria").map(String::as_str) == Some("safe")),
+            "region flag was injected into the Run args"
+        );
+        // A non-run command hits the no-op branch: it must not panic (and there
+        // is nothing to inject). Asserting the variant here would leave an
+        // always-false `matches!` arm uncovered, so the call itself is the check.
+        let mut other = Commands::Ps(commands::ps::PsArgs::default());
+        apply_region_flags(&mut other, std::collections::HashMap::new());
     }
 
     // ─── Risky variants: routed through the injected executor ────────────────

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -21,7 +21,7 @@ use tracing::info;
 
 use leviath_cli::commands;
 use leviath_cli::commands::dashboard::{CrosstermEventSource, DashboardArgs, TerminalSetup};
-use leviath_cli::dispatch::{Commands, RiskyExecutors, dispatch};
+use leviath_cli::dispatch::{Commands, RiskyExecutors, apply_region_flags, dispatch};
 
 /// Leviath CLI - Agent framework with structured context windows
 #[derive(Parser)]
@@ -39,7 +39,13 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    // Pre-scan argv for dynamic `--<region>` seed flags on `run` (region names
+    // are blueprint-defined, so clap can't declare them), then parse the rest
+    // and fold the extracted flags back in (both steps are tested lib seams).
+    let (argv, region_flags) =
+        commands::run::extract_region_flags(std::env::args().collect::<Vec<_>>());
+    let mut cli = Cli::parse_from(argv);
+    apply_region_flags(&mut cli.command, region_flags);
 
     // Initialize tracing. Logs go to stderr, never stdout: `lev agent-client`
     // uses stdout as its JSON-RPC protocol channel, and a stray log line there
@@ -176,6 +182,7 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
         args.yolo,
         args.allow,
         args.max_depth,
+        args.regions,
     )?;
     leviath_cli::daemon::client::send_spawn(&control_client()?, spawn_args).await
 }

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -162,6 +162,48 @@ impl ContextLayout {
     }
 }
 
+/// Where a region's initial content comes from at run start.
+///
+/// A region without a seed starts empty and is populated by the agent. A seeded
+/// region is filled before the first inference: `CallerInput` regions are filled
+/// by the run's caller (a CLI `--<name>` flag, an ACP `---region:<name>---`
+/// marker, or the API `regions` map); the remaining variants are resolved by the
+/// daemon from the run's workdir (which is why this type only *declares* the
+/// source — `leviath-core` stays filesystem-agnostic; resolution lives in the
+/// CLI daemon's spawner).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegionSeed {
+    /// Filled at run time by the caller, keyed by `name` (defaults to the
+    /// region's own name; the sentinel `task` maps to the `--task`/prompt text).
+    /// When the owning region is `required`, a missing value is a hard error
+    /// before any inference runs.
+    CallerInput {
+        /// The caller-input key this region is filled from.
+        name: String,
+    },
+    /// Concatenated contents of the workdir files matching a glob pattern.
+    Glob {
+        /// Glob pattern, resolved relative to the run's workdir.
+        pattern: String,
+    },
+    /// Concatenated contents of an explicit list of workdir-relative files.
+    Files {
+        /// File paths, resolved relative to the run's workdir.
+        paths: Vec<String>,
+    },
+    /// A static literal string baked into the blueprint.
+    Literal {
+        /// The verbatim seed text.
+        text: String,
+    },
+    /// The `String` returned by running a Rhai script from the workdir.
+    Rhai {
+        /// Script path, resolved relative to the run's workdir.
+        script: String,
+    },
+}
+
 /// Definition of a region in a layout.
 ///
 /// This is the blueprint for creating a Region instance. It specifies the
@@ -195,6 +237,12 @@ pub struct RegionDefinition {
     /// but empty. Falls back to a generated default when `None`.
     #[serde(default)]
     pub required_message: Option<String>,
+
+    /// Where this region's initial content comes from at run start. `None`
+    /// means the region starts empty (the agent populates it). See
+    /// [`RegionSeed`].
+    #[serde(default)]
+    pub seed: Option<RegionSeed>,
 }
 
 impl RegionDefinition {
@@ -208,7 +256,14 @@ impl RegionDefinition {
             description: None,
             required: false,
             required_message: None,
+            seed: None,
         }
+    }
+
+    /// Set this region's seed source.
+    pub fn with_seed(mut self, seed: RegionSeed) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     /// Mark this region as required, with an optional custom nudge message.

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -9,7 +9,7 @@ use crate::blueprint::{
     StageMode, TransitionCondition, TransitionEdge,
 };
 use crate::error::{Error, Result};
-use crate::layout::RegionDefinition;
+use crate::layout::{RegionDefinition, RegionSeed};
 use crate::lifecycle::CompactionConfig;
 use crate::{Blueprint, ContextLayout, EvictionStrategy, RegionKind, Stage};
 
@@ -625,11 +625,15 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
+            let seed = parse_region_seed(region_name, region_value.get("seed"));
+
             total_tokens += max_tokens;
-            regions.push(
-                RegionDefinition::new(region_name.clone(), kind, max_tokens)
-                    .with_required(required, required_message),
-            );
+            let mut def = RegionDefinition::new(region_name.clone(), kind, max_tokens)
+                .with_required(required, required_message);
+            if let Some(seed) = seed {
+                def = def.with_seed(seed);
+            }
+            regions.push(def);
         }
     }
 
@@ -818,6 +822,67 @@ fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
         from_region: str_field(v, "from_region"),
         to_region: str_field(v, "to_region"),
         transform,
+    }
+}
+
+/// Parse a region's `seed` value from `[context.regions.<name>]`.
+///
+/// String forms: `"task_input"` → caller input keyed `task` (the `--task`/prompt
+/// text); any other string → caller input keyed by that string, with the
+/// convenience alias `"input"` meaning "keyed by this region's own name".
+/// Table forms: `{ glob = "…" }`, `{ files = [...] }`, `{ literal = "…" }`,
+/// `{ rhai = "…" }`, or `{ caller = "…" }`.
+///
+/// Back-compat: a region literally named `task` with no `seed` gets an implicit
+/// `CallerInput { name: "task" }`, so unmodified blueprints seed the task text
+/// exactly as before.
+fn parse_region_seed(region_name: &str, value: Option<&toml::Value>) -> Option<RegionSeed> {
+    let Some(value) = value else {
+        return (region_name == "task").then(|| RegionSeed::CallerInput {
+            name: "task".to_string(),
+        });
+    };
+    match value {
+        toml::Value::String(s) => Some(match s.as_str() {
+            "task_input" => RegionSeed::CallerInput {
+                name: "task".to_string(),
+            },
+            "input" => RegionSeed::CallerInput {
+                name: region_name.to_string(),
+            },
+            other => RegionSeed::CallerInput {
+                name: other.to_string(),
+            },
+        }),
+        toml::Value::Table(t) => {
+            if let Some(pattern) = t.get("glob").and_then(|v| v.as_str()) {
+                Some(RegionSeed::Glob {
+                    pattern: pattern.to_string(),
+                })
+            } else if let Some(files) = t.get("files").and_then(|v| v.as_array()) {
+                Some(RegionSeed::Files {
+                    paths: files
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                })
+            } else if let Some(text) = t.get("literal").and_then(|v| v.as_str()) {
+                Some(RegionSeed::Literal {
+                    text: text.to_string(),
+                })
+            } else if let Some(script) = t.get("rhai").and_then(|v| v.as_str()) {
+                Some(RegionSeed::Rhai {
+                    script: script.to_string(),
+                })
+            } else {
+                t.get("caller")
+                    .and_then(|v| v.as_str())
+                    .map(|name| RegionSeed::CallerInput {
+                        name: name.to_string(),
+                    })
+            }
+        }
+        _ => None,
     }
 }
 
@@ -1190,6 +1255,143 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         let conv = bp.context_layout.get_region("conversation").unwrap();
         assert!(!conv.required, "unmarked region defaults to not required");
         assert!(conv.required_message.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_reads_region_seed_shapes() {
+        let toml = r#"
+[agent]
+name = "seed-test"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }
+criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }
+alias = { kind = "pinned", max_tokens = 2000, seed = "files_arg" }
+specs = { kind = "pinned", max_tokens = 8000, seed = { glob = "specs/*.md" } }
+config = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.yaml", "b.yaml"] } }
+lit = { kind = "pinned", max_tokens = 500, seed = { literal = "hello" } }
+scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "init.rhai" } }
+plain = { kind = "pinned", max_tokens = 500 }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let region = |n: &str| bp.context_layout.get_region(n).unwrap().seed.clone();
+        assert_eq!(
+            region("task"),
+            Some(RegionSeed::CallerInput {
+                name: "task".to_string()
+            })
+        );
+        assert_eq!(
+            region("criteria"),
+            Some(RegionSeed::CallerInput {
+                name: "criteria".to_string()
+            }),
+            "\"input\" is keyed by the region's own name"
+        );
+        assert_eq!(
+            region("alias"),
+            Some(RegionSeed::CallerInput {
+                name: "files_arg".to_string()
+            }),
+            "a bare string is a caller-input key"
+        );
+        assert_eq!(
+            region("specs"),
+            Some(RegionSeed::Glob {
+                pattern: "specs/*.md".to_string()
+            })
+        );
+        assert_eq!(
+            region("config"),
+            Some(RegionSeed::Files {
+                paths: vec!["a.yaml".to_string(), "b.yaml".to_string()]
+            })
+        );
+        assert_eq!(
+            region("lit"),
+            Some(RegionSeed::Literal {
+                text: "hello".to_string()
+            })
+        );
+        assert_eq!(
+            region("scripted"),
+            Some(RegionSeed::Rhai {
+                script: "init.rhai".to_string()
+            })
+        );
+        assert!(
+            region("plain").is_none(),
+            "a non-task region with no seed stays None"
+        );
+    }
+
+    #[test]
+    fn parse_manifest_region_seed_caller_table_and_non_seed_shapes() {
+        let toml = r#"
+[agent]
+name = "seed-edges"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+via_caller = { kind = "pinned", max_tokens = 500, seed = { caller = "extra" } }
+unknown_tbl = { kind = "pinned", max_tokens = 500, seed = { nope = "x" } }
+weird_type = { kind = "pinned", max_tokens = 500, seed = 42 }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let region = |n: &str| bp.context_layout.get_region(n).unwrap().seed.clone();
+        assert_eq!(
+            region("via_caller"),
+            Some(RegionSeed::CallerInput {
+                name: "extra".to_string()
+            })
+        );
+        // A table with none of the recognized keys → no seed.
+        assert!(region("unknown_tbl").is_none());
+        // A non-string, non-table seed value → no seed.
+        assert!(region("weird_type").is_none());
+    }
+
+    #[test]
+    fn parse_manifest_seeds_unnamed_task_region_by_default() {
+        // A region literally named `task` with no explicit `seed` still gets an
+        // implicit CallerInput seed, preserving pre-feature task seeding.
+        let toml = r#"
+[agent]
+name = "implicit-task"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000 }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert_eq!(
+            bp.context_layout.get_region("task").unwrap().seed,
+            Some(RegionSeed::CallerInput {
+                name: "task".to_string()
+            })
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -4,15 +4,24 @@
 //! These are pure operations over a [`ContextWindow`] driven by a
 //! blueprint/layout.
 
+use std::collections::HashMap;
+
 use leviath_core::{Blueprint, ContextLayout, EvictionStrategy, Region, RegionKind};
 
 use crate::ContextWindow;
 
-/// Initialize a [`ContextWindow`] in place from a blueprint: add each layout
-/// region plus the infra `tool_results`/`conversation` regions, and seed the
-/// task text into a pinned region. Pure over the window (no engine/entity), so
-/// both the imperative engine and the ECS pipeline's spawner can share it.
-pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str) {
+/// Initialize a [`ContextWindow`] from a blueprint and seed its regions from a
+/// name→content map. Adds each layout region plus the infra
+/// `tool_results`/`conversation` regions, then fills each seed whose key matches
+/// a declared region. The `task` key gets the legacy fallback: if there is no
+/// region literally named `task`, it seeds the first pinned region instead.
+/// Pure over the window (no engine/entity), so both the imperative engine and
+/// the ECS pipeline's spawner can share it.
+pub fn init_window_seeded(
+    window: &mut ContextWindow,
+    blueprint: &Blueprint,
+    seeds: &HashMap<String, String>,
+) {
     for region_def in &blueprint.context_layout.regions {
         let region = Region::new(
             region_def.name.clone(),
@@ -39,9 +48,32 @@ pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str
         window.add_region(conv_region);
     }
 
-    // Seed the task text into a pinned region.
-    // Prefer a region explicitly named "task"; fall back to the first pinned region.
-    let task_region_name = blueprint
+    for (name, content) in seeds {
+        // The task key keeps its legacy fallback: prefer a region named "task",
+        // else the first pinned region. Every other key targets its region by
+        // exact name (unknown names are already rejected upstream, so ignore
+        // them here to keep this pure/infallible).
+        let target = if name == "task" {
+            task_region_name(blueprint)
+        } else {
+            blueprint
+                .context_layout
+                .regions
+                .iter()
+                .find(|r| &r.name == name)
+                .map(|r| r.name.clone())
+        };
+        if let Some(region_name) = target {
+            let tokens = content.len() / 4 + 1;
+            let _ = window.add_to_region(&region_name, content.clone(), tokens);
+        }
+    }
+}
+
+/// Resolve which region the `task` text seeds into: prefer a pinned region named
+/// `task`, else the first pinned region.
+fn task_region_name(blueprint: &Blueprint) -> Option<String> {
+    blueprint
         .context_layout
         .regions
         .iter()
@@ -53,12 +85,15 @@ pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str
                 .iter()
                 .find(|r| matches!(r.kind, RegionKind::Pinned))
         })
-        .map(|r| r.name.clone());
+        .map(|r| r.name.clone())
+}
 
-    if let Some(region_name) = task_region_name {
-        let task_tokens = task.len() / 4 + 1;
-        let _ = window.add_to_region(&region_name, task.to_string(), task_tokens);
-    }
+/// Initialize a [`ContextWindow`] seeding only the task text — the thin
+/// back-compat wrapper over [`init_window_seeded`] used by callers that carry a
+/// single task string (the imperative engine and existing tests).
+pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str) {
+    let seeds = HashMap::from([("task".to_string(), task.to_string())]);
+    init_window_seeded(window, blueprint, &seeds);
 }
 
 /// Swap a [`ContextWindow`] to a stage-specific layout in place, preserving each
@@ -89,12 +124,13 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_layout, init_window};
+    use super::{apply_layout, init_window, init_window_seeded};
     use crate::ContextWindow;
     use leviath_core::{
         Blueprint, ContextLayout, EvictionStrategy, RegionKind, Stage, blueprint::ModelConfig,
         layout::RegionDefinition,
     };
+    use std::collections::HashMap;
 
     fn blueprint_with(regions: Vec<RegionDefinition>) -> Blueprint {
         let layout = ContextLayout::new(regions, 100_000);
@@ -109,6 +145,62 @@ mod tests {
         let mut window = ContextWindow::new(100_000);
         init_window(&mut window, bp, task);
         window
+    }
+
+    #[test]
+    fn init_window_seeded_fills_multiple_named_regions_and_ignores_unknown() {
+        let bp = blueprint_with(vec![
+            RegionDefinition::new("task".to_string(), RegionKind::Pinned, 5000),
+            RegionDefinition::new("criteria".to_string(), RegionKind::Pinned, 5000),
+        ]);
+        let seeds = HashMap::from([
+            ("task".to_string(), "build a parser".to_string()),
+            ("criteria".to_string(), "focus on safety".to_string()),
+            ("ghost".to_string(), "no such region".to_string()),
+        ]);
+        let mut window = ContextWindow::new(100_000);
+        init_window_seeded(&mut window, &bp, &seeds);
+
+        assert!(
+            window
+                .get_region("task")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("build a parser"))
+        );
+        assert!(
+            window
+                .get_region("criteria")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("focus on safety"))
+        );
+        // An unknown seed key targets no region and is silently dropped.
+        assert!(window.get_region("ghost").is_none());
+    }
+
+    #[test]
+    fn init_window_seeded_task_key_falls_back_to_first_pinned() {
+        // No region literally named "task": the "task" seed key still lands in
+        // the first pinned region (legacy fallback), while a named key does not.
+        let bp = blueprint_with(vec![RegionDefinition::new(
+            "system".to_string(),
+            RegionKind::Pinned,
+            5000,
+        )]);
+        let seeds = HashMap::from([("task".to_string(), "fallback text".to_string())]);
+        let mut window = ContextWindow::new(100_000);
+        init_window_seeded(&mut window, &bp, &seeds);
+        assert!(
+            window
+                .get_region("system")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("fallback text"))
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -49,8 +49,9 @@ pub use windows::{
 pub enum ControlRequest {
     /// Spawn a new agent.
     Spawn {
-        /// The spawn request.
-        args: SpawnArgs,
+        /// The spawn request. Boxed because it is much larger than the other
+        /// variants' payloads.
+        args: Box<SpawnArgs>,
     },
     /// Query a run's status.
     Status {
@@ -352,7 +353,10 @@ impl ControlClient {
 
     /// Spawn a new agent.
     pub async fn spawn(&self, args: SpawnArgs) -> std::io::Result<ControlResponse> {
-        self.request(&ControlRequest::Spawn { args }).await
+        self.request(&ControlRequest::Spawn {
+            args: Box::new(args),
+        })
+        .await
     }
 
     /// Query a run's status.
@@ -531,10 +535,11 @@ mod tests {
     #[tokio::test]
     async fn spawn_request_round_trips() {
         let resp = round_trip(&ControlRequest::Spawn {
-            args: SpawnArgs {
+            args: Box::new(SpawnArgs {
                 run_id: "run-9".to_string(),
                 blueprint_path: "/agents/x".to_string(),
                 task: "do it".to_string(),
+                regions: Default::default(),
                 model: None,
                 workdir: "/w".to_string(),
                 metadata: Default::default(),
@@ -543,7 +548,7 @@ mod tests {
                 allow: Vec::new(),
                 max_depth: None,
                 parent_run_id: None,
-            },
+            }),
         })
         .await;
         assert_eq!(
@@ -557,10 +562,10 @@ mod tests {
     #[tokio::test]
     async fn spawn_error_from_host_becomes_error_response() {
         let resp = round_trip(&ControlRequest::Spawn {
-            args: SpawnArgs {
+            args: Box::new(SpawnArgs {
                 run_id: "FAIL".to_string(),
                 ..Default::default()
-            },
+            }),
         })
         .await;
         assert_eq!(
@@ -928,7 +933,7 @@ mod tests {
             std::mem::discriminant(
                 &dispatch(
                     ControlRequest::Spawn {
-                        args: SpawnArgs::default()
+                        args: Box::new(SpawnArgs::default())
                     },
                     &op_tx
                 )

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -38,8 +38,15 @@ pub struct SpawnArgs {
     pub run_id: String,
     /// Path to the agent manifest directory or bundle.
     pub blueprint_path: String,
-    /// The task prompt.
+    /// The task prompt. Seeded into the region keyed `task` (see
+    /// [`crate::context_setup::init_window_seeded`]); a matching `regions`
+    /// entry, if present, overrides it.
     pub task: String,
+    /// Literal seed content for named caller-input regions, keyed by the
+    /// region's caller-input name. Merged over `task` at spawn. `#[serde(default)]`
+    /// keeps older requests (which never sent this) deserializing to an empty map.
+    #[serde(default)]
+    pub regions: HashMap<String, String>,
     /// Optional model override (`provider/model` or `model`).
     #[serde(default)]
     pub model: Option<String>,
@@ -132,8 +139,9 @@ pub enum SubAgentOp {
 pub enum ControlOp {
     /// Spawn a new agent. Reply is the run id on success, or an error message.
     Spawn {
-        /// The spawn request.
-        args: SpawnArgs,
+        /// The spawn request. Boxed because it is much larger than the other
+        /// variants' payloads.
+        args: Box<SpawnArgs>,
         /// Reply channel.
         reply: oneshot::Sender<Result<String, String>>,
     },
@@ -1150,10 +1158,10 @@ mod tests {
         }));
 
         let result = ask(&mut host, |reply| ControlOp::Spawn {
-            args: SpawnArgs {
+            args: Box::new(SpawnArgs {
                 run_id: "r1".to_string(),
                 ..Default::default()
-            },
+            }),
             reply,
         })
         .await;
@@ -1173,7 +1181,7 @@ mod tests {
         let mut host = host_with(vec![]);
         host.set_spawner(Box::new(|_world, _args| Err("bad blueprint".to_string())));
         let result = ask(&mut host, |reply| ControlOp::Spawn {
-            args: SpawnArgs::default(),
+            args: Box::new(SpawnArgs::default()),
             reply,
         })
         .await;
@@ -1184,7 +1192,7 @@ mod tests {
     async fn spawn_op_errors_without_a_spawner() {
         let mut host = host_with(vec![]);
         let result = ask(&mut host, |reply| ControlOp::Spawn {
-            args: SpawnArgs::default(),
+            args: Box::new(SpawnArgs::default()),
             reply,
         })
         .await;

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -2011,6 +2011,15 @@ fn unmet_required_regions(
         .regions
         .iter()
         .filter(|r| r.required)
+        // Caller-input regions are validated (and seeded) at spawn, not written
+        // by the agent — skip them here so this gate never nags the agent to
+        // populate a slot the caller owns.
+        .filter(|r| {
+            !matches!(
+                r.seed,
+                Some(leviath_core::layout::RegionSeed::CallerInput { .. })
+            )
+        })
         .filter(|r| {
             window
                 .get_region(&r.name)
@@ -2491,6 +2500,29 @@ pub fn spawn_agent(
     stages: Vec<ResolvedStage>,
     global_batch_tool_hint: bool,
 ) -> Result<Entity, String> {
+    let seeds = std::collections::HashMap::from([("task".to_string(), task.to_string())]);
+    spawn_agent_seeded(
+        world,
+        agent_id,
+        blueprint,
+        &seeds,
+        stages,
+        global_batch_tool_hint,
+    )
+}
+
+/// Like [`spawn_agent`], but seeds the context window from a name→content map
+/// (caller-input regions filled by the CLI/ACP/API, plus blueprint-resolved
+/// seeds) rather than a single task string. `spawn_agent` is the thin wrapper
+/// that seeds only the `task` key.
+pub fn spawn_agent_seeded(
+    world: &mut World,
+    agent_id: String,
+    blueprint: leviath_core::Blueprint,
+    seeds: &std::collections::HashMap<String, String>,
+    stages: Vec<ResolvedStage>,
+    global_batch_tool_hint: bool,
+) -> Result<Entity, String> {
     let stage_infs: Vec<StageInference> = stages
         .into_iter()
         .map(|rs| StageInference {
@@ -2511,7 +2543,7 @@ pub fn spawn_agent(
     // context setup (layout swap + system-prompt injection) just as entering any
     // later stage would.
     let mut window = ContextWindow::new(blueprint.context_layout.total_budget_tokens);
-    crate::context_setup::init_window(&mut window, &blueprint, task);
+    crate::context_setup::init_window_seeded(&mut window, &blueprint, seeds);
     apply_stage_context(&setups[0], &mut window)?;
 
     let stage0_name = blueprint.stages[0].name.clone();
@@ -6583,6 +6615,36 @@ mod tests {
         assert_eq!(
             unmet_required_regions(&bp.0, &bp.0.stages[0], &bare).len(),
             1
+        );
+    }
+
+    #[test]
+    fn unmet_required_regions_skips_caller_input_seeded_regions() {
+        // A required region whose content comes from the caller at spawn must NOT
+        // be flagged by the agent-facing gate, even when empty and the stage can
+        // write context — the caller owns it, not the agent.
+        let region = leviath_core::layout::RegionDefinition::new(
+            "plan".to_string(),
+            RegionKind::Pinned,
+            4000,
+        )
+        .with_required(true, None)
+        .with_seed(leviath_core::layout::RegionSeed::CallerInput {
+            name: "plan".to_string(),
+        });
+        let layout = leviath_core::layout::ContextLayout::new(vec![region], 10_000);
+        let mut stage = stage_named("a", None, false, None);
+        stage.available_tools = vec!["context_write".to_string()];
+        stage.context_layout = Some(layout.clone());
+        let bp = AgentBlueprint(leviath_core::Blueprint::new(
+            "t".to_string(),
+            "d".to_string(),
+            vec![stage],
+            layout,
+        ));
+        assert!(
+            unmet_required_regions(&bp.0, &bp.0.stages[0], &window_with_plan(false)).is_empty(),
+            "caller-input region is validated at spawn, not gated here"
         );
     }
 


### PR DESCRIPTION
## What

Adds **structured regions** for the context window, unifying issues **#84** (caller-input regions) and **#13** (configurable region seeding). Every region in `[context.regions]` may now declare a `seed`:

```toml
[context.regions]
task     = { kind = "pinned", seed = "task_input", required = true }   # the --task text
criteria = { kind = "pinned", seed = "input", required = true }        # a --criteria flag / ACP marker
specs    = { kind = "pinned", seed = { files = ["spec.md"] } }         # raw file(s), workdir-relative
docs     = { kind = "pinned", seed = { glob  = "specs/*.md" } }
notes    = { kind = "pinned", seed = { rhai  = "init.rhai" } }         # script return → region
```

### Caller-input regions (#84)
Callers fill named slots at run time, three ways:
- **CLI**: `lev run reviewer --task "…" --criteria @policy.md` — dynamic `--<region>` flags; `@path` reads a file.
- **ACP**: `---region:<name>---` markers in the `session/prompt` text (no markers → whole text is `task`, back-compat).
- **serve API**: a `regions` map on the spawn request.

Required caller-input regions that aren't provided **hard-error before any inference** (no tokens spent). Unknown region names error client-side on the CLI (typo protection) but are tolerated by the daemon so a stray ACP marker never fails a turn.

### Blueprint seed sources (#13)
`glob` / `files` / `literal` / `rhai` resolve from the run's workdir in the daemon spawner — so raw specs stay pinned alongside distilled analysis (the motivating benchmark gap where exact interface specs were lost analyze→implement).

## Design notes
- One `RegionSeed` enum on `RegionDefinition`. `seed = "task_input"` / `"input"` / bare-string → `CallerInput`. A region literally named `task` with no seed gets an **implicit** `CallerInput`, so existing blueprints are byte-for-byte unchanged.
- The two meanings of `required` are reconciled **by seed type, no new field**: on a caller-input region `required` = required-at-spawn; on any other region it keeps the existing runtime gate (`require_context_regions`, which now skips caller-input regions).
- Seeds resolve in `build_agent` (the one convergence point with both blueprint and workdir). Recovery uses a `build_agent_for_reload` variant that skips the gate, since the window is restored from a snapshot afterward.
- `SpawnArgs` gains a `regions` map (`#[serde(default)]`, wire-compatible); the `Spawn` control-op variants now box it to stay under clippy's `large_enum_variant`.

## Testing
- Unit tests per layer: seed parsing + serde, `init_window_seeded`, `resolve_seeds` (all five seed kinds incl. rhai + required-missing), `extract_region_flags`, `resolve_spawn_args` (unknown-name + `@path`), `parse_region_markers`.
- **Live end-to-end** via `lev run` against a real provider: all four seed types (task_input / input-@file / files / rhai) seeded into the persisted context window; required-missing and unknown-region both errored as designed; task-only back-compat unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)