### PR TITLE
fix: make agents always killable

### DIFF
--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -345,6 +345,14 @@ mod tests {
 
     #[tokio::test]
     async fn unexpected_response_is_an_error() {
+        // Both the `send_bool` path (`lev msg`) and `cancel_run`'s own match
+        // reject a response shape they didn't ask for.
+        let r = with_daemon(r#"{"result":"spawned","run_id":"x"}"#, |c| async move {
+            send_message(&c, &msg_args()).await
+        })
+        .await;
+        assert!(r.unwrap_err().to_string().contains("unexpected"));
+
         let r = with_daemon(r#"{"result":"spawned","run_id":"x"}"#, |c| async move {
             cancel_run(
                 &c,
@@ -357,6 +365,38 @@ mod tests {
         })
         .await;
         assert!(r.unwrap_err().to_string().contains("unexpected"));
+    }
+
+    /// `lev msg` has no on-disk fallback — an unreachable daemon is simply an
+    /// error, unlike `lev cancel`.
+    #[tokio::test]
+    async fn message_to_an_unreachable_daemon_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = ControlClient::new(control_id(&dir.path().join("no-daemon")));
+        let err = send_message(&client, &msg_args()).await.unwrap_err();
+        assert!(err.to_string().contains("not reachable"));
+    }
+
+    /// A run directory that cannot be rewritten is reported as such, rather than
+    /// as a successful cancel.
+    #[tokio::test]
+    async fn forcing_a_run_whose_metadata_cannot_be_written_reports_the_failure() {
+        crate::runstate::with_isolated_runs_dir_async("ctl-force-unwritable", |_base| async {
+            let dir = crate::runstate::run_dir("blocked-1");
+            std::fs::create_dir_all(dir.join("meta.json")).unwrap();
+
+            let err = cancel_run(
+                &ControlClient::new(control_id(std::path::Path::new("/nonexistent"))),
+                &CancelArgs {
+                    run_id: "blocked-1".to_string(),
+                    force: true,
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("could not write"), "got: {err}");
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -25,6 +25,13 @@ pub struct MsgArgs {
 pub struct CancelArgs {
     /// The run id to cancel.
     pub run_id: String,
+    /// Terminate the run's on-disk state directly, without asking the daemon.
+    ///
+    /// Use when the daemon is gone or unresponsive. The run is recorded
+    /// `Cancelled` so nothing lists it as live; if a daemon is in fact still
+    /// driving it, restart the daemon so it picks up the new state.
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Arguments for `lev respond` — answer a pending `ask_user` interaction the
@@ -85,16 +92,75 @@ pub async fn send_message(client: &ControlClient, args: &MsgArgs) -> anyhow::Res
 }
 
 /// `lev cancel`: cancel a run.
+///
+/// A kill must always be possible, so this never depends on the daemon being
+/// reachable. `--force` goes straight to the run's on-disk state; otherwise the
+/// daemon is asked first (it can also stop the work, not just record the
+/// outcome) and the on-disk write is the fallback when it can't be reached or
+/// doesn't answer in time.
 pub async fn cancel_run(client: &ControlClient, args: &CancelArgs) -> anyhow::Result<()> {
-    send_bool(
-        client,
-        ControlRequest::Cancel {
+    if args.force {
+        return report_forced(
+            crate::runstate::force_cancel(&args.run_id),
+            &args.run_id,
+            None,
+        );
+    }
+    match client
+        .request(&ControlRequest::Cancel {
             run_id: args.run_id.clone(),
+        })
+        .await
+    {
+        Ok(ControlResponse::Ok { ok: true }) => {
+            println!("cancelled");
+            Ok(())
+        }
+        Ok(ControlResponse::Ok { ok: false }) => bail!("no such run"),
+        Ok(other) => bail!("unexpected daemon response: {other:?}"),
+        // The daemon is down, wedged, or too busy to answer. Terminate the run on
+        // disk ourselves rather than leave the user with nothing.
+        Err(e) => report_forced(
+            crate::runstate::force_cancel(&args.run_id),
+            &args.run_id,
+            Some(e),
+        ),
+    }
+}
+
+/// Report the outcome of an on-disk cancel. `daemon_error` is set when this was
+/// a fallback rather than an explicit `--force`, and is included so the user
+/// knows why the daemon wasn't used.
+fn report_forced(
+    outcome: crate::runstate::ForceCancelOutcome,
+    run_id: &str,
+    daemon_error: Option<std::io::Error>,
+) -> anyhow::Result<()> {
+    use crate::runstate::ForceCancelOutcome as O;
+    let why = match &daemon_error {
+        Some(e) => format!(" (the daemon did not answer: {e})"),
+        None => String::new(),
+    };
+    match outcome {
+        O::Cancelled => {
+            println!(
+                "cancelled '{run_id}' on disk{why}; if a daemon is still running, \
+                 restart it so it picks up the change"
+            );
+            Ok(())
+        }
+        O::AlreadyTerminal => {
+            println!("'{run_id}' had already finished; nothing to cancel");
+            Ok(())
+        }
+        O::NoSuchRun => match daemon_error {
+            Some(e) => bail!(
+                "the leviath daemon is not reachable ({e}), and there is no run '{run_id}' on disk"
+            ),
+            None => bail!("no such run"),
         },
-        "cancelled",
-        "no such run",
-    )
-    .await
+        O::WriteFailed => bail!("could not write '{run_id}' metadata to record the cancel"),
+    }
 }
 
 /// A short human label for an interaction kind (used by the `lev respond` list).
@@ -252,6 +318,7 @@ mod tests {
                 &c,
                 &CancelArgs {
                     run_id: "r".to_string(),
+                    force: false,
                 },
             )
             .await
@@ -267,6 +334,7 @@ mod tests {
                 &c,
                 &CancelArgs {
                     run_id: "r".to_string(),
+                    force: false,
                 },
             )
             .await
@@ -282,6 +350,7 @@ mod tests {
                 &c,
                 &CancelArgs {
                     run_id: "r".to_string(),
+                    force: false,
                 },
             )
             .await
@@ -298,11 +367,137 @@ mod tests {
             &client,
             &CancelArgs {
                 run_id: "r".to_string(),
+                force: false,
             },
         )
         .await
         .unwrap_err();
         assert!(err.to_string().contains("not reachable"));
+    }
+
+    /// Write a live-looking run into the (isolated) runs dir.
+    fn seed_live_run(run_id: &str) {
+        crate::runstate::create_run(&crate::runstate::RunMeta {
+            status: crate::runstate::RunStatus::Running,
+            ..crate::runstate::RunMeta::new(
+                run_id.into(),
+                "a".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                1,
+            )
+        })
+        .unwrap();
+    }
+
+    fn status_of(run_id: &str) -> crate::runstate::RunStatus {
+        crate::runstate::read_meta(run_id).unwrap().status
+    }
+
+    /// `--force` never contacts the daemon, so a kill stays possible when the
+    /// daemon is dead, wedged, or was never started.
+    #[tokio::test]
+    async fn force_cancels_on_disk_without_a_daemon() {
+        crate::runstate::with_isolated_runs_dir_async("ctl-force-cancel", |_base| async {
+            seed_live_run("stuck-1");
+            let dir = tempfile::tempdir().unwrap();
+            // A socket path with nothing listening on it.
+            let client = ControlClient::new(control_id(&dir.path().join("no-daemon")));
+
+            cancel_run(
+                &client,
+                &CancelArgs {
+                    run_id: "stuck-1".to_string(),
+                    force: true,
+                },
+            )
+            .await
+            .expect("forced cancel succeeds with no daemon");
+
+            assert_eq!(status_of("stuck-1"), crate::runstate::RunStatus::Cancelled);
+        })
+        .await;
+    }
+
+    /// Without `--force`, an unreachable daemon falls back to the on-disk write
+    /// rather than leaving the user with an error and a run still marked live.
+    #[tokio::test]
+    async fn an_unreachable_daemon_falls_back_to_cancelling_on_disk() {
+        crate::runstate::with_isolated_runs_dir_async("ctl-fallback-cancel", |_base| async {
+            seed_live_run("stuck-2");
+            let dir = tempfile::tempdir().unwrap();
+            let client = ControlClient::new(control_id(&dir.path().join("no-daemon")));
+
+            cancel_run(
+                &client,
+                &CancelArgs {
+                    run_id: "stuck-2".to_string(),
+                    force: false,
+                },
+            )
+            .await
+            .expect("the fallback succeeds");
+
+            assert_eq!(status_of("stuck-2"), crate::runstate::RunStatus::Cancelled);
+        })
+        .await;
+    }
+
+    /// Forcing a run that already finished is reported, not treated as a failure.
+    #[tokio::test]
+    async fn forcing_an_already_finished_run_is_not_an_error() {
+        crate::runstate::with_isolated_runs_dir_async("ctl-force-terminal", |_base| async {
+            crate::runstate::create_run(&crate::runstate::RunMeta {
+                status: crate::runstate::RunStatus::Complete,
+                ..crate::runstate::RunMeta::new(
+                    "done-1".into(),
+                    "a".into(),
+                    "/p".into(),
+                    "t".into(),
+                    None,
+                    "/w".into(),
+                    1,
+                )
+            })
+            .unwrap();
+
+            cancel_run(
+                &ControlClient::new(control_id(std::path::Path::new("/nonexistent"))),
+                &CancelArgs {
+                    run_id: "done-1".to_string(),
+                    force: true,
+                },
+            )
+            .await
+            .expect("already-finished is reported, not an error");
+
+            assert_eq!(
+                status_of("done-1"),
+                crate::runstate::RunStatus::Complete,
+                "and the recorded outcome is left intact"
+            );
+        })
+        .await;
+    }
+
+    /// Forcing an id that names no run at all is still an honest failure.
+    #[tokio::test]
+    async fn forcing_an_unknown_run_reports_no_such_run() {
+        crate::runstate::with_isolated_runs_dir_async("ctl-force-missing", |_base| async {
+            let err = cancel_run(
+                &ControlClient::new(control_id(std::path::Path::new("/nonexistent"))),
+                &CancelArgs {
+                    run_id: "never-existed".to_string(),
+                    force: true,
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("no such run"), "got: {err}");
+        })
+        .await;
     }
 
     // ─── lev respond ──────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -414,10 +414,7 @@ impl Dashboard {
 
     fn handle_kill_from_detail(&mut self) {
         if let Some(agent) = self.selected_agent()
-            && matches!(
-                agent.status,
-                AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            )
+            && agent.status.is_killable()
         {
             let agent_id = agent.id.clone();
             let _ = self.cmd_tx.send(DaemonCommand::Cancel {
@@ -441,7 +438,7 @@ impl Dashboard {
             a.pending_request = None;
             self.input_mode = false;
             self.input_textarea = tui_textarea::TextArea::default();
-            self.add_log(format!("{}: Killed", agent_id));
+            self.add_log(format!("{}: kill requested", agent_id));
         }
     }
 
@@ -574,10 +571,7 @@ impl Dashboard {
 
     fn handle_cancel_from_list(&mut self) {
         if let Some(agent) = self.selected_agent()
-            && matches!(
-                agent.status,
-                AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            )
+            && agent.status.is_killable()
         {
             let agent_id = agent.id.clone();
             let _ = self.cmd_tx.send(DaemonCommand::Cancel {
@@ -602,10 +596,7 @@ impl Dashboard {
 
     fn handle_kill_from_list(&mut self) {
         if let Some(agent) = self.selected_agent()
-            && matches!(
-                agent.status,
-                AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
-            )
+            && agent.status.is_killable()
         {
             let agent_id = agent.id.clone();
             let _ = self.cmd_tx.send(DaemonCommand::Cancel {
@@ -624,7 +615,7 @@ impl Dashboard {
             a.status = AgentDisplayStatus::Cancelled;
             a.waiting_prompt = None;
             a.pending_request = None;
-            self.add_log(format!("{}: Killed", agent_id));
+            self.add_log(format!("{}: kill requested", agent_id));
         }
     }
 
@@ -1424,6 +1415,58 @@ mod tests {
         dash.handle_key(key(KeyCode::Char('c')));
         // Should remain Complete
         assert_complete(&dash.agents[0].status);
+    }
+
+    /// Every state that is not a finished one can be killed. The gate used to be
+    /// `Active | Waiting`, so a run showing IDLE or STALE — exactly the states a
+    /// user reaches for the kill key in — could not be killed at all.
+    #[test]
+    fn every_unfinished_state_can_be_killed() {
+        for status in [
+            AgentDisplayStatus::Active,
+            AgentDisplayStatus::Waiting,
+            AgentDisplayStatus::Idle,
+            AgentDisplayStatus::Stale,
+        ] {
+            for key_code in ['c', 'k'] {
+                let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+                let mut dash = Dashboard::new(cmd_tx);
+                dash.agents.push(make_test_agent("run-1", status.clone()));
+                dash.update_display_indices();
+                dash.handle_key(key(KeyCode::Char(key_code)));
+
+                assert_eq!(
+                    cmd_rx.try_recv().unwrap(),
+                    DaemonCommand::Cancel {
+                        run_id: "run-1".to_string()
+                    },
+                    "{status:?} must be killable via '{key_code}'"
+                );
+            }
+        }
+    }
+
+    /// …and a finished run is left alone: there is nothing to kill, and asking
+    /// the daemon would just produce a spurious failure toast.
+    #[test]
+    fn a_finished_run_is_not_killed() {
+        for status in [
+            AgentDisplayStatus::Complete,
+            AgentDisplayStatus::CompleteInteractive,
+            AgentDisplayStatus::Cancelled,
+            AgentDisplayStatus::Error("boom".to_string()),
+        ] {
+            let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+            let mut dash = Dashboard::new(cmd_tx);
+            dash.agents.push(make_test_agent("run-1", status.clone()));
+            dash.update_display_indices();
+            dash.handle_key(key(KeyCode::Char('k')));
+
+            assert!(
+                cmd_rx.try_recv().is_err(),
+                "{status:?} must not be re-killed"
+            );
+        }
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -360,6 +360,95 @@ mod tests {
         (ControlClient::new(id), handle)
     }
 
+    /// A daemon that replies with `reply` (verbatim, newline added) to one
+    /// request. `None` closes the connection without replying.
+    fn replying_daemon(
+        dir: &std::path::Path,
+        reply: Option<&'static str>,
+    ) -> (ControlClient, tokio::task::JoinHandle<()>) {
+        use leviath_runtime::control_socket::{bind_control_listener, control_id};
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let id = control_id(dir);
+        let mut listener = bind_control_listener(&id).unwrap();
+        let handle = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await;
+            if let Some(reply) = reply {
+                let _ = write_half.write_all(format!("{reply}\n").as_bytes()).await;
+            }
+        });
+        (ControlClient::new(id), handle)
+    }
+
+    /// Drive one cancel through the loop and return the reported outcome.
+    async fn cancel_outcome(reply: Option<&'static str>) -> types::DaemonOutcome {
+        let dir = tempfile::tempdir().unwrap();
+        let (control, server) = replying_daemon(dir.path(), reply);
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
+        cmd_tx
+            .send(DaemonCommand::Cancel {
+                run_id: "run-1".to_string(),
+            })
+            .unwrap();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), out_rx.recv())
+            .await
+            .expect("an outcome was reported")
+            .expect("the loop is alive");
+        let _ = server.await;
+        outcome
+    }
+
+    /// Every response shape the daemon can give is reported back, so the
+    /// dashboard can tell a kill that worked from one that did not.
+    #[tokio::test]
+    async fn daemon_background_loop_reports_each_outcome() {
+        let ok = cancel_outcome(Some(r#"{"result":"ok","ok":true}"#)).await;
+        assert!(ok.ok, "an applied cancel is reported as success");
+        assert_eq!(ok.run_id, "run-1");
+
+        let missing = cancel_outcome(Some(r#"{"result":"ok","ok":false}"#)).await;
+        assert!(!missing.ok);
+        assert!(missing.message.contains("no such run to cancel"));
+
+        let odd = cancel_outcome(Some(r#"{"result":"spawned","run_id":"x"}"#)).await;
+        assert!(!odd.ok);
+        assert!(odd.message.contains("unexpected daemon response"));
+
+        // Connection closed with no reply → a transport error, surfaced as such.
+        let broken = cancel_outcome(None).await;
+        assert!(!broken.ok);
+        assert!(
+            broken.message.contains("cancel failed"),
+            "got: {}",
+            broken.message
+        );
+    }
+
+    /// The loop stops when the dashboard has gone away, rather than spinning on
+    /// a channel nobody reads.
+    #[tokio::test]
+    async fn daemon_background_loop_exits_when_the_dashboard_is_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let (control, _server) = replying_daemon(dir.path(), Some(r#"{"result":"ok","ok":true}"#));
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
+        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        drop(out_rx); // the dashboard exited
+        let handle = tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
+        cmd_tx
+            .send(DaemonCommand::Cancel {
+                run_id: "run-1".to_string(),
+            })
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("the loop returned")
+            .unwrap();
+    }
+
     // ─── init_dashboard ──────────────────────────────────────────────────
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -15,7 +15,7 @@ pub use helpers::yank_to_clipboard_via;
 pub use types::{AgentDisplayStatus, DashboardAgent, DashboardArgs};
 
 use crossterm::event::{Event, KeyEventKind};
-use leviath_runtime::control_socket::{ControlClient, ControlRequest};
+use leviath_runtime::control_socket::{ControlClient, ControlRequest, ControlResponse};
 use ratatui::Terminal;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -29,26 +29,55 @@ use types::DaemonCommand;
 async fn daemon_background_loop(
     control: ControlClient,
     mut cmd_rx: mpsc::UnboundedReceiver<DaemonCommand>,
+    outcomes: mpsc::UnboundedSender<types::DaemonOutcome>,
 ) {
     while let Some(cmd) = cmd_rx.recv().await {
-        match cmd {
+        let (run_id, request, what) = match cmd {
             DaemonCommand::Cancel { run_id } => {
-                let _ = control.request(&ControlRequest::Cancel { run_id }).await;
+                (run_id.clone(), ControlRequest::Cancel { run_id }, "cancel")
             }
-            DaemonCommand::Answer { response } => {
-                let _ = control
-                    .request(&ControlRequest::AnswerInteraction { response })
-                    .await;
-            }
-            DaemonCommand::Message { agent_id, content } => {
-                let _ = control
-                    .request(&ControlRequest::Message {
-                        agent_id,
-                        content,
-                        target_region: None,
-                    })
-                    .await;
-            }
+            DaemonCommand::Answer { response } => (
+                response.request_id.clone(),
+                ControlRequest::AnswerInteraction { response },
+                "answer",
+            ),
+            DaemonCommand::Message { agent_id, content } => (
+                agent_id.clone(),
+                ControlRequest::Message {
+                    agent_id,
+                    content,
+                    target_region: None,
+                },
+                "message",
+            ),
+        };
+        // Report what actually happened. This used to be discarded, so a cancel
+        // the daemon refused was indistinguishable from one that worked.
+        let outcome = match control.request(&request).await {
+            Ok(ControlResponse::Ok { ok: true }) => types::DaemonOutcome {
+                run_id,
+                message: String::new(),
+                ok: true,
+            },
+            Ok(ControlResponse::Ok { ok: false }) => types::DaemonOutcome {
+                run_id,
+                message: format!("the daemon has no such run to {what}"),
+                ok: false,
+            },
+            Ok(other) => types::DaemonOutcome {
+                run_id,
+                message: format!("unexpected daemon response to {what}: {other:?}"),
+                ok: false,
+            },
+            Err(e) => types::DaemonOutcome {
+                run_id,
+                message: format!("{what} failed: {e}"),
+                ok: false,
+            },
+        };
+        // A closed receiver means the dashboard has exited; nothing to report to.
+        if outcomes.send(outcome).is_err() {
+            return;
         }
     }
 }
@@ -156,12 +185,19 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
         // is unreachable) so waiting agents show their prompt.
         dashboard.sync_interactions(control).await;
 
+        // …and which runs it actually holds, so a run on disk that nothing is
+        // driving can be shown as stale rather than ACTIVE.
+        dashboard.sync_daemon_runs(control).await;
+
         // Sync background runs from on-disk run-state dir (the daemon persists
         // meta/context/stages there).
         dashboard.sync_from_run_state();
 
         // Surface any completed MCP login/test as a toast.
         dashboard.drain_mcp_outcomes();
+
+        // Report what the daemon did with this tick's commands.
+        dashboard.drain_daemon_outcomes();
 
         // Draw
         terminal.draw(|frame| dashboard.draw(frame))?;
@@ -206,8 +242,13 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         mcp_ctx,
     );
 
-    // Forward the dashboard's control commands to the daemon.
-    tokio::spawn(daemon_background_loop(control, cmd_rx));
+    // Forward the dashboard's control commands to the daemon, and report each
+    // result back so a refused command is surfaced rather than swallowed. A
+    // freshly-built dashboard always has its outcome sender.
+    let daemon_outcome_tx = dashboard
+        .take_daemon_outcome_tx()
+        .expect("a fresh dashboard has its daemon outcome sender");
+    tokio::spawn(daemon_background_loop(control, cmd_rx, daemon_outcome_tx));
 
     // Run MCP logins/tests off the UI loop. A freshly-built dashboard always
     // has its background channel ends.
@@ -354,7 +395,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (control, server) = recording_daemon(dir.path());
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
-        tokio::spawn(daemon_background_loop(control, cmd_rx));
+        let (out_tx, _out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
         cmd_tx
             .send(DaemonCommand::Cancel {
                 run_id: "run-1".to_string(),
@@ -370,7 +412,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (control, server) = recording_daemon(dir.path());
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
-        tokio::spawn(daemon_background_loop(control, cmd_rx));
+        let (out_tx, _out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
         cmd_tx
             .send(DaemonCommand::Answer {
                 response: leviath_core::interaction::InteractionResponse::text("q1", "yes"),
@@ -386,7 +429,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (control, server) = recording_daemon(dir.path());
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
-        tokio::spawn(daemon_background_loop(control, cmd_rx));
+        let (out_tx, _out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
         cmd_tx
             .send(DaemonCommand::Message {
                 agent_id: "a1".to_string(),
@@ -401,7 +445,8 @@ mod tests {
     #[tokio::test]
     async fn daemon_background_loop_exits_when_channel_dropped() {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
-        let handle = tokio::spawn(daemon_background_loop(no_daemon_control(), cmd_rx));
+        let (out_tx, _out_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(daemon_background_loop(no_daemon_control(), cmd_rx, out_tx));
         drop(cmd_tx);
         let result = tokio::time::timeout(std::time::Duration::from_millis(500), handle).await;
         assert!(result.is_ok());

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -12,6 +12,14 @@ use super::types::*;
 use crate::runstate::{self, RunStatus};
 use leviath_core::interaction;
 
+/// Production clock for staleness checks: wall-clock Unix seconds.
+fn system_now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 /// The interactive dashboard state.
 pub(crate) struct Dashboard {
     pub(super) agents: Vec<DashboardAgent>,
@@ -101,6 +109,21 @@ pub(crate) struct Dashboard {
     pub(super) mcp_cmd_tx: mpsc::UnboundedSender<McpCommand>,
     /// Receives completed MCP action outcomes, drained into toasts each tick.
     pub(super) mcp_outcome_rx: mpsc::UnboundedReceiver<McpOutcome>,
+    /// Receives the daemon's answer to each [`DaemonCommand`], drained each tick
+    /// so a refused cancel is surfaced instead of silently reverting.
+    pub(super) daemon_outcome_rx: mpsc::UnboundedReceiver<DaemonOutcome>,
+    /// The background loop's sender for [`DaemonOutcome`]s; taken by
+    /// `init_dashboard`, retained by tests to inject outcomes.
+    pub(super) daemon_outcome_tx: Option<mpsc::UnboundedSender<DaemonOutcome>>,
+    /// Run ids the daemon reported it could not act on, so the disk sync doesn't
+    /// quietly restore them to ACTIVE without saying why.
+    pub(super) failed_cancels: std::collections::HashSet<String>,
+    /// The run ids the daemon currently holds, refreshed each tick. `None` when
+    /// the daemon did not answer — the disk view is then taken at face value
+    /// rather than declaring every run stale.
+    pub(super) daemon_run_ids: Option<std::collections::HashSet<String>>,
+    /// Wall-clock source, injected so staleness is testable without sleeping.
+    pub(super) clock: fn() -> i64,
     /// The background loop's ends of the MCP channels. `init_dashboard` takes
     /// them to spawn [`super::mcp::mcp_background_loop`]; tests keep them to
     /// assert dispatched commands and inject outcomes.
@@ -155,6 +178,7 @@ impl Dashboard {
         // retained for tests to drive.
         let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::unbounded_channel();
         let (mcp_outcome_tx, mcp_outcome_rx) = mpsc::unbounded_channel();
+        let (daemon_outcome_tx, daemon_outcome_rx) = mpsc::unbounded_channel();
 
         // Seed the in-memory log buffer from the tail of the persistent log so
         // the panel shows recent history immediately on launch (not a blank panel).
@@ -201,6 +225,11 @@ impl Dashboard {
             mcp_cmd_tx,
             mcp_outcome_rx,
             mcp_bg_ends: Some((mcp_cmd_rx, mcp_outcome_tx)),
+            daemon_outcome_rx,
+            daemon_outcome_tx: Some(daemon_outcome_tx),
+            failed_cancels: std::collections::HashSet::new(),
+            daemon_run_ids: None,
+            clock: system_now_secs,
         }
     }
 
@@ -213,6 +242,34 @@ impl Dashboard {
         mpsc::UnboundedSender<super::types::McpOutcome>,
     )> {
         self.mcp_bg_ends.take()
+    }
+
+    /// Take the daemon-outcome sender, so `init_dashboard` can hand it to
+    /// [`super::daemon_background_loop`]. Returns `None` if already taken.
+    pub(super) fn take_daemon_outcome_tx(
+        &mut self,
+    ) -> Option<mpsc::UnboundedSender<DaemonOutcome>> {
+        self.daemon_outcome_tx.take()
+    }
+
+    /// Drain the daemon's answers to this tick's commands. A refused command
+    /// becomes a toast and a log line; the run is remembered so the next disk
+    /// sync can show it truthfully rather than just flipping it back.
+    pub(super) fn drain_daemon_outcomes(&mut self) {
+        while let Ok(outcome) = self.daemon_outcome_rx.try_recv() {
+            if outcome.ok {
+                self.failed_cancels.remove(&outcome.run_id);
+                continue;
+            }
+            self.failed_cancels.insert(outcome.run_id.clone());
+            Self::push_toast(
+                &mut self.toasts,
+                outcome.message.clone(),
+                ToastLevel::Error,
+                50,
+            );
+            self.add_log(format!("{}: {}", outcome.run_id, outcome.message));
+        }
     }
 
     /// The MCP screen's context, for `init_dashboard` to hand to the loop.
@@ -265,6 +322,9 @@ impl Dashboard {
                 AgentDisplayStatus::Error(_) => 4,
                 AgentDisplayStatus::Idle => 5,
                 AgentDisplayStatus::Cancelled => 6,
+                // Above the finished states: a stale run is unfinished business
+                // the user probably wants to clear.
+                AgentDisplayStatus::Stale => 2,
             }
         };
         let mut indices: Vec<usize> = (0..self.agents.len())
@@ -449,6 +509,34 @@ impl Dashboard {
         });
     }
 
+    /// The current wall-clock time in Unix seconds, via the injected clock.
+    fn now_secs(&self) -> i64 {
+        (self.clock)()
+    }
+
+    /// How long a run's metadata may go untouched, while the daemon does not
+    /// hold it, before the dashboard stops calling it ACTIVE.
+    ///
+    /// Comfortably longer than the persistence heartbeat, so a live-but-slow run
+    /// (a long inference writes nothing else) is never mistaken for a dead one.
+    pub(super) const STALE_AFTER_SECS: i64 = 300;
+
+    /// Whether a run that claims to be live on disk actually has nothing driving
+    /// it: the daemon does not hold it *and* its metadata has not been touched
+    /// in [`STALE_AFTER_SECS`].
+    ///
+    /// Both halves are needed. The daemon's list alone is not enough — it is
+    /// empty whenever the daemon is unreachable, which would flip every healthy
+    /// run to STALE. The timestamp alone is not enough either — a run mid-request
+    /// legitimately writes nothing for a while.
+    fn looks_stale(&self, run: &runstate::RunMeta) -> bool {
+        let Some(live) = &self.daemon_run_ids else {
+            return false; // no answer from the daemon this tick; assume nothing
+        };
+        !live.contains(&run.run_id)
+            && self.now_secs().saturating_sub(run.updated_at) > Self::STALE_AFTER_SECS
+    }
+
     /// Sync agent list from on-disk run-state dir (background workers).
     pub(super) fn sync_from_run_state(&mut self) {
         let runs = runstate::list_runs();
@@ -464,6 +552,8 @@ impl Dashboard {
                 RunStatus::Starting | RunStatus::Running => {
                     if pending_request.is_some() {
                         AgentDisplayStatus::Waiting
+                    } else if self.looks_stale(&run) {
+                        AgentDisplayStatus::Stale
                     } else {
                         AgentDisplayStatus::Active
                     }
@@ -697,6 +787,22 @@ impl Dashboard {
         }
     }
 
+    /// Refresh which runs the daemon actually holds.
+    ///
+    /// The dashboard lists runs from disk and the daemon lists them from memory,
+    /// and nothing reconciled the two — so a run whose daemon had died sat at
+    /// ACTIVE with a ticking timer forever. On any transport error this is set
+    /// back to `None`, meaning "unknown", so an unreachable daemon does not make
+    /// every run look dead.
+    pub(super) async fn sync_daemon_runs(&mut self, control: &ControlClient) {
+        self.daemon_run_ids = match control.request(&ControlRequest::List).await {
+            Ok(ControlResponse::List { runs }) => {
+                Some(runs.into_iter().map(|(run_id, _)| run_id).collect())
+            }
+            _ => None,
+        };
+    }
+
     /// Cancel (via the daemon) then delete all on-disk state for the selected
     /// agent.
     pub(super) fn delete_selected_agent(&mut self) {
@@ -704,8 +810,16 @@ impl Dashboard {
             Some(i) => (i, self.agents[i].id.clone()),
             None => return,
         };
-        // Ask the daemon to cancel the run first (a no-op if already terminal),
-        // so it stops writing state before we remove the directory.
+        // Record the run terminal on disk *before* removing it, and ask the
+        // daemon to cancel it too.
+        //
+        // The daemon command is asynchronous while the removal below is not, so
+        // an in-flight persist job can `create_dir_all` the directory straight
+        // back. Writing the terminal status first means that if it does
+        // reappear, it reappears as a finished run rather than as a live one the
+        // user just tried to delete. (The daemon cancel is what actually stops
+        // it writing; this only bounds what a lost race looks like.)
+        let _ = crate::runstate::force_cancel(&id);
         let _ = self
             .cmd_tx
             .send(DaemonCommand::Cancel { run_id: id.clone() });
@@ -1851,6 +1965,151 @@ mod tests {
 
             cleanup_run(run_id);
         });
+    }
+
+    // ─── staleness: disk says live, but nothing is driving it ───
+
+    /// The reported bug's shape: a run whose `meta.json` claims `starting` /
+    /// `running`, which the daemon does not hold and which has not been touched
+    /// in a long time, is not ACTIVE — nothing is driving it.
+    #[test]
+    fn a_run_the_daemon_does_not_hold_and_has_not_moved_shows_as_stale() {
+        crate::runstate::with_isolated_runs_dir("sync-stale-run", |_d| {
+            for status in [RunStatus::Starting, RunStatus::Running] {
+                let run_id = &format!("test-stale-{status}");
+                cleanup_run(run_id);
+                let mut meta = make_run_meta(run_id, status.clone());
+                meta.updated_at = 1_000;
+                runstate::create_run(&meta).unwrap();
+
+                let mut dash = make_test_dashboard();
+                dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS + 1;
+                // The daemon answered, and knows nothing about this run.
+                dash.daemon_run_ids = Some(std::collections::HashSet::new());
+                dash.sync_from_run_state();
+
+                let agent = dash.agents.iter().find(|a| a.id == *run_id).unwrap();
+                assert_eq!(agent.status, AgentDisplayStatus::Stale, "{status}");
+                assert!(agent.status.is_killable(), "and it can still be killed");
+                cleanup_run(run_id);
+            }
+        });
+    }
+
+    /// A run the daemon *does* hold is active however old its metadata looks —
+    /// one long inference legitimately writes nothing for a while.
+    #[test]
+    fn a_run_the_daemon_holds_is_never_stale() {
+        crate::runstate::with_isolated_runs_dir("sync-held-run", |_d| {
+            let run_id = "test-held-run";
+            cleanup_run(run_id);
+            let mut meta = make_run_meta(run_id, RunStatus::Running);
+            meta.updated_at = 1_000;
+            runstate::create_run(&meta).unwrap();
+
+            let mut dash = make_test_dashboard();
+            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS * 100;
+            dash.daemon_run_ids = Some([run_id.to_string()].into_iter().collect());
+            dash.sync_from_run_state();
+
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Active);
+            cleanup_run(run_id);
+        });
+    }
+
+    /// An unreachable daemon means "unknown", not "everything is dead" — the
+    /// list is empty in both cases, so treating them alike would flip every
+    /// healthy run to STALE the moment the socket blipped.
+    #[test]
+    fn an_unreachable_daemon_does_not_make_runs_look_stale() {
+        crate::runstate::with_isolated_runs_dir("sync-daemon-unknown", |_d| {
+            let run_id = "test-daemon-unknown";
+            cleanup_run(run_id);
+            let mut meta = make_run_meta(run_id, RunStatus::Running);
+            meta.updated_at = 1_000;
+            runstate::create_run(&meta).unwrap();
+
+            let mut dash = make_test_dashboard();
+            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS * 100;
+            dash.daemon_run_ids = None; // no answer this tick
+            dash.sync_from_run_state();
+
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Active);
+            cleanup_run(run_id);
+        });
+    }
+
+    /// A run the daemon doesn't hold but which is still writing is active — it
+    /// may simply not be registered yet (a just-spawned run, a fan-out worker).
+    #[test]
+    fn a_recently_updated_run_is_not_stale_even_if_unregistered() {
+        crate::runstate::with_isolated_runs_dir("sync-recent-run", |_d| {
+            let run_id = "test-recent-run";
+            cleanup_run(run_id);
+            let mut meta = make_run_meta(run_id, RunStatus::Running);
+            meta.updated_at = 1_000;
+            runstate::create_run(&meta).unwrap();
+
+            let mut dash = make_test_dashboard();
+            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS - 1;
+            dash.daemon_run_ids = Some(std::collections::HashSet::new());
+            dash.sync_from_run_state();
+
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Active);
+            cleanup_run(run_id);
+        });
+    }
+
+    // ─── daemon outcomes are surfaced ───
+
+    /// A refused command becomes a visible toast + log line. Discarding it is
+    /// what made a failed kill look like a successful one.
+    #[test]
+    fn a_refused_daemon_command_is_surfaced() {
+        let mut dash = make_test_dashboard();
+        let tx = dash
+            .take_daemon_outcome_tx()
+            .expect("a fresh dashboard has its outcome sender");
+        tx.send(DaemonOutcome {
+            run_id: "run-x".to_string(),
+            message: "the daemon has no such run to cancel".to_string(),
+            ok: false,
+        })
+        .unwrap();
+
+        dash.drain_daemon_outcomes();
+
+        assert!(
+            dash.toasts
+                .iter()
+                .any(|t| t.message.contains("no such run")),
+            "the failure is toasted"
+        );
+        assert!(
+            dash.log.iter().any(|l| l.message.contains("run-x")),
+            "and recorded in the activity log"
+        );
+        assert!(dash.failed_cancels.contains("run-x"));
+    }
+
+    #[test]
+    fn a_successful_daemon_command_is_not_toasted() {
+        let mut dash = make_test_dashboard();
+        let tx = dash.take_daemon_outcome_tx().unwrap();
+        tx.send(DaemonOutcome {
+            run_id: "run-y".to_string(),
+            message: String::new(),
+            ok: true,
+        })
+        .unwrap();
+
+        dash.drain_daemon_outcomes();
+
+        assert!(dash.toasts.is_empty(), "success is silent");
+        assert!(!dash.failed_cancels.contains("run-y"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -115,9 +115,6 @@ pub(crate) struct Dashboard {
     /// The background loop's sender for [`DaemonOutcome`]s; taken by
     /// `init_dashboard`, retained by tests to inject outcomes.
     pub(super) daemon_outcome_tx: Option<mpsc::UnboundedSender<DaemonOutcome>>,
-    /// Run ids the daemon reported it could not act on, so the disk sync doesn't
-    /// quietly restore them to ACTIVE without saying why.
-    pub(super) failed_cancels: std::collections::HashSet<String>,
     /// The run ids the daemon currently holds, refreshed each tick. `None` when
     /// the daemon did not answer — the disk view is then taken at face value
     /// rather than declaring every run stale.
@@ -227,7 +224,6 @@ impl Dashboard {
             mcp_bg_ends: Some((mcp_cmd_rx, mcp_outcome_tx)),
             daemon_outcome_rx,
             daemon_outcome_tx: Some(daemon_outcome_tx),
-            failed_cancels: std::collections::HashSet::new(),
             daemon_run_ids: None,
             clock: system_now_secs,
         }
@@ -253,15 +249,13 @@ impl Dashboard {
     }
 
     /// Drain the daemon's answers to this tick's commands. A refused command
-    /// becomes a toast and a log line; the run is remembered so the next disk
-    /// sync can show it truthfully rather than just flipping it back.
+    /// becomes a toast and a log line, so the row reverting on the next disk
+    /// sync has a visible explanation rather than none.
     pub(super) fn drain_daemon_outcomes(&mut self) {
         while let Ok(outcome) = self.daemon_outcome_rx.try_recv() {
             if outcome.ok {
-                self.failed_cancels.remove(&outcome.run_id);
                 continue;
             }
-            self.failed_cancels.insert(outcome.run_id.clone());
             Self::push_toast(
                 &mut self.toasts,
                 outcome.message.clone(),
@@ -1969,6 +1963,18 @@ mod tests {
 
     // ─── staleness: disk says live, but nothing is driving it ───
 
+    /// A clock far enough past a run's `updated_at` (1000) that it counts as
+    /// untouched. Shared by every staleness test, including the ones whose
+    /// checks short-circuit before reading the clock.
+    fn stale_clock() -> i64 {
+        1_000 + Dashboard::STALE_AFTER_SECS * 100
+    }
+
+    /// A clock still inside the staleness window.
+    fn fresh_clock() -> i64 {
+        1_000 + Dashboard::STALE_AFTER_SECS - 1
+    }
+
     /// The reported bug's shape: a run whose `meta.json` claims `starting` /
     /// `running`, which the daemon does not hold and which has not been touched
     /// in a long time, is not ACTIVE — nothing is driving it.
@@ -1983,7 +1989,7 @@ mod tests {
                 runstate::create_run(&meta).unwrap();
 
                 let mut dash = make_test_dashboard();
-                dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS + 1;
+                dash.clock = stale_clock;
                 // The daemon answered, and knows nothing about this run.
                 dash.daemon_run_ids = Some(std::collections::HashSet::new());
                 dash.sync_from_run_state();
@@ -2008,7 +2014,7 @@ mod tests {
             runstate::create_run(&meta).unwrap();
 
             let mut dash = make_test_dashboard();
-            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS * 100;
+            dash.clock = stale_clock;
             dash.daemon_run_ids = Some([run_id.to_string()].into_iter().collect());
             dash.sync_from_run_state();
 
@@ -2031,7 +2037,7 @@ mod tests {
             runstate::create_run(&meta).unwrap();
 
             let mut dash = make_test_dashboard();
-            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS * 100;
+            dash.clock = stale_clock;
             dash.daemon_run_ids = None; // no answer this tick
             dash.sync_from_run_state();
 
@@ -2053,7 +2059,7 @@ mod tests {
             runstate::create_run(&meta).unwrap();
 
             let mut dash = make_test_dashboard();
-            dash.clock = || 1_000 + Dashboard::STALE_AFTER_SECS - 1;
+            dash.clock = fresh_clock;
             dash.daemon_run_ids = Some(std::collections::HashSet::new());
             dash.sync_from_run_state();
 
@@ -2061,6 +2067,74 @@ mod tests {
             assert_eq!(agent.status, AgentDisplayStatus::Active);
             cleanup_run(run_id);
         });
+    }
+
+    /// A reachable daemon's run list is recorded; an unreachable one leaves
+    /// "unknown" rather than an empty set, which would read as "nothing is
+    /// running" and flip every healthy run to STALE.
+    #[tokio::test]
+    async fn sync_daemon_runs_records_the_list_or_unknown() {
+        use leviath_runtime::control_socket::{bind_control_listener, control_id};
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let mut listener = bind_control_listener(&id).unwrap();
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await;
+            let _ = write_half
+                .write_all(b"{\"result\":\"list\",\"runs\":[[\"run-a\",\"Active\"]]}\n")
+                .await;
+        });
+
+        let mut dash = make_test_dashboard();
+        dash.sync_daemon_runs(&ControlClient::new(id)).await;
+        assert_eq!(
+            dash.daemon_run_ids,
+            Some(["run-a".to_string()].into_iter().collect())
+        );
+        let _ = server.await;
+
+        // No daemon at all → unknown, not "none running".
+        let gone = tempfile::tempdir().unwrap();
+        dash.sync_daemon_runs(&ControlClient::new(control_id(
+            &gone.path().join("no-daemon"),
+        )))
+        .await;
+        assert_eq!(dash.daemon_run_ids, None);
+    }
+
+    /// The production clock answers with a plausible wall-clock time (the tests
+    /// above inject a fixed one, so this is the only place it runs).
+    #[test]
+    fn system_clock_reports_a_wall_clock_time() {
+        // Well after 2020 and before 2100 — i.e. a real epoch second.
+        let now = system_now_secs();
+        assert!(now > 1_577_836_800 && now < 4_102_444_800, "got {now}");
+    }
+
+    /// A stale run sorts above the finished ones: it is unfinished business the
+    /// user probably wants to clear, not history.
+    #[test]
+    fn stale_sorts_above_the_finished_states() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("done", AgentDisplayStatus::Complete));
+        dash.agents
+            .push(make_test_agent("stale", AgentDisplayStatus::Stale));
+        dash.agents
+            .push(make_test_agent("live", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+
+        let order: Vec<&str> = dash
+            .display_indices
+            .iter()
+            .map(|&i| dash.agents[i].id.as_str())
+            .collect();
+        assert_eq!(order, vec!["live", "stale", "done"]);
     }
 
     // ─── daemon outcomes are surfaced ───
@@ -2092,7 +2166,6 @@ mod tests {
             dash.log.iter().any(|l| l.message.contains("run-x")),
             "and recorded in the activity log"
         );
-        assert!(dash.failed_cancels.contains("run-x"));
     }
 
     #[test]
@@ -2109,7 +2182,7 @@ mod tests {
         dash.drain_daemon_outcomes();
 
         assert!(dash.toasts.is_empty(), "success is silent");
-        assert!(!dash.failed_cancels.contains("run-y"));
+        assert!(dash.log.iter().all(|l| !l.message.contains("run-y")));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -33,6 +33,13 @@ pub enum AgentDisplayStatus {
     Error(String),
     Idle,
     Cancelled,
+    /// On disk the run claims to be live, but the daemon has no such run and its
+    /// metadata has not been touched in a long time — so nothing is driving it.
+    ///
+    /// Shown distinctly rather than as ACTIVE because the two are not the same
+    /// thing to the user: an ACTIVE row implies work is happening. Killable, like
+    /// every other non-finished state.
+    Stale,
 }
 
 impl std::fmt::Display for AgentDisplayStatus {
@@ -45,11 +52,27 @@ impl std::fmt::Display for AgentDisplayStatus {
             Self::Error(msg) => write!(f, "{}ERROR: {}", GLYPH_ERROR, msg),
             Self::Idle => write!(f, "{}IDLE", GLYPH_PENDING),
             Self::Cancelled => write!(f, "⊘CANCEL"),
+            Self::Stale => write!(f, "{}STALE", GLYPH_ERROR),
         }
     }
 }
 
 impl AgentDisplayStatus {
+    /// Whether this run has finished, one way or another.
+    pub(super) fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Complete | Self::CompleteInteractive | Self::Error(_) | Self::Cancelled
+        )
+    }
+
+    /// Whether the run can be killed. Anything that has not finished can be —
+    /// including `Idle` and `Stale`, which the kill action used to skip, leaving
+    /// a run the dashboard showed as live with no way to get rid of it.
+    pub(super) fn is_killable(&self) -> bool {
+        !self.is_terminal()
+    }
+
     pub(super) fn color(&self) -> Color {
         match self {
             Self::Active => C_ACTIVE,
@@ -58,6 +81,7 @@ impl AgentDisplayStatus {
             Self::Error(_) => C_ERROR,
             Self::Idle => C_DIM,
             Self::Cancelled => C_DIM,
+            Self::Stale => C_WARN,
         }
     }
 }
@@ -136,6 +160,21 @@ pub(super) enum DaemonCommand {
     },
     /// Deliver a mid-run message to a running agent.
     Message { agent_id: String, content: String },
+}
+
+/// The result of a [`DaemonCommand`], drained each tick.
+///
+/// The dashboard used to discard these. A cancel that the daemon refused looked
+/// identical to one that worked: the row flashed CANCEL, the log said "Killed",
+/// and the next disk sync put it back to ACTIVE with no explanation.
+#[derive(Debug, PartialEq)]
+pub(super) struct DaemonOutcome {
+    /// The run the command targeted.
+    pub(super) run_id: String,
+    /// Human-readable result, shown as a toast when it failed.
+    pub(super) message: String,
+    /// Whether the daemon applied it.
+    pub(super) ok: bool,
 }
 
 /// A long-running MCP action dispatched from the (sync) MCP screen to the async

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -255,6 +255,7 @@ mod tests {
         );
         assert!(AgentDisplayStatus::Idle.to_string().contains("IDLE"));
         assert!(AgentDisplayStatus::Cancelled.to_string().contains("CANCEL"));
+        assert!(AgentDisplayStatus::Stale.to_string().contains("STALE"));
     }
 
     #[test]
@@ -270,6 +271,8 @@ mod tests {
     fn agent_display_status_color_idle_and_cancelled() {
         assert_eq!(AgentDisplayStatus::Idle.color(), C_DIM);
         assert_eq!(AgentDisplayStatus::Cancelled.color(), C_DIM);
+        // Stale is a warning, not a finished state: it wants attention.
+        assert_eq!(AgentDisplayStatus::Stale.color(), C_WARN);
         assert_eq!(AgentDisplayStatus::Waiting.color(), C_WARN);
         assert_eq!(AgentDisplayStatus::CompleteInteractive.color(), C_SUCCESS);
     }

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -477,16 +477,29 @@ impl ScriptIo for RealScriptIo {
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return Err("shell is unavailable: no tokio runtime on this thread".to_string());
         };
-        // Reap the child if the future is dropped (timeout, or the whole batch
-        // dropped because the agent was cancelled) rather than detaching it.
+        // Reap the whole command tree if the future is dropped (timeout, or the
+        // batch dropped because the agent was cancelled) rather than detaching
+        // it. `kill_on_drop` covers the shell; its own children are reparented
+        // to init unless the group is signalled — see `leviath_tools`' shell
+        // tool, which does the same.
         cmd.kill_on_drop(true);
+        leviath_tools::own_process_group(&mut cmd);
+        // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
+        // command's output is still captured.
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
         handle.block_on(async move {
-            match tokio::time::timeout(timeout, cmd.output()).await {
+            let child = match cmd.spawn() {
+                Ok(child) => child,
+                Err(e) => return Err(format!("failed to spawn shell: {e}")),
+            };
+            let _reaper = child.id().map(leviath_tools::ProcessGroupReaper);
+            match tokio::time::timeout(timeout, child.wait_with_output()).await {
                 Ok(Ok(output)) => Ok(cap_script_io(combine_shell_output(
                     &output.stdout,
                     &output.stderr,
                 ))),
-                Ok(Err(e)) => Err(format!("failed to spawn shell: {e}")),
+                Ok(Err(e)) => Err(format!("failed to run shell: {e}")),
                 Err(_) => Err(format!(
                     "shell command timed out after {}s",
                     timeout.as_secs()

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -489,17 +489,21 @@ impl ScriptIo for RealScriptIo {
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
         handle.block_on(async move {
-            let child = match cmd.spawn() {
-                Ok(child) => child,
-                Err(e) => return Err(format!("failed to spawn shell: {e}")),
+            // Spawn inside the timed future so the reaper guard lives exactly as
+            // long as the command: dropping the future drops the guard, which
+            // signals the group. One fallible block also keeps a single error
+            // arm, as `Command::output()` had.
+            let run = async {
+                let child = cmd.spawn()?;
+                let _reaper = child.id().map(leviath_tools::ProcessGroupReaper);
+                child.wait_with_output().await
             };
-            let _reaper = child.id().map(leviath_tools::ProcessGroupReaper);
-            match tokio::time::timeout(timeout, child.wait_with_output()).await {
+            match tokio::time::timeout(timeout, run).await {
                 Ok(Ok(output)) => Ok(cap_script_io(combine_shell_output(
                     &output.stdout,
                     &output.stderr,
                 ))),
-                Ok(Err(e)) => Err(format!("failed to run shell: {e}")),
+                Ok(Err(e)) => Err(format!("failed to spawn shell: {e}")),
                 Err(_) => Err(format!(
                     "shell command timed out after {}s",
                     timeout.as_secs()

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -477,6 +477,9 @@ impl ScriptIo for RealScriptIo {
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return Err("shell is unavailable: no tokio runtime on this thread".to_string());
         };
+        // Reap the child if the future is dropped (timeout, or the whole batch
+        // dropped because the agent was cancelled) rather than detaching it.
+        cmd.kill_on_drop(true);
         handle.block_on(async move {
             match tokio::time::timeout(timeout, cmd.output()).await {
                 Ok(Ok(output)) => Ok(cap_script_io(combine_shell_output(

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -228,6 +228,16 @@ pub fn build_host(
         )
     }));
 
+    // Last resort for a cancel the world can't service: force the run's on-disk
+    // state to `Cancelled`. The reloader above declines whenever a run can't be
+    // rebuilt — deleted blueprint, unreadable metadata, died mid-spawn — and
+    // without this a cancel in that state wrote nothing at all, so `meta.json`
+    // went on claiming the run was live and nothing could ever clear it.
+    let terminate_runs = runs_dir.clone();
+    host.set_force_terminator(Box::new(move |run_id| {
+        crate::runstate::force_cancel_in(&terminate_runs.join(run_id), now_secs()).found_run()
+    }));
+
     // Reap hook: when a terminal agent is reaped, tear down its sandbox and drop
     // its per-agent tool state (the latter also fixing a prior leak where tool
     // state was never released). Factored into `make_reaper` so the closure body
@@ -258,6 +268,7 @@ pub fn build_host(
     // spawn time for the run's start timestamp. Per-agent MCP defs = the global
     // servers' defs plus this blueprint's declared servers' defs (warmed above).
     let spawn_pool = mcp_pool.clone();
+    let spawn_runs_dir = runs_dir.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -265,7 +276,7 @@ pub fn build_host(
         // disk at all — no run dir, no meta.json, nothing to diagnose (#107).
         // The reload path deliberately doesn't do this: it must not overwrite a
         // recovering run's own metadata.
-        write_placeholder_meta(args);
+        write_placeholder_meta(&spawn_runs_dir, args);
         let defs = per_agent_mcp_defs(&spawn_pool, &mcp_tool_defs, &args.blueprint_path);
         build_agent(
             world.world_mut(),
@@ -288,7 +299,16 @@ pub fn build_host(
 /// state existed). Everything the agent hasn't resolved yet — model, stage names,
 /// stage count — is left blank; the first persistence tick overwrites the file
 /// with the real thing. Best-effort: a failure here must not block the spawn.
-fn write_placeholder_meta(args: &leviath_runtime::host::SpawnArgs) {
+///
+/// Writes under the host's configured `runs_dir` — the same directory the
+/// persistence lane and the reloader use. It deliberately does *not* go through
+/// `runstate::create_run`, which resolves the runs dir globally from
+/// `dirs::home_dir()`: that ignored a daemon configured with a different runs dir
+/// and, because `dirs::home_dir()` cannot be redirected by `$HOME` on macOS, let
+/// any test that spawned through a real host write placeholder runs into the
+/// developer's own `~/.leviath/runs` (where they then showed as permanently
+/// ACTIVE, since nothing would ever advance them).
+fn write_placeholder_meta(runs_dir: &std::path::Path, args: &leviath_runtime::host::SpawnArgs) {
     // The real agent name lives in the blueprint, which hasn't been parsed yet —
     // but the run id is `<agent>-<unix-secs>-<hex4>`, so its prefix is the name
     // (dashes inside the agent name included).
@@ -307,7 +327,7 @@ fn write_placeholder_meta(args: &leviath_runtime::host::SpawnArgs) {
         args.workdir.clone(),
         0,
     );
-    if let Err(e) = crate::runstate::create_run(&meta) {
+    if let Err(e) = crate::runstate::create_run_in(&runs_dir.join(&args.run_id), &meta) {
         tracing::warn!(run_id = %args.run_id, error = %e, "could not pre-create run directory");
     }
 }
@@ -495,60 +515,48 @@ mod tests {
     /// spawn that fails at *any* later step still leaves a `meta.json`.
     #[tokio::test]
     async fn spawner_pre_creates_the_run_dir_even_when_the_spawn_fails() {
-        crate::runstate::with_isolated_runs_dir_async("spawn-placeholder", |_base| async {
-            let runs = tempfile::tempdir().unwrap();
-            let mut host = setup_daemon_host(
-                Config::default(),
-                runs.path().to_path_buf(),
-                Handle::current(),
-            )
-            .await;
-            let (reply, rx) = oneshot::channel();
-            host.handle(ControlOp::Spawn {
-                args: Box::new(SpawnArgs {
-                    // A blueprint path that doesn't exist: the spawn fails at the
-                    // very first step inside build_agent.
-                    run_id: "my-agent-1234-ab12".to_string(),
-                    blueprint_path: "/no/such/agent.leviath".to_string(),
-                    task: "t".to_string(),
-                    regions: Default::default(),
-                    model: None,
-                    workdir: std::env::temp_dir().to_string_lossy().to_string(),
-                    metadata: Default::default(),
-                    callback_url: None,
-                    callback_secret: None,
-                    yolo: false,
-                    no_seed_commands: false,
-                    allow: Vec::new(),
-                    max_depth: None,
-                    parent_run_id: None,
-                }),
-                reply,
-            });
-            assert!(rx.await.unwrap().is_err());
-
-            let meta = crate::runstate::read_meta("my-agent-1234-ab12")
-                .expect("a failed spawn still leaves meta.json behind");
-            assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Starting);
-            assert_eq!(meta.task, "t");
-            // The agent name is recovered from the run id's prefix, dashes and all.
-            assert_eq!(meta.agent_name, "my-agent");
-        })
+        let runs = tempfile::tempdir().unwrap();
+        let mut host = setup_daemon_host(
+            Config::default(),
+            runs.path().to_path_buf(),
+            Handle::current(),
+        )
         .await;
+        let (reply, rx) = oneshot::channel();
+        host.handle(ControlOp::Spawn {
+            args: Box::new(SpawnArgs {
+                // A blueprint path that doesn't exist: the spawn fails at the
+                // very first step inside build_agent.
+                run_id: "my-agent-1234-ab12".to_string(),
+                blueprint_path: "/no/such/agent.leviath".to_string(),
+                task: "t".to_string(),
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                ..Default::default()
+            }),
+            reply,
+        });
+        assert!(rx.await.unwrap().is_err());
+
+        let meta = crate::runstate::read_meta_from(&runs.path().join("my-agent-1234-ab12"))
+            .expect("a failed spawn still leaves meta.json behind");
+        assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Starting);
+        assert_eq!(meta.task, "t");
+        // The agent name is recovered from the run id's prefix, dashes and all.
+        assert_eq!(meta.agent_name, "my-agent");
     }
 
     #[test]
     fn placeholder_meta_falls_back_to_the_whole_run_id_as_the_agent_name() {
-        crate::runstate::with_isolated_runs_dir("spawn-placeholder-odd-id", |_base| {
-            let args = SpawnArgs {
-                // Not the `<agent>-<secs>-<hex>` shape the run-id minter makes.
-                run_id: "odd".to_string(),
-                task: "t".to_string(),
-                ..Default::default()
-            };
-            write_placeholder_meta(&args);
-            assert_eq!(crate::runstate::read_meta("odd").unwrap().agent_name, "odd");
-        });
+        let runs = tempfile::tempdir().unwrap();
+        let args = SpawnArgs {
+            // Not the `<agent>-<secs>-<hex>` shape the run-id minter makes.
+            run_id: "odd".to_string(),
+            task: "t".to_string(),
+            ..Default::default()
+        };
+        write_placeholder_meta(runs.path(), &args);
+        let meta = crate::runstate::read_meta_from(&runs.path().join("odd")).unwrap();
+        assert_eq!(meta.agent_name, "odd");
     }
 
     #[test]
@@ -559,19 +567,132 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let blocker = dir.path().join("not-a-dir");
             std::fs::write(&blocker, "x").unwrap();
-            temp_env::with_var(
-                "LEVIATH_RUNS_DIR",
-                Some(blocker.join("runs").to_string_lossy().to_string()),
-                || {
-                    let args = SpawnArgs {
-                        run_id: "blocked".to_string(),
-                        ..Default::default()
-                    };
-                    write_placeholder_meta(&args);
-                    assert!(crate::runstate::read_meta("blocked").is_err());
-                },
+            let args = SpawnArgs {
+                run_id: "blocked".to_string(),
+                ..Default::default()
+            };
+            write_placeholder_meta(&blocker.join("runs"), &args);
+            assert!(
+                crate::runstate::read_meta_from(&blocker.join("runs").join("blocked")).is_err()
             );
         });
+    }
+
+    /// The spawner stakes out the run directory under the **host's configured**
+    /// `runs_dir`, never the home-resolved global one.
+    ///
+    /// This is an isolation invariant, not a convenience: `runstate::run_dir()`
+    /// goes through `dirs::home_dir()`, which ignores a `$HOME` override on macOS,
+    /// so a spawner that used it wrote into the developer's real `~/.leviath/runs`
+    /// from any test that drove a real host — leaving `status: "starting"` runs
+    /// that no daemon owned and nothing could ever advance. Asserting the global
+    /// dir is untouched is what keeps that from coming back.
+    #[tokio::test]
+    async fn spawner_writes_the_placeholder_under_the_hosts_runs_dir() {
+        let runs = tempfile::tempdir().unwrap();
+        let global_before = existing_global_run_ids();
+
+        let mut host = setup_daemon_host(
+            Config::default(),
+            runs.path().to_path_buf(),
+            Handle::current(),
+        )
+        .await;
+        let (reply, rx) = oneshot::channel();
+        host.handle(ControlOp::Spawn {
+            args: Box::new(SpawnArgs {
+                // A blueprint that doesn't exist: the spawn fails *after* the
+                // placeholder is staked out, which is the case that leaves a run
+                // dir behind.
+                run_id: "isolation-1234-ab12".to_string(),
+                blueprint_path: "/no/such/agent.leviath".to_string(),
+                task: "t".to_string(),
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                ..Default::default()
+            }),
+            reply,
+        });
+        assert!(rx.await.unwrap().is_err(), "the spawn itself fails");
+
+        assert!(
+            crate::runstate::read_meta_from(&runs.path().join("isolation-1234-ab12")).is_ok(),
+            "the placeholder lands in the host's configured runs dir"
+        );
+        assert_eq!(
+            existing_global_run_ids(),
+            global_before,
+            "spawning through a host must not write into the home-resolved runs dir"
+        );
+    }
+
+    /// End-to-end for the reported bug: a run whose blueprint no longer exists
+    /// cannot be rebuilt, so the reloader declines — and the cancel used to stop
+    /// there, replying "no such run" and writing nothing, leaving `meta.json`
+    /// claiming the run was live with no way to ever clear it. It must now be
+    /// terminated on disk instead.
+    #[tokio::test]
+    async fn cancelling_an_unreloadable_run_terminates_it_on_disk() {
+        let runs = tempfile::tempdir().unwrap();
+        let mut host = setup_daemon_host(
+            Config::default(),
+            runs.path().to_path_buf(),
+            Handle::current(),
+        )
+        .await;
+
+        // Staked out *after* startup, so the recovery sweep (which marks
+        // un-reloadable runs as crashed) hasn't already dealt with it — this is
+        // the live case: the daemon is up and the run cannot be paged in.
+        let run_dir = runs.path().join("gone-1234-ab12");
+        let meta = leviath_core::run_meta::RunMeta::new(
+            "gone-1234-ab12".to_string(),
+            "gone".to_string(),
+            // A blueprint path that does not exist — the deleted-manifest case.
+            "/no/such/dir/agent.leviath".to_string(),
+            "t".to_string(),
+            None,
+            std::env::temp_dir().to_string_lossy().to_string(),
+            1,
+        );
+        crate::runstate::create_run_in(&run_dir, &meta).unwrap();
+        assert!(
+            !crate::runstate::is_terminal_status(
+                &crate::runstate::read_meta_from(&run_dir).unwrap().status
+            ),
+            "the run starts out looking live"
+        );
+
+        let (reply, rx) = oneshot::channel();
+        host.handle(ControlOp::Cancel {
+            run_id: "gone-1234-ab12".to_string(),
+            reply,
+        });
+        assert!(rx.await.unwrap(), "the cancel reports that it applied");
+        assert_eq!(
+            crate::runstate::read_meta_from(&run_dir).unwrap().status,
+            leviath_core::run_meta::RunStatus::Cancelled,
+            "and it reached disk, so nothing shows the run as live any more"
+        );
+
+        // A run id that names nothing at all is still an honest miss.
+        let (reply, rx) = oneshot::channel();
+        host.handle(ControlOp::Cancel {
+            run_id: "no-such-run".to_string(),
+            reply,
+        });
+        assert!(!rx.await.unwrap());
+    }
+
+    /// The run ids currently present in the home-resolved (global) runs dir.
+    /// Used to assert a test added nothing there; an unreadable/absent dir is an
+    /// empty set, which is the same assertion.
+    fn existing_global_run_ids() -> std::collections::BTreeSet<String> {
+        std::fs::read_dir(crate::runstate::runs_dir())
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect()
     }
 
     // ── per-agent MCP (issue #97) ──

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -590,7 +590,11 @@ mod tests {
     #[tokio::test]
     async fn spawner_writes_the_placeholder_under_the_hosts_runs_dir() {
         let runs = tempfile::tempdir().unwrap();
-        let global_before = existing_global_run_ids();
+        // Resolve the global dir once: sibling tests redirect it via the
+        // process-global `LEVIATH_RUNS_DIR`, so resolving it twice could compare
+        // two different directories.
+        let global = crate::runstate::runs_dir();
+        let global_before = run_ids_in(&global);
 
         let mut host = setup_daemon_host(
             Config::default(),
@@ -619,7 +623,7 @@ mod tests {
             "the placeholder lands in the host's configured runs dir"
         );
         assert_eq!(
-            existing_global_run_ids(),
+            run_ids_in(&global),
             global_before,
             "spawning through a host must not write into the home-resolved runs dir"
         );
@@ -683,16 +687,30 @@ mod tests {
         assert!(!rx.await.unwrap());
     }
 
-    /// The run ids currently present in the home-resolved (global) runs dir.
-    /// Used to assert a test added nothing there; an unreadable/absent dir is an
-    /// empty set, which is the same assertion.
-    fn existing_global_run_ids() -> std::collections::BTreeSet<String> {
-        std::fs::read_dir(crate::runstate::runs_dir())
+    /// The run ids present in `dir`. An unreadable or absent directory is an
+    /// empty set, which is the same assertion for the isolation check.
+    fn run_ids_in(dir: &std::path::Path) -> std::collections::BTreeSet<String> {
+        std::fs::read_dir(dir)
             .into_iter()
             .flatten()
             .flatten()
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .collect()
+    }
+
+    #[test]
+    fn run_ids_in_lists_entries_and_tolerates_a_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("run-one")).unwrap();
+        std::fs::create_dir_all(dir.path().join("run-two")).unwrap();
+        assert_eq!(
+            run_ids_in(dir.path()),
+            ["run-one".to_string(), "run-two".to_string()]
+                .into_iter()
+                .collect()
+        );
+        // A dir that doesn't exist reads as "nothing there", not a panic.
+        assert!(run_ids_in(&dir.path().join("nope")).is_empty());
     }
 
     // ── per-agent MCP (issue #97) ──

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -474,6 +474,26 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         );
     }
 
+    /// A caller the host no longer knows about (daemon shutting down, or the
+    /// run already reaped) also ends the wait — there is nothing left to wait
+    /// for either way.
+    #[tokio::test]
+    async fn wait_gives_up_when_the_caller_is_unknown_to_the_host() {
+        let (h, _seen, _t) = fake_host_with_parent(
+            Ok("child-1".to_string()),
+            vec![Some(AgentStatus::Active); 8],
+            false,
+            None, // the host has no such caller
+        );
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handle(&h, &tc("wait_for_agent", json!({ "agent_id": "child-1" }))),
+        )
+        .await
+        .expect("the wait returns instead of polling forever");
+        assert!(out.contains("cancelled while waiting"), "got: {out}");
+    }
+
     #[tokio::test]
     async fn spawn_requires_blueprint_and_task_and_reports_resolve_errors() {
         let (h, _seen, _t) = fake_host(Ok(String::new()), vec![], false);

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -141,8 +141,25 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
                     label(&status)
                 );
             }
+            // The caller itself was cancelled (or failed) while waiting. Give up
+            // rather than keep polling for a child that is being torn down with
+            // it — this loop has no other exit, so it would hold its tool-lane
+            // worker for as long as the daemon lived.
+            Some(_) if caller_is_terminal(h).await => {
+                return format!("[error] cancelled while waiting for '{agent_id}'");
+            }
             Some(_) => tokio::time::sleep(WAIT_POLL).await,
         }
+    }
+}
+
+/// Whether the agent that called `wait_for_agent` has itself reached a terminal
+/// state. A dropped request (daemon shutting down) counts as terminal — there is
+/// nothing left to wait for either way.
+async fn caller_is_terminal(h: &SubAgentHandle) -> bool {
+    match status_of(h, &h.parent_run_id).await {
+        Some(status) => is_terminal(&status),
+        None => true,
     }
 }
 
@@ -242,13 +259,29 @@ mod tests {
     /// no per-call-site closures, so this single service loop is the only region
     /// (covered collectively across the suite). `spawn_result` answers `Spawn`
     /// and the received args are recorded into the returned `Vec` for assertions;
-    /// `statuses` answers successive `Check`s in order (`None` once exhausted);
-    /// `ok` answers `Send`/`Kill`.
+    /// `statuses` answers successive `Check`s for *children* in order (`None`
+    /// once exhausted); `ok` answers `Send`/`Kill`. The caller ("parent") is
+    /// reported `Active` — see [`fake_host_with_parent`] to script it.
     #[allow(clippy::type_complexity)]
     fn fake_host(
         spawn_result: Result<String, String>,
         statuses: Vec<Option<AgentStatus>>,
         ok: bool,
+    ) -> (
+        SubAgentHandle,
+        std::sync::Arc<std::sync::Mutex<Vec<SpawnArgs>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        fake_host_with_parent(spawn_result, statuses, ok, Some(AgentStatus::Active))
+    }
+
+    /// [`fake_host`] with the calling agent's own status scripted too.
+    #[allow(clippy::type_complexity)]
+    fn fake_host_with_parent(
+        spawn_result: Result<String, String>,
+        statuses: Vec<Option<AgentStatus>>,
+        ok: bool,
+        parent_status: Option<AgentStatus>,
     ) -> (
         SubAgentHandle,
         std::sync::Arc<std::sync::Mutex<Vec<SpawnArgs>>>,
@@ -264,6 +297,13 @@ mod tests {
                     SubAgentOp::Spawn { reply, args, .. } => {
                         seen_task.lock().unwrap().push(*args);
                         let _ = reply.send(spawn_result.clone());
+                    }
+                    // `wait` polls the *caller* as well as the child (to bail out
+                    // if the caller was itself cancelled), so the scripted queue
+                    // answers only for children — the caller is reported Active
+                    // unless a test scripts it otherwise.
+                    SubAgentOp::Check { reply, run_id } if run_id == "parent" => {
+                        let _ = reply.send(parent_status.clone());
                     }
                     SubAgentOp::Check { reply, .. } => {
                         let _ = reply.send(checks.next().flatten());
@@ -407,6 +447,31 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         )
         .await;
         assert!(out.contains("finished with status: complete"));
+    }
+
+    /// `wait_for_agent` gives up when the *calling* agent is cancelled. The loop
+    /// has no other exit, and it runs on a tool-lane worker — of which there are
+    /// a fixed number — so a cancelled caller would otherwise poll for a child
+    /// that is being torn down with it until the daemon exits.
+    #[tokio::test]
+    async fn wait_gives_up_when_the_calling_agent_is_cancelled() {
+        let (h, _seen, _t) = fake_host_with_parent(
+            Ok("child-1".to_string()),
+            // The child never finishes on its own.
+            vec![Some(AgentStatus::Active); 8],
+            false,
+            Some(AgentStatus::Cancelled),
+        );
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handle(&h, &tc("wait_for_agent", json!({ "agent_id": "child-1" }))),
+        )
+        .await
+        .expect("the wait returns instead of polling forever");
+        assert!(
+            out.contains("cancelled while waiting"),
+            "reports why it stopped, got: {out}"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -38,7 +38,8 @@ pub enum Commands {
     /// Send a message to a running agent
     Msg(commands::ctl::MsgArgs),
 
-    /// Cancel a running agent
+    /// Cancel a running agent (alias: `kill`)
+    #[command(alias = "kill")]
     Cancel(commands::ctl::CancelArgs),
 
     /// Answer a pending interaction (or list open ones with no request id)
@@ -303,6 +304,7 @@ mod tests {
     async fn dispatch_cancel_variant_is_routed_through_the_executor() {
         let args = commands::ctl::CancelArgs {
             run_id: "r".to_string(),
+            force: false,
         };
         assert!(dispatch(Commands::Cancel(args), &MockRisky).await.is_ok());
     }

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -356,8 +356,12 @@ pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
     match write_meta_to(run_dir, &cancelled) {
         Ok(()) => ForceCancelOutcome::Cancelled,
         Err(e) => {
+            // Formatted outside the macro: a method call inside a `%field` is
+            // only evaluated when a subscriber visits the value, so it would go
+            // unexercised under the tests' no-op subscriber.
+            let path = run_dir.display().to_string();
             tracing::warn!(
-                run_dir = %run_dir.display(),
+                run_dir = %path,
                 error = %e,
                 "could not force a run to cancelled on disk"
             );

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -84,11 +84,18 @@ fn now_secs() -> i64 {
 
 /// Inner implementation of `runs_dir`, parameterised so it can be tested
 /// without touching the process-global env. All callers go through `runs_dir`.
+///
+/// The fallback resolves through [`crate::config::leviath_home_dir`], not
+/// `dirs::home_dir` directly, so `LEVIATH_HOME` redirects the runs dir like it
+/// redirects the config, the control socket and the agents dir. It used to use
+/// `dirs::home_dir` alone, which meant a test that set `LEVIATH_HOME` was
+/// isolated everywhere *except* here and still wrote runs into the developer's
+/// real `~/.leviath/runs`. `LEVIATH_RUNS_DIR` still wins over both.
 fn runs_dir_from(env_override: Option<&str>) -> PathBuf {
     if let Some(dir) = env_override {
         return PathBuf::from(dir);
     }
-    dirs::home_dir()
+    crate::config::leviath_home_dir()
         .unwrap_or_default()
         .join(".leviath")
         .join("runs")
@@ -228,7 +235,12 @@ pub fn create_run(meta: &RunMeta) -> anyhow::Result<()> {
     create_run_in(&run_dir(&meta.run_id), meta)
 }
 
-fn create_run_in(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
+/// Create an explicit run directory and write initial metadata into it.
+///
+/// Callers that already know the directory should prefer this over
+/// [`create_run`], which resolves it from the home directory — the daemon's
+/// spawner stakes out the run dir under its own configured `runs_dir`.
+pub(crate) fn create_run_in(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
     std::fs::create_dir_all(dir)?;
 
     // Restrict the run directory to owner-only (no-op on non-Unix).
@@ -258,7 +270,105 @@ pub fn read_meta(run_id: &str) -> anyhow::Result<RunMeta> {
     read_meta_from(&run_dir(run_id))
 }
 
-fn read_meta_from(dir: &std::path::Path) -> anyhow::Result<RunMeta> {
+/// Whether an on-disk run status means the run has finished and should be left
+/// alone. `Starting`/`Running`/`WaitingInput` are all "still going" as far as
+/// anything reading the runs dir is concerned.
+pub fn is_terminal_status(status: &RunStatus) -> bool {
+    matches!(
+        status,
+        RunStatus::Complete
+            | RunStatus::CompleteInteractive
+            | RunStatus::Error
+            | RunStatus::Cancelled
+    )
+}
+
+/// The outcome of forcing a run to a terminal state on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForceCancelOutcome {
+    /// The run was live on disk and is now recorded `Cancelled`.
+    Cancelled,
+    /// The run was already finished; nothing was written.
+    AlreadyTerminal,
+    /// No run directory with that id exists.
+    NoSuchRun,
+    /// The directory exists but its metadata could not be rewritten.
+    WriteFailed,
+}
+
+impl ForceCancelOutcome {
+    /// Whether the id named a run at all — i.e. whether the cancel had a target,
+    /// regardless of whether it needed to write anything.
+    pub fn found_run(&self) -> bool {
+        !matches!(self, Self::NoSuchRun)
+    }
+}
+
+/// Force a run's on-disk metadata to `Cancelled`, in the runs dir resolved from
+/// the environment. See [`force_cancel_in`].
+pub fn force_cancel(run_id: &str) -> ForceCancelOutcome {
+    force_cancel_in(&run_dir(run_id), now_secs())
+}
+
+/// Force the run in `run_dir` to `Cancelled`, stamping `updated_at` with `now`.
+///
+/// This is the floor under every kill path: it needs nothing but the filesystem,
+/// so it works for a run the daemon can't rebuild (blueprint deleted, metadata
+/// corrupt, died mid-spawn) and for a run whose daemon is gone entirely. Both
+/// the daemon's force-terminator seam and `lev cancel --force` route here so
+/// there is one definition of "terminated on disk".
+///
+/// A directory whose `meta.json` is missing or unparseable still gets a minimal
+/// `Cancelled` record written: such a run is otherwise skipped by `list_runs`,
+/// which makes it invisible *and* permanent.
+pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
+    if !run_dir.is_dir() {
+        return ForceCancelOutcome::NoSuchRun;
+    }
+    let run_id = run_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let cancelled = match read_meta_from(run_dir) {
+        Ok(meta) if is_terminal_status(&meta.status) => return ForceCancelOutcome::AlreadyTerminal,
+        Ok(meta) => RunMeta {
+            status: RunStatus::Cancelled,
+            updated_at: now,
+            ..meta
+        },
+        // Unreadable metadata: synthesize just enough to record the outcome. The
+        // run id is the directory name, which is the one field always recoverable.
+        Err(_) => RunMeta {
+            status: RunStatus::Cancelled,
+            updated_at: now,
+            error: Some("run metadata was unreadable; cancelled".to_string()),
+            ..RunMeta::new(
+                run_id.clone(),
+                run_id,
+                String::new(),
+                String::new(),
+                None,
+                String::new(),
+                0,
+            )
+        },
+    };
+    match write_meta_to(run_dir, &cancelled) {
+        Ok(()) => ForceCancelOutcome::Cancelled,
+        Err(e) => {
+            tracing::warn!(
+                run_dir = %run_dir.display(),
+                error = %e,
+                "could not force a run to cancelled on disk"
+            );
+            ForceCancelOutcome::WriteFailed
+        }
+    }
+}
+
+/// Read run metadata out of an explicit run directory (the daemon works from its
+/// own configured `runs_dir` rather than the home-resolved one).
+pub(crate) fn read_meta_from(dir: &std::path::Path) -> anyhow::Result<RunMeta> {
     let path = dir.join("meta.json");
     let json = std::fs::read_to_string(&path)?;
     Ok(serde_json::from_str(&json)?)
@@ -1190,6 +1300,28 @@ mod tests {
         assert!(path.ends_with(".leviath\\runs"));
     }
 
+    /// With no `LEVIATH_RUNS_DIR`, the runs dir must follow `LEVIATH_HOME` — the
+    /// same home every other leviath path resolves through. Without this, setting
+    /// `LEVIATH_HOME` isolates a test's config/socket/agents dir while its runs
+    /// still land in the real `~/.leviath/runs`.
+    #[test]
+    fn runs_dir_follows_leviath_home() {
+        temp_env::with_vars(
+            [
+                ("LEVIATH_RUNS_DIR", None::<&str>),
+                ("LEVIATH_HOME", Some("/tmp/leviath-home-runs-test")),
+            ],
+            || {
+                assert_eq!(
+                    runs_dir(),
+                    PathBuf::from("/tmp/leviath-home-runs-test")
+                        .join(".leviath")
+                        .join("runs")
+                );
+            },
+        );
+    }
+
     #[test]
     fn dashboard_log_path_from_uses_override_when_provided() {
         let path = dashboard_log_path_from(Some("/custom/leviath/dashboard.log"));
@@ -1845,6 +1977,104 @@ mod tests {
         assert!(runs.iter().any(|r| r.run_id == good_run_id));
         assert!(!runs.iter().any(|r| r.run_id == bad_run_id));
         assert!(!runs.iter().any(|r| r.run_id == no_meta_run_id));
+    }
+
+    // ─── force_cancel_in: the floor under every kill path ───
+
+    /// Write a run dir with `status` and return its path.
+    fn run_dir_with(base: &std::path::Path, run_id: &str, status: RunStatus) -> PathBuf {
+        let dir = base.join(run_id);
+        let meta = RunMeta {
+            status,
+            ..RunMeta::new(
+                run_id.into(),
+                "a".into(),
+                "/p".into(),
+                "t".into(),
+                None,
+                "/w".into(),
+                1,
+            )
+        };
+        create_run_in(&dir, &meta).unwrap();
+        dir
+    }
+
+    #[test]
+    fn force_cancel_terminates_every_non_terminal_status() {
+        let base = tempfile::tempdir().unwrap();
+        for status in [
+            RunStatus::Starting,
+            RunStatus::Running,
+            RunStatus::WaitingInput,
+        ] {
+            let dir = run_dir_with(base.path(), &format!("live-{status}"), status.clone());
+            assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Cancelled);
+            let meta = read_meta_from(&dir).unwrap();
+            assert_eq!(meta.status, RunStatus::Cancelled, "{status} is killable");
+            assert_eq!(meta.updated_at, 99, "the cancel is stamped");
+        }
+    }
+
+    #[test]
+    fn force_cancel_leaves_a_finished_run_alone() {
+        let base = tempfile::tempdir().unwrap();
+        for status in [
+            RunStatus::Complete,
+            RunStatus::CompleteInteractive,
+            RunStatus::Error,
+            RunStatus::Cancelled,
+        ] {
+            let dir = run_dir_with(base.path(), &format!("done-{status}"), status.clone());
+            assert_eq!(
+                force_cancel_in(&dir, 99),
+                ForceCancelOutcome::AlreadyTerminal,
+                "{status} is already finished"
+            );
+            assert_eq!(read_meta_from(&dir).unwrap().status, status);
+        }
+    }
+
+    #[test]
+    fn force_cancel_reports_no_such_run_for_a_missing_directory() {
+        let base = tempfile::tempdir().unwrap();
+        let outcome = force_cancel_in(&base.path().join("ghost"), 99);
+        assert_eq!(outcome, ForceCancelOutcome::NoSuchRun);
+        assert!(!outcome.found_run(), "nothing to cancel");
+    }
+
+    /// A run dir whose metadata can't be parsed still gets terminated. Such a run
+    /// is skipped by `list_runs`, so leaving it alone makes it both invisible and
+    /// permanent — the one state from which there is no way back.
+    #[test]
+    fn force_cancel_writes_a_record_over_unreadable_metadata() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("corrupt-run");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("meta.json"), "{ not json").unwrap();
+
+        assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Cancelled);
+        let meta = read_meta_from(&dir).expect("now parses");
+        assert_eq!(meta.status, RunStatus::Cancelled);
+        assert_eq!(meta.run_id, "corrupt-run", "recovered from the dir name");
+        assert!(meta.error.is_some(), "records why it was synthesized");
+    }
+
+    /// A directory that exists but can't be written still counts as "found" — the
+    /// caller must not report "no such run" for a run that plainly exists.
+    #[test]
+    fn force_cancel_reports_a_write_failure_but_still_found_the_run() {
+        crate::test_support::with_tracing(|| {
+            let base = tempfile::tempdir().unwrap();
+            let dir = base.path().join("blocked-run");
+            std::fs::create_dir_all(&dir).unwrap();
+            // A directory where `meta.json` must go: the rename can't succeed.
+            std::fs::create_dir_all(dir.join("meta.json")).unwrap();
+
+            let outcome = force_cancel_in(&dir, 99);
+            assert_eq!(outcome, ForceCancelOutcome::WriteFailed);
+            assert!(outcome.found_run());
+        });
     }
 
     #[test]

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1"
 
 [dev-dependencies]
 async-trait = "0.1"
+temp-env = { workspace = true, features = ["async_closure"] }
 tempfile = "3"
 
 [lints]

--- a/crates/leviath-runtime/src/cancel.rs
+++ b/crates/leviath-runtime/src/cancel.rs
@@ -1,0 +1,161 @@
+//! A one-shot "stop what you're doing" signal for work already in flight.
+//!
+//! Cancelling an agent sets its status, which stops the dispatch systems from
+//! starting *new* work — but an inference request or tool batch handed to the
+//! async lanes before that keeps running to completion. For a stalled provider
+//! call that is up to the job timeout; for a tool batch there was no bound at
+//! all, and the batch holds one of the tool lane's fixed number of workers the
+//! whole time.
+//!
+//! A [`CancelToken`] is handed to each async job when it is dispatched and kept
+//! on the agent, so cancelling the agent drops the in-flight future at its next
+//! await point: the HTTP request is aborted, the pool permit and lane worker are
+//! released, and the result is never applied.
+//!
+//! This is deliberately a few lines rather than a dependency: the whole contract
+//! is "set a flag once, wake anyone waiting".
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::Notify;
+
+#[derive(Default)]
+struct Inner {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+/// A cloneable cancellation signal. Every clone observes the same state, and
+/// cancelling is idempotent — a token that fires twice (say, a cancel racing a
+/// reap) is not an error.
+#[derive(Clone, Default)]
+pub struct CancelToken {
+    inner: Arc<Inner>,
+}
+
+impl CancelToken {
+    /// A fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fire the signal, waking every waiter. Idempotent.
+    pub fn cancel(&self) {
+        self.inner.cancelled.store(true, Ordering::SeqCst);
+        self.inner.notify.notify_waiters();
+    }
+
+    /// Whether this token has already fired.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Resolve once the token fires, immediately if it already has.
+    ///
+    /// The waiter is armed *before* the flag is re-checked. `notify_waiters`
+    /// only wakes waiters registered at the time it runs, so checking first and
+    /// waiting second would lose a cancel that landed in between — and the job
+    /// would then run to completion despite having been cancelled.
+    pub async fn cancelled(&self) {
+        let notified = self.inner.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+}
+
+impl std::fmt::Debug for CancelToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CancelToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn cancelled_resolves_when_the_token_fires() {
+        let token = CancelToken::new();
+        assert!(!token.is_cancelled());
+
+        let waiter = tokio::spawn({
+            let token = token.clone();
+            async move { token.cancelled().await }
+        });
+        // Let the waiter arm itself, then fire.
+        tokio::task::yield_now().await;
+        token.cancel();
+
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("a fired token wakes its waiter")
+            .unwrap();
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_returns_immediately_for_an_already_fired_token() {
+        let token = CancelToken::new();
+        token.cancel();
+        tokio::time::timeout(Duration::from_secs(5), token.cancelled())
+            .await
+            .expect("no wait for a token that already fired");
+    }
+
+    /// A cancel concurrent with the wait is still observed. This exercises the
+    /// path but cannot *prove* the arm-then-check ordering: the window it guards
+    /// is a few instructions with no await point in it, so a test cannot land in
+    /// it reliably. The ordering is enforced by construction (see `cancelled`),
+    /// not by this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancel_concurrent_with_the_wait_is_observed() {
+        for _ in 0..500 {
+            let token = CancelToken::new();
+            let firing = tokio::spawn({
+                let token = token.clone();
+                async move { token.cancel() }
+            });
+            tokio::time::timeout(Duration::from_secs(5), token.cancelled())
+                .await
+                .expect("the cancel was observed");
+            firing.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_is_idempotent_and_wakes_every_clone() {
+        let token = CancelToken::new();
+        let waiters: Vec<_> = (0..3)
+            .map(|_| {
+                let token = token.clone();
+                tokio::spawn(async move { token.cancelled().await })
+            })
+            .collect();
+        tokio::task::yield_now().await;
+        token.cancel();
+        token.cancel(); // twice is fine
+
+        for waiter in waiters {
+            tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("every clone observes the cancel")
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn debug_reports_the_state() {
+        let token = CancelToken::new();
+        assert!(format!("{token:?}").contains("cancelled: false"));
+        token.cancel();
+        assert!(format!("{token:?}").contains("cancelled: true"));
+    }
+}

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -945,13 +945,18 @@ mod tests {
     #[tokio::test]
     async fn client_times_out_on_a_daemon_that_never_answers() {
         let (mut listener, id, _dir) = test_listener();
-        let server = tokio::spawn(async move {
+        // The server reads the request, then hands both halves back and exits.
+        // The test holds them, so the connection stays open with no reply ever
+        // sent — a daemon that accepted the work and went quiet. Handing them
+        // over (rather than parking the task on a future that never resolves)
+        // lets the task actually finish.
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
             let stream = listener.accept().await.unwrap();
-            // Read the request, then never reply and hold the connection open.
-            let (read_half, _write_half) = tokio::io::split(stream);
+            let (read_half, write_half) = tokio::io::split(stream);
             let mut lines = BufReader::new(read_half).lines();
             let _ = lines.next_line().await;
-            std::future::pending::<()>().await;
+            let _ = tx.send((lines, write_half));
         });
 
         let err = temp_env::async_with_vars([("LEVIATH_CONTROL_TIMEOUT_SECS", Some("1"))], async {
@@ -960,7 +965,8 @@ mod tests {
         .await;
         assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
         assert!(err.to_string().contains("did not respond"), "got: {err}");
-        server.abort();
+        // Held until now so the connection outlived the client's deadline.
+        drop(rx);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -314,6 +314,47 @@ where
     Ok(())
 }
 
+/// How long a control request waits for the daemon before giving up, when
+/// `LEVIATH_CONTROL_TIMEOUT_SECS` is unset.
+///
+/// Generous enough to cover a busy daemon's control loop, short enough that a
+/// wedged one is reported rather than waited on indefinitely.
+pub const DEFAULT_CONTROL_TIMEOUT_SECS: u64 = 30;
+
+/// Floor on the deadline for a `Spawn`, which does more work than the other ops:
+/// the daemon connects the blueprint's MCP servers before spawning, and each of
+/// those has its own 30s connect timeout, so a blueprint declaring several
+/// servers can legitimately outlast the ordinary deadline. Without this floor a
+/// slow-but-succeeding spawn would be reported to the user as a timeout.
+pub const SPAWN_CONTROL_TIMEOUT_SECS: u64 = 300;
+
+/// The deadline for one control request. `LEVIATH_CONTROL_TIMEOUT_SECS`
+/// overrides it; `0` disables the deadline (for debugging a daemon that is
+/// legitimately slow). An unparseable value falls back to the default.
+pub fn request_timeout() -> std::time::Duration {
+    let secs = std::env::var("LEVIATH_CONTROL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONTROL_TIMEOUT_SECS);
+    match secs {
+        0 => std::time::Duration::MAX,
+        secs => std::time::Duration::from_secs(secs),
+    }
+}
+
+/// The deadline for `req`: [`request_timeout`], raised to at least
+/// [`SPAWN_CONTROL_TIMEOUT_SECS`] for a `Spawn`. An explicitly disabled deadline
+/// (`0`) stays disabled.
+fn timeout_for(req: &ControlRequest) -> std::time::Duration {
+    let base = request_timeout();
+    match req {
+        ControlRequest::Spawn { .. } if base != std::time::Duration::MAX => {
+            base.max(std::time::Duration::from_secs(SPAWN_CONTROL_TIMEOUT_SECS))
+        }
+        _ => base,
+    }
+}
+
 /// The client half of the control transport: connects to the daemon's control
 /// socket (resolved from a [`ControlId`]), sends one [`ControlRequest`], and
 /// reads back its [`ControlResponse`]. A fresh connection per request keeps it
@@ -330,8 +371,27 @@ impl ControlClient {
     }
 
     /// Send one request and await its response. Errors if the daemon can't be
-    /// reached, the connection closes before a reply, or the reply doesn't parse.
+    /// reached, does not answer within [`request_timeout`], the connection closes
+    /// before a reply, or the reply doesn't parse.
     pub async fn request(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
+        // The daemon services control ops from a single loop, so one op that
+        // takes a long time (or a wedged world) delays every other client. With
+        // no deadline, `lev cancel` and the dashboard simply hung — no output, no
+        // error, nothing to act on. A timeout turns that into a failure the
+        // caller can fall back from.
+        let deadline = timeout_for(req);
+        tokio::time::timeout(deadline, self.request_uncapped(req))
+            .await
+            .unwrap_or_else(|_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("the daemon did not respond within {}s", deadline.as_secs()),
+                ))
+            })
+    }
+
+    /// [`Self::request`] without the deadline.
+    async fn request_uncapped(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
         let stream = connect(&self.id).await?;
         let (read_half, mut write_half) = tokio::io::split(stream);
         let mut line = serde_json::to_string(req).expect("ControlRequest serializes");
@@ -877,6 +937,87 @@ mod tests {
 
         let err = ControlClient::new(id).list().await.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    /// A daemon that accepts the connection but never answers must not hang the
+    /// client. `lev cancel` against a wedged daemon used to block forever with no
+    /// output — nothing to see, nothing to act on, and no way to kill the run.
+    #[tokio::test]
+    async fn client_times_out_on_a_daemon_that_never_answers() {
+        let (mut listener, id, _dir) = test_listener();
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap();
+            // Read the request, then never reply and hold the connection open.
+            let (read_half, _write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await;
+            std::future::pending::<()>().await;
+        });
+
+        let err = temp_env::async_with_vars([("LEVIATH_CONTROL_TIMEOUT_SECS", Some("1"))], async {
+            ControlClient::new(id).list().await.unwrap_err()
+        })
+        .await;
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(err.to_string().contains("did not respond"), "got: {err}");
+        server.abort();
+    }
+
+    #[test]
+    fn request_timeout_honors_the_override_and_falls_back() {
+        temp_env::with_var("LEVIATH_CONTROL_TIMEOUT_SECS", Some("7"), || {
+            assert_eq!(request_timeout(), std::time::Duration::from_secs(7));
+        });
+        // `0` disables the deadline entirely, for debugging a legitimately slow
+        // daemon.
+        temp_env::with_var("LEVIATH_CONTROL_TIMEOUT_SECS", Some("0"), || {
+            assert_eq!(request_timeout(), std::time::Duration::MAX);
+        });
+        // Garbage and absence both fall back rather than failing the command.
+        temp_env::with_var("LEVIATH_CONTROL_TIMEOUT_SECS", Some("soon"), || {
+            assert_eq!(
+                request_timeout(),
+                std::time::Duration::from_secs(DEFAULT_CONTROL_TIMEOUT_SECS)
+            );
+        });
+        temp_env::with_var_unset("LEVIATH_CONTROL_TIMEOUT_SECS", || {
+            assert_eq!(
+                request_timeout(),
+                std::time::Duration::from_secs(DEFAULT_CONTROL_TIMEOUT_SECS)
+            );
+        });
+    }
+
+    /// A spawn connects the blueprint's MCP servers first (30s each), so it gets
+    /// a longer floor than the interactive ops — otherwise a slow-but-succeeding
+    /// spawn is reported to the user as a timeout.
+    #[test]
+    fn spawn_gets_a_longer_deadline_than_other_ops() {
+        let spawn = ControlRequest::Spawn {
+            args: Box::new(SpawnArgs::default()),
+        };
+        let cancel = ControlRequest::Cancel {
+            run_id: "r".to_string(),
+        };
+        temp_env::with_var_unset("LEVIATH_CONTROL_TIMEOUT_SECS", || {
+            assert_eq!(
+                timeout_for(&spawn),
+                std::time::Duration::from_secs(SPAWN_CONTROL_TIMEOUT_SECS)
+            );
+            assert_eq!(
+                timeout_for(&cancel),
+                std::time::Duration::from_secs(DEFAULT_CONTROL_TIMEOUT_SECS)
+            );
+        });
+        // A configured value larger than the floor wins for both.
+        temp_env::with_var("LEVIATH_CONTROL_TIMEOUT_SECS", Some("900"), || {
+            assert_eq!(timeout_for(&spawn), std::time::Duration::from_secs(900));
+            assert_eq!(timeout_for(&cancel), std::time::Duration::from_secs(900));
+        });
+        // A deliberately disabled deadline stays disabled, spawn included.
+        temp_env::with_var("LEVIATH_CONTROL_TIMEOUT_SECS", Some("0"), || {
+            assert_eq!(timeout_for(&spawn), std::time::Duration::MAX);
+        });
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1252,6 +1252,22 @@ mod tests {
         e
     }
 
+    /// A [`ForceTerminator`] that records each run id it was asked to terminate
+    /// and reports success for everything but `"never-existed"`. Shared by the
+    /// tests that expect it to fire and the ones that expect it not to, so its
+    /// body is exercised rather than existing only to go unused.
+    fn recording_terminator(seen: Arc<Mutex<Vec<String>>>) -> ForceTerminator {
+        Box::new(move |run_id| {
+            seen.lock().unwrap().push(run_id.to_string());
+            run_id != "never-existed"
+        })
+    }
+
+    /// A [`Reloader`] that pages any run id in as a fresh agent.
+    fn paging_reloader() -> Reloader {
+        Box::new(|world, run_id| Some(world.spawn_agent((agent_state(run_id),))))
+    }
+
     async fn ask<T>(host: &mut WorldHost, make: impl FnOnce(oneshot::Sender<T>) -> ControlOp) -> T {
         let (tx, rx) = oneshot::channel();
         host.handle(make(tx));
@@ -1647,6 +1663,37 @@ mod tests {
         );
     }
 
+    /// A child that was already reaped is skipped rather than tripping the
+    /// cancel: `SubAgentChildren` still names it, but the entity is gone, so
+    /// there is no agent id to close interactions for.
+    #[tokio::test]
+    async fn cancel_tolerates_a_child_that_has_already_been_reaped() {
+        let mut host = host_with(vec![]);
+        let parent = spawn(&mut host, "parent", "parent");
+        let ghost = host.world_mut().spawn_agent((agent_state("ghost"),));
+        host.world_mut()
+            .world_mut()
+            .entity_mut(parent)
+            .insert(SubAgentChildren {
+                children: vec![ghost],
+                max_child_depth: 3,
+            });
+        host.world_mut().world_mut().despawn(ghost);
+
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "parent".to_string(),
+                reply
+            })
+            .await,
+            "the parent is still cancelled"
+        );
+        assert_eq!(
+            host.world.agent_status(parent),
+            Some(AgentStatus::Cancelled)
+        );
+    }
+
     /// Cancelling a run closes its open prompts. The blocked `ask` occupies a
     /// tool-lane worker, and the lane has a fixed worker count — leaving it
     /// parked forever is what starves every other agent's tool batches.
@@ -1662,10 +1709,17 @@ mod tests {
                 .ask(InteractionRequest::free_text("q", "ask", "stage", true))
                 .await
         });
-        // Wait for the ask to register.
+        // Wait for the ask to register, then let the host emit it — so the
+        // emitted-interaction set is non-empty and the cancel has something to
+        // prune, rather than pruning an empty set.
         while hub.pending().is_empty() {
             tokio::task::yield_now().await;
         }
+        host.emit_events();
+        assert!(
+            !host.emitted_interactions.is_empty(),
+            "the open request was emitted"
+        );
 
         ask(&mut host, |reply| ControlOp::Cancel {
             run_id: "run-a".to_string(),
@@ -1684,6 +1738,10 @@ mod tests {
         // ...and the request stops being advertised to `lev respond` / the
         // dashboard for a run that is going away.
         assert!(hub.pending().is_empty(), "no orphaned prompt is left open");
+        assert!(
+            host.emitted_interactions.is_empty(),
+            "and it is pruned from the emitted set, not re-announced forever"
+        );
     }
 
     /// The floor under every kill: a run the reloader can't rebuild must still be
@@ -1695,11 +1753,7 @@ mod tests {
         // A reloader that always declines — the deleted-blueprint case.
         host.set_reloader(Box::new(|_world, _run_id| None));
         let terminated = Arc::new(Mutex::new(Vec::new()));
-        let seen = terminated.clone();
-        host.set_force_terminator(Box::new(move |run_id| {
-            seen.lock().unwrap().push(run_id.to_string());
-            run_id != "never-existed"
-        }));
+        host.set_force_terminator(recording_terminator(terminated.clone()));
 
         assert!(
             ask(&mut host, |reply| ControlOp::Cancel {
@@ -1729,12 +1783,8 @@ mod tests {
     async fn cancel_does_not_force_terminate_a_run_it_could_cancel() {
         let mut host = host_with(vec![]);
         spawn(&mut host, "run-a", "agent-a");
-        let forced = Arc::new(Mutex::new(false));
-        let hit = forced.clone();
-        host.set_force_terminator(Box::new(move |_run_id| {
-            *hit.lock().unwrap() = true;
-            true
-        }));
+        let terminated = Arc::new(Mutex::new(Vec::new()));
+        host.set_force_terminator(recording_terminator(terminated.clone()));
 
         assert!(
             ask(&mut host, |reply| ControlOp::Cancel {
@@ -1747,7 +1797,10 @@ mod tests {
             host.world.agent_status(host.by_run_id["run-a"]),
             Some(AgentStatus::Cancelled)
         );
-        assert!(!*forced.lock().unwrap(), "the disk fallback stayed unused");
+        assert!(
+            terminated.lock().unwrap().is_empty(),
+            "the disk fallback stayed unused"
+        );
     }
 
     /// Agents that enter the world outside a `Spawn` op (fan-out workers, built
@@ -1785,9 +1838,7 @@ mod tests {
 
         assert_eq!(host.live_entity("worker-run"), Some(entity), "adopted");
         // A reloader that would mint a duplicate if the map were still missing it.
-        host.set_reloader(Box::new(|world, run_id| {
-            Some(world.spawn_agent((agent_state(run_id),)))
-        }));
+        host.set_reloader(paging_reloader());
         assert!(
             ask(&mut host, |reply| ControlOp::Cancel {
                 run_id: "worker-run".to_string(),
@@ -2385,9 +2436,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_pages_in_an_unloaded_run() {
         let mut host = host_with(vec![]);
-        host.set_reloader(Box::new(|world, run_id| {
-            Some(world.spawn_agent((agent_state(run_id),)))
-        }));
+        host.set_reloader(paging_reloader());
         // Cancelling a run that isn't in memory pages it in, then cancels it.
         let cancelled = ask(&mut host, |reply| ControlOp::Cancel {
             run_id: "unloaded".to_string(),

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -101,6 +101,20 @@ pub type Spawner = Box<dyn FnMut(&mut PipelineWorld, &SpawnArgs) -> Result<Entit
 /// [`WorldHost::set_reloader`].
 pub type Reloader = Box<dyn FnMut(&mut PipelineWorld, &str) -> Option<Entity> + Send>;
 
+/// The daemon-installed last resort for cancelling a run the world cannot hold:
+/// given a run id, it forces that run's **on-disk** state to a terminal status
+/// and reports whether a run directory existed to act on.
+///
+/// This is what makes a cancel unconditional. [`Reloader`] declines whenever a
+/// run can't be rebuilt — its blueprint was moved or deleted, its metadata is
+/// unreadable, it died mid-spawn before any agent existed — and before this seam
+/// a cancel in that state replied `false` and wrote nothing, so `meta.json` kept
+/// claiming `running`/`starting` forever and the run could never be got rid of.
+/// The runtime has no notion of the on-disk layout, so the daemon supplies the
+/// writer. Installed with [`WorldHost::set_force_terminator`]; without one, a
+/// cancel that misses in the world simply misses (the prior behavior).
+pub type ForceTerminator = Box<dyn FnMut(&str) -> bool + Send>;
+
 /// The daemon-installed hook run just before a terminal agent's entity is
 /// despawned (reaped). It receives the world and the entity while both are still
 /// valid, so the daemon can release per-agent resources the runtime doesn't know
@@ -380,6 +394,7 @@ pub struct WorldHost {
     spawner: Option<Spawner>,
     spawn_preprocessor: Option<SpawnPreprocessor>,
     reloader: Option<Reloader>,
+    force_terminator: Option<ForceTerminator>,
     reaper: Option<Reaper>,
     events: broadcast::Sender<WorldEvent>,
     emitted: HashMap<String, Emitted>,
@@ -413,6 +428,7 @@ impl WorldHost {
             spawner: None,
             spawn_preprocessor: None,
             reloader: None,
+            force_terminator: None,
             reaper: None,
             events,
             emitted: HashMap::new(),
@@ -444,6 +460,7 @@ impl WorldHost {
     /// what changed (status/tokens/context/completion) plus any new interaction.
     /// Called after each drive to quiescence, so subscribers see every change.
     fn emit_events(&mut self) {
+        self.adopt_unregistered_runs();
         let pairs: Vec<(String, Entity)> = self
             .by_run_id
             .iter()
@@ -612,6 +629,33 @@ impl WorldHost {
         }
     }
 
+    /// Register any agent that exists in the world but is missing from the run-id
+    /// map, so the host's view is the world's view.
+    ///
+    /// Not every agent arrives through a `Spawn` control op: fan-out workers are
+    /// built straight into the world by the fan-out spawner, which has no handle
+    /// on the host to register them. An unregistered agent is invisible to `list`
+    /// (so `lev ps` never showed a worker), never reaped (its sandbox and tool
+    /// state leak), and — worst — un-cancellable, because a cancel by its run id
+    /// misses the map, falls through to the reloader, and pages a **second** live
+    /// entity in from that run's on-disk state while the original keeps running.
+    /// Adopting them here is idempotent and keeps a stale mapping from winning:
+    /// a registered id whose entity has been despawned is re-pointed.
+    fn adopt_unregistered_runs(&mut self) {
+        let live: Vec<(String, Entity)> = self
+            .world
+            .world_mut()
+            .query::<(Entity, &RunMetadata)>()
+            .iter(self.world.world())
+            .map(|(entity, md)| (md.run_id.clone(), entity))
+            .collect();
+        for (run_id, entity) in live {
+            if self.live_entity(&run_id) != Some(entity) {
+                self.by_run_id.insert(run_id, entity);
+            }
+        }
+    }
+
     /// Whether a terminal agent is safe to unload: it has no **live** parent that
     /// might still be waiting on it. True for a root (no `ParentRef`), or when its
     /// parent has been despawned or is itself terminal; false while a non-terminal
@@ -646,6 +690,13 @@ impl WorldHost {
     /// Without one, an op targeting a run that isn't in memory just misses.
     pub fn set_reloader(&mut self, reloader: Reloader) {
         self.reloader = Some(reloader);
+    }
+
+    /// Install the [`ForceTerminator`] used to terminate a run on disk when the
+    /// world cannot hold it. Without one, a cancel that misses in the world and
+    /// can't be reloaded just misses.
+    pub fn set_force_terminator(&mut self, force_terminator: ForceTerminator) {
+        self.force_terminator = Some(force_terminator);
     }
 
     /// Install the reap hook run just before each terminal agent is despawned,
@@ -789,8 +840,14 @@ impl WorldHost {
         Ok(run_id)
     }
 
-    /// Cancel a run and every descendant. Returns whether the run existed (paging
-    /// it in from disk first if it had been unloaded).
+    /// Cancel a run and every descendant, paging the root in from disk first if it
+    /// had been unloaded. Returns whether the run was found in the world.
+    ///
+    /// Cancelling only the root would leave its sub-agents and fan-out workers
+    /// running — they are independent agents the schedule keeps driving, so they
+    /// would carry on spending tokens with no parent to report to. Each cancelled
+    /// agent's open interactions are closed too, so nothing is left blocked on a
+    /// prompt for a run that is going away.
     fn cancel_tree(&mut self, run_id: &str) -> bool {
         let Some(root) = self.resolve_or_reload(run_id) else {
             return false;
@@ -806,7 +863,27 @@ impl WorldHost {
         }
         let mut cancelled = false;
         for e in subtree {
+            // Read the agent id before cancelling — the entity stays valid until
+            // it is reaped, but reading first keeps this independent of that.
+            let agent_id = self
+                .world
+                .world()
+                .get::<AgentState>(e)
+                .map(|s| s.agent_id.clone());
             cancelled |= self.world.cancel(e);
+            if let Some(agent_id) = agent_id {
+                self.interactions.cancel_for_agent(&agent_id);
+                // The hub is keyed by agent id but the emitted-interaction set is
+                // keyed by request id, so drop the ids that are no longer pending.
+                let still_open: HashSet<String> = self
+                    .interactions
+                    .pending()
+                    .into_iter()
+                    .map(|(_, req)| req.id)
+                    .collect();
+                self.emitted_interactions
+                    .retain(|id| still_open.contains(id));
+            }
         }
         cancelled
     }
@@ -883,9 +960,17 @@ impl WorldHost {
                 let _ = reply.send(ok);
             }
             ControlOp::Cancel { run_id, reply } => {
-                let ok = self
-                    .resolve_or_reload(&run_id)
-                    .is_some_and(|e| self.world.cancel(e));
+                // Cancel is unconditional: it either takes effect in the world
+                // (root plus every descendant) or, when the run can't be held
+                // there at all, is forced onto its on-disk state. It reports
+                // `false` only when there is genuinely no such run anywhere —
+                // otherwise a run whose blueprint had moved stayed `running` on
+                // disk forever with no way to get rid of it.
+                let ok = self.cancel_tree(&run_id)
+                    || self
+                        .force_terminator
+                        .as_mut()
+                        .is_some_and(|terminate| terminate(&run_id));
                 let _ = reply.send(ok);
             }
             ControlOp::List { reply } => {
@@ -1526,6 +1611,195 @@ mod tests {
         })
         .await;
         assert!(!miss);
+    }
+
+    /// A user-facing cancel must reach the sub-agent tree, not just the root —
+    /// otherwise the children keep running with nobody to report to. Before this,
+    /// only the model-facing `kill_agent` tool cascaded.
+    #[tokio::test]
+    async fn cancel_cascades_to_the_whole_tree() {
+        let mut host = host_with(vec![]);
+        host.set_spawner(child_spawner());
+        spawn(&mut host, "parent", "parent");
+        ask_sub(&mut host, |reply| SubAgentOp::Spawn {
+            args: Box::new(SpawnArgs {
+                run_id: "child".to_string(),
+                ..Default::default()
+            }),
+            parent_run_id: "parent".to_string(),
+            max_depth: 3,
+            reply,
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "parent".to_string(),
+                reply
+            })
+            .await
+        );
+        assert_eq!(
+            host.world.agent_status(host.by_run_id["child"]),
+            Some(AgentStatus::Cancelled),
+            "cancelling the parent cancels its children"
+        );
+    }
+
+    /// Cancelling a run closes its open prompts. The blocked `ask` occupies a
+    /// tool-lane worker, and the lane has a fixed worker count — leaving it
+    /// parked forever is what starves every other agent's tool batches.
+    #[tokio::test]
+    async fn cancel_closes_the_runs_open_interactions() {
+        let mut host = host_with(vec![]);
+        let hub = host.interactions();
+        spawn(&mut host, "run-a", "agent-a");
+
+        let backend = hub.backend_for("agent-a");
+        let asking = tokio::spawn(async move {
+            backend
+                .ask(InteractionRequest::free_text("q", "ask", "stage", true))
+                .await
+        });
+        // Wait for the ask to register.
+        while hub.pending().is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        ask(&mut host, |reply| ControlOp::Cancel {
+            run_id: "run-a".to_string(),
+            reply,
+        })
+        .await;
+
+        // The blocked future is released rather than parked forever. Bounded,
+        // because the regression this guards *is* an unbounded wait: without the
+        // per-agent cancel this await simply never returns, and a test that hangs
+        // rather than fails is worse than no test.
+        tokio::time::timeout(std::time::Duration::from_secs(5), asking)
+            .await
+            .expect("cancelling the run releases its blocked ask")
+            .expect("the ask task did not panic");
+        // ...and the request stops being advertised to `lev respond` / the
+        // dashboard for a run that is going away.
+        assert!(hub.pending().is_empty(), "no orphaned prompt is left open");
+    }
+
+    /// The floor under every kill: a run the reloader can't rebuild must still be
+    /// terminated, via the daemon's on-disk force-terminator. Replying `false` and
+    /// writing nothing is what made such a run permanent.
+    #[tokio::test]
+    async fn cancel_falls_back_to_the_force_terminator_when_the_world_cannot_hold_the_run() {
+        let mut host = host_with(vec![]);
+        // A reloader that always declines — the deleted-blueprint case.
+        host.set_reloader(Box::new(|_world, _run_id| None));
+        let terminated = Arc::new(Mutex::new(Vec::new()));
+        let seen = terminated.clone();
+        host.set_force_terminator(Box::new(move |run_id| {
+            seen.lock().unwrap().push(run_id.to_string());
+            run_id != "never-existed"
+        }));
+
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "unreloadable".to_string(),
+                reply
+            })
+            .await,
+            "a run that can't be reloaded is still terminated"
+        );
+        assert!(
+            !ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "never-existed".to_string(),
+                reply
+            })
+            .await,
+            "`false` is reserved for a run that exists nowhere"
+        );
+        assert_eq!(
+            *terminated.lock().unwrap(),
+            vec!["unreloadable".to_string(), "never-existed".to_string()]
+        );
+    }
+
+    /// A live run is cancelled in the world; the on-disk fallback is not consulted
+    /// (the persistence lane records the status change).
+    #[tokio::test]
+    async fn cancel_does_not_force_terminate_a_run_it_could_cancel() {
+        let mut host = host_with(vec![]);
+        spawn(&mut host, "run-a", "agent-a");
+        let forced = Arc::new(Mutex::new(false));
+        let hit = forced.clone();
+        host.set_force_terminator(Box::new(move |_run_id| {
+            *hit.lock().unwrap() = true;
+            true
+        }));
+
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "run-a".to_string(),
+                reply
+            })
+            .await
+        );
+        assert_eq!(
+            host.world.agent_status(host.by_run_id["run-a"]),
+            Some(AgentStatus::Cancelled)
+        );
+        assert!(!*forced.lock().unwrap(), "the disk fallback stayed unused");
+    }
+
+    /// Agents that enter the world outside a `Spawn` op (fan-out workers, built
+    /// directly by the fan-out spawner) are adopted into the run-id map, so they
+    /// are listed, reaped and — the point here — cancellable by id. Left
+    /// unregistered, a cancel missed the map and paged a *second* copy of the run
+    /// in from disk while the original kept going.
+    #[tokio::test]
+    async fn unregistered_world_agents_are_adopted_and_become_cancellable() {
+        let mut host = host_with(vec![]);
+        let entity = host.world_mut().spawn_agent((
+            agent_state("worker"),
+            RunMetadata {
+                run_id: "worker-run".to_string(),
+                agent_name: "w".to_string(),
+                agent_path: String::new(),
+                task: String::new(),
+                model: None,
+                workdir: String::new(),
+                num_stages: 1,
+                started_at: 0,
+                parent_run_id: None,
+                metadata: Default::default(),
+                callback_url: None,
+                callback_secret: None,
+                title: None,
+            },
+        ));
+        assert!(
+            !host.by_run_id.contains_key("worker-run"),
+            "not registered by the spawn itself"
+        );
+
+        host.emit_events();
+
+        assert_eq!(host.live_entity("worker-run"), Some(entity), "adopted");
+        // A reloader that would mint a duplicate if the map were still missing it.
+        host.set_reloader(Box::new(|world, run_id| {
+            Some(world.spawn_agent((agent_state(run_id),)))
+        }));
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "worker-run".to_string(),
+                reply
+            })
+            .await
+        );
+        assert_eq!(
+            host.world.agent_status(entity),
+            Some(AgentStatus::Cancelled),
+            "the original entity is cancelled, not a reloaded copy"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -126,6 +126,7 @@ pub async fn run_inference_job(
     results: UnboundedSender<InferenceOutcome>,
     wake: Arc<Notify>,
     retry: RetryPolicy,
+    cancel: crate::cancel::CancelToken,
 ) {
     let InferenceJob {
         entity,
@@ -169,13 +170,25 @@ pub async fn run_inference_job(
             }
         }
     };
-    let result = match tokio::time::timeout(retry.job_timeout, attempts).await {
-        Ok(result) => result,
-        Err(_elapsed) => Err(leviath_providers::ProviderError::Other(format!(
-            "inference exceeded the {}s job timeout and was aborted to free the \
-             pool slot (a stalled or never-completing response)",
-            retry.job_timeout.as_secs()
-        ))),
+    // A cancel drops the whole retry-and-backoff future — aborting the in-flight
+    // HTTP request rather than waiting out the job timeout (up to 15 minutes) —
+    // and reports nothing: the agent is already terminal, so there is no outcome
+    // to apply. Releasing the permit here is the point; a cancelled run used to
+    // hold its model's pool slot for as long as the provider took to answer.
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            drop(permit);
+            return;
+        }
+        outcome = tokio::time::timeout(retry.job_timeout, attempts) => match outcome {
+            Ok(result) => result,
+            Err(_elapsed) => Err(leviath_providers::ProviderError::Other(format!(
+                "inference exceeded the {}s job timeout and was aborted to free the \
+                 pool slot (a stalled or never-completing response)",
+                retry.job_timeout.as_secs()
+            ))),
+        },
     };
     drop(permit); // free the pool slot before the collect system runs
     let _ = results.send(InferenceOutcome { entity, result });
@@ -259,6 +272,61 @@ mod tests {
         }
     }
 
+    /// Cancelling releases the pool slot immediately instead of waiting out the
+    /// job timeout (15 minutes by default), and reports no outcome — the agent is
+    /// already terminal, so there is nothing to apply.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_job_frees_its_pool_slot_without_reporting() {
+        let mut cfg = InferencePoolConfig::new();
+        cfg.set_limit("m", 1);
+        let pools = InferencePools::new(cfg);
+        let permit = pools.try_acquire("m").expect("free pool");
+        assert!(pools.try_acquire("m").is_none(), "pool should be full");
+
+        // A provider that never answers — the stalled-call case a cancel exists
+        // to escape.
+        let provider = Arc::new(Scripted {
+            steps: std::sync::Mutex::new(vec![Step::Hang].into()),
+            calls: std::sync::Mutex::new(0),
+        });
+        let job = InferenceJob {
+            entity: Entity::from_raw(7),
+            provider,
+            request: test_request(),
+            permit,
+            exact_token_counting: false,
+        };
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let cancel = crate::cancel::CancelToken::new();
+        let running = tokio::spawn(run_inference_job(
+            job,
+            tx,
+            Arc::new(Notify::new()),
+            // A job timeout far longer than the test: only the cancel can end it.
+            RetryPolicy {
+                max_attempts: 1,
+                base_delay: Duration::ZERO,
+                job_timeout: Duration::from_secs(3600),
+            },
+            cancel.clone(),
+        ));
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(5), running)
+            .await
+            .expect("the cancel ended the job")
+            .unwrap();
+        assert!(
+            pools.try_acquire("m").is_some(),
+            "the pool slot is free for the next agent"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "and no outcome is reported for a cancelled run"
+        );
+    }
+
     #[tokio::test]
     async fn run_job_aborts_a_hung_call_and_frees_the_pool_slot() {
         // A model pool of one slot, taken by the (hung) job under test.
@@ -285,7 +353,14 @@ mod tests {
             base_delay: Duration::ZERO,
             job_timeout: Duration::from_millis(50),
         };
-        run_inference_job(job, tx, Arc::new(Notify::new()), policy).await;
+        run_inference_job(
+            job,
+            tx,
+            Arc::new(Notify::new()),
+            policy,
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
 
         // The hung call was aborted with a timeout error…
         let outcome = rx.try_recv().expect("outcome sent");
@@ -307,6 +382,7 @@ mod tests {
             tx,
             wake.clone(),
             RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
         )
         .await;
 
@@ -322,7 +398,14 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let wake = Arc::new(Notify::new());
         let err = Arc::new(Fixed::Err("boom".to_string()));
-        run_inference_job(job(err), tx, wake, RetryPolicy::default()).await;
+        run_inference_job(
+            job(err),
+            tx,
+            wake,
+            RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
 
         let outcome = rx.try_recv().expect("outcome sent");
         assert!(outcome.result.is_err());
@@ -413,6 +496,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
@@ -435,6 +519,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
@@ -464,6 +549,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
@@ -492,6 +578,7 @@ mod tests {
             tx,
             wake,
             RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
         )
         .await;
     }
@@ -571,6 +658,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             no_delay(4),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
@@ -598,6 +686,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             no_delay(3),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");
@@ -617,6 +706,7 @@ mod tests {
             tx,
             Arc::new(Notify::new()),
             no_delay(4),
+            crate::cancel::CancelToken::new(),
         )
         .await;
         let outcome = rx.try_recv().expect("outcome sent");

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -137,6 +137,29 @@ impl InteractionHub {
         removed
     }
 
+    /// Cancel every open request belonging to `agent_id`, returning how many were
+    /// closed. Each one's `submit` wakes with the neutral response.
+    ///
+    /// This is the per-agent counterpart of [`Self::cancel`], which is keyed by
+    /// request id — an id a canceller of a *run* doesn't have. Without it,
+    /// cancelling a run left its `ask` future blocked forever: the future holds a
+    /// tool-lane worker (the lane has a fixed worker count, so enough of them
+    /// stall every other agent's tool batches), and the orphaned request keeps
+    /// being surfaced by `lev respond` and the dashboard for a run that no longer
+    /// exists.
+    pub fn cancel_for_agent(&self, agent_id: &str) -> usize {
+        // Dropping each entry drops its responder, waking `submit` with an error.
+        let mut pending = self.pending.lock().unwrap_or_else(PoisonError::into_inner);
+        let before = pending.len();
+        pending.retain(|_, entry| entry.agent_id != agent_id);
+        let removed = before - pending.len();
+        drop(pending);
+        if removed > 0 {
+            self.nudge();
+        }
+        removed
+    }
+
     /// A per-agent [`InteractionBackend`] backed by this hub.
     pub fn backend_for(&self, agent_id: impl Into<String>) -> HubInteractionBackend {
         HubInteractionBackend {

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -560,6 +560,18 @@ pub fn collect_interaction_point(
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(out.entity);
+        // A run cancelled while its prompt was open is finished, and the arms
+        // below all set `Active`/`ResolveTransition` unconditionally — so without
+        // this, answering the orphaned prompt (from `lev respond`, the dashboard,
+        // or the neutral response a cancel itself delivers) walked the run
+        // straight back to `Active` and it carried on as if it had never been
+        // cancelled. Drop the outcome and let the reaper take the entity.
+        if crate::pipeline::is_terminal_status(&state.status) {
+            commands
+                .entity(out.entity)
+                .remove::<AwaitingInteractionPoint>();
+            continue;
+        }
         let idx = pc.map_or(0, |c| c.0);
         let round = rounds.map_or(0, |r| r.0);
         let (name, npoints) = match stage_points(bp, cursor) {
@@ -1286,6 +1298,55 @@ mod tests {
             AgentStatus::Cancelled
         );
         assert!(world.get::<ResolveTransition>(e).is_none());
+    }
+
+    /// Answering the prompt of a run that was cancelled while it waited must not
+    /// bring the run back. Every non-`Abort` arm sets `Active` unconditionally, so
+    /// without the terminal guard an answer — including the neutral response a
+    /// cancel itself delivers to release the blocked `ask` — walked a cancelled
+    /// run straight back into the pipeline.
+    #[test]
+    fn collect_does_not_resurrect_a_cancelled_run() {
+        for decision in [
+            PointOutcome::Approve {
+                user_text: "ok".to_string(),
+            },
+            PointOutcome::Directive {
+                user_text: "go".to_string(),
+                directive: "d".to_string(),
+            },
+            PointOutcome::Edit {
+                user_text: "go".to_string(),
+                edited: "body".to_string(),
+            },
+        ] {
+            let (mut world, tx) = collect_world();
+            let e = spawn_awaiting(&mut world, vec![plan_point()]);
+            world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Cancelled;
+
+            tx.send(InteractionPointOutcome {
+                entity: e,
+                decision,
+            })
+            .unwrap();
+            run_collect(&mut world);
+
+            assert_eq!(
+                world.get::<AgentState>(e).unwrap().status,
+                AgentStatus::Cancelled,
+                "the run stays cancelled"
+            );
+            assert!(
+                world.get::<AwaitingInteractionPoint>(e).is_none(),
+                "the awaiting marker is still cleared, so nothing re-collects it"
+            );
+            assert!(
+                world.get::<ResolveTransition>(e).is_none()
+                    && world.get::<ReadyToInfer>(e).is_none()
+                    && world.get::<ReadyForInteractionPoint>(e).is_none(),
+                "and it is not queued for any further work"
+            );
+        }
     }
 
     #[test]

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -6,6 +6,7 @@
 //! and inference execution through a game-loop-inspired architecture where agents
 //! are entities and their behaviors are systems.
 
+pub mod cancel;
 pub mod compaction_bridge;
 pub mod components;
 pub mod context_setup;

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -206,6 +206,52 @@ fn retry_policy_for(config: Option<&InferenceConfig>) -> crate::inference_bridge
     policy
 }
 
+/// The cancellation handles for an agent's currently in-flight async work (its
+/// inference request, its tool batch). Attached when the work is dispatched,
+/// removed when it lands — so the presence of this component means "there is
+/// something running for this agent that a cancel needs to stop".
+///
+/// Without it, cancelling only stopped *new* work from being dispatched: a
+/// request already handed to the async lanes ran to completion, holding its
+/// inference-pool permit or tool-lane worker the whole time.
+#[derive(Component, Default, Debug)]
+pub struct InFlightWork(pub Vec<crate::cancel::CancelToken>);
+
+/// Stop the in-flight work of every agent that has reached a terminal state, and
+/// drop the handles. Runs before the dispatch systems each tick, so a cancel
+/// takes effect on the very next tick rather than whenever the provider or tool
+/// happens to answer.
+pub fn abort_terminal_work(
+    agents: Query<(Entity, &AgentState, &InFlightWork)>,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, state, in_flight) in agents.iter() {
+        if !is_terminal_status(&state.status) {
+            continue;
+        }
+        crate::tick_scope::enter(entity);
+        for token in &in_flight.0 {
+            token.cancel();
+        }
+        commands.entity(entity).remove::<InFlightWork>();
+    }
+}
+
+/// Record `token` as in-flight work for `entity`, keeping any already attached
+/// (an agent can have both a tool batch and an inference outstanding across a
+/// tick boundary).
+fn track_in_flight(
+    commands: &mut Commands,
+    entity: Entity,
+    existing: Option<&InFlightWork>,
+    token: crate::cancel::CancelToken,
+) {
+    let mut tokens = existing.map(|w| w.0.clone()).unwrap_or_default();
+    tokens.push(token);
+    commands.entity(entity).insert(InFlightWork(tokens));
+}
+
 /// Inference-dispatch system: for every `ReadyToInfer` agent, resolve its
 /// provider and, **if a per-model permit is free**, build the request, spawn the
 /// inference job, and move it to `AwaitingInference`. If its provider is missing
@@ -220,6 +266,7 @@ pub fn dispatch_inference(
             &ContextWindow,
             Option<&InferenceConfig>,
             &StageInference,
+            Option<&InFlightWork>,
         ),
         With<ReadyToInfer>,
     >,
@@ -242,7 +289,7 @@ pub fn dispatch_inference(
     crate::tick_scope::clear();
     agents
         .par_iter()
-        .for_each(|(entity, state, window, config, si)| {
+        .for_each(|(entity, state, window, config, si, in_flight)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
                     return; // paused / waiting / cancelled — don't start new work
@@ -261,13 +308,16 @@ pub fn dispatch_inference(
                     permit,
                     exact_token_counting: stage.exact_token_counting,
                 };
+                let cancel = crate::cancel::CancelToken::new();
                 stage.runtime.spawn(run_inference_job(
                     job,
                     stage.outcomes.clone(),
                     stage.wake.clone(),
                     retry_policy_for(config),
+                    cancel.clone(),
                 ));
                 par_commands.command_scope(|mut commands| {
+                    track_in_flight(&mut commands, entity, in_flight, cancel);
                     commands
                         .entity(entity)
                         .remove::<ReadyToInfer>()
@@ -341,7 +391,8 @@ pub fn collect_inference(
         if is_terminal_status(&state.status) {
             commands
                 .entity(outcome.entity)
-                .remove::<AwaitingInference>();
+                .remove::<AwaitingInference>()
+                .remove::<InFlightWork>();
             continue;
         }
         let idx = cursor.map_or(0, |c| c.index);
@@ -376,6 +427,7 @@ pub fn collect_inference(
                     .entity(outcome.entity)
                     .insert(result)
                     .remove::<AwaitingInference>()
+                    .remove::<InFlightWork>()
                     .insert(ProcessResponse);
             }
             Err(err) => {
@@ -391,6 +443,7 @@ pub fn collect_inference(
                 commands
                     .entity(outcome.entity)
                     .remove::<AwaitingInference>()
+                    .remove::<InFlightWork>()
                     .insert(StageOutcome::Errored(err.to_string()))
                     .insert(ResolveTransition);
             }
@@ -709,6 +762,7 @@ pub fn dispatch_tools(
             Option<&mut crate::taint::TaintGate>,
             Option<&crate::gate_prompt::GateResolved>,
             Option<&crate::components::GateAutoApprove>,
+            Option<&InFlightWork>,
         ),
         With<ReadyForTools>,
     >,
@@ -738,6 +792,7 @@ pub fn dispatch_tools(
         mut gate,
         resolved,
         auto_gate,
+        in_flight,
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -884,9 +939,15 @@ pub fn dispatch_tools(
         }
 
         let exec = service.0.exec_for(entity, lane_calls);
+        let cancel = crate::cancel::CancelToken::new();
         // The lane worker is alive for the world's lifetime; a failed send would
         // only happen during shutdown, where dropping the job is fine.
-        let _ = stage.0.send(ToolJob { entity, exec });
+        let _ = stage.0.send(ToolJob {
+            entity,
+            exec,
+            cancel: cancel.clone(),
+        });
+        track_in_flight(&mut commands, entity, in_flight, cancel);
         commands
             .entity(entity)
             .remove::<ReadyForTools>()
@@ -1348,6 +1409,7 @@ pub fn collect_tools(
             .entity(outcome.entity)
             .remove::<AwaitingTools>()
             .remove::<ContextToolResults>()
+            .remove::<InFlightWork>()
             .insert(ReadyToInfer);
     }
 }
@@ -3516,6 +3578,7 @@ pub fn dispatch_transition_choice(
             &AgentBlueprint,
             &StageCursor,
             &AwaitingTransitionChoice,
+            Option<&InFlightWork>,
         ),
         With<AwaitingTransitionChoice>,
     >,
@@ -3524,7 +3587,7 @@ pub fn dispatch_transition_choice(
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, state, mut window, si, bp, cursor, choice) in agents.iter_mut() {
+    for (entity, state, mut window, si, bp, cursor, choice, in_flight) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled — don't start new work
@@ -3568,12 +3631,15 @@ pub fn dispatch_transition_choice(
             // extra count call for them.
             exact_token_counting: false,
         };
+        let cancel = crate::cancel::CancelToken::new();
         stage.runtime.spawn(run_inference_job(
             job,
             stage.transition_outcomes.clone(),
             stage.wake.clone(),
             crate::inference_bridge::RetryPolicy::default(),
+            cancel.clone(),
         ));
+        track_in_flight(&mut commands, entity, in_flight, cancel);
         commands
             .entity(entity)
             .remove::<AwaitingTransitionChoice>()
@@ -3626,7 +3692,8 @@ pub fn collect_transition_choice(
         if is_terminal_status(&state.status) {
             commands
                 .entity(outcome.entity)
-                .remove::<AwaitingTransitionResponse>();
+                .remove::<AwaitingTransitionResponse>()
+                .remove::<InFlightWork>();
             continue;
         }
         let response = match outcome.result {
@@ -4320,6 +4387,59 @@ mod tests {
         assert_eq!(led.0[1].prompt_tokens, 5);
         assert_eq!(led.0[1].completion_tokens, 3);
         assert_eq!(led.0[1].cached_tokens, 2);
+    }
+
+    // ─── abort_terminal_work ───
+
+    fn run_abort(world: &mut World) {
+        let mut s = Schedule::default();
+        s.add_systems(abort_terminal_work);
+        s.run(world);
+    }
+
+    #[test]
+    fn abort_terminal_work_stops_a_cancelled_agents_in_flight_work() {
+        for status in [
+            AgentStatus::Cancelled,
+            AgentStatus::Complete,
+            AgentStatus::Error {
+                message: "boom".to_string(),
+            },
+        ] {
+            let mut world = World::new();
+            let tokens = vec![
+                crate::cancel::CancelToken::new(),
+                crate::cancel::CancelToken::new(),
+            ];
+            let mut state = agent_state();
+            state.status = status.clone();
+            let e = world.spawn((state, InFlightWork(tokens.clone()))).id();
+
+            run_abort(&mut world);
+
+            assert!(
+                tokens.iter().all(|t| t.is_cancelled()),
+                "{status:?} stops every in-flight job"
+            );
+            assert!(
+                world.get::<InFlightWork>(e).is_none(),
+                "and the handles are dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn abort_terminal_work_leaves_a_running_agent_alone() {
+        let mut world = World::new();
+        let token = crate::cancel::CancelToken::new();
+        let e = world
+            .spawn((agent_state(), InFlightWork(vec![token.clone()])))
+            .id();
+
+        run_abort(&mut world);
+
+        assert!(!token.is_cancelled(), "an Active agent keeps working");
+        assert!(world.get::<InFlightWork>(e).is_some());
     }
 
     /// A response that lands after the run was cancelled is discarded. The

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -335,6 +335,15 @@ pub fn collect_inference(
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(outcome.entity);
+        // The agent reached a terminal state while this inference was in flight
+        // (a cancel, or a panic that failed it). Drop the response: applying it
+        // would move the run on to `ProcessResponse` and it would keep going.
+        if is_terminal_status(&state.status) {
+            commands
+                .entity(outcome.entity)
+                .remove::<AwaitingInference>();
+            continue;
+        }
         let idx = cursor.map_or(0, |c| c.index);
         match outcome.result {
             Ok(response) => {
@@ -2435,7 +2444,11 @@ fn resolve_transition_sync(
 pub struct WaitingForChildren;
 
 /// Whether an agent status is terminal (the run/child has finished).
-fn is_terminal_status(status: &AgentStatus) -> bool {
+///
+/// Every collect system consults this before applying an outcome: a run that
+/// reached a terminal state while its work was in flight must stay there, not be
+/// walked back to `Active`/`Complete` by the result landing afterwards.
+pub fn is_terminal_status(status: &AgentStatus) -> bool {
     matches!(
         status,
         AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
@@ -3607,6 +3620,15 @@ pub fn collect_transition_choice(
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(outcome.entity);
+        // Cancelled/failed mid-choice: every arm below rewrites the status
+        // (including a bare `Complete` when nothing matches), which would report
+        // a cancelled run as having finished normally.
+        if is_terminal_status(&state.status) {
+            commands
+                .entity(outcome.entity)
+                .remove::<AwaitingTransitionResponse>();
+            continue;
+        }
         let response = match outcome.result {
             Ok(response) => response,
             Err(err) => {
@@ -4298,6 +4320,44 @@ mod tests {
         assert_eq!(led.0[1].prompt_tokens, 5);
         assert_eq!(led.0[1].completion_tokens, 3);
         assert_eq!(led.0[1].cached_tokens, 2);
+    }
+
+    /// A response that lands after the run was cancelled is discarded. The
+    /// dispatch guard stops *new* inferences, but one already in flight still
+    /// returns — and applying it advanced the run to `ProcessResponse`, from
+    /// which it carried on as if nothing had happened.
+    #[test]
+    fn collect_inference_drops_a_response_for_a_cancelled_run() {
+        let (mut world, tx) = world_with_results();
+        let mut state = agent_state();
+        state.status = AgentStatus::Cancelled;
+        let e = world
+            .spawn((
+                state,
+                AwaitingInference,
+                StageCursor { index: 0 },
+                StageIoBuffer::default(),
+            ))
+            .id();
+        tx.send(InferenceOutcome {
+            entity: e,
+            result: Ok(resp("too late")),
+        })
+        .unwrap();
+
+        run_collect(&mut world);
+
+        let state = world.get::<AgentState>(e).unwrap();
+        assert_eq!(state.status, AgentStatus::Cancelled, "stays cancelled");
+        assert_eq!(state.iteration, 0, "the response was not counted");
+        assert!(
+            world.get::<ProcessResponse>(e).is_none(),
+            "and the run is not advanced by it"
+        );
+        assert!(
+            world.get::<AwaitingInference>(e).is_none(),
+            "the awaiting marker is cleared so nothing re-collects it"
+        );
     }
 
     #[test]
@@ -10347,6 +10407,46 @@ mod tests {
         assert!(world.get::<ReadyToInfer>(e).is_some());
         assert!(world.get::<AwaitingTransitionResponse>(e).is_none());
         assert_eq!(world.get::<AgentState>(e).unwrap().current_stage, "b");
+    }
+
+    /// A transition choice that lands after the run was cancelled is discarded.
+    /// Notably the no-match arm sets `Complete` unconditionally, which would
+    /// report a cancelled run as having finished normally.
+    #[test]
+    fn collect_choice_does_not_resurrect_or_complete_a_cancelled_run() {
+        for choice in ["b", "not-a-stage"] {
+            let (mut world, tx) = world_with_transition_results();
+            let bp = blueprint(vec![
+                stage_named("a", None, false, None),
+                stage_named("b", None, false, None),
+            ]);
+            let e = spawn_responding_agent(
+                &mut world,
+                bp,
+                vec![si("m0"), si("m1")],
+                vec![plain_edge("b")],
+            );
+            world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Cancelled;
+            tx.send(InferenceOutcome {
+                entity: e,
+                result: Ok(resp(choice)),
+            })
+            .unwrap();
+
+            run_collect_transition(&mut world);
+
+            assert_eq!(
+                world.get::<AgentState>(e).unwrap().status,
+                AgentStatus::Cancelled,
+                "choice {choice:?} left the run cancelled"
+            );
+            assert_eq!(
+                world.get::<StageCursor>(e).unwrap().index,
+                0,
+                "and did not advance the stage"
+            );
+            assert!(world.get::<AwaitingTransitionResponse>(e).is_none());
+        }
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -4415,6 +4415,38 @@ mod tests {
         s.run(world);
     }
 
+    /// `track_in_flight` accumulates rather than replaces, so an agent that has
+    /// something outstanding when a second job is dispatched keeps both handles
+    /// — dropping the first would make that job uncancellable.
+    #[test]
+    fn track_in_flight_accumulates_across_dispatches() {
+        fn add_one(agents: Query<(Entity, Option<&InFlightWork>)>, mut commands: Commands) {
+            for (entity, existing) in agents.iter() {
+                track_in_flight(
+                    &mut commands,
+                    entity,
+                    existing,
+                    crate::cancel::CancelToken::new(),
+                );
+            }
+        }
+
+        let mut world = World::new();
+        let e = world.spawn(agent_state()).id();
+        let mut schedule = Schedule::default();
+        schedule.add_systems(add_one);
+
+        schedule.run(&mut world); // no existing component yet
+        assert_eq!(world.get::<InFlightWork>(e).unwrap().0.len(), 1);
+
+        schedule.run(&mut world); // one already attached
+        assert_eq!(
+            world.get::<InFlightWork>(e).unwrap().0.len(),
+            2,
+            "the earlier job's handle is kept"
+        );
+    }
+
     #[test]
     fn abort_terminal_work_stops_a_cancelled_agents_in_flight_work() {
         for status in [

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -1748,6 +1748,16 @@ fn build_edge_compact_requests(
 
 // ─── Persistence (per-agent snapshot writing) ────────────────────────────────
 
+/// How long an agent may go without a snapshot before one is written purely to
+/// refresh `updated_at`.
+///
+/// The watermark below debounces on *progress*, which means a run that is busy
+/// but not progressing (one long inference, or a genuinely wedged one) writes
+/// nothing at all. Observers then cannot tell "working" from "dead", because
+/// `updated_at` looks equally old in both cases. A periodic beat makes a stale
+/// timestamp mean something.
+const PERSIST_HEARTBEAT_SECS: i64 = 30;
+
 /// Debounce watermark: the (iteration, stage index, status) last persisted for an
 /// agent. A snapshot is written only when one of these changes, so the world
 /// writes on meaningful progress rather than every tick. `None` until the first
@@ -1755,6 +1765,8 @@ fn build_edge_compact_requests(
 #[derive(Component, Default)]
 pub struct PersistWatermark {
     last: Option<(usize, usize, leviath_core::run_meta::RunStatus)>,
+    /// When the last snapshot was written, for the heartbeat above.
+    last_written_at: Option<i64>,
 }
 
 /// The sending end of the persistence I/O lane (the receiving end is drained by
@@ -1922,12 +1934,18 @@ pub fn dispatch_persistence(
         let status = crate::persistence::run_status_from(&state.status);
         let current = (state.iteration, cursor.index, status);
         let watermark_changed = watermark.last.as_ref() != Some(&current);
-        if !watermark_changed && !has_appends {
-            continue; // nothing meaningful changed and nothing buffered
+        // Beat even when nothing changed, so `updated_at` distinguishes a run
+        // that is slow from one that nothing is driving.
+        let due_for_heartbeat = watermark
+            .last_written_at
+            .is_none_or(|at| now.saturating_sub(at) >= PERSIST_HEARTBEAT_SECS);
+        if !watermark_changed && !has_appends && !due_for_heartbeat {
+            continue; // nothing meaningful changed, nothing buffered, beat not due
         }
         if watermark_changed {
             watermark.last = Some(current);
         }
+        watermark.last_written_at = Some(now);
 
         // Stream each buffered line to WS subscribers as a `Log` event (in
         // addition to the disk append below). No-op in worlds without the sink

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -149,6 +149,64 @@ mod tests {
         }
     }
 
+    /// A job whose batch blocks until `release` fires, signalling `started` once
+    /// it is running. Used both for the cancel case (where it is dropped
+    /// mid-flight) and for the released case, so the batch body is exercised.
+    fn held_job(
+        entity: u32,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+        cancel: crate::cancel::CancelToken,
+    ) -> ToolJob {
+        ToolJob {
+            entity: Entity::from_raw(entity),
+            exec: Box::new(move || {
+                Box::pin(async move {
+                    started.notify_waiters();
+                    release.notified().await;
+                    vec![("held".to_string(), "done".to_string())]
+                })
+            }),
+            cancel,
+        }
+    }
+
+    /// The released counterpart of [`held_job`]: with no cancel, the batch runs
+    /// to completion and reports its results.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_released_batch_completes_normally() {
+        let (jtx, jrx) = mpsc::unbounded_channel();
+        let (rtx, mut rrx) = mpsc::unbounded_channel();
+        let wake = Arc::new(Notify::new());
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+
+        jtx.send(held_job(
+            7,
+            started.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ))
+        .unwrap();
+        drop(jtx);
+
+        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
+        let running = started.notified();
+        tokio::pin!(running);
+        running.as_mut().enable();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), running).await;
+        release.notify_waiters();
+
+        let out = tokio::time::timeout(std::time::Duration::from_secs(5), rrx.recv())
+            .await
+            .expect("the batch finished")
+            .expect("an outcome arrived");
+        assert_eq!(out.results, vec![("held".to_string(), "done".to_string())]);
+        for h in handles {
+            let _ = h.await;
+        }
+    }
+
     fn shared(rx: UnboundedReceiver<ToolJob>) -> SharedJobRx {
         Arc::new(Mutex::new(rx))
     }
@@ -187,20 +245,15 @@ mod tests {
         let wake = Arc::new(Notify::new());
         let cancel = crate::cancel::CancelToken::new();
 
-        // A batch that never finishes on its own — the unbounded-prompt case.
+        // A batch that only finishes when released — the unbounded-prompt case.
         let started = Arc::new(Notify::new());
-        let started_tx = started.clone();
-        jtx.send(ToolJob {
-            entity: Entity::from_raw(1),
-            exec: Box::new(move || {
-                Box::pin(async move {
-                    started_tx.notify_waiters();
-                    std::future::pending::<()>().await;
-                    unreachable!("the batch is dropped before it can finish")
-                })
-            }),
-            cancel: cancel.clone(),
-        })
+        let release = Arc::new(Notify::new());
+        jtx.send(held_job(
+            1,
+            started.clone(),
+            release.clone(),
+            cancel.clone(),
+        ))
         .unwrap();
         // Queued behind it: only reachable once the worker is released.
         jtx.send(job(2, vec![("c2", "r2")])).unwrap();

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -43,6 +43,9 @@ pub struct ToolJob {
     pub entity: Entity,
     /// Runs the agent's batch of tool calls.
     pub exec: BoxedToolExec,
+    /// Fires when the agent is cancelled, so the worker drops the batch instead
+    /// of running it to completion. The agent holds the other half.
+    pub cancel: crate::cancel::CancelToken,
 }
 
 /// The result of a [`ToolJob`], applied on a later tick by the tool-collect
@@ -74,10 +77,25 @@ pub async fn tool_worker(
             let mut rx = jobs.lock().await;
             rx.recv().await
         };
-        let Some(ToolJob { entity, exec }) = next else {
+        let Some(ToolJob {
+            entity,
+            exec,
+            cancel,
+        }) = next
+        else {
             return; // channel closed → shut down
         };
-        let out = exec().await;
+        // A cancelled agent's batch is dropped rather than run to completion.
+        // This is what returns the worker to the pool: several of the things a
+        // batch can await are unbounded (a tool-approval prompt, an `ask_user`,
+        // a `wait_for_agent` poll), so without this a cancelled agent kept one
+        // of the lane's fixed number of workers forever — and once they were all
+        // taken, no other agent's tools ran either.
+        let out = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => continue,
+            out = exec() => out,
+        };
         // Harmless no-op if the collect side has gone away.
         let _ = results.send(ToolOutcome {
             entity,
@@ -109,6 +127,14 @@ mod tests {
     use tokio::sync::mpsc;
 
     fn job(entity: u32, pairs: Vec<(&'static str, &'static str)>) -> ToolJob {
+        job_with(entity, pairs, crate::cancel::CancelToken::new())
+    }
+
+    fn job_with(
+        entity: u32,
+        pairs: Vec<(&'static str, &'static str)>,
+        cancel: crate::cancel::CancelToken,
+    ) -> ToolJob {
         ToolJob {
             entity: Entity::from_raw(entity),
             exec: Box::new(move || {
@@ -119,6 +145,7 @@ mod tests {
                         .collect()
                 })
             }),
+            cancel,
         }
     }
 
@@ -144,6 +171,62 @@ mod tests {
         let second = rrx.try_recv().unwrap();
         assert_eq!(second.entity, Entity::from_raw(2));
         assert!(rrx.try_recv().is_err()); // no more outcomes
+    }
+
+    /// A cancelled batch is dropped, not run to completion, and the worker goes
+    /// back to serving the lane.
+    ///
+    /// This is what unwedges the daemon: several things a batch can await are
+    /// unbounded (a tool-approval prompt, `ask_user`, a `wait_for_agent` poll),
+    /// and the lane has a fixed number of workers — so a cancelled agent used to
+    /// hold one forever, and once all of them were held no agent's tools ran.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_batch_is_abandoned_and_frees_the_worker() {
+        let (jtx, jrx) = mpsc::unbounded_channel();
+        let (rtx, mut rrx) = mpsc::unbounded_channel();
+        let wake = Arc::new(Notify::new());
+        let cancel = crate::cancel::CancelToken::new();
+
+        // A batch that never finishes on its own — the unbounded-prompt case.
+        let started = Arc::new(Notify::new());
+        let started_tx = started.clone();
+        jtx.send(ToolJob {
+            entity: Entity::from_raw(1),
+            exec: Box::new(move || {
+                Box::pin(async move {
+                    started_tx.notify_waiters();
+                    std::future::pending::<()>().await;
+                    unreachable!("the batch is dropped before it can finish")
+                })
+            }),
+            cancel: cancel.clone(),
+        })
+        .unwrap();
+        // Queued behind it: only reachable once the worker is released.
+        jtx.send(job(2, vec![("c2", "r2")])).unwrap();
+        drop(jtx);
+
+        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
+        // Wait until the stuck batch is actually executing, then cancel it.
+        let waiting = started.notified();
+        tokio::pin!(waiting);
+        waiting.as_mut().enable();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), waiting).await;
+        cancel.cancel();
+
+        // The single worker moves on to the next job rather than staying parked.
+        let next = tokio::time::timeout(std::time::Duration::from_secs(5), rrx.recv())
+            .await
+            .expect("the worker was freed by the cancel")
+            .expect("an outcome arrived");
+        assert_eq!(next.entity, Entity::from_raw(2), "the queued batch ran");
+        assert!(
+            rrx.try_recv().is_err(),
+            "and the cancelled batch reported no results"
+        );
+        for h in handles {
+            let _ = h.await;
+        }
     }
 
     #[tokio::test]
@@ -190,6 +273,7 @@ mod tests {
                         vec![("c".to_string(), "r".to_string())]
                     })
                 }),
+                cancel: crate::cancel::CancelToken::new(),
             })
             .unwrap();
         }

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -162,7 +162,11 @@ mod tests {
             entity: Entity::from_raw(entity),
             exec: Box::new(move || {
                 Box::pin(async move {
-                    started.notify_waiters();
+                    // `notify_one` (not `notify_waiters`) on both signals: it
+                    // stores a permit when nobody is waiting yet, so neither the
+                    // test nor the batch can lose the other's wakeup by being
+                    // slow to arm — a real flake on a loaded runner.
+                    started.notify_one();
                     release.notified().await;
                     vec![("held".to_string(), "done".to_string())]
                 })
@@ -191,11 +195,10 @@ mod tests {
         drop(jtx);
 
         let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
-        let running = started.notified();
-        tokio::pin!(running);
-        running.as_mut().enable();
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), running).await;
-        release.notify_waiters();
+        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
+            .await
+            .expect("the batch started");
+        release.notify_one();
 
         let out = tokio::time::timeout(std::time::Duration::from_secs(5), rrx.recv())
             .await
@@ -261,10 +264,9 @@ mod tests {
 
         let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
         // Wait until the stuck batch is actually executing, then cancel it.
-        let waiting = started.notified();
-        tokio::pin!(waiting);
-        waiting.as_mut().enable();
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), waiting).await;
+        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
+            .await
+            .expect("the batch started");
         cancel.cancel();
 
         // The single worker moves on to the next job rather than staying parked.

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -39,10 +39,10 @@ use crate::pipeline::{
     AwaitingTransitionResponse, CompactionResults, InferenceResults, InferenceStage, MessageIntake,
     PersistenceStage, ProcessResponse, Providers, ReadyForTools, ReadyForTransition, ReadyToInfer,
     ResolveTransition, ToolResults, ToolService, ToolServiceRes, ToolStage, TransitionResults,
-    check_workspace_health, collect_compaction, collect_inference, collect_tools,
-    collect_transition_choice, deliver_messages, detect_stuck_stage, dispatch_compaction,
-    dispatch_edge_compact, dispatch_inference, dispatch_persistence, dispatch_tools,
-    dispatch_transition_choice, enforce_max_iterations, gate_requires_children,
+    abort_terminal_work, check_workspace_health, collect_compaction, collect_inference,
+    collect_tools, collect_transition_choice, deliver_messages, detect_stuck_stage,
+    dispatch_compaction, dispatch_edge_compact, dispatch_inference, dispatch_persistence,
+    dispatch_tools, dispatch_transition_choice, enforce_max_iterations, gate_requires_children,
     handle_empty_response, poll_dynamic_tool_refresh, process_response, reflect_interaction_status,
     refresh_advertised_tools, require_context_regions, resolve_transition, sync_tool_stages,
 };
@@ -187,6 +187,11 @@ impl PipelineWorld {
         let mut schedule = tick_schedule();
         schedule.add_systems(
             (
+                // First: stop whatever a now-terminal agent still has running in
+                // the async lanes. Ahead of everything else so a cancel frees its
+                // inference permit and tool-lane worker on the very next tick,
+                // rather than whenever the provider or tool happens to answer.
+                abort_terminal_work,
                 deliver_messages,
                 collect_compaction,
                 // Apply any completed Summarize context-transform summaries into

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -37,7 +37,7 @@ pub mod tty;
 
 pub use browser::{open_url, open_url_via};
 pub use perms::{ensure_file_private, secure_dir_perms, secure_file_perms};
-pub use process::{configure_detached, current_uid};
+pub use process::{configure_detached, current_uid, kill_process_group};
 pub use sandbox::{
     ContainerRunSpec, KNOWN_ENGINES, container_exec_argv, container_rm_argv, container_run_argv,
     detect_container_engine, namespace_argv, namespace_supported,

--- a/crates/leviath-sys/src/platform/fallback.rs
+++ b/crates/leviath-sys/src/platform/fallback.rs
@@ -23,3 +23,9 @@ pub(crate) fn configure_detached(_cmd: &mut std::process::Command) {}
 pub(crate) fn current_uid() -> u32 {
     0
 }
+
+/// No process groups to signal on this platform; killing the direct child is
+/// all that is available (and is what the caller already does).
+pub(crate) fn kill_process_group(_pgid: u32) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -119,6 +119,46 @@ mod tests {
         assert_eq!(ensure_private_with(&path, 0o600, set_mode).unwrap(), None);
     }
 
+    /// Signalling a real group tears down the leader *and* its children — the
+    /// whole point, since killing a shell alone leaves what it started
+    /// reparented to init and running.
+    #[test]
+    fn kill_process_group_reaps_the_leader_and_its_children() {
+        use std::process::{Command, Stdio};
+
+        // A shell that leads its own group and starts a long-lived child.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("sleep 60 & sleep 60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        configure_detached(&mut cmd);
+        let mut child = cmd.spawn().expect("sh is available");
+        let pgid = child.id();
+
+        // Let the shell get as far as starting its own child.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        kill_process_group(pgid).expect("the group is ours to signal");
+
+        // The leader is gone (and reaped, so it leaves no zombie).
+        let status = child.wait().expect("leader is waitable");
+        assert!(!status.success(), "killed, not a clean exit");
+        // And so is the group as a whole: a second signal finds nothing left.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            kill_process_group(pgid).is_err(),
+            "the whole group is gone, so there is nothing left to signal"
+        );
+    }
+
+    #[test]
+    fn kill_process_group_errors_for_a_group_that_does_not_exist() {
+        // The ordinary case when reaping — the command already finished — so it
+        // must surface as an error the caller can ignore, not a panic.
+        let err = kill_process_group(0x7FFF_FFFF).expect_err("no such group");
+        assert!(err.raw_os_error().is_some());
+    }
+
     #[test]
     fn configure_detached_sets_process_group_without_spawning() {
         // Configuring the process group must not fork/exec or panic; it only

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -69,6 +69,19 @@ pub(crate) fn current_uid() -> u32 {
     nix::unistd::getuid().as_raw()
 }
 
+/// SIGKILL the process group led by `pgid`.
+///
+/// `nix::sys::signal::killpg` with a negated pid is the safe wrapper around
+/// `killpg(2)`; no `unsafe` is involved. Errors (the group already exited, or
+/// was never ours) are the normal case when reaping and are swallowed by the
+/// caller.
+pub(crate) fn kill_process_group(pgid: u32) -> io::Result<()> {
+    use nix::sys::signal::{Signal, killpg};
+    use nix::unistd::Pid;
+    killpg(Pid::from_raw(pgid as i32), Signal::SIGKILL)
+        .map_err(|e| io::Error::from_raw_os_error(e as i32))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -11,6 +11,21 @@ pub fn configure_detached(cmd: &mut Command) {
     crate::platform::configure_detached(cmd);
 }
 
+/// SIGKILL every process in the group led by `pgid` (a no-op on platforms
+/// without process groups).
+///
+/// Killing a child shell is not enough to stop what it started: the shell's own
+/// children are reparented to init and keep running. A cancelled agent's
+/// `sleep 400` outliving the run that started it is exactly that. Spawning the
+/// shell into its own group (via [`configure_detached`]) and signalling the
+/// group tears down the whole tree.
+///
+/// Errors are the ordinary case (the group already exited) and are the caller's
+/// to ignore.
+pub fn kill_process_group(pgid: u32) -> std::io::Result<()> {
+    crate::platform::kill_process_group(pgid)
+}
+
 /// The calling user's numeric id.
 ///
 /// Used to address a per-user service domain (`launchctl bootstrap gui/<uid>`).

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -46,6 +46,15 @@ mod tests {
     }
 
     #[test]
+    fn kill_process_group_public_wrapper_reports_a_missing_group() {
+        // Exercises the public shim (distinct from the platform impl its own
+        // tests cover). A group that cannot exist errors on Unix and is a no-op
+        // where the platform has no process groups — both are outcomes the
+        // caller ignores, so either result is acceptable here.
+        let _ = kill_process_group(0x7FFF_FFFF);
+    }
+
+    #[test]
     fn configure_detached_public_wrapper_registers_without_spawning() {
         // Exercises the public `process::configure_detached` shim (distinct
         // from the platform impl its own tests cover); registering the hook

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 
 [dependencies]
 leviath-providers = { workspace = true }
+leviath-sys = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1070,16 +1070,21 @@ impl BuiltinTools {
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        let child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(e) => return format!("[error] Failed to spawn shell '{}': {}", shell, e),
+        // Spawn *inside* the timed future so the reaper guard lives exactly as
+        // long as the command does: dropping this future (timeout, or the whole
+        // batch dropped because the agent was cancelled) drops the guard, which
+        // signals the group. Keeping spawn and wait in one fallible block also
+        // keeps a single error arm, as `Command::output()` had.
+        let run = async {
+            let child = cmd.spawn()?;
+            // The child leads its own group, so its pid is the group id.
+            let _reaper = child.id().map(ProcessGroupReaper);
+            child.wait_with_output().await
         };
-        // The child leads its own group, so its pid is the group id.
-        let _reaper = child.id().map(ProcessGroupReaper);
 
-        match timeout(timeout_duration, child.wait_with_output()).await {
+        match timeout(timeout_duration, run).await {
             Err(_) => format!("[timed out] Command exceeded 60s: {}", command),
-            Ok(Err(e)) => format!("[error] Failed to run shell '{}': {}", shell, e),
+            Ok(Err(e)) => format!("[error] Failed to spawn shell '{}': {}", shell, e),
             Ok(Ok(output)) => Self::format_command_output(
                 &output.stdout,
                 &output.stderr,

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1025,6 +1025,12 @@ impl BuiltinTools {
                 c
             }
         };
+        // Kill the child if this future is dropped. Dropping a `Command` future
+        // detaches the process by default, so a cancelled agent (or an elapsed
+        // timeout, which drops the future the same way) would leave its shell
+        // running — the run is gone from every listing while its command carries
+        // on writing to the workspace.
+        cmd.kill_on_drop(true);
         let run = cmd.output();
 
         match timeout(timeout_duration, run).await {

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -10,6 +10,34 @@ use std::sync::{Arc, Mutex, PoisonError};
 use tokio::process::Command;
 use tokio::time::{Duration, timeout};
 
+/// Put `cmd` in its own process group, so the whole command tree can be
+/// signalled as one. `leviath_sys::configure_detached` does this for a
+/// `std::process::Command`; the tool lane uses tokio's, which has its own
+/// (Unix-only) setter. A no-op where the platform has no process groups —
+/// there, killing the direct child is all that exists.
+pub fn own_process_group(cmd: &mut Command) {
+    #[cfg(unix)]
+    cmd.process_group(0);
+    #[cfg(not(unix))]
+    let _ = cmd;
+}
+
+/// SIGKILLs a shell's whole process group when dropped.
+///
+/// `kill_on_drop` reaps the shell itself; this reaps what the shell started.
+/// Held for the duration of one shell tool call, so it fires on every exit path
+/// — normal completion (where the group is already gone and the signal is a
+/// harmless no-op), timeout, and the future being dropped because the agent was
+/// cancelled.
+pub struct ProcessGroupReaper(pub u32);
+
+impl Drop for ProcessGroupReaper {
+    fn drop(&mut self) {
+        // The group is usually already gone; failing to signal it is expected.
+        let _ = leviath_sys::kill_process_group(self.0);
+    }
+}
+
 /// A platform feature a built-in tool depends on.
 ///
 /// Each built-in declares the capabilities it requires (see
@@ -1025,17 +1053,33 @@ impl BuiltinTools {
                 c
             }
         };
-        // Kill the child if this future is dropped. Dropping a `Command` future
-        // detaches the process by default, so a cancelled agent (or an elapsed
-        // timeout, which drops the future the same way) would leave its shell
-        // running — the run is gone from every listing while its command carries
-        // on writing to the workspace.
+        // Reap the whole command on drop, not just the shell.
+        //
+        // Dropping a `Command` future detaches its process by default, so a
+        // cancelled agent (or an elapsed timeout, which drops the future the
+        // same way) left its shell running: the run vanished from every listing
+        // while its command carried on writing to the workspace. `kill_on_drop`
+        // fixes the shell — but only the shell. Anything the shell itself
+        // started (`sleep 400 && …`) is a *grandchild*, gets reparented to init,
+        // and keeps running. Putting the shell in its own process group and
+        // signalling the group on drop takes the whole tree down with it.
         cmd.kill_on_drop(true);
-        let run = cmd.output();
+        own_process_group(&mut cmd);
+        // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
+        // command's output is still captured.
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
 
-        match timeout(timeout_duration, run).await {
+        let child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) => return format!("[error] Failed to spawn shell '{}': {}", shell, e),
+        };
+        // The child leads its own group, so its pid is the group id.
+        let _reaper = child.id().map(ProcessGroupReaper);
+
+        match timeout(timeout_duration, child.wait_with_output()).await {
             Err(_) => format!("[timed out] Command exceeded 60s: {}", command),
-            Ok(Err(e)) => format!("[error] Failed to spawn shell '{}': {}", shell, e),
+            Ok(Err(e)) => format!("[error] Failed to run shell '{}': {}", shell, e),
             Ok(Ok(output)) => Self::format_command_output(
                 &output.stdout,
                 &output.stderr,
@@ -2007,6 +2051,37 @@ mod tests {
             .shell_with_timeout(&json!({"command": "sleep 5"}), Duration::from_millis(100))
             .await;
         assert!(result.contains("[timed out]"));
+    }
+
+    /// A timed-out (or cancelled) command takes its *grandchildren* with it.
+    ///
+    /// `kill_on_drop` only reaps the shell. Anything the shell started is
+    /// reparented to init and keeps running — a cancelled agent's `sleep`
+    /// outliving the run that spawned it. Verified by writing a marker file
+    /// after a delay: if the grandchild survived, the marker appears.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_timed_out_command_kills_its_grandchildren() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("survived");
+        let tools = make_tools(dir.path());
+
+        // A *backgrounded subshell* is the grandchild, and it is what writes the
+        // marker. Chaining (`sleep 2 && touch`) would not test anything: the
+        // `touch` is run by the shell itself, so killing the shell suppresses it
+        // whether or not the group was signalled.
+        let cmd = format!("( sleep 2; touch {} ) & sleep 30", marker.display());
+        let result = tools
+            .shell_with_timeout(&json!({ "command": cmd }), Duration::from_millis(100))
+            .await;
+        assert!(result.contains("[timed out]"), "got: {result}");
+
+        // Well past when the grandchild would have written it.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !marker.exists(),
+            "the grandchild outlived the command that started it"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The reported symptom

Three runs — `run-mcp`, `run-1`, `run-s` — sat in `lev dash` as ⚡ACTIVE indefinitely and could not be killed. `~/.leviath/dashboard.log` recorded four kill attempts; all three `meta.json` mtimes were unchanged. **The kills wrote nothing.**

They were **leaked unit-test fixtures**, not agents: `pid: 0`, only a `meta.json`, blueprint pointing at a deleted `tempfile::tempdir()`. Three tests in `daemon/setup.rs` spawn through a real host and pass in a tempdir, but `write_placeholder_meta` ignored it and went through the global `runstate::run_dir()` → `dirs::home_dir()`. `dirs::home_dir()` ignores `$HOME` on macOS, and `runs_dir()` was the one leviath path that didn't honour `LEVIATH_HOME` — so tests that looked isolated still wrote into the developer's real `~/.leviath/runs`.

They were **unkillable for a separate and general reason**: `ControlOp::Cancel` resolves through the reloader, which declines for any run it can't rebuild, and then replied `false` **without writing anything**. The dashboard didn't check that reply — it flashed CANCEL, logged "Killed", and the next disk sync read `starting` back off disk and returned the row to ACTIVE.

Investigating that turned up several other ways a run could survive being killed. This PR closes all of them.

## Root cause

- The spawner threads the host's `runs_dir` into `write_placeholder_meta` (also a production bug — a daemon on a non-default runs dir wrote placeholders to the wrong place).
- `runs_dir()` now falls back through `leviath_home_dir()`, so `LEVIATH_HOME` isolates runs like it isolates everything else.
- A regression test asserts the global runs dir gains nothing when spawning through a real host, which structurally prevents the whole class.

## A cancel now always reaches a terminal state

- **`ForceTerminator` seam** (mirrors the existing spawner/reloader/reaper). The daemon installs a writer over its `runs_dir`; `runstate::force_cancel_in` is the single definition of "terminated on disk", shared with the CLI. It also repairs a run whose metadata is corrupt — `list_runs` skips those, making them invisible *and* permanent. `false` is now reserved for a run that exists nowhere.
- **`Cancel` cascades** via `cancel_tree`. Previously only the model-facing `kill_agent` tool did, so cancelling a parent left its sub-agents and fan-out workers running.
- **Cancelling closes the run's open interactions.** The blocked `ask` held a tool-lane worker, and the lane has a fixed worker count — enough of them starve every other agent's tool batches. The orphaned prompt also kept appearing in `lev respond`.
- **Collect systems no longer resurrect a terminal agent.** The inference, transition-choice and interaction-point collectors each set status unconditionally, so a result landing after a cancel walked the run back to `Active` — or, in the no-match arm, reported it `Complete`.
- **`emit_events` adopts world agents missing from the run-id map.** Fan-out workers are built straight into the world, so they were invisible to `lev ps`, never reaped, and a cancel by their id paged a *second* copy in from disk while the original kept running.

## In-flight work is actually stopped

Cancelling only stopped *new* work from dispatching; anything already handed to the async lanes ran to completion, holding its inference permit or lane worker.

- `CancelToken` (~40 lines, no new dependency) + `InFlightWork` + `abort_terminal_work`, first in the schedule.
- `run_inference_job` and `tool_worker` select on it — the HTTP request is dropped and the permit/worker released immediately.
- **Shell commands run in their own process group and are killed as a group.** `kill_on_drop` reaps only the direct child; `/bin/zsh -c "sleep 400"` leaves the `sleep` reparented to init, still running long after the run has vanished. This also fixes the pre-existing timeout path, which detached the same way.
- `wait_for_agent` exits when its calling agent is terminal; the loop had no other exit.

## The CLI can't hang, and works with no daemon

- `ControlClient::request` gains a 30s deadline (`LEVIATH_CONTROL_TIMEOUT_SECS`, `0` disables). `Spawn` gets a 300s floor — the daemon connects the blueprint's MCP servers first, 30s each, so a slow-but-succeeding spawn must not be reported as a timeout.
- `lev cancel --force` (alias `lev kill`) writes the run's on-disk state directly. Without it, the daemon is tried first and the disk write is the fallback on unreachable/timeout. Outcomes are reported honestly instead of a bare "no such run" for every unhappy path.

## The dashboard tells the truth

- Kill is gated on "not finished" rather than `Active | Waiting` — IDLE and STALE rows, exactly what a user reaches for the kill key on, could not be killed at all.
- A `DaemonOutcome` channel surfaces refusals as a toast + log line; the log says "kill requested", not "Killed".
- New **STALE** status: the daemon doesn't hold the run *and* its metadata hasn't moved in 5 minutes. Both halves matter — an unreachable daemon returns no runs, so treating "no answer" as "not held" would flip every healthy run to STALE.
- `dispatch_persistence` beats every 30s so that timestamp means something; its watermark debounces on progress, so a busy-but-not-progressing run wrote nothing and looked exactly as old as a wedged one.

## Verification

Full workspace suite + clippy green. Every new invariant was checked to **fail when its fix is removed** (including confirming the control-socket test hangs indefinitely without the timeout, and that a naive grandchild test proves nothing).

Live-verified end to end against a real daemon and real agents:

| Scenario | Result |
|---|---|
| Unreloadable run (the reported bug), via daemon | `starting` → `cancelled` on disk |
| Same, `--force`, no daemon at all | cancelled, instant |
| `lev cancel` against a SIGKILLed daemon | falls back, reports why, doesn't hang |
| Run that exists nowhere | still an honest `no such run` |
| Cancel with a live `sleep 400` | shell **and** grandchild both killed |
| Parent → child → shell → `sleep 500`, cancel **parent only** | both runs cancelled, both processes gone |
| Child blocked on a tool-approval prompt | prompt closed, lane worker released |
| Fresh run afterwards | tool executes and completes normally |

Live testing is also what caught two bugs the unit tests missed: the surviving grandchild, and — after switching to `spawn()` for the pid — stdio being inherited rather than piped, which silently dropped every command's output. Both are fixed and now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HyeTzqmWfqE5WADhC2yQN
