### PR TITLE
fix: make byte-offset string cuts char-safe and deny raw &str slicing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,19 @@ description = "A structured agent runtime for LLMs — context memory, multi-sta
 [workspace.lints.rust]
 unsafe_code = "forbid"
 
+# `&s[a..b]` on a `&str` panics when an index lands inside a multi-byte character.
+# That is not hypothetical here: it aborted the daemon twice (issues #109 and #115,
+# a byte cut-off through an emoji inside a Rhai host function), and an audit found
+# two more live instances plus four hand-rolled copies of the walk-back loop. So it
+# is denied workspace-wide. Cut with `leviath_core::truncate_at_boundary` /
+# `floor_char_boundary`, or -- when the index provably *is* a boundary because it
+# came from `find`/`char_indices`/`starts_with` -- annotate the enclosing item with
+# `#[expect(clippy::string_slice, reason = "...")]` naming the construct that
+# guarantees it. "Looks fine" is exactly the unstated invariant this lint exists to
+# stop.
+[workspace.lints.clippy]
+string_slice = "deny"
+
 [workspace.dependencies]
 # Core crates
 leviath-core = { path = "crates/leviath-core" }

--- a/crates/leviath-cli/src/commands/agent_client/translate.rs
+++ b/crates/leviath-cli/src/commands/agent_client/translate.rs
@@ -12,6 +12,7 @@
 use std::path::{Path, PathBuf};
 
 use leviath_agent_client::MAX_FRAME_BYTES;
+use leviath_core::floor_char_boundary;
 
 /// Incremental reader over a run's readable output, across all of its stages.
 ///
@@ -87,21 +88,16 @@ fn stage_output_path(runs_dir: &Path, run_id: &str, idx: usize) -> PathBuf {
 /// zero-length chunk). The common case — output well under one frame — returns a
 /// single slice.
 pub fn split_chunks(text: &str) -> Vec<&str> {
-    if text.is_empty() {
-        return Vec::new();
-    }
     let mut chunks = Vec::new();
-    let mut start = 0;
-    while start < text.len() {
-        let mut end = (start + MAX_FRAME_BYTES).min(text.len());
-        // Back up to the nearest char boundary at or below `end`. `end > start`
-        // always holds here, and there is a boundary in (start, end] because at
-        // least one whole char began at `start`.
-        while end > start && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        chunks.push(&text[start..end]);
-        start = end;
+    let mut rest = text;
+    while !rest.is_empty() {
+        // The cut is never 0, so `rest` always shrinks and the loop terminates:
+        // a whole char begins at byte 0 of `rest` and `MAX_FRAME_BYTES` is far
+        // wider than the 4-byte maximum char, so the walk-back cannot reach the
+        // start.
+        let (chunk, tail) = rest.split_at(floor_char_boundary(rest, MAX_FRAME_BYTES));
+        chunks.push(chunk);
+        rest = tail;
     }
     chunks
 }

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -1,5 +1,7 @@
 //! Pure utility functions used across the dashboard.
 
+use leviath_core::truncate_at_boundary;
+
 /// Format a Unix timestamp as a relative time string ("just now", "2m ago", "1h ago").
 pub(super) fn relative_time(ts: i64) -> String {
     if ts == 0 {
@@ -37,13 +39,9 @@ pub(super) fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        // Find the nearest char boundary at or before `max` to avoid
-        // panicking on multi-byte UTF-8 characters (e.g. em-dashes).
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}…", &s[..end])
+        // Cut on a char boundary so multi-byte content (em-dashes, emoji in run
+        // titles) shortens instead of panicking.
+        format!("{}…", truncate_at_boundary(s, max))
     }
 }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -20,6 +20,11 @@ use crate::runstate;
 /// runs dir outside `$HOME`, which isn't portable (`std::env::temp_dir()` lives
 /// *under* the home directory on Windows, so it only ever hits the shortened
 /// branch there).
+#[expect(
+    clippy::string_slice,
+    reason = "the `starts_with(home)` guard makes `home.len()` the end of a matched prefix, which \
+              is a char boundary"
+)]
 fn shorten_home_path(raw: String, home: &str) -> String {
     if !home.is_empty() && raw.starts_with(home) {
         format!("~{}", &raw[home.len()..])
@@ -657,6 +662,11 @@ impl Dashboard {
         }
     }
 
+    #[expect(
+        clippy::string_slice,
+        reason = "`prefix_end` is only non-zero on a `starts_with` branch, where it is the length \
+                  of the ASCII tag that just matched — a char boundary"
+    )]
     fn build_output_lines(
         &self,
         agent: &DashboardAgent,

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -78,6 +78,11 @@ impl Dashboard {
         );
     }
 
+    #[expect(
+        clippy::string_slice,
+        reason = "the `starts_with(&home)` guard makes `home.len()` the end of a matched prefix, \
+                  which is a char boundary"
+    )]
     pub(in crate::commands::dashboard) fn render_info_strip(
         &self,
         frame: &mut Frame,

--- a/crates/leviath-cli/src/commands/setup.rs
+++ b/crates/leviath-cli/src/commands/setup.rs
@@ -296,12 +296,18 @@ fn parse_yes_no(input: &str, current: bool) -> bool {
     }
 }
 
-/// Redact an API key for display: show first 8 chars + "...".
+/// Redact an API key for display: show the first 8 characters + "...".
+///
+/// Counts *characters*, not bytes. A byte-based version both panicked on a key
+/// containing a multi-byte character straddling byte 8 (the shape of issue #115)
+/// and, worse, leaked: a 3-character 9-byte key is longer than 8 bytes, so the
+/// byte branch would print every character of it followed by an "I truncated
+/// this" marker.
 fn redact(key: &str) -> String {
-    if key.len() <= 8 {
+    if key.chars().count() <= 8 {
         "***".to_string()
     } else {
-        format!("{}...", &key[..8])
+        format!("{}...", key.chars().take(8).collect::<String>())
     }
 }
 
@@ -326,6 +332,18 @@ mod tests {
     #[test]
     fn redact_empty() {
         assert_eq!(redact(""), "***");
+    }
+
+    #[test]
+    fn redact_multibyte_key() {
+        // Issue #115: byte 8 falls inside the third '日' (bytes 6..9), which used
+        // to panic.
+        assert_eq!(redact("日本語日本語日本語"), "日本語日本語日本...");
+        // 3 characters but 9 bytes — the byte-length guard would have classified
+        // this as "long" and printed the whole key. Character counting redacts it.
+        assert_eq!(redact("日本語"), "***");
+        // Exactly 8 characters is still fully redacted.
+        assert_eq!(redact("日本語日本語日本"), "***");
     }
 
     // ─── apply_flags ───────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use leviath_core::manifest::parse_manifest;
+use leviath_core::truncate_at_boundary;
 
 #[derive(Args)]
 pub struct TestArgs {
@@ -392,11 +393,15 @@ fn validate_test_case(test: &TestCase) -> bool {
     true
 }
 
+/// Shorten a model response for the assertion-failure preview.
+///
+/// Cuts on a char boundary: this runs on raw model output, and a byte cut-off
+/// through an emoji panicked `lev test` outright (the shape of issue #115).
 fn truncate_str(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        format!("{}...", truncate_at_boundary(s, max))
     }
 }
 
@@ -714,9 +719,17 @@ max_tokens = 500
 
     #[test]
     fn truncate_str_unicode() {
-        // Non-ASCII content should still work (might truncate mid-char for simple impl)
-        let s = "abcde";
-        assert_eq!(truncate_str(s, 3), "abc...");
+        assert_eq!(truncate_str("abcde", 3), "abc...");
+        // Issue #115: the cut lands inside a multi-byte character. This used to
+        // panic ("byte index N is not a char boundary") on the assertion-failure
+        // path, which prints raw model output. '🎉' occupies bytes 3..7.
+        assert_eq!(truncate_str("abc🎉def", 4), "abc...");
+        assert_eq!(truncate_str("abc🎉def", 6), "abc...");
+        // A boundary-aligned cut is unaffected.
+        assert_eq!(truncate_str("abc🎉def", 7), "abc🎉...");
+        // Every character straddles the cut — the preview degrades to the marker
+        // rather than panicking.
+        assert_eq!(truncate_str("🎉🎉", 2), "...");
     }
 
     // ─── dry_run with filter ──────────────────────────────────────────────

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -18,6 +18,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use leviath_core::floor_char_boundary;
 use leviath_scripting::ScriptHost;
 use leviath_tools::ShellExecutor;
 use tokio::process::Command as TokioCommand;
@@ -439,15 +440,9 @@ const MAX_SCRIPT_IO_BYTES: usize = 900_000;
 
 pub(crate) fn cap_script_io(mut s: String) -> String {
     if s.len() > MAX_SCRIPT_IO_BYTES {
-        // Walk back to a char boundary before truncating — a byte cut-off lands
-        // mid-character on multi-byte text and panics (the shape of issue #109).
-        // The loop terminates because the branch guarantees `end < s.len()`, and
-        // byte 0 is always a boundary, so it can never run past the start.
-        let mut end = MAX_SCRIPT_IO_BYTES;
-        while !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        s.truncate(end);
+        // Cut on a char boundary — a raw byte cut-off lands mid-character on
+        // multi-byte text and panics (the shape of issue #109).
+        s.truncate(floor_char_boundary(&s, MAX_SCRIPT_IO_BYTES));
         s.push_str("\n[...truncated by leviath: response exceeded 900 KB]");
     }
     s

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod run_archive;
 pub mod run_meta;
 pub mod sandbox;
 pub mod taint;
+pub mod text;
 
 pub use blueprint::{
     Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, RepetitionDetectionConfig,
@@ -45,3 +46,4 @@ pub use taint::{
     GateDecision, GateDecisionSource, GateEvent, RegionTaint, SecurityConfig, TaintLevel,
     ToolClassification, ToolDirection,
 };
+pub use text::{floor_char_boundary, truncate_at_boundary};

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -1,0 +1,76 @@
+//! Cutting a `&str` at a byte offset without splitting a character.
+//!
+//! Rust panics on `&s[..n]` when `n` lands inside a multi-byte character, and
+//! this workspace slices strings at fixed byte budgets in a lot of places:
+//! script-tool I/O caps, ACP frame chunking, region seed truncation, dashboard
+//! column fitting, log previews. Every one of those had grown its own
+//! `while !s.is_char_boundary(end) { end -= 1 }` loop with its own comment
+//! explaining why — and two sites (`lev test`'s response preview and `lev
+//! setup`'s key redactor) never grew one at all and panicked on any emoji.
+//!
+//! That is the shape of issues #109 and #115: a byte cut-off through a flag
+//! emoji inside a Rhai host function, which double-panicked and aborted the
+//! whole daemon. Keeping the walk-back in one tested place means a new
+//! truncation site cannot forget it. The workspace also denies
+//! `clippy::string_slice`, so reaching for a raw `&s[..n]` instead of these
+//! helpers is a compile error unless the boundary is proven at the call site.
+
+/// Largest byte index `<= max` that is a char boundary in `s`.
+///
+/// `max` past the end clamps to `s.len()`. The walk-back always terminates:
+/// byte 0 is a boundary in every string, including the empty one.
+pub fn floor_char_boundary(s: &str, max: usize) -> usize {
+    let mut end = max.min(s.len());
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// `&s[..max]`, backed off to the nearest char boundary at or before `max`.
+///
+/// Returns all of `s` when `max` reaches the end. Callers append their own
+/// ellipsis or truncation marker — this only cuts.
+#[expect(
+    clippy::string_slice,
+    reason = "floor_char_boundary returns a char boundary by construction — this is the one raw \
+              slice the rest of the workspace defers to"
+)]
+pub fn truncate_at_boundary(s: &str, max: usize) -> &str {
+    &s[..floor_char_boundary(s, max)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_char_boundary_clamps_and_walks_back() {
+        // Past the end clamps to the length.
+        assert_eq!(floor_char_boundary("abc", 99), 3);
+        // Already a boundary — unchanged.
+        assert_eq!(floor_char_boundary("abc", 2), 2);
+        // Zero is always a boundary, so no walk-back happens.
+        assert_eq!(floor_char_boundary("日本語", 0), 0);
+        // Mid-character walks back to the start of that character. '🎉' is four
+        // bytes at 3..7, so 4, 5 and 6 all floor to 3.
+        let s = "abc🎉";
+        assert_eq!(floor_char_boundary(s, 4), 3);
+        assert_eq!(floor_char_boundary(s, 6), 3);
+        assert_eq!(floor_char_boundary(s, 7), 7);
+        // Walking back all the way to 0 when the first character straddles the cut.
+        assert_eq!(floor_char_boundary("🎉abc", 2), 0);
+        // Empty string: byte 0 is a boundary, so any max clamps to 0.
+        assert_eq!(floor_char_boundary("", 5), 0);
+    }
+
+    #[test]
+    fn truncate_at_boundary_never_splits_a_character() {
+        assert_eq!(truncate_at_boundary("abc", 99), "abc");
+        assert_eq!(truncate_at_boundary("abcdef", 3), "abc");
+        // The exact shape that panicked in issues #109/#115.
+        assert_eq!(truncate_at_boundary("abc🎉def", 5), "abc");
+        assert_eq!(truncate_at_boundary("🎉abc", 2), "");
+        assert_eq!(truncate_at_boundary("", 5), "");
+    }
+}

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -41,6 +41,11 @@ pub(crate) struct AuthServerMetadata {
 ///
 /// Returns `None` when the header is absent or carries no such parameter, in
 /// which case the caller falls back to the well-known path.
+#[expect(
+    clippy::string_slice,
+    reason = "`start` is a `find` hit plus the length of the ASCII needle it matched, and `end` is \
+              a `find` hit or the length — all char boundaries"
+)]
 pub(crate) fn resource_metadata_url(www_authenticate: Option<&str>) -> Option<String> {
     let header = www_authenticate?;
     // The parameter looks like: Bearer resource_metadata="https://…", …

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -65,6 +65,11 @@ fn build_http_client() -> reqwest::Client {
 /// in the environment rather than in a file on disk. An undefined variable
 /// expands to nothing (and warns) rather than leaving the literal `${NAME}` to
 /// be sent as if it were the credential.
+#[expect(
+    clippy::string_slice,
+    reason = "`start` and `end` are `find` hits, offset only by the lengths of the ASCII literals \
+              `${` and `}` — all char boundaries"
+)]
 pub(crate) fn expand_env(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     let mut rest = value;

--- a/crates/leviath-mcp/src/transport/sse.rs
+++ b/crates/leviath-mcp/src/transport/sse.rs
@@ -20,6 +20,10 @@ pub(crate) struct SseEvent {
 /// untouched so the caller can append more bytes and retry. Events are
 /// terminated by a blank line; `\r\n` is normalized, since a server behind a
 /// proxy may emit either ending.
+#[expect(
+    clippy::string_slice,
+    reason = "`end` is a `find` hit for an ASCII line terminator, so it is a char boundary"
+)]
 pub(crate) fn parse_sse_frame(buffer: &mut String) -> Option<SseEvent> {
     // A frame ends at the first blank line, in whichever line ending arrives.
     let (end, sep_len) = find_frame_end(buffer)?;

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -863,6 +863,11 @@ impl Stream for AnthropicSseStream {
 }
 
 /// Parse a single SSE event from the buffer, consuming it if found.
+#[expect(
+    clippy::string_slice,
+    reason = "`event_end` is a `find` hit for the ASCII \"\\n\\n\" terminator, so it and \
+              `event_end + 2` are char boundaries"
+)]
 fn parse_sse_event(buffer: &mut String, tool_index: &mut usize) -> Option<StreamChunk> {
     // Look for a complete event (double newline)
     let event_end = buffer.find("\n\n")?;

--- a/crates/leviath-providers/src/debug_http.rs
+++ b/crates/leviath-providers/src/debug_http.rs
@@ -3,11 +3,20 @@
 //! When enabled, logs full request/response details for every provider HTTP call.
 
 /// Redact an API key for logging, showing only the last 4 characters.
+///
+/// Counts *characters*, not bytes, for the same two reasons as `lev setup`'s
+/// redactor: `key.len() - 4` can land inside a multi-byte character and panic
+/// (the shape of issue #115), and a 5-byte 2-character key is longer than 4
+/// *bytes*, so the byte branch would print the whole thing behind four stars.
 fn redact_api_key(key: &str) -> String {
-    if key.len() <= 4 {
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() <= 4 {
         "****".to_string()
     } else {
-        format!("****{}", &key[key.len() - 4..])
+        format!(
+            "****{}",
+            chars[chars.len() - 4..].iter().collect::<String>()
+        )
     }
 }
 
@@ -93,6 +102,15 @@ mod tests {
     #[test]
     fn redact_api_key_long() {
         assert_eq!(redact_api_key("sk-ant-api03-abc123xyz"), "****3xyz");
+    }
+
+    #[test]
+    fn redact_api_key_multibyte() {
+        // Issue #115: `key.len() - 4` used to land inside the last '日' and panic.
+        assert_eq!(redact_api_key("sk-日本語日本語"), "****語日本語");
+        // 2 characters but 6 bytes — the byte-length guard called this "long" and
+        // printed the whole key. Character counting redacts it.
+        assert_eq!(redact_api_key("日本"), "****");
     }
 
     #[test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -494,6 +494,11 @@ impl OllamaNdjsonStream {
 impl Stream for OllamaNdjsonStream {
     type Item = Result<StreamChunk>;
 
+    #[expect(
+        clippy::string_slice,
+        reason = "`newline_pos` is a `find` hit for the ASCII '\\n', so it and `newline_pos + 1` \
+                  are char boundaries"
+    )]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -370,6 +370,11 @@ impl Stream for OpenAiSseStream {
 
 /// Parse a single SSE event from the buffer.
 /// Returns `Some(Some(chunk))` for data, `Some(None)` for stream end, `None` for incomplete.
+#[expect(
+    clippy::string_slice,
+    reason = "`event_end` is a `find` hit for the ASCII \"\\n\\n\" terminator, so it and \
+              `event_end + 2` are char boundaries"
+)]
 pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>> {
     let event_end = buffer.find("\n\n")?;
     let event_text = buffer[..event_end].to_string();

--- a/crates/leviath-providers/src/text_tools.rs
+++ b/crates/leviath-providers/src/text_tools.rs
@@ -92,6 +92,11 @@ pub fn render_system_suffix(tools: &[Tool]) -> String {
 /// a `name` is skipped. An *unterminated* fence is left in the prose untouched —
 /// a truncated reply shouldn't have its visible text silently eaten. An `id`
 /// emitted by the model is ignored; ids are the runtime's to allocate.
+#[expect(
+    clippy::string_slice,
+    reason = "every index here is a `find` hit offset by the length of an ASCII literal \
+              (FENCE_OPEN, FENCE_CLOSE, '\\n'), so all of them are char boundaries"
+)]
 pub fn parse_tool_calls(text: &str) -> (String, Vec<(String, serde_json::Value)>) {
     let mut prose = String::new();
     let mut calls = Vec::new();

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -6,7 +6,9 @@
 
 use std::collections::HashMap;
 
-use leviath_core::{Blueprint, ContextLayout, EvictionStrategy, Region, RegionKind};
+use leviath_core::{
+    Blueprint, ContextLayout, EvictionStrategy, Region, RegionKind, truncate_at_boundary,
+};
 
 use crate::ContextWindow;
 
@@ -98,11 +100,10 @@ fn fit_seed_to_budget(content: &str, max_tokens: usize) -> String {
     let Some(room) = allowed.checked_sub(SEED_TRUNCATION_MARKER.len()) else {
         return String::new();
     };
-    let mut end = room.min(content.len());
-    while end > 0 && !content.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}{SEED_TRUNCATION_MARKER}", &content[..end])
+    format!(
+        "{}{SEED_TRUNCATION_MARKER}",
+        truncate_at_boundary(content, room)
+    )
 }
 
 /// Resolve which region the `task` text seeds into: prefer a pinned region named

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -43,6 +43,11 @@ pub struct WorkItem {
 
 /// Parse a split response into work items. Tolerates markdown fences and prose by
 /// extracting the outermost `[ … ]`. (Ported from the deleted imperative engine.)
+#[expect(
+    clippy::string_slice,
+    reason = "`s` and `e` come from `find`/`rfind` on the ASCII '[' and ']', so both are char \
+              boundaries and the inclusive range ends on the last byte of ']'"
+)]
 pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
     let trimmed = content.trim();
     let slice = match (trimmed.find('['), trimmed.rfind(']')) {

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -703,6 +703,12 @@ fn strip_raw_text_elements(html: &str) -> String {
     s
 }
 
+#[expect(
+    clippy::string_slice,
+    reason = "`i` only ever advances by `ch.len_utf8()` and `rel` comes from `find`, so both are \
+              char boundaries; `to_ascii_lowercase` preserves byte lengths, so `lower` and `html` \
+              share them"
+)]
 fn strip_element(html: &str, tag: &str) -> String {
     let lower = html.to_ascii_lowercase();
     let open = format!("<{tag}");
@@ -761,6 +767,11 @@ const ENTITY_SCAN_CHARS: usize = 12;
 /// unstated invariant that a later edit could quietly break. Indices from
 /// `char_indices` are boundaries by construction, so there is nothing left to
 /// get wrong. Entities are all ASCII, so the two bounds agree on any real one.
+#[expect(
+    clippy::string_slice,
+    reason = "`amp` comes from `find` and `semi` from `char_indices`, so every index here is a \
+              char boundary; `after[1..]` is safe because `after` starts at the single-byte '&'"
+)]
 fn decode_entities(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
@@ -1706,6 +1717,11 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("&amp;日本語"), "&日本語");
         // Trailing '&' at the very end of the string (window == 1).
         assert_eq!(decode_entities("tail&"), "tail&");
+        // Issue #115 re-reported the same crash with a flag emoji. '&' plus nine
+        // ASCII bytes puts the four-byte regional indicator at bytes 10..14, so
+        // the old byte-12 window cut straight through it. Pinned verbatim so the
+        // reported input, not just an equivalent one, stays covered.
+        assert_eq!(decode_entities("&abcdefghi🇸"), "&abcdefghi🇸");
     }
 
     #[test]


### PR DESCRIPTION
## What #115 reported, and what was actually true

Issue #115 reports `decode_entities` slicing a flag emoji mid-character inside a Rhai host function, double-panicking into SIGABRT.

**That exact defect is already fixed on `main`**, and I verified each link in the chain rather than taking the report at face value:

- `decode_entities` (`tool.rs:764`) bounds its entity scan with `after.char_indices().take(ENTITY_SCAN_CHARS)`. `char_indices` yields only boundaries, so mid-character slicing is impossible by construction. Fixed in `214291d` (PR #113).
- `decode_entities_survives_multibyte_after_an_ampersand` (`tool.rs:1691`) already covered `&日本語日本`, `&🎉🎉🎉🎉`, em-dashes, and the window-of-1 tail. It passes.
- Independently, every Rhai host fn goes through `guard_str`/`guard_dyn` (`tool.rs:529`), which catches the panic and converts it to a Rhai runtime error — so the unwind never reaches Rhai's `ArgBackup` frame. Even a *new* panic there can no longer abort the daemon.
- The reporter's `32b4a04` is the pre-rebase SHA of the #109 fix (`aaeee34` in this history), i.e. the report was filed against a tree predating `214291d`.

The report's own input is now pinned verbatim as a test case, so it stays covered by name:

```rust
// '&' + 9 ASCII bytes puts the four-byte regional indicator at bytes 10..14,
// straddling the old byte-12 window.
assert_eq!(decode_entities("&abcdefghi🇸"), "&abcdefghi🇸");
```

## What was still broken

The *class* was live. A `clippy::string_slice` audit turned up **three functions still cutting a `&str` at a raw byte offset**, plus **four hand-rolled copies** of the walk-back loop — four copies of an invariant is how the three misses happened.

| Site | Impact |
|---|---|
| `lev test` → `truncate_str` | **Panics.** Prints raw model output on the `expect_contains` failure path. Any response >200 bytes with a multi-byte char straddling the cut kills the command. |
| `lev setup` → `redact` | **Panics, and leaks.** A 3-character 9-byte key is longer than 8 *bytes*, so the guard called it "long" and printed every character of it behind a truncation marker. |
| `debug-http` → `redact_api_key` | Same two failures from the other end (`key.len() - 4`). Feature-gated, which is why a plain `--all-targets` sweep missed it — the pre-commit hook's `--all-features` run caught it. |

The other 37 hits are provably safe: every index comes from `find` / `rfind` / `char_indices` / `starts_with(ascii)`.

## Changes

- **`leviath_core::text`** — `floor_char_boundary` / `truncate_at_boundary`. One tested place for the walk-back, mirroring the `panic_payload` module #109 added for the same "stop re-deriving this per crate" reason.
- **Three live bugs fixed.** Both redactors now count characters, which fixes the leak as well as the panic.
- **Four duplicates migrated** onto the helper: `cap_script_io`, the dashboard `truncate`, ACP `split_chunks`, and the region-seed truncator.
- **`clippy::string_slice = "deny"`** workspace-wide, so a new raw `&s[..n]` is a compile error. Safe sites carry `#[expect(...)]` whose `reason` names the construct that guarantees the boundary — "looks fine" is exactly the unstated invariant this is meant to stop. (Attributes on bare expressions are unstable, so these sit on the enclosing item; 39 raw hits collapse to ~13 annotations.)

## Verification

- 26/26 test binaries green; `cargo clippy --all-targets --all-features -- -D warnings` clean *with* the new lint active; `cargo fmt --check` clean.
- 100% coverage gate passing on all six touched crates (from a cleaned `target/llvm-cov-target` — a stale one false-negatived `debug_http.rs` mid-review).
- **The lint bites:** added a throwaway `&s[..3]`, confirmed it fails the build, removed it.
- **Live, the new bug — before and after.** Built `lev`, pointed a fixture at the real Anthropic provider with a prompt yielding 3-byte characters (so byte 200 lands inside char 67) and an assertion guaranteed to fail:

  ```
  # pre-fix
  thread 'main' panicked at crates/leviath-cli/src/commands/test.rs:406:32:
  end byte index 200 is not a char boundary; it is inside '日' (bytes 198..201 of string)

  # post-fix, identical fixture
  response: 日日日…日日...
  FAIL: multibyte_preview_straddles_byte_200: assertions failed
  ```

- **Live, the original #115 path.** Drove the shipped `web_fetch.rhai` through the real `DaemonScriptHost` (no model in the loop) against emoji-dense HTML — Wikipedia's regional-indicator page and unicode.org's full emoji list. Both return clean prose (12042 and 7625 chars, flags and emoji intact), no panic, no abort.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LvfBbrdjCZoDxibF5Agkx
