### PR TITLE
feat(context): percentage-based region budgets + per-stage layouts (closes #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ lev run . --task "Your task here"
 
 This writes an `agent.leviath` config you can customize — models per stage, context regions, tools, and workflow graph. See [agent configuration →](https://leviath.dev/docs/agents)
 
+Region budgets can be expressed as **percentages of the model's context window** so a
+blueprint's intent ("implementation gets the bulk") stays correct across models of
+different sizes. Percentages are ceilings (they may sum past 100%); absolute
+`max_tokens`/`threshold_tokens` act as optional guard-rails, and bare `max_tokens`
+(no `budget`) still works as a fixed count. Each stage may also declare its own
+`[stages.<name>.context.regions]` layout:
+
+```toml
+[context.regions]
+task           = { kind = "pinned",     budget = "2%",  max_tokens = 4000 }   # 2% of the window, capped at 4000
+codebase       = { kind = "compacting", budget = "25%", compact_at = "80%" }  # compact at 80% of the resolved budget
+implementation = { kind = "compacting", budget = "35%", compact_at = "80%" }
+conversation   = { kind = "sliding_window", max_items = 20, budget = "15%" }  # max_items is a count, stays absolute
+scratch        = { kind = "clearable",  budget = "8%",  min_tokens = 2000 }   # floor so small models don't starve it
+
+# Per-stage: the planning stage devotes the window to plan + architecture
+[stages.plan.context.regions]
+architecture = { kind = "pinned", budget = "15%" }
+plan         = { kind = "pinned", budget = "20%" }
+```
+
 ## 🧩 Features
 
 <table>

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -109,11 +109,13 @@ system_prompt = """
 Implement the plan. Create all necessary files and verify with bash.
 """
 
+# Region budgets are percentages of the model's context window (ceilings, may
+# sum past 100%); the absolute max_tokens is an optional guard-rail cap.
 [context.regions]
-task         = {{ kind = "pinned",          max_tokens = 2000 }}
-codebase     = {{ kind = "temporary",       max_tokens = 30000 }}
-conversation = {{ kind = "sliding_window",  max_items = 20, max_tokens = 15000 }}
-scratch      = {{ kind = "clearable",       max_tokens = 10000 }}
+task         = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000 }}
+codebase     = {{ kind = "temporary",       budget = "20%", max_tokens = 30000 }}
+conversation = {{ kind = "sliding_window",  max_items = 20, budget = "15%", max_tokens = 15000 }}
+scratch      = {{ kind = "clearable",       budget = "8%",  max_tokens = 10000 }}
 "#,
             name = name
         ),
@@ -138,12 +140,14 @@ description = "Synthesize findings and discuss with user"
 available_tools = ["read_file", "list_dir"]
 max_iterations = 15
 
+# Region budgets are percentages of the model's context window (ceilings, may
+# sum past 100%); the absolute max_tokens / threshold_tokens are guard-rail caps.
 [context.regions]
-objective    = {{ kind = "pinned",          max_tokens = 2000 }}
-sources      = {{ kind = "temporary",       max_tokens = 40000 }}
-findings     = {{ kind = "compacting",      threshold_tokens = 8000, max_tokens = 15000 }}
-conversation = {{ kind = "sliding_window",  max_items = 15, max_tokens = 12000 }}
-scratch      = {{ kind = "clearable",       max_tokens = 8000 }}
+objective    = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000 }}
+sources      = {{ kind = "temporary",       budget = "25%", max_tokens = 40000 }}
+findings     = {{ kind = "compacting",      budget = "12%", compact_at = "53%", threshold_tokens = 8000, max_tokens = 15000 }}
+conversation = {{ kind = "sliding_window",  max_items = 15, budget = "12%", max_tokens = 12000 }}
+scratch      = {{ kind = "clearable",       budget = "6%",  max_tokens = 8000 }}
 "#,
             name = name
         ),
@@ -164,10 +168,12 @@ system_prompt = """
 You are a helpful agent. Complete the task thoroughly.
 """
 
+# Region budgets are percentages of the model's context window (ceilings, may
+# sum past 100%); the absolute max_tokens is an optional guard-rail cap.
 [context.regions]
-system       = {{ kind = "pinned",         max_tokens = 2000 }}
-conversation = {{ kind = "sliding_window", max_items = 10, max_tokens = 10000 }}
-scratch      = {{ kind = "clearable",      max_tokens = 5000 }}
+system       = {{ kind = "pinned",         budget = "2%",  max_tokens = 2000 }}
+conversation = {{ kind = "sliding_window", max_items = 10, budget = "12%", max_tokens = 10000 }}
+scratch      = {{ kind = "clearable",      budget = "6%",  max_tokens = 5000 }}
 "#,
             name = name
         ),
@@ -233,6 +239,25 @@ mod tests {
             agent.get("name").unwrap().as_str().unwrap(),
             "my-researcher"
         );
+    }
+
+    #[test]
+    fn templates_use_percentage_budgets_and_parse_via_manifest() {
+        // Every generated template ships percentage budgets and must parse under
+        // the real manifest parser (which validates `budget`/`compact_at`).
+        for template in ["software-engineer", "coder", "researcher", "other"] {
+            let manifest = create_manifest("pct-agent", template);
+            assert!(
+                manifest.contains("budget = \""),
+                "{template} template should use percentage budgets"
+            );
+            let bp = leviath_core::manifest::parse_manifest(&manifest)
+                .expect("generated template should parse");
+            assert!(
+                bp.context_layout.has_percent_budgets(),
+                "{template} layout should have percentage budgets"
+            );
+        }
     }
 
     #[test]

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -9,6 +9,101 @@ use crate::error::ValidationError;
 use crate::region::{RegionKind, RegionSchema};
 use serde::{Deserialize, Serialize};
 
+/// How a region's token ceiling is expressed before it is resolved against a
+/// concrete model context window.
+///
+/// Blueprint authors think in **proportions** (`budget = "35%"`) so their intent
+/// stays correct regardless of the model's context size, while power users can
+/// still pin an exact count. The percentage denominator — the model's context
+/// window — is not known at parse time, so the spec is stored unresolved here and
+/// turned into a concrete token count at window-build time (see
+/// [`BudgetSpec::resolve`] and [`ContextLayout::resolved`]).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetSpec {
+    /// A fixed token ceiling, independent of the model. Resolving is a no-op.
+    Absolute(usize),
+
+    /// A ceiling expressed as a fraction of the model's context window, with
+    /// optional absolute guard-rails. `percent` is a fraction (`0.35` for
+    /// `"35%"`). `max` caps the resolved value (so e.g. 2% of a 1M window can't
+    /// balloon a task region to 20K tokens); `min` floors it (so a small-context
+    /// model doesn't starve the region below a usable size).
+    Percent {
+        /// Fraction of the model context window (0.35 == "35%").
+        percent: f64,
+        /// Absolute floor for the resolved value, if any.
+        min: Option<usize>,
+        /// Absolute cap for the resolved value, if any.
+        max: Option<usize>,
+    },
+}
+
+impl Default for BudgetSpec {
+    /// Only a serde-deserialize fallback for older persisted blueprints; live
+    /// code always sets the budget explicitly via [`RegionDefinition::new`].
+    fn default() -> Self {
+        BudgetSpec::Absolute(0)
+    }
+}
+
+impl BudgetSpec {
+    /// Parse a percentage string like `"35%"` into its fraction (`0.35`).
+    ///
+    /// Surrounding whitespace is trimmed and decimals are allowed (`"0.6%"`).
+    /// Rejects a missing `%`, a non-numeric value, and anything outside the
+    /// `(0, 100]` range — a single region can't sensibly claim ≤0% or more than
+    /// the whole window (region budgets may *sum* past 100%, but each is a
+    /// fraction of one window). Returns the human-readable reason on failure so
+    /// the caller can surface it at load time.
+    pub fn parse_budget(s: &str) -> std::result::Result<f64, String> {
+        let trimmed = s.trim();
+        let Some(num) = trimmed.strip_suffix('%') else {
+            return Err(format!("budget '{s}' must end with '%' (e.g. \"35%\")"));
+        };
+        let value: f64 = num
+            .trim()
+            .parse()
+            .map_err(|_| format!("budget '{s}' is not a valid number"))?;
+        if !(value > 0.0 && value <= 100.0) {
+            return Err(format!(
+                "budget '{s}' must be greater than 0% and at most 100%"
+            ));
+        }
+        Ok(value / 100.0)
+    }
+
+    /// Resolve this spec to a concrete token count against a model context
+    /// `window`.
+    ///
+    /// [`Absolute`](BudgetSpec::Absolute) ignores the window (idempotent — a
+    /// fully-absolute layout resolves to itself). [`Percent`](BudgetSpec::Percent)
+    /// rounds `window * percent`, then applies the `max` cap, then the `min`
+    /// floor. The floor is applied **last** so that when `min > max` the floor
+    /// wins: a region starved below a usable size is worse than one slightly over
+    /// its cap.
+    pub fn resolve(&self, window: usize) -> usize {
+        match self {
+            BudgetSpec::Absolute(n) => *n,
+            BudgetSpec::Percent { percent, min, max } => {
+                let mut v = (window as f64 * percent).round() as usize;
+                if let Some(max) = max {
+                    v = v.min(*max);
+                }
+                if let Some(min) = min {
+                    v = v.max(*min);
+                }
+                v
+            }
+        }
+    }
+
+    /// Whether this is a percentage budget (needs a model window to resolve).
+    pub fn is_percent(&self) -> bool {
+        matches!(self, BudgetSpec::Percent { .. })
+    }
+}
+
 /// A ContextLayout defines the complete memory map for an agent.
 ///
 /// Like SNES VRAM layout — every region has a defined purpose, size, and policy.
@@ -96,6 +191,15 @@ impl ContextLayout {
             );
         }
 
+        // The token-sum warning and the fixed-working-budget hard error below
+        // operate on concrete `max_tokens` values. When percentage budgets are
+        // present those values are provisional placeholders until the layout is
+        // resolved against a model window, so the checks are meaningless here —
+        // skip them and rely on the post-resolution `validate()` call at spawn.
+        if self.has_percent_budgets() {
+            return Ok(());
+        }
+
         let total_max: usize = self.regions.iter().map(|r| r.max_tokens).sum();
         if total_max > self.total_budget_tokens {
             tracing::warn!(
@@ -160,6 +264,97 @@ impl ContextLayout {
     pub fn get_region(&self, name: &str) -> Option<&RegionDefinition> {
         self.regions.iter().find(|r| r.name == name)
     }
+
+    /// Whether any region uses a percentage budget (and therefore needs a model
+    /// context window to resolve to concrete token counts).
+    pub fn has_percent_budgets(&self) -> bool {
+        self.regions.iter().any(|r| r.budget.is_percent())
+    }
+
+    /// Resolve every region's percentage budget against a concrete model context
+    /// `window`, returning a fully-absolute layout.
+    ///
+    /// Each region's `max_tokens` becomes `budget.resolve(window)`, and each
+    /// [`RegionKind::Compacting`] region's `threshold_tokens` is recomputed from
+    /// its [`compact_at`](RegionDefinition::compact_at) fraction (via the private
+    /// `resolve_compacting_threshold` helper). `eviction_order` is preserved. The
+    /// total budget becomes the model `window` when any percentage budget is
+    /// present (percentage ceilings are relative to the whole window and may sum
+    /// past 100%); a pure-absolute layout keeps its legacy summed total unchanged.
+    ///
+    /// Resolving an already-absolute layout is a no-op, so this is safe to call
+    /// unconditionally at window-build time.
+    pub fn resolved(&self, window: usize) -> ContextLayout {
+        let regions = self
+            .regions
+            .iter()
+            .map(|r| {
+                let max_tokens = r.budget.resolve(window);
+                let kind = match &r.kind {
+                    RegionKind::Compacting { threshold_tokens } => RegionKind::Compacting {
+                        threshold_tokens: Self::resolve_compacting_threshold(
+                            r.compact_at,
+                            *threshold_tokens,
+                            max_tokens,
+                        ),
+                    },
+                    other => other.clone(),
+                };
+                // Emit a fully-absolute region: the percentage has been baked
+                // into `max_tokens` and the compaction threshold into `kind`, so
+                // the resolved layout carries no `Percent` budgets. This makes
+                // `has_percent_budgets()` false on the result, so a post-resolution
+                // `validate()` runs the real token/working-budget checks.
+                RegionDefinition {
+                    kind,
+                    max_tokens,
+                    budget: BudgetSpec::Absolute(max_tokens),
+                    compact_at: None,
+                    ..r.clone()
+                }
+            })
+            .collect();
+
+        let total_budget_tokens = if self.has_percent_budgets() {
+            window
+        } else {
+            self.total_budget_tokens
+        };
+
+        ContextLayout {
+            regions,
+            total_budget_tokens,
+            eviction_order: self.eviction_order.clone(),
+        }
+    }
+
+    /// Compute a Compacting region's concrete compaction threshold from its
+    /// `compact_at` fraction, the absolute `threshold_tokens` guard carried on
+    /// the kind, and the region's resolved budget.
+    ///
+    /// - `compact_at = Some(f)` with an explicit `threshold_tokens` cap (any
+    ///   value below the [`usize::MAX`] sentinel) → `min(round(budget * f), cap)`:
+    ///   compact at the percentage, but never later than the absolute guard-rail.
+    /// - `compact_at = Some(f)` with no cap (`threshold_tokens == usize::MAX`
+    ///   sentinel) → `round(budget * f)`.
+    /// - `compact_at = None` → the absolute `threshold_tokens` as-is (back-compat,
+    ///   including the parser's `max_tokens * 8 / 10` default).
+    ///
+    /// The `usize::MAX` sentinel is safe: a layout is always resolved before any
+    /// [`Region::needs_compaction`](crate::region::Region::needs_compaction) check.
+    fn resolve_compacting_threshold(
+        compact_at: Option<f64>,
+        threshold_tokens: usize,
+        resolved_budget: usize,
+    ) -> usize {
+        match compact_at {
+            Some(fraction) => {
+                let pct = (resolved_budget as f64 * fraction).round() as usize;
+                pct.min(threshold_tokens)
+            }
+            None => threshold_tokens,
+        }
+    }
 }
 
 /// Where a region's initial content comes from at run start.
@@ -216,8 +411,26 @@ pub struct RegionDefinition {
     /// Region lifecycle policy
     pub kind: RegionKind,
 
-    /// Maximum tokens for this region
+    /// **Resolved** maximum tokens for this region. This is the concrete ceiling
+    /// every downstream consumer reads; for a percentage budget it is populated
+    /// when the layout is resolved against a model window (see
+    /// [`ContextLayout::resolved`]). [`Self::budget`] is the source of truth for
+    /// how this value is derived.
     pub max_tokens: usize,
+
+    /// How this region's ceiling is expressed. Defaults (via [`Self::new`]) to
+    /// [`BudgetSpec::Absolute`] holding `max_tokens`, so a region built the old
+    /// way behaves exactly as before. A percentage budget is resolved against the
+    /// model context window at window-build time.
+    #[serde(default)]
+    pub budget: BudgetSpec,
+
+    /// For [`RegionKind::Compacting`] regions only: compact when the region
+    /// reaches this fraction of its resolved budget (`0.80` for `compact_at =
+    /// "80%"`). `None` keeps the absolute `threshold_tokens` carried on the kind.
+    /// See [`ContextLayout::resolved`] for how this becomes a concrete threshold.
+    #[serde(default)]
+    pub compact_at: Option<f64>,
 
     /// Optional validation schema
     pub schema: Option<RegionSchema>,
@@ -246,18 +459,39 @@ pub struct RegionDefinition {
 }
 
 impl RegionDefinition {
-    /// Create a new region definition.
+    /// Create a new region definition with an absolute token ceiling.
+    ///
+    /// The `budget` is set to [`BudgetSpec::Absolute`] holding `max_tokens` and
+    /// `compact_at` to `None`, so every existing caller (and every region without
+    /// a percentage budget) is unaffected — resolving such a layout is a no-op.
     pub fn new(name: String, kind: RegionKind, max_tokens: usize) -> Self {
         Self {
             name,
             kind,
             max_tokens,
+            budget: BudgetSpec::Absolute(max_tokens),
+            compact_at: None,
             schema: None,
             description: None,
             required: false,
             required_message: None,
             seed: None,
         }
+    }
+
+    /// Set this region's budget spec (e.g. a percentage of the model window).
+    /// `max_tokens` is left as the provisional/resolved value; it is (re)computed
+    /// from the budget when the owning layout is resolved.
+    pub fn with_budget(mut self, budget: BudgetSpec) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Set the compaction trigger fraction for a [`RegionKind::Compacting`]
+    /// region (`0.80` == compact at 80% of the resolved budget).
+    pub fn with_compact_at(mut self, fraction: f64) -> Self {
+        self.compact_at = Some(fraction);
+        self
     }
 
     /// Set this region's seed source.
@@ -496,6 +730,266 @@ mod tests {
         let def = RegionDefinition::new("a".to_string(), RegionKind::Pinned, 5000)
             .with_description("holds architecture notes".to_string());
         assert_eq!(def.description.as_deref(), Some("holds architecture notes"));
+    }
+
+    #[test]
+    fn parse_budget_accepts_plain_and_decimal_percentages() {
+        assert_eq!(BudgetSpec::parse_budget("35%").unwrap(), 0.35);
+        assert_eq!(BudgetSpec::parse_budget("100%").unwrap(), 1.0);
+        assert!((BudgetSpec::parse_budget("0.6%").unwrap() - 0.006).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_budget_trims_surrounding_and_inner_whitespace() {
+        assert_eq!(BudgetSpec::parse_budget("  35 %  ").unwrap(), 0.35);
+    }
+
+    #[test]
+    fn parse_budget_rejects_missing_percent_sign() {
+        let err = BudgetSpec::parse_budget("35").unwrap_err();
+        assert!(err.contains("must end with '%'"), "{err}");
+    }
+
+    #[test]
+    fn parse_budget_rejects_non_numeric() {
+        let err = BudgetSpec::parse_budget("abc%").unwrap_err();
+        assert!(err.contains("not a valid number"), "{err}");
+    }
+
+    #[test]
+    fn parse_budget_rejects_zero_and_negative() {
+        let zero = BudgetSpec::parse_budget("0%").unwrap_err();
+        assert!(zero.contains("greater than 0%"), "{zero}");
+        let neg = BudgetSpec::parse_budget("-10%").unwrap_err();
+        assert!(neg.contains("greater than 0%"), "{neg}");
+    }
+
+    #[test]
+    fn parse_budget_rejects_over_one_hundred() {
+        let err = BudgetSpec::parse_budget("150%").unwrap_err();
+        assert!(err.contains("at most 100%"), "{err}");
+    }
+
+    #[test]
+    fn resolve_absolute_ignores_window() {
+        assert_eq!(BudgetSpec::Absolute(4000).resolve(1_000_000), 4000);
+        assert!(!BudgetSpec::Absolute(4000).is_percent());
+    }
+
+    #[test]
+    fn resolve_percent_of_window() {
+        let spec = BudgetSpec::Percent {
+            percent: 0.35,
+            min: None,
+            max: None,
+        };
+        assert_eq!(spec.resolve(1_000_000), 350_000);
+        assert!(spec.is_percent());
+    }
+
+    #[test]
+    fn resolve_percent_applies_max_cap() {
+        let spec = BudgetSpec::Percent {
+            percent: 0.02,
+            min: None,
+            max: Some(4000),
+        };
+        // 2% of 1M = 20_000, capped to 4000.
+        assert_eq!(spec.resolve(1_000_000), 4000);
+    }
+
+    #[test]
+    fn resolve_percent_applies_min_floor() {
+        let spec = BudgetSpec::Percent {
+            percent: 0.02,
+            min: Some(2000),
+            max: None,
+        };
+        // 2% of 8000 = 160, floored to 2000.
+        assert_eq!(spec.resolve(8000), 2000);
+    }
+
+    #[test]
+    fn resolve_percent_within_bounds_takes_neither_clamp() {
+        let spec = BudgetSpec::Percent {
+            percent: 0.10,
+            min: Some(1000),
+            max: Some(50_000),
+        };
+        // 10% of 200k = 20_000, between the floor and cap.
+        assert_eq!(spec.resolve(200_000), 20_000);
+    }
+
+    #[test]
+    fn resolve_percent_floor_wins_when_min_exceeds_max() {
+        let spec = BudgetSpec::Percent {
+            percent: 0.10,
+            min: Some(9000),
+            max: Some(4000),
+        };
+        // 10% of 200k = 20_000 → capped to 4000 → floored up to 9000 (floor wins).
+        assert_eq!(spec.resolve(200_000), 9000);
+    }
+
+    #[test]
+    fn has_percent_budgets_detects_percentage_regions() {
+        let absolute = ContextLayout::new(
+            vec![RegionDefinition::new(
+                "a".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            5000,
+        );
+        assert!(!absolute.has_percent_budgets());
+
+        let percent = ContextLayout::new(
+            vec![
+                RegionDefinition::new("a".to_string(), RegionKind::Pinned, 5000).with_budget(
+                    BudgetSpec::Percent {
+                        percent: 0.05,
+                        min: None,
+                        max: None,
+                    },
+                ),
+            ],
+            5000,
+        );
+        assert!(percent.has_percent_budgets());
+    }
+
+    #[test]
+    fn resolved_is_noop_for_absolute_layout() {
+        let layout = ContextLayout::new(
+            vec![RegionDefinition::new(
+                "a".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            5000,
+        );
+        let resolved = layout.resolved(1_000_000);
+        assert_eq!(resolved.regions[0].max_tokens, 5000);
+        // Absolute layout keeps its legacy summed total, not the window.
+        assert_eq!(resolved.total_budget_tokens, 5000);
+    }
+
+    #[test]
+    fn resolved_percent_layout_uses_window_as_total() {
+        let layout = ContextLayout::new(
+            vec![
+                RegionDefinition::new("a".to_string(), RegionKind::Pinned, 0).with_budget(
+                    BudgetSpec::Percent {
+                        percent: 0.10,
+                        min: None,
+                        max: None,
+                    },
+                ),
+            ],
+            0,
+        )
+        .with_eviction_order(vec!["a".to_string()]);
+        let resolved = layout.resolved(1_000_000);
+        assert_eq!(resolved.regions[0].max_tokens, 100_000);
+        assert_eq!(resolved.total_budget_tokens, 1_000_000);
+        // eviction order carried through.
+        assert_eq!(resolved.eviction_order, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn resolved_compacting_threshold_all_cases() {
+        // compact_at + explicit threshold cap → min(pct, cap).
+        let both = RegionDefinition::new(
+            "c".to_string(),
+            RegionKind::Compacting {
+                threshold_tokens: 25_000,
+            },
+            0,
+        )
+        .with_budget(BudgetSpec::Percent {
+            percent: 0.20,
+            min: None,
+            max: None,
+        })
+        .with_compact_at(0.80);
+        let r = ContextLayout::new(vec![both], 0).resolved(200_000);
+        // budget = 40_000; 80% = 32_000; capped to 25_000.
+        assert_eq!(
+            r.regions[0].kind,
+            RegionKind::Compacting {
+                threshold_tokens: 25_000
+            }
+        );
+
+        // compact_at with no cap (usize::MAX sentinel) → pct only.
+        let pct_only = RegionDefinition::new(
+            "c".to_string(),
+            RegionKind::Compacting {
+                threshold_tokens: usize::MAX,
+            },
+            0,
+        )
+        .with_budget(BudgetSpec::Percent {
+            percent: 0.20,
+            min: None,
+            max: None,
+        })
+        .with_compact_at(0.80);
+        let r = ContextLayout::new(vec![pct_only], 0).resolved(200_000);
+        assert_eq!(
+            r.regions[0].kind,
+            RegionKind::Compacting {
+                threshold_tokens: 32_000
+            }
+        );
+
+        // compact_at = None → absolute threshold passes through unchanged.
+        let absolute = RegionDefinition::new(
+            "c".to_string(),
+            RegionKind::Compacting {
+                threshold_tokens: 8000,
+            },
+            10_000,
+        );
+        let r = ContextLayout::new(vec![absolute], 10_000).resolved(1_000_000);
+        assert_eq!(
+            r.regions[0].kind,
+            RegionKind::Compacting {
+                threshold_tokens: 8000
+            }
+        );
+    }
+
+    #[test]
+    fn validate_skips_token_checks_for_percent_layouts() {
+        // A percentage layout whose provisional max_tokens are tiny/zero must not
+        // trip the fixed-working-budget hard error — that check is deferred to
+        // post-resolution. Wrap in tracing so no warn-arg lines read uncovered.
+        let regions = vec![
+            RegionDefinition::new("big_pinned".to_string(), RegionKind::Pinned, 0).with_budget(
+                BudgetSpec::Percent {
+                    percent: 0.95,
+                    min: None,
+                    max: None,
+                },
+            ),
+        ];
+        let layout = ContextLayout::new(regions, 100_000);
+        with_tracing(|| {
+            assert!(layout.validate().is_ok());
+        });
+    }
+
+    #[test]
+    fn region_definition_default_budget_matches_max_tokens() {
+        let def = RegionDefinition::new("a".to_string(), RegionKind::Pinned, 5000);
+        assert_eq!(def.budget, BudgetSpec::Absolute(5000));
+        assert_eq!(def.compact_at, None);
+    }
+
+    #[test]
+    fn budget_spec_default_is_absolute_zero() {
+        assert_eq!(BudgetSpec::default(), BudgetSpec::Absolute(0));
     }
 
     #[test]

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use blueprint::{
 };
 pub use cache::{CacheBreakpoint, CacheHint};
 pub use error::{Error, Result, ValidationError};
-pub use layout::{ContextLayout, RegionDefinition};
+pub use layout::{BudgetSpec, ContextLayout, RegionDefinition};
 pub use lifecycle::{CompactionConfig, CompactionStrategy, EvictionPolicy};
 pub use policy::{AllowlistRule, McpToolOverride, PolicyConfig, ScriptedRule};
 pub use region::{

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -425,6 +425,22 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 }
             }
 
+            // Parse per-stage context layout: [stages.<name>.context.regions].
+            // Different stages can carry different region sets — the runtime swaps
+            // to a stage's layout on entry (apply_stage_context → apply_layout),
+            // preserving overlapping regions' content by name. Absent ⇒ the stage
+            // inherits the global [context.regions] layout. NOTE (TOML nesting):
+            // like [stages.<name>.model], this must be its own `[...]` section;
+            // don't place `context = ...` inline keys after other sub-tables.
+            if let Some(regions_table) = stage_value
+                .get("context")
+                .and_then(|v| v.get("regions"))
+                .and_then(|v| v.as_table())
+            {
+                let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
+                stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
+            }
+
             // Parse max_revisits
             if let Some(mr) = stage_value.get("max_revisits").and_then(|v| v.as_integer()) {
                 stage.max_revisits = Some(mr as usize);
@@ -545,109 +561,14 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         ));
     }
 
-    let mut regions = Vec::new();
-    let mut total_tokens = 0usize;
-
-    if let Some(regions_table) = parsed
+    let (mut regions, mut total_tokens) = match parsed
         .get("context")
         .and_then(|v| v.get("regions"))
         .and_then(|v| v.as_table())
     {
-        for (region_name, region_value) in regions_table {
-            let max_tokens = region_value
-                .get("max_tokens")
-                .and_then(|v| v.as_integer())
-                .unwrap_or(5000) as usize;
-
-            let kind_str = region_value
-                .get("kind")
-                .and_then(|v| v.as_str())
-                .unwrap_or("temporary");
-
-            let kind = match kind_str {
-                "pinned" => RegionKind::Pinned,
-                "sliding_window" => {
-                    let max_items = region_value
-                        .get("max_items")
-                        .and_then(|v| v.as_integer())
-                        .unwrap_or(10) as usize;
-                    let eviction_strategy =
-                        match region_value.get("strategy").and_then(|v| v.as_str()) {
-                            Some("bulk") => {
-                                let overflow = region_value
-                                    .get("overflow")
-                                    .and_then(|v| v.as_integer())
-                                    .unwrap_or(10)
-                                    as usize;
-                                EvictionStrategy::Bulk { overflow }
-                            }
-                            Some("compact") => {
-                                let compact_count = region_value
-                                    .get("compact_count")
-                                    .and_then(|v| v.as_integer())
-                                    .unwrap_or(10)
-                                    as usize;
-                                EvictionStrategy::Compact { compact_count }
-                            }
-                            _ => EvictionStrategy::PerItem,
-                        };
-                    RegionKind::SlidingWindow {
-                        max_items,
-                        eviction_strategy,
-                    }
-                }
-                "temporary" => RegionKind::Temporary,
-                "compacting" => {
-                    let threshold = region_value
-                        .get("threshold_tokens")
-                        .and_then(|v| v.as_integer())
-                        .unwrap_or((max_tokens as i64) * 8 / 10)
-                        as usize;
-                    RegionKind::Compacting {
-                        threshold_tokens: threshold,
-                    }
-                }
-                "clearable" => RegionKind::Clearable,
-                "compact_history" => {
-                    let source = region_value
-                        .get("source_region")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    RegionKind::CompactHistory {
-                        source_region: source,
-                    }
-                }
-                "hashmap" | "hash_map" => {
-                    let max_entries = region_value
-                        .get("max_entries")
-                        .and_then(|v| v.as_integer())
-                        .map(|v| v as usize);
-                    RegionKind::HashMap { max_entries }
-                }
-                _ => RegionKind::Temporary,
-            };
-
-            let required = region_value
-                .get("required")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            let required_message = region_value
-                .get("required_message")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            let seed = parse_region_seed(region_name, region_value.get("seed"));
-
-            total_tokens += max_tokens;
-            let mut def = RegionDefinition::new(region_name.clone(), kind, max_tokens)
-                .with_required(required, required_message);
-            if let Some(seed) = seed {
-                def = def.with_seed(seed);
-            }
-            regions.push(def);
-        }
-    }
+        Some(regions_table) => parse_region_layout(regions_table)?,
+        None => (Vec::new(), 0usize),
+    };
 
     if regions.is_empty() {
         // 8000 tokens (~32K chars) for the pinned system region so a substantial
@@ -840,6 +761,189 @@ fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
         to_region: str_field(v, "to_region"),
         transform,
     }
+}
+
+/// Parse a `[context.regions]` (or `[stages.<name>.context.regions]`) table into
+/// region definitions plus the summed absolute-budget total.
+///
+/// Each region may express its ceiling as a percentage of the model context
+/// window (`budget = "35%"`) with optional absolute guard-rails (`max_tokens`
+/// caps it, `min_tokens` floors it), or as a plain absolute `max_tokens` (the
+/// legacy form, default 5000). Compacting regions may set `compact_at = "80%"`
+/// (compact at that fraction of the resolved budget) and/or an absolute
+/// `threshold_tokens` cap. Percentage regions carry a provisional `max_tokens`
+/// (the cap, or 0) that is finalized when the layout is resolved against a model
+/// window at spawn — see [`ContextLayout::resolved`]. The returned total sums
+/// only the absolute maxes; percentage regions contribute at resolution time.
+///
+/// Malformed `budget`/`compact_at` strings are a hard error so `leviath validate`
+/// catches them at load.
+fn parse_region_layout(
+    regions_table: &toml::value::Table,
+) -> Result<(Vec<RegionDefinition>, usize)> {
+    let mut regions = Vec::new();
+    let mut total_tokens = 0usize;
+
+    for (region_name, region_value) in regions_table {
+        // `budget = "N%"` opts a region into percentage mode; `max_tokens` then
+        // becomes the absolute cap and `min_tokens` the absolute floor. Without a
+        // `budget`, `max_tokens` is the literal ceiling (legacy behavior).
+        let percent = match region_value.get("budget").and_then(|v| v.as_str()) {
+            Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
+            None => None,
+        };
+        let max_tokens_opt = region_value
+            .get("max_tokens")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize);
+        let min_tokens = region_value
+            .get("min_tokens")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize);
+
+        let budget = match percent {
+            Some(percent) => crate::BudgetSpec::Percent {
+                percent,
+                min: min_tokens,
+                max: max_tokens_opt,
+            },
+            None => crate::BudgetSpec::Absolute(max_tokens_opt.unwrap_or(5000)),
+        };
+        // Provisional resolved ceiling: the literal value for absolute regions,
+        // the cap (or 0) for percentage regions until resolution overwrites it.
+        let provisional_max_tokens = match &budget {
+            crate::BudgetSpec::Absolute(n) => *n,
+            crate::BudgetSpec::Percent { max, .. } => max.unwrap_or(0),
+        };
+
+        // Compacting regions carry a compaction trigger. Parse `compact_at` (a
+        // fraction of the resolved budget) and the absolute `threshold_tokens`
+        // guard, and reconcile them into (RegionDefinition.compact_at, the value
+        // stored on RegionKind::Compacting) per the resolution contract in
+        // `ContextLayout::resolve_compacting_threshold`.
+        let compact_at = match region_value.get("compact_at").and_then(|v| v.as_str()) {
+            Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
+            None => None,
+        };
+        let explicit_threshold = region_value
+            .get("threshold_tokens")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize);
+
+        let kind_str = region_value
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("temporary");
+
+        let kind = match kind_str {
+            "pinned" => RegionKind::Pinned,
+            "sliding_window" => {
+                let max_items = region_value
+                    .get("max_items")
+                    .and_then(|v| v.as_integer())
+                    .unwrap_or(10) as usize;
+                let eviction_strategy = match region_value.get("strategy").and_then(|v| v.as_str())
+                {
+                    Some("bulk") => {
+                        let overflow = region_value
+                            .get("overflow")
+                            .and_then(|v| v.as_integer())
+                            .unwrap_or(10) as usize;
+                        EvictionStrategy::Bulk { overflow }
+                    }
+                    Some("compact") => {
+                        let compact_count = region_value
+                            .get("compact_count")
+                            .and_then(|v| v.as_integer())
+                            .unwrap_or(10) as usize;
+                        EvictionStrategy::Compact { compact_count }
+                    }
+                    _ => EvictionStrategy::PerItem,
+                };
+                RegionKind::SlidingWindow {
+                    max_items,
+                    eviction_strategy,
+                }
+            }
+            "temporary" => RegionKind::Temporary,
+            "compacting" => {
+                // Reconcile compact_at / threshold_tokens into the value stored on
+                // the kind (the absolute cap or the usize::MAX "no cap" sentinel);
+                // resolution turns it into the concrete threshold.
+                let threshold = match (compact_at, explicit_threshold, percent.is_some()) {
+                    (Some(_), Some(cap), _) => cap,
+                    (Some(_), None, _) => usize::MAX,
+                    (None, Some(t), _) => t,
+                    // No compact_at and no threshold: default to 80% of the budget
+                    // for percentage regions (resolved later), else the legacy
+                    // absolute `max_tokens * 8 / 10`.
+                    (None, None, true) => usize::MAX,
+                    (None, None, false) => provisional_max_tokens * 8 / 10,
+                };
+                RegionKind::Compacting {
+                    threshold_tokens: threshold,
+                }
+            }
+            "clearable" => RegionKind::Clearable,
+            "compact_history" => {
+                let source = region_value
+                    .get("source_region")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                RegionKind::CompactHistory {
+                    source_region: source,
+                }
+            }
+            "hashmap" | "hash_map" => {
+                let max_entries = region_value
+                    .get("max_entries")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as usize);
+                RegionKind::HashMap { max_entries }
+            }
+            _ => RegionKind::Temporary,
+        };
+
+        // The effective compact_at fraction to store on the region: an explicit
+        // value, or the 80% default for a percentage-budget compacting region
+        // with no explicit threshold (so it resolves relative to the budget).
+        let compact_at_field = match (kind_str, compact_at, explicit_threshold, percent.is_some()) {
+            ("compacting", Some(f), _, _) => Some(f),
+            ("compacting", None, None, true) => Some(0.80),
+            _ => None,
+        };
+
+        let required = region_value
+            .get("required")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let required_message = region_value
+            .get("required_message")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let seed = parse_region_seed(region_name, region_value.get("seed"));
+
+        // Percentage regions contribute their (unknown) size at resolution, so
+        // only absolute budgets add to the summed total here.
+        if percent.is_none() {
+            total_tokens += provisional_max_tokens;
+        }
+
+        let mut def = RegionDefinition::new(region_name.clone(), kind, provisional_max_tokens)
+            .with_budget(budget)
+            .with_required(required, required_message);
+        if let Some(f) = compact_at_field {
+            def = def.with_compact_at(f);
+        }
+        if let Some(seed) = seed {
+            def = def.with_seed(seed);
+        }
+        regions.push(def);
+    }
+
+    Ok((regions, total_tokens))
 }
 
 /// Parse a region's `seed` value from `[context.regions.<name>]`.
@@ -1262,6 +1366,219 @@ hist = { kind = "compact_history", source_region = "conv", max_tokens = 4000 }
                 source_region: "conv".to_string()
             }
         );
+
+        // Back-compat: with no `budget`, every region is an Absolute budget
+        // matching its max_tokens, and compact_at stays None.
+        assert_eq!(sys.budget, crate::BudgetSpec::Absolute(1000));
+        assert_eq!(sys.compact_at, None);
+        assert_eq!(comp.budget, crate::BudgetSpec::Absolute(6000));
+        assert_eq!(comp.compact_at, None);
+    }
+
+    #[test]
+    fn parse_region_percent_budget_with_guards() {
+        let toml = r#"
+[agent]
+name = "pct"
+
+[context.regions]
+task = { kind = "pinned", budget = "2%", max_tokens = 4000, min_tokens = 500 }
+free = { kind = "temporary", budget = "25%" }
+abs  = { kind = "pinned", max_tokens = 3000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let task = bp.context_layout.get_region("task").unwrap();
+        assert_eq!(
+            task.budget,
+            crate::BudgetSpec::Percent {
+                percent: 0.02,
+                min: Some(500),
+                max: Some(4000),
+            }
+        );
+        // Provisional max_tokens is the cap until resolution.
+        assert_eq!(task.max_tokens, 4000);
+
+        let free = bp.context_layout.get_region("free").unwrap();
+        assert_eq!(
+            free.budget,
+            crate::BudgetSpec::Percent {
+                percent: 0.25,
+                min: None,
+                max: None,
+            }
+        );
+        // Percentage with no cap → provisional 0 until resolved.
+        assert_eq!(free.max_tokens, 0);
+
+        let abs = bp.context_layout.get_region("abs").unwrap();
+        assert_eq!(abs.budget, crate::BudgetSpec::Absolute(3000));
+
+        assert!(bp.context_layout.has_percent_budgets());
+        // Only the absolute region contributes to the summed total.
+        assert_eq!(bp.context_layout.total_budget_tokens, 3000);
+    }
+
+    #[test]
+    fn parse_region_compact_at_variants() {
+        let toml = r#"
+[agent]
+name = "compacting"
+
+[context.regions]
+capped   = { kind = "compacting", budget = "35%", compact_at = "80%", threshold_tokens = 32000 }
+uncapped = { kind = "compacting", budget = "35%", compact_at = "80%" }
+pct_only = { kind = "compacting", budget = "35%" }
+absolute = { kind = "compacting", threshold_tokens = 9000 }
+default  = { kind = "compacting", max_tokens = 10000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+
+        let capped = bp.context_layout.get_region("capped").unwrap();
+        assert_eq!(capped.compact_at, Some(0.80));
+        assert_eq!(
+            capped.kind,
+            RegionKind::Compacting {
+                threshold_tokens: 32000
+            }
+        );
+
+        let uncapped = bp.context_layout.get_region("uncapped").unwrap();
+        assert_eq!(uncapped.compact_at, Some(0.80));
+        assert_eq!(
+            uncapped.kind,
+            RegionKind::Compacting {
+                threshold_tokens: usize::MAX
+            }
+        );
+
+        // budget but no compact_at / threshold → 80% default (percentage mode).
+        let pct_only = bp.context_layout.get_region("pct_only").unwrap();
+        assert_eq!(pct_only.compact_at, Some(0.80));
+        assert_eq!(
+            pct_only.kind,
+            RegionKind::Compacting {
+                threshold_tokens: usize::MAX
+            }
+        );
+
+        // Absolute threshold, no budget → absolute back-compat, compact_at None.
+        let absolute = bp.context_layout.get_region("absolute").unwrap();
+        assert_eq!(absolute.compact_at, None);
+        assert_eq!(
+            absolute.kind,
+            RegionKind::Compacting {
+                threshold_tokens: 9000
+            }
+        );
+
+        // No budget, no compact_at, no threshold → legacy max_tokens * 8 / 10.
+        let default = bp.context_layout.get_region("default").unwrap();
+        assert_eq!(default.compact_at, None);
+        assert_eq!(
+            default.kind,
+            RegionKind::Compacting {
+                threshold_tokens: 8000
+            }
+        );
+    }
+
+    #[test]
+    fn parse_region_rejects_malformed_budget() {
+        let toml = r#"
+[agent]
+name = "bad"
+
+[context.regions]
+task = { kind = "pinned", budget = "lots" }
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(err.contains("must end with '%'"), "{err}");
+    }
+
+    #[test]
+    fn parse_region_rejects_out_of_range_budget() {
+        let toml = r#"
+[agent]
+name = "bad"
+
+[context.regions]
+task = { kind = "pinned", budget = "150%" }
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(err.contains("at most 100%"), "{err}");
+    }
+
+    #[test]
+    fn parse_region_rejects_malformed_compact_at() {
+        let toml = r#"
+[agent]
+name = "bad"
+
+[context.regions]
+work = { kind = "compacting", budget = "35%", compact_at = "eighty" }
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(err.contains("must end with '%'"), "{err}");
+    }
+
+    #[test]
+    fn parse_manifest_reads_per_stage_context_regions() {
+        let toml = r#"
+[agent]
+name = "per-stage"
+entry_stage = "plan"
+
+[stages.plan]
+
+[stages.plan.context.regions]
+plan     = { kind = "pinned", budget = "20%", max_tokens = 40000 }
+codebase = { kind = "compacting", budget = "30%", compact_at = "70%" }
+
+[stages.implement]
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+
+        // The plan stage has its own layout with percentage budgets.
+        let plan_stage = bp.stages.iter().find(|s| s.name == "plan").unwrap();
+        let plan_layout = plan_stage.context_layout.as_ref().unwrap();
+        assert!(plan_layout.has_percent_budgets());
+        let plan_region = plan_layout.get_region("plan").unwrap();
+        assert_eq!(
+            plan_region.budget,
+            crate::BudgetSpec::Percent {
+                percent: 0.20,
+                min: None,
+                max: Some(40000),
+            }
+        );
+        let codebase = plan_layout.get_region("codebase").unwrap();
+        assert_eq!(codebase.compact_at, Some(0.70));
+
+        // The implement stage declared no regions → inherits the global layout.
+        let implement_stage = bp.stages.iter().find(|s| s.name == "implement").unwrap();
+        assert!(implement_stage.context_layout.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_rejects_malformed_per_stage_budget() {
+        // A bad budget inside a [stages.X.context.regions] table propagates the
+        // parse error just like the global layout does.
+        let toml = r#"
+[agent]
+name = "bad-stage"
+entry_stage = "plan"
+
+[stages.plan]
+
+[stages.plan.context.regions]
+plan = { kind = "pinned", budget = "nope" }
+"#;
+        let err = parse_manifest(toml).unwrap_err().to_string();
+        assert!(err.contains("must end with '%'"), "{err}");
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -2430,6 +2430,32 @@ pub struct ResolvedStage {
     pub tools: Vec<Tool>,
 }
 
+/// Fallback context window used when a stage's provider isn't registered (so
+/// percentage budgets can't be resolved against a real model). Matches
+/// [`leviath_providers::ModelCapabilities`]'s default `max_context_tokens`.
+const DEFAULT_CONTEXT_WINDOW_TOKENS: usize = 8192;
+
+/// Look up a model's context window (for resolving percentage region budgets)
+/// via the registered [`Providers`]. Falls back to
+/// [`DEFAULT_CONTEXT_WINDOW_TOKENS`] with a warning when the provider isn't
+/// registered — non-fatal, and `min_tokens` floors still protect regions.
+fn context_window_tokens(world: &World, provider_name: &str, model: &str) -> usize {
+    match world
+        .get_resource::<Providers>()
+        .and_then(|p| p.0.get(provider_name))
+    {
+        Some(provider) => provider.max_context_tokens(model),
+        None => {
+            tracing::warn!(
+                provider = provider_name,
+                model,
+                "provider not registered; using default context window for percentage budgets"
+            );
+            DEFAULT_CONTEXT_WINDOW_TOKENS
+        }
+    }
+}
+
 /// Build a stage's [`StageSetup`] from its blueprint definition: inference config
 /// (from the model parameters), tool-result routing, accepts-messages, layout,
 /// and system prompt.
@@ -2539,11 +2565,38 @@ pub fn spawn_agent(
 pub fn spawn_agent_seeded(
     world: &mut World,
     agent_id: String,
-    blueprint: leviath_core::Blueprint,
+    mut blueprint: leviath_core::Blueprint,
     seeds: &std::collections::HashMap<String, String>,
     stages: Vec<ResolvedStage>,
     global_batch_tool_hint: bool,
 ) -> Result<Entity, String> {
+    // Resolve any percentage region budgets against each stage's model context
+    // window (the only place the model — and hence the window — is known). The
+    // global layout resolves against the entry stage (stage 0); each per-stage
+    // layout resolves against that stage's own model. Absolute layouts resolve to
+    // themselves, so this is a no-op for legacy blueprints.
+    let stage_windows: Vec<usize> = stages
+        .iter()
+        .map(|rs| context_window_tokens(world, &rs.provider_name, &rs.model))
+        .collect();
+    blueprint.context_layout = blueprint.context_layout.resolved(stage_windows[0]);
+    for (i, stage) in blueprint.stages.iter_mut().enumerate() {
+        if let Some(layout) = &stage.context_layout {
+            stage.context_layout = Some(layout.resolved(stage_windows[i]));
+        }
+    }
+    // Validate the resolved (fully-absolute) layouts, now that percentages are
+    // concrete numbers judged against the real model window.
+    blueprint
+        .context_layout
+        .validate()
+        .map_err(|e| e.to_string())?;
+    for stage in &blueprint.stages {
+        if let Some(layout) = &stage.context_layout {
+            layout.validate().map_err(|e| e.to_string())?;
+        }
+    }
+
     let stage_infs: Vec<StageInference> = stages
         .into_iter()
         .map(|rs| StageInference {
@@ -3982,6 +4035,215 @@ mod tests {
                 .get::<crate::repetition::RepetitionDetector>(e)
                 .is_some()
         );
+    }
+
+    fn percent_region_blueprint(percent: f64) -> leviath_core::Blueprint {
+        let layout = leviath_core::layout::ContextLayout::new(
+            vec![
+                leviath_core::layout::RegionDefinition::new(
+                    "sys".to_string(),
+                    RegionKind::Pinned,
+                    0,
+                )
+                .with_budget(leviath_core::BudgetSpec::Percent {
+                    percent,
+                    min: None,
+                    max: None,
+                }),
+            ],
+            0,
+        );
+        let stages = vec![leviath_core::Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        )];
+        leviath_core::Blueprint::new("t".to_string(), "d".to_string(), stages, layout)
+    }
+
+    fn world_with_provider() -> World {
+        let mut world = World::new();
+        let mut reg = ProviderRegistry::new();
+        reg.register("p".to_string(), provider(true, 500));
+        world.insert_resource(Providers(reg));
+        world
+    }
+
+    #[test]
+    fn spawn_agent_seeded_resolves_percent_region_against_provider_window() {
+        // Provider "p" (Cfg) reports a 100_000-token window; a 35% region must
+        // resolve to 35_000, and the window total becomes the model window.
+        let mut world = world_with_provider();
+        let e = spawn_agent(
+            &mut world,
+            "run".to_string(),
+            percent_region_blueprint(0.35),
+            "task",
+            vec![resolved("m")],
+            true,
+        )
+        .expect("spawn");
+        let w = world.get::<ContextWindow>(e).expect("window");
+        assert_eq!(w.get_region("sys").unwrap().max_tokens, 35_000);
+        assert_eq!(w.max_tokens, 100_000);
+    }
+
+    #[test]
+    fn spawn_agent_seeded_falls_back_when_provider_missing() {
+        // No Providers resource → percentage resolves against the 8192 default
+        // window (and warns). 35% of 8192 ≈ 2867.
+        crate::test_support::with_tracing(|| {
+            let mut world = World::new();
+            let e = spawn_agent(
+                &mut world,
+                "run".to_string(),
+                percent_region_blueprint(0.35),
+                "task",
+                vec![resolved("m")],
+                true,
+            )
+            .expect("spawn");
+            let w = world.get::<ContextWindow>(e).expect("window");
+            let expected = (8192f64 * 0.35).round() as usize;
+            assert_eq!(w.get_region("sys").unwrap().max_tokens, expected);
+            assert_eq!(w.max_tokens, DEFAULT_CONTEXT_WINDOW_TOKENS);
+        });
+    }
+
+    #[test]
+    fn spawn_agent_seeded_absolute_blueprint_is_unchanged() {
+        // A pure-absolute blueprint resolves to itself: region max_tokens and the
+        // window total match the declared values, provider or not.
+        let mut world = world_with_provider();
+        let bp = blueprint(vec![leviath_core::Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        )]);
+        let e = spawn_agent(
+            &mut world,
+            "run".to_string(),
+            bp,
+            "task",
+            vec![resolved("m")],
+            true,
+        )
+        .expect("spawn");
+        let w = world.get::<ContextWindow>(e).expect("window");
+        // The `blueprint` helper declares total_budget_tokens = 12_000 (legacy sum
+        // behavior preserved for absolute layouts).
+        assert_eq!(w.max_tokens, 12_000);
+        assert_eq!(w.get_region("conversation").unwrap().max_tokens, 10_000);
+    }
+
+    #[test]
+    fn spawn_agent_seeded_resolves_per_stage_layout() {
+        // Stage 0 carries its own percentage layout; it must be resolved against
+        // that stage's model window and applied on entry (swapping the global one).
+        let mut world = world_with_provider();
+        let global = leviath_core::layout::ContextLayout::new(
+            vec![leviath_core::layout::RegionDefinition::new(
+                "sys".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            5000,
+        );
+        let mut stage = leviath_core::Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        );
+        stage.context_layout = Some(leviath_core::layout::ContextLayout::new(
+            vec![
+                leviath_core::layout::RegionDefinition::new(
+                    "sys".to_string(),
+                    RegionKind::Pinned,
+                    0,
+                )
+                .with_budget(leviath_core::BudgetSpec::Percent {
+                    percent: 0.10,
+                    min: None,
+                    max: None,
+                }),
+            ],
+            0,
+        ));
+        let bp =
+            leviath_core::Blueprint::new("t".to_string(), "d".to_string(), vec![stage], global);
+        let e = spawn_agent(
+            &mut world,
+            "run".to_string(),
+            bp,
+            "task",
+            vec![resolved("m")],
+            true,
+        )
+        .expect("spawn");
+        let w = world.get::<ContextWindow>(e).expect("window");
+        // Stage 0's per-stage layout won: 10% of 100_000 = 10_000.
+        assert_eq!(w.get_region("sys").unwrap().max_tokens, 10_000);
+    }
+
+    #[test]
+    fn spawn_agent_seeded_errors_when_resolved_global_layout_is_invalid() {
+        // A pinned region at 95% of the 100_000 window resolves to 95_000, leaving
+        // only 5_000 working tokens (< MIN_WORKING_TOKENS). Post-resolution
+        // validation must fail the spawn with an actionable message.
+        let mut world = world_with_provider();
+        let err = spawn_agent(
+            &mut world,
+            "run".to_string(),
+            percent_region_blueprint(0.95),
+            "task",
+            vec![resolved("m")],
+            true,
+        )
+        .expect_err("resolved layout should fail validation");
+        assert!(err.contains("working tokens"), "{err}");
+    }
+
+    #[test]
+    fn spawn_agent_seeded_errors_when_resolved_per_stage_layout_is_invalid() {
+        // The global layout is valid, but stage 0's per-stage layout resolves to a
+        // starved working budget → the per-stage validation branch fails the spawn.
+        let mut world = world_with_provider();
+        let global = leviath_core::layout::ContextLayout::new(
+            vec![leviath_core::layout::RegionDefinition::new(
+                "scratch".to_string(),
+                RegionKind::Clearable,
+                5000,
+            )],
+            5000,
+        );
+        let mut stage = leviath_core::Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        );
+        stage.context_layout = Some(leviath_core::layout::ContextLayout::new(
+            vec![
+                leviath_core::layout::RegionDefinition::new(
+                    "sys".to_string(),
+                    RegionKind::Pinned,
+                    0,
+                )
+                .with_budget(leviath_core::BudgetSpec::Percent {
+                    percent: 0.95,
+                    min: None,
+                    max: None,
+                }),
+            ],
+            0,
+        ));
+        let bp =
+            leviath_core::Blueprint::new("t".to_string(), "d".to_string(), vec![stage], global);
+        let err = spawn_agent(
+            &mut world,
+            "run".to_string(),
+            bp,
+            "task",
+            vec![resolved("m")],
+            true,
+        )
+        .expect_err("per-stage layout should fail validation");
+        assert!(err.contains("working tokens"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #100: region budgets can be expressed as **percentages of the model's context window** instead of only hard token counts, so a blueprint's intent ("implementation gets the bulk at 35%") stays correct across models of different context sizes (Sonnet 4.6 / Opus 4.8 are 1M-context; Haiku is 200K).

```toml
[context.regions]
task           = { kind = "pinned",     budget = "2%",  max_tokens = 4000 }   # 2% of window, capped at 4000
codebase       = { kind = "compacting", budget = "25%", compact_at = "80%" }  # compact at 80% of resolved budget
implementation = { kind = "compacting", budget = "35%", compact_at = "80%" }
conversation   = { kind = "sliding_window", max_items = 20, budget = "15%" }  # max_items stays a count
scratch        = { kind = "clearable",  budget = "8%",  min_tokens = 2000 }   # floor for small models
```

- **Percentages are ceilings** (may sum past 100%). Absolute `max_tokens`/`threshold_tokens` remain valid as fixed counts *or* as guard-rail caps alongside a percentage; `min_tokens` is a floor. Bare `max_tokens` (no `budget`) is unchanged and fully backwards-compatible.
- `compact_at = "N%"` resolves against the region's own budget; when an absolute `threshold_tokens` is also given, the threshold is `min(round(budget × compact_at), threshold_tokens)`.

### How resolution works
The percentage denominator (the model context window) is only known at spawn, so a new `BudgetSpec` on `RegionDefinition` stores the budget **unresolved**. `spawn_agent_seeded` resolves it per-stage against each stage's model window via the `Providers` registry (falling back to 8192 + a warning when a provider isn't registered), producing a fully-absolute layout that `init_window_seeded`/`apply_layout` consume unchanged. Layout validation runs **post-resolution**, so the working-budget guard is judged against real numbers.

### Per-stage context regions
Also adds `[stages.<name>.context.regions]` parsing. The plumbing (`Stage.context_layout`, runtime layout-swap on stage entry) already existed, but the TOML parser never read it — so stages couldn't carry their own regions. The region loop is refactored into a shared `parse_region_layout` helper used for both the global and per-stage tables; each per-stage layout resolves against its own stage's model window.

### Scope
Feature only. Shipped `agents/*.leviath` blueprints are intentionally **not** touched here — #98 (`feat/beep-up-default-blueprints`) already migrated them against this exact syntax and is gated on this PR. `lev create` templates are updated to scaffold percentage budgets.

## Testing
- New unit tests across `leviath-core` (BudgetSpec parse/resolve, layout resolution, all compaction-threshold cases, global + per-stage parsing, malformed-input errors) and `leviath-runtime` (spawn resolution: provider found / missing-fallback / pure-absolute back-compat / per-stage / validation-failure branches).
- **All three touched crates remain at hard 100% coverage** (`cargo xtask coverage`).
- **Live-verified end-to-end**: ran a `budget`-based agent through the real daemon against Sonnet 4.6 — regions resolved to exactly 2%→20000, 5%→50000, 3%→30000 of the 1M window, and the run completed with no error.
- Cross-checked that #98's four rewritten blueprints parse & validate cleanly under the new parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)