### PR TITLE
fix(runtime,agents): stop runs that finish having modified nothing (#107)

### DIFF
--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -74,7 +74,12 @@ You are implementing the plan from the `plan` region. Write working,
 production-quality code that matches the project's `conventions`.
 
 Work incrementally — one coherent file/change at a time, not one giant dump:
-- Use write_file to create files and edit_file to modify existing ones.
+- Use write_file to create files and edit_file to modify existing ones. Do NOT
+  edit files through bash — no `sed -i`, no `tee`, no `>`/`>>` redirection, no
+  here-docs. Bash is for running tests and builds and for read-only exploration.
+  Only write_file/edit_file are recorded in the `implementation` region the
+  reviewer reads, and this stage will not hand off to review until at least one
+  of them has landed.
 - Handle errors explicitly (validate inputs, propagate/return errors, no silent
   swallowing) — match the error-handling style already used in this codebase.
 - Write or update tests alongside the code when the task warrants it, then use
@@ -94,17 +99,28 @@ changed and the test outcome.
 # Large read output persists in `codebase`; test output persists in `test_results`
 # (the review stage reads it). Routed results leave a short pointer in conversation
 # (paired with their tool_use) and the full output as text in the region, so the
-# model still sees each action landed. Small write/edit confirmations stay inline.
+# model still sees each action landed.
+#
+# write_file/edit_file confirmations persist in `implementation`, which makes it
+# the run's changelog: it is what the review stage is told to read, it survives
+# `conversation` eviction, and — being persisted context — it also satisfies the
+# transition gate below after a daemon restart, when per-stage counters are gone.
 [stages.implement.tool_routing]
 default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
 bash       = "test_results"
+write_file = "implementation"
+edit_file  = "implementation"
 
+# The gate refuses this edge until the stage has actually written something, so an
+# agent that explored the codebase through bash and changed nothing gets sent back
+# instead of handing an untouched workspace to review (issue #107).
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
 transform = "compact"
+gate = { require_modifications = true, region = "implementation" }
 
 [stages.implement.transitions.error_recovery]
 condition = "error"

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -134,7 +134,11 @@ max_revisits = 5
 system_prompt = """
 You are the implementation stage. The plan in the `plan` region has been approved.
 Execute it step by step:
-- Use write_file to create new files and edit_file to modify existing ones.
+- Use write_file to create new files and edit_file to modify existing ones. Do
+  NOT edit files through bash — no `sed -i`, no `tee`, no `>`/`>>` redirection,
+  no here-docs. Only write_file/edit_file are recorded in the `implementation`
+  region the reviewer reads, and this stage will not hand off until at least one
+  of them has landed.
 - Use bash to run tests or verify the build after writing — output goes to
   `test_results`.
 
@@ -156,22 +160,37 @@ of what was created/modified and whether tests passed.
 
 # Large read output persists in `codebase`; test output persists in `test_results`
 # (the review stage reads it). Routed results leave a short pointer in conversation
-# (paired with their tool_use) with the full output as text in the region. Small
-# write/edit confirmations stay inline.
+# (paired with their tool_use) with the full output as text in the region.
+#
+# write_file/edit_file confirmations persist in `implementation`, alongside the
+# hand-written `changelog`: it is a mechanical record of every file touched, it
+# survives `conversation` eviction, and — being persisted context — it satisfies
+# the transition gates below after a daemon restart, when per-stage counters are
+# gone.
 [stages.implement.tool_routing]
 default_region = "conversation"
 [stages.implement.tool_routing.overrides]
 read_file  = "codebase"
 list_dir   = "codebase"
 bash       = "test_results"
+write_file = "implementation"
+edit_file  = "implementation"
 
+# Both non-error edges are gated: an agent that explored through bash and changed
+# nothing is sent back for another pass rather than handing an untouched workspace
+# to review — or slipping out sideways via the `plan` edge, which can itself end
+# the run (issue #107).
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
 transform = "compact"
+gate = { require_modifications = true, region = "implementation" }
 
+# Going back to planning with nothing written is sometimes the right call, so this
+# edge only asks once before letting a genuinely stuck agent through.
 [stages.implement.transitions.plan]
 hint = "Need to fundamentally rethink the approach"
 transform = "compact"
+gate = { require_modifications = true, region = "implementation", max_attempts = 1 }
 
 [stages.implement.transitions.error_recovery]
 condition = "error"
@@ -201,9 +220,10 @@ Minor style issues don't warrant another implementation pass.
 system_prompt = """
 You are the review stage. The implementation is complete.
 
-Use the `changelog` region to see exactly which files changed, and `decisions` to
-understand why choices were made before you question them. Read those files and
-provide a quality review:
+Use the `changelog` region to see exactly which files changed (the
+`implementation` region holds the mechanical record of every write the framework
+saw, if the changelog looks incomplete), and `decisions` to understand why choices
+were made before you question them. Read those files and provide a quality review:
 - Correctness: does it match the plan AND the original task in `task`?
 - Edge cases: what inputs or conditions could cause failures?
 - Code quality: clarity, naming, error handling, conventions.

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -34,7 +34,8 @@ pub struct RunArgs {
     #[arg(short, long)]
     pub model: Option<String>,
 
-    /// Approve every tool call without prompting.
+    /// Run unattended: approve every tool call, and answer the agent's own
+    /// prompts (ask_user_*, plan approvals) instead of waiting for a person.
     #[arg(long)]
     pub yolo: bool,
 

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -514,6 +514,7 @@ a = "true"
                 condition: Default::default(),
                 hint: None,
                 transform: Default::default(),
+                gate: None,
             },
         );
         let mut stage_a = Stage::new("a".to_string(), make_model());

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -392,6 +392,16 @@ fn reload_one(
         // `parent_run_id` was already restored via `args` into build_agent's metadata.
     }
 
+    // Carry the run's productivity flags across the restart, so a resumed run
+    // doesn't report itself as having modified nothing (issue #107).
+    {
+        let mut flags = world
+            .world_mut()
+            .get_mut::<leviath_runtime::persistence::RunOutcomeFlags>(entity)
+            .expect("build_agent attached run outcome flags");
+        flags.0 = meta.flags.clone();
+    }
+
     // If this run was parked at a stage-boundary interaction point (e.g.
     // plan_approval), re-present it in the *waiting* state rather than the default
     // `Active` + `ReadyToInfer` restore — so the open prompt survives the restart
@@ -535,6 +545,13 @@ mod tests {
             children: children.iter().map(|s| s.to_string()).collect(),
             depth,
             max_child_depth,
+            // Non-default on purpose: proves reload restores the run's
+            // productivity flags rather than starting them over (issue #107).
+            flags: leviath_core::run_meta::RunFlags {
+                modified_files: vec!["src/a.rs".to_string()],
+                modified_file_count: 1,
+                ..Default::default()
+            },
         };
         std::fs::write(dir.join("meta.json"), serde_json::to_string(&meta).unwrap()).unwrap();
         if let Some(ctx) = context {
@@ -675,6 +692,14 @@ mod tests {
         let totals = world.world().get::<TokenTotals>(*entity).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
+        // ...as are the run's productivity flags, so a resumed run doesn't report
+        // itself as having modified nothing.
+        let flags = world
+            .world()
+            .get::<leviath_runtime::persistence::RunOutcomeFlags>(*entity)
+            .unwrap();
+        assert_eq!(flags.0.modified_files, vec!["src/a.rs".to_string()]);
+        assert_eq!(flags.0.modified_file_count, 1);
     }
 
     /// Fresh + stale differ on every observable field, so the assertions below

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -286,6 +286,14 @@ impl ScriptHost for DaemonScriptHost {
         if !self.allow.write_file {
             return Err(denied("write_file"));
         }
+        // Same rule as the built-in write tools: never let `create_dir_all`
+        // resurrect a workspace that disappeared mid-run (issue #107).
+        if !std::fs::metadata(&self.workdir).is_ok_and(|m| m.is_dir()) {
+            return Err(format!(
+                "workspace '{}' is no longer accessible",
+                self.workdir.display()
+            ));
+        }
         let resolved = self.resolve_in_workdir(path)?;
         self.io.write_file(&resolved, content)
     }
@@ -659,6 +667,25 @@ mod tests {
             write_file: false,
             env_var: false,
         }
+    }
+
+    #[test]
+    fn script_write_refuses_a_deleted_workspace() {
+        // Same rule as the built-in write tools (#107): a script may not
+        // resurrect a workspace that disappeared out from under the run.
+        let dir = tempfile::tempdir().unwrap();
+        let workdir = dir.path().join("gone");
+        let io = RecordingIo::arc();
+        let host = DaemonScriptHost::with_io(all_allowed(), workdir.clone(), io.clone());
+        let err = host.write_file("out.txt", "body").unwrap_err();
+        assert!(err.contains("no longer accessible"), "got: {err}");
+        assert!(
+            io.calls.lock().unwrap().is_empty(),
+            "the io layer never ran"
+        );
+        // A live workspace still writes.
+        std::fs::create_dir(&workdir).unwrap();
+        assert_eq!(host.write_file("out.txt", "body").unwrap(), "w");
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -259,6 +259,13 @@ pub fn build_host(
     // servers' defs plus this blueprint's declared servers' defs (warmed above).
     let spawn_pool = mcp_pool.clone();
     host.set_spawner(Box::new(move |world, args| {
+        // Stake out the run directory before anything that can fail: blueprint
+        // parsing, sandbox creation, provider resolution and seed validation all
+        // come later, and until now a failure at any of them left no trace on
+        // disk at all — no run dir, no meta.json, nothing to diagnose (#107).
+        // The reload path deliberately doesn't do this: it must not overwrite a
+        // recovering run's own metadata.
+        write_placeholder_meta(args);
         let defs = per_agent_mcp_defs(&spawn_pool, &mcp_tool_defs, &args.blueprint_path);
         build_agent(
             world.world_mut(),
@@ -273,6 +280,36 @@ pub fn build_host(
         )
     }));
     host
+}
+
+/// Create the run directory and write a `Starting` `meta.json` for a run that is
+/// about to be built, so a spawn that dies partway through still leaves something
+/// on disk to explain itself (issue #107: 3/13 empty runs crashed before any
+/// state existed). Everything the agent hasn't resolved yet — model, stage names,
+/// stage count — is left blank; the first persistence tick overwrites the file
+/// with the real thing. Best-effort: a failure here must not block the spawn.
+fn write_placeholder_meta(args: &leviath_runtime::host::SpawnArgs) {
+    // The real agent name lives in the blueprint, which hasn't been parsed yet —
+    // but the run id is `<agent>-<unix-secs>-<hex4>`, so its prefix is the name
+    // (dashes inside the agent name included).
+    let agent_name = args
+        .run_id
+        .rsplitn(3, '-')
+        .nth(2)
+        .unwrap_or(&args.run_id)
+        .to_string();
+    let meta = leviath_core::run_meta::RunMeta::new(
+        args.run_id.clone(),
+        agent_name,
+        args.blueprint_path.clone(),
+        args.task.clone(),
+        None,
+        args.workdir.clone(),
+        0,
+    );
+    if let Err(e) = crate::runstate::create_run(&meta) {
+        tracing::warn!(run_id = %args.run_id, error = %e, "could not pre-create run directory");
+    }
 }
 
 /// The spawn-preprocessor body: connect the blueprint's declared `[[mcp_servers]]`
@@ -450,6 +487,89 @@ mod tests {
             reply,
         });
         assert_eq!(rx.await.unwrap(), Ok("run-s".to_string()));
+    }
+
+    /// Issue #107: 3/13 empty runs died before any state existed, leaving nothing
+    /// on disk to diagnose. The spawner stakes out the run directory first, so a
+    /// spawn that fails at *any* later step still leaves a `meta.json`.
+    #[tokio::test]
+    async fn spawner_pre_creates_the_run_dir_even_when_the_spawn_fails() {
+        crate::runstate::with_isolated_runs_dir_async("spawn-placeholder", |_base| async {
+            let runs = tempfile::tempdir().unwrap();
+            let mut host = setup_daemon_host(
+                Config::default(),
+                runs.path().to_path_buf(),
+                Handle::current(),
+            )
+            .await;
+            let (reply, rx) = oneshot::channel();
+            host.handle(ControlOp::Spawn {
+                args: Box::new(SpawnArgs {
+                    // A blueprint path that doesn't exist: the spawn fails at the
+                    // very first step inside build_agent.
+                    run_id: "my-agent-1234-ab12".to_string(),
+                    blueprint_path: "/no/such/agent.leviath".to_string(),
+                    task: "t".to_string(),
+                    regions: Default::default(),
+                    model: None,
+                    workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                    metadata: Default::default(),
+                    callback_url: None,
+                    callback_secret: None,
+                    yolo: false,
+                    allow: Vec::new(),
+                    max_depth: None,
+                    parent_run_id: None,
+                }),
+                reply,
+            });
+            assert!(rx.await.unwrap().is_err());
+
+            let meta = crate::runstate::read_meta("my-agent-1234-ab12")
+                .expect("a failed spawn still leaves meta.json behind");
+            assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Starting);
+            assert_eq!(meta.task, "t");
+            // The agent name is recovered from the run id's prefix, dashes and all.
+            assert_eq!(meta.agent_name, "my-agent");
+        })
+        .await;
+    }
+
+    #[test]
+    fn placeholder_meta_falls_back_to_the_whole_run_id_as_the_agent_name() {
+        crate::runstate::with_isolated_runs_dir("spawn-placeholder-odd-id", |_base| {
+            let args = SpawnArgs {
+                // Not the `<agent>-<secs>-<hex>` shape the run-id minter makes.
+                run_id: "odd".to_string(),
+                task: "t".to_string(),
+                ..Default::default()
+            };
+            write_placeholder_meta(&args);
+            assert_eq!(crate::runstate::read_meta("odd").unwrap().agent_name, "odd");
+        });
+    }
+
+    #[test]
+    fn placeholder_meta_failure_is_logged_not_fatal() {
+        // An unwritable runs dir (here: a path *under a regular file*) must not
+        // stop the spawn — the placeholder is a diagnostic, not a prerequisite.
+        crate::test_support::with_tracing(|| {
+            let dir = tempfile::tempdir().unwrap();
+            let blocker = dir.path().join("not-a-dir");
+            std::fs::write(&blocker, "x").unwrap();
+            temp_env::with_var(
+                "LEVIATH_RUNS_DIR",
+                Some(blocker.join("runs").to_string_lossy().to_string()),
+                || {
+                    let args = SpawnArgs {
+                        run_id: "blocked".to_string(),
+                        ..Default::default()
+                    };
+                    write_placeholder_meta(&args);
+                    assert!(crate::runstate::read_meta("blocked").is_err());
+                },
+            );
+        });
     }
 
     // ── per-agent MCP (issue #97) ──
@@ -879,6 +999,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             children: Vec::new(),
             depth: 0,
             max_child_depth: 0,
+            flags: Default::default(),
         };
         std::fs::write(
             run_dir.join("meta.json"),
@@ -972,6 +1093,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             children: Vec::new(),
             depth: 0,
             max_child_depth: 0,
+            flags: Default::default(),
         };
         std::fs::write(
             run_dir.join("meta.json"),

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -291,6 +291,7 @@ fn build_tool_state(
     script_tool_names: HashSet<String>,
     script_host: Arc<dyn leviath_scripting::ScriptHost>,
     dynamic: Option<Arc<crate::daemon::tool_service::DynamicToolCtx>>,
+    unattended: bool,
 ) -> Arc<AgentToolState> {
     let entry_perms = stage_perms_by_index
         .get(entry_index)
@@ -307,6 +308,7 @@ fn build_tool_state(
         agent_perms: Arc::new(agent_perms),
         global_perms: Arc::new(config.tool_permissions.clone()),
         interaction: hub.backend_for(run_id),
+        unattended,
         stage_name: Arc::new(StdMutex::new(entry_stage.to_string())),
         subagent,
         sandbox,
@@ -761,6 +763,16 @@ fn build_agent_inner(
             // by `recovery::reload_persisted_agents`.
             leviath_runtime::persistence::RunOutcomeFlags::default(),
         ));
+        // `--yolo` means run unattended, so a blueprint's stage-boundary
+        // checkpoints are approved rather than parked on a hub nobody is
+        // watching. (`.then_some(..).into_iter()` keeps the non-yolo path
+        // branch-free, matching the taint-gate marker below.)
+        args.yolo
+            .then_some(leviath_runtime::components::InteractionAutoApprove)
+            .into_iter()
+            .for_each(|marker| {
+                entity_mut.insert(marker);
+            });
         // `Option`'s iterator inserts compaction settings when present without a
         // dangling `if let` block-end region.
         compaction.into_iter().for_each(|cc| {
@@ -876,6 +888,7 @@ fn build_agent_inner(
         script_tool_names,
         script_host,
         dynamic,
+        args.yolo,
     );
     tool_service.register(entity, state);
 
@@ -1442,6 +1455,49 @@ mod tests {
                 .get::<leviath_runtime::components::GateAutoApprove>(entity)
                 .is_some()
         );
+        // ...and likewise for the blueprint's own stage-boundary checkpoints and
+        // the agent's `ask_user_*` tools (#107): unattended means unattended.
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::components::InteractionAutoApprove>(entity)
+                .is_some()
+        );
+        assert!(cli.take(entity).expect("tool state registered").unattended);
+    }
+
+    #[tokio::test]
+    async fn build_agent_without_yolo_keeps_prompts_interactive() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"plain\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::components::InteractionAutoApprove>(entity)
+                .is_none()
+        );
+        assert!(!cli.take(entity).expect("tool state registered").unattended);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -537,6 +537,17 @@ fn build_agent_inner(
     subagent_tx: UnboundedSender<SubAgentOp>,
     enforce_seeds: bool,
 ) -> Result<Entity, String> {
+    // 0. The working directory must exist before anything is built over it.
+    // `ToolContext::new` silently keeps a path it can't canonicalize, so without
+    // this a bogus workdir spawns a healthy-looking agent whose every tool call
+    // fails with a message naming the shell rather than the directory (#107).
+    if !std::fs::metadata(&args.workdir).is_ok_and(|m| m.is_dir()) {
+        return Err(format!(
+            "workspace '{}' does not exist or is not a directory",
+            args.workdir
+        ));
+    }
+
     // 1. Load the blueprint (the client resolves the manifest path).
     let content = std::fs::read_to_string(&args.blueprint_path)
         .map_err(|e| format!("read manifest '{}': {e}", args.blueprint_path))?;
@@ -746,6 +757,9 @@ fn build_agent_inner(
             metadata,
             TokenTotals::default(),
             PersistWatermark::default(),
+            // Fresh counters; a reloaded run gets its accumulated flags put back
+            // by `recovery::reload_persisted_agents`.
+            leviath_runtime::persistence::RunOutcomeFlags::default(),
         ));
         // `Option`'s iterator inserts compaction settings when present without a
         // dangling `if let` block-end region.
@@ -1186,6 +1200,51 @@ mod tests {
             allow: Vec::new(),
             max_depth: None,
             parent_run_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_agent_rejects_a_workdir_that_is_missing_or_not_a_directory() {
+        // `ToolContext::new` silently keeps a path it can't canonicalize, so
+        // without this check a bogus workdir spawns a healthy-looking agent
+        // whose every tool call then fails with ENOENT (issue #107).
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"w\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let not_a_dir = dir.path().join("a-file");
+        std::fs::write(&not_a_dir, "x").unwrap();
+
+        for workdir in [
+            dir.path()
+                .join("does-not-exist")
+                .to_string_lossy()
+                .to_string(),
+            not_a_dir.to_string_lossy().to_string(),
+        ] {
+            let (mut world, cli) = test_world();
+            let hub = InteractionHub::new();
+            let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+            let mut args = spawn_args(&manifest.to_string_lossy());
+            args.workdir = workdir.clone();
+            let err = build_agent(
+                world.world_mut(),
+                cli.as_ref(),
+                &Config::default(),
+                mcp,
+                &[],
+                &hub,
+                &args,
+                100,
+                sub_tx(),
+            )
+            .unwrap_err();
+            assert!(err.contains("workspace"), "got: {err}");
+            assert!(err.contains(&workdir), "got: {err}");
         }
     }
 

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -22,7 +22,9 @@ use std::sync::{Arc, Mutex as StdMutex, PoisonError};
 use bevy_ecs::entity::Entity;
 use leviath_core::interaction::{ApprovalScope, InteractionRequest};
 use leviath_providers::ToolCall;
-use leviath_runtime::dynamic_interaction::{InteractionBackend, dispatch_dynamic_interaction};
+use leviath_runtime::dynamic_interaction::{
+    InteractionBackend, UnattendedInteraction, dispatch_dynamic_interaction,
+};
 use leviath_runtime::interaction_hub::HubInteractionBackend;
 use leviath_runtime::pipeline::ToolService;
 use leviath_runtime::tool_bridge::BoxedToolExec;
@@ -60,6 +62,10 @@ pub struct AgentToolState {
     pub global_perms: Arc<HashMap<String, ToolPolicy>>,
     /// The agent's interaction backend (ask_user + tool approvals).
     pub interaction: HubInteractionBackend,
+    /// `--yolo`: nobody is watching this run, so `ask_user_*` /
+    /// `present_for_review` / `edit_document` are answered by
+    /// [`UnattendedInteraction`] rather than parked on the hub forever.
+    pub unattended: bool,
     /// The current stage name, for tagging interactions (re-synced on stage change).
     pub stage_name: Arc<StdMutex<String>>,
     /// Handle for the sub-agent tools (spawn/check/wait/send/kill), or `None`
@@ -207,15 +213,16 @@ pub async fn dispatch_tools(
     let mut queued: Vec<(usize, bool, ToolCall)> = Vec::new();
     for tc in calls {
         let slot = slots.len();
-        // ask_user_* / present_for_review are handled by the interaction backend.
-        if let Some(result) = dispatch_dynamic_interaction(
-            &state.interaction,
-            &tc.name,
-            &tc.id,
-            &tc.arguments,
-            &stage_name,
-        )
-        .await
+        // ask_user_* / present_for_review are handled by the interaction backend
+        // — the hub (a real person answers) or, for an unattended `--yolo` run,
+        // the auto-answering one.
+        let interaction: &dyn InteractionBackend = match state.unattended {
+            true => &UnattendedInteraction,
+            false => &state.interaction,
+        };
+        if let Some(result) =
+            dispatch_dynamic_interaction(interaction, &tc.name, &tc.id, &tc.arguments, &stage_name)
+                .await
         {
             slots.push((tc.id, Some(result)));
             continue;
@@ -510,6 +517,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -583,6 +591,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -654,6 +663,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(allow),
             interaction: hub.backend_for("a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -860,6 +870,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(allow),
             interaction: hub.backend_for("a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -1036,6 +1047,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -1119,6 +1131,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(HashMap::new()),
             interaction: hub.backend_for("a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: None,
             sandbox: None,
@@ -1302,6 +1315,7 @@ mod tests {
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(HashMap::new()),
             interaction: hub.backend_for("agent-a"),
+            unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
             subagent: Some(handle),
             sandbox: None,
@@ -1362,6 +1376,28 @@ mod tests {
         assert_eq!(out[0].0, "c1");
         // Once-scope approval does not persist.
         assert!(!state.session_allows.lock().await.contains("read_file"));
+    }
+
+    #[tokio::test]
+    async fn unattended_run_answers_ask_user_itself_instead_of_opening_a_prompt() {
+        // `--yolo` sets `unattended`, so `ask_user_confirm` resolves inline. With
+        // a live hub and nobody answering, the attended path would block here
+        // forever — this test finishing at all is the assertion (#107).
+        let hub = InteractionHub::new();
+        let mut state =
+            (*state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new())).clone();
+        state.unattended = true;
+        let out = dispatch_tools(
+            Arc::new(state),
+            vec![call(
+                "c1",
+                "ask_user_confirm",
+                serde_json::json!({"prompt": "proceed?"}),
+            )],
+        )
+        .await;
+        assert_eq!(out[0].1, "User answered: Yes");
+        assert!(hub.pending().is_empty(), "no prompt was opened");
     }
 
     #[tokio::test]

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -247,6 +247,29 @@ impl Blueprint {
                     }
                 }
 
+                // A `require_modifications` gate on a stage that advertises no
+                // file-modifying tool can never be satisfied — it would just
+                // burn the stage's re-run budget every time.
+                for (target_name, edge) in transitions {
+                    let Some(gate) = &edge.gate else { continue };
+                    if !gate.require_modifications {
+                        continue;
+                    }
+                    let can_modify = stage.available_tools.iter().any(|t| {
+                        MODIFYING_TOOLS.contains(&t.as_str())
+                            || gate.tools.iter().any(|extra| extra == t)
+                    });
+                    if !can_modify {
+                        return Err(ValidationError::Transition {
+                            from: stage.name.clone(),
+                            to: target_name.clone(),
+                            message: "gate requires modifications, but the stage has no \
+                                      file-modifying tool in available_tools"
+                                .to_string(),
+                        });
+                    }
+                }
+
                 // Self-loop safety: stages that transition to themselves need max_revisits
                 if transitions.contains_key(&stage.name) && stage.max_revisits.is_none() {
                     return Err(ValidationError::Stage {
@@ -359,9 +382,9 @@ impl Blueprint {
 
 /// Configuration for automatic file tracking in context regions.
 ///
-/// When configured, read_file/write_file/edit_file results are automatically
-/// synced to a HashMap region, and tool results reference the system prompt
-/// instead of duplicating content.
+/// When configured, read_file/write_file results are automatically synced to a
+/// HashMap region, and tool results reference the system prompt instead of
+/// duplicating content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileTrackingConfig {
     /// Name of the HashMap region to sync files to
@@ -369,7 +392,9 @@ pub struct FileTrackingConfig {
     /// Auto-update on read_file
     #[serde(default = "default_true_val")]
     pub track_reads: bool,
-    /// Auto-update on write_file/edit_file
+    /// Auto-update on write_file. (`edit_file` is not tracked: its arguments are
+    /// `old_str`/`new_str`, so the post-edit file body isn't available without a
+    /// re-read.)
     #[serde(default = "default_true_val")]
     pub track_writes: bool,
     /// Truncate files larger than this token count in context
@@ -912,7 +937,58 @@ pub struct TransitionEdge {
     /// How context transforms when crossing this edge
     #[serde(default)]
     pub transform: EdgeTransform,
+
+    /// Preconditions the agent must satisfy before this edge may be followed.
+    /// Absent ⇒ the edge is unconditional (beyond its `condition`).
+    #[serde(default)]
+    pub gate: Option<TransitionGate>,
 }
+
+/// Preconditions an edge imposes on the stage it leaves, checked once the edge
+/// has been chosen but before its transform runs. A gate that isn't satisfied
+/// re-runs the stage with a `[System]` nudge instead of transitioning.
+///
+/// The motivating case (issue #107): an agent that reads and reasons about the
+/// codebase entirely through `shell` and reaches the review stage without ever
+/// having called a file-writing tool, producing a run with no output at all.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransitionGate {
+    /// Require at least one successful file-modifying tool call in the stage
+    /// being left.
+    #[serde(default)]
+    pub require_modifications: bool,
+
+    /// Nudge injected when the gate blocks. A default explaining the framework's
+    /// change tracking is generated when absent.
+    #[serde(default)]
+    pub message: Option<String>,
+
+    /// Region whose non-emptiness also satisfies the gate. Per-stage tool-call
+    /// counters reset on stage entry and are not restored when a run resumes
+    /// after a daemon restart, but context regions are — so pointing the gate at
+    /// the region the write tools are routed into keeps a resumed run honest.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Tool names counted as modifying beyond the built-in `write_file` /
+    /// `edit_file` — for agents whose writes go through MCP or script tools.
+    #[serde(default)]
+    pub tools: Vec<String>,
+
+    /// How many times the stage is re-run before the gate gives up and lets the
+    /// transition through (with a warning). Defaults to
+    /// [`DEFAULT_GATE_ATTEMPTS`].
+    #[serde(default)]
+    pub max_attempts: Option<usize>,
+}
+
+/// Default re-run budget for an unsatisfied [`TransitionGate`].
+pub const DEFAULT_GATE_ATTEMPTS: usize = 3;
+
+/// Built-in tools that modify files on disk, for [`TransitionGate`]'s
+/// `require_modifications` accounting. Extended per-edge by
+/// [`TransitionGate::tools`].
+pub const MODIFYING_TOOLS: &[&str] = &["write_file", "edit_file"];
 
 /// Condition that determines when a transition edge is available.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1141,6 +1217,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         plan.transitions = Some(transitions);
@@ -1435,11 +1512,74 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         stage.transitions = Some(transitions);
         let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
         assert!(bp.validate().is_err());
+    }
+
+    /// A `require_modifications` gate on a stage that can't modify anything
+    /// could never be satisfied — it would just burn the stage's re-run budget
+    /// on every pass. Reject it at load time instead (issue #107).
+    #[test]
+    fn test_graph_validation_modification_gate_needs_a_writing_stage() {
+        let gated = |tools: &[&str], extra: &[&str]| {
+            let mut stage = Stage::new("impl".to_string(), make_model());
+            stage.available_tools = tools.iter().map(|t| t.to_string()).collect();
+            let mut transitions = HashMap::new();
+            transitions.insert(
+                "review".to_string(),
+                TransitionEdge {
+                    target: "review".to_string(),
+                    condition: TransitionCondition::Always,
+                    hint: None,
+                    transform: EdgeTransform::Direct,
+                    gate: Some(TransitionGate {
+                        require_modifications: true,
+                        tools: extra.iter().map(|t| t.to_string()).collect(),
+                        ..Default::default()
+                    }),
+                },
+            );
+            stage.transitions = Some(transitions);
+            Blueprint::new(
+                "t".into(),
+                "".into(),
+                vec![stage, Stage::new("review".to_string(), make_model())],
+                make_layout(),
+            )
+        };
+        let err = gated(&["read_file"], &[]).validate().unwrap_err();
+        assert!(err.to_string().contains("no file-modifying tool"));
+        // A built-in write tool satisfies it...
+        assert!(gated(&["read_file", "edit_file"], &[]).validate().is_ok());
+        // ...as does one the gate itself declares (MCP / script toolchains).
+        assert!(
+            gated(&["read_file", "patch_file"], &["patch_file"])
+                .validate()
+                .is_ok()
+        );
+        // A gate that doesn't require modifications is never checked.
+        let mut off = gated(&["read_file"], &[]);
+        off.stages[0]
+            .transitions
+            .as_mut()
+            .unwrap()
+            .get_mut("review")
+            .unwrap()
+            .gate = Some(TransitionGate::default());
+        assert!(off.validate().is_ok());
+        // Neither is an edge with no gate at all.
+        off.stages[0]
+            .transitions
+            .as_mut()
+            .unwrap()
+            .get_mut("review")
+            .unwrap()
+            .gate = None;
+        assert!(off.validate().is_ok());
     }
 
     #[test]
@@ -1453,6 +1593,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         stage.transitions = Some(transitions);
@@ -1472,6 +1613,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         stage.transitions = Some(transitions);
@@ -1495,6 +1637,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         plan.transitions = Some(transitions);
@@ -1517,6 +1660,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         a.transitions = Some(a_transitions);
@@ -1529,6 +1673,7 @@ mod tests {
                 condition: TransitionCondition::Always,
                 hint: None,
                 transform: EdgeTransform::Direct,
+                gate: None,
             },
         );
         b.transitions = Some(b_transitions);

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -543,6 +543,13 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                         }
                     };
 
+                    // Parse the edge gate: `gate = { require_modifications = true, ... }`
+                    // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
+                    let gate = edge_value
+                        .get("gate")
+                        .and_then(|v| v.as_table())
+                        .map(parse_transition_gate);
+
                     transitions.insert(
                         target_name.clone(),
                         TransitionEdge {
@@ -550,6 +557,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                             condition,
                             hint,
                             transform,
+                            gate,
                         },
                     );
                 }
@@ -1018,6 +1026,37 @@ fn parse_region_seed(region_name: &str, value: Option<&toml::Value>) -> Option<R
 /// A present block defaults `taint_tracking` to `true` (block presence implies
 /// intent to configure security); omit the block entirely to inherit the
 /// broader (agent/global) setting.
+/// Parse a transition edge's `gate = { ... }` table. Every key is optional; an
+/// empty table yields a gate that blocks nothing (`require_modifications` off).
+fn parse_transition_gate(table: &toml::value::Table) -> crate::blueprint::TransitionGate {
+    let mut gate = crate::blueprint::TransitionGate::default();
+    if let Some(rm) = table.get("require_modifications").and_then(|v| v.as_bool()) {
+        gate.require_modifications = rm;
+    }
+    if let Some(msg) = table.get("message").and_then(|v| v.as_str()) {
+        gate.message = Some(msg.trim().to_string());
+    }
+    if let Some(region) = table.get("region").and_then(|v| v.as_str()) {
+        gate.region = Some(region.to_string());
+    }
+    if let Some(tools) = table.get("tools").and_then(|v| v.as_array()) {
+        gate.tools = tools
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+    }
+    // A negative budget is a typo, not "never hold the stage" — fall back to the
+    // default rather than silently disabling the gate.
+    if let Some(max) = table
+        .get("max_attempts")
+        .and_then(|v| v.as_integer())
+        .filter(|max| *max >= 0)
+    {
+        gate.max_attempts = Some(max as usize);
+    }
+    gate
+}
+
 fn parse_security_config(security_table: &toml::value::Table) -> crate::SecurityConfig {
     let mut sc = crate::SecurityConfig::default();
     if let Some(tt) = security_table
@@ -2479,6 +2518,84 @@ mode = "autonomous"
     }
 
     #[test]
+    fn parse_manifest_transition_gate_reads_every_key() {
+        let toml = r#"
+[agent]
+name = "gate-test"
+
+[stages.implement]
+mode = "autonomous"
+available_tools = ["write_file"]
+
+[stages.implement.transitions.review]
+hint = "done"
+gate = { require_modifications = true, message = "  write something!  ", region = "implementation", tools = ["patch_file", 7], max_attempts = 2 }
+
+[stages.review]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let gate = bp
+            .find_stage("implement")
+            .unwrap()
+            .transitions
+            .as_ref()
+            .unwrap()["review"]
+            .gate
+            .as_ref()
+            .unwrap();
+        assert!(gate.require_modifications);
+        assert_eq!(gate.message.as_deref(), Some("write something!"));
+        assert_eq!(gate.region.as_deref(), Some("implementation"));
+        // Non-string entries in `tools` are skipped, not an error.
+        assert_eq!(gate.tools, vec!["patch_file".to_string()]);
+        assert_eq!(gate.max_attempts, Some(2));
+    }
+
+    #[test]
+    fn parse_manifest_transition_gate_defaults_and_ignores_wrong_types() {
+        let toml = r#"
+[agent]
+name = "gate-default-test"
+
+[stages.a]
+mode = "autonomous"
+
+[stages.a.transitions.b]
+hint = "no gate here"
+
+[stages.a.transitions.c]
+gate = { require_modifications = "yes", message = 3, region = [], tools = "write_file", max_attempts = -4 }
+
+[stages.b]
+mode = "autonomous"
+
+[stages.c]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let transitions = bp.find_stage("a").unwrap().transitions.as_ref().unwrap();
+        // An edge with no `gate` table has no gate at all.
+        assert!(transitions["b"].gate.is_none());
+        // A gate whose every key is the wrong type — including a negative
+        // attempt budget — falls back to the defaults, i.e. a gate that blocks
+        // nothing rather than one that silently never holds.
+        let gate = transitions["c"].gate.as_ref().unwrap();
+        assert_eq!(gate, &crate::blueprint::TransitionGate::default());
+        // Zero, on the other hand, is a deliberate "record it but never hold".
+        let toml = toml.replace("max_attempts = -4", "max_attempts = 0");
+        let bp = parse_manifest(&toml).unwrap();
+        assert_eq!(
+            bp.find_stage("a").unwrap().transitions.as_ref().unwrap()["c"]
+                .gate
+                .as_ref()
+                .unwrap()
+                .max_attempts,
+            Some(0)
+        );
+    }
+
+    #[test]
     fn parse_manifest_stage_accepts_messages_false() {
         let toml = r#"
 [agent]
@@ -2748,6 +2865,62 @@ mode = "autonomous"
         assert!(transitions.contains_key("plan"));
         // self-looping 'plan' stage must cap max_revisits.
         assert!(plan.max_revisits.is_some());
+    }
+
+    /// Issue #107: an implement stage that can leave without having written
+    /// anything is how a run ends up with no output at all. Every non-error edge
+    /// out of `implement` must carry a `require_modifications` gate, and the
+    /// write tools must be routed into the region that gate points at (which is
+    /// also what the reviewer is told to read).
+    #[test]
+    fn shipped_coding_agents_gate_every_non_error_implement_edge() {
+        for manifest_content in [
+            include_str!("../../../agents/coder/agent.leviath"),
+            include_str!("../../../agents/software-engineer/agent.leviath"),
+        ] {
+            let bp = parse_manifest(manifest_content).unwrap();
+            bp.validate().unwrap();
+            let implement = bp.find_stage("implement").unwrap();
+            assert!(
+                implement.available_tools.iter().any(|t| t == "write_file")
+                    && implement.available_tools.iter().any(|t| t == "edit_file"),
+                "{}: implement must advertise both write tools",
+                bp.name
+            );
+            let transitions = implement.transitions.as_ref().unwrap();
+            for (target, edge) in transitions {
+                if edge.condition == crate::blueprint::TransitionCondition::Error {
+                    continue; // recovery must stay reachable from a failed stage
+                }
+                assert!(
+                    edge.gate.is_some(),
+                    "{}: implement → {target} has no gate",
+                    bp.name
+                );
+                let gate = edge.gate.as_ref().unwrap();
+                assert!(gate.require_modifications, "{}: → {target}", bp.name);
+                assert_eq!(
+                    gate.region.as_deref(),
+                    Some("implementation"),
+                    "{}: → {target} must accept the persisted region as evidence",
+                    bp.name
+                );
+            }
+            // ...and the writes actually land in that region.
+            let overrides = &implement
+                .tool_result_routing
+                .as_ref()
+                .expect("implement must route tool results")
+                .tool_overrides;
+            for tool in ["write_file", "edit_file"] {
+                assert_eq!(
+                    overrides.get(tool).map(String::as_str),
+                    Some("implementation"),
+                    "{}: {tool} results must persist in `implementation`",
+                    bp.name
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -102,6 +102,56 @@ pub struct RunMeta {
     /// (0 when it has none). Restores `SubAgentChildren::max_child_depth`.
     #[serde(default)]
     pub max_child_depth: usize,
+    /// Why this run may have produced nothing useful — see [`RunFlags`].
+    #[serde(default)]
+    pub flags: RunFlags,
+}
+
+/// Post-hoc diagnosis of a run's productivity, persisted in `meta.json` so a
+/// harness (or the dashboard) can tell an empty run from a successful one
+/// without inspecting the workspace or parsing logs.
+///
+/// Issue #107: 13/300 SWE-bench runs completed their whole stage pipeline and
+/// produced no file changes at all. Nothing on disk said so, or said why.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RunFlags {
+    /// Paths passed to file-modifying tools that succeeded, in first-touch
+    /// order. Capped at [`MAX_TRACKED_MODIFIED_FILES`]; `modified_file_count`
+    /// keeps the true total.
+    #[serde(default)]
+    pub modified_files: Vec<String>,
+    /// Total successful file-modifying tool calls across the run (uncapped).
+    #[serde(default)]
+    pub modified_file_count: usize,
+    /// The run reached a terminal status having modified nothing.
+    #[serde(default)]
+    pub empty_output: bool,
+    /// How many stages exhausted their `max_iterations`.
+    #[serde(default)]
+    pub max_iterations_hit: usize,
+    /// How many transitions proceeded past an unsatisfied gate because the
+    /// gate's re-run budget ran out.
+    #[serde(default)]
+    pub gates_forced: usize,
+    /// The working directory disappeared mid-run.
+    #[serde(default)]
+    pub workspace_lost: bool,
+}
+
+/// How many distinct modified paths [`RunFlags`] records before it stops
+/// growing (the count keeps rising). Bounds `meta.json` for a long run.
+pub const MAX_TRACKED_MODIFIED_FILES: usize = 200;
+
+impl RunFlags {
+    /// Record a successful modifying tool call on `path`.
+    pub fn record_modification(&mut self, path: &str) {
+        self.modified_file_count += 1;
+        if self.modified_files.len() < MAX_TRACKED_MODIFIED_FILES
+            && !self.modified_files.iter().any(|p| p == path)
+        {
+            self.modified_files.push(path.to_string());
+        }
+    }
 }
 
 impl RunMeta {
@@ -144,6 +194,7 @@ impl RunMeta {
             children: Vec::new(),
             depth: 0,
             max_child_depth: 0,
+            flags: RunFlags::default(),
         }
     }
 
@@ -419,6 +470,44 @@ mod tests {
         assert_eq!(StageRunStatus::WaitingInput.to_string(), "WaitingInput");
         assert_eq!(StageRunStatus::Complete.to_string(), "Complete");
         assert_eq!(StageRunStatus::Error.to_string(), "Error");
+    }
+
+    #[test]
+    fn run_flags_record_modification_dedups_paths_and_caps_the_list() {
+        let mut flags = RunFlags::default();
+        flags.record_modification("src/a.rs");
+        flags.record_modification("src/a.rs");
+        flags.record_modification("src/b.rs");
+        assert_eq!(flags.modified_file_count, 3);
+        assert_eq!(flags.modified_files, vec!["src/a.rs", "src/b.rs"]);
+
+        // Past the cap the count keeps rising but the list stops growing, so a
+        // long run can't bloat meta.json.
+        for i in 0..MAX_TRACKED_MODIFIED_FILES {
+            flags.record_modification(&format!("f{i}.rs"));
+        }
+        assert_eq!(flags.modified_files.len(), MAX_TRACKED_MODIFIED_FILES);
+        assert_eq!(flags.modified_file_count, 3 + MAX_TRACKED_MODIFIED_FILES);
+    }
+
+    #[test]
+    fn run_meta_flags_default_for_older_files() {
+        // meta.json written before #107 has no `flags` key at all.
+        let mut meta = RunMeta::new(
+            "r".to_string(),
+            "a".to_string(),
+            "/p".to_string(),
+            "t".to_string(),
+            None,
+            "/w".to_string(),
+            1,
+        );
+        meta.flags.empty_output = true;
+        let json = serde_json::to_string(&meta).unwrap();
+        let stripped = json.replace(r#","flags":{"modified_files":[],"modified_file_count":0,"empty_output":true,"max_iterations_hit":0,"gates_forced":0,"workspace_lost":false}"#, "");
+        assert!(!stripped.contains("flags"));
+        let back: RunMeta = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(back.flags, RunFlags::default());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -84,6 +84,19 @@ pub struct AwaitingInteraction;
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct GateAutoApprove;
 
+/// `--yolo`'s counterpart for blueprint-declared interaction points: approve
+/// them without opening a prompt.
+///
+/// A stage-boundary checkpoint (`plan_approval` and friends) blocks on the
+/// interaction hub exactly like a tool approval does, so an unattended run
+/// would park at the first one forever — the same dead end issue #107 is about,
+/// reached a different way. When present,
+/// [`dispatch_interaction_point`](crate::interaction_points::dispatch_interaction_point)
+/// still publishes the document to its region (so the decision is inspectable
+/// afterwards) but resolves the point as approved.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct InteractionAutoApprove;
+
 /// Status of an agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum AgentStatus {

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -110,6 +110,50 @@ pub trait InteractionBackend: Send + Sync {
     }
 }
 
+/// What an unattended run tells the model when a question needed a person.
+pub const UNATTENDED_NO_ANSWER: &str =
+    "[unattended run] No user was available to answer (--yolo). Decide for yourself and continue.";
+
+/// The answer an unattended run (`--yolo`) gives a request nobody is there to
+/// see.
+///
+/// `--yolo` means "run without a human", so a prompt that blocks on one would
+/// park the run forever — a headless run would hang at the first
+/// `ask_user_confirm` (issue #107).
+///
+/// A confirmation is approved: that is exactly what the flag promises. A
+/// *choice* is deliberately **not** made — picking option 0 unseen could select
+/// "Abort" or a destructive branch — so the model is told no one answered and
+/// left to decide. An edit submits the document unchanged, and a document put up
+/// for review is acknowledged without comment (a review is a `FreeText` request
+/// carrying a `body`; a question is one without).
+pub fn unattended_answer(req: &InteractionRequest) -> InteractionResponse {
+    use leviath_core::interaction::InteractionKind;
+    match req.kind {
+        InteractionKind::Confirm | InteractionKind::ToolApproval => {
+            InteractionResponse::approval(&req.id, true, ApprovalScope::Once)
+        }
+        InteractionKind::EditText => {
+            InteractionResponse::text(&req.id, req.body.clone().unwrap_or_default())
+        }
+        InteractionKind::FreeText if req.body.is_some() => InteractionResponse::text(&req.id, ""),
+        InteractionKind::FreeText | InteractionKind::MultipleChoice => {
+            InteractionResponse::text(&req.id, UNATTENDED_NO_ANSWER)
+        }
+    }
+}
+
+/// An [`InteractionBackend`] for unattended runs: answers every request from
+/// [`unattended_answer`] instead of opening a prompt on the hub.
+pub struct UnattendedInteraction;
+
+#[async_trait]
+impl InteractionBackend for UnattendedInteraction {
+    async fn ask(&self, req: InteractionRequest) -> InteractionResponse {
+        unattended_answer(&req)
+    }
+}
+
 /// Dispatch a single dynamic-interaction tool call.
 ///
 /// Returns `Some(result_string)` if `tool_name` is one of
@@ -879,5 +923,87 @@ mod tests {
             text_asker,
         );
         assert_eq!(r, GateResolution::AllowOnce);
+    }
+
+    // ── unattended (--yolo) answers ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn unattended_answers_every_prompt_without_a_hub() {
+        // Issue #107: `--yolo` means "run without a human", so a prompt that
+        // waits for one parks the run forever. Every dynamic-interaction tool
+        // must come back with something the model can act on.
+        let backend = UnattendedInteraction;
+
+        // A confirmation is approved — that is what the flag promises.
+        let confirmed = dispatch_dynamic_interaction(
+            &backend,
+            "ask_user_confirm",
+            "c1",
+            &serde_json::json!({"prompt": "Delete the branch?"}),
+            "implement",
+        )
+        .await
+        .unwrap();
+        assert_eq!(confirmed, "User answered: Yes");
+
+        // A *choice* is deliberately left unmade: picking an option unseen could
+        // select "Abort" or a destructive branch, so the model is told nobody
+        // answered and decides for itself.
+        let chosen = dispatch_dynamic_interaction(
+            &backend,
+            "ask_user_choice",
+            "c2",
+            &serde_json::json!({"prompt": "Which?", "options": ["Ship it", "Abort"]}),
+            "implement",
+        )
+        .await
+        .unwrap();
+        assert!(chosen.contains(UNATTENDED_NO_ANSWER), "got: {chosen}");
+        assert!(!chosen.contains("Abort"), "no option may be picked blind");
+
+        // Free text says so plainly.
+        let answered = dispatch_dynamic_interaction(
+            &backend,
+            "ask_user_text",
+            "c3",
+            &serde_json::json!({"prompt": "Which database?"}),
+            "implement",
+        )
+        .await
+        .unwrap();
+        assert_eq!(answered, UNATTENDED_NO_ANSWER);
+
+        // A review is acknowledged, and an edit submits the document unchanged.
+        let reviewed = dispatch_dynamic_interaction(
+            &backend,
+            "present_for_review",
+            "c4",
+            &serde_json::json!({"title": "Plan", "markdown": "# Plan"}),
+            "plan",
+        )
+        .await
+        .unwrap();
+        assert!(reviewed.contains("acknowledged"), "got: {reviewed}");
+
+        let edited = dispatch_dynamic_interaction(
+            &backend,
+            "edit_document",
+            "c5",
+            &serde_json::json!({"content": "keep me"}),
+            "plan",
+        )
+        .await
+        .unwrap();
+        assert!(edited.contains("keep me"), "got: {edited}");
+    }
+
+    #[test]
+    fn unattended_answer_approves_a_tool_approval() {
+        // The tool-policy layer normally short-circuits these under --yolo, so
+        // cover the arm directly.
+        let req = InteractionRequest::tool_approval("t1", "shell", serde_json::json!({}), "impl");
+        let resp = unattended_answer(&req);
+        assert!(leviath_core::interaction::response_approved(&resp));
+        assert_eq!(resp.scope, Some(ApprovalScope::Once));
     }
 }

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -821,15 +821,38 @@ impl WorldHost {
         match op {
             ControlOp::Spawn { args, reply } => {
                 let result = match self.spawner.as_mut() {
-                    Some(spawner) => match spawner(&mut self.world, &args) {
-                        Ok(entity) => {
-                            self.by_run_id.insert(args.run_id.clone(), entity);
-                            Ok(args.run_id)
+                    // Spawning runs outside the pipeline schedule, so it isn't
+                    // covered by `run_isolated`'s panic guard: a panic while
+                    // parsing a blueprint or building a sandbox would otherwise
+                    // unwind the whole serve task and take the daemon with it.
+                    // As with `run_isolated`, the world may be left holding a
+                    // partially-built entity — the run just never registers.
+                    Some(spawner) => {
+                        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            spawner(&mut self.world, &args)
+                        })) {
+                            Ok(Ok(entity)) => {
+                                self.by_run_id.insert(args.run_id.clone(), entity);
+                                Ok(args.run_id.clone())
+                            }
+                            Ok(Err(e)) => Err(e),
+                            Err(_) => Err("agent spawn panicked".to_string()),
                         }
-                        Err(e) => Err(e),
-                    },
+                    }
                     None => Err("this daemon cannot spawn agents".to_string()),
                 };
+                // A failed spawn used to be invisible daemon-side: the error went
+                // back over the socket to a client that has already exited, and
+                // nothing was written to disk (issue #107).
+                if let Err(error) = &result {
+                    tracing::error!(
+                        run_id = %args.run_id,
+                        blueprint = %args.blueprint_path,
+                        workdir = %args.workdir,
+                        error = %error,
+                        "agent spawn failed"
+                    );
+                }
                 let _ = reply.send(result);
             }
             ControlOp::Status { run_id, reply } => {
@@ -1261,6 +1284,29 @@ mod tests {
         })
         .await;
         assert_eq!(result, Err("bad blueprint".to_string()));
+    }
+
+    #[tokio::test]
+    async fn spawn_op_contains_a_panicking_spawner() {
+        // A panic while building an agent (bad manifest, sandbox blow-up) must
+        // not unwind the daemon's serve task — the run just fails to start.
+        let mut host = host_with(vec![]);
+        host.set_spawner(Box::new(|_world, _args| panic!("simulated spawn panic")));
+        let (tx, rx) = oneshot::channel();
+        crate::test_support::with_silenced_panics(|| {
+            host.handle(ControlOp::Spawn {
+                args: Box::new(SpawnArgs::default()),
+                reply: tx,
+            });
+        });
+        assert_eq!(rx.await.unwrap(), Err("agent spawn panicked".to_string()));
+        // The host is still usable afterwards, and the run never registered.
+        let status = ask(&mut host, |reply| ControlOp::Status {
+            run_id: SpawnArgs::default().run_id,
+            reply,
+        })
+        .await;
+        assert!(status.is_none());
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -61,7 +61,10 @@ pub struct SpawnArgs {
     /// Optional shared secret for HMAC-SHA256 signing the webhook body.
     #[serde(default)]
     pub callback_secret: Option<String>,
-    /// Approve every tool call for this run (the `--yolo` launch override).
+    /// Run this agent unattended (the `--yolo` launch override): approve every
+    /// tool call, waive the taint gate, and auto-answer the agent's own prompts
+    /// (`ask_user_*`, blueprint interaction points) rather than parking on the
+    /// interaction hub for a person who isn't there.
     #[serde(default)]
     pub yolo: bool,
     /// Tools to allow outright for this run (the `--allow` launch override).

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -440,6 +440,7 @@ pub fn dispatch_interaction_point(
             Option<&InteractionPointCursor>,
             Option<&InteractionPointRounds>,
             Option<&PlanBodyOverride>,
+            Option<&crate::components::InteractionAutoApprove>,
         ),
         With<ReadyForInteractionPoint>,
     >,
@@ -451,7 +452,7 @@ pub fn dispatch_interaction_point(
     let (Some(hub), Some(stage)) = (hub, stage) else {
         return; // no lane wired (test world)
     };
-    for (entity, state, bp, cursor, infer, mut window, pc, rounds, plan_override) in
+    for (entity, state, bp, cursor, infer, mut window, pc, rounds, plan_override, auto_approve) in
         agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -488,6 +489,29 @@ pub fn dispatch_interaction_point(
             };
             let tokens = content.len() / 4 + 1;
             window.replace_region(region, content, tokens);
+        }
+        // An unattended run (`--yolo`) approves the checkpoint instead of
+        // opening a prompt nobody will answer. The document was published to its
+        // region above, so what was approved is still on the record.
+        if auto_approve.is_some() {
+            tracing::info!(
+                agent = %state.agent_id,
+                point = %point.name,
+                "auto-approving interaction point (unattended run)"
+            );
+            let _ = stage.outcomes.send(InteractionPointOutcome {
+                entity,
+                decision: PointOutcome::Approve {
+                    user_text: String::new(),
+                },
+            });
+            stage.wake.notify_one();
+            commands
+                .entity(entity)
+                .remove::<ReadyForInteractionPoint>()
+                .remove::<PlanBodyOverride>()
+                .insert(AwaitingInteractionPoint);
+            continue;
         }
         stage.runtime.spawn(run_interaction_point(
             entity,
@@ -1031,6 +1055,57 @@ mod tests {
             .get_region("plan")
             .unwrap();
         assert_eq!(plan.content.len(), 1);
+        assert_eq!(plan.content[0].content, "the plan");
+    }
+
+    #[tokio::test]
+    async fn dispatch_auto_approves_an_unattended_run_without_asking() {
+        // `--yolo` means nobody is watching, so a stage-boundary checkpoint must
+        // resolve itself rather than park the run on the hub forever (#107).
+        let hub = InteractionHub::new();
+        let (tx, mut rx) = unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(hub.clone());
+        world.insert_resource(InteractionPointStage {
+            outcomes: tx,
+            wake: Arc::new(Notify::new()),
+            runtime: Handle::current(),
+        });
+        let e = world
+            .spawn((
+                agent_state(AgentStatus::Active),
+                blueprint_with(vec![plan_point()]),
+                window_with_plan(),
+                StageCursor { index: 0 },
+                infer("the plan"),
+                ReadyForInteractionPoint,
+                crate::components::InteractionAutoApprove,
+            ))
+            .id();
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_interaction_point);
+        s.run(&mut world);
+
+        assert!(world.get::<AwaitingInteractionPoint>(e).is_some());
+        assert!(world.get::<ReadyForInteractionPoint>(e).is_none());
+        // Approved straight onto the outcome lane; no prompt was ever opened.
+        let outcome = rx.try_recv().expect("an outcome was published");
+        assert_eq!(outcome.entity, e);
+        assert!(matches!(
+            outcome.decision,
+            PointOutcome::Approve { ref user_text } if user_text.is_empty()
+        ));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(hub.pending().is_empty(), "no human was asked");
+        // The approved document still landed in its region, so what was waved
+        // through is on the record.
+        let plan = world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("plan")
+            .unwrap();
         assert_eq!(plan.content[0].content, "the plan");
     }
 

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -64,6 +64,14 @@ pub struct TokenTotals {
     pub tool_calls: usize,
 }
 
+/// Run-scoped productivity flags, mirrored into `meta.json` so an empty run can
+/// be recognized (and explained) from disk. Unlike [`StageProgress`], this is
+/// never reset on a stage transition — it describes the whole run.
+///
+/// [`StageProgress`]: crate::pipeline::StageProgress
+#[derive(Component, Clone, Default, Debug, PartialEq)]
+pub struct RunOutcomeFlags(pub leviath_core::run_meta::RunFlags);
+
 impl TokenTotals {
     /// Add one inference response's usage to the running totals.
     pub fn add_usage(&mut self, usage: &leviath_providers::TokenUsage) {
@@ -145,15 +153,25 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
 /// Build the run metadata (`meta.json`) from an agent's live components, stamping
 /// `updated_at` with `now_secs`. `stage_index` is the agent's current stage
 /// position within its blueprint.
+#[allow(clippy::too_many_arguments)]
 pub fn build_run_meta(
     md: &RunMetadata,
     state: &AgentState,
     totals: &TokenTotals,
+    flags: &RunOutcomeFlags,
     stage_index: usize,
     now_secs: i64,
     depth: usize,
     max_child_depth: usize,
 ) -> RunMeta {
+    // `empty_output` is only meaningful once the run has stopped: a running
+    // agent that hasn't written anything *yet* is not an empty run.
+    let status = run_status_from(&state.status);
+    let mut flags = flags.0.clone();
+    flags.empty_output = matches!(
+        status,
+        RunStatus::Complete | RunStatus::Error | RunStatus::Cancelled
+    ) && flags.modified_file_count == 0;
     RunMeta {
         run_id: md.run_id.clone(),
         agent_name: md.agent_name.clone(),
@@ -161,7 +179,7 @@ pub fn build_run_meta(
         task: md.task.clone(),
         model: md.model.clone(),
         pid: 0, // no per-run worker process in the shared world
-        status: run_status_from(&state.status),
+        status,
         current_stage: state.current_stage.clone(),
         stage_index,
         num_stages: md.num_stages,
@@ -187,6 +205,7 @@ pub fn build_run_meta(
         children: state.spawned_children_ids.clone(),
         depth,
         max_child_depth,
+        flags,
     }
 }
 
@@ -314,7 +333,16 @@ mod tests {
         };
         let mut st = state(AgentStatus::Active);
         st.spawned_children_ids = vec!["child-a".to_string(), "child-b".to_string()];
-        let meta = build_run_meta(&md, &st, &totals, 1, 2000, 1, 4);
+        let meta = build_run_meta(
+            &md,
+            &st,
+            &totals,
+            &RunOutcomeFlags::default(),
+            1,
+            2000,
+            1,
+            4,
+        );
 
         assert_eq!(meta.run_id, "run-1");
         assert_eq!(meta.status, RunStatus::Running);
@@ -338,6 +366,62 @@ mod tests {
     }
 
     #[test]
+    fn build_run_meta_flags_empty_output_only_once_the_run_has_stopped() {
+        let mut flags = RunOutcomeFlags::default();
+        flags.0.gates_forced = 2;
+        // Still running with nothing written: not (yet) an empty run.
+        let running = build_run_meta(
+            &metadata(),
+            &state(AgentStatus::Active),
+            &TokenTotals::default(),
+            &flags,
+            0,
+            1000,
+            0,
+            0,
+        );
+        assert!(!running.flags.empty_output);
+        assert_eq!(running.flags.gates_forced, 2);
+
+        // Finished with nothing written: that is the #107 signature.
+        for status in [
+            AgentStatus::Complete,
+            AgentStatus::Cancelled,
+            AgentStatus::Error {
+                message: "x".to_string(),
+            },
+        ] {
+            let meta = build_run_meta(
+                &metadata(),
+                &state(status),
+                &TokenTotals::default(),
+                &flags,
+                0,
+                1000,
+                0,
+                0,
+            );
+            assert!(meta.flags.empty_output);
+        }
+
+        // Finished having written something: not empty.
+        let mut wrote = RunOutcomeFlags::default();
+        wrote.0.record_modification("src/a.rs");
+        let meta = build_run_meta(
+            &metadata(),
+            &state(AgentStatus::Complete),
+            &TokenTotals::default(),
+            &wrote,
+            0,
+            1000,
+            0,
+            0,
+        );
+        assert!(!meta.flags.empty_output);
+        assert_eq!(meta.flags.modified_files, vec!["src/a.rs".to_string()]);
+    }
+
+    #[test]
     fn build_run_meta_carries_error_message() {
         let meta = build_run_meta(
             &metadata(),
@@ -345,6 +429,7 @@ mod tests {
                 message: "boom".to_string(),
             }),
             &TokenTotals::default(),
+            &RunOutcomeFlags::default(),
             2,
             3000,
             0,

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -414,6 +414,17 @@ pub struct StageProgress {
     /// Inferences run in this stage (per-stage, unlike the run-cumulative
     /// `AgentState.iteration`), for enforcing the stage's `max_iterations`.
     pub iterations: usize,
+    /// Successful file-modifying tool calls (`write_file`/`edit_file`, plus any
+    /// tool named by an outgoing gate) made in this stage. Read by the
+    /// transition gate to enforce `require_modifications`.
+    pub modifying_tool_calls: usize,
+    /// Modifying tool calls the permission layer refused (`[denied] ...`). A
+    /// gate lets the transition through when this is non-zero: the agent is
+    /// trying to write and cannot, so re-running the stage only burns budget.
+    pub blocked_modification_calls: usize,
+    /// How many times a transition gate has already sent this stage back for
+    /// another pass. Bounded by the gate's `max_attempts`.
+    pub gate_reentries: usize,
 }
 
 /// How a stage ended, when that governs the transition. Absent ⇒ the stage
@@ -1118,6 +1129,82 @@ fn apply_file_tracking(
     }
 }
 
+/// The tool names that count as a file modification for the agent's current
+/// stage: the built-in [`MODIFYING_TOOLS`](leviath_core::blueprint::MODIFYING_TOOLS)
+/// plus any extra names declared by that stage's outgoing transition gates (for
+/// agents whose writes go through MCP or script tools). All canonical, so a
+/// `bash`-style alias in a gate's `tools` list still matches its real tool.
+fn stage_modifying_tools(
+    blueprint: Option<&AgentBlueprint>,
+    cursor: Option<&StageCursor>,
+) -> Vec<String> {
+    let mut names: Vec<String> = leviath_core::blueprint::MODIFYING_TOOLS
+        .iter()
+        .map(|t| (*t).to_string())
+        .collect();
+    let (Some(bp), Some(cursor)) = (blueprint, cursor) else {
+        return names;
+    };
+    let Some(stage) = bp.0.stages.get(cursor.index) else {
+        return names;
+    };
+    let Some(transitions) = &stage.transitions else {
+        return names;
+    };
+    for edge in transitions.values() {
+        let Some(gate) = &edge.gate else { continue };
+        for tool in &gate.tools {
+            let canonical = leviath_tools::canonical_tool_name(tool).to_string();
+            if !names.contains(&canonical) {
+                names.push(canonical);
+            }
+        }
+    }
+    names
+}
+
+/// Tally this batch's file-modifying tool calls onto the stage's progress and the
+/// run's outcome flags. A result prefixed `[denied]` (permission layer) counts as
+/// *blocked* rather than successful — the agent tried and was refused, which a
+/// gate treats differently from never having tried. `[error]` results (the write
+/// itself failed) count as neither.
+fn record_modifications(
+    tool_calls: &[crate::components::ToolCall],
+    merged: &[(String, String)],
+    modifying: &[String],
+    progress: Option<bevy_ecs::prelude::Mut<'_, StageProgress>>,
+    flags: Option<bevy_ecs::prelude::Mut<'_, crate::persistence::RunOutcomeFlags>>,
+) {
+    let mut progress = progress;
+    let mut flags = flags;
+    for (call, (_id, result)) in tool_calls.iter().zip(merged.iter()) {
+        let canonical = leviath_tools::canonical_tool_name(&call.name);
+        if !modifying.iter().any(|t| t == canonical) {
+            continue;
+        }
+        if result.starts_with("[denied]") {
+            if let Some(progress) = progress.as_mut() {
+                progress.blocked_modification_calls += 1;
+            }
+            continue;
+        }
+        if result.starts_with("[error]") {
+            continue;
+        }
+        if let Some(progress) = progress.as_mut() {
+            progress.modifying_tool_calls += 1;
+        }
+        if let Some(flags) = flags.as_mut() {
+            let path = call
+                .arguments
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<unknown>");
+            flags.0.record_modification(path);
+        }
+    }
+}
+
 /// Tool-collect system: drain finished tool batches and apply them. Results are
 /// written into the agent's context window (routing/truncation/taint honored)
 /// and the agent loops back to `ReadyToInfer`. Outcomes for agents no longer
@@ -1136,6 +1223,8 @@ pub fn collect_tools(
             Option<&mut StageIoBuffer>,
             Option<&AgentBlueprint>,
             Option<&mut crate::repetition::RepetitionDetector>,
+            Option<&mut StageProgress>,
+            Option<&mut crate::persistence::RunOutcomeFlags>,
         ),
         With<AwaitingTools>,
     >,
@@ -1153,6 +1242,8 @@ pub fn collect_tools(
             buffer,
             blueprint,
             repetition,
+            progress,
+            flags,
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -1165,6 +1256,17 @@ pub fn collect_tools(
             parts.extend(ctx.0.iter().cloned());
         }
         let mut merged = merge_in_call_order(&infer.tool_calls, &parts);
+        // Modification accounting (issue #107): count the file-writing calls this
+        // stage actually landed, so a `require_modifications` transition gate can
+        // tell "analyzed the code and wrote nothing" from "made the change".
+        // Done before file tracking, which rewrites successful results.
+        record_modifications(
+            &infer.tool_calls,
+            &merged,
+            &stage_modifying_tools(blueprint, cursor),
+            progress,
+            flags,
+        );
         // File tracking: sync read/write results into the configured HashMap
         // region and replace the inline result with a reference (de-dup context).
         if let Some(ft) = blueprint.and_then(|bp| bp.0.file_tracking.as_ref()) {
@@ -1672,6 +1774,7 @@ pub fn dispatch_persistence(
             Option<&crate::interaction_points::AwaitingInteractionPoint>,
             Option<&crate::interaction_points::InteractionPointCursor>,
             Option<&crate::interaction_points::InteractionPointRounds>,
+            Option<&crate::persistence::RunOutcomeFlags>,
         ),
     )>,
     stage: Res<PersistenceStage>,
@@ -1693,7 +1796,7 @@ pub fn dispatch_persistence(
         parent_ref,
         children,
         fan_out_waiting,
-        (awaiting_point, ip_cursor, ip_rounds),
+        (awaiting_point, ip_cursor, ip_rounds, outcome_flags),
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -1741,7 +1844,17 @@ pub fn dispatch_persistence(
         // Tree links, for a deterministic restart-time rebuild of the graph.
         let depth = parent_ref.map(|p| p.depth).unwrap_or(0);
         let max_child_depth = children.map(|c| c.max_child_depth).unwrap_or(0);
-        let meta = build_run_meta(md, state, totals, cursor.index, now, depth, max_child_depth);
+        let flags = outcome_flags.cloned().unwrap_or_default();
+        let meta = build_run_meta(
+            md,
+            state,
+            totals,
+            &flags,
+            cursor.index,
+            now,
+            depth,
+            max_child_depth,
+        );
         let context = build_context_snapshot(window, &state.current_stage);
         let stages = ledger.as_deref().map(|l| l.0.clone()).unwrap_or_default();
         // Persist the taint gate's audit log (per-stage) when it has events, so
@@ -1904,8 +2017,13 @@ enum StageResolution {
     /// The stage errored and has no `error` edge — terminate the run as errored,
     /// preserving the error status the collect system already set.
     TerminalError,
-    /// Advance to this stage index, applying the edge's context transform.
-    Next(usize, leviath_core::blueprint::EdgeTransform),
+    /// Advance to this stage index, applying the edge's context transform once
+    /// the edge's gate (if any) is satisfied.
+    Next(
+        usize,
+        leviath_core::blueprint::EdgeTransform,
+        Option<leviath_core::blueprint::TransitionGate>,
+    ),
     /// Multiple candidate edges — an LLM must choose among them.
     Choose(Vec<leviath_core::blueprint::TransitionEdge>),
 }
@@ -1935,31 +2053,92 @@ fn find_conditioned_edge(
     })
 }
 
-/// Max-iterations guard: for each `ReadyToInfer` agent whose per-stage inference
-/// count has reached the stage's `max_iterations`, end the stage (routing to a
-/// `max_iterations` edge if one exists, else a normal transition) instead of
-/// running another inference. Ported from the imperative `run_autonomous` cap.
-pub fn enforce_max_iterations(
-    agents: Query<
+/// How often (in per-stage iterations) [`check_workspace_health`] stats the
+/// agent's working directory. One `metadata` call every few iterations is far
+/// cheaper than the tool failures it replaces.
+pub const WORKSPACE_CHECK_INTERVAL: usize = 5;
+
+/// Workspace health guard: fail a run whose working directory has disappeared.
+///
+/// Issue #107: an external harness deleted the workspace out from under running
+/// agents, which then spent every remaining iteration collecting
+/// `No such file or directory` from their tools — 16-17 of them in the observed
+/// runs — with no way back. Nothing can recreate a deleted checkout from inside
+/// the agent, so this stops immediately with a message that names the real
+/// problem, instead of routing to error recovery to flail more cheaply.
+#[allow(clippy::type_complexity)]
+pub fn check_workspace_health(
+    mut agents: Query<
         (
             Entity,
-            &AgentState,
-            &AgentBlueprint,
-            &StageCursor,
+            &RunMetadata,
             &StageProgress,
+            &mut AgentState,
+            Option<&mut crate::persistence::RunOutcomeFlags>,
         ),
         With<ReadyToInfer>,
     >,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, state, bp, cursor, progress) in agents.iter() {
+    for (entity, md, progress, mut state, flags) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        if state.status != AgentStatus::Active {
+            continue;
+        }
+        if progress.iterations % WORKSPACE_CHECK_INTERVAL != 0 {
+            continue;
+        }
+        if std::fs::metadata(&md.workdir).is_ok_and(|m| m.is_dir()) {
+            continue;
+        }
+        tracing::error!(
+            run_id = %md.run_id,
+            workdir = %md.workdir,
+            "working directory is gone; failing the run"
+        );
+        state.status = AgentStatus::Error {
+            message: format!("workspace '{}' is no longer accessible", md.workdir),
+        };
+        if let Some(mut flags) = flags {
+            flags.0.workspace_lost = true;
+        }
+        commands.entity(entity).remove::<ReadyToInfer>();
+    }
+}
+
+/// Max-iterations guard: for each `ReadyToInfer` agent whose per-stage inference
+/// count has reached the stage's `max_iterations`, end the stage (routing to a
+/// `max_iterations` edge if one exists, else a normal transition) instead of
+/// running another inference. Ported from the imperative `run_autonomous` cap.
+#[allow(clippy::type_complexity)]
+pub fn enforce_max_iterations(
+    mut agents: Query<
+        (
+            Entity,
+            &AgentState,
+            &AgentBlueprint,
+            &StageCursor,
+            &StageProgress,
+            Option<&mut crate::persistence::RunOutcomeFlags>,
+        ),
+        With<ReadyToInfer>,
+    >,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, state, bp, cursor, progress, flags) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue;
         }
         let max = bp.0.stages[cursor.index].max_iterations.unwrap_or(0);
         if max > 0 && progress.iterations >= max {
+            // Record it on the run: a stage that ran out of iterations is one of
+            // the ways a run ends up with nothing to show (issue #107).
+            if let Some(mut flags) = flags {
+                flags.0.max_iterations_hit += 1;
+            }
             commands
                 .entity(entity)
                 .remove::<ReadyToInfer>()
@@ -1983,10 +2162,12 @@ fn resolve_transition_sync(
     match &stage.transitions {
         None => {
             if stage_idx + 1 < blueprint.stages.len() {
-                // A linear fall-through carries context as-is (Direct).
+                // A linear fall-through carries context as-is (Direct), and has
+                // no edge to hang a gate on.
                 StageResolution::Next(
                     stage_idx + 1,
                     leviath_core::blueprint::EdgeTransform::Direct,
+                    None,
                 )
             } else {
                 StageResolution::Terminal
@@ -2025,7 +2206,11 @@ fn resolve_transition_sync(
                         .iter()
                         .position(|s| s.name == choosable[0].target)
                         .unwrap_or(0);
-                    StageResolution::Next(idx, choosable[0].transform.clone())
+                    StageResolution::Next(
+                        idx,
+                        choosable[0].transform.clone(),
+                        choosable[0].gate.clone(),
+                    )
                 }
                 _ => StageResolution::Choose(choosable.into_iter().cloned().collect()),
             }
@@ -2247,6 +2432,119 @@ pub fn require_context_regions(
     }
 }
 
+/// What a chosen edge's gate says about the transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GateDecision {
+    /// The gate is satisfied (or absent) — follow the edge.
+    Pass,
+    /// The gate is unsatisfied but out of re-run budget — follow the edge and
+    /// record it in the run's flags so the run explains itself afterwards.
+    Forced,
+    /// Hold the agent in this stage and show it this nudge.
+    Block(String),
+}
+
+/// Decide whether a chosen edge's [gate](leviath_core::blueprint::TransitionGate)
+/// blocks the transition.
+///
+/// Issue #107: an agent can read and reason about a codebase entirely through
+/// `shell` and arrive at the review stage having changed nothing, producing a run
+/// with no output. A `require_modifications` gate keeps it in the stage until it
+/// has actually written something.
+///
+/// The gate passes when any of these hold:
+/// - the stage advertises no file-modifying tool (it could never pass, so gating
+///   it would only burn iterations);
+/// - a modifying tool call succeeded in this stage;
+/// - one was refused by the permission layer (the agent is trying and cannot);
+/// - the gate names a region and that region is non-empty (the durable signal:
+///   per-stage counters don't survive a daemon restart, but regions do).
+///
+/// When the gate's re-run budget is spent it gives up loudly, as
+/// [`GateDecision::Forced`].
+fn gate_blocks(
+    gate: Option<&leviath_core::blueprint::TransitionGate>,
+    stage: &leviath_core::Stage,
+    progress: &StageProgress,
+    window: &ContextWindow,
+) -> GateDecision {
+    let Some(gate) = gate else {
+        return GateDecision::Pass;
+    };
+    if !gate.require_modifications {
+        return GateDecision::Pass;
+    }
+    let can_modify = stage.available_tools.iter().any(|t| {
+        let canonical = leviath_tools::canonical_tool_name(t);
+        leviath_core::blueprint::MODIFYING_TOOLS.contains(&canonical)
+            || gate
+                .tools
+                .iter()
+                .any(|extra| leviath_tools::canonical_tool_name(extra) == canonical)
+    });
+    if !can_modify {
+        return GateDecision::Pass;
+    }
+    if progress.modifying_tool_calls > 0 {
+        return GateDecision::Pass;
+    }
+    if progress.blocked_modification_calls > 0 {
+        tracing::warn!(
+            stage = %stage.name,
+            blocked = progress.blocked_modification_calls,
+            "file modifications were denied by policy; letting the gated transition through"
+        );
+        return GateDecision::Pass;
+    }
+    if let Some(region) = &gate.region
+        && window
+            .get_region(region)
+            .is_some_and(|r| !r.content.is_empty())
+    {
+        return GateDecision::Pass;
+    }
+    let cap = gate
+        .max_attempts
+        .unwrap_or(leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS);
+    if progress.gate_reentries >= cap {
+        tracing::warn!(
+            stage = %stage.name,
+            attempts = cap,
+            "stage still has no file modifications after re-run attempts; proceeding"
+        );
+        return GateDecision::Forced;
+    }
+    GateDecision::Block(gate.message.clone().unwrap_or_else(|| {
+        "No file modifications were recorded in this stage. Changes made through the shell \
+         (sed -i, tee, >, >>) are not tracked by the framework. Re-apply your changes with \
+         edit_file or write_file before moving on."
+            .to_string()
+    }))
+}
+
+/// Hold an agent in its current stage after a gate refused the transition: inject
+/// the nudge, count the re-entry, and put it back in front of the model. The
+/// stage is *not* re-entered — `StageProgress` is deliberately preserved so the
+/// stage's `max_iterations` still bounds the loop.
+fn hold_for_gate(
+    entity: Entity,
+    nudge: &str,
+    progress: &mut StageProgress,
+    window: &mut ContextWindow,
+    commands: &mut Commands,
+) {
+    let content = format!("[System] {nudge}");
+    let tokens = content.len() / 4 + 1;
+    let _ = window.add_to_region("conversation", content, tokens);
+    progress.gate_reentries += 1;
+    commands
+        .entity(entity)
+        .remove::<ResolveTransition>()
+        .remove::<AwaitingTransitionResponse>()
+        .remove::<StageOutcome>()
+        .insert(ReadyToInfer);
+}
+
 /// Transition-resolution system: for each `ResolveTransition` agent, resolve the
 /// next stage. Terminal ⇒ mark the agent `Complete`. A single/linear target ⇒
 /// enter the new stage (swap its `StageInference`, reset stage progress, bump the
@@ -2266,6 +2564,7 @@ pub fn resolve_transition(
             &mut VisitCounts,
             &mut ContextWindow,
             Option<&StageOutcome>,
+            Option<&mut crate::persistence::RunOutcomeFlags>,
         ),
         With<ResolveTransition>,
     >,
@@ -2284,6 +2583,7 @@ pub fn resolve_transition(
         mut visits,
         mut window,
         outcome,
+        mut flags,
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -2291,14 +2591,17 @@ pub fn resolve_transition(
         // How the stage ended governs the transition: an error/max-iterations
         // outcome follows its conditioned edge (e.g. → error_recovery) if present.
         let resolution = match outcome {
+            // An error/max-iterations edge is never gated: the stage already
+            // failed, and holding it back to demand file changes would strand a
+            // run that can't make any.
             Some(StageOutcome::Errored(_)) => {
                 find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error)
-                    .map(|(i, t)| StageResolution::Next(i, t))
+                    .map(|(i, t)| StageResolution::Next(i, t, None))
                     .unwrap_or(StageResolution::TerminalError)
             }
             Some(StageOutcome::MaxIterations) => {
                 find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::MaxIterations)
-                    .map(|(i, t)| StageResolution::Next(i, t))
+                    .map(|(i, t)| StageResolution::Next(i, t, None))
                     .unwrap_or_else(|| {
                         resolve_transition_sync(&bp.0, stage, cursor.index, &visits.0)
                     })
@@ -2320,7 +2623,22 @@ pub fn resolve_transition(
                     .remove::<ResolveTransition>()
                     .remove::<StageOutcome>();
             }
-            StageResolution::Next(idx, transform) => {
+            StageResolution::Next(idx, transform, gate) => {
+                // Check the edge's gate BEFORE the transform runs: the transform
+                // compacts/clears regions, and a held stage must keep its context.
+                let gate = outcome.is_none().then_some(gate).flatten();
+                match gate_blocks(gate.as_ref(), stage, &progress, &window) {
+                    GateDecision::Block(nudge) => {
+                        hold_for_gate(entity, &nudge, &mut progress, &mut window, &mut commands);
+                        continue;
+                    }
+                    GateDecision::Forced => {
+                        if let Some(flags) = flags.as_mut() {
+                            flags.0.gates_forced += 1;
+                        }
+                    }
+                    GateDecision::Pass => {}
+                }
                 // Reshape the outgoing context per the edge transform before the
                 // new stage's layout/prompt setup.
                 let to_compact = apply_edge_transform(&mut window, &transform);
@@ -3036,6 +3354,7 @@ pub fn collect_transition_choice(
         &mut VisitCounts,
         &mut ContextWindow,
         &AwaitingTransitionResponse,
+        Option<&mut crate::persistence::RunOutcomeFlags>,
     )>,
     mut commands: Commands,
 ) {
@@ -3051,6 +3370,7 @@ pub fn collect_transition_choice(
             mut visits,
             mut window,
             resp,
+            mut flags,
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -3086,14 +3406,36 @@ pub fn collect_transition_choice(
                         .iter()
                         .position(|s| s.name == target)
                         .unwrap_or(0);
-                // Apply the chosen edge's context transform (Direct when the
-                // matched target has no explicit edge, e.g. a fallback).
-                let transform = resp
-                    .0
-                    .iter()
-                    .find(|e| e.target == target)
-                    .map(|e| e.transform.clone())
-                    .unwrap_or_default();
+                // The chosen edge (absent when the matched target has no explicit
+                // edge, e.g. a fallback — then Direct, ungated).
+                let edge = resp.0.iter().find(|e| e.target == target);
+                let transform = edge.map(|e| e.transform.clone()).unwrap_or_default();
+                // The edge's gate is checked BEFORE its transform runs, so a
+                // held stage keeps the context it still needs.
+                let stage = &bp.0.stages[cursor.index];
+                match gate_blocks(
+                    edge.and_then(|e| e.gate.as_ref()),
+                    stage,
+                    &progress,
+                    &window,
+                ) {
+                    GateDecision::Block(nudge) => {
+                        hold_for_gate(
+                            outcome.entity,
+                            &nudge,
+                            &mut progress,
+                            &mut window,
+                            &mut commands,
+                        );
+                        continue;
+                    }
+                    GateDecision::Forced => {
+                        if let Some(flags) = flags.as_mut() {
+                            flags.0.gates_forced += 1;
+                        }
+                    }
+                    GateDecision::Pass => {}
+                }
                 let to_compact = apply_edge_transform(&mut window, &transform);
                 let setup = &setups.0[idx];
                 match enter_stage(
@@ -4581,6 +4923,7 @@ mod tests {
             total_tool_calls: 2,
             text_only_nudges: 0,
             iterations: 0,
+            ..Default::default()
         };
         let e = world
             .spawn((
@@ -4602,6 +4945,7 @@ mod tests {
             total_tool_calls: 0,
             text_only_nudges: MAX_TEXT_ONLY_NUDGES,
             iterations: 0,
+            ..Default::default()
         };
         let e = world
             .spawn((
@@ -5930,6 +6274,7 @@ mod tests {
                 condition: cond,
                 hint: None,
                 transform: leviath_core::blueprint::EdgeTransform::Direct,
+                gate: None,
             },
         )
     }
@@ -6010,6 +6355,7 @@ mod tests {
                     total_tool_calls: 3,
                     text_only_nudges: 1,
                     iterations: 0,
+                    ..Default::default()
                 },
                 StageInferences(stage_infs),
                 setups(n),
@@ -7142,6 +7488,7 @@ mod tests {
             condition: leviath_core::blueprint::TransitionCondition::Always,
             hint: None,
             transform: EdgeTransform::Clear,
+            gate: None,
         }
     }
 
@@ -7259,12 +7606,29 @@ mod tests {
     fn enforce_max_iterations_caps_at_the_limit() {
         let mut world = World::new();
         let e = spawn_ready_agent(&mut world, Some(3), 3, AgentStatus::Active);
+        world
+            .entity_mut(e)
+            .insert(crate::persistence::RunOutcomeFlags::default());
+        // An agent with no flags component still gets capped; there's just
+        // nowhere to record it.
+        let unflagged = spawn_ready_agent(&mut world, Some(3), 3, AgentStatus::Active);
         run_enforce(&mut world);
+        assert!(world.get::<ResolveTransition>(unflagged).is_some());
         assert!(world.get::<ResolveTransition>(e).is_some());
         assert!(world.get::<ReadyToInfer>(e).is_none());
         assert_eq!(
             world.get::<StageOutcome>(e).unwrap(),
             &StageOutcome::MaxIterations
+        );
+        // The run records it: a stage that ran out of iterations is one way a
+        // run ends up with nothing to show (issue #107).
+        assert_eq!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .max_iterations_hit,
+            1
         );
     }
 
@@ -7648,6 +8012,304 @@ mod tests {
         }
     }
 
+    // ── transition gates: require_modifications (#107) ──
+
+    fn gate(
+        region: Option<&str>,
+        message: Option<&str>,
+    ) -> leviath_core::blueprint::TransitionGate {
+        leviath_core::blueprint::TransitionGate {
+            require_modifications: true,
+            message: message.map(str::to_string),
+            region: region.map(str::to_string),
+            tools: Vec::new(),
+            max_attempts: None,
+        }
+    }
+
+    /// A stage that can write files, with `edges` attached.
+    fn writing_stage(
+        name: &str,
+        edges: Vec<(String, leviath_core::blueprint::TransitionEdge)>,
+    ) -> leviath_core::Stage {
+        let mut s = stage_named(name, Some(edges), false, None);
+        s.available_tools = vec!["write_file".to_string(), "bash".to_string()];
+        s
+    }
+
+    fn gated_edge(
+        target: &str,
+        gate: Option<leviath_core::blueprint::TransitionGate>,
+    ) -> (String, leviath_core::blueprint::TransitionEdge) {
+        (
+            target.to_string(),
+            leviath_core::blueprint::TransitionEdge {
+                target: target.to_string(),
+                condition: leviath_core::blueprint::TransitionCondition::Always,
+                hint: None,
+                transform: leviath_core::blueprint::EdgeTransform::Direct,
+                gate,
+            },
+        )
+    }
+
+    /// The nudge a gate would show, or `None` when it let the transition
+    /// through. A named helper rather than an inline `matches!` so both arms are
+    /// exercised by the assertions below.
+    fn block_message(decision: GateDecision) -> Option<String> {
+        match decision {
+            GateDecision::Block(msg) => Some(msg),
+            GateDecision::Pass | GateDecision::Forced => None,
+        }
+    }
+
+    fn progress_with(modifying: usize, blocked: usize, reentries: usize) -> StageProgress {
+        StageProgress {
+            modifying_tool_calls: modifying,
+            blocked_modification_calls: blocked,
+            gate_reentries: reentries,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn gate_blocks_only_an_unsatisfied_require_modifications_edge() {
+        let stage = writing_stage("impl", vec![gated_edge("review", Some(gate(None, None)))]);
+        let window = conv_window();
+        let zero = progress_with(0, 0, 0);
+        // Unsatisfied ⇒ blocked, with the default explanation.
+        let g = gate(None, None);
+        let msg = block_message(gate_blocks(Some(&g), &stage, &zero, &window))
+            .expect("an unsatisfied require_modifications gate blocks");
+        assert!(msg.contains("edit_file or write_file"));
+        // No gate at all, and a gate that doesn't require modifications, both pass.
+        assert_eq!(
+            gate_blocks(None, &stage, &zero, &window),
+            GateDecision::Pass
+        );
+        let off = leviath_core::blueprint::TransitionGate::default();
+        assert_eq!(
+            gate_blocks(Some(&off), &stage, &zero, &window),
+            GateDecision::Pass
+        );
+        // A landed write satisfies it.
+        assert_eq!(
+            gate_blocks(Some(&g), &stage, &progress_with(1, 0, 0), &window),
+            GateDecision::Pass
+        );
+        // So does a write the permission layer refused: the agent is trying and
+        // cannot, so another pass would only burn iterations.
+        assert_eq!(
+            gate_blocks(Some(&g), &stage, &progress_with(0, 1, 0), &window),
+            GateDecision::Pass
+        );
+    }
+
+    #[test]
+    fn gate_uses_a_custom_message_when_given() {
+        let stage = writing_stage("impl", vec![]);
+        let g = gate(None, Some("write something!"));
+        assert_eq!(
+            gate_blocks(Some(&g), &stage, &progress_with(0, 0, 0), &conv_window()),
+            GateDecision::Block("write something!".to_string())
+        );
+    }
+
+    #[test]
+    fn gate_passes_on_a_non_empty_evidence_region() {
+        // The resume case: per-stage counters are gone after a daemon restart,
+        // but the region the write tools are routed into is restored from disk.
+        let stage = writing_stage("impl", vec![]);
+        let g = gate(Some("implementation"), None);
+        let zero = progress_with(0, 0, 0);
+
+        let mut empty = conv_window();
+        empty.add_region(Region::new(
+            "implementation".to_string(),
+            RegionKind::Clearable,
+            10_000,
+        ));
+        // Region present but empty ⇒ still gated; region missing entirely ⇒ gated.
+        assert!(block_message(gate_blocks(Some(&g), &stage, &zero, &empty)).is_some());
+        assert!(block_message(gate_blocks(Some(&g), &stage, &zero, &conv_window())).is_some());
+
+        let mut filled = empty.clone();
+        filled
+            .add_to_region("implementation", "wrote src/lib.rs".to_string(), 5)
+            .unwrap();
+        assert!(block_message(gate_blocks(Some(&g), &stage, &zero, &filled)).is_none());
+    }
+
+    #[test]
+    fn gate_passes_a_stage_that_cannot_modify_anything() {
+        // Gating a stage with no write tool would loop pointlessly; the blueprint
+        // validator rejects that combination, but the runtime never relies on it.
+        let mut stage = writing_stage("review", vec![]);
+        stage.available_tools = vec!["read_file".to_string()];
+        let g = gate(None, None);
+        assert_eq!(
+            gate_blocks(Some(&g), &stage, &progress_with(0, 0, 0), &conv_window()),
+            GateDecision::Pass
+        );
+        // ...unless the gate itself names the tool the stage does have.
+        let mut custom = gate(None, None);
+        custom.tools = vec!["read_file".to_string()];
+        assert!(
+            block_message(gate_blocks(
+                Some(&custom),
+                &stage,
+                &progress_with(0, 0, 0),
+                &conv_window()
+            ))
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn gate_gives_up_after_its_attempt_budget() {
+        let stage = writing_stage("impl", vec![]);
+        let zero_window = conv_window();
+        // Default budget is 3 re-runs.
+        let g = gate(None, None);
+        assert!(
+            block_message(gate_blocks(
+                Some(&g),
+                &stage,
+                &progress_with(0, 0, 2),
+                &zero_window
+            ))
+            .is_some()
+        );
+        assert_eq!(
+            gate_blocks(Some(&g), &stage, &progress_with(0, 0, 3), &zero_window),
+            GateDecision::Forced
+        );
+        // ...and is overridable per edge.
+        let mut once = gate(None, None);
+        once.max_attempts = Some(1);
+        assert_eq!(
+            gate_blocks(Some(&once), &stage, &progress_with(0, 0, 1), &zero_window),
+            GateDecision::Forced
+        );
+    }
+
+    #[test]
+    fn resolve_transition_holds_the_stage_when_a_gate_blocks() {
+        let bp = blueprint(vec![
+            writing_stage("impl", vec![gated_edge("review", Some(gate(None, None)))]),
+            stage_named("review", None, false, None),
+        ]);
+        let mut world = World::new();
+        let e = spawn_transition_agent(
+            &mut world,
+            bp,
+            vec![si("m0"), si("m1")],
+            VisitCounts::default(),
+        );
+        world
+            .entity_mut(e)
+            .insert(progress_with(0, 0, 0))
+            .insert(crate::persistence::RunOutcomeFlags::default());
+
+        run_transition(&mut world);
+
+        // Still in `impl`, re-armed for another inference, nudged, and counted.
+        assert_eq!(world.get::<StageCursor>(e).unwrap().index, 0);
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(world.get::<ResolveTransition>(e).is_none());
+        assert_eq!(world.get::<StageProgress>(e).unwrap().gate_reentries, 1);
+        let conv = world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .iter()
+            .map(|entry| entry.content.clone())
+            .collect::<String>();
+        assert!(conv.contains("[System] No file modifications"));
+        // Not yet forced — the budget hasn't run out.
+        assert_eq!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .gates_forced,
+            0
+        );
+    }
+
+    #[test]
+    fn resolve_transition_records_a_forced_gate_and_advances() {
+        let bp = blueprint(vec![
+            writing_stage("impl", vec![gated_edge("review", Some(gate(None, None)))]),
+            stage_named("review", None, false, None),
+        ]);
+        let mut world = World::new();
+        let e = spawn_transition_agent(
+            &mut world,
+            bp.clone(),
+            vec![si("m0"), si("m1")],
+            VisitCounts::default(),
+        );
+        world
+            .entity_mut(e)
+            // Budget already spent.
+            .insert(progress_with(0, 0, 3))
+            .insert(crate::persistence::RunOutcomeFlags::default());
+        // An agent with no flags component (fan-out workers, older runs) still
+        // transitions — it just has nowhere to record the forced gate.
+        let unflagged = spawn_transition_agent(
+            &mut world,
+            bp,
+            vec![si("m0"), si("m1")],
+            VisitCounts::default(),
+        );
+        world.entity_mut(unflagged).insert(progress_with(0, 0, 3));
+
+        run_transition(&mut world);
+
+        assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+        assert_eq!(world.get::<StageCursor>(unflagged).unwrap().index, 1);
+        assert_eq!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .gates_forced,
+            1
+        );
+    }
+
+    #[test]
+    fn resolve_transition_skips_the_gate_on_an_error_edge() {
+        use leviath_core::blueprint::TransitionCondition;
+        // The error edge is followed even with zero modifications: a failed stage
+        // must be able to reach recovery.
+        let mut error_edge = gated_edge("recover", Some(gate(None, None)));
+        error_edge.1.condition = TransitionCondition::Error;
+        let bp = blueprint(vec![
+            writing_stage("impl", vec![error_edge]),
+            stage_named("recover", None, false, None),
+        ]);
+        let mut world = World::new();
+        let e = spawn_transition_agent(
+            &mut world,
+            bp,
+            vec![si("m0"), si("m1")],
+            VisitCounts::default(),
+        );
+        world
+            .entity_mut(e)
+            .insert(progress_with(0, 0, 0))
+            .insert(StageOutcome::Errored("boom".to_string()));
+
+        run_transition(&mut world);
+
+        assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+        assert_eq!(world.get::<StageProgress>(e).unwrap().gate_reentries, 0);
+    }
+
     // ── file tracking (#6) ──
 
     fn ftc(
@@ -7825,6 +8487,307 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    // ── modification accounting (#107) ──
+
+    /// Drive `collect_tools` over one batch of `(tool, result)` pairs against a
+    /// stage whose outgoing edge names `extra_tools` as modifying, returning the
+    /// resulting per-stage progress and run flags.
+    fn count_modifications(
+        calls: &[(&str, serde_json::Value, &str)],
+        extra_tools: &[&str],
+    ) -> (StageProgress, leviath_core::run_meta::RunFlags) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolResults(rx));
+        let mut g = gate(None, None);
+        g.tools = extra_tools.iter().map(|t| (*t).to_string()).collect();
+        let bp = blueprint(vec![writing_stage(
+            "impl",
+            vec![gated_edge("review", Some(g))],
+        )]);
+        let e = world
+            .spawn((
+                conv_window(),
+                infer_with(
+                    calls
+                        .iter()
+                        .enumerate()
+                        .map(|(i, (name, args, _))| fcall(&format!("c{i}"), name, args.clone()))
+                        .collect(),
+                ),
+                AwaitingTools,
+                AgentBlueprint(bp),
+                StageCursor { index: 0 },
+                StageProgress::default(),
+                crate::persistence::RunOutcomeFlags::default(),
+            ))
+            .id();
+        tx.send(ToolOutcome {
+            entity: e,
+            results: calls
+                .iter()
+                .enumerate()
+                .map(|(i, (_, _, result))| (format!("c{i}"), (*result).to_string()))
+                .collect(),
+        })
+        .unwrap();
+        run_collect_tools(&mut world);
+        (
+            world.get::<StageProgress>(e).unwrap().clone(),
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .clone(),
+        )
+    }
+
+    #[test]
+    fn collect_tools_counts_successful_writes_and_their_paths() {
+        let (progress, flags) = count_modifications(
+            &[
+                (
+                    "write_file",
+                    serde_json::json!({"path": "src/a.rs"}),
+                    "Successfully wrote 12 bytes to 'src/a.rs'",
+                ),
+                (
+                    "edit_file",
+                    serde_json::json!({"path": "src/b.rs"}),
+                    "Successfully edited 'src/b.rs'",
+                ),
+                // Same path twice: counted twice, listed once.
+                (
+                    "edit_file",
+                    serde_json::json!({"path": "src/b.rs"}),
+                    "Successfully edited 'src/b.rs'",
+                ),
+            ],
+            &[],
+        );
+        assert_eq!(progress.modifying_tool_calls, 3);
+        assert_eq!(progress.blocked_modification_calls, 0);
+        assert_eq!(flags.modified_file_count, 3);
+        assert_eq!(flags.modified_files, vec!["src/a.rs", "src/b.rs"]);
+    }
+
+    #[test]
+    fn collect_tools_separates_failed_denied_and_non_modifying_calls() {
+        let (progress, flags) = count_modifications(
+            &[
+                // Read-only work through the shell is exactly what #107 is about:
+                // it must not read as a modification.
+                ("shell", serde_json::json!({"command": "cat a.rs"}), "…"),
+                (
+                    "write_file",
+                    serde_json::json!({"path": "a.rs"}),
+                    "[error] Failed to write 'a.rs': permission denied",
+                ),
+                (
+                    "edit_file",
+                    serde_json::json!({"path": "b.rs"}),
+                    "[denied] User declined tool call 'edit_file'.",
+                ),
+            ],
+            &[],
+        );
+        assert_eq!(progress.modifying_tool_calls, 0);
+        assert_eq!(progress.blocked_modification_calls, 1);
+        assert_eq!(flags.modified_file_count, 0);
+        assert!(flags.modified_files.is_empty());
+    }
+
+    #[test]
+    fn collect_tools_counts_a_gates_extra_tools_by_canonical_name() {
+        // `bash` is an alias for `shell`; a gate naming either one counts the
+        // canonical tool the agent actually calls.
+        let (progress, flags) = count_modifications(
+            &[("shell", serde_json::json!({"command": "make"}), "ok")],
+            &["bash"],
+        );
+        assert_eq!(progress.modifying_tool_calls, 1);
+        // No `path` argument to record; the count still rises.
+        assert_eq!(flags.modified_file_count, 1);
+        assert_eq!(flags.modified_files, vec!["<unknown>"]);
+    }
+
+    #[test]
+    fn collect_tools_still_applies_results_without_stage_components() {
+        // Agents spawned without StageProgress/RunOutcomeFlags (fan-out workers
+        // mid-setup, and much of this test suite) must not have their tool
+        // results silently dropped by the accounting query.
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolResults(rx));
+        let e = world
+            .spawn((
+                conv_window(),
+                infer_with(vec![
+                    fcall("c1", "write_file", serde_json::json!({"path": "a.rs"})),
+                    fcall("c2", "edit_file", serde_json::json!({"path": "b.rs"})),
+                ]),
+                AwaitingTools,
+            ))
+            .id();
+        tx.send(ToolOutcome {
+            entity: e,
+            results: vec![
+                ("c1".to_string(), "wrote it".to_string()),
+                // Both the counted and the blocked path must tolerate the
+                // missing components.
+                (
+                    "c2".to_string(),
+                    "[denied] User declined tool call 'edit_file'.".to_string(),
+                ),
+            ],
+        })
+        .unwrap();
+        run_collect_tools(&mut world);
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(
+            world
+                .get::<ContextWindow>(e)
+                .unwrap()
+                .get_region("conversation")
+                .unwrap()
+                .current_tokens
+                > 0
+        );
+    }
+
+    #[test]
+    fn stage_modifying_tools_defaults_without_a_blueprint_or_stage() {
+        let defaults = vec!["write_file".to_string(), "edit_file".to_string()];
+        // No blueprint / no cursor.
+        assert_eq!(stage_modifying_tools(None, None), defaults);
+        // A cursor pointing past the end of the blueprint's stages.
+        let bp = AgentBlueprint(blueprint(vec![stage_named("a", None, false, None)]));
+        assert_eq!(
+            stage_modifying_tools(Some(&bp), Some(&StageCursor { index: 9 })),
+            defaults
+        );
+        // A stage with no transitions at all.
+        assert_eq!(
+            stage_modifying_tools(Some(&bp), Some(&StageCursor { index: 0 })),
+            defaults
+        );
+        // An edge with no gate.
+        let ungated = AgentBlueprint(blueprint(vec![writing_stage(
+            "a",
+            vec![gated_edge("b", None)],
+        )]));
+        assert_eq!(
+            stage_modifying_tools(Some(&ungated), Some(&StageCursor { index: 0 })),
+            defaults
+        );
+        // A gate that re-lists a built-in doesn't duplicate it.
+        let mut dup = gate(None, None);
+        dup.tools = vec!["write_file".to_string()];
+        let deduped = AgentBlueprint(blueprint(vec![writing_stage(
+            "a",
+            vec![gated_edge("b", Some(dup))],
+        )]));
+        assert_eq!(
+            stage_modifying_tools(Some(&deduped), Some(&StageCursor { index: 0 })),
+            defaults
+        );
+    }
+
+    // ── workspace health (#107) ──
+
+    fn run_workspace_check(world: &mut World) {
+        let mut s = Schedule::default();
+        s.add_systems(check_workspace_health);
+        s.run(world);
+    }
+
+    fn spawn_workspace_agent(world: &mut World, workdir: &str, iterations: usize) -> Entity {
+        let mut md = run_metadata();
+        md.workdir = workdir.to_string();
+        world
+            .spawn((
+                md,
+                StageProgress {
+                    iterations,
+                    ..Default::default()
+                },
+                agent_state(),
+                crate::persistence::RunOutcomeFlags::default(),
+                ReadyToInfer,
+            ))
+            .id()
+    }
+
+    #[test]
+    fn workspace_check_fails_a_run_whose_directory_is_gone() {
+        let mut world = World::new();
+        let e = spawn_workspace_agent(&mut world, "/definitely/not/a/real/dir", 0);
+        run_workspace_check(&mut world);
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Error {
+                message: "workspace '/definitely/not/a/real/dir' is no longer accessible"
+                    .to_string()
+            }
+        );
+        assert!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .workspace_lost
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_none());
+    }
+
+    #[test]
+    fn workspace_check_rejects_a_workdir_that_is_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-dir");
+        std::fs::write(&file, "x").unwrap();
+        let mut world = World::new();
+        let e = spawn_workspace_agent(&mut world, &file.to_string_lossy(), 0);
+        run_workspace_check(&mut world);
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Error {
+                message: format!("workspace '{}' is no longer accessible", file.display())
+            }
+        );
+    }
+
+    #[test]
+    fn workspace_check_is_a_no_op_when_healthy_off_interval_or_inactive() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().to_string_lossy().to_string();
+        let mut world = World::new();
+        // Healthy workspace.
+        let healthy = spawn_workspace_agent(&mut world, &live, 0);
+        // Missing workspace, but this iteration isn't a check point.
+        let off_interval = spawn_workspace_agent(&mut world, "/gone", 1);
+        // Missing workspace, but the agent isn't running.
+        let idle = spawn_workspace_agent(&mut world, "/gone", 0);
+        world.get_mut::<AgentState>(idle).unwrap().status = AgentStatus::Waiting;
+
+        run_workspace_check(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(healthy).unwrap().status,
+            AgentStatus::Active
+        );
+        assert_eq!(
+            world.get::<AgentState>(off_interval).unwrap().status,
+            AgentStatus::Active
+        );
+        assert_eq!(
+            world.get::<AgentState>(idle).unwrap().status,
+            AgentStatus::Waiting
+        );
+        for e in [healthy, off_interval, idle] {
+            assert!(world.get::<ReadyToInfer>(e).is_some());
+        }
     }
 
     // ── repetition detection (#8) ──
@@ -8369,6 +9332,7 @@ mod tests {
             condition: leviath_core::blueprint::TransitionCondition::LlmChoice,
             hint: None,
             transform: leviath_core::blueprint::EdgeTransform::Direct,
+            gate: None,
         }
     }
 
@@ -8723,6 +9687,85 @@ mod tests {
         assert_eq!(
             world.get::<PendingEdgeCompact>(e).unwrap().0,
             vec!["conversation".to_string()]
+        );
+    }
+
+    #[test]
+    fn collect_choice_holds_the_stage_when_the_chosen_edge_is_gated() {
+        // The LLM-choice path enforces the same gate as the linear path — and
+        // must do so before the edge transform reshapes the context it needs.
+        let (mut world, tx) = world_with_transition_results();
+        let bp = blueprint(vec![
+            writing_stage("impl", vec![]),
+            stage_named("review", None, false, None),
+        ]);
+        let mut edge = plain_edge("review");
+        edge.transform = EdgeTransform::Compact { prompt: None };
+        edge.gate = Some(gate(None, None));
+        let e = spawn_responding_agent(&mut world, bp, vec![si("m0"), si("m1")], vec![edge]);
+        world
+            .entity_mut(e)
+            .insert(crate::persistence::RunOutcomeFlags::default());
+        tx.send(InferenceOutcome {
+            entity: e,
+            result: Ok(resp("review")),
+        })
+        .unwrap();
+
+        run_collect_transition(&mut world);
+
+        assert_eq!(world.get::<StageCursor>(e).unwrap().index, 0);
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(world.get::<AwaitingTransitionResponse>(e).is_none());
+        assert_eq!(world.get::<StageProgress>(e).unwrap().gate_reentries, 1);
+        // The transform did NOT run.
+        assert!(world.get::<PendingEdgeCompact>(e).is_none());
+    }
+
+    #[test]
+    fn collect_choice_records_a_forced_gate_and_enters_the_stage() {
+        let (mut world, tx) = world_with_transition_results();
+        let bp = blueprint(vec![
+            writing_stage("impl", vec![]),
+            stage_named("review", None, false, None),
+        ]);
+        let mut edge = plain_edge("review");
+        edge.gate = Some(gate(None, None));
+        let e = spawn_responding_agent(
+            &mut world,
+            bp.clone(),
+            vec![si("m0"), si("m1")],
+            vec![edge.clone()],
+        );
+        world
+            .entity_mut(e)
+            // Budget already spent.
+            .insert(progress_with(0, 0, 3))
+            .insert(crate::persistence::RunOutcomeFlags::default());
+        // An agent with no flags component still transitions — it just has
+        // nowhere to record the forced gate.
+        let unflagged =
+            spawn_responding_agent(&mut world, bp, vec![si("m0"), si("m1")], vec![edge]);
+        world.entity_mut(unflagged).insert(progress_with(0, 0, 3));
+        for entity in [e, unflagged] {
+            tx.send(InferenceOutcome {
+                entity,
+                result: Ok(resp("review")),
+            })
+            .unwrap();
+        }
+
+        run_collect_transition(&mut world);
+
+        assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+        assert_eq!(world.get::<StageCursor>(unflagged).unwrap().index, 1);
+        assert_eq!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .gates_forced,
+            1
         );
     }
 

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -31,6 +31,27 @@ impl tracing::Subscriber for AlwaysOnSubscriber {
     }
 }
 
+/// Serializes every test that swaps the global panic hook. Without it two such
+/// tests interleave under the parallel test runner: one test's `set_hook`
+/// replaces the other's silencing closure before the other's panic fires, so
+/// that closure never runs and shows as uncovered. Hold this across each test's
+/// set-hook → panic → restore-hook sequence. (Only ever held across synchronous
+/// work.) One lock per test binary, so it must live here rather than in any one
+/// module's test block.
+pub(crate) static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Run `f` with the panic hook silenced, restoring the previous hook after.
+/// Returns whatever `f` returns; `f` is expected to swallow the panic itself
+/// (e.g. via `catch_unwind`).
+pub(crate) fn with_silenced_panics<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let out = f();
+    std::panic::set_hook(prev);
+    out
+}
+
 pub(crate) fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
     static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INSTALLED.get_or_init(|| {

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -39,12 +39,12 @@ use crate::pipeline::{
     AwaitingTransitionResponse, CompactionResults, InferenceResults, InferenceStage, MessageIntake,
     PersistenceStage, ProcessResponse, Providers, ReadyForTools, ReadyForTransition, ReadyToInfer,
     ResolveTransition, ToolResults, ToolService, ToolServiceRes, ToolStage, TransitionResults,
-    collect_compaction, collect_inference, collect_tools, collect_transition_choice,
-    deliver_messages, dispatch_compaction, dispatch_edge_compact, dispatch_inference,
-    dispatch_persistence, dispatch_tools, dispatch_transition_choice, enforce_max_iterations,
-    gate_requires_children, handle_empty_response, poll_dynamic_tool_refresh, process_response,
-    reflect_interaction_status, refresh_advertised_tools, require_context_regions,
-    resolve_transition, sync_tool_stages,
+    check_workspace_health, collect_compaction, collect_inference, collect_tools,
+    collect_transition_choice, deliver_messages, dispatch_compaction, dispatch_edge_compact,
+    dispatch_inference, dispatch_persistence, dispatch_tools, dispatch_transition_choice,
+    enforce_max_iterations, gate_requires_children, handle_empty_response,
+    poll_dynamic_tool_refresh, process_response, reflect_interaction_status,
+    refresh_advertised_tools, require_context_regions, resolve_transition, sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::spawn_tool_pool;
@@ -199,6 +199,9 @@ impl PipelineWorld {
                 dispatch_compaction,
                 // Cap a stage at its max_iterations before running more inference.
                 enforce_max_iterations,
+                // Stop a run whose working directory vanished, rather than let
+                // every tool fail with ENOENT for the rest of the run.
+                check_workspace_health,
                 // Tag dynamic_tools agents that have pending tool changes, then
                 // apply the re-advertisement before the next request is assembled
                 // so a newly-discovered tool is visible.
@@ -647,15 +650,9 @@ fn reset_executor(schedule: &mut Schedule) {
 mod tests {
     use super::*;
 
-    /// Serializes the two tests that swap the **process-global** panic hook
-    /// (`run_isolated_catches_a_system_panic` and
-    /// `run_to_fixed_point_survives_a_panicking_system`). Without this, they can
-    /// interleave under the parallel test runner: one test's `set_hook` replaces
-    /// the other's silencing closure before the other's panic fires, so that
-    /// closure never runs and shows as uncovered. Holding this lock across each
-    /// test's set-hook → panic → restore-hook sequence keeps each hook active for
-    /// its own panic. (The guard is only ever held across synchronous work.)
-    static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// Serializes every test in this binary that swaps the **process-global**
+    /// panic hook — see the definition for why they can't run concurrently.
+    use crate::test_support::PANIC_HOOK_LOCK;
 
     /// Run `f` with the process panic hook silenced (the panic is expected), and
     /// serialized against the other hook-swapping tests.
@@ -1310,7 +1307,8 @@ mod tests {
                 agent_path: "/p".to_string(),
                 task: "t".to_string(),
                 model: None,
-                workdir: "/w".to_string(),
+                // A real directory: the tick chain fails a run whose workspace is gone.
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
                 num_stages: 1,
                 started_at: 0,
                 parent_run_id: None,
@@ -1494,7 +1492,8 @@ mod tests {
                 agent_path: "/p".to_string(),
                 task: "t".to_string(),
                 model: None,
-                workdir: "/w".to_string(),
+                // A real directory: the tick chain fails a run whose workspace is gone.
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
                 num_stages: 1,
                 started_at: 0,
                 parent_run_id: None,
@@ -1575,7 +1574,8 @@ mod tests {
                 agent_path: "/p".to_string(),
                 task: "t".to_string(),
                 model: None,
-                workdir: "/w".to_string(),
+                // A real directory: the tick chain fails a run whose workspace is gone.
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
                 num_stages: 1,
                 started_at: 0,
                 parent_run_id: None,

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -703,6 +703,24 @@ impl BuiltinTools {
         }
     }
 
+    /// Refuse to create anything when the working directory itself is gone.
+    ///
+    /// `write_file` calls `create_dir_all`, which would otherwise silently
+    /// resurrect a workspace an external harness deleted mid-run — leaving the
+    /// agent writing into an empty tree that no longer resembles the checkout it
+    /// reasoned about, and masking the loss from the runtime's health check
+    /// (issue #107). Creating *sub*directories inside a live workspace is
+    /// untouched; only a missing workspace root is refused.
+    fn ensure_workspace(&self) -> Result<(), String> {
+        if std::fs::metadata(&self.ctx.workdir).is_ok_and(|m| m.is_dir()) {
+            return Ok(());
+        }
+        Err(format!(
+            "[error] workspace '{}' is no longer accessible",
+            self.ctx.workdir.display()
+        ))
+    }
+
     /// Resolve a requested path to an absolute path inside the workdir.
     ///
     /// Rejects paths that would escape the working directory via `../` components.
@@ -800,6 +818,9 @@ impl BuiltinTools {
             Some(c) => c,
             None => return "[error] missing 'content' argument".to_string(),
         };
+        if let Err(e) = self.ensure_workspace() {
+            return e;
+        }
 
         let path = match self.resolve(path_str) {
             Ok(p) => p,
@@ -845,6 +866,9 @@ impl BuiltinTools {
             Some(s) => s,
             None => return "[error] missing 'new_str' argument".to_string(),
         };
+        if let Err(e) = self.ensure_workspace() {
+            return e;
+        }
 
         let path = match self.resolve(path_str) {
             Ok(p) => p,
@@ -1390,6 +1414,36 @@ mod tests {
             .await;
         assert!(result.contains("Successfully wrote"));
         assert!(dir.path().join("sub/dir/file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn write_tools_refuse_to_resurrect_a_deleted_workspace() {
+        // Issue #107: an external harness deletes the workspace mid-run.
+        // `create_dir_all` would happily recreate it and let the agent write
+        // into an empty tree that no longer resembles the checkout it reasoned
+        // about — and the runtime's health check, which just stats the workdir,
+        // would never see it was gone.
+        let dir = tempfile::tempdir().unwrap();
+        let workdir = dir.path().join("workspace");
+        fs::create_dir(&workdir).unwrap();
+        fs::write(workdir.join("a.txt"), "before").unwrap();
+        let tools = make_tools(&workdir);
+        fs::remove_dir_all(&workdir).unwrap();
+
+        for (tool, args) in [
+            ("write_file", json!({"path": "a.txt", "content": "after"})),
+            (
+                "edit_file",
+                json!({"path": "a.txt", "old_str": "before", "new_str": "after"}),
+            ),
+        ] {
+            let result = tools.execute(tool, args).await;
+            assert!(
+                result.contains("workspace") && result.contains("no longer accessible"),
+                "{tool} got: {result}"
+            );
+        }
+        assert!(!workdir.exists(), "the workspace must stay gone");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #107.

SWE-bench Lite produced 13/300 runs with **no output at all**. Root-cause analysis in the issue splits them three ways, and each maps to a concrete hole in this codebase:

| Failure mode | Count | The hole |
|---|---|---|
| Agent never called a write tool | 7 | Nothing checked that a stage had produced changes before it transitioned |
| Workspace deleted mid-run | 3 | The workdir was never validated — not at spawn, not at runtime |
| Pre-context crash | 3 | `runstate::create_run` was only ever called from tests, and a spawn panic took the daemon with it |

## Transition gates (P0)

A `TransitionEdge` can now declare a gate, using the TOML shape from the issue:

```toml
[stages.implement.transitions.review]
transform = "compact"
gate = { require_modifications = true, region = "implementation" }
```

The check runs once the edge is chosen but **before** its transform runs — the transform compacts/clears regions a held stage still needs — in both the linear `resolve_transition` path and the LLM-choice `collect_transition_choice` path. An unsatisfied gate injects a `[System]` nudge and re-runs the stage, bounded by `max_attempts` (default 3), after which it proceeds and records `gates_forced`. Error and max-iteration edges are never gated, so `error_recovery` stays reachable.

Counters live on `StageProgress`, which `enter_stage` already resets on all three stage-entry paths — no new component, and no repeat of the latent bug where `force_transition` forgets to clear `RequiredReentries`. A policy-*denied* write passes the gate (the agent is trying and cannot), as does a non-empty evidence region: `StageProgress` isn't restored on daemon restart, but context regions are.

## Run flags — replaces the issue's `--retry-empty`

`meta.json` now carries `flags`: `modified_files`, `modified_file_count`, `empty_output`, `max_iterations_hit`, `gates_forced`, `workspace_lost`. A harness reads the file and sees that a run came up empty **and why**, rather than a CLI flag that retries blind. `#[serde(default)]` throughout, and the flags survive a daemon restart via `recovery`.

## Blueprints (P1)

`coder` and `software-engineer` gate every non-error edge out of `implement` and route `write_file`/`edit_file` results into `implementation`.

That region — 35% of the context budget, plus its `impl_history` companion — was **dead in both agents**, while coder's review prompt told the reviewer to "read the files tracked in the `implementation` region". It is now the run's changelog, makes that instruction true, and gives the gate its restart-proof evidence. Both implement prompts now forbid editing through the shell (`sed -i`, `tee`, `>`) rather than merely suggesting the native tools.

## Workspace + startup (P2/P4)

- `check_workspace_health` fails a run whose workdir vanished, instead of letting it collect 16-17 ENOENTs.
- `build_agent_inner` rejects a workdir that isn't a directory (`ToolContext::new` silently keeps a path it can't canonicalize).
- The spawner stakes out the run directory **before** anything fallible, so a spawn that dies mid-way still leaves a `meta.json`. Deliberately in the spawner closure, not `build_agent_inner`, which is shared with the reload path.
- `ControlOp::Spawn` logs its failures (it logged nothing daemon-side before) and contains spawner panics.
- `Blueprint::validate` rejects a modification gate on a stage with no write tool.

## Second commit: two gaps live-testing exposed

**`write_file` was resurrecting deleted workspaces.** `create_dir_all(parent)` silently rebuilt a workspace an external harness had deleted, so the agent wrote into an empty tree that no longer resembled the checkout it had reasoned about — and the stat-based health check never saw it was gone. Observed live: a run "completed" having written two files into a `rm -rf`'d workdir. The write tools (and the Rhai host's `write_file`) now verify the workspace root first. Sub-directory creation inside a live workspace is untouched.

**`--yolo` didn't waive the agent's own prompts.** It covered tool policy and the taint gate, but `ask_user_*` / `present_for_review` / `edit_document` and blueprint interaction points block on the interaction hub regardless — so a headless run parked forever at the first one. Hit twice during testing. A yolo run now gets `UnattendedInteraction` plus an `InteractionAutoApprove` marker. A confirmation is approved and a document acknowledged, but a **choice is never auto-picked** — option 0 could be "Abort" — so the model is told nobody answered and decides itself.

## Verification

100% line/region/function coverage held on all four touched packages (`leviath-core`, `leviath-runtime`, `leviath-cli`, `leviath-tools`), plus clippy `-D warnings`, rustfmt and rustdoc clean.

Six live runs against Sonnet 5 / Opus 5 in an isolated daemon:

1. Real fix task → both files written, `implementation` region holds `Successfully edited 'calc.py'`, flags clean.
2. Model *instructed* to edit only via `sed -i` → gate nudged 3×, warned, `gates_forced: 1`, `empty_output: true`. (The hardened prompt also made the model ask on its own: *"the framework doesn't track shell edits — may I re-apply with edit_file?"*)
3. Workspace deleted during a read-only stage → `error: workspace '...' is no longer accessible` after 4 iterations.
4. Unparseable manifest → run dir + `meta.json` exist afterwards.
5. Workspace deleted during `implement` (the resurrection case) → writes refused, run errors at iteration 6, workdir stays gone.
6. `--yolo` with a task that triggers `ask_user_confirm` → answered inline (`User answered: Yes`), zero pending prompts, run completes.

## Not included

The issue's P3 `--retry-empty` CLI flag. `lev run` is fire-and-forget, so retrying would need a new client wait/subscribe mode — and per discussion it papers over the problem rather than diagnosing it. The run flags above are the signal a harness needs to make that decision itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxqV7Xvh5rJvMaPqm7nnbr
