### PR TITLE
Persist + resume in-flight interaction points across daemon restart (closes #38)

### DIFF
--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -8,6 +8,16 @@
 //! persisted context / stage / iteration / token totals via
 //! [`leviath_runtime::restore::restore_agent`], and preserves the original run
 //! metadata. Anything unreadable or un-reloadable is skipped (logged), never fatal.
+//!
+//! One exception to the "re-issue inference" resume: a run that was parked at a
+//! stage-boundary interaction point (e.g. `plan_approval`) wrote an
+//! `interactions.json` sidecar while blocked. For those, `reload_one` calls
+//! [`leviath_runtime::interaction_points::restore_interaction_point`] to bring the
+//! agent back in the *waiting* state with the same prompt re-opened, rather than
+//! re-inferring and dropping it (issue #38). Model-initiated dynamic tools
+//! (`ask_user_*`, `present_for_review`, `edit_document`) and taint-gate prompts are
+//! not persisted — they block inside the transient tool-worker turn, so on restart
+//! they take the ordinary re-inference path and the model simply re-asks.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -18,6 +28,7 @@ use leviath_mcp::ToolExecutor;
 use leviath_providers::Tool;
 use leviath_runtime::host::{SpawnArgs, SubAgentOp};
 use leviath_runtime::interaction_hub::InteractionHub;
+use leviath_runtime::interaction_points::InteractionPointState;
 use leviath_runtime::persistence::{RunMetadata, TokenTotals};
 use leviath_runtime::restore::restore_agent;
 use leviath_runtime::world::PipelineWorld;
@@ -286,14 +297,32 @@ fn reload_one(
     );
 
     // `build_agent` stamps fresh run metadata; preserve the original identity.
-    let mut md = world
-        .world_mut()
-        .get_mut::<RunMetadata>(entity)
-        .expect("build_agent attached run metadata");
-    md.started_at = meta.started_at;
-    md.title = meta.title.clone();
-    md.callback_url = meta.callback_url.clone();
-    // `parent_run_id` was already restored via `args` into build_agent's metadata.
+    {
+        let mut md = world
+            .world_mut()
+            .get_mut::<RunMetadata>(entity)
+            .expect("build_agent attached run metadata");
+        md.started_at = meta.started_at;
+        md.title = meta.title.clone();
+        md.callback_url = meta.callback_url.clone();
+        // `parent_run_id` was already restored via `args` into build_agent's metadata.
+    }
+
+    // If this run was parked at a stage-boundary interaction point (e.g.
+    // plan_approval), re-present it in the *waiting* state rather than the default
+    // `Active` + `ReadyToInfer` restore — so the open prompt survives the restart
+    // instead of being dropped and re-inferred (issue #38). A missing/malformed
+    // sidecar, or a blueprint that no longer matches, leaves the default restore.
+    if let Some(state) = std::fs::read_to_string(run_dir.join("interactions.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str::<InteractionPointState>(&s).ok())
+    {
+        leviath_runtime::interaction_points::restore_interaction_point(
+            world.world_mut(),
+            entity,
+            state,
+        );
+    }
 
     Ok(entity)
 }
@@ -508,6 +537,91 @@ mod tests {
         let totals = world.world().get::<TokenTotals>(*entity).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
+    }
+
+    /// A temp agent dir holding the `software-engineer` manifest, whose stage 0
+    /// (`plan`) is an `interactive_points` stage with a `plan_approval` point.
+    fn interactive_agent_dir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../agents/software-engineer/agent.leviath"),
+        )
+        .expect("read software-engineer manifest");
+        std::fs::write(dir.path().join("agent.leviath"), manifest).unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn reload_resumes_a_blocked_interaction_point_in_the_waiting_state() {
+        let agent = interactive_agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let runs = tempfile::tempdir().unwrap();
+
+        // A run parked at the plan_approval interaction point (stage 0 = plan)...
+        write_run(
+            runs.path(),
+            "run-await",
+            manifest.to_str().unwrap(),
+            RunStatus::WaitingInput,
+            None,
+        );
+        // ...plus the interaction sidecar the daemon wrote while it was blocked.
+        std::fs::write(
+            runs.path().join("run-await/interactions.json"),
+            serde_json::to_string(&InteractionPointState {
+                cursor: 0,
+                round: 0,
+                body: "## Plan\n1. do it".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        world.insert_interaction_hub(hub.clone()); // restore reads the hub resource
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+
+        assert_eq!(restored.len(), 1);
+        let (run_id, entity) = &restored[0];
+        assert_eq!(run_id, "run-await");
+        // Re-armed in the *waiting* state (not the default Active), so no inference
+        // re-issues and the open prompt isn't dropped — the issue #38 fix.
+        assert_eq!(world.agent_status(*entity), Some(AgentStatus::Waiting));
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::interaction_points::AwaitingInteractionPoint>(*entity)
+                .is_some()
+        );
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::pipeline::ReadyToInfer>(*entity)
+                .is_none(),
+            "the spawn-set ReadyToInfer is cleared so the inference lane won't fire"
+        );
+
+        // The prompt was re-opened in the hub, carrying the reviewed plan.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        let pending = hub.pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, "run-await");
+        assert_eq!(pending[0].1.body.as_deref(), Some("## Plan\n1. do it"));
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use bevy_ecs::prelude::*;
 use leviath_core::blueprint::{InteractionPoint, InteractionStyle, StageMode};
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
+use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -74,6 +75,24 @@ pub struct InteractionPointRounds(pub usize);
 /// the pre-edit version) and consumed on the next dispatch.
 #[derive(Component, Debug, Clone)]
 pub struct PlanBodyOverride(pub String);
+
+// ─── Restart persistence ─────────────────────────────────────────────────────
+
+/// Serializable snapshot of an agent parked at a stage-boundary interaction point,
+/// persisted to `<run_dir>/interactions.json` so a daemon restart can re-present the
+/// exact same prompt instead of dropping it and re-issuing inference (issue #38).
+/// Mirrors the fan-out sidecar (`fanout.json`). Everything needed to resume is small:
+/// the reviewed document lives here (and in a persisted context region), and the
+/// request id is derived from the agent id + point name + round.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct InteractionPointState {
+    /// Which point (index into the stage's `points`) was open.
+    pub cursor: usize,
+    /// How many directive/edit revision rounds had been taken at that point.
+    pub round: usize,
+    /// The document that was under review (the point's `body`), re-presented as-is.
+    pub body: String,
+}
 
 // ─── Lane plumbing ───────────────────────────────────────────────────────────
 
@@ -273,6 +292,88 @@ async fn run_interaction_point(
 
     let _ = outcomes.send(InteractionPointOutcome { entity, decision });
     wake.notify_one();
+}
+
+/// Re-arm an agent that was blocked at an interaction point when the daemon stopped,
+/// bringing it back in the *waiting* state with the same open request — rather than
+/// the default `Active` + `ReadyToInfer` restore, which would re-issue inference and
+/// drop the prompt (issue #38).
+///
+/// Looks up the point from the agent's (already-restored) blueprint + stage cursor,
+/// restores the point cursor/round, flips the agent to `Waiting` (clearing the
+/// spawn-set `ReadyToInfer`, marking `AwaitingInteractionPoint`), and re-spawns the
+/// ask task so the request re-registers in the hub with the same id
+/// (`{agent_id}-point-{name}-{round}`). From there it is indistinguishable from a live
+/// dispatch: a client that had the prompt open still sees it, and answering it later
+/// routes normally through [`collect_interaction_point`].
+///
+/// A no-op (leaving the default restore in place) when the interaction-point lane
+/// isn't wired (a test world), or when the stage is no longer an interactive-points
+/// stage / the cursor is out of range (e.g. the blueprint changed under the run).
+pub fn restore_interaction_point(world: &mut World, entity: Entity, state: InteractionPointState) {
+    // The lane + hub must both be wired (they are in the daemon; absent in a test
+    // world) — otherwise there is nothing to await the re-opened request.
+    let Some(((outcomes, wake, runtime), hub)) = world
+        .get_resource::<InteractionPointStage>()
+        .map(|s| (s.outcomes.clone(), s.wake.clone(), s.runtime.clone()))
+        .zip(world.get_resource::<InteractionHub>().cloned())
+    else {
+        return;
+    };
+
+    // Resolve the point from the restored blueprint + stage cursor. A reloaded agent
+    // always carries these; a blueprint that changed out from under the run (stage no
+    // longer interactive, or fewer points) leaves the default restore in place rather
+    // than resuming a stale prompt.
+    let agent_id = world
+        .get::<AgentState>(entity)
+        .expect("a reloaded agent has AgentState")
+        .agent_id
+        .clone();
+    let point = {
+        let bp = world
+            .get::<AgentBlueprint>(entity)
+            .expect("a reloaded agent has a blueprint");
+        let cursor = world
+            .get::<StageCursor>(entity)
+            .expect("a reloaded agent has a stage cursor");
+        stage_points(bp, cursor)
+            .and_then(|p| p.get(state.cursor))
+            .cloned()
+    };
+    let Some(point) = point else {
+        tracing::warn!(
+            ?entity,
+            cursor = state.cursor,
+            "interaction-point restore skipped: stage not interactive or cursor out of range"
+        );
+        return;
+    };
+
+    // Re-arm the waiting state: restore the cursor/round, mark the agent awaiting the
+    // point, and clear the spawn-set `ReadyToInfer` so the inference lane won't fire.
+    {
+        let mut e = world.entity_mut(entity);
+        e.insert(InteractionPointCursor(state.cursor));
+        e.insert(InteractionPointRounds(state.round));
+        e.insert(AwaitingInteractionPoint);
+        e.remove::<ReadyToInfer>();
+        e.get_mut::<AgentState>()
+            .expect("a reloaded agent has AgentState")
+            .status = AgentStatus::Waiting;
+    }
+
+    // Re-open the request in the hub and await it, exactly as a live dispatch would.
+    runtime.spawn(run_interaction_point(
+        entity,
+        hub,
+        agent_id,
+        point,
+        state.body,
+        state.round,
+        outcomes,
+        wake,
+    ));
 }
 
 // ─── Systems ─────────────────────────────────────────────────────────────────
@@ -1378,5 +1479,175 @@ mod tests {
                 edited: "edited body".to_string(),
             }
         );
+    }
+
+    // ── restore (restart persistence, issue #38) ──
+
+    #[test]
+    fn interaction_point_state_round_trips() {
+        let s = InteractionPointState {
+            cursor: 2,
+            round: 1,
+            body: "# Plan\n1. do it".to_string(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(
+            serde_json::from_str::<InteractionPointState>(&json).unwrap(),
+            s
+        );
+    }
+
+    /// A world with the interaction-point lane + hub wired, keeping the results
+    /// receiver so a resumed point can be answered and collected end-to-end.
+    fn resume_world() -> (
+        World,
+        InteractionHub,
+        UnboundedReceiver<InteractionPointOutcome>,
+    ) {
+        let hub = InteractionHub::new();
+        let (tx, rx) = unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(hub.clone());
+        world.insert_resource(InteractionPointStage {
+            outcomes: tx,
+            wake: Arc::new(Notify::new()),
+            runtime: Handle::current(),
+        });
+        (world, hub, rx)
+    }
+
+    /// A freshly "restored" agent as `restore_agent` leaves it (Active +
+    /// ReadyToInfer) before interaction-point restore runs.
+    fn restored_agent(world: &mut World, bp: AgentBlueprint) -> Entity {
+        world
+            .spawn((
+                agent_state(AgentStatus::Active),
+                bp,
+                window_with_plan(),
+                StageCursor { index: 0 },
+                ReadyToInfer,
+            ))
+            .id()
+    }
+
+    #[tokio::test]
+    async fn restore_rearms_waiting_and_reopens_the_prompt() {
+        let (mut world, hub, _rx) = resume_world();
+        let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        restore_interaction_point(
+            &mut world,
+            e,
+            InteractionPointState {
+                cursor: 0,
+                round: 2,
+                body: "the plan".to_string(),
+            },
+        );
+
+        // Re-armed in the waiting state: the inference lane won't fire.
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Waiting
+        );
+        assert!(world.get::<AwaitingInteractionPoint>(e).is_some());
+        assert!(world.get::<ReadyToInfer>(e).is_none());
+        assert_eq!(world.get::<InteractionPointCursor>(e).unwrap().0, 0);
+        assert_eq!(world.get::<InteractionPointRounds>(e).unwrap().0, 2);
+
+        // The ask task re-registered the *same* request id in the hub, with the body.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        let pending = hub.pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, "run-1");
+        assert_eq!(pending[0].1.id, "run-1-point-plan_approval-2");
+        assert_eq!(pending[0].1.body.as_deref(), Some("the plan"));
+    }
+
+    #[tokio::test]
+    async fn restore_then_answer_drives_the_transition() {
+        let (mut world, hub, mut rx) = resume_world();
+        let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        restore_interaction_point(
+            &mut world,
+            e,
+            InteractionPointState {
+                cursor: 0,
+                round: 0,
+                body: "the plan".to_string(),
+            },
+        );
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+
+        // Approve the re-opened prompt; the outcome lands on the lane.
+        let id = hub.pending()[0].1.id.clone();
+        let mut r = InteractionResponse::text(&id, "");
+        r.choice_index = Some(0); // Approve
+        assert!(hub.answer(r));
+        let outcome = rx.recv().await.unwrap();
+
+        // Feed it to collect and confirm the stage proceeds.
+        let (tx2, rx2) = unbounded_channel();
+        tx2.send(outcome).unwrap();
+        world.insert_resource(InteractionPointResults(rx2));
+        let mut s = Schedule::default();
+        s.add_systems(collect_interaction_point);
+        s.run(&mut world);
+
+        assert!(world.get::<ResolveTransition>(e).is_some());
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_noop_on_noninteractive_stage() {
+        let (mut world, hub, _rx) = resume_world();
+        let e = restored_agent(&mut world, noninteractive_bp());
+        restore_interaction_point(
+            &mut world,
+            e,
+            InteractionPointState {
+                cursor: 0,
+                round: 0,
+                body: "x".to_string(),
+            },
+        );
+        // Left as the default restore: Active + ReadyToInfer, nothing re-opened.
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(world.get::<AwaitingInteractionPoint>(e).is_none());
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(hub.pending().is_empty());
+    }
+
+    #[tokio::test]
+    async fn restore_noop_without_lane_wired() {
+        // No InteractionPointStage / hub resources (a test world) ⇒ no-op.
+        let mut world = World::new();
+        let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        restore_interaction_point(
+            &mut world,
+            e,
+            InteractionPointState {
+                cursor: 0,
+                round: 0,
+                body: "x".to_string(),
+            },
+        );
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_some());
     }
 }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -38,6 +38,12 @@ pub struct PersistJob {
     /// restart. `None` ⇒ the agent isn't waiting on a fan-out (any stale file is
     /// removed).
     pub fanout: Option<String>,
+    /// Serialized [`InteractionPointState`](crate::interaction_points::InteractionPointState)
+    /// for an agent parked at a stage-boundary interaction point (e.g. plan_approval),
+    /// written to `interactions.json` so a restart re-presents the same prompt rather
+    /// than dropping it and re-inferring (issue #38). `None` ⇒ the agent isn't parked
+    /// at an interaction point (any stale file is removed).
+    pub interactions: Option<String>,
 }
 
 /// The single-lane persistence worker: writes each [`PersistJob`]'s files under
@@ -166,6 +172,15 @@ async fn write_snapshot(
         Some(json) => write_bytes_atomic(&fanout_path, json.as_bytes(), &job.run_id).await,
         None => {
             let _ = tokio::fs::remove_file(&fanout_path).await;
+        }
+    }
+    // Interaction-point waiting state (whole-file), or remove any stale file once the
+    // agent is no longer parked at a stage-boundary interaction point.
+    let interactions_path = dir.join("interactions.json");
+    match &job.interactions {
+        Some(json) => write_bytes_atomic(&interactions_path, json.as_bytes(), &job.run_id).await,
+        None => {
+            let _ = tokio::fs::remove_file(&interactions_path).await;
         }
     }
 }
@@ -339,6 +354,7 @@ mod tests {
             log_appends: vec![],
             taint_audit: None,
             fanout: None,
+            interactions: None,
         })
         .unwrap();
         drop(tx); // close so the worker loop ends
@@ -364,6 +380,7 @@ mod tests {
             log_appends: vec![],
             taint_audit: None,
             fanout: None,
+            interactions: None,
         }
     }
 
@@ -581,6 +598,7 @@ mod tests {
                 log_appends: vec![(0, "[tool] list_dir: .".to_string())],
                 taint_audit: None,
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",
@@ -613,6 +631,7 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: Some((2, r#"[{"tool_name":"shell"}]"#.to_string())),
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",
@@ -622,6 +641,31 @@ mod tests {
         let audit =
             std::fs::read_to_string(dir.path().join("r/stages/2/taint_audit.json")).unwrap();
         assert!(audit.contains("shell"));
+    }
+
+    #[tokio::test]
+    async fn interactions_sidecar_is_written_then_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("r/interactions.json");
+
+        // A job parked at an interaction point writes the sidecar.
+        write_snapshot(
+            dir.path(),
+            &PersistJob {
+                interactions: Some(r#"{"cursor":0,"round":1,"body":"the plan"}"#.to_string()),
+                ..job("r")
+            },
+            "machine-test",
+            "world-test",
+            None,
+        )
+        .await;
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("the plan"));
+
+        // A later job that is no longer parked removes the stale sidecar.
+        write_snapshot(dir.path(), &job("r"), "machine-test", "world-test", None).await;
+        assert!(!path.exists());
     }
 
     #[tokio::test]
@@ -638,6 +682,7 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",
@@ -675,6 +720,7 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",
@@ -703,6 +749,7 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",
@@ -735,6 +782,7 @@ mod tests {
                 log_appends: vec![],
                 taint_audit: None,
                 fanout: None,
+                interactions: None,
             },
             "machine-test",
             "world-test",

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -1505,8 +1505,14 @@ pub fn dispatch_persistence(
         Option<&crate::components::ParentRef>,
         Option<&crate::components::SubAgentChildren>,
         Option<&crate::fanout::FanOutWaiting>,
+        (
+            Option<&crate::interaction_points::AwaitingInteractionPoint>,
+            Option<&crate::interaction_points::InteractionPointCursor>,
+            Option<&crate::interaction_points::InteractionPointRounds>,
+        ),
     )>,
     stage: Res<PersistenceStage>,
+    hub: Option<Res<InteractionHub>>,
 ) {
     for (
         md,
@@ -1521,6 +1527,7 @@ pub fn dispatch_persistence(
         parent_ref,
         children,
         fan_out_waiting,
+        (awaiting_point, ip_cursor, ip_rounds),
     ) in agents.iter_mut()
     {
         let now = chrono::Utc::now().timestamp();
@@ -1571,6 +1578,26 @@ pub fn dispatch_persistence(
         // waiting — see the writer).
         let fanout = fan_out_waiting
             .map(|w| serde_json::to_string(&w.to_state()).expect("FanOutState always serializes"));
+        // An agent parked at a stage-boundary interaction point: persist the open
+        // point (cursor/round + the reviewed document) so a restart re-presents the
+        // same prompt rather than dropping it and re-inferring (issue #38). The
+        // document comes from the open request in the hub — which is present by the
+        // time `reflect_interaction_status` (running just before this system) has
+        // flipped the agent to `Waiting`. If the request isn't registered yet, skip
+        // this tick; the next persist captures it (removing any stale sidecar).
+        let interactions = awaiting_point.and_then(|_| {
+            let request = hub
+                .as_ref()?
+                .pending()
+                .into_iter()
+                .find(|(aid, req)| aid == &state.agent_id && req.id.contains("-point-"))?;
+            let ip_state = crate::interaction_points::InteractionPointState {
+                cursor: ip_cursor.map_or(0, |c| c.0),
+                round: ip_rounds.map_or(0, |r| r.0),
+                body: request.1.body.unwrap_or_default(),
+            };
+            Some(serde_json::to_string(&ip_state).expect("InteractionPointState always serializes"))
+        });
         let _ = stage.0.send(PersistJob {
             run_id: md.run_id.clone(),
             meta,
@@ -1580,6 +1607,7 @@ pub fn dispatch_persistence(
             log_appends,
             taint_audit,
             fanout,
+            interactions,
         });
     }
 }
@@ -3469,6 +3497,112 @@ mod tests {
         run_dispatch_persistence(&mut world);
         let job = rx.try_recv().expect("job sent");
         assert!(job.fanout.is_some(), "fan-out waiting state persisted");
+    }
+
+    #[tokio::test]
+    async fn dispatch_persistence_serializes_interaction_point() {
+        use crate::dynamic_interaction::InteractionBackend;
+        let (mut world, mut rx) = world_with_persistence();
+        let hub = InteractionHub::new();
+        world.insert_resource(hub.clone());
+        world.spawn((
+            run_metadata(),
+            agent_state(), // agent_id = "a"
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            crate::interaction_points::AwaitingInteractionPoint,
+            crate::interaction_points::InteractionPointCursor(1),
+            crate::interaction_points::InteractionPointRounds(3),
+        ));
+
+        // Open the point request for this agent in the hub, carrying the document.
+        let backend = hub.backend_for("a".to_string());
+        let ask = tokio::spawn(async move {
+            let mut req = leviath_core::interaction::InteractionRequest::multiple_choice(
+                "a-point-plan_approval-3",
+                "Approve?",
+                vec!["Approve".to_string(), "Abort".to_string()],
+                "plan",
+            );
+            req.body = Some("the plan".to_string());
+            backend.ask(req).await
+        });
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+
+        run_dispatch_persistence(&mut world);
+        let job = rx.try_recv().expect("job sent");
+        let json = job.interactions.expect("interaction-point state persisted");
+        let state: crate::interaction_points::InteractionPointState =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(state.cursor, 1);
+        assert_eq!(state.round, 3);
+        assert_eq!(state.body, "the plan");
+
+        // Let the still-blocked ask complete so its task ends cleanly.
+        assert!(
+            hub.answer(leviath_core::interaction::InteractionResponse::text(
+                "a-point-plan_approval-3",
+                "",
+            ))
+        );
+        ask.await.unwrap();
+    }
+
+    #[test]
+    fn dispatch_persistence_omits_interactions_when_not_at_a_point() {
+        let (mut world, mut rx) = world_with_persistence();
+        world.spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+        ));
+        run_dispatch_persistence(&mut world);
+        let job = rx.try_recv().expect("job sent");
+        assert!(job.interactions.is_none());
+    }
+
+    #[test]
+    fn dispatch_persistence_omits_interactions_without_a_hub() {
+        // Awaiting a point but no hub resource (e.g. a test world) ⇒ nothing to read
+        // the open request from, so no sidecar is written.
+        let (mut world, mut rx) = world_with_persistence();
+        world.spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            crate::interaction_points::AwaitingInteractionPoint,
+        ));
+        run_dispatch_persistence(&mut world);
+        assert!(rx.try_recv().expect("job sent").interactions.is_none());
+    }
+
+    #[test]
+    fn dispatch_persistence_omits_interactions_when_request_not_yet_registered() {
+        // Awaiting a point with a hub present, but the ask task hasn't registered the
+        // request yet ⇒ skip this tick (the next persist captures it).
+        let (mut world, mut rx) = world_with_persistence();
+        world.insert_resource(InteractionHub::new()); // empty
+        world.spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            crate::interaction_points::AwaitingInteractionPoint,
+        ));
+        run_dispatch_persistence(&mut world);
+        assert!(rx.try_recv().expect("job sent").interactions.is_none());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -967,6 +967,120 @@ mod tests {
         assert!(dir.path().join("run-42").join("context.json").exists());
     }
 
+    /// A single-stage blueprint whose stage is an `interactive_points` stage with a
+    /// `plan_approval` point (the shape that blocks awaiting human approval).
+    fn interactive_blueprint() -> leviath_core::Blueprint {
+        use leviath_core::blueprint::{InteractionPoint, InteractionStyle, StageMode};
+        let layout = leviath_core::layout::ContextLayout::new(
+            vec![leviath_core::layout::RegionDefinition::new(
+                "conversation".to_string(),
+                RegionKind::Clearable,
+                10_000,
+            )],
+            12_000,
+        );
+        let mut s = leviath_core::Stage::new(
+            "plan".to_string(),
+            leviath_core::blueprint::ModelConfig::new("script".to_string(), "m".to_string()),
+        );
+        s.mode = StageMode::InteractivePoints {
+            points: vec![InteractionPoint {
+                name: "plan_approval".to_string(),
+                prompt: "Approve?".to_string(),
+                required: true,
+                style: InteractionStyle::MultipleChoice,
+                options: vec!["Approve".to_string(), "Abort".to_string()],
+                directives: std::collections::HashMap::new(),
+                abort_options: vec!["Abort".to_string()],
+                edit_options: vec![],
+                document_region: None,
+            }],
+        };
+        leviath_core::Blueprint::new("t".to_string(), "d".to_string(), vec![s], layout)
+    }
+
+    #[tokio::test]
+    async fn persists_interaction_point_when_a_live_agent_blocks() {
+        // Drive a real agent through inference → transition → the interaction-point
+        // lane until it blocks awaiting approval, and assert the daemon wrote the
+        // `interactions.json` sidecar — the issue #38 persist side, end-to-end
+        // through the live lane (a tool call first, then a text "plan", so the stage
+        // transitions into the interaction point rather than looping on nudges).
+        let dir = tempfile::tempdir().unwrap();
+        let mut world = PipelineWorld::new(
+            registry_with(vec![with_tool("c1", "read"), text("## Plan\n1. do it")]),
+            Arc::new(EchoTools),
+            InferencePoolConfig::new(),
+            dir.path().to_path_buf(),
+            Handle::current(),
+        );
+        world.insert_interaction_hub(crate::interaction_hub::InteractionHub::new());
+        let e = world.spawn_agent((
+            AgentBlueprint(interactive_blueprint()),
+            StageCursor { index: 0 },
+            agent_state(),
+            crate::components::MessageInbox::default(),
+            StageProgress::default(),
+            StageInferences(vec![stage("m")]),
+            StageSetups(vec![setup()]),
+            VisitCounts::default(),
+            window(),
+            stage("m"),
+            setup().inference_config,
+            crate::persistence::RunMetadata {
+                run_id: "run-ip".to_string(),
+                agent_name: "a".to_string(),
+                agent_path: "/p".to_string(),
+                task: "t".to_string(),
+                model: None,
+                workdir: "/w".to_string(),
+                num_stages: 1,
+                started_at: 0,
+                parent_run_id: None,
+                metadata: std::collections::HashMap::new(),
+                callback_url: None,
+                title: None,
+            },
+            crate::persistence::TokenTotals::default(),
+            crate::pipeline::PersistWatermark::default(),
+            ReadyToInfer,
+        ));
+
+        world.run_until_idle(30).await;
+        // `run_until_idle` stops once no inference/tool is in flight, but the
+        // interaction-point ask task registers in the hub just after; the real
+        // daemon's `run()` loop catches its wake, so pump fixed points here until
+        // `reflect_interaction_status` flips the agent to Waiting (and persistence
+        // captures the sidecar).
+        for _ in 0..50 {
+            if world.agent_status(e) == Some(AgentStatus::Waiting) {
+                break;
+            }
+            tokio::task::yield_now().await;
+            world.run_to_fixed_point();
+        }
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Waiting));
+
+        // Poll until the interaction sidecar lands (the persistence worker writes it
+        // on its own task once the agent is parked Waiting at the point).
+        let path = dir.path().join("run-ip").join("interactions.json");
+        let mut sidecar = None;
+        for _ in 0..200 {
+            if let Ok(t) = std::fs::read_to_string(&path)
+                && let Ok(s) =
+                    serde_json::from_str::<crate::interaction_points::InteractionPointState>(&t)
+            {
+                sidecar = Some(s);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let s = sidecar.expect("interaction-point sidecar flushed to disk");
+        assert_eq!(s.cursor, 0);
+        assert_eq!(s.round, 0);
+        assert_eq!(s.body, "## Plan\n1. do it");
+    }
+
     #[tokio::test]
     async fn spawn_from_blueprint_errors_on_oversized_system_prompt() {
         let mut world = build_world(registry_with(vec![]));


### PR DESCRIPTION
## Summary

Fixes #38. The interaction hub is in-memory only, so an agent blocked awaiting a human answer reloaded as `Active` + `ReadyToInfer` on daemon restart and **re-issued inference, dropping the open prompt**.

This persists an agent parked at a stage-boundary **interaction point** (e.g. `plan_approval`) to a `<run_dir>/interactions.json` sidecar — mirroring the existing `fanout.json` pattern — and, on restart, re-arms it in the **waiting** state with the same prompt re-opened in the hub (same request id). Answering the resumed prompt routes normally through `collect_interaction_point`, so a restart is transparent.

## Changes

- **persistence_bridge**: new `PersistJob.interactions`; write/remove `interactions.json` alongside `fanout.json`.
- **pipeline** (`dispatch_persistence`): serialize `InteractionPointState { cursor, round, body }` for an `AwaitingInteractionPoint` agent, reading the reviewed document from the open hub request (present once `reflect_interaction_status`, which runs immediately before persistence, has flipped the agent to `Waiting`).
- **interaction_points**: `InteractionPointState` + `restore_interaction_point`, which re-spawns the ask task via the existing `run_interaction_point` (same request id `{agent_id}-point-{name}-{round}`).
- **recovery** (`reload_one`): restore the sidecar; a missing/mismatched sidecar leaves the default restore in place (safe fallback, logged). Covers both `reload_persisted_agents` (startup) and `reload_run` (on-demand paging).

## Scope

**Interaction points only.** Model-initiated dynamic tools (`ask_user_*`, `present_for_review`, `edit_document`) and taint-gate prompts block inside the transient tool-worker turn (the in-flight assistant turn + tool batch is unpersisted), so faithful mid-batch resume would require persisting that batch and risks re-running already-executed side-effecting tools. On restart they take the ordinary re-inference path and the model re-asks — documented in the recovery module.

## Testing

- **Unit / integration** (all real systems + types): serde round-trip; `restore_interaction_point` rearms Waiting + reopens the prompt; restore + answer drives the transition; no-ops on non-interactive stage / no lane wired; `dispatch_persistence` emits/omits the sidecar; `write_snapshot` write+remove; recovery integration reload → **Waiting (not Active)** using the real `software-engineer` blueprint; and an **end-to-end `PipelineWorld` test** driving a live agent through the inference → transition → interaction-point lane to a genuine block, asserting the sidecar is written.
- `leviath-runtime` stays at **100% coverage**.
- **Live daemon test** (real Claude model, isolated `LEVIATH_HOME`/`LEVIATH_RUNS_DIR`): drove a `software-engineer` run to the `plan_approval` prompt → **stopped + restarted the daemon** → the same prompt was re-opened, `ps` showed `waiting`, and iteration stayed at 2 (no re-inference) → answering **Approve** transitioned the run `plan` → `implement` and it continued normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)