### PR TITLE
feat(dashboard): mouse text selection with copy on release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
+ "unicode-width 0.2.0",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,10 @@ temp-env = "0.3"
 # tui-textarea moves.
 crossterm = "0.28"
 ratatui = "0.29"
+# Already in the tree via ratatui; named explicitly so the dashboard's mouse
+# selection can measure symbol display widths when reading cells back out of
+# the drawn frame (wide CJK/emoji symbols occupy continuation cells).
+unicode-width = "0.2"
 pulldown-cmark = "0.13"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 axum = { version = "0.8", features = ["ws"] }

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ The two coding agents can also detour through an optional **`prototype`** spike 
   <img src="docs/assets/dashboard-final.png" alt="lev dash — the Leviath terminal dashboard showing the agent list and live activity log" width="900">
 </p>
 
-`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, clipboard yank, and mouse support. Press **`m`** to open the MCP management screen — add, remove, log in to, and test tool servers without leaving the dashboard.
+`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, and full mouse support. Scroll with the wheel, or click-drag to select text in any pane; releasing the drag copies it to your clipboard (works over SSH via OSC52), and `y` still yanks a whole pane at once. Shift+drag reaches your terminal's native selection. Press **`m`** to open the MCP management screen — add, remove, log in to, and test tool servers without leaving the dashboard.
 
 ## 🌐 API Server
 

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -47,6 +47,7 @@ chrono = { workspace = true }
 bevy_ecs = { workspace = true }
 crossterm = { workspace = true }
 ratatui = { workspace = true }
+unicode-width = { workspace = true }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
 dotenvy = { workspace = true }

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -192,7 +192,12 @@ impl Dashboard {
     ///
     /// One place so the keyboard and the mouse wheel cannot disagree about
     /// which pane a gesture moves.
+    ///
+    /// Scrolling clears any mouse selection: the highlight is anchored to
+    /// screen cells, so moving text under it would leave it over the wrong
+    /// content.
     pub(crate) fn scroll_by(&mut self, lines: i32) {
+        self.selection = None;
         let target = match self.scroll_target_is_review() {
             true => &mut self.review_scroll,
             false => &mut self.detail_scroll,

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -5,6 +5,7 @@ mod helpers;
 mod input;
 mod mcp;
 mod render;
+mod selection;
 mod state;
 #[cfg(test)]
 mod test_support;
@@ -178,14 +179,9 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     dashboard.handle_key(key);
                 }
-                // The wheel scrolls the same pane the keyboard does. Three lines
-                // per notch is the usual terminal convention; one felt broken on
-                // a long plan, which is the document people actually scroll.
-                Event::Mouse(m) => match m.kind {
-                    crossterm::event::MouseEventKind::ScrollUp => dashboard.scroll_by(3),
-                    crossterm::event::MouseEventKind::ScrollDown => dashboard.scroll_by(-3),
-                    _ => {}
-                },
+                // Wheel scrolling and click-drag text selection, handled in one
+                // place (`selection.rs`) so they cannot disagree about state.
+                Event::Mouse(m) => dashboard.handle_mouse(m),
                 Event::Resize(_, _) => {
                     // Terminal will redraw automatically on next tick
                 }
@@ -602,24 +598,29 @@ mod tests {
         let mut dashboard = make_test_dashboard();
         let control = no_daemon_control();
         let mut terminal = test_terminal();
-        // A no-op Resize tick, then both wheel directions, then the Esc that
+        // A no-op Resize tick, then both wheel directions, a full
+        // press-drag-release selection over the log panel, and the Esc that
         // triggers quit -- covers every arm of the event match, including the
-        // mouse one that carries scrolling.
-        let wheel = |kind| {
+        // mouse one that carries scrolling and selection.
+        let mouse = |kind, column, row| {
             Event::Mouse(crossterm::event::MouseEvent {
                 kind,
-                column: 0,
-                row: 0,
+                column,
+                row,
                 modifiers: crossterm::event::KeyModifiers::NONE,
             })
         };
+        use crossterm::event::{MouseButton, MouseEventKind};
         let mut events = TestEventSource::new(vec![
             Event::Resize(80, 24),
-            wheel(crossterm::event::MouseEventKind::ScrollUp),
-            wheel(crossterm::event::MouseEventKind::ScrollDown),
-            // A button press is not a scroll and must be ignored rather than
-            // moving the view under the user.
-            wheel(crossterm::event::MouseEventKind::Moved),
+            mouse(MouseEventKind::ScrollUp, 0, 0),
+            mouse(MouseEventKind::ScrollDown, 0, 0),
+            // Cursor motion without a button is not a gesture and must be
+            // ignored rather than moving the view under the user.
+            mouse(MouseEventKind::Moved, 0, 0),
+            mouse(MouseEventKind::Down(MouseButton::Left), 3, 15),
+            mouse(MouseEventKind::Drag(MouseButton::Left), 20, 16),
+            mouse(MouseEventKind::Up(MouseButton::Left), 20, 16),
             key(KeyCode::Esc),
         ]);
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -178,6 +178,15 @@ impl Dashboard {
             return;
         }
 
+        // Read-only stage content accepts mouse selection; the rect excludes
+        // the borders (and with them the scrollbar track, which sits on the
+        // right border column). The editor branch above deliberately does not
+        // register: tui-textarea owns those cells.
+        self.selection_regions.push(content_area.inner(Margin {
+            vertical: 1,
+            horizontal: 1,
+        }));
+
         let inner_h = content_area.height.saturating_sub(2) as usize;
         let render_width = content_area.width.saturating_sub(2);
         let is_context = self.stage_content_mode == StageContentMode::Context;
@@ -943,6 +952,48 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn render_content_pane_registers_its_selection_region() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let agent = make_test_agent("run-selreg", AgentDisplayStatus::Active);
+        let area = Rect::new(0, 0, 100, 20);
+        terminal
+            .draw(|f| dash.render_content_pane(f, area, &agent, 100))
+            .unwrap();
+        // Borders excluded, so mouse selection can never grab the frame or
+        // the scrollbar track on the right border column.
+        assert_eq!(
+            dash.selection_regions,
+            vec![area.inner(ratatui::layout::Margin {
+                vertical: 1,
+                horizontal: 1,
+            })]
+        );
+    }
+
+    #[test]
+    fn render_content_pane_does_not_register_selection_while_editing() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-selreg-edit", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::edit_text(
+            "et2", "Edit", "plan", "line A",
+        ));
+        dash.agents.push(agent.clone());
+        dash.update_display_indices();
+        dash.input_mode = true;
+        assert!(dash.editing_document());
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+            .unwrap();
+        // tui-textarea owns those cells; a selection there would fight the
+        // editor's own cursor and highlighting.
+        assert!(dash.selection_regions.is_empty());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -22,6 +22,13 @@ impl Dashboard {
         review_lines: &[ratatui::text::Line<'static>],
         pending_req: &Option<interaction::InteractionRequest>,
     ) {
+        // The review document accepts mouse selection; borders (and the
+        // scrollbar track on the right border column) are excluded.
+        self.selection_regions.push(review_area.inner(Margin {
+            vertical: 1,
+            horizontal: 1,
+        }));
+
         let inner_h = review_area.height.saturating_sub(2) as usize;
 
         // Clamp scroll
@@ -327,6 +334,15 @@ mod tests {
             })
             .unwrap();
         assert!(dash.review_scroll < usize::MAX);
+        // The review pane accepts mouse selection: its inner rect (borders
+        // excluded) is registered for hit-testing.
+        assert_eq!(
+            dash.selection_regions,
+            vec![Rect::new(0, 0, 80, 10).inner(Margin {
+                vertical: 1,
+                horizontal: 1,
+            })]
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -18,8 +18,15 @@ use super::types::*;
 
 impl Dashboard {
     pub(super) fn draw(&mut self, frame: &mut Frame) {
+        // Selectable panes re-register their rects as they render; anything
+        // still selected in a pane that does not come back this frame is
+        // dropped by the overlay pass below.
+        self.selection_regions.clear();
+
         if self.mcp_screen {
             self.draw_mcp_screen(frame, frame.area());
+            // No pane registered a rect, so this drops any selection.
+            self.validate_selection();
             self.draw_toasts(frame);
             return;
         }
@@ -44,6 +51,10 @@ impl Dashboard {
             self.draw_log_panel(frame, chunks[1]);
             self.draw_help_bar(frame, chunks[2]);
         }
+
+        // Mouse-selection highlight and released-selection copy, painted over
+        // the panes but under the popups below.
+        self.apply_selection_overlay(frame);
 
         // Render toasts (top-right overlay)
         self.draw_toasts(frame);
@@ -304,6 +315,41 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
         terminal.draw(|f| dash.draw(f)).unwrap();
+    }
+
+    #[test]
+    fn draw_reregisters_selection_regions_every_frame() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let first_frame = dash.selection_regions.clone();
+        assert!(!first_frame.is_empty());
+        // A second draw replaces the registrations instead of accumulating.
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        assert_eq!(dash.selection_regions, first_frame);
+    }
+
+    #[test]
+    fn draw_mcp_screen_drops_any_selection() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        // Start a drag over the log panel on the normal screen.
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let region = dash.selection_regions[0];
+        dash.handle_mouse(crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: region.x,
+            row: region.y,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        });
+        assert!(dash.selection.is_some());
+        // The MCP screen has no selectable panes; switching to it clears.
+        dash.mcp_screen = true;
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        assert!(dash.selection.is_none());
+        assert!(dash.selection_regions.is_empty());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -230,6 +230,13 @@ impl Dashboard {
             ]),
             Line::from(vec![
                 Span::styled(
+                    "  drag     ",
+                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("Select text; release copies (Shift+drag: terminal select)"),
+            ]),
+            Line::from(vec![
+                Span::styled(
                     "  i        ",
                     Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
                 ),

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -1,7 +1,7 @@
 //! Agent table, log panel, and help bar rendering.
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
@@ -164,7 +164,13 @@ impl Dashboard {
         frame.render_stateful_widget(table, area, &mut self.table_state);
     }
 
-    pub(in crate::commands::dashboard) fn draw_log_panel(&self, frame: &mut Frame, area: Rect) {
+    pub(in crate::commands::dashboard) fn draw_log_panel(&mut self, frame: &mut Frame, area: Rect) {
+        // The activity log accepts mouse selection (borders excluded).
+        self.selection_regions.push(area.inner(Margin {
+            vertical: 1,
+            horizontal: 1,
+        }));
+
         let log_lines: Vec<Line> = self
             .log
             .iter()
@@ -666,6 +672,14 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
+        // The activity log accepts mouse selection inside its borders.
+        assert_eq!(
+            dash.selection_regions,
+            vec![Rect::new(0, 0, 120, 40).inner(Margin {
+                vertical: 1,
+                horizontal: 1,
+            })]
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -1,0 +1,678 @@
+//! Mouse text selection for the dashboard's text panes.
+//!
+//! Selection is anchored to *screen cells*, not to the pane's source lines.
+//! Panes wrap long lines at draw time, so the only representation that always
+//! matches what the user sees is the drawn frame itself: the highlight is
+//! painted over the frame buffer after the panes render, and the copied text
+//! is read back from those same cells. This is the semantics of native
+//! terminal selection, which mouse capture otherwise takes away.
+//!
+//! Lifecycle: a left-button press inside a registered pane starts a drag,
+//! dragging extends the highlight (clamped to that pane), and release copies
+//! the highlighted cells through the same clipboard seam as `y` yank. A plain
+//! click, any scroll, or a frame that no longer draws the pane clears the
+//! selection - the highlight must never outlive the text it was drawn over.
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::style::Modifier;
+use unicode_width::UnicodeWidthStr;
+
+use super::state::Dashboard;
+use super::types::ToastLevel;
+
+/// An in-progress or just-released mouse selection over one pane.
+///
+/// Coordinates are absolute screen cells `(column, row)`, both endpoints
+/// inclusive and always inside `region`.
+pub(super) struct Selection {
+    /// The pane's inner rect (borders excluded) as registered by the pane's
+    /// renderer on the frame where the drag started.
+    pub(super) region: Rect,
+    /// Where the drag started.
+    pub(super) anchor: (u16, u16),
+    /// Where the drag currently is (or ended).
+    pub(super) cursor: (u16, u16),
+    /// True between button press and release.
+    pub(super) dragging: bool,
+    /// True once any drag motion arrived; release without motion is a plain
+    /// click and clears instead of copying.
+    pub(super) moved: bool,
+    /// Set on release; the next draw extracts the text and copies it.
+    pub(super) pending_copy: bool,
+}
+
+/// The registered pane containing the given screen cell, if any.
+fn hit_region(regions: &[Rect], column: u16, row: u16) -> Option<Rect> {
+    regions
+        .iter()
+        .copied()
+        .find(|r| r.contains(Position::new(column, row)))
+}
+
+/// Clamp a screen cell into a non-empty rect (a drag may wander outside the
+/// pane it started in).
+fn clamp_to_region(region: Rect, column: u16, row: u16) -> (u16, u16) {
+    (
+        column.clamp(region.left(), region.right().saturating_sub(1)),
+        row.clamp(region.top(), region.bottom().saturating_sub(1)),
+    )
+}
+
+/// Order two endpoints into reading order (top-to-bottom, then left-to-right),
+/// so a drag upward or backward selects the same range as its mirror.
+fn ordered(a: (u16, u16), b: (u16, u16)) -> ((u16, u16), (u16, u16)) {
+    if (a.1, a.0) <= (b.1, b.0) {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// The inclusive column range a selection covers on one row: partial on the
+/// first and last rows, the full pane width in between.
+fn row_span(region: Rect, start: (u16, u16), end: (u16, u16), row: u16) -> (u16, u16) {
+    let first = if row == start.1 {
+        start.0
+    } else {
+        region.left()
+    };
+    let last = if row == end.1 {
+        end.0
+    } else {
+        region.right().saturating_sub(1)
+    };
+    (first, last)
+}
+
+/// Read the selected cells back out of the drawn frame as plain text.
+///
+/// Rows are trimmed of the buffer's padding spaces and joined with newlines,
+/// which is what native terminal selection produces. Wide symbols (CJK,
+/// emoji) occupy continuation cells in the buffer; advancing by each symbol's
+/// display width skips them so nothing is doubled.
+fn extract_from_buffer(buf: &Buffer, region: Rect, a: (u16, u16), b: (u16, u16)) -> String {
+    let (start, end) = ordered(a, b);
+    let mut rows = Vec::new();
+    for row in start.1..=end.1 {
+        let (first, last) = row_span(region, start, end, row);
+        let mut text = String::new();
+        let mut column = first;
+        while column <= last {
+            let Some(cell) = buf.cell(Position::new(column, row)) else {
+                break;
+            };
+            let symbol = cell.symbol();
+            text.push_str(symbol);
+            column += (UnicodeWidthStr::width(symbol).max(1)) as u16;
+        }
+        rows.push(text.trim_end().to_string());
+    }
+    rows.join("\n")
+}
+
+/// Paint the selection over the drawn frame by inverting each selected cell.
+/// `REVERSED` composes with whatever style the pane drew (including search
+/// highlights) instead of erasing it.
+fn highlight_in_buffer(buf: &mut Buffer, region: Rect, a: (u16, u16), b: (u16, u16)) {
+    let (start, end) = ordered(a, b);
+    for row in start.1..=end.1 {
+        let (first, last) = row_span(region, start, end, row);
+        for column in first..=last {
+            if let Some(cell) = buf.cell_mut(Position::new(column, row)) {
+                let style = cell.style().add_modifier(Modifier::REVERSED);
+                cell.set_style(style);
+            }
+        }
+    }
+}
+
+impl Dashboard {
+    /// Single entry point for every mouse event, so the wheel and selection
+    /// cannot disagree about state. The wheel arms are the pre-selection
+    /// behavior, unchanged: three lines per notch into whichever pane the
+    /// keyboard would scroll.
+    pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
+        match event.kind {
+            MouseEventKind::ScrollUp => self.scroll_by(3),
+            MouseEventKind::ScrollDown => self.scroll_by(-3),
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.selection_begin(event.column, event.row);
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                self.selection_drag(event.column, event.row);
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                self.selection_release(event.column, event.row);
+            }
+            _ => {}
+        }
+    }
+
+    /// A left press inside a selectable pane starts a drag there; anywhere
+    /// else it clears whatever selection existed.
+    fn selection_begin(&mut self, column: u16, row: u16) {
+        self.selection = hit_region(&self.selection_regions, column, row).map(|region| Selection {
+            region,
+            anchor: (column, row),
+            cursor: (column, row),
+            dragging: true,
+            moved: false,
+            pending_copy: false,
+        });
+    }
+
+    fn selection_drag(&mut self, column: u16, row: u16) {
+        if let Some(sel) = self.selection.as_mut().filter(|s| s.dragging) {
+            sel.cursor = clamp_to_region(sel.region, column, row);
+            sel.moved = true;
+        }
+    }
+
+    /// Release ends the drag: with motion it schedules the copy for the next
+    /// draw (extraction needs the drawn buffer), without motion it was a plain
+    /// click and clears.
+    fn selection_release(&mut self, column: u16, row: u16) {
+        let Some(sel) = self.selection.as_mut().filter(|s| s.dragging) else {
+            return;
+        };
+        sel.cursor = clamp_to_region(sel.region, column, row);
+        sel.dragging = false;
+        if sel.moved {
+            sel.pending_copy = true;
+        } else {
+            self.selection = None;
+        }
+    }
+
+    /// Drop a selection whose pane was not drawn this frame. Panes re-register
+    /// their rects every draw, so one containment check covers resize, view
+    /// switches, the document editor taking over the content pane, and any
+    /// other layout change that moved the text out from under the highlight.
+    pub(super) fn validate_selection(&mut self) {
+        if let Some(sel) = &self.selection
+            && !self.selection_regions.contains(&sel.region)
+        {
+            self.selection = None;
+        }
+    }
+
+    /// Post-render pass: paint the highlight over the drawn panes and, on the
+    /// draw after release, read the highlighted text back and copy it.
+    ///
+    /// Runs after the panes render (so the cells exist) and before toasts and
+    /// overlays (so those draw over the highlight, and the copy's toast shows
+    /// this same frame).
+    pub(super) fn apply_selection_overlay(&mut self, frame: &mut Frame) {
+        self.validate_selection();
+        let Some(sel) = &self.selection else {
+            return;
+        };
+        let (region, anchor, cursor, pending) =
+            (sel.region, sel.anchor, sel.cursor, sel.pending_copy);
+        highlight_in_buffer(frame.buffer_mut(), region, anchor, cursor);
+        if pending {
+            let text = extract_from_buffer(frame.buffer_mut(), region, anchor, cursor);
+            self.selection = None;
+            self.finish_copy(&text);
+        }
+    }
+
+    /// Copy released-selection text through the same clipboard seam as `y`
+    /// yank. Whitespace-only selections (an empty stretch of pane) copy
+    /// nothing and show nothing.
+    fn finish_copy(&mut self, text: &str) {
+        if text.trim().is_empty() {
+            return;
+        }
+        if (self.yank_fn)(text) {
+            let chars = text.chars().count();
+            let lines = text.lines().count();
+            let message = if lines > 1 {
+                format!("Copied {} chars ({} lines)", chars, lines)
+            } else {
+                format!("Copied {} chars", chars)
+            };
+            self.toast(message, ToastLevel::Info);
+        } else {
+            self.toast(
+                "Clipboard unavailable (no pbcopy/xclip/OSC52)",
+                ToastLevel::Error,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::make_test_dashboard;
+    use super::*;
+    use crossterm::event::KeyModifiers;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::widgets::Paragraph;
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn region() -> Rect {
+        Rect::new(2, 1, 10, 4)
+    }
+
+    // ── Pure geometry ────────────────────────────────────────────────────
+
+    #[test]
+    fn hit_region_finds_the_containing_rect() {
+        // Panes never overlap in the real layout, so the fixture keeps the
+        // rects disjoint.
+        let other = Rect::new(20, 10, 5, 5);
+        let regions = [other, region()];
+        assert_eq!(hit_region(&regions, 3, 2), Some(region()));
+        assert_eq!(hit_region(&regions, 22, 12), Some(other));
+    }
+
+    #[test]
+    fn hit_region_misses_outside_and_on_the_exclusive_edge() {
+        let regions = [region()];
+        // right() and bottom() are exclusive: the last cell inside is (11, 4).
+        assert_eq!(hit_region(&regions, 11, 4), Some(region()));
+        assert_eq!(hit_region(&regions, 12, 4), None);
+        assert_eq!(hit_region(&regions, 11, 5), None);
+        assert_eq!(hit_region(&[], 3, 2), None);
+    }
+
+    #[test]
+    fn clamp_to_region_pulls_outside_points_to_the_edges() {
+        let r = region();
+        assert_eq!(clamp_to_region(r, 0, 0), (2, 1));
+        assert_eq!(clamp_to_region(r, 50, 50), (11, 4));
+        assert_eq!(clamp_to_region(r, 5, 2), (5, 2));
+    }
+
+    #[test]
+    fn ordered_sorts_by_row_then_column() {
+        assert_eq!(ordered((3, 1), (7, 2)), ((3, 1), (7, 2)));
+        assert_eq!(ordered((7, 2), (3, 1)), ((3, 1), (7, 2)));
+        // Same row, dragged right-to-left.
+        assert_eq!(ordered((9, 2), (4, 2)), ((4, 2), (9, 2)));
+    }
+
+    #[test]
+    fn row_span_is_partial_on_first_and_last_rows_and_full_between() {
+        let r = region();
+        let start = (5, 1);
+        let end = (8, 3);
+        assert_eq!(row_span(r, start, end, 1), (5, 11));
+        assert_eq!(row_span(r, start, end, 2), (2, 11));
+        assert_eq!(row_span(r, start, end, 3), (2, 8));
+    }
+
+    #[test]
+    fn row_span_on_a_single_row_selection_uses_both_endpoints() {
+        let r = region();
+        assert_eq!(row_span(r, (4, 2), (9, 2), 2), (4, 9));
+    }
+
+    // ── Buffer extraction + highlight ────────────────────────────────────
+
+    #[test]
+    fn extract_single_row_takes_the_exact_column_range() {
+        let buf = Buffer::with_lines(["hello world"]);
+        let r = Rect::new(0, 0, 11, 1);
+        assert_eq!(extract_from_buffer(&buf, r, (6, 0), (10, 0)), "world");
+    }
+
+    #[test]
+    fn extract_multi_row_spans_full_middle_rows_and_trims_padding() {
+        let buf = Buffer::with_lines(["first line   ", "middle       ", "last line    "]);
+        let r = Rect::new(0, 0, 13, 3);
+        let text = extract_from_buffer(&buf, r, (6, 0), (3, 2));
+        assert_eq!(text, "line\nmiddle\nlast");
+    }
+
+    #[test]
+    fn extract_preserves_interior_empty_rows() {
+        let buf = Buffer::with_lines(["top", "   ", "bottom"]);
+        let r = Rect::new(0, 0, 6, 3);
+        assert_eq!(
+            extract_from_buffer(&buf, r, (0, 0), (5, 2)),
+            "top\n\nbottom"
+        );
+    }
+
+    #[test]
+    fn extract_skips_wide_char_continuation_cells() {
+        let buf = Buffer::with_lines(["日本語 ok"]);
+        let r = Rect::new(0, 0, 9, 1);
+        assert_eq!(extract_from_buffer(&buf, r, (0, 0), (8, 0)), "日本語 ok");
+    }
+
+    #[test]
+    fn extract_reversed_drag_matches_forward_drag() {
+        let buf = Buffer::with_lines(["hello world"]);
+        let r = Rect::new(0, 0, 11, 1);
+        assert_eq!(
+            extract_from_buffer(&buf, r, (10, 0), (6, 0)),
+            extract_from_buffer(&buf, r, (6, 0), (10, 0)),
+        );
+    }
+
+    #[test]
+    fn extract_stops_at_the_buffer_edge_when_the_region_overhangs() {
+        // A region wider than the buffer must not panic; extraction takes
+        // whatever cells exist.
+        let buf = Buffer::with_lines(["abc"]);
+        let overhanging = Rect::new(0, 0, 10, 1);
+        assert_eq!(
+            extract_from_buffer(&buf, overhanging, (0, 0), (9, 0)),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn highlight_ignores_cells_beyond_the_buffer_edge() {
+        let mut buf = Buffer::with_lines(["abc"]);
+        let overhanging = Rect::new(0, 0, 10, 1);
+        highlight_in_buffer(&mut buf, overhanging, (0, 0), (9, 0));
+        let reversed = |x: u16| {
+            buf.cell(Position::new(x, 0))
+                .unwrap()
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        };
+        assert!(reversed(0) && reversed(2));
+    }
+
+    #[test]
+    fn highlight_reverses_selected_cells_and_leaves_the_rest() {
+        let mut buf = Buffer::with_lines(["hello world"]);
+        let r = Rect::new(0, 0, 11, 1);
+        highlight_in_buffer(&mut buf, r, (6, 0), (10, 0));
+        let reversed = |x: u16| {
+            buf.cell(Position::new(x, 0))
+                .unwrap()
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        };
+        assert!(reversed(6) && reversed(10));
+        assert!(!reversed(0) && !reversed(5));
+    }
+
+    // ── Mouse event handling ─────────────────────────────────────────────
+
+    #[test]
+    fn wheel_events_still_scroll_three_lines_per_notch() {
+        let mut dash = make_test_dashboard();
+        dash.handle_mouse(mouse(MouseEventKind::ScrollUp, 0, 0));
+        assert_eq!(dash.detail_scroll, 3);
+        dash.handle_mouse(mouse(MouseEventKind::ScrollDown, 0, 0));
+        assert_eq!(dash.detail_scroll, 0);
+    }
+
+    #[test]
+    fn left_down_inside_a_registered_pane_starts_a_drag() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        let sel = dash.selection.as_ref().unwrap();
+        assert_eq!(sel.anchor, (4, 2));
+        assert_eq!(sel.cursor, (4, 2));
+        assert!(sel.dragging && !sel.moved && !sel.pending_copy);
+    }
+
+    #[test]
+    fn left_down_outside_any_pane_clears_the_selection() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        assert!(dash.selection.is_some());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 50));
+        assert!(dash.selection.is_none());
+    }
+
+    #[test]
+    fn drag_moves_the_cursor_and_clamps_to_the_pane() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 50));
+        let sel = dash.selection.as_ref().unwrap();
+        assert_eq!(sel.cursor, (11, 4));
+        assert!(sel.moved);
+    }
+
+    #[test]
+    fn drag_without_an_active_selection_is_ignored() {
+        let mut dash = make_test_dashboard();
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 2));
+        assert!(dash.selection.is_none());
+    }
+
+    #[test]
+    fn release_after_motion_schedules_the_copy() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 8, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 8, 2));
+        let sel = dash.selection.as_ref().unwrap();
+        assert!(!sel.dragging && sel.pending_copy);
+    }
+
+    #[test]
+    fn release_without_motion_is_a_click_and_clears() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 2));
+        assert!(dash.selection.is_none());
+    }
+
+    #[test]
+    fn release_without_a_prior_press_is_ignored() {
+        let mut dash = make_test_dashboard();
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 2));
+        assert!(dash.selection.is_none());
+    }
+
+    #[test]
+    fn drag_after_release_no_longer_extends_the_selection() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 8, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 8, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 10, 3));
+        assert_eq!(dash.selection.as_ref().unwrap().cursor, (8, 2));
+    }
+
+    #[test]
+    fn other_buttons_and_motion_events_are_ignored() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Right), 4, 2));
+        dash.handle_mouse(mouse(MouseEventKind::Moved, 4, 2));
+        assert!(dash.selection.is_none());
+        assert_eq!(dash.detail_scroll, 0);
+    }
+
+    #[test]
+    fn scrolling_clears_an_active_selection() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        assert!(dash.selection.is_some());
+        dash.scroll_by(1);
+        assert!(dash.selection.is_none());
+    }
+
+    // ── Validation + overlay ─────────────────────────────────────────────
+
+    #[test]
+    fn validate_drops_a_selection_whose_pane_was_not_redrawn() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.selection_regions.clear();
+        dash.validate_selection();
+        assert!(dash.selection.is_none());
+    }
+
+    #[test]
+    fn validate_keeps_a_selection_whose_pane_is_still_registered() {
+        let mut dash = make_test_dashboard();
+        dash.selection_regions.push(region());
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 4, 2));
+        dash.validate_selection();
+        assert!(dash.selection.is_some());
+    }
+
+    /// Draw `text` at the origin, run the selection overlay, and return the
+    /// backend buffer for assertions.
+    fn draw_with_overlay(dash: &mut Dashboard, text: &str, area: Rect) -> Buffer {
+        let backend = TestBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                f.render_widget(Paragraph::new(text.to_string()), area);
+                dash.selection_regions.push(area);
+                dash.apply_selection_overlay(f);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn overlay_highlights_the_dragged_range() {
+        let mut dash = make_test_dashboard();
+        let area = Rect::new(0, 0, 20, 2);
+        dash.selection_regions.push(area);
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 6, 0));
+        dash.selection_regions.clear();
+        let buf = draw_with_overlay(&mut dash, "hello world", area);
+        let reversed = |x: u16| {
+            buf.cell(Position::new(x, 0))
+                .unwrap()
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        };
+        assert!(reversed(2) && reversed(6));
+        assert!(!reversed(0) && !reversed(7));
+        // Still an active drag: nothing copied, selection retained.
+        assert!(dash.selection.is_some());
+        assert!(dash.toasts.is_empty());
+    }
+
+    #[test]
+    fn overlay_without_a_selection_does_nothing() {
+        let mut dash = make_test_dashboard();
+        let area = Rect::new(0, 0, 20, 2);
+        let buf = draw_with_overlay(&mut dash, "hello world", area);
+        let any_reversed = (0..20).any(|x| {
+            buf.cell(Position::new(x, 0))
+                .unwrap()
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        });
+        assert!(!any_reversed);
+    }
+
+    /// A clipboard recorder for `fn(&str) -> bool` seams: captures the copied
+    /// text into a static slot. Each test gets its own module (and so its own
+    /// slot), because tests run in parallel and a shared slot would race.
+    macro_rules! clipboard_recorder {
+        ($name:ident) => {
+            mod $name {
+                use std::sync::Mutex;
+                pub(super) static COPIED: Mutex<String> = Mutex::new(String::new());
+                pub(super) fn capture(text: &str) -> bool {
+                    *COPIED.lock().unwrap() = text.to_string();
+                    true
+                }
+            }
+        };
+    }
+    clipboard_recorder!(single_line_recorder);
+    clipboard_recorder!(multi_line_recorder);
+
+    /// A clipboard that always refuses. Shared by the failure-toast test
+    /// (which executes it) and the whitespace test (which must not reach it;
+    /// the absence of any toast proves that, since a call in either direction
+    /// would have pushed one).
+    fn deny(_: &str) -> bool {
+        false
+    }
+
+    fn select_range(dash: &mut Dashboard, area: Rect, from: (u16, u16), to: (u16, u16)) {
+        dash.selection_regions.push(area);
+        dash.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            from.0,
+            from.1,
+        ));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), to.0, to.1));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), to.0, to.1));
+        dash.selection_regions.clear();
+    }
+
+    #[test]
+    fn released_selection_copies_the_visible_text_and_toasts() {
+        let mut dash = make_test_dashboard();
+        dash.yank_fn = single_line_recorder::capture;
+        let area = Rect::new(0, 0, 20, 2);
+        select_range(&mut dash, area, (6, 0), (10, 0));
+        draw_with_overlay(&mut dash, "hello world", area);
+        assert_eq!(*single_line_recorder::COPIED.lock().unwrap(), "world");
+        assert!(dash.selection.is_none());
+        assert_eq!(dash.toasts.len(), 1);
+        assert_eq!(dash.toasts[0].message, "Copied 5 chars");
+    }
+
+    #[test]
+    fn multi_line_copy_reports_the_line_count() {
+        let mut dash = make_test_dashboard();
+        dash.yank_fn = multi_line_recorder::capture;
+        let area = Rect::new(0, 0, 10, 3);
+        select_range(&mut dash, area, (0, 0), (2, 1));
+        draw_with_overlay(&mut dash, "abc\ndef", area);
+        assert_eq!(*multi_line_recorder::COPIED.lock().unwrap(), "abc\ndef");
+        assert_eq!(dash.toasts[0].message, "Copied 7 chars (2 lines)");
+    }
+
+    #[test]
+    fn whitespace_only_selection_copies_nothing_and_stays_silent() {
+        let mut dash = make_test_dashboard();
+        dash.yank_fn = deny;
+        let area = Rect::new(0, 0, 20, 2);
+        select_range(&mut dash, area, (0, 1), (5, 1));
+        draw_with_overlay(&mut dash, "text on row zero only", area);
+        assert!(dash.selection.is_none());
+        assert!(dash.toasts.is_empty());
+    }
+
+    #[test]
+    fn clipboard_failure_shows_the_unavailable_toast() {
+        let mut dash = make_test_dashboard();
+        dash.yank_fn = deny;
+        let area = Rect::new(0, 0, 20, 2);
+        select_range(&mut dash, area, (0, 0), (4, 0));
+        draw_with_overlay(&mut dash, "hello world", area);
+        assert_eq!(
+            dash.toasts[0].message,
+            "Clipboard unavailable (no pbcopy/xclip/OSC52)"
+        );
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -91,6 +91,12 @@ pub(crate) struct Dashboard {
     /// (and [`new`](Self::new)) inject a no-op so a `y` keypress never touches
     /// the clipboard or TTY.
     pub(super) yank_fn: fn(&str) -> bool,
+    /// The active mouse text selection, if any (see `selection.rs`).
+    pub(super) selection: Option<super::selection::Selection>,
+    /// Screen rects of the panes that accept mouse selection, re-registered by
+    /// each pane's renderer every frame so hit-testing always matches what is
+    /// actually on screen.
+    pub(super) selection_regions: Vec<ratatui::layout::Rect>,
 
     // ── MCP management screen ──────────────────────────────────────────────
     /// True when the full-screen MCP management view is open.
@@ -184,6 +190,8 @@ impl Dashboard {
         Self {
             log_path,
             yank_fn,
+            selection: None,
+            selection_regions: Vec::new(),
             agents: Vec::new(),
             selected: 0,
             log,

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -587,11 +587,10 @@ impl TerminalSetup for CrosstermSetup {
         io::stdout()
             .execute(EnterAlternateScreen)
             .map_err(anyhow::Error::from)?;
-        // Mouse capture is what delivers wheel events. It also takes over
-        // click-drag, so the terminal's own text selection stops working while
-        // the dashboard is up — hold Shift (or Option on macOS Terminal) to
-        // select as usual. Worth the trade: reading a long plan by wheel is the
-        // common case, copying out of the dashboard is not.
+        // Mouse capture is what delivers wheel events, and it routes click-drag
+        // to the dashboard's own text selection (drag to highlight, release to
+        // copy). Hold Shift (or Option on macOS Terminal) to bypass capture and
+        // use the terminal's native selection instead.
         io::stdout()
             .execute(EnableMouseCapture)
             .map_err(anyhow::Error::from)?;


### PR DESCRIPTION
## What

Click-drag now selects text in the dashboard's content, review, and activity-log panes. The drag paints a reverse-video highlight over the drawn cells; releasing the button copies the highlighted text through the same clipboard seam as `y` yank (pbcopy/xclip/wl-copy, OSC52 fallback so it works over SSH). A plain click, any scroll, or a frame that stops drawing the pane clears the selection. Wheel scrolling is unchanged (3 lines per notch, same pane the keyboard scrolls), `y` yank is unchanged, and Shift+drag still reaches the terminal's native selection.

## Why screen-space selection

The panes are `Paragraph`s with `Wrap { trim: false }`, so ratatui re-wraps long lines at draw time and no logical-line mapping can reproduce what is on screen. Selection is therefore anchored to screen cells and the copied text is read back from the drawn frame buffer: what you copy is exactly what you see, the same semantics as native terminal selection.

## Notes

- New `commands/dashboard/selection.rs` holds all selection state, geometry, extraction, and highlight logic; the event loop's mouse arm collapses to one `handle_mouse` delegation so mouse behavior is unit-testable.
- Panes register their inner rects every frame; a selection whose pane is not re-registered is dropped, which covers resize, view switches, and the document editor taking over the content pane in one invariant.
- `main.rs` change is comment-only (the mouse-capture tradeoff note now describes the in-app selection) - label applied.

## Testing

- 30 new unit tests: geometry, buffer extraction (incl. wide CJK symbols, buffer-edge overhang, reversed drags), every mouse-event arm, region registration per pane, highlight styling, copy/toast branches, loop-level press-drag-release.
- `cargo xtask coverage --package leviath-cli` green at 100% lines/functions/regions.
- Live pty check against the real binary: injected SGR mouse sequences, verified the reverse-video highlight via pyte, and byte-compared the decoded OSC52 payload against the on-screen cells (exact match, em dash included). "Copied" toast shown; no clipboard-failure toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3