### PR TITLE
feat(inference): batch-tool-calls system-prompt hint (closes #17)

### DIFF
--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -92,6 +92,22 @@ pub struct Config {
     /// Runtime resource limits (inference concurrency + iteration caps).
     #[serde(default)]
     pub limits: LimitsConfig,
+
+    /// Global master switch for the batch-tool-calls system-prompt hint.
+    ///
+    /// **On by default (opt-out).** When `true`, every stage's request carries a
+    /// short hint telling the model it may emit several `tool_use` blocks in one
+    /// response and should batch *independent* operations (but never dependent
+    /// ones) to cut API round trips. Individual agents or stages can opt out by
+    /// setting `batch_tool_hint = false` in their `[agent]` / `[stages.<name>]`
+    /// blocks; when this global is `false`, they opt back *in* by setting it to
+    /// `true` at the narrower scope.
+    #[serde(default = "default_true")]
+    pub batch_tool_hint: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_max_concurrent_inferences() -> Option<usize> {
@@ -191,6 +207,7 @@ impl Default for Config {
             request_timeout_secs: None,
             taint_tracking: false,
             limits: LimitsConfig::default(),
+            batch_tool_hint: true,
         }
     }
 }
@@ -1666,6 +1683,7 @@ anthropic_api_key = "sk-ant-test-key"
                 max_concurrent_inferences: Some(4),
                 default_max_iterations: Some(99),
             },
+            batch_tool_hint: true,
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -306,7 +306,14 @@ pub fn build_agent(
         .map(|s| format!("{}/{}", s.provider_name, s.model));
 
     // 5. Spawn the agent.
-    let entity = spawn_agent(world, args.run_id.clone(), blueprint, &args.task, stages)?;
+    let entity = spawn_agent(
+        world,
+        args.run_id.clone(),
+        blueprint,
+        &args.task,
+        stages,
+        config.batch_tool_hint,
+    )?;
 
     // 6. Attach run metadata / token totals / persistence watermark (+ optional
     // compaction settings).

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -52,6 +52,12 @@ pub struct Blueprint {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security: Option<crate::taint::SecurityConfig>,
 
+    /// Agent-level override for the batch-tool-calls system-prompt hint. `None`
+    /// inherits the global config toggle; a per-stage `batch_tool_hint` overrides
+    /// this. See [`crate::taint::resolve_batch_tool_hint`] for the cascade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_tool_hint: Option<bool>,
+
     /// Repetition detection configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repetition_detection: Option<RepetitionDetectionConfig>,
@@ -81,6 +87,7 @@ impl Blueprint {
             entry_stage: None,
             metadata: HashMap::new(),
             security: None,
+            batch_tool_hint: None,
             repetition_detection: None,
             file_tracking: None,
         }
@@ -650,6 +657,13 @@ pub struct Stage {
     #[serde(default)]
     pub security: Option<crate::taint::SecurityConfig>,
 
+    /// Per-stage override for the batch-tool-calls system-prompt hint. `None`
+    /// inherits the agent-level `Blueprint.batch_tool_hint` (which in turn
+    /// inherits the global config toggle). Set `false` to opt a sequential stage
+    /// out, or `true` to opt it in independently of the agent/global setting.
+    #[serde(default)]
+    pub batch_tool_hint: Option<bool>,
+
     /// Optional routing configuration for tool results.
     /// When set, tool results are routed to the configured region(s) instead
     /// of the default "conversation" region.
@@ -683,6 +697,7 @@ impl Stage {
             allow_complete: false,
             allow_as_worker: false,
             security: None,
+            batch_tool_hint: None,
             tool_result_routing: None,
         }
     }

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -381,6 +381,13 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 stage.security = Some(parse_security_config(sec_table));
             }
 
+            // Parse per-stage batch_tool_hint override: opt an individual stage
+            // in/out of the batch-tool-calls system-prompt hint (e.g. `false` for
+            // a sequential validate stage). Absent ⇒ inherit agent/global.
+            if let Some(bth) = stage_value.get("batch_tool_hint").and_then(|v| v.as_bool()) {
+                stage.batch_tool_hint = Some(bth);
+            }
+
             // Parse accepts_messages flag: whether mid-run user messages are
             // injected into context between inference calls. Defaults to true
             // (via the Stage constructor); set false for stages that shouldn't
@@ -688,6 +695,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // Parse agent-level security config: [security]
     if let Some(security_table) = parsed.get("security").and_then(|v| v.as_table()) {
         blueprint.security = Some(parse_security_config(security_table));
+    }
+
+    // Parse agent-level batch_tool_hint override: `[agent] batch_tool_hint`.
+    // Absent ⇒ inherit the global config toggle; a per-stage value overrides it.
+    if let Some(bth) = agent.get("batch_tool_hint").and_then(|v| v.as_bool()) {
+        blueprint.batch_tool_hint = Some(bth);
     }
 
     // Parse agent-level tool permissions: [tool_permissions]
@@ -1665,6 +1678,55 @@ mode = "autonomous"
         // A stage with no [security] inherits (None).
         let build = bp.find_stage("build").unwrap();
         assert!(build.security.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_agent_and_stage_batch_tool_hint() {
+        let toml = r#"
+[agent]
+name = "batch-test"
+batch_tool_hint = true
+
+[stages.plan]
+mode = "autonomous"
+batch_tool_hint = false
+
+[stages.build]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        // Agent-level `[agent] batch_tool_hint` parsed.
+        assert_eq!(bp.batch_tool_hint, Some(true));
+        // Stage-level override opts this stage out.
+        assert_eq!(bp.find_stage("plan").unwrap().batch_tool_hint, Some(false));
+        // A stage with no override inherits (None).
+        assert_eq!(bp.find_stage("build").unwrap().batch_tool_hint, None);
+        // End-to-end cascade: plan resolves off, build inherits the agent's on.
+        assert!(!crate::taint::resolve_batch_tool_hint(
+            true,
+            bp.batch_tool_hint,
+            bp.find_stage("plan").unwrap().batch_tool_hint,
+        ));
+        assert!(crate::taint::resolve_batch_tool_hint(
+            true,
+            bp.batch_tool_hint,
+            bp.find_stage("build").unwrap().batch_tool_hint,
+        ));
+    }
+
+    #[test]
+    fn parse_manifest_no_batch_tool_hint_is_none() {
+        // No `batch_tool_hint` anywhere ⇒ both levels None ⇒ inherit global.
+        let toml = r#"
+[agent]
+name = "no-batch"
+
+[stages.main]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert_eq!(bp.batch_tool_hint, None);
+        assert_eq!(bp.find_stage("main").unwrap().batch_tool_hint, None);
     }
 
     #[test]

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -316,6 +316,15 @@ pub fn resolve_security(
     }
 }
 
+/// Resolve whether the batch-tool-calls system-prompt hint is enabled for a
+/// stage, cascading stage → agent → global. A `Some(_)` at a narrower level
+/// overrides broader levels; when neither the stage nor the agent sets it, the
+/// global toggle (on by default) applies. (Same shape as
+/// [`resolve_taint_enabled`], but the global default is on rather than off.)
+pub fn resolve_batch_tool_hint(global: bool, agent: Option<bool>, stage: Option<bool>) -> bool {
+    stage.or(agent).unwrap_or(global)
+}
+
 /// Result of a gate check — whether a tool invocation is allowed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GateDecision {
@@ -943,6 +952,19 @@ mod tests {
             Some(&sec(false)),
             Some(&sec(true))
         ));
+    }
+
+    #[test]
+    fn resolve_batch_tool_hint_cascade() {
+        // Nothing set at narrower levels → inherit the global toggle (on default).
+        assert!(resolve_batch_tool_hint(true, None, None));
+        assert!(!resolve_batch_tool_hint(false, None, None));
+        // Agent override beats global (both directions).
+        assert!(!resolve_batch_tool_hint(true, Some(false), None));
+        assert!(resolve_batch_tool_hint(false, Some(true), None));
+        // Stage override beats agent and global (both directions).
+        assert!(!resolve_batch_tool_hint(true, Some(true), Some(false)));
+        assert!(resolve_batch_tool_hint(false, Some(false), Some(true)));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -131,6 +131,11 @@ pub struct InferenceConfig {
     /// `frequency_penalty`). Passed through to the provider request so models can
     /// be tuned from the manifest. Empty when none are set.
     pub extra_params: serde_json::Map<String, serde_json::Value>,
+    /// Whether to prepend the batch-tool-calls hint to this stage's system
+    /// prompt. Resolved from the global config → agent → stage cascade at spawn
+    /// (see [`leviath_core::taint::resolve_batch_tool_hint`]); `false` by default
+    /// so an unset config is a no-op.
+    pub batch_tool_hint: bool,
 }
 
 /// Per-entity tool result routing configuration.

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -565,6 +565,7 @@ mod tests {
                 temperature: None,
                 max_output_tokens: None,
                 extra_params: Default::default(),
+                batch_tool_hint: false,
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -988,6 +988,7 @@ mod tests {
                 temperature: None,
                 max_output_tokens: None,
                 extra_params: Default::default(),
+                batch_tool_hint: false,
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -110,6 +110,18 @@ fn truncate_on_char_boundary(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
+/// The batch-tool-calls hint, prepended to a stage's system blocks when
+/// `InferenceConfig::batch_tool_hint` is set. Identical across every agent,
+/// stage, and run, so it is a stable cache prefix (`CacheHint::Always`). It tells
+/// the model it may emit several `tool_use` blocks per response and should batch
+/// *independent* operations — while explicitly forbidding batching of dependent
+/// ones. See issue #17.
+const BATCH_TOOL_HINT: &str = "You can call multiple tools in a single response. \
+When operations are independent (reading, editing, or writing different files, or \
+writing a file then running a command that doesn't need its output), batch them in \
+one response to cut round trips. Do NOT batch when a call depends on a previous \
+call's result, or when you must see a command's output before deciding the next step.";
+
 /// Build the [`InferenceRequest`] for an agent from its context window + stage
 /// data. Pure; no `.await`. (Ported from `AgentEngine::build_inference_request`,
 /// with provider resolution lifted into the caller so this stays query-friendly.)
@@ -150,8 +162,23 @@ fn build_request(
         _ => serde_json::Value::Null,
     };
 
+    // Prepend the batch-tool-calls hint as a stable, always-cacheable system
+    // block when this stage opts in. Prepending keeps it at the front of the
+    // `Always`-tier prefix (which `assemble` already sorts first), maximizing
+    // prefix-cache hits since the text never varies across agents/stages/runs.
+    let mut system = assembled.system_blocks;
+    if config.map(|c| c.batch_tool_hint).unwrap_or(false) {
+        system.insert(
+            0,
+            leviath_providers::SystemBlock {
+                text: BATCH_TOOL_HINT.to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+            },
+        );
+    }
+
     InferenceRequest {
-        system: assembled.system_blocks,
+        system,
         messages: assembled.messages,
         model: stage.model.clone(),
         max_tokens,
@@ -2335,7 +2362,11 @@ pub struct ResolvedStage {
 /// Build a stage's [`StageSetup`] from its blueprint definition: inference config
 /// (from the model parameters), tool-result routing, accepts-messages, layout,
 /// and system prompt.
-fn stage_setup_from(stage: &leviath_core::Stage) -> StageSetup {
+fn stage_setup_from(
+    stage: &leviath_core::Stage,
+    global_batch_tool_hint: bool,
+    agent_batch_tool_hint: Option<bool>,
+) -> StageSetup {
     let temperature = stage
         .model
         .parameters
@@ -2377,11 +2408,18 @@ fn stage_setup_from(stage: &leviath_core::Stage) -> StageSetup {
         }
         _ => base_prompt,
     };
+    // Cascade the batch-tool-hint toggle: stage > agent > global (default on).
+    let batch_tool_hint = leviath_core::taint::resolve_batch_tool_hint(
+        global_batch_tool_hint,
+        agent_batch_tool_hint,
+        stage.batch_tool_hint,
+    );
     StageSetup {
         inference_config: InferenceConfig {
             temperature,
             max_output_tokens,
             extra_params,
+            batch_tool_hint,
         },
         routing: stage.tool_result_routing.clone(),
         accepts_messages: stage.accepts_messages,
@@ -2399,12 +2437,17 @@ fn stage_setup_from(stage: &leviath_core::Stage) -> StageSetup {
 /// its region (the same hard failure the imperative loop raises at stage 0).
 ///
 /// `stages` must be aligned with `blueprint.stages` (one [`ResolvedStage`] each).
+///
+/// `global_batch_tool_hint` is the caller's global config toggle for the
+/// batch-tool-calls system-prompt hint; it is resolved per stage against the
+/// blueprint's agent-level and each stage's `batch_tool_hint`.
 pub fn spawn_agent(
     world: &mut World,
     agent_id: String,
     blueprint: leviath_core::Blueprint,
     task: &str,
     stages: Vec<ResolvedStage>,
+    global_batch_tool_hint: bool,
 ) -> Result<Entity, String> {
     let stage_infs: Vec<StageInference> = stages
         .into_iter()
@@ -2415,7 +2458,12 @@ pub fn spawn_agent(
             tool_filter: None, // tools already resolved to the effective set
         })
         .collect();
-    let setups: Vec<StageSetup> = blueprint.stages.iter().map(stage_setup_from).collect();
+    let agent_batch_tool_hint = blueprint.batch_tool_hint;
+    let setups: Vec<StageSetup> = blueprint
+        .stages
+        .iter()
+        .map(|s| stage_setup_from(s, global_batch_tool_hint, agent_batch_tool_hint))
+        .collect();
 
     // Seed the window from the blueprint layout + task, then apply stage 0's
     // context setup (layout swap + system-prompt injection) just as entering any
@@ -2901,6 +2949,7 @@ mod tests {
             temperature: Some(0.1),
             max_output_tokens: Some(42),
             extra_params: Default::default(),
+            batch_tool_hint: false,
         };
         let si = stage(
             "m",
@@ -2923,10 +2972,64 @@ mod tests {
             temperature: None,
             max_output_tokens: None,
             extra_params,
+            batch_tool_hint: false,
         };
         let si = stage("m", vec![], None);
         let req = build_request(&window(), Some(&cfg), &si, &provider(true, 500));
         assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
+    }
+
+    /// A window whose pinned region carries a real entry, so `assemble` yields a
+    /// non-empty `system` — required for the batch-hint tests to actually iterate
+    /// the assembled blocks (an empty `system` would skip every closure).
+    fn window_with_sys() -> ContextWindow {
+        let mut w = window();
+        w.add_to_region("sys", "base system instructions".to_string(), 6)
+            .expect("seed pinned region");
+        w
+    }
+
+    #[test]
+    fn build_request_prepends_batch_hint_when_enabled() {
+        let cfg = InferenceConfig {
+            temperature: None,
+            max_output_tokens: None,
+            extra_params: Default::default(),
+            batch_tool_hint: true,
+        };
+        let si = stage("m", vec![], None);
+        let req = build_request(&window_with_sys(), Some(&cfg), &si, &provider(true, 500));
+        // The hint is prepended ahead of the stage's own system block(s).
+        assert_eq!(
+            req.system.first().map(|b| b.text.as_str()),
+            Some(BATCH_TOOL_HINT)
+        );
+        assert_eq!(req.system[0].cache_hint, leviath_core::CacheHint::Always);
+        assert!(
+            req.system[1..]
+                .iter()
+                .any(|b| b.text.contains("base system")),
+            "the stage's own system block is preserved after the hint"
+        );
+    }
+
+    #[test]
+    fn build_request_omits_batch_hint_when_disabled_or_absent() {
+        let si = stage("m", vec![], None);
+        // Disabled via config.
+        let cfg = InferenceConfig {
+            temperature: None,
+            max_output_tokens: None,
+            extra_params: Default::default(),
+            batch_tool_hint: false,
+        };
+        let req = build_request(&window_with_sys(), Some(&cfg), &si, &provider(true, 500));
+        assert!(!req.system.is_empty());
+        assert!(req.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
+        // Absent config → no hint.
+        let req_none = build_request(&window_with_sys(), None, &si, &provider(true, 500));
+        assert!(!req_none.system.is_empty());
+        assert!(req_none.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
     }
 
     #[test]
@@ -3569,6 +3672,7 @@ mod tests {
             bp,
             "task",
             vec![resolved("m"), resolved("m")],
+            true,
         )
         .expect("spawn");
         let led = world.get::<StageLedger>(e).expect("ledger seeded");
@@ -4788,6 +4892,7 @@ mod tests {
                 temperature: None,
                 max_output_tokens: None,
                 extra_params: Default::default(),
+                batch_tool_hint: false,
             },
             routing: None,
             accepts_messages: true,
@@ -5095,6 +5200,7 @@ mod tests {
             temperature: Some(0.3),
             max_output_tokens: Some(99),
             extra_params: Default::default(),
+            batch_tool_hint: false,
         };
         s.accepts_messages = false;
         let mut world = World::new();
@@ -5282,6 +5388,7 @@ mod tests {
             bp,
             "the task",
             vec![resolved("m")],
+            true,
         )
         .unwrap();
 
@@ -5322,7 +5429,15 @@ mod tests {
         // routing component.
         let bp = blueprint(vec![stage_named("only", None, false, None)]);
         let mut world = World::new();
-        let e = spawn_agent(&mut world, "a".to_string(), bp, "t", vec![resolved("m")]).unwrap();
+        let e = spawn_agent(
+            &mut world,
+            "a".to_string(),
+            bp,
+            "t",
+            vec![resolved("m")],
+            true,
+        )
+        .unwrap();
 
         let cfg = world.get::<InferenceConfig>(e).unwrap();
         assert_eq!(cfg.temperature, None);
@@ -5356,21 +5471,21 @@ mod tests {
             "system_prompt".to_string(),
             serde_json::Value::String("base instructions".to_string()),
         );
-        let sp = stage_setup_from(&s).system_prompt.unwrap();
+        let sp = stage_setup_from(&s, true, None).system_prompt.unwrap();
         assert!(sp.contains("base instructions") && sp.contains("SPLIT NOW"));
 
         // Fan-out stage with no base prompt: the split prompt alone.
         let mut s2 = stage_named("fan", None, false, None);
         s2.mode = fanout("ONLY SPLIT");
         assert_eq!(
-            stage_setup_from(&s2).system_prompt,
+            stage_setup_from(&s2, true, None).system_prompt,
             Some("ONLY SPLIT".to_string())
         );
 
         // Fan-out stage with an empty split prompt: base prompt is left as-is.
         let mut s3 = stage_named("fan", None, false, None);
         s3.mode = fanout("   ");
-        assert_eq!(stage_setup_from(&s3).system_prompt, None);
+        assert_eq!(stage_setup_from(&s3, true, None).system_prompt, None);
     }
 
     #[test]
@@ -5391,7 +5506,7 @@ mod tests {
             .parameters
             .insert("seed".to_string(), serde_json::json!(11));
 
-        let setup = stage_setup_from(&s);
+        let setup = stage_setup_from(&s, true, None);
         assert_eq!(setup.inference_config.temperature, Some(0.3));
         assert_eq!(setup.inference_config.max_output_tokens, Some(256));
         let extra = &setup.inference_config.extra_params;
@@ -5422,7 +5537,14 @@ mod tests {
         let bp = leviath_core::Blueprint::new("t".to_string(), "d".to_string(), vec![s], layout);
 
         let mut world = World::new();
-        let err = spawn_agent(&mut world, "a".to_string(), bp, "t", vec![resolved("m")]);
+        let err = spawn_agent(
+            &mut world,
+            "a".to_string(),
+            bp,
+            "t",
+            vec![resolved("m")],
+            true,
+        );
         assert!(err.is_err());
     }
 

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -111,6 +111,7 @@ mod tests {
                 temperature: temp,
                 max_output_tokens: None,
                 extra_params: Default::default(),
+                batch_tool_hint: false,
             },
             routing: None,
             accepts_messages: true,

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -243,8 +243,16 @@ impl PipelineWorld {
         blueprint: leviath_core::Blueprint,
         task: &str,
         stages: Vec<crate::pipeline::ResolvedStage>,
+        global_batch_tool_hint: bool,
     ) -> Result<Entity, String> {
-        let e = crate::pipeline::spawn_agent(&mut self.world, agent_id, blueprint, task, stages)?;
+        let e = crate::pipeline::spawn_agent(
+            &mut self.world,
+            agent_id,
+            blueprint,
+            task,
+            stages,
+            global_batch_tool_hint,
+        )?;
         self.wake.notify_one();
         Ok(e)
     }
@@ -427,6 +435,16 @@ fn run_isolated(schedule: &mut Schedule, world: &mut World) -> bool {
 mod tests {
     use super::*;
 
+    /// Serializes the two tests that swap the **process-global** panic hook
+    /// (`run_isolated_catches_a_system_panic` and
+    /// `run_to_fixed_point_survives_a_panicking_system`). Without this, they can
+    /// interleave under the parallel test runner: one test's `set_hook` replaces
+    /// the other's silencing closure before the other's panic fires, so that
+    /// closure never runs and shows as uncovered. Holding this lock across each
+    /// test's set-hook → panic → restore-hook sequence keeps each hook active for
+    /// its own panic. (The guard is only ever held across synchronous work.)
+    static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn run_isolated_catches_a_system_panic() {
         fn ok_system() {}
@@ -443,6 +461,7 @@ mod tests {
         // A panicking system is caught (the daemon would survive).
         let mut bad = Schedule::default();
         bad.add_systems(boom_system);
+        let _hook_guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
         let prev_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {})); // silence the expected panic
         let survived = run_isolated(&mut bad, &mut world);
@@ -574,6 +593,7 @@ mod tests {
                 temperature: None,
                 max_output_tokens: None,
                 extra_params: Default::default(),
+                batch_tool_hint: false,
             },
             routing: None,
             accepts_messages: true,
@@ -637,6 +657,7 @@ mod tests {
         }
         let mut world = build_world(ProviderRegistry::new());
         world.add_test_system(boom_system);
+        let _hook_guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
         let prev_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
         world.run_to_fixed_point(); // returns (breaks on the caught panic)
@@ -891,6 +912,7 @@ mod tests {
                     model: "m".to_string(),
                     tools: vec![],
                 }],
+                true,
             )
             .unwrap();
 
@@ -999,6 +1021,7 @@ mod tests {
                 model: "m".to_string(),
                 tools: vec![],
             }],
+            true,
         );
         assert!(err.is_err());
     }


### PR DESCRIPTION
## Summary

Closes #17. Encourages the model to emit several `tool_use` blocks per response, batching **independent** operations to cut API round trips. Leviath's dispatch path already handles N tool calls per response with per-call error isolation, so this is a prompt-engineering change plus a small config surface — no changes to how tool calls are executed.

## Design

- **Default ON** (opt-out), with a full **global → agent → stage** cascade resolved by `resolve_batch_tool_hint` (mirrors the existing `resolve_taint_enabled`).
- **Injected as a prepended `SystemBlock { cache_hint: Always }` in `build_request`**, not folded into a context region. This is budget-safe (can't overflow a tight pinned region and hard-fail spawn) and forms a stable cache prefix that folds into the existing `Always`-tier run — no extra Anthropic cache breakpoint (respects the issue #12 ≤4 limit).
- Carried on `InferenceConfig.batch_tool_hint`, resolved once per stage in `stage_setup_from`; the global flag threads through `build_agent`, so every spawn path (initial, fan-out workers, reload) inherits it.

## Config surfaces

| Level | Field | Source |
|---|---|---|
| Global | `Config.batch_tool_hint` (default `true`) | `~/.leviath/config.toml` |
| Agent | `Blueprint.batch_tool_hint: Option<bool>` | `[agent] batch_tool_hint` |
| Stage | `Stage.batch_tool_hint: Option<bool>` | `[stages.<name>] batch_tool_hint` |

Most-specific wins; unset inherits the broader level.

## Note on the issue text

The issue referenced `worker.rs` / `foreground.rs::dispatch_tool_calls`; those were removed when the imperative loop became the ECS pipeline. The work maps to `pipeline.rs` (`build_request`, `stage_setup_from`) and `tool_service.rs::dispatch_tools`.

## Testing

- **Unit**: cascade resolver (stage>agent>global, both directions); `build_request` present-when-enabled / absent-when-disabled-or-unset; manifest round-trip for both levels + end-to-end cascade.
- **Full workspace suite green** (`cargo test --workspace`), fmt + clippy clean (pre-commit hooks pass).
- **Live end-to-end** (real Anthropic Sonnet, daemon path): the default agent resolves `batch_tool_hint=true` at `build_request` and the model batches multiple `write_file` calls into a single response (task completed in 2 iterations); a per-stage `batch_tool_hint = false` correctly propagated `false` through the full spawn chain live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePn3YeAKqwvmPLRBWnPtT