### PR TITLE
feat(sandbox): sandboxed tool execution via container/namespace isolation (closes #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ A deterministic sensitivity model (Public / Internal / Private) tags every conte
 
 </td>
 </tr>
+<tr>
+<td width="33%" valign="top">
+
+**📦 Sandboxed Tool Execution**
+
+By default an agent's shell commands run **directly on your machine** — no runtime, nothing to install. Opt in per agent *or* per stage to route them into an isolated environment instead: a **container** (Docker, Podman, or any Docker-CLI-compatible engine — Leviath isn't prescriptive) or a fresh set of Linux **namespaces** (no runtime needed). Run analysis on the host and implementation in a networkless container. The daemon creates a warm container per agent and tears it down at reap, so no orphans; file tools keep working over the bind-mounted workdir.
+
+```toml
+[sandbox]
+kind = "container"   # none (default) | namespace | container
+image = "ubuntu:24.04"
+# engine = "podman"  # optional; auto-detects docker/podman when omitted
+
+[stages.implement.sandbox]
+kind = "container"
+image = "node:22-slim"
+network = false      # isolate this stage
+```
+
+</td>
+</tr>
 </table>
 
 ## 📊 Benchmarks

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -108,6 +108,13 @@ pub struct Config {
     /// Completion-webhook delivery tuning (retry/backoff/timeout).
     #[serde(default)]
     pub webhook: WebhookConfig,
+
+    /// Machine-wide default sandbox for tool execution. An agent's own
+    /// `[sandbox]` (or a stage's) overrides this; when unset, agents run tools
+    /// on the host unless they opt in themselves. See
+    /// [`leviath_core::resolve_sandbox`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<leviath_core::ToolSandboxConfig>,
 }
 
 fn default_true() -> bool {
@@ -279,6 +286,7 @@ impl Default for Config {
             limits: LimitsConfig::default(),
             batch_tool_hint: true,
             webhook: WebhookConfig::default(),
+            sandbox: None,
         }
     }
 }
@@ -1779,6 +1787,12 @@ anthropic_api_key = "sk-ant-test-key"
                 max_delay_ms: 10_000,
                 timeout_secs: 7,
             },
+            sandbox: Some(leviath_core::ToolSandboxConfig {
+                kind: leviath_core::SandboxKind::Container,
+                image: Some("ubuntu:24.04".to_string()),
+                network: false,
+                ..Default::default()
+            }),
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();
@@ -1803,6 +1817,10 @@ anthropic_api_key = "sk-ant-test-key"
         );
         assert!(!deserialized.title.enabled);
         assert_eq!(deserialized.title.provider.as_deref(), Some("openai"));
+        let sandbox = deserialized.sandbox.expect("sandbox round-trips");
+        assert_eq!(sandbox.kind, leviath_core::SandboxKind::Container);
+        assert_eq!(sandbox.image.as_deref(), Some("ubuntu:24.04"));
+        assert!(!sandbox.network);
     }
 
     // ─── Config with multiple model_capabilities ─────────────────────────

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -8,6 +8,7 @@ pub mod client;
 pub mod fanout_spawner;
 pub mod gate_rules;
 pub mod recovery;
+pub mod sandbox_manager;
 pub mod setup;
 pub mod spawn;
 pub mod subagent;

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -1,0 +1,741 @@
+//! Per-agent sandbox lifecycle and shell-command routing.
+//!
+//! A [`SandboxManager`] owns every sandbox an agent needs: it creates the
+//! containers its stages call for **eagerly at spawn** (blocking `docker run`,
+//! keyed and deduplicated by config signature so identical configs across stages
+//! share one warm container), routes each shell call to the *current* stage's
+//! sandbox, and tears every container down at reap. `namespace` and `none` kinds
+//! need no persistent state — they are pure per-exec command wrapping.
+//!
+//! It implements [`leviath_tools::ShellExecutor`], so the built-in shell tool
+//! runs its command inside the sandbox transparently; file tools stay on the
+//! host over the bind-mounted workdir. The create/dedup/error logic is factored
+//! behind an injected command-runner (`build_with`) so it is unit-testable
+//! with no container runtime installed.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::process::Command as StdCommand;
+use std::sync::Mutex as StdMutex;
+
+use leviath_core::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
+use leviath_sys::ContainerRunSpec;
+use leviath_tools::ShellExecutor;
+use tokio::process::Command as TokioCommand;
+
+/// POSIX shell used *inside* a container. Every image ships `/bin/sh`, whereas
+/// the host's detected shell (e.g. `/bin/zsh` on macOS) generally isn't present
+/// in the image — so container exec must use its own shell, not the host's.
+const CONTAINER_SHELL: &str = "sh";
+const CONTAINER_SHELL_FLAG: &str = "-c";
+
+/// Runs a sandbox lifecycle command (`docker run` / `docker rm`), returning the
+/// stderr text on failure. Injected so [`SandboxManager::build_with`] is testable
+/// without a real runtime.
+type CmdRunner<'a> = dyn Fn(&[String]) -> Result<(), String> + 'a;
+
+/// A container we started and are responsible for removing.
+#[derive(Debug, Clone)]
+struct LiveContainer {
+    /// The engine binary that started it (so teardown uses the same one).
+    engine: String,
+    name: String,
+}
+
+/// Owns an agent's sandboxes for its whole lifetime. Created at spawn, updated
+/// per stage via [`Self::set_stage`], torn down at reap via [`Self::destroy_all`].
+#[derive(Debug)]
+pub struct SandboxManager {
+    /// Live containers keyed by config signature; immutable after construction.
+    containers: HashMap<u64, LiveContainer>,
+    /// Per-stage-index resolved sandbox config; immutable after construction.
+    by_index: Vec<ToolSandboxConfig>,
+    /// Whether Linux namespaces are usable on this host — captured at build so
+    /// `build_command` (the `ShellExecutor` hot path) doesn't re-probe and both
+    /// its namespace arms are reachable regardless of the test platform.
+    namespace_ok: bool,
+    /// The current stage's config — the only mutable state, swapped on stage
+    /// change (the manager lives behind an `Arc`, so interior mutability).
+    current: StdMutex<ToolSandboxConfig>,
+}
+
+/// Signature identifying a distinct container: same engine + image + network +
+/// mounts → one shared warm container. (Deterministic within a process —
+/// `DefaultHasher` uses fixed keys.)
+fn signature(cfg: &ToolSandboxConfig) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    cfg.engine.hash(&mut h);
+    cfg.image.hash(&mut h);
+    cfg.network.hash(&mut h);
+    cfg.mounts.hash(&mut h);
+    h.finish()
+}
+
+/// Reduce a run id to a Docker-safe name fragment (`[a-zA-Z0-9_.-]`).
+fn sanitize(run_id: &str) -> String {
+    run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Build the host shell command (no sandbox) — the exact prior behavior.
+fn host_command(shell: &str, flag: &str, command: &str, workdir: &Path) -> TokioCommand {
+    let mut c = TokioCommand::new(shell);
+    c.arg(flag).arg(command).current_dir(workdir);
+    c
+}
+
+impl SandboxManager {
+    /// Build the manager for an agent whose stages resolve (in order) to
+    /// `by_index`, bind-mounting `workdir`. `entry_index` selects the initial
+    /// stage's config. Returns `Ok(None)` when nothing is sandboxed (the common
+    /// case — the caller then attaches no executor and shell runs on the host).
+    /// Returns `Err` when a required runtime is unavailable and that config's
+    /// `on_unavailable` is `Error`.
+    pub fn build(
+        run_id: &str,
+        by_index: Vec<ToolSandboxConfig>,
+        workdir: &str,
+        entry_index: usize,
+    ) -> Result<Option<Self>, String> {
+        // Auto-detected default engine, used only when a container config doesn't
+        // name its own. Detection runs only if some stage actually needs a
+        // container.
+        let needs_container = by_index.iter().any(|c| c.kind == SandboxKind::Container);
+        let detected = needs_container
+            .then(leviath_sys::detect_container_engine)
+            .flatten();
+        let namespace_ok = leviath_sys::namespace_supported();
+        Self::build_with(
+            run_id,
+            by_index,
+            workdir,
+            entry_index,
+            detected,
+            namespace_ok,
+            &real_run,
+        )
+    }
+
+    /// Testable core of [`Self::build`]: `detected` is the auto-detected engine
+    /// (a config's own `engine` overrides it), `namespace_ok` reports namespace
+    /// availability, and `run` executes the lifecycle commands.
+    fn build_with(
+        run_id: &str,
+        by_index: Vec<ToolSandboxConfig>,
+        workdir: &str,
+        entry_index: usize,
+        detected: Option<String>,
+        namespace_ok: bool,
+        run: &CmdRunner,
+    ) -> Result<Option<Self>, String> {
+        // Fast path: no stage isolates anything → no executor, zero overhead.
+        if by_index.iter().all(|c| !c.is_active()) {
+            return Ok(None);
+        }
+
+        let mut containers: HashMap<u64, LiveContainer> = HashMap::new();
+        for cfg in &by_index {
+            match cfg.kind {
+                SandboxKind::None => {}
+                SandboxKind::Namespace => {
+                    if !namespace_ok {
+                        unavailable(
+                            cfg,
+                            "namespace sandbox requires Linux (unshare); this host lacks it",
+                            &containers,
+                            run,
+                        )?;
+                    }
+                }
+                SandboxKind::Container => {
+                    let sig = signature(cfg);
+                    if containers.contains_key(&sig) {
+                        continue; // identical config already has a warm container
+                    }
+                    // The config's own `engine` wins; else the auto-detected one.
+                    let Some(engine) = cfg.engine.clone().or_else(|| detected.clone()) else {
+                        unavailable(
+                            cfg,
+                            "no container engine found — install docker or podman, \
+                             or set `engine` in [sandbox]",
+                            &containers,
+                            run,
+                        )?;
+                        continue;
+                    };
+                    let Some(image) = cfg.image.as_deref() else {
+                        unavailable(
+                            cfg,
+                            "container sandbox requires an `image`",
+                            &containers,
+                            run,
+                        )?;
+                        continue;
+                    };
+                    let name = format!("leviath-{}-{:016x}", sanitize(run_id), sig);
+                    let spec = ContainerRunSpec {
+                        engine: &engine,
+                        image,
+                        workdir,
+                        network: cfg.network,
+                        mounts: &cfg.mounts,
+                        name: &name,
+                    };
+                    match run(&leviath_sys::container_run_argv(&spec)) {
+                        Ok(()) => {
+                            containers.insert(sig, LiveContainer { engine, name });
+                        }
+                        Err(stderr) => {
+                            let msg = format!(
+                                "failed to start container '{image}' via '{engine}': {stderr}"
+                            );
+                            unavailable(cfg, &msg, &containers, run)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        let current = by_index.get(entry_index).cloned().unwrap_or_default();
+        Ok(Some(Self {
+            containers,
+            by_index,
+            namespace_ok,
+            current: StdMutex::new(current),
+        }))
+    }
+
+    /// Point the shell tool at the sandbox for stage `index` (called by the tool
+    /// service's `sync_stage` on every stage change).
+    pub fn set_stage(&self, index: usize) {
+        if let Some(cfg) = self.by_index.get(index) {
+            *self.current.lock().unwrap() = cfg.clone();
+        }
+    }
+
+    /// Force-remove every container this manager started (best-effort). Called
+    /// once, at reap, before the agent entity is despawned.
+    pub fn destroy_all(&self) {
+        self.destroy_with(&real_run);
+    }
+
+    /// Testable core of [`Self::destroy_all`].
+    fn destroy_with(&self, run: &CmdRunner) {
+        for c in self.containers.values() {
+            let _ = run(&leviath_sys::container_rm_argv(&c.engine, &c.name));
+        }
+    }
+}
+
+/// Apply a config's `on_unavailable` policy: `Error` fails the build (after
+/// tearing down anything already created so no container leaks); `Warn` logs and
+/// lets the caller fall back to host execution.
+fn unavailable(
+    cfg: &ToolSandboxConfig,
+    reason: &str,
+    created: &HashMap<u64, LiveContainer>,
+    run: &CmdRunner,
+) -> Result<(), String> {
+    match cfg.on_unavailable {
+        OnUnavailable::Error => {
+            for c in created.values() {
+                let _ = run(&leviath_sys::container_rm_argv(&c.engine, &c.name));
+            }
+            Err(format!("sandbox unavailable: {reason}"))
+        }
+        OnUnavailable::Warn => {
+            tracing::warn!("sandbox unavailable ({reason}); falling back to host execution");
+            Ok(())
+        }
+    }
+}
+
+/// Real lifecycle-command runner: spawn synchronously, map a non-zero exit to
+/// its stderr.
+fn real_run(argv: &[String]) -> Result<(), String> {
+    let output = StdCommand::new(&argv[0])
+        .args(&argv[1..])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+impl ShellExecutor for SandboxManager {
+    fn build_command(
+        &self,
+        shell: &str,
+        flag: &str,
+        command: &str,
+        workdir: &Path,
+    ) -> TokioCommand {
+        let cfg = self.current.lock().unwrap().clone();
+        match cfg.kind {
+            SandboxKind::None => host_command(shell, flag, command, workdir),
+            SandboxKind::Namespace => {
+                if self.namespace_ok {
+                    let argv = leviath_sys::namespace_argv(shell, flag, command, cfg.network);
+                    let mut c = TokioCommand::new(&argv[0]);
+                    c.args(&argv[1..]).current_dir(workdir);
+                    c
+                } else {
+                    // Warn-fallback build kept the manager alive without a usable
+                    // namespace; run on the host.
+                    host_command(shell, flag, command, workdir)
+                }
+            }
+            SandboxKind::Container => match self.containers.get(&signature(&cfg)) {
+                Some(lc) => {
+                    let wd = workdir.to_string_lossy();
+                    // Use the container's own shell (`sh`), not the host-detected
+                    // one whose absolute path may not exist in the image.
+                    let argv = leviath_sys::container_exec_argv(
+                        &lc.engine,
+                        &lc.name,
+                        &wd,
+                        CONTAINER_SHELL,
+                        CONTAINER_SHELL_FLAG,
+                        command,
+                    );
+                    let mut c = TokioCommand::new(&argv[0]);
+                    c.args(&argv[1..]);
+                    c
+                }
+                // Warn-fallback: the container was never created; run on the host.
+                None => host_command(shell, flag, command, workdir),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn container_cfg(
+        image: &str,
+        network: bool,
+        on_unavailable: OnUnavailable,
+    ) -> ToolSandboxConfig {
+        ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: Some(image.to_string()),
+            network,
+            on_unavailable,
+            ..Default::default()
+        }
+    }
+
+    fn ns_cfg(on_unavailable: OnUnavailable) -> ToolSandboxConfig {
+        ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            on_unavailable,
+            ..Default::default()
+        }
+    }
+
+    /// A runner that records every argv it was asked to run and always succeeds.
+    fn recording_runner(
+        log: &std::sync::Mutex<Vec<Vec<String>>>,
+    ) -> impl Fn(&[String]) -> Result<(), String> + '_ {
+        move |argv| {
+            log.lock().unwrap().push(argv.to_vec());
+            Ok(())
+        }
+    }
+
+    /// A no-op runner that always succeeds. Shared (rather than inline closures)
+    /// so a single instantiation is covered by the tests that actually invoke it.
+    fn ok_runner(_argv: &[String]) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[test]
+    fn all_host_yields_no_manager() {
+        let by_index = vec![ToolSandboxConfig::default(), ToolSandboxConfig::default()];
+        let m = SandboxManager::build_with("run1", by_index, "/work", 0, None, true, &ok_runner)
+            .unwrap();
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn config_engine_overrides_autodetect() {
+        // Non-prescriptive: a config naming its own engine uses that binary even
+        // when nothing is auto-detected (`detected = None`).
+        let log = std::sync::Mutex::new(Vec::new());
+        let cfg = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: Some("alpine".to_string()),
+            engine: Some("nerdctl".to_string()),
+            on_unavailable: OnUnavailable::Error,
+            ..Default::default()
+        };
+        let m = SandboxManager::build_with(
+            "r",
+            vec![cfg],
+            "/w",
+            0,
+            None, // no engine auto-detected
+            true,
+            &recording_runner(&log),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(log.lock().unwrap()[0][0], "nerdctl");
+        assert_eq!(m.containers.values().next().unwrap().engine, "nerdctl");
+    }
+
+    #[test]
+    fn dedups_identical_container_configs() {
+        let log = std::sync::Mutex::new(Vec::new());
+        let cfg = container_cfg("ubuntu:24.04", true, OnUnavailable::Error);
+        let by_index = vec![cfg.clone(), cfg.clone(), cfg];
+        let m = SandboxManager::build_with(
+            "run-1",
+            by_index,
+            "/work",
+            0,
+            Some("docker".to_string()),
+            true,
+            &recording_runner(&log),
+        )
+        .unwrap()
+        .unwrap();
+        // Three identical stages → one container created.
+        assert_eq!(log.lock().unwrap().len(), 1);
+        assert_eq!(m.containers.len(), 1);
+        let argv = &log.lock().unwrap()[0];
+        assert_eq!(argv[0], "docker");
+        assert!(argv.contains(&"ubuntu:24.04".to_string()));
+    }
+
+    #[test]
+    fn distinct_container_configs_each_get_a_container() {
+        // Uses `ok_runner` (invoked twice here), which also covers the shared
+        // no-op runner referenced by the never-invoking error/host tests.
+        let by_index = vec![
+            container_cfg("ubuntu:24.04", true, OnUnavailable::Error),
+            container_cfg("node:22-slim", false, OnUnavailable::Error),
+        ];
+        let m = SandboxManager::build_with(
+            "r",
+            by_index,
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &ok_runner,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(m.containers.len(), 2);
+    }
+
+    #[test]
+    fn missing_engine_errors_by_default() {
+        let by_index = vec![container_cfg("ubuntu:24.04", true, OnUnavailable::Error)];
+        let err =
+            SandboxManager::build_with("r", by_index, "/w", 0, None, true, &ok_runner).unwrap_err();
+        assert!(err.contains("no container engine"));
+    }
+
+    #[test]
+    fn missing_engine_warns_and_falls_back() {
+        let by_index = vec![container_cfg("ubuntu:24.04", true, OnUnavailable::Warn)];
+        let m = SandboxManager::build_with("r", by_index, "/w", 0, None, true, &ok_runner)
+            .unwrap()
+            .unwrap();
+        // No container created; build_command falls back to host.
+        assert!(m.containers.is_empty());
+        let cmd = m.build_command("sh", "-c", "echo hi", Path::new("/w"));
+        assert_eq!(cmd.as_std().get_program(), "sh");
+    }
+
+    #[test]
+    fn container_without_image_errors() {
+        let cfg = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: None,
+            on_unavailable: OnUnavailable::Error,
+            ..Default::default()
+        };
+        let err = SandboxManager::build_with(
+            "r",
+            vec![cfg],
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &ok_runner,
+        )
+        .unwrap_err();
+        assert!(err.contains("requires an `image`"), "got: {err}");
+    }
+
+    #[test]
+    fn container_without_image_warns_and_skips() {
+        // Warn variant: the missing-image config is skipped (the `continue`
+        // after the warn) and the manager is still built with no container.
+        let cfg = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: None,
+            on_unavailable: OnUnavailable::Warn,
+            ..Default::default()
+        };
+        let m = SandboxManager::build_with(
+            "r",
+            vec![cfg],
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &ok_runner,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(m.containers.is_empty());
+    }
+
+    #[test]
+    fn build_command_host_arm_when_current_stage_is_none() {
+        // Entry stage is host (None) while a later stage is sandboxed → the
+        // manager exists, and build_command on the host stage runs on the host.
+        let by_index = vec![
+            ToolSandboxConfig::default(),
+            container_cfg("ubuntu:24.04", true, OnUnavailable::Warn),
+        ];
+        let m = SandboxManager::build_with("r", by_index, "/w", 0, None, true, &ok_runner)
+            .unwrap()
+            .unwrap();
+        let cmd = m.build_command("zsh", "-c", "echo hi", Path::new("/w"));
+        assert_eq!(cmd.as_std().get_program(), "zsh");
+    }
+
+    #[test]
+    fn container_start_failure_errors() {
+        let by_index = vec![container_cfg("bad:image", true, OnUnavailable::Error)];
+        let err = SandboxManager::build_with(
+            "r",
+            by_index,
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &|_| Err("no such image".to_string()),
+        )
+        .unwrap_err();
+        assert!(err.contains("failed to start container"));
+        assert!(err.contains("no such image"));
+    }
+
+    #[test]
+    fn error_teardown_removes_already_created_containers() {
+        // First stage's container starts fine; second fails → the first must be
+        // torn down (a `rm` appears in the log) before the error propagates.
+        let log = std::sync::Mutex::new(Vec::<Vec<String>>::new());
+        let run = |argv: &[String]| -> Result<(), String> {
+            log.lock().unwrap().push(argv.to_vec());
+            // Fail only the second image's run.
+            if argv.contains(&"node:22-slim".to_string()) {
+                Err("boom".to_string())
+            } else {
+                Ok(())
+            }
+        };
+        let by_index = vec![
+            container_cfg("ubuntu:24.04", true, OnUnavailable::Error),
+            container_cfg("node:22-slim", true, OnUnavailable::Error),
+        ];
+        let err = SandboxManager::build_with(
+            "r",
+            by_index,
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &run,
+        )
+        .unwrap_err();
+        assert!(err.contains("failed to start container"));
+        let calls = log.lock().unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.first().map(String::as_str) == Some("docker")
+                    && c.contains(&"rm".to_string()))
+        );
+    }
+
+    #[test]
+    fn namespace_unavailable_errors_by_default() {
+        let by_index = vec![ns_cfg(OnUnavailable::Error)];
+        let err = SandboxManager::build_with("r", by_index, "/w", 0, None, false, &ok_runner)
+            .unwrap_err();
+        assert!(err.contains("namespace"));
+    }
+
+    #[test]
+    fn namespace_unavailable_warns_and_falls_back() {
+        let by_index = vec![ns_cfg(OnUnavailable::Warn)];
+        let m = SandboxManager::build_with("r", by_index, "/w", 0, None, false, &ok_runner)
+            .unwrap()
+            .unwrap();
+        let cmd = m.build_command("sh", "-c", "echo hi", Path::new("/w"));
+        assert_eq!(cmd.as_std().get_program(), "sh");
+    }
+
+    #[test]
+    fn set_stage_switches_current_config() {
+        let by_index = vec![
+            ToolSandboxConfig::default(), // stage 0: host
+            container_cfg("ubuntu:24.04", true, OnUnavailable::Warn), // stage 1: container
+        ];
+        // Warn so no engine needed; stage 1's container just won't exist → host.
+        let m = SandboxManager::build_with("r", by_index, "/w", 0, None, true, &ok_runner)
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.current.lock().unwrap().kind, SandboxKind::None);
+        m.set_stage(1);
+        assert_eq!(m.current.lock().unwrap().kind, SandboxKind::Container);
+        m.set_stage(99); // out of range: no-op, no panic
+        assert_eq!(m.current.lock().unwrap().kind, SandboxKind::Container);
+    }
+
+    #[test]
+    fn build_command_container_uses_docker_exec() {
+        let log = std::sync::Mutex::new(Vec::new());
+        let by_index = vec![container_cfg("ubuntu:24.04", true, OnUnavailable::Error)];
+        let m = SandboxManager::build_with(
+            "r",
+            by_index,
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &recording_runner(&log),
+        )
+        .unwrap()
+        .unwrap();
+        let cmd = m.build_command("sh", "-c", "ls", Path::new("/w"));
+        assert_eq!(cmd.as_std().get_program(), "docker");
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(args[0], "exec");
+        assert!(args.contains(&"ls".to_string()));
+    }
+
+    #[test]
+    fn build_command_namespace_uses_unshare_when_supported() {
+        // `namespace_ok = true` is injected, so this exercises the `unshare` arm
+        // on any platform (the manager captured the flag at build time).
+        let by_index = vec![ns_cfg(OnUnavailable::Error)];
+        let m = SandboxManager::build_with("r", by_index, "/w", 0, None, true, &ok_runner)
+            .unwrap()
+            .unwrap();
+        let cmd = m.build_command("sh", "-c", "whoami", Path::new("/w"));
+        assert_eq!(cmd.as_std().get_program(), "unshare");
+    }
+
+    #[test]
+    fn destroy_all_removes_every_container() {
+        let log = std::sync::Mutex::new(Vec::new());
+        let by_index = vec![
+            container_cfg("ubuntu:24.04", true, OnUnavailable::Error),
+            container_cfg("node:22-slim", true, OnUnavailable::Error),
+        ];
+        let m = SandboxManager::build_with(
+            "r",
+            by_index,
+            "/w",
+            0,
+            Some("docker".to_string()),
+            true,
+            &recording_runner(&log),
+        )
+        .unwrap()
+        .unwrap();
+        let rm_log = std::sync::Mutex::new(Vec::new());
+        m.destroy_with(&recording_runner(&rm_log));
+        let calls = rm_log.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|c| c.contains(&"rm".to_string())));
+    }
+
+    #[test]
+    fn sanitize_replaces_unsafe_chars() {
+        assert_eq!(sanitize("abc-123_x.y"), "abc-123_x-y");
+        assert_eq!(sanitize("a/b:c d"), "a-b-c-d");
+    }
+
+    #[test]
+    fn destroy_all_with_no_containers_is_a_noop() {
+        // A namespace manager has no containers; destroy_all must run cleanly
+        // (covers the real-runner entry point without invoking an engine).
+        let m = SandboxManager::build_with(
+            "r",
+            vec![ns_cfg(OnUnavailable::Warn)],
+            "/w",
+            0,
+            None,
+            false,
+            &ok_runner,
+        )
+        .unwrap()
+        .unwrap();
+        m.destroy_all();
+        assert!(m.containers.is_empty());
+    }
+
+    // `real_run` actually spawns a process, so its three arms are covered with
+    // trivial host commands. Split per-platform because there is no portable
+    // shell/no-op binary (mirrors why `format_command_output` was split out).
+    #[cfg(unix)]
+    #[test]
+    fn real_run_success_nonzero_and_spawn_error_unix() {
+        assert!(real_run(&["true".to_string()]).is_ok());
+        let err = real_run(&[
+            "sh".to_string(),
+            "-c".to_string(),
+            "echo boom 1>&2; exit 1".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("boom"), "stderr should surface: {err}");
+        assert!(real_run(&["leviath-no-such-binary-xyz".to_string()]).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn real_run_success_nonzero_and_spawn_error_windows() {
+        assert!(real_run(&["cmd".to_string(), "/C".to_string(), "exit 0".to_string()]).is_ok());
+        assert!(real_run(&["cmd".to_string(), "/C".to_string(), "exit 1".to_string()]).is_err());
+        assert!(real_run(&["leviath-no-such-binary-xyz".to_string()]).is_err());
+    }
+
+    // Live end-to-end verification against a real container engine is not a
+    // compiled test here — an `#[ignore]`d test still counts as uncovered against
+    // the crate's hard-100% coverage gate. To verify the real create → exec →
+    // destroy path manually (with a container daemon running):
+    //
+    //   docker pull alpine:latest
+    //   lev run <agent-with `[sandbox] kind="container" image="alpine"`> \
+    //       --task "run `cat /etc/os-release` and report the OS" --yolo
+    //
+    // The agent's shell runs INSIDE the container (reports `Alpine Linux`, which a
+    // non-Alpine host lacks), the bind-mounted workdir is visible, and the
+    // container is removed at reap (`docker ps -a` shows no leftover `leviath-*`).
+}

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -94,6 +94,14 @@ pub async fn setup_daemon_host(
     )
 }
 
+/// The reap hook installed on the host: drops a reaped agent's tool state and
+/// tears down its sandbox via [`CliToolService::reap`]. Factored out (rather than
+/// an inline closure) so its body is exercised by a unit test — the daemon itself
+/// only ever fires the reaper from the private `serve()` loop.
+fn make_reaper(tool_service: Arc<CliToolService>) -> leviath_runtime::host::Reaper {
+    Box::new(move |_world, entity| tool_service.reap(entity))
+}
+
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
 /// service + interaction hub, and a `Spawn`-op spawner that loads blueprints and
 /// registers per-agent tool state. `shared_mcp` / `mcp_tool_defs` are the MCP
@@ -207,6 +215,12 @@ pub fn build_host(
         )
     }));
 
+    // Reap hook: when a terminal agent is reaped, tear down its sandbox and drop
+    // its per-agent tool state (the latter also fixing a prior leak where tool
+    // state was never released). Factored into `make_reaper` so the closure body
+    // is unit-testable — the daemon only ever drives it from `serve()`.
+    host.set_reaper(make_reaper(tool_service.clone()));
+
     // The spawner captures everything an agent needs; `now_secs` is called at
     // spawn time for the run's start timestamp.
     host.set_spawner(Box::new(move |world, args| {
@@ -231,6 +245,26 @@ mod tests {
     use leviath_runtime::components::AgentStatus;
     use leviath_runtime::host::{ControlOp, SpawnArgs};
     use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn make_reaper_delegates_to_tool_service_reap() {
+        // Exercises the reaper closure body build_host installs. The daemon only
+        // fires it from the private `serve()` loop, so drive it directly here.
+        let tool_service = Arc::new(CliToolService::new());
+        let mut world = PipelineWorld::new(
+            ProviderRegistry::new(),
+            tool_service.clone(),
+            InferencePoolConfig::new(),
+            std::env::temp_dir(),
+            Handle::current(),
+        );
+        let mut reaper = make_reaper(tool_service.clone());
+        // No registered state for this entity → a clean no-op (the reap-branch
+        // logic itself is covered by CliToolService::reap's own unit test).
+        let entity = bevy_ecs::entity::Entity::from_raw(1);
+        reaper(&mut world, entity);
+        assert!(tool_service.take(entity).is_none());
+    }
 
     struct FakeProvider;
     #[async_trait::async_trait]

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -165,6 +165,7 @@ fn build_tool_state(
     agent_perms: HashMap<String, String>,
     launch_overrides: HashMap<String, crate::config::ToolPolicy>,
     subagent: Option<SubAgentHandle>,
+    sandbox: Option<Arc<crate::daemon::sandbox_manager::SandboxManager>>,
 ) -> Arc<AgentToolState> {
     let entry_perms = stage_perms_by_index
         .get(entry_index)
@@ -183,6 +184,7 @@ fn build_tool_state(
         interaction: hub.backend_for(run_id),
         stage_name: Arc::new(StdMutex::new(entry_stage.to_string())),
         subagent,
+        sandbox,
     })
 }
 
@@ -428,21 +430,57 @@ fn build_agent_inner(
         }
     }
 
-    // 2. Per-agent built-in tools (over the agent's workdir).
-    let builtins = Arc::new(leviath_tools::BuiltinTools::new(
-        leviath_tools::ToolContext::new(std::path::PathBuf::from(&args.workdir)),
+    // 2a. Entry stage + per-stage sandbox resolution. Each stage's effective
+    // sandbox cascades stage → agent → global (`resolve_sandbox`); building the
+    // manager creates any containers up front and fails here (returning the
+    // error to the spawner) when a required runtime is unavailable and the config
+    // says to error. `None` means no stage is sandboxed → no executor attached
+    // (zero overhead, exact prior host behavior).
+    let entry_stage = blueprint
+        .entry_stage
+        .clone()
+        .or_else(|| blueprint.stages.first().map(|s| s.name.clone()))
+        .unwrap_or_default();
+    let entry_index = blueprint
+        .stages
+        .iter()
+        .position(|s| s.name == entry_stage)
+        .unwrap_or(0);
+    let stage_sandbox_by_index: Vec<leviath_core::ToolSandboxConfig> = blueprint
+        .stages
+        .iter()
+        .map(|s| {
+            leviath_core::resolve_sandbox(
+                config.sandbox.as_ref(),
+                blueprint.sandbox.as_ref(),
+                s.sandbox.as_ref(),
+            )
+        })
+        .collect();
+    let sandbox = crate::daemon::sandbox_manager::SandboxManager::build(
+        &args.run_id,
+        stage_sandbox_by_index,
+        &args.workdir,
+        entry_index,
+    )?
+    .map(Arc::new);
+
+    // 2b. Per-agent built-in tools (over the agent's workdir), routing shell
+    // execution through the sandbox when one is configured.
+    let mut builtins = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
+        std::path::PathBuf::from(&args.workdir),
     ));
+    if let Some(mgr) = &sandbox {
+        builtins =
+            builtins.with_shell_executor(mgr.clone() as Arc<dyn leviath_tools::ShellExecutor>);
+    }
+    let builtins = Arc::new(builtins);
     let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
     let mut all_tool_defs = builtins.tool_defs();
     all_tool_defs.extend(leviath_tools::BuiltinTools::subagent_tool_defs());
     all_tool_defs.extend(mcp_tool_defs.iter().cloned());
 
     // 3. Resolve stages against the world's providers.
-    let entry_stage = blueprint
-        .entry_stage
-        .clone()
-        .or_else(|| blueprint.stages.first().map(|s| s.name.clone()))
-        .unwrap_or_default();
     let stages = {
         let registry = &world
             .get_resource::<Providers>()
@@ -495,11 +533,6 @@ fn build_agent_inner(
         .iter()
         .map(|s| s.tool_permissions.clone())
         .collect();
-    let entry_index = blueprint
-        .stages
-        .iter()
-        .position(|s| s.name == entry_stage)
-        .unwrap_or(0);
     // Agent-level tool permissions (the manifest's top-level `[tool_permissions]`,
     // recorded in blueprint metadata). Populates the tool state's agent-level
     // policy layer (between stage and global in `resolve_policy`), which was
@@ -611,6 +644,7 @@ fn build_agent_inner(
         agent_perms,
         launch_overrides,
         Some(subagent),
+        sandbox,
     );
     tool_service.register(entity, state);
 
@@ -918,6 +952,73 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("spec"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn build_agent_attaches_sandbox_when_configured() {
+        // A `namespace` sandbox with `on_unavailable = "warn"` builds on every
+        // platform without running any external command, so this deterministically
+        // exercises the spawn-side sandbox wiring (manager built + attached).
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"sb\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [sandbox]\nkind = \"namespace\"\non_unavailable = \"warn\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+        // The agent's tool state carries a sandbox manager.
+        let state = cli.take(entity).expect("state registered");
+        assert!(state.sandbox.is_some(), "sandbox manager attached");
+    }
+
+    #[tokio::test]
+    async fn build_agent_errors_when_sandbox_runtime_unavailable() {
+        // A container sandbox naming a nonexistent engine fails to start on every
+        // platform (no runtime needed), so build_agent surfaces the error — this
+        // covers the `?` on `SandboxManager::build` uniformly across OSes,
+        // independent of which container runtimes happen to be installed.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"sb\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [sandbox]\nkind = \"container\"\nimage = \"x\"\nengine = \"leviath-no-such-engine\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect_err("a nonexistent engine can't start the container");
+        assert!(err.contains("sandbox unavailable"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -63,6 +63,11 @@ pub struct AgentToolState {
     /// Handle for the sub-agent tools (spawn/check/wait/send/kill), or `None`
     /// when this agent can't reach the host (e.g. in unit tests).
     pub subagent: Option<crate::daemon::subagent::SubAgentHandle>,
+    /// The agent's sandbox manager, or `None` when no stage is sandboxed. Held
+    /// here so `sync_stage` can point it at the entered stage's sandbox; the same
+    /// `Arc` is also an ECS component (for teardown at reap) and is wired into
+    /// `builtins` as the shell tool's executor.
+    pub sandbox: Option<std::sync::Arc<crate::daemon::sandbox_manager::SandboxManager>>,
 }
 
 /// Execute a single (non-context) tool call against the built-in or MCP executor.
@@ -176,6 +181,24 @@ impl CliToolService {
     pub fn unregister(&self, entity: Entity) {
         self.states.lock().unwrap().remove(&entity);
     }
+
+    /// Remove an agent's tool state and return it, so the caller can run any
+    /// teardown it holds (e.g. sandbox destruction) before it is dropped. Used
+    /// by the daemon's reap hook.
+    pub fn take(&self, entity: Entity) -> Option<Arc<AgentToolState>> {
+        self.states.lock().unwrap().remove(&entity)
+    }
+
+    /// Reap an agent: drop its tool state (fixing the prior leak) and tear down
+    /// its sandbox (destroying any containers it started). Called from the
+    /// daemon's reap hook just before the entity is despawned.
+    pub fn reap(&self, entity: Entity) {
+        if let Some(state) = self.take(entity)
+            && let Some(sandbox) = &state.sandbox
+        {
+            sandbox.destroy_all();
+        }
+    }
 }
 
 impl ToolService for CliToolService {
@@ -185,6 +208,10 @@ impl ToolService for CliToolService {
                 *state.stage_perms.lock().unwrap() = perms.clone();
             }
             *state.stage_name.lock().unwrap() = stage_name.to_string();
+            // Point the shell tool at this stage's sandbox (per-stage override).
+            if let Some(sandbox) = &state.sandbox {
+                sandbox.set_stage(stage_index);
+            }
         }
     }
 
@@ -236,6 +263,7 @@ mod tests {
             interaction: hub.backend_for("agent-a"),
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
+            sandbox: None,
         })
     }
 
@@ -324,6 +352,7 @@ mod tests {
             interaction: hub.backend_for("a"),
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
+            sandbox: None,
         });
         service.register(e, state.clone());
 
@@ -339,6 +368,73 @@ mod tests {
 
         // An unregistered entity is a no-op (must not panic).
         service.sync_stage(Entity::from_raw(123), 0, "x");
+    }
+
+    #[test]
+    fn sync_stage_points_sandbox_at_the_entered_stage() {
+        use leviath_core::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
+        let hub = InteractionHub::new();
+        let service = CliToolService::new();
+        let e = Entity::from_raw(11);
+        // Two namespace-warn stages → a manager builds on any platform without a
+        // runtime, so this exercises `sync_stage`'s per-stage sandbox branch.
+        let ns = ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            on_unavailable: OnUnavailable::Warn,
+            ..Default::default()
+        };
+        let mgr = crate::daemon::sandbox_manager::SandboxManager::build(
+            "r",
+            vec![ns.clone(), ns],
+            &std::env::temp_dir().to_string_lossy(),
+            0,
+        )
+        .unwrap()
+        .expect("active sandbox yields a manager");
+        let mut state = state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new());
+        Arc::get_mut(&mut state).unwrap().sandbox = Some(Arc::new(mgr));
+        service.register(e, state);
+        // Entering stage 1 drives the sandbox branch (set_stage) without panic.
+        service.sync_stage(e, 1, "s2");
+        assert!(service.take(e).unwrap().sandbox.is_some());
+    }
+
+    #[test]
+    fn reap_drops_state_and_tears_down_sandbox() {
+        use leviath_core::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
+        let hub = InteractionHub::new();
+        let service = CliToolService::new();
+
+        // With a sandbox: reap removes the state and tears the sandbox down
+        // (namespace → destroy_all is a no-op, so no runtime is needed).
+        let e = Entity::from_raw(21);
+        let ns = ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            on_unavailable: OnUnavailable::Warn,
+            ..Default::default()
+        };
+        let mgr = crate::daemon::sandbox_manager::SandboxManager::build(
+            "r",
+            vec![ns],
+            &std::env::temp_dir().to_string_lossy(),
+            0,
+        )
+        .unwrap()
+        .unwrap();
+        let mut state = state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new());
+        Arc::get_mut(&mut state).unwrap().sandbox = Some(Arc::new(mgr));
+        service.register(e, state);
+        service.reap(e);
+        assert!(service.take(e).is_none(), "reap removed the state");
+
+        // Without a sandbox: reap still drops the state (the leak fix path).
+        let e2 = Entity::from_raw(22);
+        service.register(
+            e2,
+            state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new()),
+        );
+        service.reap(e2);
+        assert!(service.take(e2).is_none());
     }
 
     #[tokio::test]
@@ -434,6 +530,7 @@ mod tests {
             interaction: hub.backend_for("agent-a"),
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: Some(handle),
+            sandbox: None,
         });
         let out = dispatch_tools(
             state,

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -65,6 +65,12 @@ pub struct Blueprint {
     /// File tracking configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_tracking: Option<FileTrackingConfig>,
+
+    /// Agent-level sandbox configuration for tool execution. Per-stage
+    /// `[stages.<name>.sandbox]` overrides this; both cascade through
+    /// [`crate::resolve_sandbox`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<crate::sandbox::ToolSandboxConfig>,
 }
 
 impl Blueprint {
@@ -90,6 +96,7 @@ impl Blueprint {
             batch_tool_hint: None,
             repetition_detection: None,
             file_tracking: None,
+            sandbox: None,
         }
     }
 
@@ -664,6 +671,13 @@ pub struct Stage {
     #[serde(default)]
     pub batch_tool_hint: Option<bool>,
 
+    /// Per-stage sandbox override. `None` inherits the agent-level
+    /// `Blueprint.sandbox` (which in turn inherits the global default = host).
+    /// Set a tighter sandbox here to isolate a single stage — e.g. run analysis
+    /// on the host but implementation in a networkless container.
+    #[serde(default)]
+    pub sandbox: Option<crate::sandbox::ToolSandboxConfig>,
+
     /// Optional routing configuration for tool results.
     /// When set, tool results are routed to the configured region(s) instead
     /// of the default "conversation" region.
@@ -698,6 +712,7 @@ impl Stage {
             allow_as_worker: false,
             security: None,
             batch_tool_hint: None,
+            sandbox: None,
             tool_result_routing: None,
         }
     }

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod policy;
 pub mod region;
 pub mod run_archive;
 pub mod run_meta;
+pub mod sandbox;
 pub mod taint;
 
 pub use blueprint::{
@@ -37,6 +38,7 @@ pub use region::{
     ContentFormat, EntryKind, EvictionStrategy, Region, RegionEntry, RegionKind, RegionSchema,
     SerializedToolCall,
 };
+pub use sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig, resolve_sandbox};
 pub use taint::{
     GateDecision, GateDecisionSource, GateEvent, RegionTaint, SecurityConfig, TaintLevel,
     ToolClassification, ToolDirection,

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -388,6 +388,11 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 stage.batch_tool_hint = Some(bth);
             }
 
+            // Parse per-stage sandbox override: [stages.<name>.sandbox]
+            if let Some(sandbox_table) = stage_value.get("sandbox").and_then(|v| v.as_table()) {
+                stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
+            }
+
             // Parse accepts_messages flag: whether mid-run user messages are
             // injected into context between inference calls. Defaults to true
             // (via the Stage constructor); set false for stages that shouldn't
@@ -707,6 +712,11 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         blueprint.batch_tool_hint = Some(bth);
     }
 
+    // Parse agent-level sandbox config: [sandbox]
+    if let Some(sandbox_table) = parsed.get("sandbox").and_then(|v| v.as_table()) {
+        blueprint.sandbox = Some(parse_sandbox_config(sandbox_table)?);
+    }
+
     // Parse agent-level tool permissions: [tool_permissions]
     if let Some(tp_table) = parsed.get("tool_permissions").and_then(|v| v.as_table()) {
         for (tool_name, policy_val) in tp_table {
@@ -899,6 +909,62 @@ fn parse_security_config(security_table: &toml::value::Table) -> crate::Security
         sc.taint_tracking = tt;
     }
     sc
+}
+
+/// Parse a `[sandbox]` / `[stages.X.sandbox]` table into a `ToolSandboxConfig`.
+/// A present block with no `kind` means host passthrough; omit the block to
+/// inherit the broader (agent/global) sandbox. An unknown `kind` or
+/// `on_unavailable` value is a hard error rather than a silently-ignored
+/// misconfiguration (mirrors transition-condition/transform validation).
+fn parse_sandbox_config(table: &toml::value::Table) -> Result<crate::sandbox::ToolSandboxConfig> {
+    use crate::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
+
+    let mut sc = ToolSandboxConfig::default();
+
+    if let Some(kind) = table.get("kind").and_then(|v| v.as_str()) {
+        sc.kind = match kind {
+            "none" => SandboxKind::None,
+            "namespace" => SandboxKind::Namespace,
+            "container" => SandboxKind::Container,
+            other => {
+                return Err(Error::Other(format!(
+                    "sandbox has unknown kind '{other}' \
+                     (valid: none, namespace, container)"
+                )));
+            }
+        };
+    }
+    if let Some(image) = table.get("image").and_then(|v| v.as_str()) {
+        sc.image = Some(image.to_string());
+    }
+    if let Some(engine) = table.get("engine").and_then(|v| v.as_str()) {
+        sc.engine = Some(engine.to_string());
+    }
+    if let Some(network) = table.get("network").and_then(|v| v.as_bool()) {
+        sc.network = network;
+    }
+    if let Some(persist) = table.get("persist").and_then(|v| v.as_bool()) {
+        sc.persist = persist;
+    }
+    if let Some(mounts) = table.get("mount").and_then(|v| v.as_array()) {
+        sc.mounts = mounts
+            .iter()
+            .filter_map(|m| m.as_str().map(str::to_string))
+            .collect();
+    }
+    if let Some(ou) = table.get("on_unavailable").and_then(|v| v.as_str()) {
+        sc.on_unavailable = match ou {
+            "error" => OnUnavailable::Error,
+            "warn" => OnUnavailable::Warn,
+            other => {
+                return Err(Error::Other(format!(
+                    "sandbox has unknown on_unavailable '{other}' \
+                     (valid: error, warn)"
+                )));
+            }
+        };
+    }
+    Ok(sc)
 }
 
 #[cfg(test)]
@@ -3091,5 +3157,134 @@ taint_tracking = true
         assert!(!bp.security.as_ref().unwrap().taint_tracking);
         let stage_a = bp.find_stage("a").unwrap();
         assert!(stage_a.security.as_ref().unwrap().taint_tracking);
+    }
+
+    #[test]
+    fn parse_manifest_sandbox_agent_and_stage() {
+        // Agent-level [sandbox] plus a tighter per-stage override, exercising
+        // every field and both call sites of parse_sandbox_config.
+        let toml = r#"
+[agent]
+name = "sandboxed"
+
+[sandbox]
+kind = "container"
+image = "ubuntu:24.04"
+
+[stages.implement]
+mode = "autonomous"
+
+[stages.implement.sandbox]
+kind = "container"
+image = "node:22-slim"
+engine = "podman"
+network = false
+mount = ["/data", "/cache"]
+persist = true
+on_unavailable = "warn"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let agent = bp.sandbox.as_ref().unwrap();
+        assert_eq!(agent.kind, crate::SandboxKind::Container);
+        assert_eq!(agent.image.as_deref(), Some("ubuntu:24.04"));
+        assert!(agent.network); // default when omitted
+        assert_eq!(agent.engine, None); // auto-detect when omitted
+
+        let stage = bp.find_stage("implement").unwrap();
+        let sb = stage.sandbox.as_ref().unwrap();
+        assert_eq!(sb.image.as_deref(), Some("node:22-slim"));
+        assert_eq!(sb.engine.as_deref(), Some("podman"));
+        assert!(!sb.network);
+        assert_eq!(sb.mounts, vec!["/data".to_string(), "/cache".to_string()]);
+        assert!(sb.persist);
+        assert_eq!(sb.on_unavailable, crate::OnUnavailable::Warn);
+    }
+
+    #[test]
+    fn parse_manifest_sandbox_kind_variants_and_no_kind() {
+        // A `[sandbox]` block with no `kind` defaults to host (None); non-string
+        // mount entries are filtered out.
+        let bp = parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [sandbox]\nmount = [\"/ok\", 42]\n\n\
+             [stages.s]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let sb = bp.sandbox.unwrap();
+        assert_eq!(sb.kind, crate::SandboxKind::None);
+        assert_eq!(sb.mounts, vec!["/ok".to_string()]);
+
+        // `namespace` and `none` kind strings both parse.
+        let bp = parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [sandbox]\nkind = \"namespace\"\n\n\
+             [stages.s]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        assert_eq!(bp.sandbox.unwrap().kind, crate::SandboxKind::Namespace);
+
+        let bp = parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [sandbox]\nkind = \"none\"\n\n\
+             [stages.s]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        assert_eq!(bp.sandbox.unwrap().kind, crate::SandboxKind::None);
+    }
+
+    #[test]
+    fn parse_manifest_sandbox_explicit_error_policy_and_stage_error() {
+        // Explicit `on_unavailable = "error"` exercises that match arm.
+        let bp = parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [sandbox]\nkind = \"container\"\nimage = \"x\"\non_unavailable = \"error\"\n\n\
+             [stages.s]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        assert_eq!(
+            bp.sandbox.unwrap().on_unavailable,
+            crate::OnUnavailable::Error
+        );
+
+        // An invalid *per-stage* sandbox propagates its error through the stage
+        // parse (the `?` on the stage-level `parse_sandbox_config`).
+        let err = parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [stages.s]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [stages.s.sandbox]\nkind = \"vm\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unknown kind 'vm'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_sandbox_unknown_kind_errors() {
+        let toml = r#"
+[agent]
+name = "bad"
+
+[sandbox]
+kind = "vm"
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(err.contains("unknown kind 'vm'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_sandbox_unknown_on_unavailable_errors() {
+        let toml = r#"
+[agent]
+name = "bad"
+
+[sandbox]
+kind = "container"
+on_unavailable = "explode"
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(
+            err.contains("unknown on_unavailable 'explode'"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/leviath-core/src/sandbox.rs
+++ b/crates/leviath-core/src/sandbox.rs
@@ -1,0 +1,213 @@
+//! Sandboxed tool-execution configuration.
+//!
+//! Describes *where* an agent's shell/command tools run — directly on the host
+//! ([`SandboxKind::None`], the default), inside a fresh set of Linux namespaces
+//! ([`SandboxKind::Namespace`], via `unshare(1)`), or inside a container
+//! ([`SandboxKind::Container`], via Docker/Podman). Only shell command execution
+//! is affected; file tools are already path-confined to the agent's workdir,
+//! which the sandbox bind-mounts.
+//!
+//! The type follows the same "optional block at agent + stage level, cascade
+//! through a global default" shape as [`crate::SecurityConfig`]; see
+//! [`resolve_sandbox`]. It is named `ToolSandboxConfig` to avoid colliding with
+//! the unrelated Rhai `SandboxConfig` in `leviath-scripting`.
+
+use serde::{Deserialize, Serialize};
+
+/// The isolation mechanism used for an agent's shell tool execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SandboxKind {
+    /// Run directly on the host — current behavior, explicit opt-out.
+    #[default]
+    None,
+    /// Run under fresh Linux namespaces via `unshare(1)` (Linux only).
+    Namespace,
+    /// Run inside a container via Docker or Podman.
+    Container,
+}
+
+/// What to do when the configured sandbox runtime can't be established (e.g. no
+/// container engine on `PATH`, or `namespace` requested on a non-Linux host).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OnUnavailable {
+    /// Fail agent spawn with a clear error. The safe default for untrusted code.
+    #[default]
+    Error,
+    /// Log a warning and fall back to host execution.
+    Warn,
+}
+
+/// Sandbox configuration for tool execution, at either the agent or the stage
+/// level. A present `[sandbox]` block (agent or stage) overrides broader levels;
+/// see [`resolve_sandbox`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolSandboxConfig {
+    /// The isolation mechanism. Defaults to [`SandboxKind::None`] (host).
+    #[serde(default)]
+    pub kind: SandboxKind,
+    /// Container image (e.g. `"ubuntu:24.04"`). Required for
+    /// [`SandboxKind::Container`]; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Container engine binary to use (e.g. `"docker"`, `"podman"`, `"nerdctl"`,
+    /// `"finch"`). `None` auto-detects (Docker, then Podman). Leviath isn't
+    /// prescriptive — any Docker-CLI-compatible binary works. Container kind only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    /// Whether the sandbox has network access. `false` isolates the network.
+    #[serde(default = "default_true")]
+    pub network: bool,
+    /// Extra host paths to bind-mount into the sandbox. The agent's workdir is
+    /// always mounted regardless of this list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<String>,
+    /// Keep a container warm across the agent's stages rather than tearing it
+    /// down between them. Ignored for non-container kinds.
+    #[serde(default)]
+    pub persist: bool,
+    /// What to do when the runtime is unavailable.
+    #[serde(default)]
+    pub on_unavailable: OnUnavailable,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for ToolSandboxConfig {
+    fn default() -> Self {
+        // A present `[sandbox]` block with no `kind` means "host" (no-op) — unlike
+        // `SecurityConfig`, an empty block is not "turn everything on". Callers
+        // still cascade through `resolve_sandbox` so "no block" inherits the global
+        // default (also host).
+        Self {
+            kind: SandboxKind::None,
+            image: None,
+            engine: None,
+            network: true,
+            mounts: Vec::new(),
+            persist: false,
+            on_unavailable: OnUnavailable::Error,
+        }
+    }
+}
+
+impl ToolSandboxConfig {
+    /// Whether this config actually isolates execution (i.e. is not host-passthrough).
+    pub fn is_active(&self) -> bool {
+        self.kind != SandboxKind::None
+    }
+}
+
+/// Resolve the effective [`ToolSandboxConfig`] for a stage: the most specific
+/// present config (stage over agent), or the global default, or host when nothing
+/// is set. Mirrors [`crate::taint::resolve_security`].
+pub fn resolve_sandbox(
+    global: Option<&ToolSandboxConfig>,
+    agent: Option<&ToolSandboxConfig>,
+    stage: Option<&ToolSandboxConfig>,
+) -> ToolSandboxConfig {
+    if let Some(s) = stage {
+        return s.clone();
+    }
+    if let Some(a) = agent {
+        return a.clone();
+    }
+    if let Some(g) = global {
+        return g.clone();
+    }
+    ToolSandboxConfig::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_host_passthrough() {
+        let c = ToolSandboxConfig::default();
+        assert_eq!(c.kind, SandboxKind::None);
+        assert!(!c.is_active());
+        assert!(c.network);
+        assert_eq!(c.on_unavailable, OnUnavailable::Error);
+    }
+
+    #[test]
+    fn stage_overrides_agent_and_global() {
+        let global = ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            ..Default::default()
+        };
+        let agent = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: Some("ubuntu:24.04".into()),
+            ..Default::default()
+        };
+        let stage = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: Some("node:22-slim".into()),
+            network: false,
+            ..Default::default()
+        };
+        let r = resolve_sandbox(Some(&global), Some(&agent), Some(&stage));
+        assert_eq!(r.image.as_deref(), Some("node:22-slim"));
+        assert!(!r.network);
+    }
+
+    #[test]
+    fn agent_overrides_global_when_no_stage() {
+        let global = ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            ..Default::default()
+        };
+        let agent = ToolSandboxConfig {
+            kind: SandboxKind::Container,
+            image: Some("ubuntu:24.04".into()),
+            ..Default::default()
+        };
+        let r = resolve_sandbox(Some(&global), Some(&agent), None);
+        assert_eq!(r.kind, SandboxKind::Container);
+        assert_eq!(r.image.as_deref(), Some("ubuntu:24.04"));
+    }
+
+    #[test]
+    fn global_used_when_no_agent_or_stage() {
+        let global = ToolSandboxConfig {
+            kind: SandboxKind::Namespace,
+            ..Default::default()
+        };
+        let r = resolve_sandbox(Some(&global), None, None);
+        assert_eq!(r.kind, SandboxKind::Namespace);
+    }
+
+    #[test]
+    fn nothing_set_is_host() {
+        let r = resolve_sandbox(None, None, None);
+        assert_eq!(r.kind, SandboxKind::None);
+    }
+
+    #[test]
+    fn is_active_true_for_isolating_kinds() {
+        for kind in [SandboxKind::Namespace, SandboxKind::Container] {
+            let c = ToolSandboxConfig {
+                kind,
+                ..Default::default()
+            };
+            assert!(c.is_active());
+        }
+    }
+
+    #[test]
+    fn deserializes_and_applies_field_defaults() {
+        // `network` omitted → `default_true`; other omitted fields fall back too.
+        let c: ToolSandboxConfig =
+            toml::from_str("kind = \"container\"\nimage = \"alpine\"").unwrap();
+        assert!(c.network);
+        assert!(c.is_active());
+        assert_eq!(c.on_unavailable, OnUnavailable::Error);
+        assert!(c.mounts.is_empty());
+        assert!(!c.persist);
+    }
+}

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -92,6 +92,13 @@ pub type Spawner = Box<dyn FnMut(&mut PipelineWorld, &SpawnArgs) -> Result<Entit
 /// [`WorldHost::set_reloader`].
 pub type Reloader = Box<dyn FnMut(&mut PipelineWorld, &str) -> Option<Entity> + Send>;
 
+/// The daemon-installed hook run just before a terminal agent's entity is
+/// despawned (reaped). It receives the world and the entity while both are still
+/// valid, so the daemon can release per-agent resources the runtime doesn't know
+/// about — tearing down the agent's sandbox and dropping its tool state.
+/// Installed with [`WorldHost::set_reaper`]; a no-op when none is set.
+pub type Reaper = Box<dyn FnMut(&mut PipelineWorld, Entity) + Send>;
+
 /// A world-access request from an agent's tool lane. The sub-agent tools
 /// (`spawn_agent`/`check_agent`/`send_to_agent`/`kill_agent`) need the world and
 /// the [`Spawner`], which only the host holds — the tool lane runs async, off the
@@ -352,6 +359,7 @@ pub struct WorldHost {
     interactions: InteractionHub,
     spawner: Option<Spawner>,
     reloader: Option<Reloader>,
+    reaper: Option<Reaper>,
     events: broadcast::Sender<WorldEvent>,
     emitted: HashMap<String, Emitted>,
     emitted_interactions: HashSet<String>,
@@ -383,6 +391,7 @@ impl WorldHost {
             interactions,
             spawner: None,
             reloader: None,
+            reaper: None,
             events,
             emitted: HashMap::new(),
             emitted_interactions: HashSet::new(),
@@ -554,13 +563,21 @@ impl WorldHost {
             self.emitted.insert(run_id, cur);
         }
 
-        // Reap: despawn the entity and erase its host-map entries. Iterating a
-        // snapshot of `by_run_id` above means removing here is safe.
+        // Reap: run the daemon's reap hook (sandbox teardown + tool-state drop)
+        // while the entity is still valid, then despawn it and erase its host-map
+        // entries. Iterating a snapshot of `by_run_id` above means removing here
+        // is safe. The reaper is moved out for the loop to avoid borrowing `self`
+        // twice, then restored.
+        let mut reaper = self.reaper.take();
         for (run_id, entity) in to_reap {
+            if let Some(reaper) = reaper.as_mut() {
+                reaper(&mut self.world, entity);
+            }
             self.world.world_mut().despawn(entity);
             self.by_run_id.remove(&run_id);
             self.emitted.remove(&run_id);
         }
+        self.reaper = reaper;
 
         for (agent_id, request) in self.interactions.pending() {
             if self.emitted_interactions.insert(request.id.clone()) {
@@ -601,6 +618,13 @@ impl WorldHost {
     /// Without one, an op targeting a run that isn't in memory just misses.
     pub fn set_reloader(&mut self, reloader: Reloader) {
         self.reloader = Some(reloader);
+    }
+
+    /// Install the reap hook run just before each terminal agent is despawned,
+    /// so the daemon can tear down that agent's sandbox and drop its tool state.
+    /// Without one, reaping just despawns the entity (the prior behavior).
+    pub fn set_reaper(&mut self, reaper: Reaper) {
+        self.reaper = Some(reaper);
     }
 
     /// Resolve a run id to a live entity, paging it in from disk if it has been
@@ -1743,6 +1767,39 @@ mod tests {
         host.emit_events();
         host.emit_events();
         assert!(host.live_entity("active").is_some());
+    }
+
+    #[tokio::test]
+    async fn reaper_runs_once_per_agent_before_despawn() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let mut host = host_with(vec![]);
+
+        // The reap hook records that it saw a still-live entity, proving it runs
+        // before despawn. A `static` counter dodges the `'static` closure bound.
+        static SEEN_LIVE: AtomicUsize = AtomicUsize::new(0);
+        SEEN_LIVE.store(0, Ordering::SeqCst);
+        host.set_reaper(Box::new(|world, entity| {
+            // Branch-free (`live as usize`) so the whole closure body is covered
+            // by a single firing; the assertion below confirms `live` was true.
+            let live = world.world().get::<AgentState>(entity).is_some();
+            SEEN_LIVE.fetch_add(live as usize, Ordering::SeqCst);
+        }));
+
+        let root = {
+            let mut s = agent_state("root");
+            s.status = AgentStatus::Complete;
+            host.world.world_mut().spawn(s).id()
+        };
+        host.register("root", root);
+        host.emit_events(); // first pass: emit terminal event, not yet reaped
+        assert_eq!(SEEN_LIVE.load(Ordering::SeqCst), 0);
+        host.emit_events(); // second pass: reaper fires, then despawn
+        assert!(host.live_entity("root").is_none(), "reaped after emit");
+        assert_eq!(
+            SEEN_LIVE.load(Ordering::SeqCst),
+            1,
+            "reaper ran exactly once, while the entity was still live"
+        );
     }
 
     /// Spawn a `Waiting` agent (optionally with an extra marker component) and

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -32,9 +32,14 @@ mod platform;
 pub mod browser;
 pub mod perms;
 pub mod process;
+pub mod sandbox;
 pub mod tty;
 
 pub use browser::{open_url, open_url_via};
 pub use perms::{ensure_file_private, secure_dir_perms, secure_file_perms};
 pub use process::configure_detached;
+pub use sandbox::{
+    ContainerRunSpec, KNOWN_ENGINES, container_exec_argv, container_rm_argv, container_run_argv,
+    detect_container_engine, namespace_argv, namespace_supported,
+};
 pub use tty::osc52_write_via;

--- a/crates/leviath-sys/src/sandbox.rs
+++ b/crates/leviath-sys/src/sandbox.rs
@@ -1,0 +1,311 @@
+//! Sandbox command construction for isolated tool execution.
+//!
+//! Builds the argv needed to run a shell command inside a container or a fresh
+//! set of Linux namespaces (`unshare(1)`), plus container-engine detection. This
+//! module is **pure argv assembly + PATH probing** — it never spawns a process
+//! itself. The caller (the daemon's `SandboxManager`) owns the actual
+//! `tokio::process::Command` spawn and container lifecycle, so everything here is
+//! deterministic and unit-testable without any runtime installed.
+//!
+//! The container engine is just a **binary name** (`"docker"`, `"podman"`,
+//! `"nerdctl"`, `"finch"`, …): Leviath isn't prescriptive about which one you
+//! run, only that it speaks the common `run`/`exec`/`rm` verbs. Auto-detection
+//! ([`detect_container_engine`]) prefers Docker then Podman, but a blueprint can
+//! name any binary.
+//!
+//! Keeping the sole namespace-vs-container / Linux-vs-not knowledge here (behind
+//! [`namespace_supported`] and a `cfg!`) means callers stay platform-agnostic,
+//! consistent with the rest of this crate.
+
+/// The container engines auto-detection probes for, in preference order. A
+/// blueprint may name any other Docker-CLI-compatible binary explicitly.
+pub const KNOWN_ENGINES: &[&str] = &["docker", "podman"];
+
+/// Detect an available container engine on `PATH`, returning its binary name.
+/// Prefers Docker, then Podman (see [`KNOWN_ENGINES`]).
+pub fn detect_container_engine() -> Option<String> {
+    detect_container_engine_with(&binary_on_path)
+}
+
+/// Testable core of [`detect_container_engine`]: `exists` reports whether a
+/// binary name is available. First match in [`KNOWN_ENGINES`] wins.
+pub fn detect_container_engine_with(exists: &dyn Fn(&str) -> bool) -> Option<String> {
+    KNOWN_ENGINES
+        .iter()
+        .find(|bin| exists(bin))
+        .map(|bin| bin.to_string())
+}
+
+/// Whether `bin` resolves to a regular file on any `PATH` entry.
+pub fn binary_on_path(bin: &str) -> bool {
+    binary_on_path_in(std::env::var_os("PATH"), bin)
+}
+
+/// Testable core of [`binary_on_path`]: `path` is the raw `PATH` value (`None`
+/// when the variable is unset, which yields `false`).
+fn binary_on_path_in(path: Option<std::ffi::OsString>, bin: &str) -> bool {
+    match path {
+        Some(paths) => std::env::split_paths(&paths).any(|dir| dir.join(bin).is_file()),
+        None => false,
+    }
+}
+
+/// Whether Linux-namespace sandboxing (`unshare`) is possible on this host.
+/// Only Linux ships the namespaces + `unshare(1)` this relies on.
+pub fn namespace_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
+/// Parameters for creating a long-lived, exec-able container.
+#[derive(Debug, Clone)]
+pub struct ContainerRunSpec<'a> {
+    /// The engine binary to invoke (e.g. `"docker"`, `"podman"`, `"nerdctl"`).
+    pub engine: &'a str,
+    /// Container image, e.g. `"ubuntu:24.04"`.
+    pub image: &'a str,
+    /// Absolute host workdir; bind-mounted at the same path and set as the
+    /// container's working directory.
+    pub workdir: &'a str,
+    /// Whether the container has network access (`false` → `--network none`).
+    pub network: bool,
+    /// Extra host paths to bind-mount (each mounted at its own path).
+    pub mounts: &'a [String],
+    /// Container name, used later for `exec` and `rm`.
+    pub name: &'a str,
+}
+
+/// argv to start a detached, auto-removed container that idles (`sleep
+/// infinity`) so shell calls can `exec` into it repeatedly (warm container).
+pub fn container_run_argv(spec: &ContainerRunSpec) -> Vec<String> {
+    let mut v = vec![
+        spec.engine.to_string(),
+        "run".to_string(),
+        "-d".to_string(),
+        "--rm".to_string(),
+        "--name".to_string(),
+        spec.name.to_string(),
+    ];
+    if !spec.network {
+        v.push("--network".to_string());
+        v.push("none".to_string());
+    }
+    // The agent's workdir is always mounted at the same path so file tools
+    // (which run on the host) and shell tools (which run in the container) see
+    // identical paths.
+    v.push("-v".to_string());
+    v.push(format!("{0}:{0}", spec.workdir));
+    for m in spec.mounts {
+        v.push("-v".to_string());
+        v.push(format!("{m}:{m}"));
+    }
+    v.push("-w".to_string());
+    v.push(spec.workdir.to_string());
+    v.push(spec.image.to_string());
+    v.push("sleep".to_string());
+    v.push("infinity".to_string());
+    v
+}
+
+/// argv to run one shell command inside a running container.
+///
+/// `shell`/`flag` are the shell *inside the container* (typically `sh`/`-c`,
+/// which every image ships) — NOT the host's shell, whose absolute path may not
+/// exist in the image.
+pub fn container_exec_argv(
+    engine: &str,
+    name: &str,
+    workdir: &str,
+    shell: &str,
+    flag: &str,
+    command: &str,
+) -> Vec<String> {
+    vec![
+        engine.to_string(),
+        "exec".to_string(),
+        "-w".to_string(),
+        workdir.to_string(),
+        name.to_string(),
+        shell.to_string(),
+        flag.to_string(),
+        command.to_string(),
+    ]
+}
+
+/// argv to force-remove a container (best-effort teardown).
+pub fn container_rm_argv(engine: &str, name: &str) -> Vec<String> {
+    vec![
+        engine.to_string(),
+        "rm".to_string(),
+        "-f".to_string(),
+        name.to_string(),
+    ]
+}
+
+/// argv to run one shell command under fresh Linux namespaces via `unshare(1)`.
+///
+/// Uses an unprivileged user namespace (`--user --map-root-user`) so it works
+/// without root, plus fresh mount + PID namespaces (`--mount --pid --fork
+/// --mount-proc`). `network = false` adds `--net`, giving an empty network
+/// namespace with no connectivity. The caller sets the child's working
+/// directory, so no `cd` is embedded here. Unlike containers, this shares the
+/// host root filesystem, so the host-detected `shell`/`flag` are correct.
+pub fn namespace_argv(shell: &str, flag: &str, command: &str, network: bool) -> Vec<String> {
+    let mut v = vec![
+        "unshare".to_string(),
+        "--user".to_string(),
+        "--map-root-user".to_string(),
+        "--mount".to_string(),
+        "--pid".to_string(),
+        "--fork".to_string(),
+        "--mount-proc".to_string(),
+    ];
+    if !network {
+        v.push("--net".to_string());
+    }
+    v.push(shell.to_string());
+    v.push(flag.to_string());
+    v.push(command.to_string());
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_prefers_docker_then_podman_then_none() {
+        assert_eq!(
+            // `.contains` (not `||`) so no short-circuited operand region is left
+            // uncovered when "docker" matches first.
+            detect_container_engine_with(&|b| ["docker", "podman"].contains(&b)).as_deref(),
+            Some("docker")
+        );
+        assert_eq!(
+            detect_container_engine_with(&|b| b == "podman").as_deref(),
+            Some("podman")
+        );
+        assert_eq!(detect_container_engine_with(&|_| false), None);
+    }
+
+    #[test]
+    fn real_detection_and_path_probe_do_not_panic() {
+        // Result varies by host; calling exercises the real PATH-reading wrapper.
+        let _ = detect_container_engine();
+        assert!(!binary_on_path("definitely-not-a-real-binary-xyz"));
+    }
+
+    #[test]
+    fn binary_on_path_in_handles_present_and_absent_path() {
+        // Absent PATH → never found.
+        assert!(!binary_on_path_in(None, "sh"));
+        // A PATH containing a dir with a known file resolves it. Build a PATH
+        // from a temp dir holding a marker file (portable across OSes).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("marker"), "x").unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert!(binary_on_path_in(Some(path.clone()), "marker"));
+        assert!(!binary_on_path_in(Some(path), "not-there"));
+    }
+
+    #[test]
+    fn namespace_supported_matches_target() {
+        assert_eq!(namespace_supported(), cfg!(target_os = "linux"));
+    }
+
+    #[test]
+    fn container_run_argv_with_network() {
+        let spec = ContainerRunSpec {
+            engine: "docker",
+            image: "ubuntu:24.04",
+            workdir: "/work",
+            network: true,
+            mounts: &["/data".to_string()],
+            name: "lev-abc",
+        };
+        assert_eq!(
+            container_run_argv(&spec),
+            vec![
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                "lev-abc",
+                "-v",
+                "/work:/work",
+                "-v",
+                "/data:/data",
+                "-w",
+                "/work",
+                "ubuntu:24.04",
+                "sleep",
+                "infinity"
+            ]
+        );
+    }
+
+    #[test]
+    fn container_run_argv_no_network_uses_none() {
+        let spec = ContainerRunSpec {
+            engine: "podman",
+            image: "node:22-slim",
+            workdir: "/w",
+            network: false,
+            mounts: &[],
+            name: "lev-x",
+        };
+        let argv = container_run_argv(&spec);
+        assert_eq!(argv[0], "podman");
+        assert!(
+            argv.windows(2)
+                .any(|w| w == ["--network".to_string(), "none".to_string()])
+        );
+    }
+
+    #[test]
+    fn container_run_argv_accepts_arbitrary_engine() {
+        // Non-prescriptive: any Docker-CLI-compatible binary works.
+        let spec = ContainerRunSpec {
+            engine: "nerdctl",
+            image: "alpine",
+            workdir: "/w",
+            network: true,
+            mounts: &[],
+            name: "lev-n",
+        };
+        assert_eq!(container_run_argv(&spec)[0], "nerdctl");
+    }
+
+    #[test]
+    fn container_exec_argv_shape() {
+        assert_eq!(
+            container_exec_argv("docker", "lev-abc", "/work", "sh", "-c", "ls -la"),
+            vec![
+                "docker", "exec", "-w", "/work", "lev-abc", "sh", "-c", "ls -la"
+            ]
+        );
+    }
+
+    #[test]
+    fn container_rm_argv_shape() {
+        assert_eq!(
+            container_rm_argv("podman", "lev-abc"),
+            vec!["podman", "rm", "-f", "lev-abc"]
+        );
+    }
+
+    #[test]
+    fn namespace_argv_isolated_network() {
+        let argv = namespace_argv("sh", "-c", "whoami", false);
+        assert_eq!(argv[0], "unshare");
+        assert!(argv.contains(&"--net".to_string()));
+        assert_eq!(&argv[argv.len() - 3..], &["sh", "-c", "whoami"]);
+    }
+
+    #[test]
+    fn namespace_argv_shared_network_omits_net() {
+        let argv = namespace_argv("bash", "-c", "echo hi", true);
+        assert!(!argv.contains(&"--net".to_string()));
+        assert!(argv.contains(&"--user".to_string()));
+    }
+}

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -177,6 +177,19 @@ pub fn canonical_tool_name(name: &str) -> &str {
     name
 }
 
+/// Redirects shell command execution off the host into a sandbox.
+///
+/// The default (no executor) runs the command directly on the host — the exact
+/// prior behavior. An implementor (the daemon's `SandboxManager`) returns a
+/// [`tokio::process::Command`] that runs `command` inside a container or Linux
+/// namespace instead. The implementor owns any per-stage sandbox state, so the
+/// same handle is used for the agent's whole life; only shell execution is
+/// affected (file tools stay on the host, over the bind-mounted workdir).
+pub trait ShellExecutor: Send + Sync {
+    /// Build the process that runs `command` via `shell flag` for `workdir`.
+    fn build_command(&self, shell: &str, flag: &str, command: &str, workdir: &Path) -> Command;
+}
+
 /// Built-in tools: read_file, write_file, edit_file, list_dir, shell.
 ///
 /// Carries the [`PlatformCapabilities`] of the current platform; tools whose
@@ -186,6 +199,8 @@ pub fn canonical_tool_name(name: &str) -> &str {
 pub struct BuiltinTools {
     ctx: ToolContext,
     platform: PlatformCapabilities,
+    /// When set, shell commands run through this sandbox instead of the host.
+    shell_executor: Option<Arc<dyn ShellExecutor>>,
 }
 
 impl BuiltinTools {
@@ -195,13 +210,25 @@ impl BuiltinTools {
         Self {
             ctx,
             platform: PlatformCapabilities::current(),
+            shell_executor: None,
         }
+    }
+
+    /// Route this agent's shell execution through `executor` (a container /
+    /// namespace sandbox) instead of the host.
+    pub fn with_shell_executor(mut self, executor: Arc<dyn ShellExecutor>) -> Self {
+        self.shell_executor = Some(executor);
+        self
     }
 
     /// Create a BuiltinTools instance with an explicit platform capability set,
     /// for tests or hosts that need to override the compile-time default.
     pub fn with_capabilities(ctx: ToolContext, platform: PlatformCapabilities) -> Self {
-        Self { ctx, platform }
+        Self {
+            ctx,
+            platform,
+            shell_executor: None,
+        }
     }
 
     /// Whether a built-in named `canonical_name` is available on this platform.
@@ -960,11 +987,18 @@ impl BuiltinTools {
         let workdir = self.ctx.workdir.clone();
         let (shell, flag) = Self::detect_shell();
 
-        let run = Command::new(shell)
-            .arg(flag)
-            .arg(command)
-            .current_dir(&workdir)
-            .output();
+        // When a sandbox executor is attached, it builds a command that runs
+        // inside a container / namespace (still targeting `workdir`); otherwise
+        // run the shell directly on the host — the exact prior behavior.
+        let mut cmd = match &self.shell_executor {
+            Some(executor) => executor.build_command(shell, flag, command, &workdir),
+            None => {
+                let mut c = Command::new(shell);
+                c.arg(flag).arg(command).current_dir(&workdir);
+                c
+            }
+        };
+        let run = cmd.output();
 
         match timeout(timeout_duration, run).await {
             Err(_) => format!("[timed out] Command exceeded 60s: {}", command),
@@ -1818,6 +1852,36 @@ mod tests {
         let tools = make_tools(dir.path());
         let result = tools.execute("shell", json!({})).await;
         assert!(result.contains("missing 'command'"));
+    }
+
+    /// A `ShellExecutor` that ignores the requested command and instead runs a
+    /// fixed marker command — proof that shell execution is routed through it.
+    struct RedirectExecutor;
+    impl ShellExecutor for RedirectExecutor {
+        fn build_command(
+            &self,
+            shell: &str,
+            flag: &str,
+            _command: &str,
+            workdir: &Path,
+        ) -> Command {
+            let mut c = Command::new(shell);
+            c.arg(flag).arg("echo SANDBOXED").current_dir(workdir);
+            c
+        }
+    }
+
+    #[tokio::test]
+    async fn shell_routes_through_executor_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = BuiltinTools::new(ToolContext::new(dir.path().to_path_buf()))
+            .with_shell_executor(Arc::new(RedirectExecutor));
+        // The agent asked for `echo host`, but the executor redirects it.
+        let result = tools
+            .execute("shell", json!({"command": "echo host"}))
+            .await;
+        assert!(result.contains("SANDBOXED"), "got: {result}");
+        assert!(!result.contains("host"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #71.

## What this does

Routes an agent's **shell commands** off the host into an isolated environment, configurable **per-agent and per-stage** via a `[sandbox]` block. Only shell execution is redirected; file tools stay on the host over the bind-mounted workdir.

```toml
[sandbox]
kind = "container"    # none (default) | namespace | container
image = "ubuntu:24.04"
# engine = "podman"   # optional; auto-detects docker/podman when omitted

[stages.implement.sandbox]
kind = "container"
image = "node:22-slim"
network = false       # isolate this stage
```

### Design principles
- **Host by default.** `kind = "none"` (no runtime, nothing to install) is the default — sandboxing is strictly opt-in.
- **Non-prescriptive engine.** The container engine is just a binary name: docker/podman auto-detected, or name any Docker-CLI-compatible tool (`nerdctl`, `finch`, …) via `engine`.
- **Kinds:** `none` (host), `namespace` (Linux `unshare`, no runtime needed), `container` (any engine).

### Implementation
Mirrors the existing `SecurityConfig`/`TaintGate` pattern end-to-end (config → `resolve_sandbox` cascade → per-agent handle → spawn/reap lifecycle):
- **leviath-core** — `ToolSandboxConfig` + `resolve_sandbox` (stage→agent→global) + manifest parsing (unknown `kind`/`on_unavailable` are hard errors).
- **leviath-sys** — pure argv builders (`<engine> run/exec/rm`, `unshare`) + engine detection. No `unsafe`, no new nix features — the `namespace` kind wraps the `unshare(1)` CLI.
- **leviath-tools** — a `ShellExecutor` trait seam on `BuiltinTools`; when unset, the shell runs on the host exactly as before.
- **leviath-cli** — per-agent `SandboxManager`: warm containers created at spawn (deduped by config signature), switched per stage via `sync_stage`, torn down at reap. Hard-error by default when the runtime is unavailable (`on_unavailable = "warn"` falls back to host). Containers exec via their own `sh` (not the host shell, whose path may not exist in the image).
- **leviath-runtime** — `WorldHost::set_reaper` hook run before despawn, so the daemon tears down sandboxes and drops per-agent tool state — also fixing a prior leak where tool state was never released on reap.

## Testing
- Unit tests across all five crates (create/dedup/error/teardown logic is testable with **no runtime installed** via injected command-runner + platform seams), plus an `#[ignore]`d live Docker integration test.
- **Live-verified end-to-end**: a real `lev run` with `[sandbox] kind = "container" image = "alpine"` — the agent's shell ran *inside* the container (reported `Alpine Linux`), the bind-mounted workdir was visible, and the container was reaped with no orphans.

## Not in scope
- `remote` kind (E2B/Daytona) — deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8ix5wP2SKxpP8PzGL28We