### PR TITLE
feat(serve): stream per-agent logs over the WebSocket API (closes #40)

### DIFF
--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -731,7 +731,8 @@ fn world_event_run_id(event: &WorldEvent) -> &str {
         | WorldEvent::Tokens { run_id, .. }
         | WorldEvent::Context { run_id, .. }
         | WorldEvent::Interaction { run_id, .. }
-        | WorldEvent::Completed { run_id, .. } => run_id,
+        | WorldEvent::Completed { run_id, .. }
+        | WorldEvent::Log { run_id, .. } => run_id,
     }
 }
 

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -771,6 +771,18 @@ async fn events_for_other_runs_are_ignored() {
     h.close_input().await;
 }
 
+#[test]
+fn world_event_run_id_reads_the_run_id_from_a_log_event() {
+    // A `Log` event carries the run id like every other variant; the pump uses
+    // this to filter events to the active run.
+    let ev = WorldEvent::Log {
+        run_id: "run-log".to_string(),
+        agent_id: "a".to_string(),
+        line: "some output".to_string(),
+    };
+    assert_eq!(world_event_run_id(&ev), "run-log");
+}
+
 // ─── session/prompt: spawn / message failures ────────────────────────────────
 
 #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -123,6 +123,15 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             // error (if any) rides the webhook payload below.
             result: runstate::read_meta(&run_id).ok().and_then(|m| m.error),
         },
+        WorldEvent::Log {
+            run_id,
+            agent_id,
+            line,
+        } => ServerEvent::Log {
+            agent_id,
+            run_id,
+            line,
+        },
     }
 }
 
@@ -257,6 +266,14 @@ mod tests {
                 status: "complete".into()
             }),
             "agent_completed"
+        );
+        assert_eq!(
+            mapped_tag(WorldEvent::Log {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                line: "hello".into()
+            }),
+            "log"
         );
     }
 

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -286,7 +286,25 @@ pub enum WorldEvent {
         /// The terminal status label.
         status: String,
     },
+    /// A run produced a per-agent log/output line (readable assistant output or
+    /// an operational `[Tokens: …]` / `[tool] …` / `[error] …` line).
+    Log {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The log line text.
+        line: String,
+    },
 }
+
+/// A world resource holding a clone of the host's [`WorldEvent`] broadcast
+/// sender, so ECS systems (e.g. the persistence drain) can push events — notably
+/// per-agent [`WorldEvent::Log`] lines — into the same stream the control
+/// transport serves. Absent in worlds that don't stream (test / `lev run`), where
+/// systems that depend on it become no-ops.
+#[derive(bevy_ecs::system::Resource, Clone)]
+pub struct WorldEventSink(pub broadcast::Sender<WorldEvent>);
 
 /// A short, stable status label for [`WorldEvent`].
 fn status_str(status: &AgentStatus) -> &'static str {
@@ -340,8 +358,13 @@ impl WorldHost {
 
     /// Wrap a world with a specific interaction hub — the daemon shares one hub
     /// between the tool service's per-agent backends and this host.
-    pub fn with_interactions(world: PipelineWorld, interactions: InteractionHub) -> Self {
+    pub fn with_interactions(mut world: PipelineWorld, interactions: InteractionHub) -> Self {
         let (events, _) = broadcast::channel(1024);
+        // Let ECS systems (the persistence drain) push events — per-agent log
+        // lines — into the same stream the control transport serves.
+        world
+            .world_mut()
+            .insert_resource(WorldEventSink(events.clone()));
         let (subagent_tx, subagent_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             world,

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -1513,6 +1513,7 @@ pub fn dispatch_persistence(
     )>,
     stage: Res<PersistenceStage>,
     hub: Option<Res<InteractionHub>>,
+    sink: Option<Res<crate::host::WorldEventSink>>,
 ) {
     for (
         md,
@@ -1556,6 +1557,19 @@ pub fn dispatch_persistence(
         }
         if watermark_changed {
             watermark.last = Some(current);
+        }
+
+        // Stream each buffered line to WS subscribers as a `Log` event (in
+        // addition to the disk append below). No-op in worlds without the sink
+        // (test / `lev run`); a zero-subscriber `send` error is ignored.
+        if let Some(sink) = &sink {
+            for (_idx, line) in output_appends.iter().chain(log_appends.iter()) {
+                let _ = sink.0.send(crate::host::WorldEvent::Log {
+                    run_id: md.run_id.clone(),
+                    agent_id: state.agent_id.clone(),
+                    line: line.clone(),
+                });
+            }
         }
 
         // Tree links, for a deterministic restart-time rebuild of the graph.
@@ -3633,6 +3647,75 @@ mod tests {
         run_dispatch_persistence(&mut world);
         let job = rx.try_recv().expect("append-triggered job");
         assert_eq!(job.log_appends, vec![(0, "late log".to_string())]);
+    }
+
+    #[test]
+    fn dispatch_persistence_broadcasts_buffered_lines_as_log_events() {
+        use crate::host::{WorldEvent, WorldEventSink};
+        let (mut world, _rx) = world_with_persistence();
+        let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+        world.insert_resource(WorldEventSink(sink_tx));
+        let mut buf = StageIoBuffer::default();
+        buf.output.push((0, "readable output".to_string()));
+        buf.logs.push((0, "[Tokens: 1 in, 2 out]".to_string()));
+        world.spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            buf,
+        ));
+
+        run_dispatch_persistence(&mut world);
+
+        // Output lines stream first, then operational logs — each as a `Log`
+        // carrying the agent's run/agent ids and the raw line.
+        let first = sink_rx.try_recv().expect("output log event");
+        assert_eq!(
+            first,
+            WorldEvent::Log {
+                run_id: "run-1".to_string(),
+                agent_id: "a".to_string(),
+                line: "readable output".to_string(),
+            }
+        );
+        let second = sink_rx.try_recv().expect("operational log event");
+        assert_eq!(
+            second,
+            WorldEvent::Log {
+                run_id: "run-1".to_string(),
+                agent_id: "a".to_string(),
+                line: "[Tokens: 1 in, 2 out]".to_string(),
+            }
+        );
+        assert!(sink_rx.try_recv().is_err(), "no extra events");
+    }
+
+    #[test]
+    fn dispatch_persistence_emits_no_log_events_without_a_sink() {
+        use crate::host::WorldEventSink;
+        let (mut world, _rx) = world_with_persistence();
+        // A sink whose sender is *not* installed as a world resource: the system
+        // can't reach it, so nothing is broadcast.
+        let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+        let _keep_alive = WorldEventSink(sink_tx);
+        let mut buf = StageIoBuffer::default();
+        buf.output.push((0, "line".to_string()));
+        world.spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            buf,
+        ));
+
+        run_dispatch_persistence(&mut world);
+
+        assert!(sink_rx.try_recv().is_err(), "no events without the sink");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #40. `ServerEvent::Log` was a defined WebSocket event and the WS layer already fully supported it (per-run filtering, serialization, tests) — but **nothing ever produced it**: its source enum `WorldEvent` had no log variant, so `to_server_event` could never emit one. Per-agent log lines only reached disk (`stages/<idx>/output.log`), never the live stream.

This wires them in. Per user decision, **both** readable assistant output *and* operational lines (`[Tokens: …]`, `[tool] …`, `[error] …`) stream as `Log` events.

## Changes

- **`host.rs`** — new `WorldEvent::Log { run_id, agent_id, line }` variant + a `WorldEventSink` resource holding a clone of the host's event broadcast sender; the host installs it into the ECS world in `WorldHost::with_interactions`.
- **`pipeline.rs`** — `dispatch_persistence` broadcasts one `Log` per buffered output/logs line as it drains them (reusing lines already in hand — no double-drain). No-op when the sink is absent (test / `lev run` worlds).
- **`polling.rs`** — maps `WorldEvent::Log` → `ServerEvent::Log`.
- **`agent_client/mod.rs`** — adds the variant to the one other exhaustive `WorldEvent` match (`world_event_run_id`).

## Tests

- `to_server_event_maps_every_variant` extended with the `Log` case.
- `dispatch_persistence` broadcast coverage — with the sink (asserts output-then-logs `Log` events with correct ids) and without it (asserts nothing is emitted).

## Verification

- `cargo build` + `cargo clippy --all-targets` clean; full `leviath-runtime` lib suite (522) and targeted `leviath-cli` polling/websocket/agent_client suites green.
- **Live end-to-end**: ran `lev serve`, spawned a `software-engineer` agent, connected a raw WS client. The global `/ws` stream delivered `{"type":"log",...}` frames carrying both the agent's readable plan output and `[Tokens: 325 in, 60 out]` lines; the per-run `/ws/agents/{id}` stream delivered only that run's events (no cross-run leakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1p3optRsgKrFxheUJ3bBS