### PR TITLE
fix(daemon): stop the double-panic abort at the Rhai boundary, and contain agent failures (#109)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tar = "0.4"
 dirs = "6.0.0"
 dotenvy = "0.15"
 libc = "0.2"
-nix = { version = "0.28", default-features = false, features = ["signal", "process"] }
+nix = { version = "0.28", default-features = false, features = ["signal", "process", "user"] }
 temp-env = "0.3"
 crossterm = "0.28"
 ratatui = "0.29"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ lev run deep-researcher --task "Survey the current state of solid-state battery 
 `lev run` hands the agent to a background **daemon** that hosts every agent in
 one shared world, so runs keep going after your terminal closes. The daemon
 starts automatically on first use (run it yourself with `lev daemon` to watch its
-logs). Inspect and steer running agents from any terminal:
+logs). For unattended, long-running agents, `lev daemon install` hands it to the
+OS supervisor — launchd on macOS, a systemd `--user` unit on Linux — so it starts
+at login and comes back on its own if it ever dies; on the next start it reloads
+every interrupted run. Inspect and steer running agents from any terminal:
 
 ```bash
 lev ps                       # list running agents and their status
@@ -412,6 +415,7 @@ For a clean "sling a task and get a result" flow with Gas City, prefer **autonom
 | `lev cancel <run-id>` | Cancel a running agent |
 | `lev respond [req-id] [value]` | List or answer pending `ask_user` interactions |
 | `lev daemon` | Run the shared-world daemon in the foreground |
+| `lev daemon install` / `uninstall` | Supervise the daemon (launchd / systemd `--user`) so it restarts automatically |
 | `lev dash` | TUI dashboard |
 | `lev serve` | REST + WebSocket API server |
 | `lev agent-client` | Serve an agent over the Agent Client Protocol (stdio; Gas City / Zed) |

--- a/crates/leviath-cli/src/commands/daemon.rs
+++ b/crates/leviath-cli/src/commands/daemon.rs
@@ -33,6 +33,11 @@ pub enum DaemonAction {
     Status,
     /// Restart the daemon (stop, then start) — reloading persisted agents.
     Restart,
+    /// Register the daemon with the OS supervisor (launchd / systemd --user) so
+    /// it starts at login and is restarted automatically if it ever dies.
+    Install,
+    /// Deregister the daemon from the OS supervisor.
+    Uninstall,
 }
 
 /// Ask the daemon to shut down and report the outcome.

--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -1,0 +1,447 @@
+//! `lev daemon install` / `lev daemon uninstall` — hand the daemon to the OS
+//! supervisor so it comes back by itself after a crash.
+//!
+//! Nothing restarted the daemon when it died (issue #109): a long-running agent
+//! simply stopped, and the next `lev run` was the only thing that would bring
+//! the daemon back. Registering a launchd agent (macOS) or a systemd *user*
+//! unit (Linux) with a restart policy closes that gap — and on the next start
+//! the daemon's own recovery pass reloads every interrupted run.
+//!
+//! This module is the tested core: rendering the unit file, resolving where it
+//! goes, writing/removing it, and building the activation command line. Running
+//! that command is real subprocess I/O and lives in the binary.
+//!
+//! Platform differences are `#[cfg]`-gated rather than branched at runtime, so
+//! each target compiles exactly the code it uses (and covers all of it).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// The reverse-DNS label both platforms key the service by.
+pub const SERVICE_LABEL: &str = "ai.sunforge.leviath";
+
+/// Where a supervised daemon's stdout/stderr are appended, under the leviath
+/// home directory. Only the platforms with a supervisor render a unit file.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+const LOG_FILE: &str = "daemon.log";
+
+/// A rendered service definition and where it belongs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceUnit {
+    /// Absolute path the unit file is written to.
+    pub path: PathBuf,
+    /// The file's contents.
+    pub contents: String,
+    /// Command + args that tell the supervisor to pick it up.
+    pub activate: (String, Vec<String>),
+    /// Command + args that tell the supervisor to let it go.
+    pub deactivate: (String, Vec<String>),
+}
+
+// ── macOS: a launchd user agent ──────────────────────────────────────────────
+
+/// Build the service definition for this platform.
+///
+/// `exe` is the absolute path to the `lev` binary, `home` the leviath home
+/// directory (the unit points the daemon at it explicitly, since a supervised
+/// process inherits none of the user's shell environment), `config_home` the
+/// directory the unit file is written into, and `uid` the user's numeric id
+/// (launchd addresses per-user domains by it).
+#[cfg(target_os = "macos")]
+pub fn service_unit(exe: &Path, home: &Path, config_home: &Path, uid: u32) -> Result<ServiceUnit> {
+    let path = config_home.join(format!("{SERVICE_LABEL}.plist"));
+    Ok(ServiceUnit {
+        contents: launchd_plist(exe, home, &home.join(LOG_FILE)),
+        activate: (
+            "launchctl".to_string(),
+            vec![
+                "bootstrap".to_string(),
+                format!("gui/{uid}"),
+                display(&path),
+            ],
+        ),
+        deactivate: (
+            "launchctl".to_string(),
+            vec!["bootout".to_string(), format!("gui/{uid}/{SERVICE_LABEL}")],
+        ),
+        path,
+    })
+}
+
+/// Where the unit file goes, relative to the user's home directory.
+#[cfg(target_os = "macos")]
+pub fn config_home(user_home: &Path) -> Result<PathBuf> {
+    Ok(user_home.join("Library").join("LaunchAgents"))
+}
+
+/// A launchd user agent that starts the daemon at login and restarts it
+/// whenever it exits — including the `abort()` this issue was about.
+#[cfg(target_os = "macos")]
+fn launchd_plist(exe: &Path, home: &Path, log: &Path) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{exe}</string>
+        <string>daemon</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>LEVIATH_HOME</key>
+        <string>{home}</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>{log}</string>
+    <key>StandardErrorPath</key>
+    <string>{log}</string>
+</dict>
+</plist>
+"#,
+        label = SERVICE_LABEL,
+        exe = xml_escape(&display(exe)),
+        home = xml_escape(&display(home)),
+        log = xml_escape(&display(log)),
+    )
+}
+
+/// Escape the five XML metacharacters so an odd path can't break the plist.
+#[cfg(target_os = "macos")]
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+// ── Linux: a systemd user unit ───────────────────────────────────────────────
+
+/// Build the service definition for this platform (see the macOS variant for
+/// the argument contract; `uid` is unused here — systemd's `--user` mode
+/// already addresses the calling user's manager).
+#[cfg(target_os = "linux")]
+pub fn service_unit(exe: &Path, home: &Path, config_home: &Path, _uid: u32) -> Result<ServiceUnit> {
+    Ok(ServiceUnit {
+        path: config_home.join("leviath.service"),
+        contents: systemd_unit(exe, home, &home.join(LOG_FILE)),
+        activate: (
+            "systemctl".to_string(),
+            vec![
+                "--user".to_string(),
+                "enable".to_string(),
+                "--now".to_string(),
+                "leviath.service".to_string(),
+            ],
+        ),
+        deactivate: (
+            "systemctl".to_string(),
+            vec![
+                "--user".to_string(),
+                "disable".to_string(),
+                "--now".to_string(),
+                "leviath.service".to_string(),
+            ],
+        ),
+    })
+}
+
+/// Where the unit file goes, relative to the user's home directory.
+#[cfg(target_os = "linux")]
+pub fn config_home(user_home: &Path) -> Result<PathBuf> {
+    Ok(user_home.join(".config").join("systemd").join("user"))
+}
+
+/// A systemd *user* unit (no root needed) with the same restart policy.
+#[cfg(target_os = "linux")]
+fn systemd_unit(exe: &Path, home: &Path, log: &Path) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Leviath shared-world agent daemon\n\
+         After=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={exe} daemon\n\
+         Environment=LEVIATH_HOME={home}\n\
+         Restart=always\n\
+         RestartSec=10\n\
+         StandardOutput=append:{log}\n\
+         StandardError=append:{log}\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        exe = display(exe),
+        home = display(home),
+        log = display(log),
+    )
+}
+
+// ── Everywhere else: no supported user-level supervisor ──────────────────────
+
+/// The error shown on a platform with no supported user-level supervisor.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+const UNSUPPORTED: &str = "`lev daemon install` supports macOS (launchd) and Linux (systemd user \
+                           units); on this platform, start `lev daemon` from your own login script";
+
+/// No user-level supervisor is wired up for this platform.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn service_unit(
+    _exe: &Path,
+    _home: &Path,
+    _config_home: &Path,
+    _uid: u32,
+) -> Result<ServiceUnit> {
+    anyhow::bail!(UNSUPPORTED)
+}
+
+/// No user-level supervisor is wired up for this platform.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn config_home(_user_home: &Path) -> Result<PathBuf> {
+    anyhow::bail!(UNSUPPORTED)
+}
+
+// ── Platform-independent ─────────────────────────────────────────────────────
+
+/// Write `unit` to disk, creating its parent directory. Returns the path.
+pub fn install(unit: &ServiceUnit) -> Result<&Path> {
+    if let Some(parent) = unit.path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(&unit.path, &unit.contents)
+        .with_context(|| format!("writing {}", unit.path.display()))?;
+    Ok(&unit.path)
+}
+
+/// Remove the unit file. Returns whether there was one to remove.
+pub fn uninstall(unit: &ServiceUnit) -> Result<bool> {
+    match std::fs::remove_file(&unit.path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).with_context(|| format!("removing {}", unit.path.display())),
+    }
+}
+
+/// The line `lev daemon status` adds about supervision.
+pub fn format_supervision(installed: bool, path: &Path) -> String {
+    if installed {
+        format!("supervised: yes ({})", path.display())
+    } else {
+        "supervised: no (`lev daemon install` restarts it automatically)".to_string()
+    }
+}
+
+/// A path as a string, lossily — these are user home paths, valid UTF-8 in
+/// every case that matters, and a lossy rendering beats failing.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn display(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A unit that needs no platform support to construct, for the shared
+    /// filesystem helpers.
+    fn bare_unit(path: PathBuf) -> ServiceUnit {
+        ServiceUnit {
+            path,
+            contents: "unit body\n".to_string(),
+            activate: ("sup".to_string(), vec!["on".to_string()]),
+            deactivate: ("sup".to_string(), vec!["off".to_string()]),
+        }
+    }
+
+    #[test]
+    fn install_writes_then_uninstall_removes_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("nested").join("leviath.unit"));
+
+        let written = install(&unit).unwrap().to_path_buf();
+        assert_eq!(std::fs::read_to_string(&written).unwrap(), unit.contents);
+        assert!(uninstall(&unit).unwrap(), "first removal reports a removal");
+        assert!(
+            !uninstall(&unit).unwrap(),
+            "second is a no-op, not an error"
+        );
+    }
+
+    #[test]
+    fn install_and_uninstall_surface_io_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        // A file where the parent directory should be ⇒ create_dir_all fails.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, "x").unwrap();
+        assert!(install(&bare_unit(blocker.join("child").join("unit"))).is_err());
+
+        // A *directory* where the unit file should be: the parent exists, so
+        // create_dir_all succeeds and the write itself is what fails.
+        let occupied = dir.path().join("occupied");
+        std::fs::create_dir(&occupied).unwrap();
+        assert!(install(&bare_unit(occupied.clone())).is_err());
+
+        // Removing a directory as if it were the unit file is a real error,
+        // distinct from "there was nothing to remove".
+        assert!(uninstall(&bare_unit(occupied)).is_err());
+
+        // A path with no parent directory to create (the `if let` falls through
+        // straight to the write, which then fails on the empty path).
+        assert!(install(&bare_unit(PathBuf::new())).is_err());
+    }
+
+    #[test]
+    fn supervision_status_reads_both_ways() {
+        let path = Path::new("/home/u/unit");
+        assert!(format_supervision(true, path).contains("yes"));
+        assert!(format_supervision(true, path).contains("/home/u/unit"));
+        assert!(format_supervision(false, path).contains("no"));
+    }
+
+    // ── Platforms with a supervisor ──────────────────────────────────────────
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    mod supported {
+        use super::*;
+
+        fn unit() -> ServiceUnit {
+            service_unit(
+                Path::new("/usr/local/bin/lev"),
+                Path::new("/home/u/.leviath"),
+                Path::new("/tmp/lev-units"),
+                501,
+            )
+            .expect("this platform has a supervisor")
+        }
+
+        #[test]
+        fn the_unit_restarts_the_daemon_and_points_it_at_the_leviath_home() {
+            let u = unit();
+            assert!(u.contents.contains("/usr/local/bin/lev"));
+            assert!(u.contents.contains("/home/u/.leviath"));
+            assert!(u.contents.contains(LOG_FILE));
+            // Activation and deactivation drive the same supervisor.
+            assert_eq!(u.activate.0, u.deactivate.0);
+            assert!(!u.activate.1.is_empty() && !u.deactivate.1.is_empty());
+            assert!(u.path.starts_with("/tmp/lev-units"));
+            // The unit file lives under the user's home.
+            let home = config_home(Path::new("/home/u")).expect("this platform has a supervisor");
+            assert!(home.starts_with("/home/u"));
+        }
+
+        #[test]
+        fn display_renders_a_path_losslessly_when_it_can() {
+            assert_eq!(display(Path::new("/a/b")), "/a/b");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    mod macos {
+        use super::*;
+
+        #[test]
+        fn paths_with_xml_metacharacters_are_escaped() {
+            assert_eq!(
+                xml_escape("a&b<c>d\"e'f"),
+                "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+            );
+            assert_eq!(xml_escape("plain/path"), "plain/path");
+        }
+
+        #[test]
+        fn it_is_a_launchd_plist_bootstrapped_into_the_gui_domain() {
+            let u = service_unit(
+                Path::new("/usr/local/bin/lev"),
+                Path::new("/home/u/.leviath"),
+                Path::new("/tmp/lev-units"),
+                501,
+            )
+            .unwrap();
+            assert_eq!(
+                u.path.file_name().unwrap().to_string_lossy(),
+                format!("{SERVICE_LABEL}.plist")
+            );
+            assert_eq!(u.activate.1[0], "bootstrap");
+            assert_eq!(u.activate.1[1], "gui/501");
+            assert_eq!(u.deactivate.1[1], format!("gui/501/{SERVICE_LABEL}"));
+            // The whole point: launchd brings the daemon back after a crash.
+            assert!(u.contents.contains("<key>KeepAlive</key>"));
+            assert!(u.contents.contains("<key>RunAtLoad</key>"));
+            assert!(
+                config_home(Path::new("/home/u"))
+                    .unwrap()
+                    .ends_with("LaunchAgents")
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    mod linux {
+        use super::*;
+
+        #[test]
+        fn it_is_a_systemd_user_unit_enabled_for_the_calling_user() {
+            let u = service_unit(
+                Path::new("/usr/local/bin/lev"),
+                Path::new("/home/u/.leviath"),
+                Path::new("/tmp/lev-units"),
+                501,
+            )
+            .unwrap();
+            assert_eq!(u.path.file_name().unwrap(), "leviath.service");
+            assert_eq!(
+                u.activate.1,
+                ["--user", "enable", "--now", "leviath.service"]
+            );
+            assert_eq!(
+                u.deactivate.1,
+                ["--user", "disable", "--now", "leviath.service"]
+            );
+            // The whole point: systemd brings the daemon back after a crash.
+            assert!(u.contents.contains("Restart=always"));
+            assert!(u.contents.contains("WantedBy=default.target"));
+            assert!(config_home(Path::new("/home/u")).unwrap().ends_with("user"));
+        }
+    }
+
+    // ── Platforms without one ────────────────────────────────────────────────
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    mod unsupported {
+        use super::*;
+
+        #[test]
+        fn install_is_refused_with_an_actionable_message() {
+            let err = service_unit(
+                Path::new("lev.exe"),
+                Path::new("home"),
+                Path::new("units"),
+                0,
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("macOS"), "got: {err}");
+            assert!(err.contains("lev daemon"), "got: {err}");
+            assert!(config_home(Path::new("home")).is_err());
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/mod.rs
+++ b/crates/leviath-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod context;
 pub mod create;
 pub mod ctl;
 pub mod daemon;
+pub mod daemon_service;
 pub mod dashboard;
 pub mod list;
 pub mod mcp;

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -11,7 +11,7 @@
 //! So the pool is warm by the time an agent's tools are advertised.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, PoisonError};
 
 use leviath_mcp::{MCPServerConfig, ToolDiscovery, ToolExecutor};
 use leviath_providers::Tool;
@@ -76,7 +76,7 @@ impl McpPool {
     pub fn seed(&self, config: &MCPServerConfig, defs: Vec<Tool>) {
         self.connected
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(signature(config), defs);
     }
 
@@ -86,7 +86,12 @@ impl McpPool {
     /// spawn retries.
     pub async fn ensure(&self, config: &MCPServerConfig) -> Vec<Tool> {
         let sig = signature(config);
-        if let Some(defs) = self.connected.lock().unwrap().get(&sig) {
+        if let Some(defs) = self
+            .connected
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&sig)
+        {
             return defs.clone();
         }
         // Resolve a stored OAuth bearer for an HTTP server (refreshing it
@@ -133,7 +138,10 @@ impl McpPool {
                         parameters: m.schema,
                     })
                     .collect();
-                self.connected.lock().unwrap().insert(sig, defs.clone());
+                self.connected
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .insert(sig, defs.clone());
                 // Pre-format the count so the tracing field carries no inline
                 // method call (an uncoverable macro sub-region otherwise).
                 let count = defs.len();
@@ -197,7 +205,10 @@ impl McpPool {
     /// for them — call [`Self::ensure`] first). Unknown/unconnected configs
     /// contribute nothing. This is the sync read the spawner uses.
     pub fn cached_defs_for(&self, configs: &[MCPServerConfig]) -> Vec<Tool> {
-        let cache = self.connected.lock().unwrap();
+        let cache = self
+            .connected
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         configs
             .iter()
             .filter_map(|c| cache.get(&signature(c)))

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -93,6 +93,7 @@ pub fn reload_persisted_agents(
             Ok(entity) => reloaded.push((meta, entity)),
             Err(e) => {
                 tracing::warn!(run_id = %meta.run_id, error = %e, "skipping un-reloadable run");
+                mark_crashed(&run_dir, meta, &e.to_string(), now_secs);
             }
         }
     }
@@ -240,6 +241,35 @@ fn totals_from(meta: &RunMeta) -> TokenTotals {
         cached_tokens: meta.cached_tokens,
         cache_write_tokens: meta.cache_write_tokens,
         tool_calls: meta.tool_calls,
+    }
+}
+
+/// Record a run that could not be reloaded as terminally errored.
+///
+/// The daemon is the sole owner of these runs, so anything still marked
+/// `running` at startup is by definition not running. Runs that *can* be
+/// reloaded are resumed (that is the whole point of this module); this is only
+/// for the ones that can't — which used to be logged and then left claiming
+/// `"status": "running"` on disk forever, so `lev ps` and the dashboard showed
+/// a live run that no longer existed (issue #109).
+///
+/// Best-effort: a write failure here is logged, never fatal — the daemon is
+/// mid-startup and the rest of the recovery pass must still run.
+fn mark_crashed(run_dir: &Path, meta: RunMeta, reason: &str, now_secs: i64) {
+    let crashed = RunMeta {
+        status: RunStatus::Error,
+        error: Some(format!(
+            "the daemon exited while this run was active and it could not be recovered: {reason}"
+        )),
+        updated_at: now_secs,
+        ..meta
+    };
+    if let Err(e) = crate::runstate::write_meta_to(run_dir, &crashed) {
+        tracing::warn!(
+            run_id = %crashed.run_id,
+            error = %e,
+            "could not record an un-reloadable run as crashed"
+        );
     }
 }
 
@@ -1289,6 +1319,42 @@ mod tests {
             &sub_tx(),
         );
         assert!(restored.is_empty()); // all skipped, none fatal
+
+        // The un-reloadable run is recorded as crashed rather than left claiming
+        // it is still running (issue #109) — `lev ps` and the dashboard would
+        // otherwise show a live run that no longer exists.
+        let meta: RunMeta = serde_json::from_str(
+            &std::fs::read_to_string(runs.path().join("run-badpath").join("meta.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(meta.status, RunStatus::Error);
+        let error = meta.error.unwrap_or_default();
+        assert!(error.contains("could not be recovered"), "got: {error}");
+        assert_eq!(meta.updated_at, 1);
+        // Junk that never parsed as a run has nothing to rewrite.
+        assert!(!runs.path().join("no-meta").join("meta.json").exists());
+        assert_eq!(
+            std::fs::read_to_string(corrupt.join("meta.json")).unwrap(),
+            "not json"
+        );
+    }
+
+    #[test]
+    fn marking_a_crash_is_best_effort() {
+        // The run directory can vanish between the scan and the rewrite (a
+        // concurrent `lev rm`, a wiped runs dir). Recovery must log and carry
+        // on — the daemon is mid-startup and the other runs still need it.
+        let runs = tempfile::tempdir().unwrap();
+        write_run(
+            runs.path(),
+            "run-x",
+            "/no/such/agent.leviath",
+            RunStatus::Running,
+            None,
+        );
+        let meta = read_meta(&runs.path().join("run-x")).expect("written above");
+        mark_crashed(&runs.path().join("gone"), meta, "boom", 7);
+        assert!(!runs.path().join("gone").exists());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::process::Command as StdCommand;
-use std::sync::Mutex as StdMutex;
+use std::sync::{Mutex as StdMutex, PoisonError};
 
 use leviath_core::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
 use leviath_sys::ContainerRunSpec;
@@ -218,7 +218,7 @@ impl SandboxManager {
     /// service's `sync_stage` on every stage change).
     pub fn set_stage(&self, index: usize) {
         if let Some(cfg) = self.by_index.get(index) {
-            *self.current.lock().unwrap() = cfg.clone();
+            *self.current.lock().unwrap_or_else(PoisonError::into_inner) = cfg.clone();
         }
     }
 
@@ -281,7 +281,11 @@ impl ShellExecutor for SandboxManager {
         command: &str,
         workdir: &Path,
     ) -> TokioCommand {
-        let cfg = self.current.lock().unwrap().clone();
+        let cfg = self
+            .current
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
         match cfg.kind {
             SandboxKind::None => host_command(shell, flag, command, workdir),
             SandboxKind::Namespace => {

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -307,8 +307,9 @@ pub struct RealScriptIo;
 
 impl RealScriptIo {
     /// Build a short-timeout blocking HTTP client for a single request. The
-    /// builder only fails on TLS-backend init, which never happens in practice
-    /// (mirrors `leviath_providers::build_http_client`'s `.expect`).
+    /// builder only fails on TLS-backend init, which never happens in practice.
+    /// If it ever does panic, `leviath_scripting::execute`'s `catch_unwind`
+    /// catches it cleanly (issue #109).
     fn client() -> reqwest::blocking::Client {
         reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(30))

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -305,16 +305,32 @@ impl ScriptHost for DaemonScriptHost {
 /// are safe here.
 pub struct RealScriptIo;
 
-impl RealScriptIo {
-    /// Build a short-timeout blocking HTTP client for a single request. The
-    /// builder only fails on TLS-backend init, which never happens in practice.
-    /// If it ever does panic, `leviath_scripting::execute`'s `catch_unwind`
-    /// catches it cleanly (issue #109).
-    fn client() -> reqwest::blocking::Client {
+/// The one process-wide blocking HTTP client for script tools.
+///
+/// Built once, then cloned per request. A `reqwest::blocking::Client` owns a
+/// dedicated OS thread running a current-thread tokio runtime, so the previous
+/// build-one-per-request shape spawned (and tore down) a thread plus a runtime
+/// plus a TLS root-store load for *every* `http_get` — a researcher agent
+/// fanning out over dozens of pages could exhaust thread/FD limits, at which
+/// point `build()` fails and the `.expect` panics inside a Rhai native call
+/// (issue #109). One shared client also gives connection reuse across calls.
+///
+/// The builder can still only fail on TLS-backend init, and that failure is now
+/// contained: `leviath_scripting`'s native-function guards turn a panic here
+/// into an ordinary script error instead of aborting the daemon.
+static HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
+    std::sync::LazyLock::new(|| {
         reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
             .expect("failed to build blocking reqwest client")
+    });
+
+impl RealScriptIo {
+    /// A handle on the shared [`HTTP_CLIENT`] (cloning a `Client` shares its
+    /// connection pool; it does not build a new one).
+    fn client() -> reqwest::blocking::Client {
+        HTTP_CLIENT.clone()
     }
 
     /// Apply a header map to a blocking request builder.
@@ -383,8 +399,12 @@ impl ScriptIo for RealScriptIo {
         // The script engine drives this from a `spawn_blocking` thread (not a
         // runtime worker), so blocking on the current runtime is safe here and
         // lets us reuse tokio's timeout — the same mechanism the built-in shell
-        // tool uses.
-        let handle = tokio::runtime::Handle::current();
+        // tool uses. `try_current` rather than `current`: a blocking thread can
+        // outlive runtime shutdown, and `current` would *panic* there — which,
+        // inside a Rhai native call, used to abort the daemon (issue #109).
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return Err("shell is unavailable: no tokio runtime on this thread".to_string());
+        };
         handle.block_on(async move {
             match tokio::time::timeout(timeout, cmd.output()).await {
                 Ok(Ok(output)) => Ok(cap_script_io(combine_shell_output(
@@ -868,6 +888,25 @@ mod tests {
         })
         .await
         .unwrap()
+    }
+
+    #[test]
+    fn real_shell_off_a_runtime_errors_instead_of_panicking() {
+        // A blocking thread can outlive runtime shutdown; `Handle::current()`
+        // would panic there, and a panic inside a Rhai native call aborted the
+        // whole daemon before issue #109 was fixed. A plain `std::thread` is
+        // the same "no reactor on this thread" condition.
+        let dir = tempfile::tempdir().unwrap();
+        let workdir = dir.path().to_path_buf();
+        let err = std::thread::spawn(move || {
+            let (shell, flag) = default_shell();
+            let cmd = host_shell_command(shell, flag, "echo hi", &workdir);
+            RealScriptIo.run_shell(cmd, Duration::from_secs(5))
+        })
+        .join()
+        .unwrap()
+        .unwrap_err();
+        assert!(err.contains("no tokio runtime"), "got: {err}");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -151,14 +151,22 @@ async fn execute_script_tool(state: &AgentToolState, tc: &ToolCall) -> String {
     };
     let host = state.script_host.clone();
     let args = tc.arguments.clone();
-    match tokio::task::spawn_blocking(move || {
-        leviath_scripting::execute_script_tool(&tool, args, host)
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(e) => format!("[error] script tool panicked: {e}"),
-    }
+    tokio::task::spawn_blocking(move || leviath_scripting::execute_script_tool(&tool, args, host))
+        .await
+        .unwrap_or_else(script_tool_join_failed)
+}
+
+/// Last-resort net for a script tool: a panic that escaped the script engine's
+/// own native-function guards, or a task cancelled by runtime shutdown, becomes
+/// a tool error rather than taking the daemon (and every other run) with it.
+///
+/// A free function applied via `unwrap_or_else` — not a `match` arm — because
+/// the arm can no longer be reached from a test now that panics are contained
+/// inside `leviath_scripting` (issue #109), while this body is directly
+/// unit-testable with a real `JoinError`. Mirrors
+/// `leviath_providers::rhai_provider`'s `task_failed`.
+fn script_tool_join_failed(e: tokio::task::JoinError) -> String {
+    format!("[error] script tool panicked: {e}")
 }
 
 /// Resolve policy, handle approvals / dynamic interactions, and execute a batch
@@ -819,9 +827,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn script_tool_panic_is_caught() {
-        // A host function that panics propagates a Rust panic through the Rhai
-        // engine; spawn_blocking turns it into a JoinError, which we report as a
-        // tool error instead of aborting the daemon.
+        // A host function that panics is stopped at the Rhai native-function
+        // boundary and surfaced as an ordinary tool error. It must never unwind
+        // through the engine: rhai's `ArgBackup` destructor asserts during
+        // unwinding, which double-panics and aborts the whole daemon (#109).
         struct PanicHost;
         impl leviath_scripting::ScriptHost for PanicHost {
             fn http_get(
@@ -873,7 +882,27 @@ mod tests {
         let names: HashSet<String> = ["boom".to_string()].into_iter().collect();
         let (state, _dir) = script_state(&hub, &[("boom", "env_var(\"X\")")], names, host, allow);
         let out = dispatch_tools(state, vec![call("c1", "boom", serde_json::json!({}))]).await;
-        assert!(out[0].1.contains("panicked"));
+        let result = &out[0].1;
+        assert!(result.contains("env_var panicked"), "got: {result}");
+        assert!(result.contains("boom in host"), "got: {result}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn script_tool_join_failure_becomes_a_tool_error() {
+        // The blocking-task net beneath the engine's own guards: whatever kills
+        // the task (a panic that slipped past them, or runtime shutdown) must
+        // read back as a tool error, not take the daemon down.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // silence the expected panic
+        let join_err = tokio::task::spawn_blocking(|| panic!("kaboom"))
+            .await
+            .expect_err("the blocking task must fail");
+        std::panic::set_hook(prev);
+        let out = script_tool_join_failed(join_err);
+        assert!(
+            out.starts_with("[error] script tool panicked:"),
+            "got: {out}"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -17,7 +17,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, PoisonError};
 
 use bevy_ecs::entity::Entity;
 use leviath_core::interaction::{ApprovalScope, InteractionRequest};
@@ -105,7 +105,12 @@ pub struct DynamicToolCtx {
 /// dispatches to the Rhai engine; the compiled script and permission-enforcing
 /// host run on a blocking thread (the engine is synchronous).
 async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -> String {
-    if state.script_tool_names.lock().unwrap().contains(&tc.name) {
+    if state
+        .script_tool_names
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .contains(&tc.name)
+    {
         return execute_script_tool(state, tc).await;
     }
     if is_builtin {
@@ -145,7 +150,13 @@ fn mark_dirty_on_tool_write(state: &AgentToolState, tc: &ToolCall) {
 
 /// Run a Rhai script tool on a blocking thread and return its result string.
 async fn execute_script_tool(state: &AgentToolState, tc: &ToolCall) -> String {
-    let Some(tool) = state.script_tools.lock().unwrap().get(&tc.name).cloned() else {
+    let Some(tool) = state
+        .script_tools
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .get(&tc.name)
+        .cloned()
+    else {
         // Name was in `script_tool_names` but the tool is gone — treat as unknown.
         return format!("[error] unknown script tool: {}", tc.name);
     };
@@ -184,7 +195,11 @@ pub async fn dispatch_tools(
     state: Arc<AgentToolState>,
     calls: Vec<ToolCall>,
 ) -> Vec<(String, String)> {
-    let stage_name = state.stage_name.lock().unwrap().clone();
+    let stage_name = state
+        .stage_name
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone();
 
     // Pass 1: sequential resolution. `slots[i].1 == None` means "execute in pass
     // 2"; the queued `(slot_index, is_builtin, call)` records what to run.
@@ -221,7 +236,11 @@ pub async fn dispatch_tools(
         let policy = if state.session_allows.lock().await.contains(&tc.name) {
             ToolPolicy::Allow
         } else {
-            let stage_snap = state.stage_perms.lock().unwrap().clone();
+            let stage_snap = state
+                .stage_perms
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone();
             resolve_policy(
                 &tc.name,
                 is_builtin,
@@ -299,19 +318,28 @@ impl CliToolService {
 
     /// Register an agent's tool state (called when the agent is spawned).
     pub fn register(&self, entity: Entity, state: Arc<AgentToolState>) {
-        self.states.lock().unwrap().insert(entity, state);
+        self.states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(entity, state);
     }
 
     /// Drop an agent's tool state (called when the agent is reaped).
     pub fn unregister(&self, entity: Entity) {
-        self.states.lock().unwrap().remove(&entity);
+        self.states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&entity);
     }
 
     /// Remove an agent's tool state and return it, so the caller can run any
     /// teardown it holds (e.g. sandbox destruction) before it is dropped. Used
     /// by the daemon's reap hook.
     pub fn take(&self, entity: Entity) -> Option<Arc<AgentToolState>> {
-        self.states.lock().unwrap().remove(&entity)
+        self.states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&entity)
     }
 
     /// Reap an agent: drop its tool state (fixing the prior leak) and tear down
@@ -328,20 +356,43 @@ impl CliToolService {
 
 impl ToolService for CliToolService {
     fn sync_stage(&self, entity: Entity, stage_index: usize, stage_name: &str) {
-        if let Some(state) = self.states.lock().unwrap().get(&entity) {
-            if let Some(perms) = state.stage_perms_by_index.get(stage_index) {
-                *state.stage_perms.lock().unwrap() = perms.clone();
-            }
-            *state.stage_name.lock().unwrap() = stage_name.to_string();
-            // Point the shell tool at this stage's sandbox (per-stage override).
-            if let Some(sandbox) = &state.sandbox {
-                sandbox.set_stage(stage_index);
-            }
+        // Take a handle and drop the `states` guard before touching anything
+        // else. `states` is the process-wide map of *every* agent's tool state,
+        // and the work below reaches three more mutexes (including the sandbox
+        // manager's); holding the global guard across all of that means one
+        // agent's panic poisons the map every other agent depends on (#109).
+        let Some(state) = self
+            .states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+            .cloned()
+        else {
+            return;
+        };
+        if let Some(perms) = state.stage_perms_by_index.get(stage_index) {
+            *state
+                .stage_perms
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = perms.clone();
+        }
+        *state
+            .stage_name
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = stage_name.to_string();
+        // Point the shell tool at this stage's sandbox (per-stage override).
+        if let Some(sandbox) = &state.sandbox {
+            sandbox.set_stage(stage_index);
         }
     }
 
     fn exec_for(&self, entity: Entity, calls: Vec<ToolCall>) -> BoxedToolExec {
-        let state = self.states.lock().unwrap().get(&entity).cloned();
+        let state = self
+            .states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+            .cloned();
         Box::new(move || {
             Box::pin(async move {
                 match state {
@@ -361,7 +412,7 @@ impl ToolService for CliToolService {
         // Drain the per-agent dirty flag (set when a dynamic agent wrote a .rhai).
         self.states
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .get(&entity)
             .and_then(|s| s.dynamic.as_ref())
             .map(|ctx| ctx.dirty.swap(false, Ordering::SeqCst))
@@ -373,14 +424,25 @@ impl ToolService for CliToolService {
         entity: Entity,
         stage_index: usize,
     ) -> Option<Vec<leviath_providers::Tool>> {
-        let state = self.states.lock().unwrap().get(&entity).cloned()?;
+        let state = self
+            .states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+            .cloned()?;
         let ctx = state.dynamic.as_ref()?;
         // Re-discover the agent's script tools from disk and swap them into the
         // live set so a new tool is both advertised *and* dispatchable.
         let (set, names, script_defs) =
             crate::daemon::spawn::discover_script_tools_in(&ctx.scan_dirs, &ctx.reserved_names);
-        *state.script_tools.lock().unwrap() = set;
-        *state.script_tool_names.lock().unwrap() = names;
+        *state
+            .script_tools
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = set;
+        *state
+            .script_tool_names
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = names;
         // Re-filter this stage's advertised tools = static defs + fresh script defs.
         let available = ctx.stage_available.get(stage_index)?;
         let mut all = ctx.static_defs.clone();
@@ -630,6 +692,36 @@ mod tests {
         // The live script set + names now include the freshly discovered tool.
         assert!(state.script_tool_names.lock().unwrap().contains("echo"));
         assert!(state.script_tools.lock().unwrap().contains("echo"));
+    }
+
+    #[test]
+    fn a_poisoned_state_map_does_not_wedge_every_other_agent() {
+        // `states` holds *every* agent's tool state. A panic while holding it
+        // used to poison it, so from then on `.lock().unwrap()` panicked for all
+        // agents — one bad agent taking the whole daemon's tool dispatch with it
+        // (issue #109). Recovering the guard keeps the map usable.
+        let svc = CliToolService::new();
+        let e = Entity::from_raw(1);
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // silence the deliberate panic
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = svc.states.lock().expect("fresh lock");
+            panic!("a panic while holding the global state map");
+        }));
+        std::panic::set_hook(prev);
+        assert!(poisoned.is_err());
+        assert!(svc.states.is_poisoned(), "the lock really is poisoned");
+
+        // Every entry point still works over the poisoned lock.
+        let hub = InteractionHub::new();
+        svc.register(
+            e,
+            state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new()),
+        );
+        assert!(svc.take(e).is_some());
+        svc.unregister(e);
+        svc.sync_stage(e, 0, "stage"); // unregistered ⇒ no-op, must not panic
+        assert!(!svc.wants_refresh(e));
     }
 
     #[test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -138,6 +138,8 @@ impl RiskyExecutors for RealExecutors {
             Some(DaemonAction::Stop) => real_daemon_stop().await,
             Some(DaemonAction::Status) => real_daemon_status().await,
             Some(DaemonAction::Restart) => real_daemon_restart().await,
+            Some(DaemonAction::Install) => real_daemon_install(),
+            Some(DaemonAction::Uninstall) => real_daemon_uninstall(),
         }
     }
 
@@ -282,6 +284,14 @@ async fn real_daemon_status() -> anyhow::Result<()> {
         0
     };
     println!("{}", commands::daemon::format_status(running, count));
+    // Supervision is best-effort information: on a platform with no supported
+    // supervisor there is simply nothing to report.
+    if let Ok(unit) = resolve_service_unit() {
+        println!(
+            "{}",
+            commands::daemon_service::format_supervision(unit.path.exists(), &unit.path)
+        );
+    }
     Ok(())
 }
 
@@ -290,6 +300,69 @@ async fn real_daemon_status() -> anyhow::Result<()> {
 async fn real_daemon_restart() -> anyhow::Result<()> {
     real_daemon_stop().await?;
     real_daemon_start().await
+}
+
+/// Resolve the platform's service definition for this installation. Wiring only
+/// — the rendering, paths, and command lines are the tested
+/// `commands::daemon_service` core; this supplies the real exe path, home
+/// directory, and uid.
+fn resolve_service_unit() -> anyhow::Result<commands::daemon_service::ServiceUnit> {
+    let user_home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the service file"))?;
+    let leviath_home = leviath_cli::config::leviath_home_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve a leviath home directory"))?
+        .join(".leviath");
+    let exe = std::env::current_exe()?;
+    commands::daemon_service::service_unit(
+        &exe,
+        &leviath_home,
+        &commands::daemon_service::config_home(&user_home)?,
+        leviath_sys::current_uid(),
+    )
+}
+
+/// Run a supervisor command (`launchctl` / `systemctl`), reporting its stderr on
+/// failure. The real subprocess spawn — the argv it runs is built and tested in
+/// `commands::daemon_service`.
+fn run_supervisor(cmd: &(String, Vec<String>)) -> anyhow::Result<()> {
+    let out = std::process::Command::new(&cmd.0).args(&cmd.1).output()?;
+    if out.status.success() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "`{} {}` failed: {}",
+        cmd.0,
+        cmd.1.join(" "),
+        String::from_utf8_lossy(&out.stderr).trim()
+    )
+}
+
+/// `lev daemon install`: write the platform service file and hand it to the
+/// supervisor, so the daemon starts at login and is restarted if it ever dies.
+fn real_daemon_install() -> anyhow::Result<()> {
+    let unit = resolve_service_unit()?;
+    let path = commands::daemon_service::install(&unit)?;
+    println!("wrote {}", path.display());
+    // Re-registering a live service is an error on both platforms; drop any
+    // previous registration first so `install` is idempotent.
+    let _ = run_supervisor(&unit.deactivate);
+    run_supervisor(&unit.activate)?;
+    println!("the leviath daemon is now supervised and will restart automatically");
+    Ok(())
+}
+
+/// `lev daemon uninstall`: deregister from the supervisor and remove the file.
+fn real_daemon_uninstall() -> anyhow::Result<()> {
+    let unit = resolve_service_unit()?;
+    // Deregistration fails when nothing is registered; that's the desired end
+    // state either way, so only the file removal is reported.
+    let _ = run_supervisor(&unit.deactivate);
+    if commands::daemon_service::uninstall(&unit)? {
+        println!("removed {}", unit.path.display());
+    } else {
+        println!("no leviath service was installed");
+    }
+    Ok(())
 }
 
 /// Real `lev daemon`: bind the platform control socket and drive the shared world

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -234,7 +234,12 @@ pub fn write_meta(meta: &RunMeta) -> anyhow::Result<()> {
     write_meta_to(&run_dir(&meta.run_id), meta)
 }
 
-fn write_meta_to(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
+/// Atomically write `meta.json` into an explicit run directory.
+///
+/// Callers that already know the directory should prefer this over
+/// [`write_meta`], which resolves it from the home directory — the daemon's
+/// recovery pass works from its configured `runs_dir` instead.
+pub(crate) fn write_meta_to(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
     let json =
         serde_json::to_string_pretty(meta).expect("infallible: RunMeta always serializes to JSON");
     write_json_atomic(&dir.join("meta.json"), &json)

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod interaction;
 pub mod layout;
 pub mod lifecycle;
 pub mod manifest;
+pub mod panic_payload;
 pub mod policy;
 pub mod region;
 pub mod run_archive;
@@ -33,6 +34,7 @@ pub use cache::{CacheBreakpoint, CacheHint};
 pub use error::{Error, Result, ValidationError};
 pub use layout::{BudgetSpec, ContextLayout, RegionDefinition};
 pub use lifecycle::{CompactionConfig, CompactionStrategy, EvictionPolicy};
+pub use panic_payload::panic_message;
 pub use policy::{AllowlistRule, McpToolOverride, PolicyConfig, ScriptedRule};
 pub use region::{
     ContentFormat, EntryKind, EvictionStrategy, Region, RegionEntry, RegionKind, RegionSchema,

--- a/crates/leviath-core/src/panic_payload.rs
+++ b/crates/leviath-core/src/panic_payload.rs
@@ -1,0 +1,53 @@
+//! Rendering a caught panic payload as a human-readable message.
+//!
+//! Every place that recovers from a panic with [`std::panic::catch_unwind`]
+//! needs the same three-way downcast, so it lives here once rather than being
+//! re-derived per crate (`leviath-scripting`'s Rhai host-function guards and
+//! `leviath-runtime`'s pipeline-tick isolation both use it).
+
+use std::any::Any;
+
+/// Text used when a panic payload is neither a `String` nor a `&'static str`
+/// (e.g. `std::panic::panic_any(42)`).
+const UNKNOWN: &str = "unknown panic";
+
+/// Render a [`catch_unwind`](std::panic::catch_unwind) payload as a message.
+///
+/// `panic!("{x}")` yields a `String` payload and `panic!("literal")` a
+/// `&'static str`; anything else (`panic_any`) has no text to show and renders
+/// as `"unknown panic"`.
+pub fn panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    UNKNOWN.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run `f`, expecting it to panic, and return the rendered payload.
+    fn caught(f: impl FnOnce()) -> String {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // silence the expected panic
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+            .expect_err("the closure must panic");
+        std::panic::set_hook(prev);
+        panic_message(payload.as_ref())
+    }
+
+    #[test]
+    fn renders_all_three_payload_kinds() {
+        // `panic!("{}", …)` → String payload.
+        let formatted = "formatted message";
+        assert_eq!(caught(|| panic!("{formatted}")), "formatted message");
+        // `panic!("literal")` → &'static str payload.
+        assert_eq!(caught(|| panic!("literal message")), "literal message");
+        // Anything else has no text.
+        assert_eq!(caught(|| std::panic::panic_any(42_i32)), UNKNOWN);
+    }
+}

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -106,7 +106,9 @@ pub fn dispatch_content_summary(
     providers: Res<Providers>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, state, pending, settings) in agents.iter() {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / cancelled — don't start new work
         }
@@ -159,10 +161,12 @@ pub fn collect_content_summary(
     mut agents: Query<&mut ContextWindow, With<AwaitingContentSummary>>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok(mut window) = agents.get_mut(outcome.entity) else {
             continue; // stale: child cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(outcome.entity);
         if let Ok(summaries) = outcome.result {
             for (region, summary) in summaries {
                 let tokens = summary.len() / 4 + 1;

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -174,6 +174,7 @@ pub fn restore_fan_out_waiting(
 /// `Error` if the split output isn't a JSON array). Removing `ProcessResponse`
 /// here keeps the normal `process_response` routing from touching these agents.
 pub fn fan_out_split(world: &mut World) {
+    crate::tick_scope::clear();
     let mut candidates: Vec<(Entity, String, FanOutConfig)> = Vec::new();
     {
         let mut q = world.query_filtered::<(
@@ -194,6 +195,7 @@ pub fn fan_out_split(world: &mut World) {
     }
 
     for (parent, response, config) in candidates {
+        crate::tick_scope::enter(parent);
         world
             .entity_mut(parent)
             .remove::<ProcessResponse>()
@@ -229,12 +231,14 @@ pub fn fan_out_split(world: &mut World) {
 /// running apply the failure policy, inject the consolidated report, and
 /// transition to the merge stage (or resolve the stage's own transition).
 pub fn fan_out_collect(world: &mut World) {
+    crate::tick_scope::clear();
     let parents: Vec<Entity> = {
         let mut q = world.query_filtered::<Entity, With<FanOutWaiting>>();
         q.iter(world).collect()
     };
 
     for parent in parents {
+        crate::tick_scope::enter(parent);
         // A cancelled/errored parent abandons the fan-out; its workers are reaped
         // by the host's cascade cancel (which walks SubAgentChildren).
         if !matches!(agent_status(world, parent), Some(AgentStatus::Waiting)) {

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -149,10 +149,12 @@ pub fn collect_gate_prompt(
     )>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(out) = results.0.try_recv() {
         let Ok((state, mut awaiting, mut resolved, gate)) = agents.get_mut(out.entity) else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(out.entity);
         // Apply the resolution through the gate (raises clearance for AlwaysAllow).
         let denied = gate.and_then(|mut g| {
             g.apply_resolution(

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -13,7 +13,7 @@
 //! agents, which is acceptable (the lane becomes a pool later).
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 use bevy_ecs::prelude::Resource;
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
@@ -69,14 +69,17 @@ impl InteractionHub {
     async fn submit(&self, agent_id: &str, request: InteractionRequest) -> InteractionResponse {
         let id = request.id.clone();
         let (responder, rx) = oneshot::channel();
-        self.pending.lock().unwrap().insert(
-            id.clone(),
-            PendingEntry {
-                agent_id: agent_id.to_string(),
-                request,
-                responder,
-            },
-        );
+        self.pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(
+                id.clone(),
+                PendingEntry {
+                    agent_id: agent_id.to_string(),
+                    request,
+                    responder,
+                },
+            );
         // Wake the driver so it ticks and reflects this open request into the
         // agent's status (Active → Waiting) for the dashboard to surface.
         self.nudge();
@@ -90,7 +93,7 @@ impl InteractionHub {
     pub fn pending(&self) -> Vec<(String, InteractionRequest)> {
         self.pending
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .values()
             .map(|e| (e.agent_id.clone(), e.request.clone()))
             .collect()
@@ -99,7 +102,11 @@ impl InteractionHub {
     /// Answer an open request. Returns `false` if no request with that id is
     /// open (already answered, cancelled, or never existed).
     pub fn answer(&self, response: InteractionResponse) -> bool {
-        let entry = self.pending.lock().unwrap().remove(&response.request_id);
+        let entry = self
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&response.request_id);
         match entry {
             Some(entry) => {
                 // The awaiting `submit` may have gone away (agent despawned); a
@@ -118,7 +125,12 @@ impl InteractionHub {
     /// Returns `false` if no such request is open.
     pub fn cancel(&self, request_id: &str) -> bool {
         // Dropping the entry drops its responder, waking `submit` with an error.
-        let removed = self.pending.lock().unwrap().remove(request_id).is_some();
+        let removed = self
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(request_id)
+            .is_some();
         if removed {
             self.nudge();
         }
@@ -164,6 +176,27 @@ mod tests {
         for _ in 0..8 {
             tokio::task::yield_now().await;
         }
+    }
+
+    #[test]
+    fn a_poisoned_registry_still_serves_every_other_agent() {
+        // `pending` holds *every* agent's open prompt. A panic while holding it
+        // used to poison it, after which `pending()`/`answer()`/`cancel()`
+        // panicked for all agents and the dashboard (issue #109).
+        let hub = InteractionHub::new();
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // silence the deliberate panic
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = hub.pending.lock().expect("fresh lock");
+            panic!("a panic while holding the interaction registry");
+        }));
+        std::panic::set_hook(prev);
+        assert!(poisoned.is_err());
+        assert!(hub.pending.is_poisoned(), "the lock really is poisoned");
+
+        assert!(hub.pending().is_empty());
+        assert!(!hub.cancel("nope"));
+        assert!(!hub.answer(InteractionResponse::text("nope", "x")));
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -407,7 +407,9 @@ pub fn gate_interaction_points(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, bp, cursor, pc) in agents.iter() {
+        crate::tick_scope::enter(entity);
         let Some(points) = stage_points(bp, cursor) else {
             continue;
         };
@@ -445,12 +447,14 @@ pub fn dispatch_interaction_point(
     stage: Option<Res<InteractionPointStage>>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     let (Some(hub), Some(stage)) = (hub, stage) else {
         return; // no lane wired (test world)
     };
     for (entity, state, bp, cursor, infer, mut window, pc, rounds, plan_override) in
         agents.iter_mut()
     {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / cancelled — don't open a prompt
         }
@@ -524,12 +528,14 @@ pub fn collect_interaction_point(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(out) = results.0.try_recv() {
         let Ok((mut state, mut window, bp, cursor, pc, rounds, io_buf)) =
             agents.get_mut(out.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(out.entity);
         let idx = pc.map_or(0, |c| c.0);
         let round = rounds.map_or(0, |r| r.0);
         let (name, npoints) = match stage_points(bp, cursor) {

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod repetition;
 pub mod restore;
 pub mod script_provider;
 pub mod taint;
+pub mod tick_scope;
 pub mod tool_bridge;
 pub mod world;
 // test_support.rs gates itself with an inner `#![cfg(test)]` attribute, so no

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -231,6 +231,13 @@ pub fn dispatch_inference(
     // per-agent CPU cost and is independent, so it runs in parallel on the
     // compute pool. Permit acquisition (an atomic semaphore) and the tokio spawn
     // are thread-safe; the marker swap is batched via `ParallelCommands`.
+    //
+    // This is the one system whose body runs off the driver thread, so
+    // `tick_scope` (a thread-local) can't attribute a panic raised in here to
+    // the agent that caused it. Clear it so such a panic is reported
+    // unattributed rather than blamed on whichever agent a previous system
+    // happened to leave recorded (issue #109).
+    crate::tick_scope::clear();
     agents
         .par_iter()
         .for_each(|(entity, state, window, config, si)| {
@@ -317,11 +324,13 @@ pub fn collect_inference(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok((mut state, totals, cursor, mut ledger, buffer)) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(outcome.entity);
         let idx = cursor.map_or(0, |c| c.index);
         match outcome.result {
             Ok(response) => {
@@ -454,7 +463,9 @@ pub fn process_response(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, result, mut progress, totals) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         progress.iterations += 1; // per-stage inference count (for max_iterations)
         let mut e = commands.entity(entity);
         e.remove::<ProcessResponse>();
@@ -494,7 +505,9 @@ pub fn handle_empty_response(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, mut window, infer, mut progress) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if progress.total_tool_calls > 0 || progress.text_only_nudges >= MAX_TEXT_ONLY_NUDGES {
             commands
                 .entity(entity)
@@ -653,6 +666,7 @@ pub fn dispatch_tools(
     gate_stage: Option<Res<crate::gate_prompt::GatePromptStage>>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     let default_policy = leviath_core::PolicyConfig::default();
     let policy_ref = policy.as_ref().map(|p| &p.0).unwrap_or(&default_policy);
     let script_checker = script_rules.as_ref().map(|r| r.0.as_ref());
@@ -672,6 +686,7 @@ pub fn dispatch_tools(
         auto_gate,
     ) in agents.iter_mut()
     {
+        crate::tick_scope::enter(entity);
         // `--yolo`: waive taint-gate enforcement so a headless run never blocks
         // on a gate prompt no one can answer (taint tracking still records).
         let auto_approve_gates = auto_gate.is_some();
@@ -1122,6 +1137,7 @@ pub fn collect_tools(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok((
             mut window,
@@ -1137,6 +1153,7 @@ pub fn collect_tools(
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(outcome.entity);
         // Merge the inline context-tool results (if any) with the lane results,
         // ordered by the original tool calls.
         let mut parts = outcome.results;
@@ -1231,7 +1248,9 @@ pub fn dispatch_compaction(
     providers: Res<Providers>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, state, mut window, settings) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled — don't start new work
         }
@@ -1306,10 +1325,12 @@ pub fn collect_compaction(
     mut agents: Query<&mut ContextWindow, With<AwaitingCompaction>>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok(mut window) = agents.get_mut(outcome.entity) else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(outcome.entity);
         if let Ok(summaries) = outcome.result {
             for (region_name, summary) in summaries {
                 let summary_tokens = summary.len() / 4;
@@ -1460,7 +1481,9 @@ pub fn dispatch_edge_compact(
     providers: Res<Providers>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, state, window, pending, settings) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled — don't start new work
         }
@@ -1558,10 +1581,12 @@ pub fn reflect_interaction_status(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     let Some(hub) = hub else { return };
     let pending: std::collections::HashSet<String> =
         hub.pending().into_iter().map(|(id, _)| id).collect();
     for (entity, mut state, marked) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         match (pending.contains(&state.agent_id), marked.is_some()) {
             // Newly blocked on a prompt: surface it as Waiting.
             (true, false) => {
@@ -1626,6 +1651,7 @@ fn reconcile_stage_ledger(
 #[allow(clippy::type_complexity)]
 pub fn dispatch_persistence(
     mut agents: Query<(
+        Entity,
         &RunMetadata,
         &AgentState,
         &ContextWindow,
@@ -1648,7 +1674,9 @@ pub fn dispatch_persistence(
     hub: Option<Res<InteractionHub>>,
     sink: Option<Res<crate::host::WorldEventSink>>,
 ) {
+    crate::tick_scope::clear();
     for (
+        entity,
         md,
         state,
         window,
@@ -1664,6 +1692,7 @@ pub fn dispatch_persistence(
         (awaiting_point, ip_cursor, ip_rounds),
     ) in agents.iter_mut()
     {
+        crate::tick_scope::enter(entity);
         let now = chrono::Utc::now().timestamp();
 
         // Reconcile the stage ledger every persist tick so status/timestamps track
@@ -1772,15 +1801,17 @@ pub struct MessageIntake(pub UnboundedReceiver<AgentMessage>);
 /// `AgentEngine::process_messages` / `deliver_inbox_messages`.
 pub fn deliver_messages(
     mut intake: ResMut<MessageIntake>,
-    mut agents: Query<(&AgentState, &mut MessageInbox, &mut ContextWindow)>,
+    mut agents: Query<(Entity, &AgentState, &mut MessageInbox, &mut ContextWindow)>,
 ) {
+    crate::tick_scope::clear();
     // Route inbound channel messages to their target agent's inbox.
     let mut incoming = Vec::new();
     while let Ok(msg) = intake.0.try_recv() {
         incoming.push(msg);
     }
     for msg in incoming {
-        for (state, mut inbox, _) in agents.iter_mut() {
+        for (entity, state, mut inbox, _) in agents.iter_mut() {
+            crate::tick_scope::enter(entity);
             if state.agent_id == msg.agent_id {
                 inbox.push(msg.clone());
                 break;
@@ -1790,7 +1821,8 @@ pub fn deliver_messages(
     }
 
     // Deliver inboxes into context windows for agents that accept messages.
-    for (state, mut inbox, mut window) in agents.iter_mut() {
+    for (entity, state, mut inbox, mut window) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if !state.accepts_messages {
             continue; // hold until a stage that accepts messages
         }
@@ -1916,7 +1948,9 @@ pub fn enforce_max_iterations(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, state, bp, cursor, progress) in agents.iter() {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue;
         }
@@ -2016,6 +2050,7 @@ fn is_terminal_status(status: &AgentStatus) -> bool {
 /// resumes (re-inserting `ResolveTransition`, back to `Active`) once every child
 /// is terminal.
 pub fn gate_requires_children(world: &mut World) {
+    crate::tick_scope::clear();
     use crate::components::SubAgentChildren;
 
     // Hold: transitioning agents whose stage requires children that aren't done.
@@ -2036,6 +2071,7 @@ pub fn gate_requires_children(world: &mut World) {
         }
     }
     for (entity, children) in candidates {
+        crate::tick_scope::enter(entity);
         let pending = children.iter().any(|&c| {
             world
                 .get::<AgentState>(c)
@@ -2054,6 +2090,7 @@ pub fn gate_requires_children(world: &mut World) {
     }
 
     // Resume: held agents whose children have all finished.
+    crate::tick_scope::clear();
     let mut waiting: Vec<(Entity, Vec<Entity>)> = Vec::new();
     {
         let mut q = world.query_filtered::<
@@ -2065,6 +2102,7 @@ pub fn gate_requires_children(world: &mut World) {
         }
     }
     for (entity, children) in waiting {
+        crate::tick_scope::enter(entity);
         let all_done = children.iter().all(|&c| {
             world
                 .get::<AgentState>(c)
@@ -2173,7 +2211,9 @@ pub fn require_context_regions(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, bp, cursor, mut window, reentries, outcome) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if outcome.is_some() {
             continue; // error / max-iterations transition takes precedence
         }
@@ -2227,6 +2267,7 @@ pub fn resolve_transition(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     use leviath_core::blueprint::TransitionCondition;
     for (
         entity,
@@ -2241,6 +2282,7 @@ pub fn resolve_transition(
         outcome,
     ) in agents.iter_mut()
     {
+        crate::tick_scope::enter(entity);
         let stage = &bp.0.stages[cursor.index];
         // How the stage ended governs the transition: an error/max-iterations
         // outcome follows its conditioned edge (e.g. → error_recovery) if present.
@@ -2915,7 +2957,9 @@ pub fn dispatch_transition_choice(
     providers: Res<Providers>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, state, mut window, si, bp, cursor, choice) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled — don't start new work
         }
@@ -2991,6 +3035,7 @@ pub fn collect_transition_choice(
     )>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok((
             bp,
@@ -3006,6 +3051,7 @@ pub fn collect_transition_choice(
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
+        crate::tick_scope::enter(outcome.entity);
         let response = match outcome.result {
             Ok(response) => response,
             Err(err) => {
@@ -3094,7 +3140,9 @@ pub fn sync_tool_stages(
     entered: Query<(Entity, &StageJustEntered)>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, stage) in entered.iter() {
+        crate::tick_scope::enter(entity);
         service.0.sync_stage(entity, stage.index, &stage.name);
         commands.entity(entity).remove::<StageJustEntered>();
     }
@@ -3120,7 +3168,9 @@ pub fn refresh_advertised_tools(
     >,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for (entity, cursor, mut si, mut sis) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
         if let Some(tools) = service.0.refresh_tools(entity, cursor.index) {
             si.tools = tools.clone();
             // Keep the catalog entry in sync so re-entering this stage advertises
@@ -3142,7 +3192,9 @@ pub fn poll_dynamic_tool_refresh(
     agents: Query<Entity, With<DynamicTools>>,
     mut commands: Commands,
 ) {
+    crate::tick_scope::clear();
     for entity in agents.iter() {
+        crate::tick_scope::enter(entity);
         if service.0.wants_refresh(entity) {
             commands.entity(entity).insert(ToolsNeedRefresh);
         }

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -232,43 +232,47 @@ pub fn dispatch_inference(
     // compute pool. Permit acquisition (an atomic semaphore) and the tokio spawn
     // are thread-safe; the marker swap is batched via `ParallelCommands`.
     //
-    // This is the one system whose body runs off the driver thread, so
-    // `tick_scope` (a thread-local) can't attribute a panic raised in here to
-    // the agent that caused it. Clear it so such a panic is reported
-    // unattributed rather than blamed on whichever agent a previous system
-    // happened to leave recorded (issue #109).
+    // This is the one system whose per-agent body runs off the driver thread, so
+    // the thread-local `tick_scope` can't carry an entity back to the catcher.
+    // Each agent's share runs under `run_agent_parallel`, which catches there —
+    // where the entity is known — and marks that agent for `tick` to fail
+    // (issue #109). Clearing the thread-local keeps a panic in the fan-out
+    // machinery *itself* unattributed rather than blamed on whichever agent a
+    // previous system left recorded.
     crate::tick_scope::clear();
     agents
         .par_iter()
         .for_each(|(entity, state, window, config, si)| {
-            if state.status != AgentStatus::Active {
-                return; // paused / waiting / cancelled — don't start new work
-            }
-            let Some(provider) = providers.0.get(&si.provider_name) else {
-                return; // provider not registered — leave ready, retry later
-            };
-            let Some(permit) = stage.pools.try_acquire(&si.model) else {
-                return; // pool full — leave ready, retry next tick
-            };
-            let request = build_request(window, config, si, &provider);
-            let job = InferenceJob {
-                entity,
-                provider,
-                request,
-                permit,
-                exact_token_counting: stage.exact_token_counting,
-            };
-            stage.runtime.spawn(run_inference_job(
-                job,
-                stage.outcomes.clone(),
-                stage.wake.clone(),
-                retry_policy_for(config),
-            ));
-            par_commands.command_scope(|mut commands| {
-                commands
-                    .entity(entity)
-                    .remove::<ReadyToInfer>()
-                    .insert(AwaitingInference);
+            crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
+                if state.status != AgentStatus::Active {
+                    return; // paused / waiting / cancelled — don't start new work
+                }
+                let Some(provider) = providers.0.get(&si.provider_name) else {
+                    return; // provider not registered — leave ready, retry later
+                };
+                let Some(permit) = stage.pools.try_acquire(&si.model) else {
+                    return; // pool full — leave ready, retry next tick
+                };
+                let request = build_request(window, config, si, &provider);
+                let job = InferenceJob {
+                    entity,
+                    provider,
+                    request,
+                    permit,
+                    exact_token_counting: stage.exact_token_counting,
+                };
+                stage.runtime.spawn(run_inference_job(
+                    job,
+                    stage.outcomes.clone(),
+                    stage.wake.clone(),
+                    retry_policy_for(config),
+                ));
+                par_commands.command_scope(|mut commands| {
+                    commands
+                        .entity(entity)
+                        .remove::<ReadyToInfer>()
+                        .insert(AwaitingInference);
+                });
             });
         });
 }

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -92,55 +92,85 @@ impl ScriptProviderLayer {
 
     /// Get (or lazily load / reload) the provider named `name`, or `None` when
     /// there is no such script or it fails to load.
+    ///
+    /// The cache lock is taken three times — a read, then a write on whichever
+    /// arm the compile lands on — and is **never held across
+    /// `RhaiProvider::from_script`**, which parses and initializes an arbitrary
+    /// user-authored `.rhai` file. That call is the slowest and least
+    /// trustworthy thing this layer does; holding a process-wide lock across it
+    /// serialized every agent's provider lookup behind one compile, and a panic
+    /// inside it poisoned the cache for the whole daemon (issue #109).
+    ///
+    /// The cost is that two callers racing on the same cold name may both
+    /// compile it. Both get a working provider and the later `insert` wins —
+    /// wasted work, never a wrong answer, and it self-corrects on the next
+    /// lookup because entries are validated by mtime.
     pub fn get_or_load(&self, name: &str) -> Option<Arc<dyn Provider>> {
         let path = self.resolve_path(name);
-        let mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+        let Some(mtime) = std::fs::metadata(&path).and_then(|m| m.modified()).ok() else {
+            // File gone (or unreadable): drop any stale entry, no provider.
+            self.evict(name);
+            return None;
+        };
+        if let Some(cached) = self.cached_fresh(name, mtime) {
+            return Some(cached);
+        }
 
-        let mut cache = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
-        match mtime {
-            None => {
-                // File gone (or unreadable): drop any stale entry, no provider.
-                cache.remove(name);
+        let spec = self.overrides.get(name);
+        let init_config = spec
+            .map(|s| s.init_config.clone())
+            .unwrap_or_else(|| serde_json::json!({}));
+        let rate_limit = spec.and_then(|s| s.rate_limit.clone());
+        // No lock held here — see the note above.
+        match RhaiProvider::from_script(
+            name.to_string(),
+            &path,
+            init_config,
+            self.default_caps.clone(),
+            rate_limit,
+            self.request_timeout_secs,
+        ) {
+            Ok(p) => {
+                let provider: Arc<dyn Provider> = Arc::new(p);
+                self.cache
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .insert(
+                        name.to_string(),
+                        Cached {
+                            mtime,
+                            provider: provider.clone(),
+                        },
+                    );
+                Some(provider)
+            }
+            Err(e) => {
+                self.evict(name);
+                tracing::warn!(provider = %name, error = %e, "script provider load failed");
                 None
             }
-            Some(mtime) => {
-                if let Some(c) = cache.get(name)
-                    && c.mtime == mtime
-                {
-                    return Some(c.provider.clone());
-                }
-                let spec = self.overrides.get(name);
-                let init_config = spec
-                    .map(|s| s.init_config.clone())
-                    .unwrap_or_else(|| serde_json::json!({}));
-                let rate_limit = spec.and_then(|s| s.rate_limit.clone());
-                match RhaiProvider::from_script(
-                    name.to_string(),
-                    &path,
-                    init_config,
-                    self.default_caps.clone(),
-                    rate_limit,
-                    self.request_timeout_secs,
-                ) {
-                    Ok(p) => {
-                        let provider: Arc<dyn Provider> = Arc::new(p);
-                        cache.insert(
-                            name.to_string(),
-                            Cached {
-                                mtime,
-                                provider: provider.clone(),
-                            },
-                        );
-                        Some(provider)
-                    }
-                    Err(e) => {
-                        cache.remove(name);
-                        tracing::warn!(provider = %name, error = %e, "script provider load failed");
-                        None
-                    }
-                }
-            }
         }
+    }
+
+    /// The cached provider for `name`, but only if it was built from the script
+    /// as it is on disk right now. Holds the lock just long enough to clone an
+    /// `Arc`.
+    fn cached_fresh(&self, name: &str, mtime: SystemTime) -> Option<Arc<dyn Provider>> {
+        let cache = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
+        let cached = cache.get(name)?;
+        if cached.mtime == mtime {
+            Some(cached.provider.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Drop any cached entry for `name`.
+    fn evict(&self, name: &str) {
+        self.cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(name);
     }
 }
 

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::SystemTime;
 
 use leviath_providers::{ModelCapabilities, Provider, RateLimitConfig, RhaiProvider};
@@ -96,7 +96,7 @@ impl ScriptProviderLayer {
         let path = self.resolve_path(name);
         let mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
 
-        let mut cache = self.cache.lock().unwrap();
+        let mut cache = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         match mtime {
             None => {
                 // File gone (or unreadable): drop any stale entry, no provider.

--- a/crates/leviath-runtime/src/tick_scope.rs
+++ b/crates/leviath-runtime/src/tick_scope.rs
@@ -23,10 +23,23 @@
 //!
 //! And plainly set/cleared rather than a `Drop` guard: a guard would clear the
 //! slot *while unwinding*, destroying the very evidence the catch needs.
+//!
+//! ## Work that runs off the driver thread
+//!
+//! One system fans its per-agent work out over the compute task pool
+//! ([`dispatch_inference`](crate::pipeline::dispatch_inference)'s `par_iter`).
+//! A thread-local set inside that closure lives on a pool thread and is
+//! invisible to the driver thread that catches the unwind, so the mechanism
+//! above cannot see it. Those bodies run under [`run_agent_parallel`] instead,
+//! which catches the panic where the entity *is* known and leaves a
+//! [`PanickedInParallel`] marker for
+//! [`PipelineWorld::tick`](crate::world::PipelineWorld::tick) to act on.
 
 use std::cell::Cell;
 
 use bevy_ecs::entity::Entity;
+use bevy_ecs::prelude::Component;
+use bevy_ecs::system::ParallelCommands;
 
 thread_local! {
     /// The agent this thread's schedule is currently processing, if any.
@@ -47,6 +60,46 @@ pub fn clear() {
 /// The agent recorded by the last [`enter`] that has not been [`clear`]ed.
 pub fn current() -> Option<Entity> {
     CURRENT.with(Cell::get)
+}
+
+/// Left on an agent whose per-agent work panicked on a compute-pool thread.
+///
+/// [`PipelineWorld::tick`](crate::world::PipelineWorld::tick) drains these after
+/// the schedule returns and fails each marked agent, exactly as it would for a
+/// panic caught on the driver thread.
+#[derive(Component, Debug, Clone)]
+pub struct PanickedInParallel {
+    /// The panic payload, rendered as text.
+    pub message: String,
+}
+
+/// Run one agent's share of a parallel system body, containing a panic to that
+/// agent.
+///
+/// Catching *here* — inside the closure, where `entity` is in hand — is what
+/// makes a compute-pool panic attributable at all: the thread-local scope can't
+/// cross back to the driver thread, and letting the panic unwind out of the task
+/// pool would take down the whole fan-out rather than one agent. The remaining
+/// agents in the batch finish normally.
+///
+/// `body` is a `&mut dyn FnMut` rather than a generic so every caller shares one
+/// instantiation — the workspace gates a hard 100%, and a generic would give
+/// each call site its own panic arm to cover.
+pub fn run_agent_parallel(entity: Entity, par_commands: &ParallelCommands, body: &mut dyn FnMut()) {
+    let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+    if let Err(payload) = caught {
+        let message = leviath_core::panic_message(payload.as_ref());
+        tracing::error!(
+            ?entity,
+            panic = %message,
+            "an agent's parallel work panicked on the compute pool; failing that agent"
+        );
+        par_commands.command_scope(|mut commands| {
+            commands
+                .entity(entity)
+                .insert(PanickedInParallel { message });
+        });
+    }
 }
 
 #[cfg(test)]

--- a/crates/leviath-runtime/src/tick_scope.rs
+++ b/crates/leviath-runtime/src/tick_scope.rs
@@ -1,0 +1,88 @@
+//! Which agent the pipeline is currently working on, so a panic inside a
+//! schedule system can be blamed on the run that caused it (issue #109).
+//!
+//! Every agent lives in one shared [`World`](bevy_ecs::world::World) driven by
+//! one [`Schedule`](bevy_ecs::schedule::Schedule), so a caught panic carries no
+//! hint of *whose* data tripped it. Without attribution the daemon can only log
+//! "something panicked" and re-tick the same unchanged state on the next wake —
+//! panicking again, forever, while every other agent stalls behind it.
+//!
+//! Each per-agent loop in the pipeline therefore calls [`enter`] before touching
+//! an entity and [`clear`] once the loop is done. If a system panics mid-loop,
+//! the slot still holds the offending entity when
+//! [`PipelineWorld::tick`](crate::world::PipelineWorld::tick) catches the
+//! unwind, which then fails that one agent and lets the world carry on.
+//!
+//! ## Why a thread-local, and why no RAII guard
+//!
+//! Thread-local rather than a global: parallel tests each drive their own world
+//! on their own thread and would otherwise trample a shared slot. This is sound
+//! because the schedule runs single-threaded (see
+//! [`PipelineWorld::new`](crate::world::PipelineWorld::new)) — systems run on
+//! the same thread that catches the panic.
+//!
+//! And plainly set/cleared rather than a `Drop` guard: a guard would clear the
+//! slot *while unwinding*, destroying the very evidence the catch needs.
+
+use std::cell::Cell;
+
+use bevy_ecs::entity::Entity;
+
+thread_local! {
+    /// The agent this thread's schedule is currently processing, if any.
+    static CURRENT: Cell<Option<Entity>> = const { Cell::new(None) };
+}
+
+/// Record `entity` as the agent being processed right now.
+pub fn enter(entity: Entity) {
+    CURRENT.with(|c| c.set(Some(entity)));
+}
+
+/// Forget the current agent — call this when a per-agent loop finishes, so a
+/// later panic in agent-independent code isn't blamed on the last agent seen.
+pub fn clear() {
+    CURRENT.with(|c| c.set(None));
+}
+
+/// The agent recorded by the last [`enter`] that has not been [`clear`]ed.
+pub fn current() -> Option<Entity> {
+    CURRENT.with(Cell::get)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enter_records_and_clear_forgets() {
+        clear();
+        assert_eq!(current(), None);
+        let e = Entity::from_raw(7);
+        enter(e);
+        assert_eq!(current(), Some(e));
+        // A second enter replaces rather than nests.
+        let f = Entity::from_raw(9);
+        enter(f);
+        assert_eq!(current(), Some(f));
+        clear();
+        assert_eq!(current(), None);
+    }
+
+    #[test]
+    fn a_panic_leaves_the_entity_recorded_for_the_catcher() {
+        // The whole point: the slot must survive unwinding, which is why there
+        // is no `Drop` guard.
+        clear();
+        let e = Entity::from_raw(3);
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let caught = std::panic::catch_unwind(|| {
+            enter(e);
+            panic!("mid-loop");
+        });
+        std::panic::set_hook(prev);
+        assert!(caught.is_err());
+        assert_eq!(current(), Some(e));
+        clear();
+    }
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -53,6 +53,38 @@ use crate::tool_bridge::spawn_tool_pool;
 /// Two consecutive equal fingerprints mean a tick changed nothing (quiescence).
 type Fingerprint = [usize; 10];
 
+/// How many attributed system panics one [`PipelineWorld::run_to_fixed_point`]
+/// round will absorb before it stops driving. Each one fails a different agent,
+/// so this only bites if the world is thoroughly broken — it exists so a
+/// pathological agent can't spin the loop.
+const MAX_TICK_FAILURES_PER_ROUND: usize = 8;
+
+/// A schedule configured the way the pipeline needs it.
+///
+/// Every pipeline system is `.chain()`ed, so the multi-threaded executor can
+/// never overlap two of them — it only adds a hop through the compute task
+/// pool. Running single-threaded keeps systems on the thread that catches their
+/// panics, which is what lets [`run_isolated`] read the offending agent out of
+/// the (thread-local) [`crate::tick_scope`] (issue #109).
+fn tick_schedule() -> Schedule {
+    let mut schedule = Schedule::default();
+    schedule.set_executor_kind(bevy_ecs::schedule::ExecutorKind::SingleThreaded);
+    schedule
+}
+
+/// What one [`PipelineWorld::tick`] did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TickOutcome {
+    /// Every system ran to completion.
+    Clean,
+    /// A system panicked and the agent responsible was failed; the rest of the
+    /// world is unaffected and can keep being driven.
+    AgentFailed,
+    /// A system panicked with no agent in scope, so nothing could be failed.
+    /// Re-ticking would just re-panic.
+    Unattributed,
+}
+
 /// The shared ECS world that hosts and drives every agent.
 pub struct PipelineWorld {
     world: World,
@@ -82,9 +114,10 @@ impl PipelineWorld {
         runs_dir: std::path::PathBuf,
         runtime: Handle,
     ) -> Self {
-        // The multi-threaded schedule executor and `Query::par_iter` fan out over
-        // the compute task pool; initialize it once (idempotent) so per-agent
-        // phases (e.g. request assembly in `dispatch_inference`) run in parallel.
+        // `Query::par_iter` fans out over the compute task pool; initialize it
+        // once (idempotent) so per-agent request assembly in `dispatch_inference`
+        // runs in parallel. (The schedule executor itself is single-threaded —
+        // see `tick_schedule`.)
         bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
 
         let wake = Arc::new(Notify::new());
@@ -151,7 +184,7 @@ impl PipelineWorld {
 
         // The tick chain is split into two `.chain()`ed groups (bevy caps a
         // system tuple at 20); the second group runs strictly after the first.
-        let mut schedule = Schedule::default();
+        let mut schedule = tick_schedule();
         schedule.add_systems(
             (
                 deliver_messages,
@@ -381,11 +414,42 @@ impl PipelineWorld {
         self.set_status(entity, AgentStatus::Cancelled)
     }
 
-    /// Run one schedule tick over every agent. Returns `false` if a system
-    /// panicked — the panic is caught so one bad agent can't crash the daemon
-    /// and take down every other hosted agent with it.
-    pub fn tick(&mut self) -> bool {
-        run_isolated(&mut self.schedule, &mut self.world)
+    /// Run one schedule tick over every agent, catching a panic from any system
+    /// so one bad agent can't crash the daemon and take every other hosted agent
+    /// with it.
+    ///
+    /// When the panic can be traced to a specific agent (the usual case — see
+    /// [`crate::tick_scope`]), that agent is failed with the panic message so it
+    /// stops being driven, its run is persisted as errored, and the host reaps
+    /// it. Without that, the world would re-tick the same unchanged state on
+    /// every wake and panic again indefinitely (issue #109).
+    pub fn tick(&mut self) -> TickOutcome {
+        let Err(panicked) = run_isolated(&mut self.schedule, &mut self.world) else {
+            return TickOutcome::Clean;
+        };
+        let message = format!(
+            "internal error: a pipeline system panicked: {}",
+            panicked.message
+        );
+        match panicked.entity {
+            Some(entity) if self.set_status(entity, AgentStatus::Error { message }) => {
+                tracing::error!(
+                    ?entity,
+                    panic = %panicked.message,
+                    "a pipeline system panicked; failing that agent — the daemon and every \
+                     other run keep going"
+                );
+                TickOutcome::AgentFailed
+            }
+            _ => {
+                tracing::error!(
+                    panic = %panicked.message,
+                    "a pipeline system panicked outside any agent's scope; the daemon survived \
+                     (an agent may be wedged — cancel it via `lev cancel <run-id>`)"
+                );
+                TickOutcome::Unattributed
+            }
+        }
     }
 
     /// Append a system to the schedule (test-only, for panic-isolation tests).
@@ -431,16 +495,33 @@ impl PipelineWorld {
     /// host loop can interleave control operations between quiescent points.
     pub fn run_to_fixed_point(&mut self) {
         let mut prev = self.fingerprint();
+        let mut failures = 0;
         loop {
-            if !self.tick() {
-                // A system panicked; stop driving this round. The daemon stays
-                // alive, other agents keep running, and the wedged agent can be
-                // cancelled via the control socket (dispatch systems skip
-                // non-Active agents once cancelled).
-                break;
+            let outcome = self.tick();
+            match outcome {
+                TickOutcome::Clean => {}
+                // The offending agent has been failed, so it won't be driven
+                // again. Keep ticking: the rest of the world still has work to
+                // do, and only a later tick reaches `dispatch_persistence` (the
+                // last system in the chain) to record the failure on disk. The
+                // budget stops a pathological agent that somehow panics again
+                // from spinning this loop.
+                TickOutcome::AgentFailed if failures < MAX_TICK_FAILURES_PER_ROUND => {
+                    failures += 1;
+                }
+                // Nothing to fail, so re-ticking would just re-panic: stop
+                // driving this round. The daemon stays alive, other agents keep
+                // running, and a wedged agent can be cancelled via the control
+                // socket (dispatch systems skip non-Active agents once
+                // cancelled).
+                TickOutcome::AgentFailed | TickOutcome::Unattributed => break,
             }
             let now = self.fingerprint();
-            if now == prev {
+            // Quiescence, but only trust it after a clean tick: a panicking tick
+            // abandons the rest of the chain (and its buffered commands), so the
+            // markers can look unchanged while the world very much has changed.
+            // Force at least one more tick so the failed agent gets persisted.
+            if now == prev && outcome == TickOutcome::Clean {
                 break;
             }
             prev = now;
@@ -476,20 +557,51 @@ impl PipelineWorld {
     }
 }
 
+/// A panic caught while ticking the schedule, and the agent it belongs to.
+struct TickPanic {
+    /// The agent being processed when the panic fired, if the pipeline had
+    /// recorded one (see [`crate::tick_scope`]).
+    entity: Option<Entity>,
+    /// The panic payload rendered as text.
+    message: String,
+}
+
 /// Run a schedule over a world, catching a panic from any system so it can't
-/// unwind the daemon's drive loop and take down every hosted agent. Returns
-/// `true` on a clean tick, `false` (logged) if a system panicked. The world may
-/// be partially updated after a panic; the offending agent stays as-is and can
-/// be cancelled via the control socket.
-fn run_isolated(schedule: &mut Schedule, world: &mut World) -> bool {
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| schedule.run(world)));
-    if result.is_err() {
-        tracing::error!(
-            "a pipeline system panicked; the daemon survived (an agent may be \
-             wedged — cancel it via `lev cancel <run-id>`)"
-        );
+/// unwind the daemon's drive loop and take down every hosted agent.
+///
+/// The world may be partially updated after a panic: the panicking system's
+/// buffered `Commands` are lost, but resources and components already written
+/// are intact, so the caller can still fail the offending agent.
+fn run_isolated(schedule: &mut Schedule, world: &mut World) -> Result<(), TickPanic> {
+    // Clear first: the slot is thread-local and survives across ticks, so a
+    // stale entity from an earlier tick must not be blamed for this one.
+    crate::tick_scope::clear();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| schedule.run(world))) {
+        Ok(()) => Ok(()),
+        Err(payload) => {
+            reset_executor(schedule);
+            Err(TickPanic {
+                entity: crate::tick_scope::current(),
+                message: leviath_core::panic_message(payload.as_ref()),
+            })
+        }
     }
-    result.is_ok()
+}
+
+/// Give `schedule` a fresh executor after a caught panic.
+///
+/// bevy's executors mark a system "completed" *before* running it and only
+/// clear that set when `run` returns normally. A panic therefore leaves every
+/// system up to and including the offending one marked done, so the **next**
+/// tick silently skips them and only runs the tail of the chain — a partial
+/// tick that would, among other things, keep `dispatch_persistence` from ever
+/// seeing an agent we just failed. Swapping the executor kind and back is the
+/// public API for forcing a rebuild (`set_executor_kind` is a no-op when the
+/// kind is unchanged).
+fn reset_executor(schedule: &mut Schedule) {
+    use bevy_ecs::schedule::ExecutorKind;
+    schedule.set_executor_kind(ExecutorKind::Simple);
+    schedule.set_executor_kind(ExecutorKind::SingleThreaded);
 }
 
 #[cfg(test)]
@@ -506,28 +618,58 @@ mod tests {
     /// its own panic. (The guard is only ever held across synchronous work.)
     static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Run `f` with the process panic hook silenced (the panic is expected), and
+    /// serialized against the other hook-swapping tests.
+    fn with_silent_panics<T>(f: impl FnOnce() -> T) -> T {
+        let _hook_guard = PANIC_HOOK_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let out = f();
+        std::panic::set_hook(prev_hook);
+        out
+    }
+
     #[test]
-    fn run_isolated_catches_a_system_panic() {
+    fn run_isolated_catches_a_system_panic_and_reports_the_agent() {
         fn ok_system() {}
         fn boom_system() {
             panic!("simulated system panic");
         }
+        // A system that panics *while working on a specific agent* — the shape
+        // every real pipeline system has.
+        fn boom_on_agent_system() {
+            crate::tick_scope::enter(Entity::from_raw(41));
+            panic!("agent-scoped panic");
+        }
         let mut world = World::new();
 
         // A clean schedule ticks normally.
-        let mut ok = Schedule::default();
+        let mut ok = tick_schedule();
         ok.add_systems(ok_system);
-        assert!(run_isolated(&mut ok, &mut world));
+        assert!(run_isolated(&mut ok, &mut world).is_ok());
 
-        // A panicking system is caught (the daemon would survive).
-        let mut bad = Schedule::default();
+        // A panicking system is caught (the daemon would survive) and, with no
+        // agent in scope, reports no entity to blame.
+        let mut bad = tick_schedule();
         bad.add_systems(boom_system);
-        let _hook_guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {})); // silence the expected panic
-        let survived = run_isolated(&mut bad, &mut world);
-        std::panic::set_hook(prev_hook);
-        assert!(!survived);
+        let err = with_silent_panics(|| run_isolated(&mut bad, &mut world))
+            .expect_err("the panic must be caught");
+        assert_eq!(err.entity, None);
+        assert_eq!(err.message, "simulated system panic");
+
+        // With an agent in scope, the panic is attributed to it.
+        let mut blamed = tick_schedule();
+        blamed.add_systems(boom_on_agent_system);
+        let err = with_silent_panics(|| run_isolated(&mut blamed, &mut world))
+            .expect_err("the panic must be caught");
+        assert_eq!(err.entity, Some(Entity::from_raw(41)));
+        assert_eq!(err.message, "agent-scoped panic");
+
+        // A later clean tick must not inherit the previous tick's entity.
+        assert!(run_isolated(&mut ok, &mut world).is_ok());
+        assert_eq!(crate::tick_scope::current(), None);
     }
 
     use crate::components::{AgentState, ContextWindow, InferenceConfig};
@@ -739,11 +881,59 @@ mod tests {
         }
         let mut world = build_world(ProviderRegistry::new());
         world.add_test_system(boom_system);
-        let _hook_guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        world.run_to_fixed_point(); // returns (breaks on the caught panic)
-        std::panic::set_hook(prev_hook);
+        // Unattributed: nothing to fail, so the round stops immediately.
+        with_silent_panics(|| world.run_to_fixed_point());
+    }
+
+    #[tokio::test]
+    async fn a_panicking_system_fails_its_agent_instead_of_looping_forever() {
+        // Before issue #109 was fixed, a panicking system was swallowed
+        // anonymously: nothing changed, so the very next wake re-ticked the same
+        // state and panicked again, forever, while every other agent stalled.
+        // Now the agent in scope is failed, which takes it out of the dispatch
+        // systems (they only act on `Active` agents) and lets the world settle.
+        static VICTIM: std::sync::Mutex<Option<Entity>> = std::sync::Mutex::new(None);
+        static PANICS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+        fn boom_on_active_agent(agents: Query<(Entity, &AgentState)>) {
+            // No trailing statements after the `panic!`: an unreachable tail
+            // would read as uncovered under the workspace's 100% gate.
+            let Some((entity, _)) = agents
+                .iter()
+                .find(|(_, state)| state.status == AgentStatus::Active)
+            else {
+                return; // the agent has been failed — nothing left to blow up
+            };
+            crate::tick_scope::enter(entity);
+            *VICTIM
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(entity);
+            PANICS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            panic!("blew up on this agent");
+        }
+
+        let mut world = build_world(ProviderRegistry::new());
+        let entity = spawn(&mut world);
+        world.add_test_system(boom_on_active_agent);
+        with_silent_panics(|| world.run_to_fixed_point());
+
+        let victim = VICTIM
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        assert_eq!(victim, Some(entity), "the system saw the spawned agent");
+        let status = world.agent_status(entity);
+        assert!(
+            matches!(status, Some(AgentStatus::Error { ref message })
+                if message.contains("a pipeline system panicked")
+                    && message.contains("blew up on this agent")),
+            "got: {status:?}"
+        );
+        // The loop terminated rather than re-panicking without bound.
+        assert!(
+            PANICS.load(std::sync::atomic::Ordering::SeqCst) <= MAX_TICK_FAILURES_PER_ROUND + 1,
+            "the panic budget must stop the round"
+        );
     }
 
     fn registry_with(responses: Vec<InferenceResponse>) -> ProviderRegistry {
@@ -1071,6 +1261,84 @@ mod tests {
         let meta = meta.expect("final Complete snapshot flushed to disk");
         assert_eq!(meta.run_id, "run-42");
         assert!(dir.path().join("run-42").join("context.json").exists());
+    }
+
+    #[tokio::test]
+    async fn a_panicked_agent_is_recorded_as_errored_on_disk() {
+        // The reported symptom in issue #109: a crashed run stayed `"running"`
+        // in meta.json forever. `dispatch_persistence` is the *last* system in
+        // the chain, so the tick that panics never reaches it — which is exactly
+        // why `run_to_fixed_point` keeps driving after failing the agent.
+        fn boom_on_active_agent(agents: Query<(Entity, &AgentState)>) {
+            let Some((entity, _)) = agents
+                .iter()
+                .find(|(_, state)| state.status == AgentStatus::Active)
+            else {
+                return; // the agent has been failed — nothing left to blow up
+            };
+            crate::tick_scope::enter(entity);
+            panic!("exploded mid-stage");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut world = PipelineWorld::new(
+            registry_with(vec![]),
+            Arc::new(EchoTools),
+            InferencePoolConfig::new(),
+            1,
+            dir.path().to_path_buf(),
+            Handle::current(),
+        );
+        world.spawn_agent((
+            AgentBlueprint(blueprint()),
+            StageCursor { index: 0 },
+            agent_state(),
+            crate::components::MessageInbox::default(),
+            StageProgress::default(),
+            StageInferences(vec![stage("m")]),
+            StageSetups(vec![setup()]),
+            VisitCounts::default(),
+            window(),
+            stage("m"),
+            setup().inference_config,
+            crate::persistence::RunMetadata {
+                run_id: "run-boom".to_string(),
+                agent_name: "a".to_string(),
+                agent_path: "/p".to_string(),
+                task: "t".to_string(),
+                model: None,
+                workdir: "/w".to_string(),
+                num_stages: 1,
+                started_at: 0,
+                parent_run_id: None,
+                metadata: std::collections::HashMap::new(),
+                callback_url: None,
+                callback_secret: None,
+                title: None,
+            },
+            crate::persistence::TokenTotals::default(),
+            crate::pipeline::PersistWatermark::default(),
+            ReadyToInfer,
+        ));
+        world.add_test_system(boom_on_active_agent);
+        with_silent_panics(|| world.run_to_fixed_point());
+
+        let meta_path = dir.path().join("run-boom").join("meta.json");
+        let mut meta = None;
+        for _ in 0..200 {
+            if let Ok(text) = std::fs::read_to_string(&meta_path)
+                && let Ok(m) = serde_json::from_str::<leviath_core::run_meta::RunMeta>(&text)
+                && m.status == leviath_core::run_meta::RunStatus::Error
+            {
+                meta = Some(m);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let meta = meta.expect("the panicked run must be persisted as errored");
+        let error = meta.error.unwrap_or_default();
+        assert!(error.contains("a pipeline system panicked"), "got: {error}");
+        assert!(error.contains("exploded mid-stage"), "got: {error}");
     }
 
     /// A single-stage blueprint whose stage is an `interactive_points` stage with a

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -425,12 +425,12 @@ impl PipelineWorld {
     /// every wake and panic again indefinitely (issue #109).
     pub fn tick(&mut self) -> TickOutcome {
         let Err(panicked) = run_isolated(&mut self.schedule, &mut self.world) else {
-            return TickOutcome::Clean;
+            // A clean unwind doesn't mean a clean tick: work that ran on the
+            // compute pool catches its own panics, since they can't unwind back
+            // here, and leaves a marker instead.
+            return self.fail_agents_panicked_in_parallel();
         };
-        let message = format!(
-            "internal error: a pipeline system panicked: {}",
-            panicked.message
-        );
+        let message = panic_status_message(&panicked.message);
         match panicked.entity {
             Some(entity) if self.set_status(entity, AgentStatus::Error { message }) => {
                 tracing::error!(
@@ -450,6 +450,38 @@ impl PipelineWorld {
                 TickOutcome::Unattributed
             }
         }
+    }
+
+    /// Fail every agent that a compute-pool body marked
+    /// [`PanickedInParallel`](crate::tick_scope::PanickedInParallel), and report
+    /// whether there were any.
+    ///
+    /// These panics were caught on a task-pool thread rather than unwinding into
+    /// `tick`, so the marker component is how they reach the driver — but from
+    /// here on they are handled exactly like an attributed unwind: the agent is
+    /// failed, stops being driven, and its run persists as errored.
+    fn fail_agents_panicked_in_parallel(&mut self) -> TickOutcome {
+        let mut query = self
+            .world
+            .query::<(Entity, &crate::tick_scope::PanickedInParallel)>();
+        let failed: Vec<(Entity, String)> = query
+            .iter(&self.world)
+            .map(|(entity, p)| (entity, p.message.clone()))
+            .collect();
+        if failed.is_empty() {
+            return TickOutcome::Clean;
+        }
+        for (entity, message) in failed {
+            self.world
+                .entity_mut(entity)
+                .remove::<crate::tick_scope::PanickedInParallel>();
+            let status = AgentStatus::Error {
+                message: panic_status_message(&message),
+            };
+            // The entity came straight out of the query above, so it exists.
+            let _ = self.set_status(entity, status);
+        }
+        TickOutcome::AgentFailed
     }
 
     /// Append a system to the schedule (test-only, for panic-isolation tests).
@@ -555,6 +587,13 @@ impl PipelineWorld {
             }
         }
     }
+}
+
+/// How a caught panic is recorded on the agent it is blamed on. Shared by the
+/// unwind path and the compute-pool path so a run's `error` reads the same
+/// either way.
+fn panic_status_message(panic: &str) -> String {
+    format!("internal error: a pipeline system panicked: {panic}")
 }
 
 /// A panic caught while ticking the schedule, and the agent it belongs to.
@@ -883,6 +922,53 @@ mod tests {
         world.add_test_system(boom_system);
         // Unattributed: nothing to fail, so the round stops immediately.
         with_silent_panics(|| world.run_to_fixed_point());
+    }
+
+    #[tokio::test]
+    async fn a_panic_on_the_compute_pool_is_attributed_to_its_agent() {
+        // `dispatch_inference` fans its per-agent work out over the compute task
+        // pool, where the thread-local scope can't reach the driver thread that
+        // catches unwinds. Those bodies run under `run_agent_parallel`, which
+        // catches on the pool thread and marks the agent instead — this proves
+        // the marker makes it back and fails the right run (issue #109).
+        fn boom_in_parallel(
+            agents: Query<(Entity, &AgentState)>,
+            par_commands: bevy_ecs::system::ParallelCommands,
+        ) {
+            agents.par_iter().for_each(|(entity, state)| {
+                if state.status != AgentStatus::Active {
+                    return; // already failed — nothing left to blow up
+                }
+                // Clear the thread-local first: whatever attributes this panic,
+                // it is demonstrably not the `enter`/`current` mechanism.
+                crate::tick_scope::clear();
+                crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
+                    panic!("blew up on the compute pool");
+                });
+            });
+        }
+
+        let mut world = build_world(ProviderRegistry::new());
+        let entity = spawn(&mut world);
+        world.add_test_system(boom_in_parallel);
+        with_silent_panics(|| world.run_to_fixed_point());
+
+        let status = world.agent_status(entity);
+        assert!(
+            matches!(status, Some(AgentStatus::Error { ref message })
+                if message.contains("a pipeline system panicked")
+                    && message.contains("blew up on the compute pool")),
+            "got: {status:?}"
+        );
+        // The marker is consumed, so a later tick doesn't re-fail the agent.
+        assert!(
+            world
+                .world()
+                .entity(entity)
+                .get::<crate::tick_scope::PanickedInParallel>()
+                .is_none(),
+            "the marker must be drained once acted on"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -431,10 +431,12 @@ pub const SCRIPT_TOOL_MAX_OPERATIONS: u64 = 500_000;
 /// is already a string (returned verbatim). Any script error becomes an
 /// `[error] …` string.
 ///
-/// The eval is wrapped in [`std::panic::catch_unwind`] so a panic in a host
-/// function (e.g. a TLS-backend failure) is caught cleanly — without unwinding
-/// through Rhai's stack. This prevents a double-panic abort when a `Drop` impl
-/// panics during unwinding (issue #109).
+/// A panic raised by a native (host) function never unwinds through this call:
+/// it is caught at the native-function boundary by `guard_str`/`guard_dyn`
+/// and arrives here as an ordinary script error (issue #109). Anything that
+/// still escapes — a panic from Rhai's own internals — is contained one level
+/// up, where the daemon runs this on a `spawn_blocking` task and turns the
+/// resulting `JoinError` into a tool error.
 pub fn execute(tool: &ScriptTool, args: serde_json::Value, host: Arc<dyn ScriptHost>) -> String {
     let engine = build_tool_engine(host);
     // Converting a `serde_json::Value` to a Rhai `Dynamic` is infallible (any
@@ -443,25 +445,9 @@ pub fn execute(tool: &ScriptTool, args: serde_json::Value, host: Arc<dyn ScriptH
     let params = rhai::serde::to_dynamic(args).unwrap_or(Dynamic::UNIT);
     let mut scope = Scope::new();
     scope.push_dynamic("params", params);
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        engine.eval_ast_with_scope::<Dynamic>(&mut scope, &tool.ast)
-    }));
-    match result {
-        Ok(Ok(value)) => dynamic_to_result_string(value),
-        Ok(Err(e)) => format!("[error] {}: {}", tool.meta.name, e),
-        Err(payload) => {
-            let msg = payload
-                .downcast_ref::<String>()
-                .map(|s| s.as_str())
-                .or_else(|| payload.downcast_ref::<&str>().copied())
-                .unwrap_or("unknown panic");
-            tracing::warn!(
-                tool = %tool.meta.name,
-                panic = msg,
-                "script tool panicked during execution (issue #109)"
-            );
-            format!("[error] {}: script panicked: {msg}", tool.meta.name)
-        }
+    match engine.eval_ast_with_scope::<Dynamic>(&mut scope, &tool.ast) {
+        Ok(value) => dynamic_to_result_string(value),
+        Err(e) => format!("[error] {}: {}", tool.meta.name, e),
     }
 }
 
@@ -500,75 +486,154 @@ fn build_tool_engine(host: Arc<dyn ScriptHost>) -> Engine {
     engine
 }
 
+/// What a registered native function hands back to Rhai.
+type HostRes<T> = std::result::Result<T, Box<EvalAltResult>>;
+
 /// Turn a host `Result<String, String>` into a Rhai fn result, mapping `Err`
 /// into a runtime exception (which `execute` renders as `[error] …`).
-fn to_rhai(
-    r: std::result::Result<String, String>,
-) -> std::result::Result<String, Box<EvalAltResult>> {
+fn to_rhai(r: std::result::Result<String, String>) -> HostRes<String> {
     r.map_err(|msg| Box::new(EvalAltResult::ErrorRuntime(msg.into(), Position::NONE)))
+}
+
+/// Turn a caught panic payload into the same runtime exception a normal host
+/// error produces, so Rhai unwinds nothing.
+fn panic_to_rhai(name: &str, payload: Box<dyn std::any::Any + Send>) -> Box<EvalAltResult> {
+    let msg = leviath_core::panic_message(payload.as_ref());
+    tracing::warn!(
+        host_fn = name,
+        panic = %msg,
+        "a script-tool host function panicked; surfacing it as a script error (issue #109)"
+    );
+    Box::new(EvalAltResult::ErrorRuntime(
+        format!("{name} panicked: {msg}").into(),
+        Position::NONE,
+    ))
+}
+
+/// Run a `String`-returning native function so a panic inside it **never**
+/// unwinds into Rhai.
+///
+/// This is the primary fix for issue #109. Rhai's `exec_native_fn_call` takes an
+/// `ArgBackup` whenever the first argument is a variable reference (which is
+/// every real call shape, e.g. `http_get(params.url)`), and restores it *after*
+/// the call returns. A panicking native function skips that restore, and
+/// `ArgBackup`'s destructor then asserts during unwinding — a second panic while
+/// panicking, which Rust turns into `abort()`. That aborted the whole daemon,
+/// killing every concurrent run. Catching here means the unwind never reaches
+/// Rhai's frame at all.
+///
+/// Deliberately **not generic**: a generic guard monomorphizes per closure, and
+/// each instantiation's panic arm would then need its own test to hold the
+/// workspace's 100% coverage gate. One `&mut dyn FnMut` instantiation keeps
+/// every caller's regions merged into one.
+fn guard_str(name: &str, f: &mut dyn FnMut() -> HostRes<String>) -> HostRes<String> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(r) => r,
+        Err(payload) => Err(panic_to_rhai(name, payload)),
+    }
+}
+
+/// [`guard_str`] for the one native function that returns a `Dynamic`
+/// (`parse_json`). Same rationale, different return type — kept non-generic for
+/// the same coverage reason.
+fn guard_dyn(name: &str, f: &mut dyn FnMut() -> HostRes<Dynamic>) -> HostRes<Dynamic> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(r) => r,
+        Err(payload) => Err(panic_to_rhai(name, payload)),
+    }
 }
 
 /// Convert a Rhai object-map of headers into a `BTreeMap<String,String>`, each
 /// value stringified.
-fn headers_from_map(map: Map) -> BTreeMap<String, String> {
-    map.into_iter()
+/// Borrows rather than consumes so the guarded `FnMut` wrappers in
+/// [`register_host_functions`] can call it without moving out of a capture.
+fn headers_from_map(map: &Map) -> BTreeMap<String, String> {
+    map.iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect()
 }
 
 /// Register the eight host functions. Five delegate to [`ScriptHost`]; three
 /// (`parse_json`, `to_json`, `encode_uri`) are pure.
+///
+/// **Every** registration goes through [`guard_str`] / [`guard_dyn`], so a panic
+/// anywhere in a native function becomes an ordinary Rhai runtime error instead
+/// of unwinding into Rhai and aborting the process (issue #109). The pure
+/// helpers are guarded too — they run on untrusted, model- and network-supplied
+/// input, so "this one can't panic" is not a property worth betting the daemon on.
 fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
     // http_get(url) / http_get(url, headers)
     let h = host.clone();
     engine.register_fn("http_get", move |url: &str| {
-        to_rhai(h.http_get(url, BTreeMap::new()))
+        guard_str("http_get", &mut || {
+            to_rhai(h.http_get(url, BTreeMap::new()))
+        })
     });
     let h = host.clone();
     engine.register_fn("http_get", move |url: &str, headers: Map| {
-        to_rhai(h.http_get(url, headers_from_map(headers)))
+        guard_str("http_get", &mut || {
+            to_rhai(h.http_get(url, headers_from_map(&headers)))
+        })
     });
 
     // http_post(url, body) / http_post(url, body, headers)
     let h = host.clone();
     engine.register_fn("http_post", move |url: &str, body: &str| {
-        to_rhai(h.http_post(url, body, BTreeMap::new()))
+        guard_str("http_post", &mut || {
+            to_rhai(h.http_post(url, body, BTreeMap::new()))
+        })
     });
     let h = host.clone();
     engine.register_fn("http_post", move |url: &str, body: &str, headers: Map| {
-        to_rhai(h.http_post(url, body, headers_from_map(headers)))
+        guard_str("http_post", &mut || {
+            to_rhai(h.http_post(url, body, headers_from_map(&headers)))
+        })
     });
 
     // shell(cmd)
     let h = host.clone();
-    engine.register_fn("shell", move |cmd: &str| to_rhai(h.shell(cmd)));
+    engine.register_fn("shell", move |cmd: &str| {
+        guard_str("shell", &mut || to_rhai(h.shell(cmd)))
+    });
 
     // read_file(path)
     let h = host.clone();
-    engine.register_fn("read_file", move |path: &str| to_rhai(h.read_file(path)));
+    engine.register_fn("read_file", move |path: &str| {
+        guard_str("read_file", &mut || to_rhai(h.read_file(path)))
+    });
 
     // write_file(path, content)
     let h = host.clone();
     engine.register_fn("write_file", move |path: &str, content: &str| {
-        to_rhai(h.write_file(path, content))
+        guard_str("write_file", &mut || to_rhai(h.write_file(path, content)))
     });
 
     // env_var(name)
     let h = host.clone();
-    engine.register_fn("env_var", move |name: &str| to_rhai(h.env_var(name)));
+    engine.register_fn("env_var", move |name: &str| {
+        guard_str("env_var", &mut || to_rhai(h.env_var(name)))
+    });
 
-    // Pure helpers. These are named free functions (not inline closures) so
-    // their bodies get a single, cleanly-attributed monomorphization under
+    // Pure helpers. Their bodies live in named free functions (not inline
+    // closures) so they get a single, cleanly-attributed monomorphization under
     // coverage instrumentation instead of being inlined into rhai's generic
     // `register_fn` wrapper (a known attribution artifact).
-    engine.register_fn("parse_json", parse_json_fn);
-    engine.register_fn("to_json", to_json_fn);
-    engine.register_fn("encode_uri", |s: &str| -> String { percent_encode(s) });
-    engine.register_fn("html_to_text", |s: &str| -> String { html_to_text(s) });
+    engine.register_fn("parse_json", |s: &str| -> HostRes<Dynamic> {
+        guard_dyn("parse_json", &mut || parse_json_fn(s))
+    });
+    engine.register_fn("to_json", |v: Dynamic| -> HostRes<String> {
+        guard_str("to_json", &mut || to_json_fn(&v))
+    });
+    engine.register_fn("encode_uri", |s: &str| -> HostRes<String> {
+        guard_str("encode_uri", &mut || Ok(percent_encode(s)))
+    });
+    engine.register_fn("html_to_text", |s: &str| -> HostRes<String> {
+        guard_str("html_to_text", &mut || Ok(html_to_text(s)))
+    });
 }
 
 /// `parse_json(str)` host function: JSON string → Rhai value.
-fn parse_json_fn(s: &str) -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+fn parse_json_fn(s: &str) -> HostRes<Dynamic> {
     let value: serde_json::Value = serde_json::from_str(s).map_err(|e| {
         Box::new(EvalAltResult::ErrorRuntime(
             format!("parse_json: {e}").into(),
@@ -581,8 +646,8 @@ fn parse_json_fn(s: &str) -> std::result::Result<Dynamic, Box<EvalAltResult>> {
 /// `to_json(value)` host function: Rhai value → JSON string. `from_dynamic`
 /// fails for values with no JSON representation (e.g. a function pointer);
 /// `Value::to_string` (Display) is then infallible.
-fn to_json_fn(v: Dynamic) -> std::result::Result<String, Box<EvalAltResult>> {
-    let json: serde_json::Value = rhai::serde::from_dynamic(&v)?;
+fn to_json_fn(v: &Dynamic) -> HostRes<String> {
+    let json: serde_json::Value = rhai::serde::from_dynamic(v)?;
     Ok(json.to_string())
 }
 
@@ -680,6 +745,10 @@ fn strip_tags(html: &str) -> String {
     out
 }
 
+/// How far past an `&` to look for the closing `;`. The longest entity this
+/// decoder recognises is `&#x10FFFF;` (10 bytes); 12 leaves headroom.
+const ENTITY_SCAN_BYTES: usize = 12;
+
 /// Decode common HTML entities (named + numeric decimal/hex). Unknown or
 /// unterminated entities are left verbatim.
 fn decode_entities(s: &str) -> String {
@@ -688,7 +757,15 @@ fn decode_entities(s: &str) -> String {
     while let Some(amp) = rest.find('&') {
         out.push_str(&rest[..amp]);
         let after = &rest[amp..];
-        let window = after.len().min(12);
+        // Only the first few bytes can hold an entity, but the cut-off must land
+        // on a char boundary: `after` starts at `&`, so a fixed byte 12 slices
+        // mid-character on any multi-byte text ("&日本語日本" panicked with
+        // "byte index 12 is not a char boundary") — and since `html_to_text`
+        // runs on every fetched page, that panic aborted the daemon (issue #109).
+        let mut window = after.len().min(ENTITY_SCAN_BYTES);
+        while !after.is_char_boundary(window) {
+            window -= 1;
+        }
         match after[..window].find(';') {
             Some(semi) => match decode_one_entity(&after[1..semi]) {
                 Some(ch) => {
@@ -754,7 +831,13 @@ fn collapse_whitespace(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, PoisonError};
+
+    /// Serializes the tests that swap the **process-global** panic hook. Without
+    /// it they interleave under the parallel test runner: one test's `set_hook`
+    /// replaces another's silencing closure before that test's panic fires, so
+    /// the closure never runs and reads as uncovered.
+    static PANIC_HOOK_LOCK: Mutex<()> = Mutex::new(());
 
     // ── A fake host recording calls and returning canned results. ──
 
@@ -1236,103 +1319,119 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         }
     }
 
-    #[test]
-    fn execute_host_panic_is_caught_by_catch_unwind() {
-        // A host function that panics is caught by catch_unwind in execute(),
-        // preventing a double-panic abort when a Drop impl also panics during
-        // unwinding (issue #109).
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("TLS init failed"),
-        });
-        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
+    /// Run a script whose only host call panics and return the tool's output,
+    /// with the process panic hook silenced for the duration (the panic is
+    /// expected; its default backtrace would just spam the test log).
+    fn execute_with_panicking_host(payload: PanicPayload, script: &str) -> String {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost { payload });
+        let tool = tool_from(script);
+        let _guard = PANIC_HOOK_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
         let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("TLS init failed"), "got: {out}");
+        std::panic::set_hook(prev);
+        out
+    }
+
+    /// Assert the tool reported a guarded panic from `host_fn` carrying `detail`.
+    fn assert_guarded_panic(out: &str, tool_name: &str, host_fn: &str, detail: &str) {
+        assert!(
+            out.starts_with(&format!("[error] {tool_name}:")),
+            "got: {out}"
+        );
+        assert!(out.contains(&format!("{host_fn} panicked")), "got: {out}");
+        assert!(out.contains(detail), "got: {out}");
     }
 
     #[test]
-    fn execute_shell_panic_is_caught_by_catch_unwind() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("sandbox init exploded"),
-        });
-        let tool = tool_from("// @tool sh\nshell(\"ls\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error] sh:"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("sandbox init exploded"), "got: {out}");
+    fn every_host_fn_panic_becomes_a_script_error() {
+        // A panicking host function must NEVER unwind into Rhai: rhai's
+        // `exec_native_fn_call` holds an `ArgBackup` whose destructor asserts,
+        // so unwinding through it is a double panic → `abort()` → the whole
+        // daemon dies (issue #109). Each of these would have aborted the test
+        // process before the guards existed.
+        for (host_fn, tool_name, script) in [
+            ("http_get", "t", "// @tool t\nhttp_get(\"http://x\")"),
+            (
+                "http_get",
+                "t",
+                "// @tool t\nhttp_get(\"http://x\", #{ \"A\": \"b\" })",
+            ),
+            (
+                "http_post",
+                "t",
+                "// @tool t\nhttp_post(\"http://x\", \"b\")",
+            ),
+            (
+                "http_post",
+                "t",
+                "// @tool t\nhttp_post(\"http://x\", \"b\", #{ \"A\": \"b\" })",
+            ),
+            ("shell", "sh", "// @tool sh\nshell(\"ls\")"),
+            ("read_file", "rf", "// @tool rf\nread_file(\"x.txt\")"),
+            (
+                "write_file",
+                "wf",
+                "// @tool wf\nwrite_file(\"out.txt\", \"data\")",
+            ),
+            ("env_var", "ev", "// @tool ev\nenv_var(\"HOME\")"),
+        ] {
+            let out =
+                execute_with_panicking_host(PanicPayload::Formatted("TLS init failed"), script);
+            assert_guarded_panic(&out, tool_name, host_fn, "TLS init failed");
+        }
     }
 
     #[test]
-    fn execute_read_file_panic_is_caught_by_catch_unwind() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("filesystem corrupted"),
-        });
-        let tool = tool_from("// @tool rf\nread_file(\"x.txt\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error] rf:"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("filesystem corrupted"), "got: {out}");
+    fn guarded_panic_renders_str_and_non_string_payloads() {
+        let out = execute_with_panicking_host(
+            PanicPayload::Literal,
+            "// @tool t\nhttp_get(\"http://x\")",
+        );
+        assert_guarded_panic(&out, "t", "http_get", "literal str panic");
+
+        let out = execute_with_panicking_host(
+            PanicPayload::NonString,
+            "// @tool t\nhttp_get(\"http://x\")",
+        );
+        assert_guarded_panic(&out, "t", "http_get", "unknown panic");
     }
 
     #[test]
-    fn execute_http_post_panic_is_caught_by_catch_unwind() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("post failed"),
-        });
-        let tool = tool_from("// @tool t\nhttp_post(\"http://x\", \"body\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("post failed"), "got: {out}");
-    }
+    fn guards_pass_through_success_and_convert_panics() {
+        // Both guards, both arms, called directly: the pure host functions
+        // (`parse_json` / `html_to_text` / …) can't be made to panic through a
+        // script, so their panic arm is exercised here.
+        let _guard = PANIC_HOOK_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        assert_eq!(
+            guard_str("ok_str", &mut || Ok("value".to_string())).unwrap(),
+            "value"
+        );
+        assert!(
+            guard_dyn("ok_dyn", &mut || Ok(Dynamic::from(7_i64)))
+                .unwrap()
+                .is_int()
+        );
 
-    #[test]
-    fn execute_write_file_panic_is_caught_by_catch_unwind() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("write failed"),
-        });
-        let tool = tool_from("// @tool t\nwrite_file(\"out.txt\", \"data\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("write failed"), "got: {out}");
-    }
-
-    #[test]
-    fn execute_env_var_panic_is_caught_by_catch_unwind() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Formatted("env exploded"),
-        });
-        let tool = tool_from("// @tool t\nenv_var(\"HOME\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("env exploded"), "got: {out}");
-    }
-
-    #[test]
-    fn execute_panic_with_str_payload() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::Literal,
-        });
-        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("literal str panic"), "got: {out}");
-    }
-
-    #[test]
-    fn execute_panic_with_non_string_payload() {
-        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
-            payload: PanicPayload::NonString,
-        });
-        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
-        let out = execute(&tool, serde_json::json!({}), host);
-        assert!(out.contains("[error]"), "got: {out}");
-        assert!(out.contains("script panicked"), "got: {out}");
-        assert!(out.contains("unknown panic"), "got: {out}");
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let str_err = guard_str("boom_str", &mut || panic!("string arm")).unwrap_err();
+        let dyn_err = guard_dyn("boom_dyn", &mut || panic!("dynamic arm")).unwrap_err();
+        std::panic::set_hook(prev);
+        assert!(
+            str_err
+                .to_string()
+                .contains("boom_str panicked: string arm")
+        );
+        assert!(
+            dyn_err
+                .to_string()
+                .contains("boom_dyn panicked: dynamic arm")
+        );
     }
 
     #[test]
@@ -1496,11 +1595,11 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         // independent of rhai's generic `register_fn` wrapper.
         let mut map = Map::new();
         map.insert("a".into(), Dynamic::from(1_i64));
-        assert_eq!(to_json_fn(Dynamic::from_map(map)).unwrap(), "{\"a\":1}");
+        assert_eq!(to_json_fn(&Dynamic::from_map(map)).unwrap(), "{\"a\":1}");
         // A function pointer has no JSON representation → Err.
         let engine = Engine::new();
         let fnptr: Dynamic = engine.eval("|| 1").unwrap();
-        assert!(to_json_fn(fnptr).is_err());
+        assert!(to_json_fn(&fnptr).is_err());
     }
 
     #[test]
@@ -1527,7 +1626,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     fn headers_from_map_stringifies_values() {
         let mut m = Map::new();
         m.insert("n".into(), Dynamic::from(42_i64));
-        let headers = headers_from_map(m);
+        let headers = headers_from_map(&m);
         assert_eq!(headers.get("n").map(String::as_str), Some("42"));
     }
 
@@ -1581,6 +1680,26 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("&#99999999;"), "&#99999999;"); // decimal out of range (from_u32 None)
         // No ampersand at all.
         assert_eq!(decode_entities("plain"), "plain");
+    }
+
+    #[test]
+    fn decode_entities_survives_multibyte_after_an_ampersand() {
+        // Regression for issue #109: the entity-scan window is a byte count, so
+        // a bare '&' followed by multi-byte text used to slice mid-character and
+        // panic ("byte index 12 is not a char boundary") — inside a Rhai native
+        // fn, which aborted the daemon. Every one of these is a real shape from
+        // fetched HTML.
+        assert_eq!(decode_entities("&日本語日本"), "&日本語日本");
+        assert_eq!(decode_entities("R&D 日本語です"), "R&D 日本語です");
+        assert_eq!(decode_entities("&🎉🎉🎉🎉"), "&🎉🎉🎉🎉");
+        assert_eq!(
+            decode_entities("&\u{2014}\u{2014}\u{2014}\u{2014}"),
+            "&————"
+        );
+        // A real entity immediately followed by multi-byte text still decodes.
+        assert_eq!(decode_entities("&amp;日本語"), "&日本語");
+        // Trailing '&' at the very end of the string (window == 1).
+        assert_eq!(decode_entities("tail&"), "tail&");
     }
 
     #[test]

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -430,6 +430,11 @@ pub const SCRIPT_TOOL_MAX_OPERATIONS: u64 = 500_000;
 /// `params` object-map. The returned Rhai value is serialized to JSON unless it
 /// is already a string (returned verbatim). Any script error becomes an
 /// `[error] …` string.
+///
+/// The eval is wrapped in [`std::panic::catch_unwind`] so a panic in a host
+/// function (e.g. a TLS-backend failure) is caught cleanly — without unwinding
+/// through Rhai's stack. This prevents a double-panic abort when a `Drop` impl
+/// panics during unwinding (issue #109).
 pub fn execute(tool: &ScriptTool, args: serde_json::Value, host: Arc<dyn ScriptHost>) -> String {
     let engine = build_tool_engine(host);
     // Converting a `serde_json::Value` to a Rhai `Dynamic` is infallible (any
@@ -438,9 +443,25 @@ pub fn execute(tool: &ScriptTool, args: serde_json::Value, host: Arc<dyn ScriptH
     let params = rhai::serde::to_dynamic(args).unwrap_or(Dynamic::UNIT);
     let mut scope = Scope::new();
     scope.push_dynamic("params", params);
-    match engine.eval_ast_with_scope::<Dynamic>(&mut scope, &tool.ast) {
-        Ok(value) => dynamic_to_result_string(value),
-        Err(e) => format!("[error] {}: {}", tool.meta.name, e),
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        engine.eval_ast_with_scope::<Dynamic>(&mut scope, &tool.ast)
+    }));
+    match result {
+        Ok(Ok(value)) => dynamic_to_result_string(value),
+        Ok(Err(e)) => format!("[error] {}: {}", tool.meta.name, e),
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<String>()
+                .map(|s| s.as_str())
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown panic");
+            tracing::warn!(
+                tool = %tool.meta.name,
+                panic = msg,
+                "script tool panicked during execution (issue #109)"
+            );
+            format!("[error] {}: script panicked: {msg}", tool.meta.name)
+        }
     }
 }
 
@@ -1155,6 +1176,163 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         let out = execute(&tool, serde_json::json!({}), FakeHost::arc());
         assert!(out.starts_with("[error] t:"), "got: {out}");
         assert!(out.contains("boom"));
+    }
+
+    /// Controls what kind of panic payload a [`PanickingHost`] produces.
+    enum PanicPayload {
+        /// `panic!("{}", msg)` → `String` payload (downcast_ref::<String>).
+        Formatted(&'static str),
+        /// `panic!("…")` → `&'static str` payload (downcast_ref::<&str>).
+        Literal,
+        /// `panic_any(42i32)` → non-string payload (falls through to
+        /// "unknown panic").
+        NonString,
+    }
+
+    /// A [`ScriptHost`] where every method panics unconditionally, using
+    /// the payload kind specified by `payload`. This avoids dead
+    /// `Ok(…)` branches that would show up as uncovered.
+    struct PanickingHost {
+        payload: PanicPayload,
+    }
+
+    impl PanickingHost {
+        fn do_panic(&self) -> ! {
+            match &self.payload {
+                PanicPayload::Formatted(msg) => panic!("{}", msg),
+                PanicPayload::Literal => panic!("literal str panic"),
+                PanicPayload::NonString => std::panic::panic_any(42_i32),
+            }
+        }
+    }
+
+    impl ScriptHost for PanickingHost {
+        fn http_get(
+            &self,
+            _u: &str,
+            _h: BTreeMap<String, String>,
+        ) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+        fn http_post(
+            &self,
+            _u: &str,
+            _b: &str,
+            _h: BTreeMap<String, String>,
+        ) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+        fn shell(&self, _c: &str) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+        fn read_file(&self, _p: &str) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+        fn write_file(&self, _p: &str, _c: &str) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+        fn env_var(&self, _n: &str) -> std::result::Result<String, String> {
+            self.do_panic();
+        }
+    }
+
+    #[test]
+    fn execute_host_panic_is_caught_by_catch_unwind() {
+        // A host function that panics is caught by catch_unwind in execute(),
+        // preventing a double-panic abort when a Drop impl also panics during
+        // unwinding (issue #109).
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("TLS init failed"),
+        });
+        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("TLS init failed"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_shell_panic_is_caught_by_catch_unwind() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("sandbox init exploded"),
+        });
+        let tool = tool_from("// @tool sh\nshell(\"ls\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error] sh:"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("sandbox init exploded"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_read_file_panic_is_caught_by_catch_unwind() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("filesystem corrupted"),
+        });
+        let tool = tool_from("// @tool rf\nread_file(\"x.txt\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error] rf:"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("filesystem corrupted"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_http_post_panic_is_caught_by_catch_unwind() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("post failed"),
+        });
+        let tool = tool_from("// @tool t\nhttp_post(\"http://x\", \"body\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("post failed"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_write_file_panic_is_caught_by_catch_unwind() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("write failed"),
+        });
+        let tool = tool_from("// @tool t\nwrite_file(\"out.txt\", \"data\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("write failed"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_env_var_panic_is_caught_by_catch_unwind() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Formatted("env exploded"),
+        });
+        let tool = tool_from("// @tool t\nenv_var(\"HOME\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("env exploded"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_panic_with_str_payload() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::Literal,
+        });
+        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("literal str panic"), "got: {out}");
+    }
+
+    #[test]
+    fn execute_panic_with_non_string_payload() {
+        let host: Arc<dyn ScriptHost> = Arc::new(PanickingHost {
+            payload: PanicPayload::NonString,
+        });
+        let tool = tool_from("// @tool t\nhttp_get(\"http://x\")");
+        let out = execute(&tool, serde_json::json!({}), host);
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("script panicked"), "got: {out}");
+        assert!(out.contains("unknown panic"), "got: {out}");
     }
 
     #[test]

--- a/crates/leviath-scripting/src/types.rs
+++ b/crates/leviath-scripting/src/types.rs
@@ -47,10 +47,12 @@ pub fn register_types(engine: &mut Engine) {
         }
     });
 
-    // Token budget helpers
+    // Token budget helpers. The operands come from a script (ultimately from
+    // model output), so plain `-` would panic on overflow in a debug build —
+    // and a panic inside a Rhai native fn used to abort the process (#109).
     engine.register_fn(
         "tokens_remaining",
-        |max_tokens: i64, current_tokens: i64| -> i64 { max_tokens - current_tokens },
+        |max_tokens: i64, current_tokens: i64| -> i64 { max_tokens.saturating_sub(current_tokens) },
     );
 
     engine.register_fn(
@@ -212,6 +214,17 @@ mod tests {
         let e = engine();
         let result: i64 = e.eval("tokens_remaining(100, 100)").unwrap();
         assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn tokens_remaining_saturates_instead_of_overflowing() {
+        // The operands come from a script, so extreme values must not panic —
+        // a panic in a Rhai native fn used to abort the daemon (issue #109).
+        let e = engine();
+        let low: i64 = e.eval("tokens_remaining(-9223372036854775808, 1)").unwrap();
+        assert_eq!(low, i64::MIN);
+        let high: i64 = e.eval("tokens_remaining(9223372036854775807, -1)").unwrap();
+        assert_eq!(high, i64::MAX);
     }
 
     // --- usage_ratio ---

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -37,7 +37,7 @@ pub mod tty;
 
 pub use browser::{open_url, open_url_via};
 pub use perms::{ensure_file_private, secure_dir_perms, secure_file_perms};
-pub use process::configure_detached;
+pub use process::{configure_detached, current_uid};
 pub use sandbox::{
     ContainerRunSpec, KNOWN_ENGINES, container_exec_argv, container_rm_argv, container_run_argv,
     detect_container_engine, namespace_argv, namespace_supported,

--- a/crates/leviath-sys/src/platform/fallback.rs
+++ b/crates/leviath-sys/src/platform/fallback.rs
@@ -17,3 +17,9 @@ pub(crate) fn ensure_private(_path: &Path, _mode: u32) -> io::Result<Option<u32>
 }
 
 pub(crate) fn configure_detached(_cmd: &mut std::process::Command) {}
+
+/// Windows has no POSIX uid; the value is only used to address a per-user
+/// launchd/systemd domain, neither of which exists here.
+pub(crate) fn current_uid() -> u32 {
+    0
+}

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -64,6 +64,11 @@ fn ensure_private_with(
     }
 }
 
+/// The calling user's real numeric id.
+pub(crate) fn current_uid() -> u32 {
+    nix::unistd::getuid().as_raw()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -11,9 +11,24 @@ pub fn configure_detached(cmd: &mut Command) {
     crate::platform::configure_detached(cmd);
 }
 
+/// The calling user's numeric id.
+///
+/// Used to address a per-user service domain (`launchctl bootstrap gui/<uid>`).
+/// Returns `0` on platforms with no POSIX uid, where no such domain exists.
+pub fn current_uid() -> u32 {
+    crate::platform::current_uid()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn current_uid_is_reported() {
+        // Just has to answer without panicking; root (0) is a legitimate value
+        // on Unix and the only value on non-Unix.
+        let _uid: u32 = current_uid();
+    }
 
     #[test]
     fn configure_detached_public_wrapper_registers_without_spawning() {

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -6,7 +6,7 @@ use leviath_providers::Tool;
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use tokio::process::Command;
 use tokio::time::{Duration, timeout};
 
@@ -141,7 +141,10 @@ impl ToolContext {
     /// briefly to look up / insert; the returned per-file lock is what callers
     /// `.await` on across their read-modify-write.
     fn lock_for(&self, path: &Path) -> Arc<tokio::sync::Mutex<()>> {
-        let mut map = self.file_locks.lock().unwrap();
+        let mut map = self
+            .file_locks
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         map.entry(path.to_path_buf())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()


### PR DESCRIPTION
Fixes #109.

## What was actually wrong

Two panics, one abort mechanism.

**The abort.** rhai's `exec_native_fn_call` takes an `ArgBackup` whenever a native
function's first argument is a variable reference — which is every real call shape,
e.g. `http_get(params.url, #{..})` and `html_to_text(body)` in the shipped
`web_fetch.rhai`. It restores that backup *after* the call returns, so a panicking
native fn skips the restore and unwinding runs `ArgBackup::drop`, whose `assert!`
panics again. A second panic while panicking is `panic_in_cleanup` → `abort()`, and
the whole daemon dies with every concurrent run.

This is why the first attempt on this branch didn't work: it wrapped
`Engine::eval_ast_with_scope` in `catch_unwind`, but the abort happens *inside* rhai,
well below that frame.

**The panic that was firing.** `decode_entities` scanned a fixed 12 *bytes* past an
`&` looking for the closing `;`. `&` is one byte, so byte 12 lands mid-character on
any multi-byte text: `"&日本語日本"` panicked with *"byte index 12 is not a char
boundary"*. That code runs on every `html_to_text(body)` — i.e. every `web_fetch` —
which is the reported `wide-researcher` crash path. It shipped with `html_to_text`
in #98 (merged Jul 24; crashes Jul 26).

Reproduced against this PR's base commit with a realistic page body through the
shipped `web_fetch` call shape:

```
thread 'main' panicked at leviath-scripting/src/tool.rs:671:
end byte index 12 is not a char boundary; it is inside '日' (bytes 10..13)
thread 'main' panicked at rhai-1.25.1/src/func/call.rs:107:      <- ArgBackup::drop
panic in a destructor during cleanup
thread caused non-unwinding panic. aborting.
exit 134
```

Same harness on this branch: exit 0, `Q&日本語日本語です` returned.

## The fix

**Stop panics at the native-function boundary.** Every closure registered by
`register_host_functions` now runs under `guard_str`/`guard_dyn`, which convert a
panic into the same `EvalAltResult::ErrorRuntime` an ordinary host error produces.
Nothing unwinds into rhai at all. The guards are non-generic (`&mut dyn FnMut`) so
all callers share one instantiation and the 100% coverage gate stays exact. The pure
helpers (`parse_json`, `to_json`, `encode_uri`, `html_to_text`) are guarded too —
they run on model- and network-supplied input.

**Fix the panics that were firing:** the `decode_entities` char-boundary bug, and
`tokens_remaining`'s plain `-` on script-supplied `i64`s (debug-build overflow).

**Remove the remaining panic sources on the real I/O path:** `RealScriptIo::client()`
built a fresh `reqwest::blocking::Client` — an OS thread, a tokio runtime, and a TLS
root-store load — for *every* request, so a fan-out could churn threads until
`build()` failed and its `.expect` panicked. It's now built once in a `LazyLock`.
`run_shell` uses `Handle::try_current()` instead of the panicking `current()`.

## Beyond the immediate crash

The issue also asked for panic attribution, run-status recovery, and auto-restart;
auditing turned up two more cross-agent failure modes worth fixing at the same time.

**Pipeline panics are now attributed to an agent.** A panic in any of the 29 shared
systems was swallowed anonymously — nothing was marked failed and nothing changed, so
the next wake re-ticked identical state and panicked again, forever, while every other
agent stalled behind the aborted round. Each per-agent loop now records its entity in
a thread-local `tick_scope`, and `tick` fails that one agent with the panic message.
Two supporting changes: the schedule runs `SingleThreaded` (every system is already
`.chain()`ed, so the multi-threaded executor only moved systems onto pool threads
where a thread-local is invisible to the catcher), and `run_isolated` rebuilds the
executor after a caught panic — bevy marks a system "completed" *before* running it
and only clears that set on a normal return, so the next tick was silently skipping
the whole prefix of the chain.

**Poison-tolerant locks.** 27 non-test `std::sync::Mutex` unwraps sit on the tick /
tool-execution path; a panic while holding any of them poisoned it and turned every
later `.lock().unwrap()` into a fresh panic. The worst are process-wide:
`CliToolService.states`, `AgentMcpPool.connected`, `InteractionHub.pending`. All 27
now recover the guard via the idiom already in-tree at `inference_pool.rs`. `sync_stage`
also stops holding the global `states` guard while it takes three more locks.

**Un-reloadable runs are recorded as crashed.** The reported symptom — `meta.json` stuck
at `"status": "running"` forever — was recovery's other arm: a run that *can't* be
reloaded was logged and left alone. It's now written back as `Error` with the reason.
Reloadable runs still resume, unchanged.

**`lev daemon install` / `uninstall`.** Registers the daemon with launchd (macOS) or a
systemd `--user` unit (Linux) so it restarts on its own; `lev daemon status` reports
whether supervision is in place. The rendering, paths, and supervisor argv are a tested
core in `commands/daemon_service.rs`, `#[cfg]`-gated per platform; only the subprocess
spawn is in main.rs (hence the `allow-main-rs-change` label).

## Verification

- All 9 crates at 100% coverage locally (lines/regions/functions), `cargo test
  --workspace`, clippy, fmt, and the ast-grep suppression lint clean.
- Pre/post binary repro of the SIGABRT, above.
- Live daemon run: a `.rhai` tool doing `read_file` + `html_to_text` over
  `<p>Q&日本語日本語です</p>` — the exact bytes that aborted the daemon — completed and
  the daemon survived, with the decoded text in the run's context.
- Live recovery: two runs left at `"running"` on disk; the one whose blueprint was
  intact reloaded and finished, the one whose blueprint had moved was written back as
  `error` with the reason.

## Off-driver-thread work and the provider cache

`dispatch_inference` is the one system that fans its per-agent work over the compute
task pool, so a thread-local set inside that closure is invisible to the driver thread
catching the unwind. Each agent's share runs under `tick_scope::run_agent_parallel`,
which catches on the pool thread *where the entity is in hand* and leaves a
`PanickedInParallel` marker; `tick` drains those after a clean schedule run and fails
each marked agent on the same path as an attributed unwind. The other agents in the
batch still get dispatched. Its test clears the thread-local immediately before
panicking, so it can only pass if the marker carried the attribution.

`ScriptProviderLayer::get_or_load` no longer holds its cache lock across
`RhaiProvider::from_script` — parsing and initializing an arbitrary user-authored
`.rhai` file, which was serializing every agent's provider lookup behind one compile
and giving a panic in there a process-wide lock to poison. Two callers racing a cold
name may now both compile it: wasted work, never a wrong answer, and it self-corrects
on the next lookup since entries are validated by mtime.

