### PR TITLE
fix: harden the fetch path and make run ids collision-proof

### DIFF
--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -56,6 +56,7 @@ tower = { version = "0.5", features = ["util"] }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -345,9 +345,24 @@ impl RealScriptIo {
     }
 
     /// Send a built request and read its body as text.
+    ///
+    /// A body the `Content-Type` marks as binary is refused rather than decoded.
+    /// `Response::text` decodes *anything* lossily, so a PNG or MP3 came back as
+    /// a page of U+FFFD replacement characters reported as a **successful**
+    /// fetch — no error, no signal, straight into the model's context.
     fn send(req: reqwest::blocking::RequestBuilder) -> Result<String, String> {
         let resp = req.send().map_err(|e| format!("request failed: {e}"))?;
         let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        if is_binary_content_type(&content_type) {
+            let len = resp.content_length();
+            return Err(non_text_body_message(&content_type, len));
+        }
         let text = cap_script_io(resp.text().map_err(|e| format!("read body: {e}"))?);
         if status.is_success() {
             Ok(text)
@@ -355,6 +370,56 @@ impl RealScriptIo {
             Err(format!("http {status}: {text}"))
         }
     }
+}
+
+/// Media types that are never text, so decoding them would only produce noise.
+///
+/// The check is on the declared type, deliberately **not** on UTF-8 validity of
+/// the bytes: `Response::text` is charset-aware and decodes Shift-JIS,
+/// ISO-8859-1 and Windows-1252 pages *correctly*, and a strict `from_utf8` test
+/// would misclassify exactly those as binary — the non-English pages a
+/// researcher agent is most likely to fetch. Anything unrecognised (including a
+/// missing header) falls through to the existing text path.
+const BINARY_CONTENT_PREFIXES: &[&str] = &[
+    "image/",
+    "audio/",
+    "video/",
+    "font/",
+    "application/octet-stream",
+    "application/pdf",
+    "application/zip",
+    "application/gzip",
+    "application/x-tar",
+    "application/x-bzip",
+    "application/wasm",
+    "application/vnd.",
+    "application/msword",
+];
+
+/// Whether a `Content-Type` header names content this tool cannot render as text.
+fn is_binary_content_type(content_type: &str) -> bool {
+    // Trim parameters (`image/png; charset=binary`) and normalise case.
+    let essence = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    // `application/xml`, `+json`, `+xml` etc. are structured *text* despite the
+    // `application/` prefix, so match on the concrete list rather than the tree.
+    BINARY_CONTENT_PREFIXES
+        .iter()
+        .any(|prefix| essence.starts_with(prefix))
+}
+
+/// The diagnostic a script tool sees for a binary body. Phrased for the model:
+/// it names the type and size so the agent can pick a different source.
+fn non_text_body_message(content_type: &str, len: Option<u64>) -> String {
+    let size = match len {
+        Some(bytes) => format!(", {} KB", bytes.div_ceil(1024)),
+        None => String::new(),
+    };
+    format!("non-text content ({content_type}{size}) — this tool returns text only")
 }
 
 /// Cap a host-I/O string below the tool engine's 1 MB `max_string_size`
@@ -366,6 +431,10 @@ const MAX_SCRIPT_IO_BYTES: usize = 900_000;
 
 fn cap_script_io(mut s: String) -> String {
     if s.len() > MAX_SCRIPT_IO_BYTES {
+        // Walk back to a char boundary before truncating — a byte cut-off lands
+        // mid-character on multi-byte text and panics (the shape of issue #109).
+        // The loop terminates because the branch guarantees `end < s.len()`, and
+        // byte 0 is always a boundary, so it can never run past the start.
         let mut end = MAX_SCRIPT_IO_BYTES;
         while !s.is_char_boundary(end) {
             end -= 1;
@@ -780,11 +849,111 @@ mod tests {
                         "server error",
                     )
                 }),
+            )
+            // A binary body: `Response::text` would lossily decode this into
+            // replacement characters and report success.
+            .route(
+                "/png",
+                get(|| async {
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "image/png")],
+                        // A real PNG signature + IHDR-ish bytes; invalid UTF-8.
+                        vec![0x89u8, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe],
+                    )
+                }),
+            )
+            // Declared text in a non-UTF-8 charset — must still decode, which is
+            // why the guard reads the header rather than testing UTF-8 validity.
+            .route(
+                "/shiftjis",
+                get(|| async {
+                    (
+                        [(
+                            axum::http::header::CONTENT_TYPE,
+                            "text/html; charset=shift_jis",
+                        )],
+                        // "日本語" in Shift-JIS.
+                        vec![0x93u8, 0xfa, 0x96, 0x7b, 0x8c, 0xea],
+                    )
+                }),
             );
         tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
             listener, app,
         )));
         base
+    }
+
+    #[test]
+    fn binary_content_types_are_classified_but_structured_text_is_not() {
+        for text in [
+            "",
+            "text/html; charset=utf-8",
+            "text/plain",
+            "application/json",
+            "application/xml",
+            "application/xhtml+xml",
+            "application/ld+json",
+            "application/javascript",
+        ] {
+            assert!(!is_binary_content_type(text), "should be text: {text:?}");
+        }
+        for binary in [
+            "image/png",
+            "IMAGE/PNG",
+            "image/jpeg; charset=binary",
+            "  audio/mpeg  ",
+            "video/mp4",
+            "font/woff2",
+            "application/octet-stream",
+            "application/pdf",
+            "application/zip",
+            "application/gzip",
+            "application/x-tar",
+            "application/x-bzip2",
+            "application/wasm",
+            "application/vnd.ms-excel",
+            "application/msword",
+        ] {
+            assert!(
+                is_binary_content_type(binary),
+                "should be binary: {binary:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_non_text_diagnostic_names_the_type_and_size_when_known() {
+        let with_len = non_text_body_message("image/png", Some(2049));
+        assert!(with_len.contains("image/png"), "got: {with_len}");
+        assert!(with_len.contains("3 KB"), "rounds up: {with_len}");
+        let without_len = non_text_body_message("audio/mpeg", None);
+        assert!(without_len.contains("audio/mpeg"), "got: {without_len}");
+        assert!(
+            !without_len.contains("KB"),
+            "no size to report: {without_len}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn binary_bodies_are_refused_and_non_utf8_text_still_decodes() {
+        let base = mock_http().await;
+        let (png, sjis) = tokio::task::spawn_blocking(move || {
+            (
+                RealScriptIo.http_get(&format!("{base}/png"), BTreeMap::new()),
+                RealScriptIo.http_get(&format!("{base}/shiftjis"), BTreeMap::new()),
+            )
+        })
+        .await
+        .unwrap();
+
+        // A PNG is refused outright rather than returned as replacement chars.
+        let err = png.unwrap_err();
+        assert!(err.contains("non-text content"), "got: {err}");
+        assert!(err.contains("image/png"), "got: {err}");
+
+        // A Shift-JIS page is text: it must still come back decoded. Guarding on
+        // UTF-8 validity instead of the header would have broken this.
+        assert_eq!(sjis.unwrap(), "日本語");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -195,24 +195,32 @@ fn roll_log_if_over_cap(path: &Path, max_bytes: u64) {
     }
 }
 
-/// Process-wide counter mixed into [`new_run_id`]'s suffix so that multiple
-/// runs spawned in a tight loop (e.g. `lev run --count N`) within the same
-/// wall-clock second never collide. Without it, a suffix derived purely from
-/// `now` (whole seconds) gives every run in a `--count N` batch the *same* run
-/// ID -- silently collapsing N runs into one on-disk entry and leaving N-1
-/// worker processes writing state nobody could see.
-static RUN_ID_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+/// How many random bits go in a run ID's suffix, rendered as 12 hex digits.
+/// Collisions only matter within one wall-clock second for one agent name, so 48
+/// bits is many orders of magnitude more than needed while staying short enough
+/// to read in `lev ps` and the dashboard.
+const RUN_ID_ENTROPY_BITS: u32 = 48;
 
-/// Generate a unique run ID: `<agent_name>-<timestamp>-<suffix>`.
+/// Generate a unique run ID: `<agent_name>-<timestamp>-<random>`.
+///
+/// The suffix is **random**, not derived. It used to be
+/// `(now ^ (now >> 16) ^ counter)` over a process-local counter, which defended
+/// a `lev run --count N` batch inside one process but degenerated to a pure
+/// function of the current second across separate processes: three concurrent
+/// `lev run` invocations all minted `fetcher-1785127214-8b48` and silently shared
+/// one run directory. Nothing downstream detects that — `create_dir_all` is a
+/// no-op on an existing directory and the persistence worker then last-writer-wins
+/// over `meta.json` / `context.json` / `run.lvr`, interleaving two runs'
+/// state irrecoverably.
+///
+/// The `<name>-<secs>-<hex>` shape is preserved: the timestamp keeps IDs sorting
+/// and reading chronologically, and the dashboard's short-ID display
+/// (`split('-').next_back()`) still lands on the unique component.
 pub fn new_run_id(agent_name: &str) -> String {
-    let now = now_secs();
-    let counter = RUN_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as i64;
-    let suffix = format!(
-        "{:04x}",
-        ((now & 0xffff) ^ (now >> 16 & 0xffff) ^ counter) & 0xffff
-    );
+    use rand::Rng as _;
+    let entropy: u64 = rand::rng().random::<u64>() >> (u64::BITS - RUN_ID_ENTROPY_BITS);
     let safe_name = agent_name.replace(|c: char| !c.is_alphanumeric() && c != '-', "-");
-    format!("{}-{}-{}", safe_name, now, suffix)
+    format!("{}-{}-{:012x}", safe_name, now_secs(), entropy)
 }
 
 /// Create the run directory and write initial metadata.
@@ -793,13 +801,54 @@ mod tests {
 
     #[test]
     fn new_run_id_is_unique_across_rapid_calls_in_same_second() {
-        // Regression test: `--count N` calls `new_run_id` N times in a tight
-        // loop, all within the same wall-clock second. Before the
-        // `RUN_ID_COUNTER` fix, every one of these produced the identical
-        // ID, silently collapsing N runs into a single on-disk entry.
+        // `--count N` calls `new_run_id` N times in a tight loop, all within the
+        // same wall-clock second.
         let ids: std::collections::HashSet<String> =
             (0..100).map(|_| new_run_id("same-agent")).collect();
         assert_eq!(ids.len(), 100);
+    }
+
+    /// Split `<name>-<secs>-<hex>` from the right — the agent name itself may
+    /// contain dashes.
+    fn split_run_id(id: &str) -> (&str, &str) {
+        let mut parts = id.rsplitn(3, '-');
+        let suffix = parts.next().expect("run id has a suffix");
+        let secs = parts.next().expect("run id has a timestamp");
+        (secs, suffix)
+    }
+
+    #[test]
+    fn new_run_id_suffix_is_random_not_derived_from_the_clock() {
+        // The collision this guards against was *across processes*: the suffix
+        // used to be `(now ^ (now >> 16) ^ counter)` over a process-local
+        // counter that every new process starts at 0, so it degenerated to a
+        // pure function of the current second. Three concurrent `lev run`
+        // invocations all minted `fetcher-1785127214-8b48` and silently shared
+        // one run directory. A fresh process has no state to vary, so the
+        // property that has to hold is: IDs that share a timestamp still differ.
+        let ids: Vec<String> = (0..200).map(|_| new_run_id("same-agent")).collect();
+        let mut by_second: std::collections::HashMap<&str, Vec<&str>> =
+            std::collections::HashMap::new();
+        for id in &ids {
+            let (secs, suffix) = split_run_id(id);
+            by_second.entry(secs).or_default().push(suffix);
+        }
+        let mut largest = 0;
+        for (secs, suffixes) in &by_second {
+            let distinct: std::collections::HashSet<&&str> = suffixes.iter().collect();
+            assert_eq!(
+                distinct.len(),
+                suffixes.len(),
+                "two runs in second {secs} share a suffix: {suffixes:?}"
+            );
+            largest = largest.max(suffixes.len());
+        }
+        // 200 calls take microseconds, so they cannot all land in distinct
+        // seconds — without this the assertion above would be vacuous.
+        assert!(
+            largest > 1,
+            "expected IDs sharing a second, got {by_second:?}"
+        );
     }
 
     // ─── write_meta / read_meta roundtrip ───────────────────────────────────

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -745,28 +745,34 @@ fn strip_tags(html: &str) -> String {
     out
 }
 
-/// How far past an `&` to look for the closing `;`. The longest entity this
-/// decoder recognises is `&#x10FFFF;` (10 bytes); 12 leaves headroom.
-const ENTITY_SCAN_BYTES: usize = 12;
+/// How many characters past an `&` to look for the closing `;`. The longest
+/// entity this decoder recognises is `&#x10FFFF;` (10 chars); 12 leaves headroom.
+const ENTITY_SCAN_CHARS: usize = 12;
 
 /// Decode common HTML entities (named + numeric decimal/hex). Unknown or
 /// unterminated entities are left verbatim.
+///
+/// The scan is bounded by **characters**, not bytes. Bounding it by bytes is
+/// what aborted the daemon in issue #109: `after` begins at an `&`, so a fixed
+/// byte-12 cut-off slices mid-character on any multi-byte text
+/// (`"&日本語日本"` → *"byte index 12 is not a char boundary"*), and
+/// `html_to_text` runs this over every fetched page. Clamping the byte window
+/// down to a boundary also worked, but only because `&` is single-byte — an
+/// unstated invariant that a later edit could quietly break. Indices from
+/// `char_indices` are boundaries by construction, so there is nothing left to
+/// get wrong. Entities are all ASCII, so the two bounds agree on any real one.
 fn decode_entities(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while let Some(amp) = rest.find('&') {
         out.push_str(&rest[..amp]);
         let after = &rest[amp..];
-        // Only the first few bytes can hold an entity, but the cut-off must land
-        // on a char boundary: `after` starts at `&`, so a fixed byte 12 slices
-        // mid-character on any multi-byte text ("&日本語日本" panicked with
-        // "byte index 12 is not a char boundary") — and since `html_to_text`
-        // runs on every fetched page, that panic aborted the daemon (issue #109).
-        let mut window = after.len().min(ENTITY_SCAN_BYTES);
-        while !after.is_char_boundary(window) {
-            window -= 1;
-        }
-        match after[..window].find(';') {
+        let semi = after
+            .char_indices()
+            .take(ENTITY_SCAN_CHARS)
+            .find(|&(_, c)| c == ';')
+            .map(|(i, _)| i);
+        match semi {
             Some(semi) => match decode_one_entity(&after[1..semi]) {
                 Some(ch) => {
                     out.push(ch);


### PR DESCRIPTION
Three latent traps found while verifying the #109 daemon-abort fix. None is a live crash today; all three sit on paths we now know matter.

### 1. `decode_entities` scans by characters

The char-boundary panic that aborted the daemon was already fixed, but by clamping a byte window down with `while !is_char_boundary(w) { w -= 1 }` — a loop that only terminates because `after` always begins with an ASCII `&`. Nothing stated or enforced that; change the constant or the slicing base and it underflow-panics again on the exact path that took the daemon down.

Indices from `char_indices` are boundaries by construction, so there is nothing left to get wrong. Entities are all ASCII, so both bounds agree on any real one — **the #109 regression tests pass unchanged**, which is the proof the rewrite is behaviour-preserving.

### 2. Run ids get real entropy

The suffix was `(now ^ (now >> 16) ^ counter)` over a **process-local** counter that every new process starts at 0 — so across processes it degenerated to a pure function of the current second. Three concurrent `lev run` invocations all minted `fetcher-1785127214-8b48` and silently shared one run directory. Nothing detects that: `create_dir_all` is a no-op on an existing directory, and the persistence worker then last-writer-wins over `meta.json` / `context.json` / `run.lvr`, interleaving two runs irrecoverably.

Now 48 random bits. `rand` was already a workspace dep and already in this crate's graph via `leviath-mcp`, so **`Cargo.lock` is unchanged**. The `<name>-<secs>-<hex>` shape is preserved: timestamps still sort, and the dashboard's `split('-').next_back()` short id still lands on the unique part. ACP session ids mint from the same function and are fixed with it.

### 3. Binary bodies are refused instead of lossily decoded

`Response::text` decodes *anything*, so a PNG or MP3 came back as a page of U+FFFD replacement characters reported as a **successful** fetch — no error, no signal, straight into the model's context. `send` now checks `Content-Type` first and returns an explicit diagnostic.

The check is on the declared type and deliberately **not** on UTF-8 validity of the bytes: `text()` is charset-aware and decodes Shift-JIS / ISO-8859-1 / Windows-1252 pages correctly, and a strict `from_utf8` test would misclassify exactly those as binary — the non-English pages a researcher agent is most likely to fetch. There's a test pinning that.

## Verification

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace` / `cargo doc -D warnings` / `ast-grep` all clean; **100% coverage** on `leviath-scripting` and `leviath-cli`.

**Decoder — differential fuzz.** 200k randomised documents (alphabet weighted to bare `&`, entity fragments, and multi-byte chars landing on the scan-window edge) through `execute_script_tool` using the shipped variable-reference call shape. Against the pre-fix decoder the same harness aborts with `panic in a destructor during cleanup`; against this branch it runs 200k clean.

**Run ids — the exact failing case.** 5 concurrent `lev run` in the same second now produce 5 distinct directories:

```
fetcher-1785129216-37147d720d26   fetcher-1785129216-b551772c57d5
fetcher-1785129216-62e9f4906ab1   fetcher-1785129216-dc2fe4274c91
fetcher-1785129216-a7224c8f1f9a
```

**Binary guard — live, through the shipped script.** The real `agents/researcher/tools/web_fetch.rhai` driven through a real `DaemonScriptHost` against a local server:

```
/png       [web_fetch could not retrieve …: non-text content (image/png, 1 KB) — this tool returns text only. …]
/mp3       [web_fetch could not retrieve …: non-text content (audio/mpeg, 2 KB) — this tool returns text only. …]
/shiftjis  日本語のページ & entities
/html      Caf&eacute; 😀 & more
```

The Shift-JIS row is the regression to watch — it decodes correctly, which a UTF-8-validity check would have broken.

(`&eacute;` passing through undecoded is pre-existing and unrelated: the named-entity table has 9 entries and this PR doesn't touch it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BonXMuGcCqWm59zs7iMrzG