### PR TITLE
fix(runtime,agents): a stage's tool grant is a grant, not a suggestion

### DIFF
--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -130,6 +130,8 @@ Then:
 2. Check `conventions` and `architecture` — pre-loaded style/lint rules and design
    docs. Follow them; don't rediscover them.
 3. Estimate scope: which files to create/modify, and roughly how large the change is.
+   Name them — do not create them. This stage has no tool that writes or edits a
+   file, and calling one is refused; `implement` makes the change you describe.
 4. Identify dependencies — modules, libraries, config, or tests this touches.
    Use list_dir/read_file ONLY to fill real gaps left by `discovery`. For a fresh
    task with no existing code, skip exploration entirely.
@@ -360,6 +362,10 @@ Minor style nits don't warrant another implementation pass.
 system_prompt = """
 You are reviewing the implementation. Verify it against the ORIGINAL task in the
 `task` region — not just against the plan (the plan can be wrong).
+
+You review here; you do not repair. This stage has no write or edit tool and
+calling one is refused — report what you find and route back to `implement`,
+which is where changes are made and re-reviewed.
 
 1. Read the files that were created or modified (they are tracked in the
    `implementation` region; read_file for anything you need to confirm).

--- a/agents/reviewer/agent.leviath
+++ b/agents/reviewer/agent.leviath
@@ -110,7 +110,8 @@ nothing is skipped:
 
 For each finding give: location, the concrete failure scenario (inputs/state →
 wrong result or crash), a severity (critical / warning / info), and a recommended
-fix. Append each finding to `findings` (context_append).
+fix. Recommend it — do not apply it. This agent reads and judges; no stage here
+has a tool that writes or edits a file, and calling one is refused. Append each finding to `findings` (context_append).
 
 Keep a running tally in the `severity_index` region: rewrite it with
 context_write each time the counts change, e.g. "critical: 2, warning: 5, info: 3".

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -157,6 +157,12 @@ ask_user_choice to ask BEFORE producing the plan — don't guess on things
 only the user can answer. Don't ask about things you can reasonably decide
 yourself.
 
+This stage does not touch the codebase. You have no tool here that writes or
+edits a file, and calling one is refused — planning that starts writing is how a
+run ends up with code nobody approved. Describe the change; `implement` makes it.
+If a claim in the plan needs proving before it is worth writing down, that is what
+`prototype` is for.
+
 Be specific — the implement stage will execute exactly what you write here.
 End with:
 
@@ -438,6 +444,11 @@ Use the `changelog` region to see exactly which files changed (the
 `implementation` region holds the mechanical record of every write the framework
 saw, if the changelog looks incomplete), and `decisions` to understand why choices
 were made before you question them. Read those files and provide a quality review:
+You review here; you do not repair. There is no write or edit tool in this
+stage and calling one is refused — a reviewer who fixes what they find is the
+same person marking their own work. Report the problem and route back to
+`implement`, which is where changes are made and re-reviewed.
+
 - Correctness: does it match the plan AND the original task in `task`?
 - Edge cases: what inputs or conditions could cause failures?
 - Code quality: clarity, naming, error handling, conventions.

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -222,6 +222,120 @@ mod tests {
         }
     }
 
+    /// Every name in a stage's `available_tools` has to resolve to a tool that
+    /// exists, and every `[stages.X.tool_permissions]` key has to be a tool that
+    /// stage actually grants.
+    ///
+    /// A typo used to be invisible: `filter_tools_by_available` silently omits a
+    /// name matching nothing, so the stage just quietly advertised one tool
+    /// fewer. Now that dispatch refuses anything a stage did not offer, the same
+    /// typo means the model is told the tool does not exist and the stage cannot
+    /// do its job — a silent omission became a silent failure, which is worth a
+    /// test. A permission entry for an ungranted tool is the same drift seen
+    /// from the other side: it reads as a grant and is not one.
+    ///
+    /// An invariant over all discovered agents rather than a list of names —
+    /// naming them would stop testing the property the moment the list drifted.
+    #[test]
+    fn every_stage_tool_name_resolves_and_every_permission_names_a_granted_tool() {
+        // Sub-agent tools are provided by the host, not `BuiltinTools`.
+        const SUBAGENT: &[&str] = &[
+            "spawn_agent",
+            "check_agent",
+            "wait_for_agent",
+            "send_to_agent",
+            "kill_agent",
+        ];
+        let builtin = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
+            std::path::PathBuf::from("."),
+        ))
+        .names();
+
+        for agent in BUNDLED_AGENTS {
+            // This agent's own Rhai tools: `tools/<name>.rhai` defines `<name>`.
+            let scripts: Vec<&str> = agent
+                .files
+                .iter()
+                .filter_map(|(rel, _)| rel.strip_prefix("tools/"))
+                .filter_map(|f| f.strip_suffix(".rhai"))
+                .collect();
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent has a manifest");
+            let parsed = leviath_core::manifest::parse_manifest(manifest);
+            assert!(
+                parsed.is_ok(),
+                "bundled agent {} does not parse",
+                agent.name
+            );
+            let blueprint = parsed.expect("asserted Ok just above");
+
+            for stage in &blueprint.stages {
+                for tool in &stage.available_tools {
+                    // `server__tool` is an MCP tool, resolvable only once that
+                    // server is installed — not something a manifest can be
+                    // checked against here.
+                    let known = tool.contains("__")
+                        || builtin.iter().any(|b| b == tool)
+                        || SUBAGENT.contains(&tool.as_str())
+                        || scripts.contains(&tool.as_str());
+                    assert!(
+                        known,
+                        "{}: stage '{}' grants '{}', which is not a built-in,                          a sub-agent tool, or one of this agent's own tools/*.rhai",
+                        agent.name, stage.name, tool
+                    );
+                }
+                for granted in stage.tool_permissions.keys() {
+                    assert!(
+                        stage.available_tools.contains(granted),
+                        "{}: stage '{}' sets a permission for '{}', which it does                          not grant in available_tools",
+                        agent.name,
+                        stage.name,
+                        granted
+                    );
+                }
+            }
+        }
+    }
+
+    /// The invariant above can actually fail — a check over shipped data that
+    /// happens to pass says nothing about whether it would catch drift.
+    #[test]
+    fn the_stage_tool_invariant_rejects_a_typo_and_an_orphan_permission() {
+        let builtin = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
+            std::path::PathBuf::from("."),
+        ))
+        .names();
+        assert!(
+            !builtin.iter().any(|b| b == "raed_file"),
+            "a misspelled tool must not resolve"
+        );
+
+        let manifest = r#"
+[agent]
+name = "x"
+version = "0.1.0"
+description = "x"
+
+[stages.only]
+model = { provider = "anthropic", model = "m" }
+available_tools = ["read_file"]
+
+[stages.only.tool_permissions]
+write_file = "allow"
+"#;
+        let bp = leviath_core::manifest::parse_manifest(manifest)
+            .expect("the fixture parses; it is the invariant that should object");
+        let stage = &bp.stages[0];
+        assert!(
+            !stage.available_tools.contains(&"write_file".to_string()),
+            "the orphan-permission arm has something to catch"
+        );
+    }
+
     #[test]
     fn bundled_agent_names_are_unique() {
         let mut names: Vec<&str> = BUNDLED_AGENTS.iter().map(|a| a.name).collect();

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -1005,27 +1005,36 @@ mod tests {
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
         // Re-run the command capture directly so we can read stderr.
-        let out = std::process::Command::new(&script)
-            .args([
-                "--print",
-                "--output-format",
-                "json",
-                "--no-session-persistence",
-                "--tools",
-                "",
-                "--setting-sources",
-                "",
-                "--strict-mcp-config",
-                "--disable-slash-commands",
-                "--model",
-                "claude-sonnet-4-6",
-                "--effort",
-                "medium",
-                "--system-prompt-file",
-                "/tmp/x",
-            ])
-            .output()
-            .unwrap();
+        //
+        // Through `retry_etxtbsy` for the same reason production spawns are: a
+        // write fd inherited by another test's in-flight fork makes `exec` fail
+        // with "Text file busy" even though this stub was written, synced and
+        // closed before `chmod`. It is a race against the rest of the suite, so
+        // it fails perhaps one CI run in twenty and always somewhere unrelated.
+        let out = retry_etxtbsy(|| {
+            std::process::Command::new(&script)
+                .args([
+                    "--print",
+                    "--output-format",
+                    "json",
+                    "--no-session-persistence",
+                    "--tools",
+                    "",
+                    "--setting-sources",
+                    "",
+                    "--strict-mcp-config",
+                    "--disable-slash-commands",
+                    "--model",
+                    "claude-sonnet-4-6",
+                    "--effort",
+                    "medium",
+                    "--system-prompt-file",
+                    "/tmp/x",
+                ])
+                .output()
+        })
+        .await
+        .expect("the stub runs once no other process holds a write fd to it");
         let argv = String::from_utf8_lossy(&out.stderr).to_string();
         assert!(!argv.contains("--bare"), "argv must never carry --bare");
         assert!(!argv.contains("--allowed-tools"));

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -619,7 +619,7 @@ fn stage_output_is_reviewed(bp: &AgentBlueprint, cursor: &StageCursor) -> bool {
 /// `ReadyToInfer`. Ported from `AgentEngine::loop_handle_empty_tool_calls`.
 ///
 /// A stage whose output is reviewed is never nudged — see
-/// [`stage_output_is_reviewed`].
+/// `stage_output_is_reviewed`.
 #[allow(clippy::type_complexity)]
 pub fn handle_empty_response(
     mut agents: Query<

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -742,6 +742,62 @@ fn merge_in_call_order(
         .collect()
 }
 
+/// Whether a tool result describes a call whose side effect never happened.
+///
+/// `[error]` (it ran and failed), `[denied]` (policy refused it) and
+/// `[unavailable]` (the stage never offered it) all mean the same thing to
+/// anything reasoning about what the agent *did*: file tracking must not record
+/// a write that was not written, and the modification counters behind a
+/// transition gate must not count it as work. Three separate prefix lists is
+/// exactly how a fourth prefix gets missed — `[unavailable]` was, when dispatch
+/// began refusing unoffered tools and both call sites still listed only two.
+fn call_had_no_effect(result: &str) -> bool {
+    result.starts_with("[error]")
+        || result.starts_with("[denied]")
+        || result.starts_with("[unavailable]")
+}
+
+/// The effective tool names this stage advertised, canonicalised.
+///
+/// The same narrowing the request builder applies: `tools`, then `tool_filter`
+/// when it is set and non-empty. Deriving both from one function is what keeps
+/// "what the model was offered" and "what the model may call" the same set.
+fn offered_tool_names(stage: &StageInference) -> Vec<&str> {
+    stage
+        .tools
+        .iter()
+        .filter(|t| match stage.tool_filter.as_deref() {
+            Some(filter) if !filter.is_empty() => filter.iter().any(|f| f == &t.name),
+            _ => true,
+        })
+        .map(|t| leviath_tools::canonical_tool_name(&t.name))
+        .collect()
+}
+
+/// `Some(message)` when `name` is not among the stage's advertised tools.
+///
+/// The message is written for the model, not the user: it says plainly that the
+/// tool does not exist *here* and lists what does, so the next turn is a usable
+/// call rather than a retry of the same one. A stage advertising nothing says so
+/// instead of printing an empty list.
+fn unoffered_tool_refusal(stage: &StageInference, name: &str) -> Option<String> {
+    let canonical = leviath_tools::canonical_tool_name(name);
+    let offered = offered_tool_names(stage);
+    if offered.contains(&canonical) {
+        return None;
+    }
+    Some(match offered.is_empty() {
+        true => format!(
+            "[unavailable] '{name}' is not available in this stage, which has no \
+             tools at all. Answer directly instead of calling a tool."
+        ),
+        false => format!(
+            "[unavailable] '{name}' is not available in this stage. You may call: {}.",
+            offered.join(", ")
+        ),
+    })
+}
+
 /// Tool-dispatch system: for each `ReadyForTools` agent, apply its `context_*`
 /// tool calls inline (they mutate the ECS window) and hand the rest to the
 /// sequential tool lane, moving it to `AwaitingTools`. If a batch is *all*
@@ -755,6 +811,7 @@ pub fn dispatch_tools(
         (
             Entity,
             &AgentState,
+            &StageInference,
             &crate::components::InferenceResult,
             &mut ContextWindow,
             Option<&crate::components::ToolResultRoutingComponent>,
@@ -785,6 +842,7 @@ pub fn dispatch_tools(
     for (
         entity,
         state,
+        stage_inf,
         result,
         mut window,
         routing,
@@ -817,6 +875,29 @@ pub fn dispatch_tools(
             leviath_core::TaintLevel,
         )> = Vec::new();
         for c in &result.tool_calls {
+            // Layer 1, enforced rather than merely advertised.
+            //
+            // A stage's `available_tools` was applied only when building the
+            // schema list sent to the model. Nothing checked it again here, so a
+            // model that *named* a tool it had never been offered got that call
+            // dispatched anyway — reaching the permission gate, and for a
+            // default-`Ask` tool surfacing to the user as an approval prompt for
+            // something the stage was never granted.
+            //
+            // That is not hypothetical. A `plan` stage granting only
+            // `read_file`/`list_dir`/`ask_user_*`/`edit_document` emitted
+            // `write_file` with a complete source file in it, and the user was
+            // asked to approve writing code from the planning stage. Declining
+            // it was the only thing that stopped it.
+            //
+            // Checked against `StageInference`, which *is* the set advertised
+            // for this stage — resolved at spawn, swapped on every transition,
+            // and rewritten by the dynamic-tools refresh — so enforcement cannot
+            // drift from advertising the way a second copy of the rule would.
+            if let Some(refusal) = unoffered_tool_refusal(stage_inf, &c.name) {
+                context_results.push((c.tool_id.clone(), refusal));
+                continue;
+            }
             if crate::context_tools::is_context_tool(&c.name) {
                 let text =
                     crate::context_tools::handle_context_tool(&c.name, &c.arguments, &mut window);
@@ -1199,7 +1280,7 @@ fn apply_file_tracking(
         return;
     }
     for (call, (_id, result)) in tool_calls.iter().zip(merged.iter_mut()) {
-        if result.starts_with("[error]") || result.starts_with("[denied]") {
+        if call_had_no_effect(result) {
             continue;
         }
         let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) else {
@@ -1288,7 +1369,7 @@ fn record_modifications(
             }
             continue;
         }
-        if result.starts_with("[error]") {
+        if call_had_no_effect(result) {
             continue;
         }
         if let Some(progress) = progress.as_mut() {
@@ -5293,7 +5374,18 @@ mod tests {
 
     // ── process-response routing ──
 
-    fn infer_result(with_tools: bool) -> crate::components::InferenceResult {
+    /// An inference result, paired with the advertisement that makes its call
+    /// legal — see [`infer_with`]. `false` yields no calls and so offers
+    /// nothing, which is what a stage with no tools looks like.
+    fn infer_result(with_tools: bool) -> (StageInference, crate::components::InferenceResult) {
+        let offers = offering(match with_tools {
+            true => &["n"],
+            false => &[],
+        });
+        (offers, infer_result_only(with_tools))
+    }
+
+    fn infer_result_only(with_tools: bool) -> crate::components::InferenceResult {
         crate::components::InferenceResult {
             response: "r".to_string(),
             tool_calls: if with_tools {
@@ -5818,13 +5910,41 @@ mod tests {
         assert!(jrx.try_recv().is_err());
     }
 
-    fn infer_with(calls: Vec<crate::components::ToolCall>) -> crate::components::InferenceResult {
-        crate::components::InferenceResult {
-            response: "r".to_string(),
-            tool_calls: calls,
-            tokens_used: 0,
-            timestamp: 0,
+    /// A stage advertising exactly `names`.
+    fn offering(names: &[&str]) -> StageInference {
+        StageInference {
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
+            tools: names
+                .iter()
+                .map(|n| leviath_providers::Tool {
+                    name: (*n).to_string(),
+                    description: String::new(),
+                    parameters: serde_json::json!({}),
+                })
+                .collect(),
+            tool_filter: None,
         }
+    }
+
+    /// An inference result **and** the advertisement that makes its own calls
+    /// legal — dispatch refuses a tool the stage never offered, so a fixture
+    /// that calls one has to offer it. Returned together as a bundle so every
+    /// test exercising some *other* part of dispatch is not restating its own
+    /// call list. Tests about the Layer-1 check itself build the two separately.
+    fn infer_with(
+        calls: Vec<crate::components::ToolCall>,
+    ) -> (StageInference, crate::components::InferenceResult) {
+        let offers = offering(&calls.iter().map(|c| c.name.as_str()).collect::<Vec<_>>());
+        (
+            offers,
+            crate::components::InferenceResult {
+                response: "r".to_string(),
+                tool_calls: calls,
+                tokens_used: 0,
+                timestamp: 0,
+            },
+        )
     }
 
     fn ctx_call(id: &str, region: &str, content: &str) -> crate::components::ToolCall {
@@ -5878,6 +5998,217 @@ mod tests {
                 .current_tokens
                 > 0
         );
+    }
+
+    /// The text dispatch left in the agent's conversation for the model to read.
+    /// A batch with no lane work is applied inline, so there is no
+    /// `ContextToolResults` to inspect — the window is the only record.
+    fn conversation_text(world: &World, e: Entity) -> String {
+        world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .iter()
+            .map(|entry| entry.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The reason this check exists, as it actually happened: a `plan` stage
+    /// granting only reads emitted `write_file` with a complete source file in
+    /// it. `available_tools` was applied when building the schema list and never
+    /// again, so the call was dispatched anyway and the *user* was asked to
+    /// approve writing code from the planning stage. It never reaches the lane
+    /// or the permission gate now — the model is told, and the turn continues.
+    #[tokio::test]
+    async fn dispatch_tools_refuses_a_tool_the_stage_never_offered() {
+        let (jtx, mut jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let (_, result) = infer_with(vec![tc("c1", "write_file"), tc("c2", "read_file")]);
+        let e = world
+            .spawn((
+                agent_state(),
+                offering(&["read_file", "list_dir"]),
+                result,
+                conv_window(),
+                ReadyForTools,
+            ))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        let stashed = &world.get::<ContextToolResults>(e).unwrap().0;
+        assert_eq!(
+            stashed.len(),
+            1,
+            "only the unoffered call was answered here"
+        );
+        assert_eq!(stashed[0].0, "c1");
+        let refusal = stashed[0].1.clone();
+        assert!(refusal.contains("not available in this stage"), "{refusal}");
+        // And it names what the model *can* use, so the next turn is a usable
+        // call rather than a retry of the same one.
+        assert!(refusal.contains("read_file"), "{refusal}");
+
+        // The offered call still went to the lane: this refuses what was not
+        // granted, it does not refuse everything.
+        let job = jrx.try_recv().expect("the offered call still runs");
+        assert_eq!(job.entity, e);
+    }
+
+    /// A stage may advertise nothing at all (`available_tools = []` is a real
+    /// setting, not "unset"). Saying "you may call: " with an empty list would
+    /// read as a bug, so it says what is true instead.
+    #[tokio::test]
+    async fn dispatch_tools_tells_a_toolless_stage_to_answer_directly() {
+        let (jtx, _jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let (_, result) = infer_with(vec![tc("c1", "read_file")]);
+        let e = world
+            .spawn((
+                agent_state(),
+                offering(&[]),
+                result,
+                conv_window(),
+                ReadyForTools,
+            ))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        let text = conversation_text(&world, e);
+        assert!(
+            text.contains("no tools at all") && text.contains("Answer directly"),
+            "{text}"
+        );
+    }
+
+    /// Aliases resolve on both sides. A manifest says `bash` and the model calls
+    /// `shell` (or the reverse) — matching the raw strings would refuse a tool
+    /// the stage plainly granted, which is a worse failure than the one this
+    /// check exists to prevent.
+    #[tokio::test]
+    async fn dispatch_tools_matches_an_offered_tool_through_its_alias() {
+        let (jtx, mut jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let canonical = leviath_tools::canonical_tool_name("bash");
+        assert_ne!(
+            canonical, "bash",
+            "this test needs a real alias to be a test"
+        );
+        let (_, result) = infer_with(vec![tc("c1", canonical)]);
+        let e = world
+            .spawn((
+                agent_state(),
+                offering(&["bash"]),
+                result,
+                conv_window(),
+                ReadyForTools,
+            ))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        assert!(
+            world.get::<ContextToolResults>(e).unwrap().0.is_empty(),
+            "nothing was refused"
+        );
+        assert!(jrx.try_recv().is_ok(), "the aliased call ran");
+    }
+
+    /// `tool_filter` narrows what a request advertises, so it has to narrow what
+    /// dispatch accepts too — otherwise the filtered-out tool is callable by
+    /// name, which is the exact hole this check closes one level up.
+    #[tokio::test]
+    async fn dispatch_tools_honours_the_stage_tool_filter() {
+        let (jtx, _jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let mut offers = offering(&["read_file", "write_file"]);
+        offers.tool_filter = Some(vec!["read_file".to_string()]);
+        let (_, result) = infer_with(vec![tc("c1", "write_file")]);
+        let e = world
+            .spawn((agent_state(), offers, result, conv_window(), ReadyForTools))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        let text = conversation_text(&world, e);
+        assert!(text.contains("not available in this stage"), "{text}");
+    }
+
+    /// An empty `tool_filter` means "no narrowing", matching the request
+    /// builder — not "nothing is allowed".
+    #[tokio::test]
+    async fn dispatch_tools_treats_an_empty_tool_filter_as_no_narrowing() {
+        let (jtx, mut jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let mut offers = offering(&["read_file"]);
+        offers.tool_filter = Some(vec![]);
+        let (_, result) = infer_with(vec![tc("c1", "read_file")]);
+        let e = world
+            .spawn((agent_state(), offers, result, conv_window(), ReadyForTools))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        assert!(
+            world.get::<ContextToolResults>(e).unwrap().0.is_empty(),
+            "nothing was refused"
+        );
+        assert!(jrx.try_recv().is_ok(), "the call ran");
+    }
+
+    /// Context tools go through the same gate. They are applied inline rather
+    /// than on the lane, so a check that lived only in the lane would have left
+    /// `context_write` callable from a stage that never granted it.
+    #[tokio::test]
+    async fn dispatch_tools_refuses_an_unoffered_context_tool() {
+        let (jtx, _jrx) = mpsc::unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+        world.insert_resource(ToolStage(jtx));
+        let (_, result) = infer_with(vec![ctx_call("c1", "notes", "smuggled")]);
+        let e = world
+            .spawn((
+                agent_state(),
+                offering(&["read_file"]),
+                result,
+                notes_window(),
+                ReadyForTools,
+            ))
+            .id();
+
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_tools);
+        s.run(&mut world);
+
+        let text = conversation_text(&world, e);
+        assert!(text.contains("not available in this stage"), "{text}");
+        // And nothing was written to the region.
+        let w = world.get::<ContextWindow>(e).unwrap();
+        assert!(w.get_region("notes").unwrap().content.is_empty());
     }
 
     #[tokio::test]
@@ -9344,6 +9675,13 @@ mod tests {
             fcall("3", "list_dir", serde_json::json!({"path": "d"})),  // untracked tool
             fcall("4", "write_file", serde_json::json!({"path": "e"})), // no content
             fcall("5", "read_file", serde_json::json!({"path": "f"})), // result is denied
+            // Never offered by this stage: the write did not happen, so tracking
+            // it would put a file in the region that does not exist on disk.
+            fcall(
+                "6",
+                "write_file",
+                serde_json::json!({"path": "g", "content": "print(1)"}),
+            ),
         ];
         let mut merged = vec![
             ("1".to_string(), "[error] boom".to_string()),
@@ -9351,6 +9689,10 @@ mod tests {
             ("3".to_string(), "listing".to_string()),
             ("4".to_string(), "written".to_string()),
             ("5".to_string(), "[denied] nope".to_string()),
+            (
+                "6".to_string(),
+                "[unavailable] 'write_file' is not available in this stage.".to_string(),
+            ),
         ];
         apply_file_tracking(&mut w, &ft, &calls, &mut merged);
         for (_, r) in &merged {
@@ -9535,6 +9877,36 @@ mod tests {
         );
         assert_eq!(progress.modifying_tool_calls, 0);
         assert_eq!(progress.blocked_modification_calls, 1);
+        assert_eq!(flags.modified_file_count, 0);
+        assert!(flags.modified_files.is_empty());
+    }
+
+    /// A write the stage never offered is not a modification. It matters twice
+    /// over: `modified_files` in `meta.json` would name a file that was never
+    /// written, and `modifying_tool_calls` is what a `require_modifications`
+    /// transition gate reads — so a stage that had every write refused could
+    /// still answer "yes, I did work" on the way out.
+    #[test]
+    fn collect_tools_ignores_a_write_the_stage_never_offered() {
+        let (progress, flags) = count_modifications(
+            &[
+                (
+                    "write_file",
+                    serde_json::json!({"path": "smuggled.py"}),
+                    "[unavailable] 'write_file' is not available in this stage. \
+                     You may call: read_file, list_dir.",
+                ),
+                (
+                    "edit_file",
+                    serde_json::json!({"path": "also-not.rs"}),
+                    "[unavailable] 'edit_file' is not available in this stage.",
+                ),
+            ],
+            &[],
+        );
+        assert_eq!(progress.modifying_tool_calls, 0);
+        // Not "blocked" either — nobody declined it; the stage never had it.
+        assert_eq!(progress.blocked_modification_calls, 0);
         assert_eq!(flags.modified_file_count, 0);
         assert!(flags.modified_files.is_empty());
     }

--- a/crates/leviath-runtime/src/pipeline.rs
+++ b/crates/leviath-runtime/src/pipeline.rs
@@ -594,12 +594,33 @@ const NUDGE_TEXT: &str = "You have tools available. Please use them to complete 
 /// How many text-only responses to nudge before accepting the text as final.
 const MAX_TEXT_ONLY_NUDGES: usize = 3;
 
+/// Whether this stage's deliverable *is* its text response.
+///
+/// A stage with interaction points presents what it writes for the user to
+/// approve, revise or edit — the text is the work product, not a model stalling
+/// before it starts. Nudging one is worse than wasteful: the nudge says "use
+/// your tools to complete the task", and a stage built to produce a document
+/// usually has no tool that could. A planning stage told to complete the task
+/// went looking for a way to write the file, found none, and asked the user to
+/// grant it a write tool or create the file by hand — instead of ending the
+/// stage and presenting the plan it had already finished writing.
+fn stage_output_is_reviewed(bp: &AgentBlueprint, cursor: &StageCursor) -> bool {
+    matches!(
+        bp.0.stages.get(cursor.index).map(|s| &s.mode),
+        Some(leviath_core::blueprint::StageMode::InteractivePoints { points }) if !points.is_empty()
+    )
+}
+
 /// Empty-response system: for each `ReadyForTransition` agent decide whether the
 /// stage is done. If the agent has already made tool calls, or we've nudged the
 /// max number of times, the text response is accepted and the agent advances to
 /// `ResolveTransition`. Otherwise (text only, no work yet) the response + a
 /// "use your tools" nudge are added to context and the agent loops back to
 /// `ReadyToInfer`. Ported from `AgentEngine::loop_handle_empty_tool_calls`.
+///
+/// A stage whose output is reviewed is never nudged — see
+/// [`stage_output_is_reviewed`].
+#[allow(clippy::type_complexity)]
 pub fn handle_empty_response(
     mut agents: Query<
         (
@@ -607,15 +628,20 @@ pub fn handle_empty_response(
             &mut ContextWindow,
             &crate::components::InferenceResult,
             &mut StageProgress,
+            &AgentBlueprint,
+            &StageCursor,
         ),
         With<ReadyForTransition>,
     >,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, mut window, infer, mut progress) in agents.iter_mut() {
+    for (entity, mut window, infer, mut progress, bp, cursor) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
-        if progress.total_tool_calls > 0 || progress.text_only_nudges >= MAX_TEXT_ONLY_NUDGES {
+        if progress.total_tool_calls > 0
+            || progress.text_only_nudges >= MAX_TEXT_ONLY_NUDGES
+            || stage_output_is_reviewed(bp, cursor)
+        {
             commands
                 .entity(entity)
                 .remove::<ReadyForTransition>()
@@ -5511,6 +5537,29 @@ mod tests {
         s.run(world);
     }
 
+    /// A one-stage blueprint whose stage either presents its output for review
+    /// or runs autonomously.
+    fn nudge_bp(reviewed: bool) -> AgentBlueprint {
+        let mut stage = stage_named("a", None, false, None);
+        if reviewed {
+            let point = leviath_core::blueprint::InteractionPoint {
+                name: "plan_approval".to_string(),
+                prompt: "Review the plan above.".to_string(),
+                required: true,
+                style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
+                options: vec!["Approve".to_string()],
+                directives: std::collections::HashMap::new(),
+                abort_options: Vec::new(),
+                edit_options: Vec::new(),
+                document_region: Some("plan".to_string()),
+            };
+            stage.mode = leviath_core::blueprint::StageMode::InteractivePoints {
+                points: vec![point],
+            };
+        }
+        AgentBlueprint(blueprint(vec![stage]))
+    }
+
     #[test]
     fn empty_response_finishes_when_agent_made_tool_calls() {
         let mut world = World::new();
@@ -5525,6 +5574,8 @@ mod tests {
                 ctx(&[("conversation", 10_000)]),
                 infer_result(false),
                 progress,
+                nudge_bp(false),
+                StageCursor { index: 0 },
                 ReadyForTransition,
             ))
             .id();
@@ -5547,11 +5598,64 @@ mod tests {
                 ctx(&[("conversation", 10_000)]),
                 infer_result(false),
                 progress,
+                nudge_bp(false),
+                StageCursor { index: 0 },
                 ReadyForTransition,
             ))
             .id();
         run_empty(&mut world);
         assert!(world.get::<ResolveTransition>(e).is_some());
+    }
+
+    /// A stage that presents its output for review is finished when it produces
+    /// that output. This is the whole failure, from a real run: `plan` wrote a
+    /// complete plan on its first turn — correctly, with no tool calls, because
+    /// writing the plan *is* the job — and the nudge read that as a model
+    /// stalling and told it to "use your tools to complete the task". `plan`
+    /// has no tool that writes anything, so the model went looking for one,
+    /// could not find it, and asked the user to grant it a write tool or create
+    /// the file by hand. The plan it had already finished was never presented.
+    #[test]
+    fn empty_response_never_nudges_a_stage_whose_output_is_reviewed() {
+        let mut world = World::new();
+        let e = world
+            .spawn((
+                ctx(&[("conversation", 10_000)]),
+                infer_result(false),      // text only, no tool calls
+                StageProgress::default(), // and no work done yet this stage
+                nudge_bp(true),
+                StageCursor { index: 0 },
+                ReadyForTransition,
+            ))
+            .id();
+        run_empty(&mut world);
+
+        assert!(
+            world.get::<ResolveTransition>(e).is_some(),
+            "the stage is done: its text is what gets reviewed"
+        );
+        assert!(
+            world.get::<ReadyToInfer>(e).is_none(),
+            "not sent round again"
+        );
+        assert_eq!(
+            world.get::<StageProgress>(e).unwrap().text_only_nudges,
+            0,
+            "and not counted as a nudge"
+        );
+        // Nothing was injected — the model is not told to go do work it has no
+        // tool for, which is what sent it asking the user for one.
+        assert!(
+            world
+                .get::<ContextWindow>(e)
+                .unwrap()
+                .get_region("conversation")
+                .unwrap()
+                .content
+                .is_empty(),
+            "nothing is injected: no nudge telling the model to go do work it \
+             has no tool for, which is what sent it asking the user for one"
+        );
     }
 
     #[test]
@@ -5562,6 +5666,8 @@ mod tests {
                 ctx(&[("conversation", 10_000)]),
                 infer_result(false),
                 StageProgress::default(),
+                nudge_bp(false),
+                StageCursor { index: 0 },
                 ReadyForTransition,
             ))
             .id();

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -846,11 +846,24 @@ mod tests {
         }
     }
 
+    /// A stage advertising the tools the scripted responses here actually call.
+    ///
+    /// It used to advertise none, which stopped mattering the moment dispatch
+    /// began refusing tools a stage never offered: every end-to-end test that
+    /// drives a tool call short-circuited into a refusal, and the tool service
+    /// was never reached at all.
     fn stage(model: &str) -> StageInference {
         StageInference {
             provider_name: "script".to_string(),
             model: model.to_string(),
-            tools: vec![],
+            tools: ["do", "read"]
+                .iter()
+                .map(|n| leviath_providers::Tool {
+                    name: (*n).to_string(),
+                    description: String::new(),
+                    parameters: serde_json::json!({}),
+                })
+                .collect(),
             tool_filter: None,
         }
     }


### PR DESCRIPTION
## What happened

Run `software-engineer-1785280455-37b2cf770ed9` asked the user to approve
`write_file` during the **plan** stage, with a complete Python file in the
arguments:

```
[tool] write_file: [denied] User declined tool call 'write_file'.
[tool] ask_user_text: User provided no answer.
```

Declining it was the only thing that stopped planning from writing code. The run
then cancelled.

## Why the manifest was not the problem

`plan` grants exactly `read_file`, `list_dir`, `ask_user_text`,
`ask_user_choice`, `edit_document`. It never granted a write tool, and its
prompt never asked for one.

`available_tools` was applied in exactly one place — building the schema list
sent to the model — and nothing checked it again at dispatch. A model that
*named* a tool it had never been offered got that call dispatched anyway, where
it reached the permission gate; `write_file` defaults to `Ask`, so it became a
prompt to the user. **Layer 1 was advertising, not enforcement.** Editing the
manifest would not have prevented this run, because the manifest was already
right.

It also closes an unattended path: `--yolo` collapses `Ask` to `Allow`, so the
same run with nobody watching would have written the file silently.

## The fix

Dispatch refuses a call the current stage did not advertise, checked against
`StageInference` — which *is* the advertised set, resolved at spawn, swapped on
every transition, and rewritten by the dynamic-tools refresh. Deriving both from
one source is what stops enforcement drifting from advertising the way a second
copy of the rule would.

It sits where tool calls are first triaged, so one check covers context tools
(applied inline, never on the lane), interaction tools, built-ins, MCP and
script tools. Aliases resolve on both sides, so a manifest saying `bash` still
accepts a `shell` call — refusing a tool the stage plainly granted would be a
worse failure than the one this prevents. The refusal is written for the model
and names what it may call instead, so the next turn is a usable call rather
than a retry.

## Two things the enforcement broke, fixed here rather than shipped

- **A refused write still counted as work.** It went through file tracking and
  the modification counters, so `modified_files` in `meta.json` would have named
  a file that was never written — and `modifying_tool_calls` is what a
  `require_modifications` transition gate reads, so a stage with every write
  refused could still answer "yes, I did work" on the way out. `[error]`,
  `[denied]` and `[unavailable]` go through one predicate now; three separate
  prefix lists is exactly how the fourth prefix got missed.
- **Every world-level test that drove a tool call stopped testing anything.**
  The fixture stage advertised nothing while its scripted responses called
  `do`/`read`, so each one short-circuited into a refusal and the tool service
  was never reached. The coverage gate caught it as a never-invoked `EchoTools`.

Both fixes were verified load-bearing by removing them and watching the tests
fail.

## The agents

The mechanical audit came back clean: across all ten agents, every
`available_tools` name resolves to a real tool and every
`[stages.X.tool_permissions]` key is one that stage grants. That is now an
invariant test over all *discovered* agents rather than a property that happened
to hold — and it earns its place because of the change above. A typo used to
mean one tool quietly missing from the schema; it now means the model is told
the tool does not exist and the stage cannot do its job. Both arms were checked
against a deliberately broken manifest.

What the audit did find is a documentation gap. Only `writing-assistant/outline`
stated its own boundary — *"do NOT write the article itself and do NOT create
any files here"* — and it is the stage nobody has had trouble with. The planning
and review stages of `software-engineer`, `coder` and `reviewer` left it
implied. They say it now: the runtime is the guarantee, but a model that knows
the rule does not burn a turn discovering it. The review stages also say plainly
that a reviewer reports rather than repairs.

`log-analyzer/script` looked like a mismatch — it is told to write scripts but
grants no write tool — and is not one: `tool_routing.default_region = "scripts"`
routes its bash output there. Checked rather than assumed, since enforcement
would have broken it if the prompt had been right.

Versions stay at **0.0.1** by request — these get reinstalled directly. Worth
knowing for anyone who does not reinstall by hand: update planning treats an
equal version as up to date, so a changed prompt at an unchanged version will
not reach an install that already has it.

## A second stage-contract bug, from a follow-up run

Run `software-engineer-1785286345-e1dbd6379e59` stopped in `plan` and asked the
user to *grant it a write tool or create the file by hand*, instead of
presenting the plan for approval.

The model had already done its job. Its first turn in `plan` was a complete plan
— `## Plan`, `## Files`, the lot — returned as text with no tool calls, which is
exactly right for a stage whose deliverable is a document. `handle_empty_response`
saw `total_tool_calls == 0` (the counter resets on stage entry, so `discover`'s
calls do not carry over), read it as a model stalling before starting work, and
injected:

> You have tools available. Please use them to complete the task. Start by
> reading the relevant files in the working directory.

`plan` has no tool that writes anything. Told to "complete the task", the model
went looking for a way to create the file, `list_dir`'d and `read_file`'d a file
that did not exist yet, concluded it was missing a capability, and asked the user
for one. The finished plan was never presented.

The nudge exists for #107 — a stage that claims work and calls nothing. That
premise does not hold for a stage that presents its output for review: there the
text *is* the work and the interaction point is the gate. Such a stage is now
accepted on its first text response and advances to its point. Two shipped
stages are affected, `software-engineer/plan` and `writing-assistant/outline` —
both built to produce a document with no tool that could act on it, which is why
the nudge there is not merely wasteful but actively misdirects.

The fix narrows the rule rather than removing it: `discover`, which is
autonomous, still gets its three nudges.

## Verification

5,037 tests, 100% coverage on all 10 packages, clippy clean.

Verified against the **real `software-engineer` manifest**, not a toy, driven by
a Rhai script provider that reports the schema list it was handed — determinstic,
no dependence on what a model happens to do, no API cost.

**The advertising path was already correct**, and that is worth stating plainly
because it settles what the bug was. Each stage received exactly what its
manifest grants:

```
discover   4  read_file, list_dir, shell, context_write
plan       5  read_file, list_dir, ask_user_text, ask_user_choice, edit_document
prototype  7  read_file, write_file, edit_file, list_dir, shell, context_write, context_append
implement  8  read_file, write_file, edit_file, list_dir, shell, ask_user_text, ask_user_confirm, context_append
review     3  read_file, list_dir, shell
```

`plan` was never handed `write_file`, and a scan of its full assembled system
prompt does not so much as name it. Nothing leaked it — the model produced a
tool name it was never given, and the runtime ran with it. (The stage-*routing*
inferences advertise no tools at all, by design; checked, so that "0 tools"
reading is not mistaken for a stage losing its grant.)

With enforcement on, a provider that emits `write_file` from that stage anyway
produced **8 such calls, 0 files written**, an empty workdir and empty
`modified_files`, each answered:

```
[unavailable] 'write_file' is not available in this stage. You may call: read_file, list_dir, shell, context_write.
```

Both runs were `--yolo`, which is where the old behaviour would have written the
file with no prompt at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYEetmjRipJW2fv4oya162
