### PR TITLE
Beef up all 10 default agents: structured regions, stage graphs, web tools + runtime fixes (closes #98)

### DIFF
--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "coder"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-stage coding agent — analyze, implement, and review with graph-based error recovery and multi-provider model fallback"
 entry_stage = "analyze"
 
@@ -22,17 +22,30 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Understand requirements and plan the implementation"
-available_tools = ["read_file", "list_dir"]
+available_tools = ["read_file", "list_dir", "context_write"]
 max_iterations = 15
 system_prompt = """
 You are analyzing a coding task to produce a concise implementation plan.
-Use list_dir or read_file only if you need to check what already exists in the project.
-For a fresh task with no existing code, skip exploration entirely.
-Output a short bullet-list plan: which files to create/modify, what each does, and any key decisions.
-Be brief — the implement stage will do the actual coding.
+
+Start by categorizing the task — it drives everything downstream:
+- NEW FEATURE: what to build, where it slots in, which existing patterns to follow.
+- BUGFIX: reproduce first, isolate the root cause, then scope the minimal fix.
+- REFACTOR: preserve behavior; identify the seam and what must stay invariant.
+
+Then:
+1. Check the `conventions` and `architecture` regions — they are pre-loaded with
+   the project's style/lint rules and design docs. Follow them; don't rediscover them.
+2. Estimate scope: which files to create/modify, and roughly how large the change is.
+3. Identify dependencies — modules, libraries, config, or tests this touches.
+   Use list_dir/read_file ONLY to fill real gaps. For a fresh task with no existing
+   code, skip exploration entirely.
+
+Output a short bullet-list plan into the `plan` region (via context_write): files to
+create/modify, what each does, key decisions, and the dependencies you found. Be
+brief — the implement stage does the actual coding.
 """
 
-# Route exploration output into the persistent codebase region, not scratch.
+# Exploration output lands in the persistent `codebase` region, not scratch.
 [stages.analyze.tool_routing]
 default_region = "scratch"
 [stages.analyze.tool_routing.overrides]
@@ -56,23 +69,35 @@ available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "
 max_iterations = 50
 max_revisits = 3
 system_prompt = """
-You are implementing a coding task. Write working, production-quality code.
-Use write_file to create files and edit_file to modify existing ones.
-Use bash to run tests or verify the build once files are written.
-Do NOT spend iterations reading the codebase unless you need to check something specific.
+You are implementing the plan from the `plan` region. Write working,
+production-quality code that matches the project's `conventions`.
+
+Work incrementally — one coherent file/change at a time, not one giant dump:
+- Use write_file to create files and edit_file to modify existing ones.
+- Handle errors explicitly (validate inputs, propagate/return errors, no silent
+  swallowing) — match the error-handling style already used in this codebase.
+- Write or update tests alongside the code when the task warrants it, then use
+  bash to run them and verify the build. Test output is routed to `test_results`.
+- Do NOT spend iterations re-reading the codebase unless you need something specific.
+
+If a test keeps failing, check the `errors` region — it keeps the recent failures
+so you can spot a repeating pattern instead of chasing the same wall.
 
 If you hit a destructive or hard-to-reverse action you're unsure about, use
 ask_user_confirm before proceeding. Otherwise work autonomously.
 
-Create/modify all files needed, then confirm with a short summary of what changed
-and whether tests passed.
+When all files are written and tests pass, finish with a short summary of what
+changed and the test outcome.
 """
 
 [stages.implement.tool_routing]
 default_region = "scratch"
 [stages.implement.tool_routing.overrides]
-read_file = "codebase"
-list_dir  = "codebase"
+read_file  = "codebase"
+list_dir   = "codebase"
+write_file = "implementation"
+edit_file  = "implementation"
+bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -90,7 +115,7 @@ transform = "direct"
 mode = "interactive"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Review the code before finalizing"
-available_tools = ["read_file", "list_dir"]
+available_tools = ["read_file", "list_dir", "bash"]
 max_iterations = 10
 max_revisits = 3
 allow_complete = true
@@ -102,9 +127,15 @@ Review complete. Based on your findings:
 Minor style nits don't warrant another implementation pass.
 """
 system_prompt = """
-You are reviewing the implementation. Use read_file to read the files that were
-just created or modified. Provide concise, actionable feedback: correctness,
-edge cases, error handling, security, and code quality.
+You are reviewing the implementation. Verify it against the ORIGINAL task in the
+`task` region — not just against the plan (the plan can be wrong).
+
+1. Read the files that were created or modified (they are tracked in the
+   `implementation` region; read_file for anything you need to confirm).
+2. Re-run the tests with bash and confirm they pass — output goes to `test_results`.
+   Don't approve on unverified claims that "tests pass".
+3. Check: correctness vs. the task, edge cases, error handling, security, and
+   code quality/conventions.
 
 End with one of:
   APPROVED — no significant issues
@@ -114,16 +145,25 @@ End with one of:
 [stages.review.tool_permissions]
 read_file = "allow"
 list_dir  = "allow"
+bash      = "ask"
 
-# Custom transform: carry the plan/architecture/codebase forward, compact the
-# review conversation into a fix list, and clear scratch before re-implementing.
+[stages.review.tool_routing]
+default_region = "scratch"
+[stages.review.tool_routing.overrides]
+read_file = "codebase"
+list_dir  = "codebase"
+bash      = "test_results"
+
+# Custom transform: carry the plan/architecture/task/codebase forward, compact the
+# review conversation into a fix list, and clear scratch + test_results before
+# re-implementing so stale failures don't confuse the next pass.
 [stages.review.transitions.implement]
 hint = "Issues found — needs another implementation pass"
 transform = "custom"
 [stages.review.transitions.implement.transform_config]
-carry = ["architecture", "task", "codebase"]
+carry = ["architecture", "conventions", "task", "plan", "codebase"]
 compact = ["conversation"]
-clear = ["scratch"]
+clear = ["scratch", "test_results"]
 compact_prompt = "Summarize the review findings as a numbered list of required fixes."
 
 [stages.review.transitions.error_recovery]
@@ -136,14 +176,21 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and resolve errors encountered during implementation"
-available_tools = ["read_file", "bash"]
+available_tools = ["read_file", "bash", "context_append"]
 max_iterations = 10
 max_revisits = 2
 system_prompt = """
-An error occurred. Read the error details from the conversation context, diagnose
-the root cause, and suggest a fix or workaround. Then transition back to implement
-to retry.
+An error occurred. Read the error details from context, diagnose the root cause,
+and note a fix or workaround. Append a one-line summary of the failure to the
+`errors` region (context_append) so repeated failures become visible as a pattern,
+then transition back to implement to retry. If you see the SAME error recurring in
+`errors`, change approach rather than repeating the fix.
 """
+
+[stages.error_recovery.tool_routing]
+default_region = "errors"
+[stages.error_recovery.tool_routing.overrides]
+read_file = "codebase"
 
 [stages.error_recovery.transitions.implement]
 hint = "Error diagnosed — retry implementation"
@@ -155,19 +202,31 @@ provider = "anthropic"
 model = "claude-sonnet-4-6"
 
 # ─── Context layout ───────────────────────────────────────────────────────────
+# Budgets are given as a percentage of the model's context window (issue #100),
+# with an absolute `max_tokens`/`threshold_tokens` guard-rail so the layout is
+# sensible on any model. Percentages are ceilings, not reservations — they may
+# sum past 100% since regions rarely fill at once.
 [context.regions]
-# System-level (pinned, stable, cacheable — combined > 1024 tokens for Anthropic caching)
-architecture   = { kind = "pinned",          max_tokens = 6000 }
-task           = { kind = "pinned",          max_tokens = 4000 }
+# ── Inputs (pinned, stable, cacheable) ──
+task         = { kind = "pinned", budget = "2%", max_tokens = 4000, required = true, required_message = "Describe the coding task via --task (or the API/ACP task field)." }
+# Pre-loaded on startup: coding style, lint rules, contribution guide (missing files skipped).
+conventions  = { kind = "pinned", budget = "2%", max_tokens = 3000, seed = { files = ["CONVENTIONS.md", "CONTRIBUTING.md", "STYLEGUIDE.md", "STYLE.md", ".editorconfig", "rustfmt.toml", ".rustfmt.toml", ".prettierrc", ".eslintrc.json", "ruff.toml", "pyproject.toml"] } }
+# Pre-loaded on startup: architecture / design docs (missing files skipped).
+architecture = { kind = "pinned", budget = "3%", max_tokens = 6000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] } }
+plan         = { kind = "pinned", budget = "3%", max_tokens = 4000 }
 
-# Knowledge (non-volatile, survives message eviction)
-codebase       = { kind = "compacting",      threshold_tokens = 25000, max_tokens = 40000 }
-codebase_history = { kind = "compact_history", source_region = "codebase", max_tokens = 8000 }
-implementation = { kind = "compacting",      threshold_tokens = 25000, max_tokens = 40000 }
-impl_history   = { kind = "compact_history", source_region = "implementation", max_tokens = 8000 }
+# ── Knowledge (non-volatile, survives message eviction; compacts to *_history) ──
+codebase         = { kind = "compacting",      budget = "25%", compact_at = "80%", threshold_tokens = 25000, max_tokens = 40000 }
+codebase_history = { kind = "compact_history", source_region = "codebase",      budget = "2%", max_tokens = 8000 }
+implementation   = { kind = "compacting",      budget = "35%", compact_at = "80%", threshold_tokens = 32000, max_tokens = 40000 }
+impl_history     = { kind = "compact_history", source_region = "implementation", budget = "2%", max_tokens = 8000 }
 
-# Conversation (bulk eviction for caching — 20 iterations of stable prefix between evictions)
-conversation   = { kind = "sliding_window",  max_items = 40, max_tokens = 30000, strategy = "bulk", overflow = 20 }
+# ── Feedback loops ──
+# test_results is clearable so stale failures are wiped between retry passes.
+test_results = { kind = "clearable",      budget = "4%", max_tokens = 5000 }
+# errors is a small sliding window so a repeating failure is visible as a pattern.
+errors       = { kind = "sliding_window", max_items = 5, budget = "2%", max_tokens = 3000 }
 
-# Working memory (volatile)
-scratch        = { kind = "clearable",       max_tokens = 10000 }
+# ── Conversation (bulk eviction for prompt caching) + working memory ──
+conversation = { kind = "sliding_window", max_items = 40, budget = "20%", max_tokens = 30000, strategy = "bulk", overflow = 20 }
+scratch      = { kind = "clearable",      budget = "8%", max_tokens = 10000 }

--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -22,7 +22,7 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Understand requirements and plan the implementation"
-available_tools = ["read_file", "list_dir", "context_write"]
+available_tools = ["read_file", "list_dir"]
 max_iterations = 15
 system_prompt = """
 You are analyzing a coding task to produce a concise implementation plan.
@@ -40,14 +40,15 @@ Then:
    Use list_dir/read_file ONLY to fill real gaps. For a fresh task with no existing
    code, skip exploration entirely.
 
-Output a short bullet-list plan into the `plan` region (via context_write): files to
-create/modify, what each does, key decisions, and the dependencies you found. Be
-brief — the implement stage does the actual coding.
+Output a short bullet-list plan: which files to create/modify, what each does, key
+decisions, and the dependencies you found. Be brief — the implement stage does the
+actual coding and reads this plan from the conversation.
 """
 
-# Exploration output lands in the persistent `codebase` region, not scratch.
+# Only passive reads route to the persistent `codebase` region; everything else
+# stays in conversation.
 [stages.analyze.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.analyze.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
@@ -90,14 +91,14 @@ When all files are written and tests pass, finish with a short summary of what
 changed and the test outcome.
 """
 
+# Only passive reads route to a knowledge region. Action-tool results (write_file,
+# edit_file, bash) MUST stay in conversation: routing them away strips the
+# tool_result, so the model can't see the action landed and repeats it in a loop.
 [stages.implement.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
-write_file = "implementation"
-edit_file  = "implementation"
-bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -147,12 +148,12 @@ read_file = "allow"
 list_dir  = "allow"
 bash      = "ask"
 
+# bash (test runs) stays in conversation so the reviewer sees the results.
 [stages.review.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.review.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
-bash      = "test_results"
 
 # Custom transform: carry the plan/architecture/task/codebase forward, compact the
 # review conversation into a fix list, and clear scratch + test_results before
@@ -187,8 +188,12 @@ then transition back to implement to retry. If you see the SAME error recurring 
 `errors`, change approach rather than repeating the fix.
 """
 
+# Route tool chatter to scratch (clearable), not `errors`: `errors` is a
+# sliding_window and only `conversation` may hold routed ToolResult blocks
+# (a second sliding_window desyncs the result from its tool_use → API 400).
+# The agent still records failures to `errors` explicitly via context_append.
 [stages.error_recovery.tool_routing]
-default_region = "errors"
+default_region = "conversation"
 [stages.error_recovery.tool_routing.overrides]
 read_file = "codebase"
 

--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -91,14 +91,16 @@ When all files are written and tests pass, finish with a short summary of what
 changed and the test outcome.
 """
 
-# Only passive reads route to a knowledge region. Action-tool results (write_file,
-# edit_file, bash) MUST stay in conversation: routing them away strips the
-# tool_result, so the model can't see the action landed and repeats it in a loop.
+# Large read output persists in `codebase`; test output persists in `test_results`
+# (the review stage reads it). Routed results leave a short pointer in conversation
+# (paired with their tool_use) and the full output as text in the region, so the
+# model still sees each action landed. Small write/edit confirmations stay inline.
 [stages.implement.tool_routing]
 default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
+bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -148,12 +150,13 @@ read_file = "allow"
 list_dir  = "allow"
 bash      = "ask"
 
-# bash (test runs) stays in conversation so the reviewer sees the results.
+# Test re-runs persist to `test_results` (a pointer + preview stays in conversation).
 [stages.review.tool_routing]
 default_region = "conversation"
 [stages.review.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
+bash      = "test_results"
 
 # Custom transform: carry the plan/architecture/task/codebase forward, compact the
 # review conversation into a fix list, and clear scratch + test_results before

--- a/agents/daily-briefer/agent.leviath
+++ b/agents/daily-briefer/agent.leviath
@@ -1,35 +1,45 @@
 [agent]
 name = "daily-briefer"
-version = "0.2.0"
-description = "Morning summary agent — gathers from multiple sources, prioritizes, and delivers a concise briefing, with a prioritize→collect gap-filling loop and error recovery"
+version = "0.3.0"
+description = "Morning summary agent — gathers from local + web sources, prioritizes into a running index, and delivers a concise briefing"
 entry_stage = "collect"
+
+[tool_permissions]
+read_file  = "allow"
+list_dir   = "allow"
+web_search = "allow"
+web_fetch  = "allow"
+bash       = "ask"
+write_file = "ask"
 
 # ─── Stage 1: Collect ─────────────────────────────────────────────────────────
 [stages.collect]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
-description = "Gather information from configured sources"
-available_tools = ["read_file", "bash"]
+description = "Gather information from configured local + web sources"
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "bash", "context_append"]
 max_iterations = 20
-# Prioritize can send us back here to fill a gap; cap the round-trips.
 max_revisits = 2
 system_prompt = """
-You are gathering information for a daily briefing. Check each configured source:
-- Read local files (notes, logs, task lists)
-- Use bash to fetch web content (curl for APIs, RSS feeds, etc.)
-- Check for new items since the last briefing
+Gather material for a daily briefing per the request in `task` (which sources,
+what to watch). Check each source:
+- read_file / list_dir for local files (notes, logs, task lists)
+- web_search + web_fetch for news/topics; bash (curl) for a specific API or feed
+- Focus on what's NEW/actionable, not a full dump.
 
-Collect raw data. Don't analyze yet — just gather everything relevant.
-Tag each item with its source and timestamp. If you were sent back to fill a
-specific gap, focus only on that gap.
+Collect raw items into `raw_data`. Don't analyze yet. For each item, append a
+one-line source note to `sources_index` (context_append): `[n] <source> — <what>
+— <date/time if known>`. If sent back to fill a specific gap, focus only on it.
 """
 
-# Raw pulls go into the raw_data region.
 [stages.collect.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.collect.tool_routing.overrides]
-read_file = "raw_data"
-bash      = "raw_data"
+web_search = "raw_data"
+web_fetch  = "raw_data"
+read_file  = "raw_data"
+list_dir   = "raw_data"
+bash       = "raw_data"
 
 [stages.collect.transitions.prioritize]
 hint = "Sources checked — rank what was found"
@@ -40,12 +50,11 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 2: Prioritize ──────────────────────────────────────────────────────
-# Branches: usually → brief, but can loop back to collect if a critical source
-# turned up nothing and a gap needs filling.
 [stages.prioritize]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
-description = "Rank items by urgency and relevance"
+description = "Rank items by urgency and relevance into the priorities index"
+available_tools = ["context_write", "context_append"]
 max_iterations = 12
 max_revisits = 3
 transition_prompt = """
@@ -54,14 +63,15 @@ You've triaged everything collected. Decide what happens next:
 - Otherwise, respond with: brief
 """
 system_prompt = """
-Review everything collected and prioritize:
-1. **Action required** — needs a decision or response today
-2. **Important updates** — significant changes or news worth knowing
-3. **FYI** — interesting but not urgent
-4. **Skip** — noise, duplicates, or irrelevant items
+Triage everything in `raw_data` and write each kept item to the `priorities`
+region (context_append) as `<TIER> | <one-sentence summary> | <source ref>`,
+using these tiers:
+1. ACTION — needs a decision or response today
+2. UPDATE — significant change or news worth knowing
+3. FYI    — interesting but not urgent
 
-For each item, write a one-sentence summary and assign a priority tier.
-Drop anything in the Skip tier entirely.
+Drop noise, duplicates, and irrelevant items entirely (don't write them). If a
+critical configured source came back empty, consider one more collect pass.
 """
 
 [stages.prioritize.transitions.brief]
@@ -81,24 +91,25 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Compose the final briefing"
-available_tools = ["write_file"]
+available_tools = ["write_file", "read_file"]
 max_iterations = 10
 system_prompt = """
-Write a concise daily briefing. Format:
+Write a concise daily briefing (write_file) from the `priorities` region, citing
+`sources_index` where relevant. Format:
 
 ## Daily Briefing — [Date]
 
 ### 🔴 Action Required
-(items needing decisions/responses today)
+(ACTION-tier items needing decisions/responses today)
 
 ### 📌 Key Updates
-(significant changes worth knowing)
+(UPDATE-tier significant changes)
 
 ### 📎 Worth Noting
-(interesting but non-urgent items)
+(FYI-tier items)
 
-Keep each item to 1-2 sentences. Link to sources where relevant.
-The entire briefing should be readable in under 2 minutes.
+Keep each item to 1-2 sentences. The whole briefing should read in under 2 minutes.
+If a source failed, add a short "⚠️ Gaps" note listing what couldn't be checked.
 """
 
 # Explicit empty transitions = terminal.
@@ -113,8 +124,8 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-A source fetch or parse failed. Read the error from context, note which source
-is unavailable, and record that gap so the briefing can flag it. Then return to
+A source fetch or parse failed. Read the error from context, note which source is
+unavailable, and record that gap so the briefing can flag it. Then return to
 prioritize with whatever was successfully collected.
 """
 
@@ -126,8 +137,13 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-task        = { kind = "pinned",         max_tokens = 1000 }
-raw_data    = { kind = "temporary",      max_tokens = 40000 }
-prioritized = { kind = "sliding_window", max_tokens = 15000, strategy = "bulk", overflow = 10 }
-scratch     = { kind = "clearable",      max_tokens = 5000 }
+task        = { kind = "pinned", budget = "2%", max_tokens = 2000, required = true, seed = "task", required_message = "Describe the briefing (which sources, what to watch) via --task." }
+sources_index = { kind = "pinned", budget = "3%", max_tokens = 3000 }
+
+raw_data    = { kind = "temporary",      budget = "30%", max_tokens = 40000 }
+priorities  = { kind = "sliding_window", max_items = 25, budget = "10%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+brief       = { kind = "clearable",      budget = "5%", max_tokens = 6000 }
+
+conversation = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/daily-briefer/tools/web_fetch.rhai
+++ b/agents/daily-briefer/tools/web_fetch.rhai
@@ -1,0 +1,21 @@
+// @tool web_fetch
+// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @param url string required "The URL to fetch (http or https)"
+// @requires network
+
+let out = "";
+try {
+    // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
+    let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
+    // Cap very large pages so a single fetch can't blow the context budget.
+    if body.len() > 12000 {
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+    } else {
+        out = body;
+    }
+} catch(e) {
+    // Most commonly the page exceeds the engine's 1MB string limit, or the host
+    // blocked the request. Report it so the agent can pick a smaller/other source.
+    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+}
+out

--- a/agents/daily-briefer/tools/web_fetch.rhai
+++ b/agents/daily-briefer/tools/web_fetch.rhai
@@ -1,5 +1,5 @@
 // @tool web_fetch
-// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
 
@@ -7,9 +7,18 @@ let out = "";
 try {
     // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
     let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
-    // Cap very large pages so a single fetch can't blow the context budget.
+
+    // If the response looks like HTML, extract readable text so the model reads
+    // prose instead of markup. (Content injected by client-side JS isn't in the
+    // source and can't be recovered here.)
+    let lo = body.to_lower();
+    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+        body = html_to_text(body);
+    }
+
+    // Cap very large content so a single fetch can't blow the context budget.
     if body.len() > 12000 {
-        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;
     }

--- a/agents/daily-briefer/tools/web_search.rhai
+++ b/agents/daily-briefer/tools/web_search.rhai
@@ -1,0 +1,51 @@
+// @tool web_search
+// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @param query string required "The search query"
+// @param count integer optional "Maximum number of results to return (default 5)"
+// @requires network
+
+let n = if params.count == () { 5 } else { params.count };
+let results = [];
+
+// Prefer Brave Search when an API key is configured. env_var throws when the
+// variable is unset, so probe it inside try/catch and fall back to keyless search.
+let key = "";
+try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+
+let got = false;
+if key != "" {
+    try {
+        let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
+        if data.web != () && data.web.results != () {
+            for r in data.web.results {
+                if results.len() >= n { break; }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+            }
+            got = true;
+        }
+    } catch(e) {
+        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
+        got = false;
+    }
+}
+
+if !got {
+    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
+    // queries (no key required). Each page becomes a {title, url, snippet} result.
+    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+    // Wikipedia requires a descriptive User-Agent (403 otherwise).
+    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+    if data.pages != () {
+        for p in data.pages {
+            if results.len() >= n { break; }
+            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
+            snippet.replace("<span class=\"searchmatch\">", "");
+            snippet.replace("</span>", "");
+            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+        }
+    }
+}
+
+results

--- a/agents/deep-researcher/agent.leviath
+++ b/agents/deep-researcher/agent.leviath
@@ -1,39 +1,54 @@
 [agent]
 name = "deep-researcher"
-version = "0.2.0"
-description = "Thorough investigation of a single topic — follows citations, reads sources, and produces a structured report, with a gather↔analyze loop and error recovery"
+version = "0.3.0"
+description = "Thorough single-topic investigation — searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
+
+# Read/search agent: writes only its final report.
+[tool_permissions]
+read_file  = "allow"
+list_dir   = "allow"
+web_search = "allow"
+web_fetch  = "allow"
+write_file = "ask"
+bash       = "ask"
 
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
-available_tools = ["read_file", "bash"]
-max_iterations = 30
+# web_search / web_fetch are provided by this agent's tools/ (issue #97).
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
+max_iterations = 25
 max_revisits = 3
 system_prompt = """
-You are researching a topic in depth. Find primary sources, key papers, official
-documentation, and authoritative references. Use bash (curl/wget) for web sources
-or read_file for local documents.
+You are investigating the topic in the `query` region in DEPTH, within any bounds
+in `scope`. This is a single-topic deep dive — go for primary sources and
+authoritative references, not a broad skim.
 
-For each source found:
-- Note the author/organization and date
-- Extract key claims with direct quotes
-- Note any citations worth following
+- Run a focused first round of web_search calls across the distinct facets of the
+  question, then web_fetch the most authoritative results for detail. Prefer
+  primary sources (papers, standards, official docs) over summaries. read_file for
+  local documents. Raw content lands in `sources`.
+- For every source you actually use, append one bibliography line to
+  `sources_index` (context_append): `[n] <title> — <url/path> — <date> —
+  credibility: <high/med/low + why>`.
+- Note citations worth chasing — the analyze stage can send you to follow them.
 
-Be thorough. Follow citation chains. Prefer primary sources over summaries.
-If you were sent back to fill a gap, focus on the specific sub-topic named.
+Once you have solid primary coverage of the core facets, hand off to analyze.
 """
 
 [stages.gather.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.gather.tool_routing.overrides]
-read_file = "sources"
-bash      = "sources"
+web_search = "sources"
+web_fetch  = "sources"
+read_file  = "sources"
+list_dir   = "sources"
 
 [stages.gather.transitions.analyze]
-hint = "Enough sources gathered for meaningful analysis"
+hint = "Enough primary sources gathered for meaningful analysis"
 transform = "direct"
 
 [stages.gather.transitions.error_recovery]
@@ -41,65 +56,113 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 2: Analyze ─────────────────────────────────────────────────────────
+# Three open edges: more breadth (gather), chase a specific citation
+# (follow_citations), or write the report (synthesize).
 [stages.analyze]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
-description = "Analyze findings, identify patterns, and synthesize insights"
-available_tools = ["read_file"]
+description = "Analyze findings, cross-reference claims, and decide the next move"
+available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 20
-max_revisits = 2
+max_revisits = 3
 transition_prompt = """
-You've analyzed the gathered material. Decide what happens next:
-- If there are gaps that need more sources on specific sub-topics, respond with: gather
-- If you have enough evidence to write a comprehensive report, respond with: synthesize
+Decide the next move:
+- Broad gaps that need new sources on a sub-topic → respond with: gather
+- A specific cited source you should pull and read before concluding →
+  respond with: follow_citations
+- Enough well-supported evidence to write the report → respond with: synthesize
 """
 system_prompt = """
-Analyze the research findings:
-1. Identify key themes and patterns across sources
-2. Note areas of consensus and disagreement
-3. Evaluate source quality and potential biases
-4. Identify gaps — what questions remain unanswered?
-5. Form preliminary conclusions supported by evidence
+Analyze the `sources` against `sources_index`. Be rigorous:
+1. Extract factual claims into `claims` (context_append), each with its source
+   ref: `<claim> [n]`. Separate well-supported (multiple credible sources) from
+   single-source or speculative.
+2. Record source disagreements in `contradictions` (context_write) — who claims
+   what, with refs. Never silently pick a side.
+3. Evaluate source quality and bias; note gaps and the specific citations worth
+   chasing next.
 
-Be rigorous. Distinguish well-supported claims from speculation.
+Prefer following a key citation (follow_citations) over re-searching when a claim
+hinges on a source you haven't read directly.
 """
 
 [stages.analyze.transitions.gather]
-hint = "Gaps identified — need more sources on specific sub-topics"
+hint = "Broad gaps — need new sources on specific sub-topics"
+transform = "compact"
+
+[stages.analyze.transitions.follow_citations]
+hint = "A specific cited source should be pulled and read directly"
 transform = "compact"
 
 [stages.analyze.transitions.synthesize]
-hint = "Analysis complete — ready to write the report"
+hint = "Evidence is sufficient — write the report"
 transform = "compact"
 
 [stages.analyze.transitions.error_recovery]
 condition = "error"
 transform = "direct"
 
-# ─── Stage 3: Synthesize (terminal) ───────────────────────────────────────────
+# ─── Stage 3: Follow citations ────────────────────────────────────────────────
+# The "follows citation chains" behavior as a real stage: pull the specific
+# sources analyze flagged, then hand back.
+[stages.follow_citations]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Pull and read specific cited sources flagged during analysis"
+available_tools = ["web_fetch", "web_search", "read_file", "context_append"]
+max_iterations = 12
+max_revisits = 3
+system_prompt = """
+Analysis flagged specific citations to chase. For each: web_fetch the source
+directly (or web_search for it by title/author first), read it, and append the
+new material to `sources` plus a bibliography line to `sources_index`. Extract
+any new or corrected claims to `claims`. Then hand back to analyze.
+
+Stay focused on the flagged citations — this is a targeted deep read, not a new
+broad search.
+"""
+
+[stages.follow_citations.tool_routing]
+default_region = "conversation"
+[stages.follow_citations.tool_routing.overrides]
+web_fetch  = "sources"
+web_search = "sources"
+read_file  = "sources"
+
+[stages.follow_citations.transitions.analyze]
+hint = "Cited sources read — resume analysis"
+transform = "compact"
+
+[stages.follow_citations.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
+# ─── Stage 4: Synthesize (terminal) ───────────────────────────────────────────
 [stages.synthesize]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
-description = "Produce a structured research report with citations"
-available_tools = ["write_file"]
+description = "Produce a structured, cited research report"
+available_tools = ["write_file", "read_file"]
 max_iterations = 15
 system_prompt = """
-Write a structured research report based on your analysis. Include:
-- Executive summary (key findings in 3-5 sentences)
+Write the report (write_file), built from `claims` and citing `sources_index`,
+following the citation/confidence rules in `format`. Structure:
+- Executive summary (key findings in 3-5 sentences, each with a confidence level)
 - Background and context
-- Methodology (what sources were consulted)
-- Findings organized by theme
+- Findings organized by theme, every non-obvious claim carrying a [n] citation
+- Disagreements — pull these straight from `contradictions`; never drop a
+  recorded conflict
 - Analysis and implications
-- Open questions and areas for further research
-- References with links/citations
+- Open questions
+- References — the numbered bibliography from `sources_index`
 
-Write for a technical audience. Be precise. Cite specific sources for claims.
+Write for a technical audience. Be precise. Distinguish evidence from inference.
 """
 
 # Explicit empty transitions = terminal.
 [stages.synthesize.transitions]
 
-# ─── Stage 4: Error recovery ──────────────────────────────────────────────────
+# ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
@@ -108,9 +171,9 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-A source fetch or parse failed. Read the error from context, note which source
-is unavailable and why, and record the gap. Then return to analyze to continue
-with the sources you do have.
+A source fetch or parse failed. Read the error from context, record which source
+is unavailable and why (as a gap), and hand back to analyze to continue with the
+material you do have.
 """
 
 [stages.error_recovery.transitions.analyze]
@@ -121,9 +184,18 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
+# Percentage budgets (issue #100) with absolute guard-rails.
 [context.regions]
-query            = { kind = "pinned",          max_tokens = 1500 }
-sources          = { kind = "temporary",       max_tokens = 50000 }
-analysis         = { kind = "compacting",      threshold_tokens = 30000, max_tokens = 40000 }
-analysis_history = { kind = "compact_history", source_region = "analysis", max_tokens = 15000 }
-scratch          = { kind = "clearable",       max_tokens = 5000 }
+query          = { kind = "pinned", budget = "1%", max_tokens = 1500, required = true, seed = "task", required_message = "State the research topic via --task." }
+scope          = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope" }
+sources_index  = { kind = "pinned", budget = "4%", max_tokens = 4000 }
+format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." } }
+
+sources        = { kind = "temporary",      budget = "30%", max_tokens = 50000 }
+claims         = { kind = "sliding_window", max_items = 40, budget = "8%", max_tokens = 9000 }
+contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
+analysis         = { kind = "compacting",      budget = "30%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 40000 }
+analysis_history = { kind = "compact_history", source_region = "analysis", budget = "3%", max_tokens = 15000 }
+
+conversation   = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/deep-researcher/tools/web_fetch.rhai
+++ b/agents/deep-researcher/tools/web_fetch.rhai
@@ -1,0 +1,21 @@
+// @tool web_fetch
+// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @param url string required "The URL to fetch (http or https)"
+// @requires network
+
+let out = "";
+try {
+    // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
+    let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
+    // Cap very large pages so a single fetch can't blow the context budget.
+    if body.len() > 12000 {
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+    } else {
+        out = body;
+    }
+} catch(e) {
+    // Most commonly the page exceeds the engine's 1MB string limit, or the host
+    // blocked the request. Report it so the agent can pick a smaller/other source.
+    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+}
+out

--- a/agents/deep-researcher/tools/web_fetch.rhai
+++ b/agents/deep-researcher/tools/web_fetch.rhai
@@ -1,5 +1,5 @@
 // @tool web_fetch
-// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
 
@@ -7,9 +7,18 @@ let out = "";
 try {
     // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
     let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
-    // Cap very large pages so a single fetch can't blow the context budget.
+
+    // If the response looks like HTML, extract readable text so the model reads
+    // prose instead of markup. (Content injected by client-side JS isn't in the
+    // source and can't be recovered here.)
+    let lo = body.to_lower();
+    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+        body = html_to_text(body);
+    }
+
+    // Cap very large content so a single fetch can't blow the context budget.
     if body.len() > 12000 {
-        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;
     }

--- a/agents/deep-researcher/tools/web_search.rhai
+++ b/agents/deep-researcher/tools/web_search.rhai
@@ -1,0 +1,51 @@
+// @tool web_search
+// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @param query string required "The search query"
+// @param count integer optional "Maximum number of results to return (default 5)"
+// @requires network
+
+let n = if params.count == () { 5 } else { params.count };
+let results = [];
+
+// Prefer Brave Search when an API key is configured. env_var throws when the
+// variable is unset, so probe it inside try/catch and fall back to keyless search.
+let key = "";
+try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+
+let got = false;
+if key != "" {
+    try {
+        let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
+        if data.web != () && data.web.results != () {
+            for r in data.web.results {
+                if results.len() >= n { break; }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+            }
+            got = true;
+        }
+    } catch(e) {
+        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
+        got = false;
+    }
+}
+
+if !got {
+    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
+    // queries (no key required). Each page becomes a {title, url, snippet} result.
+    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+    // Wikipedia requires a descriptive User-Agent (403 otherwise).
+    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+    if data.pages != () {
+        for p in data.pages {
+            if results.len() >= n { break; }
+            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
+            snippet.replace("<span class=\"searchmatch\">", "");
+            snippet.replace("</span>", "");
+            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+        }
+    }
+}
+
+results

--- a/agents/log-analyzer/agent.leviath
+++ b/agents/log-analyzer/agent.leviath
@@ -1,36 +1,39 @@
 [agent]
 name = "log-analyzer"
-version = "0.2.0"
-description = "Analyzes log files — identifies anomalies, trends, and error patterns via a scripted analyze↔script loop, with error recovery and multi-provider fallback"
+version = "0.3.0"
+description = "Analyzes log files — identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
 [tool_permissions]
 read_file = "allow"
 list_dir  = "allow"
 bash      = "ask"
+write_file = "ask"
 
 # ─── Stage 1: Ingest ──────────────────────────────────────────────────────────
 [stages.ingest]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Read log files, identify format and structure"
-available_tools = ["read_file", "list_dir", "bash"]
+available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 15
 system_prompt = """
-You are ingesting log files for analysis. Your job:
-1. Read the provided log files or directories
-2. Identify the log format (JSON, syslog, Apache, custom, etc.)
-3. Note the time range covered and total volume
-4. Identify the fields/columns available
-5. Look for obvious structural issues (corrupted lines, encoding problems)
+Ingest the log files named in `task`. Determine:
+1. Log format (JSON, syslog, Apache, custom, etc.)
+2. Time range covered and total volume
+3. Available fields/columns
+4. Obvious structural issues (corrupted lines, encoding problems)
 
-Store your findings about format and structure in context for the next stage.
+Use bash (head/wc/file) to sample rather than reading whole huge files. Write a
+short format/structure summary to `findings` (context_write) so the analyze stage
+starts oriented. Raw sampled content lands in `logs`.
 """
 
 [stages.ingest.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.ingest.tool_routing.overrides]
 read_file = "logs"
+bash      = "logs"
 
 [stages.ingest.transitions.analyze]
 hint = "Log format identified, ready to analyze"
@@ -45,29 +48,34 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Identify anomalies, trends, and error patterns"
-available_tools = ["read_file", "bash"]
+available_tools = ["read_file", "bash", "context_write", "context_append"]
 max_iterations = 25
 max_revisits = 3
 transition_prompt = """
-You've analyzed the logs. Decide what happens next:
+Decide what happens next:
 - If you need a script to parse/filter/aggregate the data more precisely, respond with: script
 - If you have enough findings to produce a report, respond with: report
 """
 system_prompt = """
-Analyze the log data. Look for:
+Analyze the log data for:
 1. Error patterns — recurring errors, error spikes, cascading failures
 2. Anomalies — unusual request rates, latency outliers, unexpected status codes
 3. Trends — gradual degradation, growing queue depths, memory creep
 4. Correlations — errors that co-occur, time-based patterns
-5. Security signals — auth failures, unusual access patterns, injection attempts
+5. Security signals — auth failures, unusual access, injection attempts
 
-Quantify everything. Note timestamps and frequencies. Rank findings by severity.
+Quantify everything (timestamps, counts, rates). For each finding, append to
+`findings` (context_append): `<SEVERITY> | <finding> | <evidence: counts/timestamps>`
+with SEVERITY in {critical, warning, info}. Keep a running tally in `severity_index`
+(context_write), e.g. "critical: 2, warning: 5, info: 3". Use the `script` stage
+when you need precise parsing/aggregation you can't eyeball.
 """
 
 [stages.analyze.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.analyze.tool_routing.overrides]
 read_file = "logs"
+bash      = "scratch"
 
 [stages.analyze.transitions.script]
 hint = "Need a script to parse/filter/aggregate log data"
@@ -82,8 +90,6 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 3: Script ──────────────────────────────────────────────────────────
-# Self-loops for iterative script refinement (capped by max_revisits), and
-# hands results back to analyze.
 [stages.script]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
@@ -97,16 +103,15 @@ Your script has produced results. Decide what happens next:
 - If the results answer the analysis questions, respond with: analyze
 """
 system_prompt = """
-You are writing scripts to process log data. Use bash to run your scripts
-against the log files. Common tasks:
-- Parse structured fields from log lines
-- Filter by time range, severity, or pattern
+Write scripts (awk/grep/python via bash) to process the logs:
+- Parse structured fields, filter by time/severity/pattern
 - Aggregate counts, rates, percentiles
-- Detect anomalies using statistical thresholds
-- Extract and correlate events across log sources
+- Detect anomalies via statistical thresholds
+- Correlate events across sources
 
-Write small, focused scripts. Test each one before building on it.
-Iterate until the output answers the analysis questions.
+Write small, focused scripts; test each before building on it. Script code and
+output land in `scripts`. Iterate until the output answers the analysis questions,
+then return to analyze.
 """
 
 [stages.script.tool_routing]
@@ -131,21 +136,23 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Produce a structured analysis report with findings"
-available_tools = ["write_file"]
+available_tools = ["write_file", "read_file"]
 max_iterations = 10
 # Generating the final report — don't inject mid-run user messages into it.
 accepts_messages = false
 system_prompt = """
-Write a structured log analysis report. Include:
+Write a structured log analysis report (write_file) from the `findings` region,
+structured by the `severity_index` tally. Include:
 - Executive summary (top findings in 3-5 bullets)
 - Log source overview (files, format, time range, volume)
-- Findings by severity (critical, warning, info)
-  - For each finding: description, evidence, frequency, impact
+- Findings by severity (🔴 critical / 🟡 warning / 🔵 info)
+  - For each: description, evidence (counts/timestamps), impact
 - Trends and patterns observed
 - Recommendations (what to fix, what to monitor)
-- Raw data appendix (key log excerpts, script outputs)
+- Appendix: key log excerpts and script outputs
 
-Be precise. Include timestamps, counts, and percentages. Reference specific log lines.
+Be precise — timestamps, counts, percentages, specific log lines. The report's
+severity counts must match `severity_index`.
 """
 
 # Explicit empty transitions = terminal.
@@ -161,8 +168,8 @@ max_iterations = 10
 max_revisits = 1
 system_prompt = """
 A read or script execution failed. Read the error from context, diagnose it
-(e.g. a malformed log line, a script bug, a missing file), note a workaround,
-then return to analyze to continue with the data available.
+(a malformed log line, a script bug, a missing file), note a workaround, then
+return to analyze to continue with the data available.
 """
 
 [stages.error_recovery.transitions.analyze]
@@ -173,8 +180,15 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-logs    = { kind = "temporary",  max_tokens = 50000 }
-scripts = { kind = "compacting", threshold_tokens = 20000, max_tokens = 30000 }
-findings = { kind = "pinned",    max_tokens = 15000 }
-scratch = { kind = "clearable",  max_tokens = 5000 }
+task            = { kind = "pinned", budget = "2%", max_tokens = 3000, required = true, seed = "task", required_message = "Name the log file(s)/dir and what to look for via --task." }
+severity_index  = { kind = "pinned", budget = "2%", max_tokens = 2000 }
+findings        = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+
+logs            = { kind = "temporary",       budget = "30%", max_tokens = 50000 }
+scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", threshold_tokens = 20000, max_tokens = 30000 }
+scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", max_tokens = 10000 }
+
+conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+scratch         = { kind = "clearable", budget = "6%", max_tokens = 6000 }

--- a/agents/parallel-fixer/agent.leviath
+++ b/agents/parallel-fixer/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "parallel-fixer"
-version = "0.1.0"
-description = "Fixes failing tests in parallel: validate → fan out one worker per failure → merge"
+version = "0.2.0"
+description = "Fixes failing tests in parallel: validate → fan out one worker per failure → merge → verify (re-round until the suite is green)"
 entry_stage = "validate"
 
 [tool_permissions]
@@ -14,22 +14,31 @@ bash = "ask"
 
 # ─── Stage 1: Validate ───────────────────────────────────────────────────────
 # Run the test suite and record the set of failing tests + their diagnoses.
-
 [stages.validate]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Run the tests and diagnose each failure"
-available_tools = ["read_file", "read_files", "list_dir", "shell"]
+available_tools = ["read_file", "read_files", "list_dir", "shell", "context_write"]
 max_iterations = 20
+max_revisits = 2
 system_prompt = """
-Run the project's test suite and, for each failing test, record:
-- the test name
-- the source file most likely responsible
-- a one-line diagnosis of the failure
+DIAGNOSE ONLY — do NOT edit any files or fix anything here. The parallel workers
+do the fixing; your job is to run the tests read-only and describe the failures.
 
-Write the collected failures into the `diagnosis` context region as a summary
-the next stage can split into per-test work items.
+Run the project's test suite (per the command/instructions in `task`) with shell.
+For each failing test, record: the test name, the source file most likely
+responsible, and a one-line diagnosis with the intended fix.
+
+Write the collected failures into the `diagnosis` region with context_write, as a
+list the next stage can split into per-test work items. Group failures that touch
+the SAME source file together so two workers never edit the same file. If the
+suite is already fully green, write exactly "NO FAILURES" to `diagnosis`. Then stop.
 """
+
+[stages.validate.tool_routing]
+default_region = "conversation"
+[stages.validate.tool_routing.overrides]
+shell = "test_results"
 
 [stages.validate.transitions.parallel_fix]
 hint = "Tests were run and failures diagnosed"
@@ -39,32 +48,25 @@ transform = "direct"
 # Split the diagnosis into one work item per failing test and fix each in a
 # parallel in-process sub-agent worker. Workers share the workdir; file-level
 # locking prevents concurrent writes to the same file from clobbering.
-
 [stages.parallel_fix]
 mode = "fan_out"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }] }
 description = "Fix each failing test in parallel"
-# Run each work item as this same blueprint entered at the `fix_worker` stage.
-# (Alternatively, point at a separate installed agent type:
-#   worker_agent = "test-fixer"
-#  or discover one by capability:
-#   worker_query = "test fixing")
 worker_stage = "fix_worker"
 merge_stage = "merge_fixes"
 max_workers = 5
 on_worker_failure = "continue"
 split_prompt = """
-Read the `diagnosis` region and output ONLY a JSON array of work items — no prose.
-Each item: {"id": "<test_name>", "context": {"test": "...", "source_file": "...", "diagnosis": "..."}}
-Group failures that touch the SAME source file into a single work item so two
-workers never edit the same file.
+Read the `diagnosis` region. Output ONLY a JSON array — start with '[' and end
+with ']', no prose, no markdown fences, nothing else. One work item per DISTINCT
+source file (group tests that share a file). Shape:
+
+[{"id": "mathx.py", "context": {"tests": "test_factorial, test_fib", "source_file": "mathx.py", "diagnosis": "..."}}]
+
+If `diagnosis` is exactly "NO FAILURES" (or lists none), output exactly: []
 """
 
 # ─── Worker stage: fix one failing test ──────────────────────────────────────
-# `allow_as_worker = true` opts this stage in to being a fan-out worker entry.
-# Each worker receives its work item (test + source_file + diagnosis) seeded
-# into its pinned context.
-
 [stages.fix_worker]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }] }
@@ -77,43 +79,84 @@ You are fixing ONE failing test. Your work item (test name, source file, and
 diagnosis) is in your pinned context.
 
 1. Read the test and the implicated source file.
-2. Make the minimal edit that fixes the failure.
+2. Make the MINIMAL edit that fixes the failure — don't refactor unrelated code.
 3. Re-run just this test to confirm it passes.
+4. Report exactly which file(s) you changed and what you changed.
 
 Only touch the source file for your work item — other workers are fixing other
 files in parallel.
 """
 
 # ─── Stage 3: Merge ──────────────────────────────────────────────────────────
-# Reconcile the workers' fixes, resolve any conflicts, and re-validate.
-
 [stages.merge_fixes]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
-description = "Verify all fixes are compatible and the full suite passes"
-available_tools = ["read_file", "read_files", "edit_file", "shell"]
+description = "Reconcile the workers' fixes and resolve conflicts"
+available_tools = ["read_file", "read_files", "edit_file", "shell", "context_append"]
 max_iterations = 30
 system_prompt = """
 The parallel workers' results are in your conversation context. Your job:
-1. Run the full test suite again.
-2. If any test still fails (including new failures from interacting fixes),
-   resolve the conflict.
-3. Report the final state.
+1. Reconcile the fixes — if two touched related code, make them consistent.
+2. Run the full test suite once.
+3. Record what changed in the `fixes` region (context_append): one line per file
+   touched and the net effect.
+
+Don't chase every remaining failure here — the verify stage decides whether
+another parallel round is needed. Just make the fixes coherent and report state.
 """
 
-# Terminal: no outgoing transitions — the run completes after merge.
-[stages.merge_fixes.transitions]
+[stages.merge_fixes.tool_routing]
+default_region = "conversation"
+[stages.merge_fixes.tool_routing.overrides]
+shell = "test_results"
+
+[stages.merge_fixes.transitions.verify]
+hint = "Fixes reconciled — verify the full suite"
+transform = "compact"
+
+# ─── Stage 4: Verify ─────────────────────────────────────────────────────────
+# Authoritative green gate. Loops back to validate for another parallel round if
+# residual/interacting failures remain (bounded by validate's max_revisits).
+[stages.verify]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Run the full suite and decide: done, or another fix round"
+available_tools = ["read_file", "read_files", "shell"]
+max_iterations = 10
+allow_complete = true
+transition_prompt = """
+Based on the full suite result:
+- If ALL tests pass, respond with: DONE
+- If tests still fail (residual or newly introduced by interacting fixes) and
+  another parallel round is worthwhile, respond with: validate
+"""
+system_prompt = """
+Run the full test suite one more time (output goes to `test_results`). Summarize:
+total / passed / failed, and name any still-failing tests. If everything passes,
+finish (DONE). If failures remain, hand back to validate to re-diagnose the
+remaining set and fan out another round.
+"""
+
+[stages.verify.tool_routing]
+default_region = "conversation"
+[stages.verify.tool_routing.overrides]
+shell = "test_results"
+
+[stages.verify.transitions.validate]
+hint = "Failures remain — re-diagnose and fan out another round"
+transform = "compact"
 
 # ─── Compaction ──────────────────────────────────────────────────────────────
-
 [compaction]
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
 # ─── Context layout ──────────────────────────────────────────────────────────
-
 [context.regions]
-task = { kind = "pinned", max_tokens = 4000 }
-diagnosis = { kind = "pinned", max_tokens = 8000 }
-conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000, strategy = "bulk", overflow = 20 }
-scratch = { kind = "clearable", max_tokens = 8000 }
+task         = { kind = "pinned", budget = "3%", max_tokens = 4000, required = true, seed = "task", required_message = "Describe the project + how to run its tests via --task." }
+diagnosis    = { kind = "pinned", budget = "8%", max_tokens = 8000 }
+fixes        = { kind = "sliding_window", max_items = 20, budget = "8%", max_tokens = 6000 }
+test_results = { kind = "clearable", budget = "6%", max_tokens = 8000 }
+
+conversation = { kind = "sliding_window", max_items = 40, budget = "20%", max_tokens = 20000, strategy = "bulk", overflow = 20 }
+scratch      = { kind = "clearable", budget = "8%", max_tokens = 8000 }

--- a/agents/researcher/agent.leviath
+++ b/agents/researcher/agent.leviath
@@ -20,20 +20,25 @@ model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { p
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
-max_iterations = 20
-max_revisits = 3
+max_iterations = 8
+max_revisits = 2
 system_prompt = """
 You are gathering source material on the topic in the `query` region, within any
-bounds set in `scope`. Search breadth-first: cover the main sub-topics and a range
-of viewpoints before going deep on any one.
+bounds set in `scope`.
 
-Use web_search to find sources, web_fetch to pull their content, and read_file for
-local documents. Raw source content lands in `raw_findings`.
+Be efficient — do not search exhaustively:
+1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
+   sub-topics of the question (not many rephrasings of the same query).
+2. web_fetch only the 2-3 most promising sources for detail; the search snippets
+   in `raw_findings` are usually enough on their own.
+3. As you go, append one bibliography line per source you actually use to the
+   `sources_index` region with context_append:
+   `[n] <title> — <url or path> — credibility: <high/med/low + why>`.
 
-For every source, append one bibliography line to `sources_index` (context_append):
-`[n] <title> — <url or path> — <date if known> — credibility: <high/med/low + why>`.
 Prefer primary sources and well-established outlets; note when something is a blog,
-forum, or vendor claim. The analyze stage decides whether the coverage is enough.
+forum, or vendor claim. Once you have solid coverage of the sub-topics, transition
+to analyze — don't keep searching for marginal additions. The analyze stage will
+send you back if it finds a real gap.
 """
 
 [stages.gather.tool_routing]
@@ -159,3 +164,8 @@ contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
 # Synthesis workspace (compacts to a running history when it grows).
 synthesis         = { kind = "compacting",      budget = "40%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 50000 }
 synthesis_history = { kind = "compact_history", source_region = "synthesis", budget = "3%", max_tokens = 10000 }
+
+# The message stream. An explicit sliding_window `conversation` region is required —
+# the per-stage layout is rebuilt from this table on each transition, so an
+# auto-added one would be dropped after the first stage.
+conversation      = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/researcher/agent.leviath
+++ b/agents/researcher/agent.leviath
@@ -1,30 +1,43 @@
 [agent]
 name = "researcher"
-version = "0.2.0"
+version = "0.3.0"
 description = "Research assistant — gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
+
+# Read/search agent: it gathers and synthesizes, writing only its final report.
+[tool_permissions]
+read_file  = "allow"
+list_dir   = "allow"
+web_search = "allow"
+web_fetch  = "allow"
+write_file = "ask"
+bash       = "ask"
 
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
-available_tools = ["read_file", "bash"]
+# web_search / web_fetch are provided by the agent's script tools (issue #97).
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
 max_iterations = 20
 max_revisits = 3
 system_prompt = """
-You are gathering source material on a topic. Use bash (curl/wget) for web
-sources and read_file for local documents. For each item, note where it came
-from and the key claims it supports. Cast a reasonably wide net, but stay on
-topic — the analyze stage will decide whether it's enough.
+You are gathering source material on the topic in the `query` region, within any
+bounds set in `scope`. Search breadth-first: cover the main sub-topics and a range
+of viewpoints before going deep on any one.
+
+Use web_search to find sources, web_fetch to pull their content, and read_file for
+local documents. Raw source content lands in `raw_findings`.
+
+For every source, append one bibliography line to `sources_index` (context_append):
+`[n] <title> — <url or path> — <date if known> — credibility: <high/med/low + why>`.
+Prefer primary sources and well-established outlets; note when something is a blog,
+forum, or vendor claim. The analyze stage decides whether the coverage is enough.
 """
 
-# Raw source material lands in the findings region, not scratch.
 [stages.gather.tool_routing]
-default_region = "scratch"
-[stages.gather.tool_routing.overrides]
-read_file = "findings"
-bash      = "findings"
+default_region = "raw_findings"
 
 [stages.gather.transitions.analyze]
 hint = "Enough gathered for a first pass of analysis"
@@ -41,7 +54,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Analyze and synthesize findings"
-available_tools = ["read_file"]
+available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 20
 max_revisits = 3
 transition_prompt = """
@@ -50,10 +63,21 @@ You've analyzed the material gathered so far. Decide what happens next:
 - If you have enough to write a useful summary, respond with: summarize
 """
 system_prompt = """
-Analyze the gathered findings: identify themes, note agreements and
-disagreements across sources, evaluate source quality, and flag open
-questions. Distinguish well-supported claims from speculation.
+Analyze the `raw_findings` against the `sources_index`. Do three things:
+
+1. Extract factual claims into the `claims` region (context_append), each with its
+   source reference: `<claim> [n]`. These are what the summary is built from.
+2. When sources DISAGREE, record the conflict in `contradictions` (context_write)
+   — who claims what, with source refs. Don't silently pick a side; surface it.
+3. Judge strength: separate well-supported claims (multiple credible sources) from
+   single-source or speculative ones.
+
+Use web_fetch for a targeted follow-up only when a specific gap blocks a claim.
+Flag open questions you couldn't resolve.
 """
+
+[stages.analyze.tool_routing]
+default_region = "raw_findings"
 
 [stages.analyze.transitions.gather]
 hint = "More information needed on specific sub-topics"
@@ -72,12 +96,20 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Create a concise, well-organized summary"
-available_tools = ["write_file"]
+available_tools = ["write_file", "read_file"]
 max_iterations = 10
 system_prompt = """
-Write a concise summary of the research: the key findings organized by theme,
-the strength of the evidence for each, notable disagreements, and open
-questions. Cite specific sources. Keep it tight and skimmable.
+Write the research report (write_file), built from the `claims` region and citing
+`sources_index`. Follow the citation/confidence rules in the `format` region.
+
+Structure:
+- Key findings organized by theme, each with a confidence level.
+- Notable disagreements — pull these straight from the `contradictions` region;
+  never drop a recorded conflict.
+- Open questions.
+- Sources — the numbered bibliography from `sources_index`.
+
+Keep it tight and skimmable. Every non-obvious claim must carry a [n] citation.
 """
 
 # Explicit empty transitions table = terminal stage (the run ends here).
@@ -105,9 +137,25 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
+# Budgets are a percentage of the model's context window (issue #100) with an
+# absolute `max_tokens`/`threshold_tokens` guard-rail. Percentages are ceilings.
 [context.regions]
-query    = { kind = "pinned",          max_tokens = 1000 }
-findings = { kind = "temporary",       max_tokens = 40000 }
-analysis = { kind = "compacting",      threshold_tokens = 30000, max_tokens = 50000 }
-summary  = { kind = "compact_history", source_region = "analysis", max_tokens = 10000 }
-scratch  = { kind = "clearable",       max_tokens = 5000 }
+# The research question — required. Supplied via --task (or the API/ACP task field).
+query          = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the research question via --task." }
+# Optional caller bounds: --scope "peer-reviewed sources since 2020 only".
+scope          = { kind = "pinned", budget = "1%", max_tokens = 1000, seed = "scope" }
+# Growing bibliography with credibility notes (curated by the agent).
+sources_index  = { kind = "pinned", budget = "3%", max_tokens = 3000 }
+# Citation/confidence rules (seeded with a sensible default the agent follows).
+format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." } }
+
+# Raw source material (bulk, evictable).
+raw_findings   = { kind = "temporary", budget = "30%", max_tokens = 40000 }
+# Extracted claims (with source refs) and cross-source conflicts.
+claims         = { kind = "sliding_window", max_items = 30, budget = "7%", max_tokens = 8000 }
+contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
+
+# Synthesis workspace (compacts to a running history when it grows).
+synthesis         = { kind = "compacting",      budget = "40%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 50000 }
+synthesis_history = { kind = "compact_history", source_region = "synthesis", budget = "3%", max_tokens = 10000 }

--- a/agents/researcher/tools/web_fetch.rhai
+++ b/agents/researcher/tools/web_fetch.rhai
@@ -1,0 +1,21 @@
+// @tool web_fetch
+// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @param url string required "The URL to fetch (http or https)"
+// @requires network
+
+let out = "";
+try {
+    // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
+    let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
+    // Cap very large pages so a single fetch can't blow the context budget.
+    if body.len() > 12000 {
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+    } else {
+        out = body;
+    }
+} catch(e) {
+    // Most commonly the page exceeds the engine's 1MB string limit, or the host
+    // blocked the request. Report it so the agent can pick a smaller/other source.
+    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+}
+out

--- a/agents/researcher/tools/web_fetch.rhai
+++ b/agents/researcher/tools/web_fetch.rhai
@@ -1,5 +1,5 @@
 // @tool web_fetch
-// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
 
@@ -7,9 +7,18 @@ let out = "";
 try {
     // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
     let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
-    // Cap very large pages so a single fetch can't blow the context budget.
+
+    // If the response looks like HTML, extract readable text so the model reads
+    // prose instead of markup. (Content injected by client-side JS isn't in the
+    // source and can't be recovered here.)
+    let lo = body.to_lower();
+    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+        body = html_to_text(body);
+    }
+
+    // Cap very large content so a single fetch can't blow the context budget.
     if body.len() > 12000 {
-        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;
     }

--- a/agents/researcher/tools/web_search.rhai
+++ b/agents/researcher/tools/web_search.rhai
@@ -1,0 +1,51 @@
+// @tool web_search
+// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @param query string required "The search query"
+// @param count integer optional "Maximum number of results to return (default 5)"
+// @requires network
+
+let n = if params.count == () { 5 } else { params.count };
+let results = [];
+
+// Prefer Brave Search when an API key is configured. env_var throws when the
+// variable is unset, so probe it inside try/catch and fall back to keyless search.
+let key = "";
+try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+
+let got = false;
+if key != "" {
+    try {
+        let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
+        if data.web != () && data.web.results != () {
+            for r in data.web.results {
+                if results.len() >= n { break; }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+            }
+            got = true;
+        }
+    } catch(e) {
+        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
+        got = false;
+    }
+}
+
+if !got {
+    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
+    // queries (no key required). Each page becomes a {title, url, snippet} result.
+    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+    // Wikipedia requires a descriptive User-Agent (403 otherwise).
+    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+    if data.pages != () {
+        for p in data.pages {
+            if results.len() >= n { break; }
+            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
+            snippet.replace("<span class=\"searchmatch\">", "");
+            snippet.replace("</span>", "");
+            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+        }
+    }
+}
+
+results

--- a/agents/reviewer/agent.leviath
+++ b/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.2.0"
+version = "0.3.0"
 description = "Code review agent — scan, deep review, and report with error recovery and multi-provider fallback"
 entry_stage = "scan"
 
@@ -15,13 +15,21 @@ bash      = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fast first pass for obvious issues"
-available_tools = ["read_file", "list_dir"]
+available_tools = ["read_file", "list_dir", "context_append"]
 max_iterations = 12
 system_prompt = """
-Do a fast first pass over the diff/codebase. Flag the obvious: syntax smells,
-missing error handling, dead code, TODO/FIXME markers, and anything that looks
-risky. Don't go deep yet — just build a list of areas the deep review should
-scrutinize.
+Do a fast first pass over the code in the `diff` region (and read_file for
+surrounding context). Honor any focus in `review_criteria`, and use
+`project_context` (pre-loaded architecture/conventions) to judge what "correct"
+means here.
+
+Flag the obvious red flags — don't go deep yet:
+- Security: injection, unsafe deserialization, secrets in code, missing authz.
+- Correctness smells: unhandled errors, nil/None derefs, off-by-one, dead code.
+- Missing input validation, TODO/FIXME markers, and anything that looks risky.
+
+Append the flagged areas (file + one line each) to the `findings` region via
+context_append — this is the worklist the deep review scrutinizes.
 """
 
 [stages.scan.tool_routing]
@@ -42,15 +50,28 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "In-depth analysis of correctness, security, and architecture"
-available_tools = ["read_file", "list_dir", "bash"]
+available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
 max_iterations = 25
 max_revisits = 2
 system_prompt = """
-Scrutinize the code in depth. For each finding, give: the location, the concrete
-failure scenario (inputs/state → wrong result or crash), the severity, and a
-recommended fix. Cover correctness bugs, security issues, race conditions,
-resource leaks, and architectural concerns. Use bash only to confirm a
-hypothesis (e.g. run a test), never to modify anything.
+Scrutinize the flagged areas in depth. Work the review through a fixed framework so
+nothing is skipped:
+  1. Correctness — does it do what the task/diff intends? Trace the logic.
+  2. Security — injection, authz, secret handling, unsafe input.
+  3. Performance — hot-path allocations, N+1 queries, needless work.
+  4. Maintainability — clarity, naming, duplication, conventions.
+  5. Test coverage — are the risky paths actually tested?
+
+For each finding give: location, the concrete failure scenario (inputs/state →
+wrong result or crash), a severity (critical / warning / info), and a recommended
+fix. Append each finding to `findings` (context_append).
+
+Keep a running tally in the `severity_index` region: rewrite it with
+context_write each time the counts change, e.g. "critical: 2, warning: 5, info: 3".
+This survives even if the finding detail is compacted, so the report stage always
+has the totals.
+
+Use bash only to CONFIRM a hypothesis (e.g. run a test), never to modify anything.
 """
 
 [stages.deep_review.tool_routing]
@@ -74,9 +95,16 @@ description = "Produce an actionable, ranked review report"
 available_tools = ["read_file"]
 max_iterations = 10
 system_prompt = """
-Produce the review report, findings ranked most-severe first. For each: file
-and line, one-sentence defect summary, the failure scenario, severity, and the
-fix. End with a short overall assessment (ship / ship-with-fixes / needs-work).
+Produce the review report from the `findings` region, structured by the
+`severity_index` tally so the counts and the report agree.
+
+Order findings most-severe first and group by severity level:
+  ## Critical — <must fix before merge>
+  ## Warning  — <should fix>
+  ## Info     — <nice to have>
+For each: file and line, one-sentence defect summary, the failure scenario, and the
+fix. End with a short overall assessment (ship / ship-with-fixes / needs-work) that
+matches the severity_index totals.
 """
 
 # Explicit empty transitions = terminal.
@@ -104,9 +132,22 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
+# Budgets are a percentage of the model's context window (issue #100) with an
+# absolute `max_tokens` guard-rail. Percentages are ceilings, not reservations.
 [context.regions]
-guidelines = { kind = "pinned",         max_tokens = 3000 }
-diff       = { kind = "pinned",         max_tokens = 20000 }
-findings   = { kind = "temporary",      max_tokens = 25000 }
-analysis   = { kind = "sliding_window", max_items = 15, max_tokens = 20000, strategy = "bulk", overflow = 10 }
-report     = { kind = "clearable",      max_tokens = 8000 }
+# The code/diff to review — required. Supply via `--diff <text|@file>` (CLI),
+# a ---region:diff--- block (ACP), or the API `regions` field.
+diff            = { kind = "pinned", budget = "20%", max_tokens = 20000, required = true, seed = "diff", required_message = "Provide the code or diff to review via --diff <text|@file>." }
+# Optional caller focus, e.g. --criteria "focus on security / backwards-compat".
+review_criteria = { kind = "pinned", budget = "2%",  max_tokens = 3000, seed = "criteria" }
+# Pre-loaded on startup: architecture / conventions (missing files skipped).
+project_context = { kind = "pinned", budget = "4%",  max_tokens = 5000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "CONVENTIONS.md", "CONTRIBUTING.md", "README.md"] } }
+
+# Accumulated review findings and the running severity tally.
+findings        = { kind = "temporary", budget = "20%", max_tokens = 25000 }
+severity_index  = { kind = "pinned",    budget = "2%",  max_tokens = 2000 }
+report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
+
+# Bulk-evicting scratch for tool chatter (stable prefix for prompt caching).
+analysis        = { kind = "sliding_window", max_items = 15, budget = "15%", max_tokens = 20000, strategy = "bulk", overflow = 10 }

--- a/agents/reviewer/agent.leviath
+++ b/agents/reviewer/agent.leviath
@@ -32,10 +32,12 @@ Append the flagged areas (file + one line each) to the `findings` region via
 context_append — this is the worklist the deep review scrutinizes.
 """
 
+# Passive reads go to `findings`; everything else stays in conversation.
 [stages.scan.tool_routing]
-default_region = "analysis"
+default_region = "conversation"
 [stages.scan.tool_routing.overrides]
 read_file = "findings"
+list_dir  = "findings"
 
 [stages.scan.transitions.deep_review]
 hint = "First pass complete — scrutinize the flagged areas"
@@ -74,10 +76,12 @@ has the totals.
 Use bash only to CONFIRM a hypothesis (e.g. run a test), never to modify anything.
 """
 
+# Passive reads go to `findings`; bash (hypothesis checks) stays in conversation.
 [stages.deep_review.tool_routing]
-default_region = "analysis"
+default_region = "conversation"
 [stages.deep_review.tool_routing.overrides]
 read_file = "findings"
+list_dir  = "findings"
 
 [stages.deep_review.transitions.report]
 hint = "Analysis complete — write the report"
@@ -149,5 +153,13 @@ findings        = { kind = "temporary", budget = "20%", max_tokens = 25000 }
 severity_index  = { kind = "pinned",    budget = "2%",  max_tokens = 2000 }
 report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
 
-# Bulk-evicting scratch for tool chatter (stable prefix for prompt caching).
-analysis        = { kind = "sliding_window", max_items = 15, budget = "15%", max_tokens = 20000, strategy = "bulk", overflow = 10 }
+# Scratch for tool chatter. Must NOT be a sliding_window: tool-result routing
+# targets this region, and only `conversation` may hold ToolResult message blocks
+# (a routed result in a second sliding_window desyncs from its tool_use → API 400).
+# Temporary renders as a plain-text system block, which is safe.
+analysis        = { kind = "temporary", budget = "15%", max_tokens = 20000 }
+
+# The message stream. Every blueprint needs an explicit sliding_window
+# `conversation` region — the layout that replaces it on each stage transition is
+# rebuilt from this table, so an auto-added one would be dropped after stage 1.
+conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/reviewer/agent.leviath
+++ b/agents/reviewer/agent.leviath
@@ -153,13 +153,7 @@ findings        = { kind = "temporary", budget = "20%", max_tokens = 25000 }
 severity_index  = { kind = "pinned",    budget = "2%",  max_tokens = 2000 }
 report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
 
-# Scratch for tool chatter. Must NOT be a sliding_window: tool-result routing
-# targets this region, and only `conversation` may hold ToolResult message blocks
-# (a routed result in a second sliding_window desyncs from its tool_use → API 400).
-# Temporary renders as a plain-text system block, which is safe.
-analysis        = { kind = "temporary", budget = "15%", max_tokens = 20000 }
-
 # The message stream. Every blueprint needs an explicit sliding_window
 # `conversation` region — the layout that replaces it on each stage transition is
 # rebuilt from this table, so an auto-added one would be dropped after stage 1.
-conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+conversation    = { kind = "sliding_window", max_items = 30, budget = "15%", max_tokens = 18000, strategy = "bulk", overflow = 10 }

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -154,14 +154,16 @@ Work methodically through each plan step. After all steps, give a concise summar
 of what was created/modified and whether tests passed.
 """
 
-# Only passive reads route to a knowledge region. Action-tool results (write_file,
-# edit_file, bash) MUST stay in conversation: routing them away strips the
-# tool_result, so the model can't see the action landed and repeats it in a loop.
+# Large read output persists in `codebase`; test output persists in `test_results`
+# (the review stage reads it). Routed results leave a short pointer in conversation
+# (paired with their tool_use) with the full output as text in the region. Small
+# write/edit confirmations stay inline.
 [stages.implement.tool_routing]
 default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
+bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -220,12 +222,13 @@ read_file = "allow"
 list_dir  = "allow"
 bash      = "ask"
 
-# bash (test runs) stays in conversation so the reviewer sees the results.
+# Test re-runs persist to `test_results` (a pointer + preview stays in conversation).
 [stages.review.tool_routing]
 default_region = "conversation"
 [stages.review.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
+bash      = "test_results"
 
 [stages.review.transitions.implement]
 hint = "Issues found — needs another implementation pass"

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "software-engineer"
-version = "0.2.0"
+version = "0.3.0"
 description = "Plan-then-implement agent — mirrors the Claude Code plan→approve→code→review workflow"
 entry_stage = "plan"
 
@@ -42,7 +42,10 @@ You are the planning stage of a code assistant.
 
 Your job:
 1. Explore the codebase to understand relevant structure (list_dir, read_file).
-2. Think through the implementation approach.
+   The `architecture` region is pre-loaded with design docs and `constraints`
+   holds any caller-supplied limits (tech stack, timeline, budget) — read both
+   before exploring so you don't rediscover what's already given.
+2. Think through the implementation approach, respecting the constraints.
 3. Produce a concise, numbered plan:
    - Files to create or modify
    - What each change does
@@ -70,6 +73,13 @@ list_dir  = "allow"
 ask_user_text   = "allow"
 ask_user_choice = "allow"
 edit_document   = "allow"
+
+# Exploration output feeds the persistent codebase region.
+[stages.plan.tool_routing]
+default_region = "scratch"
+[stages.plan.tool_routing.overrides]
+read_file = "codebase"
+list_dir  = "codebase"
 
 [stages.plan.transitions.implement]
 hint = "Plan approved — proceed to implementation"
@@ -117,24 +127,40 @@ edit_options = ["Add detail — expand a section"]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Write code according to the approved plan"
-available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm"]
+available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append"]
 max_iterations = 50
 max_revisits = 5
 system_prompt = """
-You are the implementation stage. The plan has been approved by the user.
-Execute the plan step by step:
-- Use write_file to create new files.
-- Use edit_file to modify existing files.
-- Use bash to run tests or verify the build after writing.
+You are the implementation stage. The plan in the `plan` region has been approved.
+Execute it step by step:
+- Use write_file to create new files and edit_file to modify existing ones.
+- Use bash to run tests or verify the build after writing — output goes to
+  `test_results`.
+
+As you work, keep two running logs so the review stage (and any restart) has
+the full picture without re-scanning:
+- `decisions` (context_append): each non-obvious design/architectural choice and
+  the WHY behind it — invaluable when review questions a call.
+- `changelog` (context_append): one line per file created/modified, so review
+  knows exactly what to check.
 
 If you hit a genuine ambiguity the plan didn't resolve (e.g. conflicting
 requirements, or a destructive/hard-to-reverse action you're unsure about),
 use ask_user_text or ask_user_confirm to check before proceeding — don't
 silently guess on something the user would want a say in.
 
-Work methodically through each plan step. After completing all steps, provide a concise
-summary of what was created/modified and whether tests passed.
+Work methodically through each plan step. After all steps, give a concise summary
+of what was created/modified and whether tests passed.
 """
+
+[stages.implement.tool_routing]
+default_region = "scratch"
+[stages.implement.tool_routing.overrides]
+read_file  = "codebase"
+list_dir   = "codebase"
+write_file = "implementation"
+edit_file  = "implementation"
+bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -157,7 +183,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Review the implementation and evaluate code quality"
-available_tools = ["read_file", "list_dir"]
+available_tools = ["read_file", "list_dir", "bash"]
 max_revisits = 3
 # Lets the run end here (via "DONE") when the review approves the work,
 # instead of being forced down the only declared edge back to implement.
@@ -171,11 +197,17 @@ Minor style issues don't warrant another implementation pass.
 """
 system_prompt = """
 You are the review stage. The implementation is complete.
-Read the files that were created or modified and provide a quality review:
-- Correctness: does it match the plan and the original task?
+
+Use the `changelog` region to see exactly which files changed, and `decisions` to
+understand why choices were made before you question them. Read those files and
+provide a quality review:
+- Correctness: does it match the plan AND the original task in `task`?
 - Edge cases: what inputs or conditions could cause failures?
-- Code quality: clarity, naming, error handling.
+- Code quality: clarity, naming, error handling, conventions.
 - Security: any obvious vulnerabilities?
+
+Re-run the tests with bash and confirm they pass (output → `test_results`) — don't
+approve on an unverified claim that tests pass.
 
 End with one of:
   APPROVED — no significant issues
@@ -185,15 +217,23 @@ End with one of:
 [stages.review.tool_permissions]
 read_file = "allow"
 list_dir  = "allow"
+bash      = "ask"
+
+[stages.review.tool_routing]
+default_region = "scratch"
+[stages.review.tool_routing.overrides]
+read_file = "codebase"
+list_dir  = "codebase"
+bash      = "test_results"
 
 [stages.review.transitions.implement]
 hint = "Issues found — needs another implementation pass"
 transform = "custom"
 
 [stages.review.transitions.implement.transform_config]
-carry = ["task", "codebase"]
+carry = ["task", "constraints", "architecture", "plan", "codebase", "changelog", "decisions"]
 compact = ["conversation"]
-clear = ["scratch"]
+clear = ["scratch", "test_results"]
 compact_prompt = "Summarize review findings as a numbered list of required fixes."
 
 [stages.review.transitions.error_recovery]
@@ -230,21 +270,30 @@ provider = "anthropic"
 model    = "claude-sonnet-4-6"
 
 # ─── Context layout ──────────────────────────────────────────────────────────
+# Budgets are a percentage of the model's context window (issue #100) with an
+# absolute `max_tokens`/`threshold_tokens` guard-rail. Percentages are ceilings.
 
 [context.regions]
-# System-level (pinned, stable, cacheable)
-architecture    = { kind = "pinned",          max_tokens = 6000 }
-task            = { kind = "pinned",          max_tokens = 4000 }
-plan            = { kind = "pinned",          max_tokens = 6000 }
+# ── Inputs (pinned, stable, cacheable) ──
+task         = { kind = "pinned", budget = "2%", max_tokens = 4000, required = true, required_message = "Describe the task via --task (or the API/ACP task field)." }
+# Optional caller limits: --constraints "must stay on Node 18, no new deps".
+constraints  = { kind = "pinned", budget = "1%", max_tokens = 2000, seed = "constraints" }
+# Pre-loaded on startup: architecture / design docs (missing files skipped).
+architecture = { kind = "pinned", budget = "3%", max_tokens = 6000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] } }
+plan         = { kind = "pinned", budget = "5%", max_tokens = 6000 }
 
-# Knowledge (non-volatile, survives message eviction)
-codebase        = { kind = "compacting",      threshold_tokens = 25000, max_tokens = 40000 }
-codebase_history = { kind = "compact_history", source_region = "codebase", max_tokens = 8000 }
-implementation  = { kind = "compacting",      threshold_tokens = 25000, max_tokens = 40000 }
-impl_history    = { kind = "compact_history", source_region = "implementation", max_tokens = 8000 }
+# ── Knowledge (non-volatile; compacts to *_history) ──
+codebase         = { kind = "compacting",      budget = "25%", compact_at = "80%", threshold_tokens = 25000, max_tokens = 40000 }
+codebase_history = { kind = "compact_history", source_region = "codebase",      budget = "2%", max_tokens = 8000 }
+implementation   = { kind = "compacting",      budget = "35%", compact_at = "80%", threshold_tokens = 32000, max_tokens = 40000 }
+impl_history     = { kind = "compact_history", source_region = "implementation", budget = "2%", max_tokens = 8000 }
 
-# Conversation (bulk eviction for caching)
-conversation    = { kind = "sliding_window",  max_items = 40, max_tokens = 30000, strategy = "bulk", overflow = 20 }
+# ── Working records (sliding windows) + test feedback ──
+# decisions: WHY choices were made. changelog: which files changed.
+decisions    = { kind = "sliding_window", max_items = 10, budget = "3%", max_tokens = 4000 }
+changelog    = { kind = "sliding_window", max_items = 20, budget = "2%", max_tokens = 3000 }
+test_results = { kind = "clearable",      budget = "4%", max_tokens = 5000 }
 
-# Working memory (volatile)
-scratch         = { kind = "clearable",       max_tokens = 10000 }
+# ── Conversation (bulk eviction for caching) + working memory ──
+conversation = { kind = "sliding_window", max_items = 40, budget = "20%", max_tokens = 30000, strategy = "bulk", overflow = 20 }
+scratch      = { kind = "clearable",      budget = "8%", max_tokens = 10000 }

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -74,9 +74,10 @@ ask_user_text   = "allow"
 ask_user_choice = "allow"
 edit_document   = "allow"
 
-# Exploration output feeds the persistent codebase region.
+# Only passive reads feed the persistent codebase region; everything else stays
+# in conversation.
 [stages.plan.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.plan.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
@@ -153,14 +154,14 @@ Work methodically through each plan step. After all steps, give a concise summar
 of what was created/modified and whether tests passed.
 """
 
+# Only passive reads route to a knowledge region. Action-tool results (write_file,
+# edit_file, bash) MUST stay in conversation: routing them away strips the
+# tool_result, so the model can't see the action landed and repeats it in a loop.
 [stages.implement.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
-write_file = "implementation"
-edit_file  = "implementation"
-bash       = "test_results"
 
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -219,12 +220,12 @@ read_file = "allow"
 list_dir  = "allow"
 bash      = "ask"
 
+# bash (test runs) stays in conversation so the reviewer sees the results.
 [stages.review.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.review.tool_routing.overrides]
 read_file = "codebase"
 list_dir  = "codebase"
-bash      = "test_results"
 
 [stages.review.transitions.implement]
 hint = "Issues found — needs another implementation pass"

--- a/agents/wide-researcher/agent.leviath
+++ b/agents/wide-researcher/agent.leviath
@@ -1,33 +1,46 @@
 [agent]
 name = "wide-researcher"
-version = "0.2.0"
-description = "Broad multi-topic survey — cast a wide net, compare approaches, surface what's interesting, with a survey↔compare loop and error recovery"
+version = "0.3.0"
+description = "Broad multi-topic survey — cast a wide net, compare approaches, dive on the interesting threads, and produce a landscape overview"
 entry_stage = "survey"
+
+[tool_permissions]
+read_file  = "allow"
+list_dir   = "allow"
+web_search = "allow"
+web_fetch  = "allow"
+write_file = "ask"
+bash       = "ask"
 
 # ─── Stage 1: Survey ──────────────────────────────────────────────────────────
 [stages.survey]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
-available_tools = ["read_file", "bash"]
-max_iterations = 30
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
+max_iterations = 25
 max_revisits = 2
 system_prompt = """
-Conduct a broad survey across a topic area. Map the landscape:
-- What are the major approaches/schools of thought?
-- Who are the key players/projects/companies?
-- What's the current state of the art?
-- What's actively being worked on vs mature vs abandoned?
+Map the landscape of the area in `query` (within any bounds in `scope`). Breadth
+over depth:
+- Major approaches / schools of thought, key players / projects / companies
+- Current state of the art; what's active vs mature vs abandoned
 
-Cast a wide net. Breadth over depth. Note interesting threads worth pulling on
-later. If you were sent back, focus on the coverage gap named.
+Run web_search across the distinct facets, web_fetch a few representative sources
+per facet, read_file for local material. Landscape material lands in `landscape`.
+For each source you use, append a bibliography line to `sources_index`
+(context_append): `[n] <title> — <url/path> — credibility: <high/med/low>`.
+Note interesting threads worth pulling on later. If sent back, focus on the named
+coverage gap.
 """
 
 [stages.survey.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.survey.tool_routing.overrides]
-read_file = "landscape"
-bash      = "landscape"
+web_search = "landscape"
+web_fetch  = "landscape"
+read_file  = "landscape"
+list_dir   = "landscape"
 
 [stages.survey.transitions.compare]
 hint = "Landscape mapped — ready to compare approaches"
@@ -38,31 +51,37 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 2: Compare ─────────────────────────────────────────────────────────
+# Three edges: more breadth (survey), dive on a thread (deep_dive), or write it up.
 [stages.compare]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
-description = "Compare and contrast findings across sub-topics"
-available_tools = ["read_file"]
+description = "Compare and contrast approaches across the landscape"
+available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 15
 max_revisits = 2
 transition_prompt = """
-You've compared the approaches you found. Decide what happens next:
-- If there are areas worth surveying further before you can write a useful overview, respond with: survey
-- If you've covered enough ground, respond with: summarize
+Decide the next move:
+- Coverage gaps that need broader surveying → respond with: survey
+- One especially interesting/consequential thread worth a focused deep read
+  before you can judge it fairly → respond with: deep_dive
+- You've covered enough ground to write a useful overview → respond with: summarize
 """
 system_prompt = """
-Compare what you found across the landscape:
-- What patterns emerge across different approaches?
-- Where do approaches converge or diverge?
-- What tradeoffs does each approach make?
-- What's overhyped vs underappreciated?
-- What would you recommend investigating further?
-
-Organize by theme, not by source. Help the reader see the shape of the field.
+Compare across the `landscape`, organizing by THEME not by source:
+- Patterns; where approaches converge or diverge
+- The tradeoffs each approach makes
+- What's overhyped vs underappreciated
+Record the key comparative judgments in `comparisons` (context_write) and any
+source disagreements you notice. Flag threads that deserve a deep_dive before you
+can rank them fairly. Help the reader see the shape of the field.
 """
 
 [stages.compare.transitions.survey]
-hint = "Gaps in coverage — survey additional areas"
+hint = "Coverage gaps — survey additional areas"
+transform = "compact"
+
+[stages.compare.transitions.deep_dive]
+hint = "An interesting thread deserves a focused deep read"
 transform = "compact"
 
 [stages.compare.transitions.summarize]
@@ -73,29 +92,62 @@ transform = "compact"
 condition = "error"
 transform = "direct"
 
-# ─── Stage 3: Summarize (terminal) ────────────────────────────────────────────
+# ─── Stage 3: Deep dive ───────────────────────────────────────────────────────
+[stages.deep_dive]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Focused deep read on one interesting thread flagged during comparison"
+available_tools = ["web_search", "web_fetch", "read_file", "context_append"]
+max_iterations = 12
+max_revisits = 2
+system_prompt = """
+Compare flagged a specific thread for a focused read. web_search / web_fetch the
+best sources on JUST that thread, read them, and append the findings to
+`landscape` plus a note to `deep_dives` capturing what makes it notable (with
+source refs) and a bibliography line to `sources_index`. Then hand back to compare.
+Stay on the flagged thread — this is depth on one item, not a new broad survey.
+"""
+
+[stages.deep_dive.tool_routing]
+default_region = "conversation"
+[stages.deep_dive.tool_routing.overrides]
+web_search = "landscape"
+web_fetch  = "landscape"
+read_file  = "landscape"
+
+[stages.deep_dive.transitions.compare]
+hint = "Thread explored — resume comparing"
+transform = "compact"
+
+[stages.deep_dive.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
+# ─── Stage 4: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a landscape overview with recommendations"
-available_tools = ["write_file"]
+available_tools = ["write_file", "read_file"]
 max_iterations = 10
 system_prompt = """
-Write a landscape overview based on your survey. Include:
-- Overview of the space (what is this field about)
+Write a landscape overview (write_file) built from `comparisons` and `deep_dives`,
+citing `sources_index` per the rules in `format`. Include:
+- Overview of the space
 - Major categories/approaches with brief descriptions
-- Comparison matrix (approaches vs key criteria)
-- Notable projects or implementations worth watching
-- Trends and trajectory (where is this heading)
-- Recommendations (what to look at first depending on goals)
+- A comparison matrix (approaches vs key criteria)
+- Notable projects/implementations worth watching (draw on deep_dives)
+- Trends and trajectory
+- Recommendations (what to look at first, by goal)
 
-Write concisely. The reader wants to understand the lay of the land quickly.
+Write concisely — the reader wants the lay of the land quickly. Cite sources for
+non-obvious claims.
 """
 
 # Explicit empty transitions = terminal.
 [stages.summarize.transitions]
 
-# ─── Stage 4: Error recovery ──────────────────────────────────────────────────
+# ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
@@ -116,9 +168,16 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-query              = { kind = "pinned",          max_tokens = 1000 }
-landscape          = { kind = "temporary",       max_tokens = 50000 }
-comparisons        = { kind = "compacting",      threshold_tokens = 25000, max_tokens = 35000 }
-comparison_history = { kind = "compact_history", source_region = "comparisons", max_tokens = 10000 }
-scratch            = { kind = "clearable",       max_tokens = 5000 }
+query              = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the survey topic/area via --task." }
+scope              = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope" }
+sources_index      = { kind = "pinned", budget = "3%", max_tokens = 4000 }
+format             = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." } }
+
+landscape          = { kind = "temporary",      budget = "30%", max_tokens = 50000 }
+deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%", max_tokens = 9000 }
+comparisons        = { kind = "compacting",      budget = "25%", compact_at = "80%", threshold_tokens = 25000, max_tokens = 35000 }
+comparison_history = { kind = "compact_history", source_region = "comparisons", budget = "3%", max_tokens = 10000 }
+
+conversation       = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/wide-researcher/tools/web_fetch.rhai
+++ b/agents/wide-researcher/tools/web_fetch.rhai
@@ -1,0 +1,21 @@
+// @tool web_fetch
+// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @param url string required "The URL to fetch (http or https)"
+// @requires network
+
+let out = "";
+try {
+    // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
+    let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
+    // Cap very large pages so a single fetch can't blow the context budget.
+    if body.len() > 12000 {
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+    } else {
+        out = body;
+    }
+} catch(e) {
+    // Most commonly the page exceeds the engine's 1MB string limit, or the host
+    // blocked the request. Report it so the agent can pick a smaller/other source.
+    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+}
+out

--- a/agents/wide-researcher/tools/web_fetch.rhai
+++ b/agents/wide-researcher/tools/web_fetch.rhai
@@ -1,5 +1,5 @@
 // @tool web_fetch
-// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
 
@@ -7,9 +7,18 @@ let out = "";
 try {
     // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
     let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
-    // Cap very large pages so a single fetch can't blow the context budget.
+
+    // If the response looks like HTML, extract readable text so the model reads
+    // prose instead of markup. (Content injected by client-side JS isn't in the
+    // source and can't be recovered here.)
+    let lo = body.to_lower();
+    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+        body = html_to_text(body);
+    }
+
+    // Cap very large content so a single fetch can't blow the context budget.
     if body.len() > 12000 {
-        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;
     }

--- a/agents/wide-researcher/tools/web_search.rhai
+++ b/agents/wide-researcher/tools/web_search.rhai
@@ -1,0 +1,51 @@
+// @tool web_search
+// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @param query string required "The search query"
+// @param count integer optional "Maximum number of results to return (default 5)"
+// @requires network
+
+let n = if params.count == () { 5 } else { params.count };
+let results = [];
+
+// Prefer Brave Search when an API key is configured. env_var throws when the
+// variable is unset, so probe it inside try/catch and fall back to keyless search.
+let key = "";
+try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+
+let got = false;
+if key != "" {
+    try {
+        let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
+        if data.web != () && data.web.results != () {
+            for r in data.web.results {
+                if results.len() >= n { break; }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+            }
+            got = true;
+        }
+    } catch(e) {
+        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
+        got = false;
+    }
+}
+
+if !got {
+    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
+    // queries (no key required). Each page becomes a {title, url, snippet} result.
+    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+    // Wikipedia requires a descriptive User-Agent (403 otherwise).
+    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+    if data.pages != () {
+        for p in data.pages {
+            if results.len() >= n { break; }
+            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
+            snippet.replace("<span class=\"searchmatch\">", "");
+            snippet.replace("</span>", "");
+            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+        }
+    }
+}
+
+results

--- a/agents/writing-assistant/agent.leviath
+++ b/agents/writing-assistant/agent.leviath
@@ -1,34 +1,45 @@
 [agent]
 name = "writing-assistant"
-version = "0.2.0"
-description = "Research-backed writing — from topic to polished draft, with an interactive outline checkpoint, a draft↔edit polish loop, and error recovery"
+version = "0.3.0"
+description = "Research-backed writing — topic to polished draft, with a web-research stage, an interactive outline checkpoint, a draft⇄edit loop, and a final proofread pass"
 entry_stage = "research"
+
+[tool_permissions]
+read_file  = "allow"
+list_dir   = "allow"
+web_search = "allow"
+web_fetch  = "allow"
+write_file = "ask"
+bash       = "ask"
 
 # ─── Stage 1: Research ────────────────────────────────────────────────────────
 [stages.research]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research the topic and gather supporting material"
-available_tools = ["read_file", "bash"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
 max_iterations = 20
 max_revisits = 2
 system_prompt = """
-You are researching a topic to prepare for writing. Gather:
-- Key facts, data points, and statistics
+Research the topic in `task` to prepare for writing. Gather:
+- Key facts, data points, statistics
 - Expert opinions and notable quotes
-- Existing coverage (what's already been written about this)
-- Counterarguments and alternative perspectives
+- Existing coverage; counterarguments and alternative perspectives
 
-Organize your findings by theme. Note which points are well-supported vs
-speculative. Flag anything that needs verification. If you were sent back to
-research more, focus on the gap the user or outline identified.
+Use web_search + web_fetch for sources and read_file for local material; findings
+land in `research`. For each source you'll rely on, append a bibliography line to
+`sources_index` (context_append): `[n] <title> — <url/path>`. Organize by theme;
+mark points well-supported vs speculative; flag anything needing verification. If
+sent back, focus on the gap the user or outline identified.
 """
 
 [stages.research.tool_routing]
-default_region = "scratch"
+default_region = "conversation"
 [stages.research.tool_routing.overrides]
-read_file = "research"
-bash      = "research"
+web_search = "research"
+web_fetch  = "research"
+read_file  = "research"
+list_dir   = "research"
 
 [stages.research.transitions.outline]
 hint = "Enough material to structure the piece"
@@ -39,14 +50,11 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 2: Outline (human-in-the-loop) ─────────────────────────────────────
-# The user reviews the proposed outline and chooses how to proceed. The choice
-# is fed into the transition decision (multiple outgoing edges force LLM
-# routing); allow_complete lets the user abort the piece entirely.
 [stages.outline]
 mode = "interactive_points"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Create and refine an outline with user input"
-available_tools = ["ask_user_text"]
+available_tools = ["ask_user_text", "read_file"]
 max_iterations = 15
 max_revisits = 4
 allow_complete = true
@@ -59,14 +67,19 @@ You've shown the outline and asked the user what to do:
 - If they want to gather more material first, transition to 'research'.
 """
 system_prompt = """
-Based on your research, propose an outline for the piece:
+Propose an OUTLINE for the piece based on `research` — do NOT write the article
+itself and do NOT create any files here. The draft stage writes the piece AFTER
+the user approves this outline; your job is only to get the structure right.
+
+Present, as your response text:
 - Thesis / main argument
 - Section structure with key points per section
-- Where specific evidence or examples will go
+- Where specific evidence or examples (with [n] source refs) will go
 - Estimated length
 
-Present the outline, then let the user steer. If they revise or expand, produce
-an updated outline grounded in their actual feedback before asking again.
+Then let the user steer via the approval prompt. If they revise or expand, produce
+an updated outline grounded in their actual feedback before asking again. Keep it
+to an outline — no prose paragraphs of the finished piece.
 """
 
 [stages.outline.transitions.draft]
@@ -107,19 +120,19 @@ abort_options = ["Abort — cancel this piece"]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Write the full draft"
-available_tools = ["write_file"]
+available_tools = ["write_file", "read_file"]
 max_iterations = 25
 max_revisits = 2
 system_prompt = """
-Write the full draft based on the approved outline. Guidelines:
+Write the full draft (write_file) from the approved `outline`, backing claims with
+evidence from `research` (cite [n] where relevant). Guidelines:
 - Strong opening that hooks the reader
 - Each section flows logically to the next
-- Claims backed by evidence from your research
 - Concrete examples over abstract statements
 - Clear, direct prose — no filler or hedging
 - Strong conclusion that ties back to the thesis
 
-Write the complete piece. Don't leave placeholders or TODO markers.
+Write the complete piece. No placeholders or TODO markers.
 """
 
 [stages.draft.transitions.edit]
@@ -130,52 +143,88 @@ transform = "compact"
 condition = "error"
 transform = "direct"
 
-# ─── Stage 4: Edit ────────────────────────────────────────────────────────────
-# allow_complete lets the editor ship the piece (DONE) instead of being forced
-# into another rewrite pass.
+# ─── Stage 4: Edit (structural) ───────────────────────────────────────────────
 [stages.edit]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-4-8" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
-description = "Self-edit for clarity, accuracy, and flow"
-available_tools = ["read_file", "write_file"]
+description = "Structural edit for clarity, accuracy, and flow"
+available_tools = ["read_file", "write_file", "context_append"]
 max_iterations = 15
 max_revisits = 2
-allow_complete = true
 transition_prompt = """
-Review your edits. Decide what happens next:
-- If there are structural problems that need a significant rewrite, respond with: draft
-- If the piece is ready for the reader, respond with: DONE
-
-Be honest — if it's good, ship it. Don't over-polish.
+Decide what happens next:
+- If there are STRUCTURAL problems needing a significant rewrite, respond with: draft
+- If the structure and argument are sound and it's ready for a line-level pass,
+  respond with: proofread
 """
 system_prompt = """
-Edit the draft with fresh eyes. Check for:
-1. **Accuracy** — are all claims supported? Any overstatements?
-2. **Clarity** — can every sentence be understood on first read?
-3. **Flow** — does each paragraph lead naturally to the next?
-4. **Concision** — cut anything that doesn't earn its place
-5. **Voice** — is the tone consistent and appropriate for the audience?
-6. **Opening/closing** — do they land?
+Edit the draft for structure and substance (not line-level polish yet):
+1. Accuracy — are claims supported by `research`? Any overstatements?
+2. Clarity — is each idea understandable on first read?
+3. Flow — does each section lead naturally to the next?
+4. Concision — cut anything that doesn't earn its place
+5. Voice — consistent, appropriate for the audience?
+6. Opening/closing — do they land?
 
-Make the edits directly. Write the improved version to the output file.
+Make the edits directly (write the improved version). Note any substantive changes
+in `revisions` (context_append). Hand to proofread only once the structure is sound.
 """
 
-# Custom transform: keep the task/outline/research pinned, compact the draft
-# discussion into a rewrite brief, and clear scratch before rewriting.
+# Custom transform: keep task/outline/research/sources pinned, compact the draft
+# discussion into a rewrite brief, clear scratch before rewriting.
 [stages.edit.transitions.draft]
 hint = "Structural issues found — needs a significant rewrite"
 transform = "custom"
 [stages.edit.transitions.draft.transform_config]
-carry = ["task", "outline", "research"]
+carry = ["task", "style_guide", "outline", "research", "sources_index"]
 compact = ["draft"]
 clear = ["scratch"]
 compact_prompt = "Summarize the structural problems as a numbered rewrite brief."
+
+[stages.edit.transitions.proofread]
+hint = "Structure is sound — do the final line-level pass"
+transform = "compact"
 
 [stages.edit.transitions.error_recovery]
 condition = "error"
 transform = "direct"
 
-# ─── Stage 5: Error recovery ──────────────────────────────────────────────────
+# ─── Stage 5: Proofread (terminal) ────────────────────────────────────────────
+# Final line-level pass. allow_complete lets it ship; can bounce back to edit if
+# it turns up a substantive problem.
+[stages.proofread]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Final line-level proofread and fact-check"
+available_tools = ["read_file", "write_file", "web_fetch"]
+max_iterations = 10
+max_revisits = 1
+allow_complete = true
+transition_prompt = """
+Final pass done. Decide:
+- If you found a SUBSTANTIVE problem (a wrong fact, a broken argument) that needs
+  a structural fix, respond with: edit
+- If the piece is clean and ready for the reader, respond with: DONE
+"""
+system_prompt = """
+Final line-level pass following `style_guide`:
+- Grammar, spelling, punctuation, consistent terminology and formatting
+- Every citation resolves to a `sources_index` entry; spot-check any shaky fact
+  with web_fetch and correct or hedge it
+- Tighten wording; kill remaining filler
+Write the final polished version. Don't introduce new claims. Ship it (DONE) once
+clean — don't over-polish.
+"""
+
+[stages.proofread.transitions.edit]
+hint = "A substantive problem surfaced — back to structural editing"
+transform = "compact"
+
+[stages.proofread.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
+# ─── Stage 6: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-4-6" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
@@ -184,9 +233,8 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-Something failed (a research fetch or a file write). Read the error from
-context, note a workaround, then return to draft to continue with the material
-available.
+Something failed (a research fetch or a file write). Read the error from context,
+note a workaround, then return to draft to continue with the material available.
 """
 
 [stages.error_recovery.transitions.draft]
@@ -197,10 +245,17 @@ transform = "compact"
 provider = "anthropic"
 model = "claude-sonnet-4-6"
 
+# ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-task          = { kind = "pinned",          max_tokens = 2000 }
-research      = { kind = "temporary",       max_tokens = 40000 }
-outline       = { kind = "pinned",          max_tokens = 3000 }
-draft         = { kind = "compacting",      threshold_tokens = 35000, max_tokens = 50000 }
-draft_history = { kind = "compact_history", source_region = "draft", max_tokens = 10000 }
-scratch       = { kind = "clearable",       max_tokens = 5000 }
+task          = { kind = "pinned", budget = "2%", max_tokens = 2000, required = true, seed = "task", required_message = "Describe what to write (topic, audience, length) via --task." }
+style_guide   = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "style" }
+sources_index = { kind = "pinned", budget = "3%", max_tokens = 4000 }
+outline       = { kind = "pinned", budget = "4%", max_tokens = 4000 }
+
+research      = { kind = "temporary",      budget = "25%", max_tokens = 40000 }
+draft         = { kind = "compacting",      budget = "30%", compact_at = "80%", threshold_tokens = 35000, max_tokens = 50000 }
+draft_history = { kind = "compact_history", source_region = "draft", budget = "3%", max_tokens = 10000 }
+revisions     = { kind = "sliding_window", max_items = 15, budget = "4%", max_tokens = 5000 }
+
+conversation  = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+scratch       = { kind = "clearable", budget = "5%", max_tokens = 6000 }

--- a/agents/writing-assistant/tools/web_fetch.rhai
+++ b/agents/writing-assistant/tools/web_fetch.rhai
@@ -1,0 +1,21 @@
+// @tool web_fetch
+// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @param url string required "The URL to fetch (http or https)"
+// @requires network
+
+let out = "";
+try {
+    // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
+    let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
+    // Cap very large pages so a single fetch can't blow the context budget.
+    if body.len() > 12000 {
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+    } else {
+        out = body;
+    }
+} catch(e) {
+    // Most commonly the page exceeds the engine's 1MB string limit, or the host
+    // blocked the request. Report it so the agent can pick a smaller/other source.
+    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+}
+out

--- a/agents/writing-assistant/tools/web_fetch.rhai
+++ b/agents/writing-assistant/tools/web_fetch.rhai
@@ -1,5 +1,5 @@
 // @tool web_fetch
-// @description Fetch the raw contents of a URL over HTTP(S) and return the response body as text. Large pages are truncated; pages over the engine's 1MB limit or blocked requests return a diagnostic message instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
 
@@ -7,9 +7,18 @@ let out = "";
 try {
     // A descriptive User-Agent avoids 403s from sites that block empty/default UAs.
     let body = http_get(params.url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)" });
-    // Cap very large pages so a single fetch can't blow the context budget.
+
+    // If the response looks like HTML, extract readable text so the model reads
+    // prose instead of markup. (Content injected by client-side JS isn't in the
+    // source and can't be recovered here.)
+    let lo = body.to_lower();
+    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+        body = html_to_text(body);
+    }
+
+    // Cap very large content so a single fetch can't blow the context budget.
     if body.len() > 12000 {
-        out = body.sub_string(0, 12000) + "\n\n...[truncated — page was " + body.len() + " chars]";
+        out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;
     }

--- a/agents/writing-assistant/tools/web_search.rhai
+++ b/agents/writing-assistant/tools/web_search.rhai
@@ -1,0 +1,51 @@
+// @tool web_search
+// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @param query string required "The search query"
+// @param count integer optional "Maximum number of results to return (default 5)"
+// @requires network
+
+let n = if params.count == () { 5 } else { params.count };
+let results = [];
+
+// Prefer Brave Search when an API key is configured. env_var throws when the
+// variable is unset, so probe it inside try/catch and fall back to keyless search.
+let key = "";
+try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+
+let got = false;
+if key != "" {
+    try {
+        let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
+        if data.web != () && data.web.results != () {
+            for r in data.web.results {
+                if results.len() >= n { break; }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+            }
+            got = true;
+        }
+    } catch(e) {
+        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
+        got = false;
+    }
+}
+
+if !got {
+    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
+    // queries (no key required). Each page becomes a {title, url, snippet} result.
+    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+    // Wikipedia requires a descriptive User-Agent (403 otherwise).
+    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+    if data.pages != () {
+        for p in data.pages {
+            if results.len() >= n { break; }
+            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
+            snippet.replace("<span class=\"searchmatch\">", "");
+            snippet.replace("</span>", "");
+            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+        }
+    }
+}
+
+results

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -89,6 +89,14 @@ name = "{name}"
 version = "0.1.0"
 description = "A coding assistant blueprint"
 
+# Global tool permissions: write/exec require approval unless overridden.
+[tool_permissions]
+read_file = "allow"
+list_dir = "allow"
+write_file = "ask"
+edit_file = "ask"
+bash = "ask"
+
 [stages.analyze]
 mode = "autonomous"
 model = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}
@@ -96,8 +104,19 @@ description = "Understand the task and plan the implementation"
 available_tools = ["read_file", "list_dir"]
 max_iterations = 15
 system_prompt = """
-Analyze the coding task and produce a concise implementation plan.
+Analyze the coding task in the `task` region and produce a concise implementation
+plan: which files to create/modify, what each does, and the key decisions.
 """
+# Large file reads persist in the `codebase` region (a short pointer stays in the
+# conversation); action-tool results stay inline. Never route to a sliding_window
+# other than `conversation`.
+[stages.analyze.tool_routing]
+default_region = "conversation"
+[stages.analyze.tool_routing.overrides]
+read_file = "codebase"
+list_dir = "codebase"
+[stages.analyze.transitions.implement]
+transform = "direct"
 
 [stages.implement]
 mode = "autonomous"
@@ -106,15 +125,23 @@ description = "Write code according to the plan"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash"]
 max_iterations = 50
 system_prompt = """
-Implement the plan. Create all necessary files and verify with bash.
+Implement the plan. Create all necessary files, then use bash to run tests and
+verify the build. Read existing code from the `codebase` region.
 """
+[stages.implement.tool_routing]
+default_region = "conversation"
+[stages.implement.tool_routing.overrides]
+read_file = "codebase"
+list_dir = "codebase"
 
-# Region budgets are percentages of the model's context window (ceilings, may
-# sum past 100%); the absolute max_tokens is an optional guard-rail cap.
+# Region budgets are percentages of the model's context window (ceilings, may sum
+# past 100%); the absolute max_tokens is an optional guard-rail cap. Every
+# blueprint needs an explicit `conversation` sliding_window — it holds the message
+# stream and is carried across stage transitions.
 [context.regions]
-task         = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000 }}
+task         = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "Describe the coding task via --task." }}
 codebase     = {{ kind = "temporary",       budget = "20%", max_tokens = 30000 }}
-conversation = {{ kind = "sliding_window",  max_items = 20, budget = "15%", max_tokens = 15000 }}
+conversation = {{ kind = "sliding_window",  max_items = 20, budget = "15%", max_tokens = 15000, strategy = "bulk", overflow = 10 }}
 scratch      = {{ kind = "clearable",       budget = "8%",  max_tokens = 10000 }}
 "#,
             name = name
@@ -126,12 +153,32 @@ name = "{name}"
 version = "0.1.0"
 description = "A research assistant blueprint"
 
+[tool_permissions]
+read_file = "allow"
+list_dir = "allow"
+bash = "ask"
+
 [stages.gather]
 mode = "autonomous"
 model = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}
 description = "Gather relevant information"
 available_tools = ["read_file", "list_dir", "bash"]
 max_iterations = 20
+system_prompt = """
+Gather source material on the topic in the `query` region. Use read_file/list_dir
+for local material and bash for anything else; raw content lands in `sources`.
+Note where each item came from and the claims it supports.
+"""
+# (Tip: drop web_search.rhai / web_fetch.rhai into a `tools/` dir beside this file
+# and add them to available_tools for real web research — see the researcher agent.)
+[stages.gather.tool_routing]
+default_region = "conversation"
+[stages.gather.tool_routing.overrides]
+read_file = "sources"
+list_dir = "sources"
+bash = "sources"
+[stages.gather.transitions.synthesize]
+transform = "compact"
 
 [stages.synthesize]
 mode = "interactive"
@@ -139,15 +186,21 @@ model = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}
 description = "Synthesize findings and discuss with user"
 available_tools = ["read_file", "list_dir"]
 max_iterations = 15
+system_prompt = """
+Synthesize the `sources` into `findings`: themes, agreements/disagreements, and
+well-supported vs speculative claims. Cite specific sources.
+"""
 
-# Region budgets are percentages of the model's context window (ceilings, may
-# sum past 100%); the absolute max_tokens / threshold_tokens are guard-rail caps.
+# Region budgets are percentages of the model's context window (ceilings, may sum
+# past 100%); absolute max_tokens / threshold_tokens are guard-rail caps. A
+# `compacting` region needs a paired `compact_history` region for its summaries.
 [context.regions]
-objective    = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000 }}
-sources      = {{ kind = "temporary",       budget = "25%", max_tokens = 40000 }}
-findings     = {{ kind = "compacting",      budget = "12%", compact_at = "53%", threshold_tokens = 8000, max_tokens = 15000 }}
-conversation = {{ kind = "sliding_window",  max_items = 15, budget = "12%", max_tokens = 12000 }}
-scratch      = {{ kind = "clearable",       budget = "6%",  max_tokens = 8000 }}
+query           = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "State the research question via --task." }}
+sources         = {{ kind = "temporary",       budget = "25%", max_tokens = 40000 }}
+findings        = {{ kind = "compacting",      budget = "12%", compact_at = "80%", threshold_tokens = 12000, max_tokens = 15000 }}
+findings_history = {{ kind = "compact_history", source_region = "findings", budget = "3%", max_tokens = 6000 }}
+conversation    = {{ kind = "sliding_window",  max_items = 15, budget = "12%", max_tokens = 12000, strategy = "bulk", overflow = 10 }}
+scratch         = {{ kind = "clearable",       budget = "6%",  max_tokens = 8000 }}
 "#,
             name = name
         ),
@@ -158,6 +211,12 @@ name = "{name}"
 version = "0.1.0"
 description = "A simple agent blueprint"
 
+[tool_permissions]
+read_file = "allow"
+list_dir = "allow"
+write_file = "ask"
+bash = "ask"
+
 [stages.main]
 mode = "autonomous"
 model = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}
@@ -165,14 +224,16 @@ description = "Main execution stage"
 available_tools = ["read_file", "list_dir", "write_file", "bash"]
 max_iterations = 30
 system_prompt = """
-You are a helpful agent. Complete the task thoroughly.
+You are a helpful agent. Complete the task described in the `task` region
+thoroughly.
 """
 
-# Region budgets are percentages of the model's context window (ceilings, may
-# sum past 100%); the absolute max_tokens is an optional guard-rail cap.
+# Region budgets are percentages of the model's context window (ceilings, may sum
+# past 100%); the absolute max_tokens is an optional guard-rail cap. Every
+# blueprint needs an explicit `conversation` sliding_window region.
 [context.regions]
-system       = {{ kind = "pinned",         budget = "2%",  max_tokens = 2000 }}
-conversation = {{ kind = "sliding_window", max_items = 10, budget = "12%", max_tokens = 10000 }}
+task         = {{ kind = "pinned",         budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "Describe the task via --task." }}
+conversation = {{ kind = "sliding_window", max_items = 10, budget = "12%", max_tokens = 10000, strategy = "bulk", overflow = 10 }}
 scratch      = {{ kind = "clearable",      budget = "6%",  max_tokens = 5000 }}
 "#,
             name = name
@@ -257,6 +318,66 @@ mod tests {
                 bp.context_layout.has_percent_budgets(),
                 "{template} layout should have percentage budgets"
             );
+        }
+    }
+
+    #[test]
+    fn every_template_satisfies_context_layout_invariants() {
+        use leviath_core::RegionKind;
+        for template in ["software-engineer", "coder", "researcher", "other"] {
+            let manifest = create_manifest("inv-agent", template);
+            let bp = leviath_core::manifest::parse_manifest(&manifest).unwrap();
+            let regions = &bp.context_layout.regions;
+
+            // Explicit conversation sliding_window.
+            assert!(
+                matches!(
+                    regions
+                        .iter()
+                        .find(|r| r.name == "conversation")
+                        .map(|r| &r.kind),
+                    Some(RegionKind::SlidingWindow { .. })
+                ),
+                "{template} template needs an explicit conversation sliding_window"
+            );
+
+            // No routing targets a non-conversation sliding_window.
+            let sliding: std::collections::HashSet<&str> = regions
+                .iter()
+                .filter(|r| matches!(r.kind, RegionKind::SlidingWindow { .. }))
+                .map(|r| r.name.as_str())
+                .collect();
+            for stage in &bp.stages {
+                if let Some(routing) = &stage.tool_result_routing {
+                    let mut targets = vec![routing.default_region.as_str()];
+                    targets.extend(routing.tool_overrides.values().map(String::as_str));
+                    for t in targets {
+                        assert!(
+                            t == "conversation" || !sliding.contains(t),
+                            "{template} stage '{}' routes to non-conversation sliding_window '{t}'",
+                            stage.name
+                        );
+                    }
+                }
+            }
+
+            // Every compacting region has a compact_history pair.
+            let hist: std::collections::HashSet<&str> = regions
+                .iter()
+                .filter_map(|r| match &r.kind {
+                    RegionKind::CompactHistory { source_region } => Some(source_region.as_str()),
+                    _ => None,
+                })
+                .collect();
+            for r in regions {
+                if matches!(r.kind, RegionKind::Compacting { .. }) {
+                    assert!(
+                        hist.contains(r.name.as_str()),
+                        "{template} compacting region '{}' has no compact_history pair",
+                        r.name
+                    );
+                }
+            }
         }
     }
 

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -329,15 +329,14 @@ mod tests {
             let bp = leviath_core::manifest::parse_manifest(&manifest).unwrap();
             let regions = &bp.context_layout.regions;
 
-            // Explicit conversation sliding_window.
+            // Explicit conversation sliding_window. (matches! is the FIRST operand
+            // so it's evaluated for every region — non-sliding regions exercise its
+            // false arm, the conversation region its true arm.)
+            let has_conv_sliding = regions.iter().any(|r| {
+                matches!(r.kind, RegionKind::SlidingWindow { .. }) && r.name == "conversation"
+            });
             assert!(
-                matches!(
-                    regions
-                        .iter()
-                        .find(|r| r.name == "conversation")
-                        .map(|r| &r.kind),
-                    Some(RegionKind::SlidingWindow { .. })
-                ),
+                has_conv_sliding,
                 "{template} template needs an explicit conversation sliding_window"
             );
 

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -116,11 +116,7 @@ mod tests {
     fn write_manifest(dir: &std::path::Path) -> std::path::PathBuf {
         std::fs::write(
             dir.join("agent.leviath"),
-            std::fs::read_to_string(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../agents/coder/agent.leviath"),
-            )
-            .unwrap(),
+            crate::test_support::inline_coder_manifest(),
         )
         .unwrap();
         dir.join("agent.leviath")

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -434,11 +434,8 @@ mod tests {
     }
 
     fn coder_manifest() -> String {
-        std::fs::read_to_string(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../../agents/coder/agent.leviath"),
-        )
-        .expect("read coder manifest")
+        // Self-contained fixture — not the shipped blueprint (see test_support).
+        crate::test_support::inline_coder_manifest()
     }
 
     /// Write a `<runs_dir>/<run_id>/meta.json` (+ optional context.json) for a run
@@ -784,12 +781,11 @@ mod tests {
     /// (`plan`) is an `interactive_points` stage with a `plan_approval` point.
     fn interactive_agent_dir() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
-        let manifest = std::fs::read_to_string(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../../agents/software-engineer/agent.leviath"),
+        std::fs::write(
+            dir.path().join("agent.leviath"),
+            crate::test_support::inline_interactive_manifest(),
         )
-        .expect("read software-engineer manifest");
-        std::fs::write(dir.path().join("agent.leviath"), manifest).unwrap();
+        .unwrap();
         dir
     }
 

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -331,13 +331,32 @@ impl RealScriptIo {
     fn send(req: reqwest::blocking::RequestBuilder) -> Result<String, String> {
         let resp = req.send().map_err(|e| format!("request failed: {e}"))?;
         let status = resp.status();
-        let text = resp.text().map_err(|e| format!("read body: {e}"))?;
+        let text = cap_script_io(resp.text().map_err(|e| format!("read body: {e}"))?);
         if status.is_success() {
             Ok(text)
         } else {
             Err(format!("http {status}: {text}"))
         }
     }
+}
+
+/// Cap a host-I/O string below the tool engine's 1 MB `max_string_size`
+/// (`build_tool_engine`) so an oversized fetch/read/shell result can't raise the
+/// NON-CATCHABLE `ErrorDataTooLarge` inside a Rhai tool script (it aborts the tool
+/// even inside try/catch). This is only a crash guard — context-size truncation is
+/// handled downstream by region budgets and any in-script truncation.
+const MAX_SCRIPT_IO_BYTES: usize = 900_000;
+
+fn cap_script_io(mut s: String) -> String {
+    if s.len() > MAX_SCRIPT_IO_BYTES {
+        let mut end = MAX_SCRIPT_IO_BYTES;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+        s.push_str("\n[...truncated by leviath: response exceeded 900 KB]");
+    }
+    s
 }
 
 impl ScriptIo for RealScriptIo {
@@ -367,7 +386,10 @@ impl ScriptIo for RealScriptIo {
         let handle = tokio::runtime::Handle::current();
         handle.block_on(async move {
             match tokio::time::timeout(timeout, cmd.output()).await {
-                Ok(Ok(output)) => Ok(combine_shell_output(&output.stdout, &output.stderr)),
+                Ok(Ok(output)) => Ok(cap_script_io(combine_shell_output(
+                    &output.stdout,
+                    &output.stderr,
+                ))),
                 Ok(Err(e)) => Err(format!("failed to spawn shell: {e}")),
                 Err(_) => Err(format!(
                     "shell command timed out after {}s",
@@ -378,7 +400,9 @@ impl ScriptIo for RealScriptIo {
     }
 
     fn read_file(&self, path: &Path) -> Result<String, String> {
-        std::fs::read_to_string(path).map_err(|e| format!("read '{}': {e}", path.display()))
+        std::fs::read_to_string(path)
+            .map(cap_script_io)
+            .map_err(|e| format!("read '{}': {e}", path.display()))
     }
 
     fn write_file(&self, path: &Path, content: &str) -> Result<String, String> {
@@ -1013,5 +1037,30 @@ mod tests {
         temp_env::with_var_unset("LEVIATH_DEFINITELY_UNSET_XYZ", || {
             assert!(host.env_var("LEVIATH_DEFINITELY_UNSET_XYZ").is_err());
         });
+    }
+
+    #[test]
+    fn cap_script_io_leaves_small_strings_untouched() {
+        let s = "small".to_string();
+        assert_eq!(cap_script_io(s.clone()), s);
+    }
+
+    #[test]
+    fn cap_script_io_truncates_oversized_strings_below_the_rhai_limit() {
+        let big = "x".repeat(MAX_SCRIPT_IO_BYTES + 5_000);
+        let capped = cap_script_io(big);
+        assert!(capped.len() < 1_000_000, "must stay under the 1MB Rhai cap");
+        assert!(capped.contains("[...truncated by leviath"));
+    }
+
+    #[test]
+    fn cap_script_io_truncates_on_a_char_boundary() {
+        // A multi-byte char straddling the cap must not be split mid-codepoint.
+        let mut s = "a".repeat(MAX_SCRIPT_IO_BYTES - 1);
+        s.push('é'); // 2 bytes, crossing the boundary
+        s.push_str(&"b".repeat(10));
+        let capped = cap_script_io(s);
+        // Valid UTF-8 (would panic on construction if a codepoint were split).
+        assert!(capped.contains("[...truncated by leviath"));
     }
 }

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -429,15 +429,7 @@ mod tests {
         // (including the now_secs timestamp closure).
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
-        std::fs::write(
-            &manifest,
-            std::fs::read_to_string(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../agents/coder/agent.leviath"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
         let (reply, rx) = oneshot::channel();
         host.handle(ControlOp::Spawn {
             args: Box::new(SpawnArgs {
@@ -795,15 +787,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
     async fn build_host_spawns_agents_through_the_installed_spawner() {
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
-        std::fs::write(
-            &manifest,
-            std::fs::read_to_string(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../agents/coder/agent.leviath"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
 
         let mut registry = ProviderRegistry::new();
         registry.register("anthropic".to_string(), Arc::new(FakeProvider));
@@ -861,15 +845,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         // by `build_host` (exercising the recovery register loop).
         let agent = tempfile::tempdir().unwrap();
         let manifest = agent.path().join("agent.leviath");
-        std::fs::write(
-            &manifest,
-            std::fs::read_to_string(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../agents/coder/agent.leviath"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
 
         let runs = tempfile::tempdir().unwrap();
         let run_dir = runs.path().join("resumed");
@@ -943,15 +919,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         // reloader, which pages it into the world on demand.
         let agent = tempfile::tempdir().unwrap();
         let manifest = agent.path().join("agent.leviath");
-        std::fs::write(
-            &manifest,
-            std::fs::read_to_string(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../../agents/coder/agent.leviath"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
 
         let runs = tempfile::tempdir().unwrap();
         let mut registry = ProviderRegistry::new();

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1153,11 +1153,9 @@ mod tests {
     use tokio::runtime::Handle;
 
     fn coder_manifest() -> String {
-        std::fs::read_to_string(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../../agents/coder/agent.leviath"),
-        )
-        .expect("read coder manifest")
+        // Self-contained fixture — not the shipped blueprint, so these spawn-logic
+        // tests stay isolated from agents/coder edits.
+        crate::test_support::inline_coder_manifest()
     }
 
     fn test_world() -> (PipelineWorld, Arc<CliToolService>) {

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -81,6 +81,109 @@ pub(crate) fn write_test_agent(
     path
 }
 
+/// A self-contained, coder-shaped blueprint for daemon spawn/recovery/setup
+/// tests. Deliberately does NOT read the shipped `agents/coder/agent.leviath`:
+/// those tests exercise spawn/reload *logic*, not the shipped blueprint, so they
+/// must stay isolated from blueprint edits. Budgets are absolute (window-
+/// independent) so a fake small-context test model can't starve the region the
+/// stage system prompt is injected into.
+#[cfg(test)]
+pub(crate) fn inline_coder_manifest() -> String {
+    r#"[agent]
+name = "coder"
+version = "0.0.0"
+description = "Inline test blueprint (coder-shaped); self-contained."
+entry_stage = "analyze"
+
+[tool_permissions]
+read_file = "allow"
+list_dir = "allow"
+write_file = "ask"
+bash = "ask"
+
+[stages.analyze]
+mode = "autonomous"
+model = { provider = "anthropic", model = "m" }
+description = "Understand the task"
+available_tools = ["read_file", "list_dir"]
+system_prompt = "Analyze the task and outline a short plan."
+[stages.analyze.transitions.implement]
+transform = "direct"
+
+[stages.implement]
+mode = "autonomous"
+model = { provider = "anthropic", model = "m" }
+description = "Write the code"
+available_tools = ["write_file", "read_file", "list_dir", "bash"]
+system_prompt = "Implement the plan."
+[stages.implement.transitions.review]
+transform = "compact"
+
+[stages.review]
+mode = "autonomous"
+model = { provider = "anthropic", model = "m" }
+description = "Review the code"
+available_tools = ["read_file", "list_dir"]
+allow_complete = true
+system_prompt = "Review the implementation."
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 8000 }
+codebase = { kind = "temporary", max_tokens = 20000 }
+conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
+"#
+    .to_string()
+}
+
+/// A self-contained blueprint whose stage 0 (`plan`) is an `interactive_points`
+/// stage with a `plan_approval` interaction point — for recovery tests that
+/// resume a run parked at an interaction point. Self-contained for the same
+/// isolation reason as [`inline_coder_manifest`].
+#[cfg(test)]
+pub(crate) fn inline_interactive_manifest() -> String {
+    r#"[agent]
+name = "software-engineer"
+version = "0.0.0"
+description = "Inline test blueprint (interactive plan); self-contained."
+entry_stage = "plan"
+
+[tool_permissions]
+read_file = "allow"
+
+[stages.plan]
+mode = "interactive_points"
+model = { provider = "anthropic", model = "m" }
+description = "Plan"
+available_tools = ["read_file", "ask_user_text", "edit_document"]
+allow_complete = true
+system_prompt = "Produce a plan and ask for approval."
+[stages.plan.transitions.implement]
+hint = "approved"
+
+[[stages.plan.interaction_points]]
+name = "plan_approval"
+prompt = "Approve the plan?"
+required = true
+style = "multiple_choice"
+options = ["Approve", "Abort"]
+document_region = "plan"
+abort_options = ["Abort"]
+
+[stages.implement]
+mode = "autonomous"
+model = { provider = "anthropic", model = "m" }
+description = "Implement"
+available_tools = ["write_file"]
+system_prompt = "Implement the approved plan."
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 8000 }
+plan = { kind = "pinned", max_tokens = 6000 }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/leviath-cli/tests/manifest_integration.rs
+++ b/crates/leviath-cli/tests/manifest_integration.rs
@@ -150,6 +150,74 @@ fn specific_agent_researcher_has_graph_transitions() {
     );
 }
 
+/// Enforce the context-layout invariants that keep tool_routing + message
+/// assembly sound (see the runtime fixes in pipeline.rs / context_setup.rs):
+///   1. every agent declares an explicit `conversation` SlidingWindow region
+///      (an auto-added one is dropped on the first stage transition);
+///   2. no tool-routing target is a SlidingWindow OTHER than `conversation`
+///      (only `conversation` may hold ToolResult message blocks — a routed
+///      result elsewhere desyncs from its tool_use → Anthropic 400);
+///   3. every Compacting region has a paired CompactHistory region.
+#[test]
+fn all_builtin_agents_have_sound_context_layout() {
+    use leviath_core::RegionKind;
+
+    for (name, path) in &discover_agent_manifests() {
+        let content = std::fs::read_to_string(path).unwrap();
+        let bp = leviath_core::manifest::parse_manifest(&content).unwrap();
+        let regions = &bp.context_layout.regions;
+
+        // (1) explicit conversation sliding_window
+        let conv = regions.iter().find(|r| r.name == "conversation");
+        assert!(
+            matches!(
+                conv.map(|r| &r.kind),
+                Some(RegionKind::SlidingWindow { .. })
+            ),
+            "agent '{name}' must declare an explicit `conversation` sliding_window region"
+        );
+
+        // (2) no routing targets a non-conversation sliding_window
+        let sliding: std::collections::HashSet<&str> = regions
+            .iter()
+            .filter(|r| matches!(r.kind, RegionKind::SlidingWindow { .. }))
+            .map(|r| r.name.as_str())
+            .collect();
+        for stage in &bp.stages {
+            if let Some(routing) = &stage.tool_result_routing {
+                let mut targets = vec![routing.default_region.as_str()];
+                targets.extend(routing.tool_overrides.values().map(String::as_str));
+                for t in targets {
+                    assert!(
+                        t == "conversation" || !sliding.contains(t),
+                        "agent '{name}' stage '{}' routes tool results to non-conversation \
+                         sliding_window region '{t}' (would desync tool_result from tool_use)",
+                        stage.name
+                    );
+                }
+            }
+        }
+
+        // (3) every compacting region has a compact_history pair
+        let hist_sources: std::collections::HashSet<&str> = regions
+            .iter()
+            .filter_map(|r| match &r.kind {
+                RegionKind::CompactHistory { source_region } => Some(source_region.as_str()),
+                _ => None,
+            })
+            .collect();
+        for r in regions {
+            if matches!(r.kind, RegionKind::Compacting { .. }) {
+                assert!(
+                    hist_sources.contains(r.name.as_str()),
+                    "agent '{name}': compacting region '{}' has no paired compact_history region",
+                    r.name
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn at_least_nine_builtin_agents_exist() {
     let manifests = discover_agent_manifests();

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 [dependencies]
 leviath-core = { workspace = true }
 leviath-providers = { workspace = true }
+leviath-tools = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_tasks = { workspace = true }
 tokio = { workspace = true }

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -102,6 +102,7 @@ pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str
 /// stage-entry can share it.
 pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
     let mut new_regions = Vec::new();
+    let mut kept: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for region_def in &layout.regions {
         let mut new_region = Region::new(
             region_def.name.clone(),
@@ -115,7 +116,30 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             }
         }
 
+        kept.insert(region_def.name.as_str());
         new_regions.push(new_region);
+    }
+
+    // Carry the message-stream regions across the transition even when the new
+    // stage layout doesn't declare them. Dropping `conversation` (the sole
+    // SlidingWindow that holds typed turns) would strand the whole message history
+    // — the next stage would assemble with no messages, and its typed tool_use/
+    // tool_result turns would have nowhere to land. `tool_results` likewise. A
+    // blueprint that DOES declare them keeps its own budget (handled above).
+    for infra in ["conversation", "tool_results"] {
+        if !kept.contains(infra)
+            && let Some(existing) = window.get_region(infra)
+        {
+            let mut carried = Region::new(
+                existing.name.clone(),
+                existing.kind.clone(),
+                existing.max_tokens,
+            );
+            for entry in &existing.content {
+                let _ = carried.add_entry(entry.content.clone(), entry.tokens);
+            }
+            new_regions.push(carried);
+        }
     }
 
     window.regions = new_regions;
@@ -332,7 +356,12 @@ mod tests {
 
         apply_layout(&mut window, &new_layout);
 
-        assert_eq!(window.regions.len(), 2);
+        // system + scratch from the new layout, PLUS the auto-added message-stream
+        // regions (conversation, tool_results) carried across the transition so the
+        // message history survives even though the new layout doesn't declare them.
+        assert_eq!(window.regions.len(), 4);
+        assert!(window.get_region("conversation").is_some());
+        assert!(window.get_region("tool_results").is_some());
         assert!(
             window
                 .get_region("system")
@@ -345,5 +374,47 @@ mod tests {
         // Token total recomputed from the surviving content.
         assert_eq!(window.current_tokens, window.calculate_tokens());
         assert!(window.current_tokens > 0);
+    }
+
+    #[test]
+    fn apply_layout_carries_conversation_when_new_layout_omits_it() {
+        // A blueprint whose stage layout has NO conversation region. The auto-added
+        // conversation (with typed history) must survive the transition, else the
+        // next stage assembles with no messages.
+        let bp = blueprint_with(vec![RegionDefinition::new(
+            "task".to_string(),
+            RegionKind::Pinned,
+            5000,
+        )]);
+        let mut window = seeded_window(&bp, "the task");
+        window
+            .add_typed_entry(
+                "conversation",
+                leviath_core::EntryKind::UserMessage,
+                "hello from stage 0".to_string(),
+                10,
+            )
+            .unwrap();
+
+        // Transition to a layout that omits conversation entirely.
+        let next = ContextLayout::new(
+            vec![RegionDefinition::new(
+                "task".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            8000,
+        );
+        apply_layout(&mut window, &next);
+
+        let conv = window
+            .get_region("conversation")
+            .expect("conversation carried across transition");
+        assert!(
+            conv.content
+                .iter()
+                .any(|e| e.content.contains("hello from stage 0")),
+            "carried conversation must retain its history"
+        );
     }
 }

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -5389,6 +5389,42 @@ mod tests {
     }
 
     #[test]
+    fn routing_away_pointer_previews_and_truncates_long_results() {
+        // A routed result longer than the 160-char preview gets an ellipsis in the
+        // conversation pointer; the full text still lands in the region.
+        let mut w = ctx(&[("conversation", 10_000), ("codebase", 10_000)]);
+        let long = "L".repeat(500);
+        let r = routing("conversation", &[("read_file", "codebase")], true, None);
+        apply_tool_results(
+            &mut w,
+            "read",
+            &[tc("c1", "read_file")],
+            &[("c1".to_string(), long.clone())],
+            Some(&r),
+            None,
+        );
+        let conv_txt: String = w
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .iter()
+            .map(|e| e.content.clone())
+            .collect();
+        assert!(
+            conv_txt.contains('…'),
+            "long result pointer should be elided"
+        );
+        assert!(
+            w.get_region("codebase")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains(&long)),
+            "full result stored in the region"
+        );
+    }
+
+    #[test]
     fn routing_away_keeps_pair_in_conversation_and_text_in_region() {
         // Regression: routing a tool result to a knowledge region must keep the
         // tool_use/tool_result PAIR in `conversation` (a pointer) and store the full
@@ -5409,6 +5445,15 @@ mod tests {
             },
             10_000,
         ));
+        // A plain user message renders as a non-Blocks message (exercises the
+        // other arm of the assemble scan below).
+        w.add_typed_entry(
+            "conversation",
+            leviath_core::EntryKind::UserMessage,
+            "please read a.rs".to_string(),
+            5,
+        )
+        .unwrap();
         let r = routing("conversation", &[("read_file", "codebase")], true, None);
         apply_tool_results(
             &mut w,

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -926,11 +926,17 @@ fn apply_tool_results(
         let result_tokens = result_text.len() / 4 + 1;
 
         let base_region = match routing {
-            Some(r) => r
-                .tool_overrides
-                .get(&tool_name)
-                .map(String::as_str)
-                .unwrap_or(r.default_region.as_str()),
+            Some(r) => {
+                // Match overrides by CANONICAL tool name so a `bash = "..."` override
+                // routes the `shell` tool (bash is an alias — the model calls the
+                // canonical `shell`, so a literal-key lookup would silently miss).
+                let canon = leviath_tools::canonical_tool_name(&tool_name);
+                r.tool_overrides
+                    .iter()
+                    .find(|(k, _)| leviath_tools::canonical_tool_name(k) == canon)
+                    .map(|(_, v)| v.as_str())
+                    .unwrap_or(r.default_region.as_str())
+            }
             None => "conversation",
         };
         let target_region = match routing {
@@ -943,37 +949,85 @@ fn apply_tool_results(
                 .copied()
                 .unwrap_or(leviath_core::TaintLevel::Public)
         });
-        let add = |window: &mut ContextWindow, region: &str, content: String, tokens: usize| {
-            let kind = leviath_core::EntryKind::ToolResult {
-                tool_call_id: tool_call_id.clone(),
-                tool_name: tool_name.clone(),
-                is_error: false,
+        // Add `content` (with entry `kind`) to `region`, honoring taint and falling
+        // back to a truncated (then omitted) entry if the region is full.
+        let add_kind = |window: &mut ContextWindow,
+                        region: &str,
+                        kind: leviath_core::EntryKind,
+                        content: String,
+                        tokens: usize| {
+            let put = |w: &mut ContextWindow, c: String, t: usize| match taint_level {
+                Some(level) => w.add_typed_tainted_to_region(region, kind.clone(), c, t, level),
+                None => w.add_typed_entry(region, kind.clone(), c, t),
             };
-            match taint_level {
-                Some(level) => {
-                    window.add_typed_tainted_to_region(region, kind, content, tokens, level)
+            if put(window, content.clone(), tokens).is_err() {
+                let available = window
+                    .get_region(region)
+                    .map(|r| r.max_tokens.saturating_sub(r.current_tokens))
+                    .unwrap_or(0);
+                let truncated = if available > 100 {
+                    let char_budget = (available - 10) * 4;
+                    let prefix = truncate_on_char_boundary(&content, char_budget);
+                    let omitted = content.len().saturating_sub(prefix.len());
+                    format!("{}... [truncated, {} chars omitted]", prefix, omitted)
+                } else {
+                    "[tool result truncated — context window full]".to_string()
+                };
+                let trunc_tokens = truncated.len() / 4 + 1;
+                if put(window, truncated, trunc_tokens).is_err() {
+                    let _ = put(window, "[result omitted]".to_string(), 5);
                 }
-                None => window.add_typed_entry(region, kind, content, tokens),
             }
         };
+        let result_kind = || leviath_core::EntryKind::ToolResult {
+            tool_call_id: tool_call_id.clone(),
+            tool_name: tool_name.clone(),
+            is_error: false,
+        };
 
-        if add(window, target_region, result_text.clone(), result_tokens).is_err() {
-            let available = window
-                .get_region(target_region)
-                .map(|r| r.max_tokens.saturating_sub(r.current_tokens))
-                .unwrap_or(0);
-            let truncated = if available > 100 {
-                let char_budget = (available - 10) * 4;
-                let prefix = truncate_on_char_boundary(&result_text, char_budget);
-                let omitted = result_text.len().saturating_sub(prefix.len());
-                format!("{}... [truncated, {} chars omitted]", prefix, omitted)
+        if target_region == "conversation" {
+            // Not routed (or routed back to the message stream): the tool_result
+            // lives in `conversation`, paired with its tool_use.
+            add_kind(
+                window,
+                "conversation",
+                result_kind(),
+                result_text,
+                result_tokens,
+            );
+        } else {
+            // Routed to a knowledge region. Anthropic requires each tool_result to sit
+            // in the message immediately after its tool_use, so the PAIR must stay in
+            // `conversation`: we keep a short pointer tool_result there (valid + cheap)
+            // and store the FULL output in the target region as TEXT. Text renders as a
+            // stable knowledge block for any region kind — a ToolResult block in a
+            // second sliding_window would desync from its tool_use (→ API 400), and
+            // dropping the conversation tool_result would orphan the tool_use (the
+            // assembler strips it, so the model can't see its own call landed → loops).
+            let preview: String = result_text.chars().take(160).collect();
+            let ellipsis = if result_text.len() > preview.len() {
+                "…"
             } else {
-                "[tool result truncated — context window full]".to_string()
+                ""
             };
-            let trunc_tokens = truncated.len() / 4 + 1;
-            if add(window, target_region, truncated, trunc_tokens).is_err() {
-                let _ = add(window, target_region, "[result omitted]".to_string(), 5);
-            }
+            let pointer = format!(
+                "[output stored in context region '{target_region}' ({result_tokens} tokens) — read that region for the full result. Preview: {preview}{ellipsis}]"
+            );
+            let pointer_tokens = pointer.len() / 4 + 1;
+            add_kind(
+                window,
+                "conversation",
+                result_kind(),
+                pointer,
+                pointer_tokens,
+            );
+            add_kind(
+                window,
+                target_region,
+                leviath_core::EntryKind::Text,
+                result_text,
+                result_tokens,
+            );
         }
     }
 }
@@ -5332,6 +5386,111 @@ mod tests {
             None,
         );
         assert!(w.get_region("special").unwrap().current_tokens > 0);
+    }
+
+    #[test]
+    fn routing_away_keeps_pair_in_conversation_and_text_in_region() {
+        // Regression: routing a tool result to a knowledge region must keep the
+        // tool_use/tool_result PAIR in `conversation` (a pointer) and store the full
+        // output in the region as TEXT — so assemble() produces a valid, orphan-free
+        // message sequence (no ToolResult block outside conversation → no API 400;
+        // no orphaned tool_use → no write-loop).
+        let mut w = ContextWindow::new(100_000);
+        w.add_region(Region::new(
+            "codebase".to_string(),
+            RegionKind::Temporary,
+            10_000,
+        ));
+        w.add_region(Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 100,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            10_000,
+        ));
+        let r = routing("conversation", &[("read_file", "codebase")], true, None);
+        apply_tool_results(
+            &mut w,
+            "I'll read it.",
+            &[tc("c1", "read_file")],
+            &[("c1".to_string(), "FULL FILE BODY".to_string())],
+            Some(&r),
+            None,
+        );
+
+        // Full output landed in the knowledge region as text.
+        let cb = w.get_region("codebase").unwrap();
+        assert!(
+            cb.content
+                .iter()
+                .any(|e| e.content.contains("FULL FILE BODY"))
+        );
+        assert!(
+            cb.content
+                .iter()
+                .all(|e| matches!(e.kind, leviath_core::EntryKind::Text)),
+            "routed content must be stored as Text, not a ToolResult block"
+        );
+
+        // Conversation holds the tool_use AND a paired tool_result (pointer).
+        let conv = w.get_region("conversation").unwrap();
+        assert!(conv.content.iter().any(
+            |e| matches!(&e.kind, leviath_core::EntryKind::AssistantTurn { tool_calls } if tool_calls.iter().any(|c| c.id == "c1"))
+        ));
+        assert!(conv.content.iter().any(
+            |e| matches!(&e.kind, leviath_core::EntryKind::ToolResult { tool_call_id, .. } if tool_call_id == "c1")
+        ));
+
+        // The assembled request is valid: every tool_use has a matching tool_result
+        // and nothing gets stripped as orphaned.
+        let a = w.assemble();
+        let mut uses = std::collections::HashSet::new();
+        let mut results = std::collections::HashSet::new();
+        for m in &a.messages {
+            if let leviath_providers::MessageContent::Blocks(blocks) = &m.content {
+                for b in blocks {
+                    match b {
+                        leviath_providers::ContentBlock::ToolUse { id, .. } => {
+                            uses.insert(id.clone());
+                        }
+                        leviath_providers::ContentBlock::ToolResult { tool_use_id, .. } => {
+                            results.insert(tool_use_id.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            uses, results,
+            "every tool_use must have a matching tool_result"
+        );
+        assert!(uses.contains("c1"), "the read_file tool_use must survive");
+    }
+
+    #[test]
+    fn routing_override_matches_bash_alias_to_shell() {
+        // Blueprint routes `bash`, but the model calls the canonical `shell`
+        // (bash is an alias). The override must still match.
+        let mut w = ctx(&[("conversation", 10_000), ("test_results", 10_000)]);
+        let r = routing("conversation", &[("bash", "test_results")], true, None);
+        apply_tool_results(
+            &mut w,
+            "run tests",
+            &[tc("c1", "shell")],
+            &[("c1".to_string(), "All tests passed".to_string())],
+            Some(&r),
+            None,
+        );
+        assert!(
+            w.get_region("test_results")
+                .unwrap()
+                .content
+                .iter()
+                .any(|e| e.content.contains("All tests passed")),
+            "a `bash` override must route the canonical `shell` tool's result"
+        );
     }
 
     #[test]

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -543,6 +543,7 @@ fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
     engine.register_fn("parse_json", parse_json_fn);
     engine.register_fn("to_json", to_json_fn);
     engine.register_fn("encode_uri", |s: &str| -> String { percent_encode(s) });
+    engine.register_fn("html_to_text", |s: &str| -> String { html_to_text(s) });
 }
 
 /// `parse_json(str)` host function: JSON string → Rhai value.
@@ -590,6 +591,143 @@ fn hex_digit(nibble: u8) -> char {
         0..=9 => (b'0' + nibble) as char,
         _ => (b'A' + (nibble - 10)) as char,
     }
+}
+
+/// `html_to_text(html)` host function: best-effort HTML → readable plain text.
+/// Drops `<script>`/`<style>` blocks, strips tags, decodes common entities, and
+/// collapses whitespace — so a script tool (e.g. `web_fetch`) can hand the model
+/// prose from a server-rendered page instead of markup. Not a full HTML parser;
+/// content injected by client-side JS is not present in the source and cannot be
+/// recovered here.
+fn html_to_text(html: &str) -> String {
+    let without_raw = strip_raw_text_elements(html);
+    let without_tags = strip_tags(&without_raw);
+    let decoded = decode_entities(&without_tags);
+    collapse_whitespace(&decoded)
+}
+
+/// Remove `<script>…</script>` and `<style>…</style>` element contents (their
+/// text is code/CSS, never prose). Case-insensitive; an unclosed element drops
+/// the remainder.
+fn strip_raw_text_elements(html: &str) -> String {
+    let mut s = html.to_string();
+    for tag in ["script", "style"] {
+        s = strip_element(&s, tag);
+    }
+    s
+}
+
+fn strip_element(html: &str, tag: &str) -> String {
+    let lower = html.to_ascii_lowercase();
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let mut out = String::with_capacity(html.len());
+    let mut i = 0;
+    while i < html.len() {
+        if lower[i..].starts_with(&open) {
+            match lower[i..].find(&close) {
+                Some(rel) => {
+                    i += rel + close.len();
+                    continue;
+                }
+                None => break, // unclosed element — drop the rest
+            }
+        }
+        let ch = html[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Strip `<...>` tags. Each tag boundary becomes a space so adjacent words don't
+/// run together. A `<` with no matching `>` drops the remainder (malformed).
+fn strip_tags(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' if in_tag => {
+                in_tag = false;
+                out.push(' ');
+            }
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Decode common HTML entities (named + numeric decimal/hex). Unknown or
+/// unterminated entities are left verbatim.
+fn decode_entities(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        let after = &rest[amp..];
+        let window = after.len().min(12);
+        match after[..window].find(';') {
+            Some(semi) => match decode_one_entity(&after[1..semi]) {
+                Some(ch) => {
+                    out.push(ch);
+                    rest = &after[semi + 1..];
+                }
+                None => {
+                    out.push('&');
+                    rest = &after[1..];
+                }
+            },
+            None => {
+                out.push('&');
+                rest = &after[1..];
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn decode_one_entity(e: &str) -> Option<char> {
+    match e {
+        "amp" => Some('&'),
+        "lt" => Some('<'),
+        "gt" => Some('>'),
+        "quot" => Some('"'),
+        "apos" => Some('\''),
+        "nbsp" => Some(' '),
+        "mdash" => Some('—'),
+        "ndash" => Some('–'),
+        "hellip" => Some('…'),
+        _ => {
+            if let Some(hex) = e.strip_prefix("#x").or_else(|| e.strip_prefix("#X")) {
+                u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+            } else if let Some(dec) = e.strip_prefix('#') {
+                dec.parse::<u32>().ok().and_then(char::from_u32)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Collapse every run of whitespace to a single space and trim.
+fn collapse_whitespace(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_ws = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+                prev_ws = true;
+            }
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
 }
 
 #[cfg(test)]
@@ -1204,5 +1342,61 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         m.insert("n".into(), Dynamic::from(42_i64));
         let headers = headers_from_map(m);
         assert_eq!(headers.get("n").map(String::as_str), Some("42"));
+    }
+
+    #[test]
+    fn html_to_text_full_pipeline() {
+        let html = "<html><head><style>.a{color:red}</style></head>\
+            <body><h1>Tit&amp;le</h1><script>var x=1<2;</script>\
+            <p>Hello&nbsp;world &#39;quoted&#39; &#x2014; done.</p></body></html>";
+        let text = html_to_text(html);
+        assert!(text.contains("Tit&le"), "entity decoded: {text}");
+        assert!(text.contains("Hello world 'quoted' — done."), "got: {text}");
+        assert!(!text.contains("color:red"), "style content dropped");
+        assert!(!text.contains("var x"), "script content dropped");
+        assert!(!text.contains('<'), "tags stripped");
+    }
+
+    #[test]
+    fn strip_element_handles_case_unclosed_and_utf8() {
+        // Case-insensitive open + close.
+        assert_eq!(strip_element("a<SCRIPT>x</script>b", "script"), "ab");
+        // Unclosed element drops the remainder.
+        assert_eq!(strip_element("keep<style>rest", "style"), "keep");
+        // Non-matching content (incl. multi-byte chars) passes through.
+        assert_eq!(strip_element("café < 3", "script"), "café < 3");
+    }
+
+    #[test]
+    fn strip_tags_edges() {
+        assert_eq!(strip_tags("<b>hi</b>").trim(), "hi");
+        // '>' outside a tag is kept.
+        assert_eq!(strip_tags("2 > 1").trim(), "2 > 1");
+        // Unclosed '<' drops the rest.
+        assert_eq!(strip_tags("ok <broken").trim(), "ok");
+    }
+
+    #[test]
+    fn decode_entities_named_numeric_and_unknown() {
+        assert_eq!(decode_entities("a&amp;b"), "a&b");
+        assert_eq!(decode_entities("&lt;&gt;&quot;&apos;"), "<>\"'");
+        assert_eq!(decode_entities("x&nbsp;y"), "x y");
+        assert_eq!(decode_entities("&mdash;&ndash;&hellip;"), "—–…");
+        assert_eq!(decode_entities("&#65;&#x42;&#X43;"), "ABC");
+        // Unknown entity kept verbatim.
+        assert_eq!(decode_entities("&bogus;"), "&bogus;");
+        // No terminating ';' within the window → '&' kept, scan continues.
+        assert_eq!(decode_entities("a & b"), "a & b");
+        // Invalid numeric → kept verbatim.
+        assert_eq!(decode_entities("&#zz;"), "&#zz;");
+        assert_eq!(decode_entities("&#x110000;"), "&#x110000;"); // out of range
+        // No ampersand at all.
+        assert_eq!(decode_entities("plain"), "plain");
+    }
+
+    #[test]
+    fn collapse_whitespace_runs_and_trims() {
+        assert_eq!(collapse_whitespace("  a \n\t b  "), "a b");
+        assert_eq!(collapse_whitespace(""), "");
     }
 }

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -1133,6 +1133,15 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     }
 
     #[test]
+    fn execute_html_to_text_host_fn_via_script() {
+        // Exercises the registered `html_to_text` engine binding (not just the
+        // free function): a script strips markup to prose.
+        let tool = tool_from("// @tool t\nhtml_to_text(\"<p>Hi&amp;<b>bye</b></p>\")");
+        let out = execute(&tool, serde_json::json!({}), FakeHost::arc());
+        assert_eq!(out, "Hi& bye");
+    }
+
+    #[test]
     fn execute_missing_optional_param_reads_as_unit() {
         // Mirrors the issue's `params.count == ()` idiom.
         let tool = tool_from("// @tool t\nif params.count == () { \"default\" } else { \"set\" }");
@@ -1388,8 +1397,10 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         // No terminating ';' within the window → '&' kept, scan continues.
         assert_eq!(decode_entities("a & b"), "a & b");
         // Invalid numeric → kept verbatim.
-        assert_eq!(decode_entities("&#zz;"), "&#zz;");
-        assert_eq!(decode_entities("&#x110000;"), "&#x110000;"); // out of range
+        assert_eq!(decode_entities("&#zz;"), "&#zz;"); // decimal parse Err
+        assert_eq!(decode_entities("&#xZZ;"), "&#xZZ;"); // hex from_str_radix Err
+        assert_eq!(decode_entities("&#x110000;"), "&#x110000;"); // hex out of range (from_u32 None)
+        assert_eq!(decode_entities("&#99999999;"), "&#99999999;"); // decimal out of range (from_u32 None)
         // No ampersand at all.
         assert_eq!(decode_entities("plain"), "plain");
     }


### PR DESCRIPTION
## Summary

Brings **all 10 default agents** to production quality (issue #98), on top of the now-merged percentage budgets (#100) and Rhai script tools (#97). Along the way it fixes three **latent runtime bugs** in the tool-routing × message-assembly path that any user of `tool_routing` + compaction could hit.

## Agents (all 10)
`coder`, `reviewer`, `software-engineer`, `researcher`, `deep-researcher`, `wide-researcher`, `daily-briefer`, `writing-assistant`, `log-analyzer`, `parallel-fixer`:
- Percentage-based region budgets with absolute guard-rails (#100 syntax).
- Explicit `conversation` regions, tool-output routing to knowledge regions, `context_write` curation.
- Richer stage graphs: `follow_citations` (deep-researcher), `deep_dive` (wide-researcher), `proofread` (writing-assistant), `verify` re-round (parallel-fixer).
- Per-agent `web_search`/`web_fetch` Rhai tools (Brave-when-keyed, keyless Wikipedia fallback). They travel with the agent through `lev add` and `lev pack`.

## Runtime fixes (root causes, with regression tests)
1. **Routing a tool result away from `conversation` → 400 / write-loop.** `apply_tool_results` now keeps the `tool_use`/`tool_result` pair in `conversation` (a short pointer) and stores the full output in the target region as text. Fixes both the message-ordering 400 and the orphaned-tool_use write-loop.
2. **`apply_layout` dropped `conversation`/`tool_results` on stage transitions** → stranded history. Now carried across transitions.
3. **Routing overrides matched literal tool names**, so `bash = "..."` never matched the canonical `shell`. Now matched by canonical name.
4. **`html_to_text` host fn** so `web_fetch` returns readable prose from HTML, and a host-level cap below the Rhai 1 MB string limit.

## Cleanup / hardening
- Isolated `daemon::spawn/recovery/setup` tests from the shipped blueprints (inline fixtures).
- Added `all_builtin_agents_have_sound_context_layout` enforcing the invariants (explicit `conversation`, no non-`conversation` sliding_window routing, `compacting`↔`compact_history`).
- Modernized `lev create` scaffolding templates to the same patterns, with an equivalent invariants test.

## Verification
All agents live-verified end-to-end against real models + web (isolated daemon): reviewer caught all planted bugs and verified them via bash; log-analyzer caught every planted anomaly with counts + correlation; parallel-fixer fixed both bugs (3/3 green) through validate→fan-out→merge→verify; researchers produced ~2000-word cited reports; `web_fetch` now returns clean prose. `available_tools` confirmed enforced (controlled test). Full `leviath-cli`, `leviath-runtime`, `leviath-core`, `leviath-scripting` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Rzo6RCCrV1LL8cRDnK7Ds