### PR TITLE
fix(recovery): atomic meta/context snapshot pairing on resume (closes #43)

### DIFF
--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use bevy_ecs::entity::Entity;
+use leviath_core::run_archive;
 use leviath_core::run_meta::{ContextSnapshot, RunMeta, RunStatus};
 use leviath_mcp::ToolExecutor;
 use leviath_providers::Tool;
@@ -231,6 +232,17 @@ fn read_meta(run_dir: &Path) -> Option<RunMeta> {
     serde_json::from_str(&text).ok()
 }
 
+/// The cumulative token totals recorded in a run's metadata.
+fn totals_from(meta: &RunMeta) -> TokenTotals {
+    TokenTotals {
+        prompt_tokens: meta.prompt_tokens,
+        completion_tokens: meta.completion_tokens,
+        cached_tokens: meta.cached_tokens,
+        cache_write_tokens: meta.cache_write_tokens,
+        tool_calls: meta.tool_calls,
+    }
+}
+
 /// Whether a run's status means it should not be resumed.
 fn is_terminal(status: &RunStatus) -> bool {
     matches!(
@@ -286,29 +298,54 @@ fn reload_one(
         subagent_tx.clone(),
     )?;
 
-    // Restore the persisted context (if any), stage, iteration, and token totals.
-    let snapshot = std::fs::read_to_string(run_dir.join("context.json"))
+    // Restore the persisted context, stage, iteration, and token totals.
+    //
+    // Prefer the run's atomic journal (`run.lvr`): it records meta + context
+    // together, so a crash between the separate `meta.json` and `context.json`
+    // writes can't leave us with a mismatched pair (new stage/iteration + stale
+    // context). The archive is appended *before* either JSON file, so in that exact
+    // crash window it already holds the newer generation and folds to a consistent
+    // `{meta, context}`. Fall back to the separate JSON files only for runs written
+    // before the archive existed, or an archive that couldn't be read at all — that
+    // pair may be one tick out of sync, but it's the pre-existing behavior.
+    let folded = std::fs::read(run_dir.join("run.lvr"))
         .ok()
-        .and_then(|s| serde_json::from_str::<ContextSnapshot>(&s).ok())
-        .unwrap_or_else(|| ContextSnapshot {
-            stage_name: meta.current_stage.clone(),
-            total_tokens: 0,
-            max_tokens: 0,
-            regions: Vec::new(),
-        });
-    let totals = TokenTotals {
-        prompt_tokens: meta.prompt_tokens,
-        completion_tokens: meta.completion_tokens,
-        cached_tokens: meta.cached_tokens,
-        cache_write_tokens: meta.cache_write_tokens,
-        tool_calls: meta.tool_calls,
+        .and_then(|bytes| run_archive::read_archive_lenient(&mut bytes.as_slice()).ok())
+        .and_then(|(_version, records)| run_archive::fold(&records));
+    let (snapshot, stage_index, iteration, totals) = match folded {
+        Some(folded) => {
+            let totals = totals_from(&folded.meta);
+            (
+                folded.context,
+                folded.meta.stage_index,
+                folded.meta.iteration,
+                totals,
+            )
+        }
+        None => {
+            let snapshot = std::fs::read_to_string(run_dir.join("context.json"))
+                .ok()
+                .and_then(|s| serde_json::from_str::<ContextSnapshot>(&s).ok())
+                .unwrap_or_else(|| ContextSnapshot {
+                    stage_name: meta.current_stage.clone(),
+                    total_tokens: 0,
+                    max_tokens: 0,
+                    regions: Vec::new(),
+                });
+            (
+                snapshot,
+                meta.stage_index,
+                meta.iteration,
+                totals_from(meta),
+            )
+        }
     };
     restore_agent(
         world.world_mut(),
         entity,
         &snapshot,
-        meta.stage_index,
-        meta.iteration,
+        stage_index,
+        iteration,
         totals,
     );
 
@@ -487,6 +524,61 @@ mod tests {
         dir
     }
 
+    /// Write a `<runs_dir>/<run_id>/run.lvr` that folds to the given `stage_index`,
+    /// `iteration`, `prompt_tokens`, and `context` — the run's atomic journal. Used
+    /// to prove recovery prefers this consistent pair over a stale `context.json`.
+    fn write_run_archive(
+        runs_dir: &Path,
+        run_id: &str,
+        agent_path: &str,
+        stage_index: usize,
+        iteration: usize,
+        prompt_tokens: usize,
+        context: &ContextSnapshot,
+    ) {
+        use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+        let dir = runs_dir.join(run_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut meta = RunMeta::new(
+            run_id.to_string(),
+            "coder".to_string(),
+            agent_path.to_string(),
+            "resume me".to_string(),
+            None,
+            std::env::temp_dir().to_string_lossy().to_string(),
+            1,
+        );
+        meta.status = RunStatus::Running;
+        meta.current_stage = "implement".to_string();
+        meta.stage_index = stage_index;
+        meta.iteration = iteration;
+        meta.prompt_tokens = prompt_tokens;
+        let mut buf = Vec::new();
+        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::Header {
+                identity: RunIdentity {
+                    run_id: run_id.to_string(),
+                    machine_id: "m".to_string(),
+                    world_id: "w".to_string(),
+                    created_at: 1,
+                },
+                meta: Box::new(meta),
+            },
+        )
+        .unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::ContextCheckpoint {
+                snapshot: context.clone(),
+                at: 2,
+            },
+        )
+        .unwrap();
+        std::fs::write(dir.join("run.lvr"), &buf).unwrap();
+    }
+
     #[tokio::test]
     async fn reloads_nonterminal_runs_and_restores_state() {
         let agent = agent_dir();
@@ -555,6 +647,136 @@ mod tests {
         let totals = world.world().get::<TokenTotals>(*entity).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
+    }
+
+    /// Fresh + stale differ on every observable field, so the assertions below
+    /// pin down exactly which source recovery restored from.
+    fn assert_restored_from_archive(world: &PipelineWorld, entity: Entity) {
+        use leviath_runtime::components::AgentState;
+        let state = world.world().get::<AgentState>(entity).unwrap();
+        // stage_name comes from the archive's context (not the stale context.json),
+        // iteration from the archive's meta (not meta.json's 5).
+        assert_eq!(state.current_stage, "fresh-stage");
+        assert_eq!(state.iteration, 9);
+        // token totals come from the archive's meta (not meta.json's 42).
+        let totals = world.world().get::<TokenTotals>(entity).unwrap();
+        assert_eq!(totals.prompt_tokens, 99);
+    }
+
+    /// The issue #43 fix: when the atomic journal (`run.lvr`) and the separate
+    /// `context.json` disagree — the crash-window state where a new `meta.json`
+    /// sits next to a stale `context.json` — resume restores the journal's
+    /// consistent `{meta, context}` pair, not the stale JSON.
+    #[tokio::test]
+    async fn reload_prefers_the_atomic_journal_over_a_stale_context_json() {
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+
+        // A STALE context.json (older generation) alongside a meta.json whose
+        // iteration/totals are also older than the journal — write_run stamps
+        // iteration 5 / prompt_tokens 42.
+        let stale = ContextSnapshot {
+            stage_name: "stale-stage".to_string(),
+            total_tokens: 1,
+            max_tokens: 100,
+            regions: vec![],
+        };
+        write_run(
+            runs.path(),
+            "run-torn",
+            mpath,
+            RunStatus::Running,
+            Some(&stale),
+        );
+        // The journal at the newer generation: iteration 9, prompt_tokens 99,
+        // context stage "fresh-stage".
+        let fresh = ContextSnapshot {
+            stage_name: "fresh-stage".to_string(),
+            total_tokens: 4,
+            max_tokens: 100_000,
+            regions: vec![],
+        };
+        write_run_archive(runs.path(), "run-torn", mpath, 0, 9, 99, &fresh);
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+
+        assert_eq!(restored.len(), 1);
+        assert_restored_from_archive(&world, restored[0].1);
+    }
+
+    /// A crash *during* the journal append can leave a torn trailing frame. Recovery
+    /// reads the journal leniently, so the valid prefix still resolves the resume
+    /// state (rather than silently falling back to the possibly-mismatched JSON).
+    #[tokio::test]
+    async fn reload_tolerates_a_torn_journal_tail() {
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+
+        let stale = ContextSnapshot {
+            stage_name: "stale-stage".to_string(),
+            total_tokens: 1,
+            max_tokens: 100,
+            regions: vec![],
+        };
+        write_run(
+            runs.path(),
+            "run-torn2",
+            mpath,
+            RunStatus::Running,
+            Some(&stale),
+        );
+        let fresh = ContextSnapshot {
+            stage_name: "fresh-stage".to_string(),
+            total_tokens: 4,
+            max_tokens: 100_000,
+            regions: vec![],
+        };
+        write_run_archive(runs.path(), "run-torn2", mpath, 0, 9, 99, &fresh);
+        // Append a torn frame (length prefix promising bytes that aren't there).
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(runs.path().join("run-torn2/run.lvr"))
+                .unwrap();
+            f.write_all(&[0, 0, 0, 0, 0, 0, 0, 10, 1, 2]).unwrap();
+        }
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+
+        assert_eq!(restored.len(), 1);
+        // The valid prefix folds → resume still uses the journal's fresh state.
+        assert_restored_from_archive(&world, restored[0].1);
     }
 
     /// A temp agent dir holding the `software-engineer` manifest, whose stage 0

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -431,6 +431,29 @@ pub fn read_archive(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
     Ok((version, records))
 }
 
+/// Read the archive tolerantly: validate the preamble strictly, then read records
+/// until a clean end-of-stream **or the first unreadable frame**, returning the
+/// records collected so far.
+///
+/// A crash while the persistence lane is appending a record can leave a partial
+/// final frame (a truncated length prefix or payload). The strict [`read_archive`]
+/// would reject the whole file for that torn tail — and once a fallback-resume
+/// appends fresh records *past* the torn bytes, the archive would stay unreadable
+/// forever. This variant instead stops at the torn tail and keeps everything valid
+/// before it, so recovery can still fold the archive to its last intact point. The
+/// preamble is still validated strictly, so a file that isn't a run archive at all
+/// still errors rather than folding to nothing.
+pub fn read_archive_lenient(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
+    let version = read_archive_start(r)?;
+    let mut records = Vec::new();
+    // A torn/invalid frame ends the read early with whatever preceded it, rather
+    // than propagating the error.
+    while let Ok(Some(record)) = read_record(r) {
+        records.push(record);
+    }
+    Ok((version, records))
+}
+
 // ─── fold ───────────────────────────────────────────────────────────────────
 
 /// The state reconstructed from a run journal — enough to resume or inspect the
@@ -1017,6 +1040,61 @@ mod tests {
         // Fail on the 8-byte length prefix, and (after it) on the payload.
         assert!(write_record(&mut FailAfter { remaining: 0 }, &rec).is_err());
         assert!(write_record(&mut FailAfter { remaining: 8 }, &rec).is_err());
+    }
+
+    #[test]
+    fn read_archive_lenient_matches_strict_on_a_clean_archive() {
+        // With no torn tail, the lenient reader returns exactly what the strict
+        // reader does.
+        let records = all_record_kinds();
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        for r in &records {
+            write_record(&mut buf, r).unwrap();
+        }
+        let (version, read) = read_archive_lenient(&mut buf.as_slice()).unwrap();
+        assert_eq!(version, RUN_ARCHIVE_VERSION);
+        assert_eq!(read, records);
+    }
+
+    #[test]
+    fn read_archive_lenient_keeps_valid_prefix_before_a_torn_tail() {
+        // A valid preamble + two full records, then a truncated frame (a crash
+        // mid-append). The strict reader would reject the whole file; the lenient
+        // reader returns the two intact records and stops at the torn tail.
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        write_record(&mut buf, &header()).unwrap();
+        write_record(
+            &mut buf,
+            &RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 1,
+            },
+        )
+        .unwrap();
+        // A frame claiming 10 payload bytes but only 2 present → torn tail.
+        buf.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 10, 1, 2]);
+
+        // Strict rejects the whole archive.
+        assert!(read_archive(&mut buf.as_slice()).is_err());
+        // Lenient keeps the valid prefix and folds cleanly.
+        let (version, records) = read_archive_lenient(&mut buf.as_slice()).unwrap();
+        assert_eq!(version, RUN_ARCHIVE_VERSION);
+        assert_eq!(records.len(), 2);
+        let folded = fold(&records).expect("prefix starts with a Header");
+        assert_eq!(folded.context.regions[0].entries.len(), 1);
+    }
+
+    #[test]
+    fn read_archive_lenient_still_errors_on_a_bad_preamble() {
+        // The preamble is validated strictly: a file that isn't a run archive at
+        // all errors rather than folding to nothing.
+        let mut bad_magic: &[u8] = b"XXXX\x00\x01";
+        assert!(read_archive_lenient(&mut bad_magic).is_err());
+        // A truncated version (valid magic, no version bytes) also errors.
+        let mut short: &[u8] = b"LVR1";
+        assert!(read_archive_lenient(&mut short).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`meta.json` and `context.json` are each written temp+rename atomic, but the **pair is not**. A crash between the two writes leaves a new `meta.json` (new stage/iteration) next to a stale `context.json`. On restart, `recovery::reload_one` read the two files separately and restored the stale context window while jumping the agent to the new stage/iteration — the "mildly inconsistent resume" from the v1-readiness audit (#43, MINOR).

## Fix

The `run.lvr` archive is appended **first** in `write_snapshot` and already records meta+context together, so `fold()` reconstructs a guaranteed-consistent `{meta, context}` even in the crash window. This changes only the **resume read path**:

- **`recovery::reload_one`** now prefers folding `run.lvr` for the resume context/stage/iteration/totals, falling back to the separate JSON files only when no archive exists (legacy runs). A shared `totals_from(meta)` helper feeds both arms.
- **`run_archive::read_archive_lenient`** — a crash mid-append can leave a torn trailing frame that the strict reader rejects wholesale (and which would permanently poison the archive once more records are appended past it). The lenient reader validates the preamble strictly, then returns every intact record before the torn tail.

`write_snapshot` is **unchanged** — no new on-disk files and no extra writes in the hot persistence lane.

## Tests

- `run_archive`: lenient reader — clean archive parity, valid-prefix-before-torn-tail, still-errors-on-bad-preamble.
- `recovery`: prefers the journal over a deliberately stale `context.json` (the #43 regression), and tolerates a torn journal tail. Existing no-archive tests exercise the JSON fallback.
- Full suites green for `leviath-core` + `leviath-cli`; **all 10 packages remain at 100% coverage** (`cargo xtask coverage`).

## Live daemon verification

Ran the real daemon in an isolated `LEVIATH_HOME` (user's real daemon untouched):

1. Started a `software-engineer` run; it parked at the `plan_approval` interaction point (`waiting_input`, stage `plan`, iter 4) with real `run.lvr`/`meta.json`/`context.json`.
2. Stopped the daemon; overwrote `context.json` with a stale marker (`stage_name=STALE-STAGE`, conversation → single `STALE_MARKER`), leaving `meta.json` + `run.lvr` fresh — reproducing the crash window.
3. Restarted the daemon. Recovery folded `run.lvr` and restored the consistent context:
   - `STALE_MARKER` appears nowhere in the resumed context ✓
   - `stage_name == plan` (archive), not `STALE-STAGE` ✓
   - resumed conversation first entry == the archive's first entry ✓
4. Verified a run with **no** `run.lvr` still resumes via the `context.json` fallback and the daemon stays healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gJwQTZzZhVhen3zHFsdPt