### PR TITLE
fix: close five wiring gaps (per-agent script grants, mcp_overrides, policy test, rate limits, route table)

### DIFF
--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -267,20 +267,52 @@ async fn execute_test(args: PolicyTestArgs) -> anyhow::Result<()> {
         )
     })?;
 
-    execute_test_with(&args, taint, load_policy())
+    execute_test_with(&args, taint, load_policy(), &rules_dir())
 }
 
-/// Core of [`execute_test`] with the parsed taint level and the loaded policy
-/// (as a `Result`) passed in, so both the `load_policy()?` error arm and the
-/// allowlist-hit branch are unit-testable with crafted configs (the real
-/// default config has an empty allowlist).
+/// Build a one-region context window carrying `taint`, so the diagnostic runs
+/// the same gate code as the daemon instead of re-deriving the verdict.
+fn window_with_taint(
+    taint: leviath_core::TaintLevel,
+) -> leviath_runtime::components::ContextWindow {
+    let mut window = leviath_runtime::components::ContextWindow::new(1024);
+    let mut region = leviath_core::Region::new(
+        "scenario".to_string(),
+        leviath_core::RegionKind::Temporary,
+        512,
+    );
+    region.enable_taint_tracking();
+    window.add_region(region);
+    if taint != leviath_core::TaintLevel::Public {
+        window
+            .add_tainted_to_region("scenario", "sample".to_string(), 8, taint)
+            .expect("infallible: the region was just added");
+    }
+    window
+}
+
+/// Core of [`execute_test`] with the parsed taint level, the loaded policy
+/// (as a `Result`), and the scripted-rules directory passed in, so every
+/// verdict arm is unit-testable with crafted configs and temp rule dirs.
+///
+/// The verdict comes from the same [`leviath_runtime::TaintGate`] the daemon
+/// attaches at spawn - `[mcp_overrides]` applied, static allowlist and
+/// scripted rules consulted - because a diagnostic that re-derives gate
+/// semantics drifts from the enforcer and then lies about it.
 fn execute_test_with(
     args: &PolicyTestArgs,
     taint: leviath_core::TaintLevel,
     loaded: anyhow::Result<leviath_core::PolicyConfig>,
+    rules: &std::path::Path,
 ) -> anyhow::Result<()> {
+    use leviath_core::taint::{GateDecision, GateDecisionSource, SecurityConfig};
+
     let config = loaded?;
-    let classification = leviath_core::taint::builtin_tool_classification(&args.tool);
+    let mut gate = leviath_runtime::TaintGate::new(SecurityConfig {
+        taint_tracking: true,
+    });
+    gate.apply_mcp_overrides(&config.mcp_overrides);
+    let classification = gate.tool_classification(&args.tool);
 
     println!("Tool: {}", args.tool);
     println!("  Sensitivity: {}", classification.sensitivity);
@@ -292,34 +324,52 @@ fn execute_test_with(
     if let Some(target) = &args.target {
         println!("  Target: {}", target);
     }
-
-    if !classification.is_outbound() {
-        println!();
-        println!("Result: ALLOWED (tool is not outbound — no gate check needed)");
-        return Ok(());
-    }
-
-    if classification.check_clearance(taint) {
-        println!();
-        println!(
-            "Result: ALLOWED (taint {} ≤ clearance {})",
-            taint, classification.clearance
-        );
-        return Ok(());
-    }
-
-    // Would be blocked — check allowlist
     println!();
-    println!(
-        "Gate would fire: taint {} > clearance {}",
-        taint, classification.clearance
+
+    let window = window_with_taint(taint);
+    let checker = crate::daemon::gate_rules::build_gate_script_checker(rules);
+    let decision = gate.check_with_policy(
+        "policy-test",
+        &args.tool,
+        &window,
+        args.target.as_deref(),
+        &config,
+        Some(checker.as_ref()),
     );
 
-    if let Some(rule_idx) = config.check_allowlist(&args.tool, args.target.as_deref(), taint) {
-        println!("Result: ALLOWED by allowlist rule #{}", rule_idx + 1);
-    } else {
-        println!("Result: BLOCKED (no matching allowlist rule)");
-        println!("  The user would be prompted to allow/deny.");
+    match decision {
+        GateDecision::Allowed => {
+            let source = gate.audit_log().last().map(|e| e.decision_source.clone());
+            match source {
+                Some(GateDecisionSource::AllowlistRule { rule_index }) => {
+                    println!("Result: ALLOWED by allowlist rule #{}", rule_index + 1);
+                }
+                Some(GateDecisionSource::ScriptedRule { script_name }) => {
+                    println!("Result: ALLOWED by scripted rule '{}'", script_name);
+                }
+                _ if !classification.is_outbound() => {
+                    println!("Result: ALLOWED (tool is not outbound - no gate check needed)");
+                }
+                _ => {
+                    println!(
+                        "Result: ALLOWED (taint {} <= clearance {})",
+                        taint, classification.clearance
+                    );
+                }
+            }
+        }
+        GateDecision::Blocked {
+            taint_level,
+            clearance,
+            ..
+        } => {
+            println!(
+                "Gate fires: taint {} > clearance {}",
+                taint_level, clearance
+            );
+            println!("Result: BLOCKED (no allowlist or scripted rule matched)");
+            println!("  The user would be prompted to allow/deny.");
+        }
     }
 
     Ok(())
@@ -460,14 +510,21 @@ mod tests {
             &args,
             leviath_core::TaintLevel::Private,
             Err(anyhow::anyhow!("boom")),
+            std::env::temp_dir().as_path(),
         );
         assert!(res.is_err());
+    }
+
+    /// An empty scripted-rules directory, so a test exercises only the arm it
+    /// crafts.
+    fn no_rules() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
     }
 
     #[test]
     fn execute_test_with_allowlist_rule_hit() {
         // An outbound tool blocked by clearance but permitted by a matching
-        // allowlist rule exercises the `check_allowlist(...) == Some` branch.
+        // allowlist rule exercises the `AllowlistRule` verdict arm.
         let args = PolicyTestArgs {
             tool: "shell".to_string(),
             target: None,
@@ -482,7 +539,98 @@ mod tests {
             }],
             mcp_overrides: Default::default(),
         };
-        let res = execute_test_with(&args, leviath_core::TaintLevel::Private, Ok(config));
+        let rules = no_rules();
+        let res = execute_test_with(
+            &args,
+            leviath_core::TaintLevel::Private,
+            Ok(config),
+            rules.path(),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn execute_test_with_scripted_rule_flips_the_verdict() {
+        // A rules/*.rhai script that allows the call must be reflected by the
+        // diagnostic - the daemon consults scripted rules, so `lev policy
+        // test` has to as well or it reports BLOCKED for a call the runtime
+        // would allow.
+        let args = PolicyTestArgs {
+            tool: "shell".to_string(),
+            target: None,
+            taint: "private".to_string(),
+        };
+        let rules = tempfile::tempdir().unwrap();
+        std::fs::write(
+            rules.path().join("allow-shell.rhai"),
+            "context.tool == \"shell\"",
+        )
+        .unwrap();
+        let res = execute_test_with(
+            &args,
+            leviath_core::TaintLevel::Private,
+            Ok(leviath_core::PolicyConfig::default()),
+            rules.path(),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn execute_test_with_mcp_override_changes_the_classification() {
+        // An [mcp_overrides] entry making an unknown (default-internal) MCP
+        // tool outbound with a public clearance must make the gate fire.
+        let args = PolicyTestArgs {
+            tool: "srv.share".to_string(),
+            target: None,
+            taint: "private".to_string(),
+        };
+        let config = leviath_core::PolicyConfig {
+            allowlist: vec![],
+            mcp_overrides: std::collections::HashMap::from([(
+                "srv.share".to_string(),
+                leviath_core::policy::McpToolOverride {
+                    sensitivity: None,
+                    direction: Some("outbound".to_string()),
+                    clearance: Some(leviath_core::TaintLevel::Public),
+                },
+            )]),
+        };
+        let rules = no_rules();
+        let res = execute_test_with(
+            &args,
+            leviath_core::TaintLevel::Private,
+            Ok(config),
+            rules.path(),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn execute_test_with_non_outbound_and_clearance_allow_arms() {
+        let rules = no_rules();
+        // read_file is inbound: the not-outbound arm.
+        let res = execute_test_with(
+            &PolicyTestArgs {
+                tool: "read_file".to_string(),
+                target: None,
+                taint: "private".to_string(),
+            },
+            leviath_core::TaintLevel::Private,
+            Ok(leviath_core::PolicyConfig::default()),
+            rules.path(),
+        );
+        assert!(res.is_ok());
+        // shell at public taint: outbound, within clearance.
+        let res = execute_test_with(
+            &PolicyTestArgs {
+                tool: "shell".to_string(),
+                target: Some("localhost".to_string()),
+                taint: "public".to_string(),
+            },
+            leviath_core::TaintLevel::Public,
+            Ok(leviath_core::PolicyConfig::default()),
+            rules.path(),
+        );
         assert!(res.is_ok());
     }
 

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -377,6 +377,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: timeout,
+                rate_limit: config.rate_limits.get(name).cloned(),
                 options: std::collections::HashMap::new(),
             });
         }
@@ -395,6 +396,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
         ),
         model_capabilities: caps.clone(),
         request_timeout_secs: timeout,
+        rate_limit: None,
         options: std::collections::HashMap::new(),
     });
 
@@ -417,6 +419,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
             base_url: None,
             model_capabilities: caps.clone(),
             request_timeout_secs: None,
+            rate_limit: None,
             options,
         });
     }
@@ -871,6 +874,34 @@ mod tests {
         let ollama = creds.iter().find(|c| c.name == "ollama").unwrap();
         assert_eq!(ollama.base_url.as_deref(), Some("http://custom:11434"));
         assert!(ollama.api_key.is_none());
+    }
+
+    #[test]
+    fn provider_creds_from_config_carries_rate_limits() {
+        let config = Config {
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some("sk-ant".to_string()),
+                openai_api_key: Some("sk-oa".to_string()),
+                ..Config::default().providers
+            },
+            rate_limits: std::collections::HashMap::from([(
+                "anthropic".to_string(),
+                leviath_providers::RateLimitConfig {
+                    requests_per_minute: 50,
+                    tokens_per_minute: 40_000,
+                },
+            )]),
+            ..Config::default()
+        };
+        let creds = provider_creds_from_config(&config);
+        let anthropic = creds.iter().find(|c| c.name == "anthropic").unwrap();
+        assert_eq!(
+            anthropic.rate_limit.as_ref().map(|r| r.requests_per_minute),
+            Some(50)
+        );
+        // A provider without a [rate_limits.<name>] entry stays unthrottled.
+        let openai = creds.iter().find(|c| c.name == "openai").unwrap();
+        assert!(openai.rate_limit.is_none());
     }
 
     // ─── resolve_task: multiline file content ───────────────────────────

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -49,6 +49,68 @@ pub async fn execute(
     execute_with_shutdown(args, control, Box::pin(std::future::pending()), None).await
 }
 
+/// Every API route with its production handlers - the single route table,
+/// shared by [`execute_with_shutdown`] and the tests. A hand-copied test
+/// router drifted seven routes behind production, which meant a route could
+/// be added, typo'd, and never exercised. Admin routes, the auth middleware,
+/// CORS, and `with_state` are layered on by the caller.
+fn api_router() -> Router<AppState> {
+    Router::new()
+        // Blueprints
+        .route(
+            "/api/blueprints",
+            get(blueprints::list_blueprints).post(blueprints::create_blueprint),
+        )
+        .route(
+            "/api/blueprints/validate",
+            post(blueprints::validate_blueprint),
+        )
+        .route(
+            "/api/blueprints/{name}",
+            get(blueprints::get_blueprint)
+                .put(blueprints::update_blueprint)
+                .delete(blueprints::delete_blueprint),
+        )
+        // Agents
+        .route(
+            "/api/agents",
+            get(agents::list_agents).post(agents::spawn_agent),
+        )
+        .route("/api/agents/tree", get(tree::agents_tree))
+        .route(
+            "/api/agents/{id}",
+            get(agents::get_agent).delete(agents::kill_agent),
+        )
+        .route("/api/agents/{id}/children", get(agents::agent_children))
+        .route("/api/agents/{id}/context", get(agents::agent_context))
+        .route(
+            "/api/agents/{id}/context/history",
+            get(agents::agent_context_history),
+        )
+        .route("/api/agents/{id}/logs", get(agents::agent_logs))
+        .route("/api/agents/{id}/result", get(agents::agent_result))
+        .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
+        // Messages
+        .route("/api/agents/{id}/message", post(interactions::send_message))
+        // Interactions
+        .route(
+            "/api/agents/{id}/interaction",
+            get(interactions::get_interaction).post(interactions::submit_interaction),
+        )
+        // MCP servers - read-only surface. The mutating half is mounted by
+        // `execute_with_shutdown`, behind `--allow-admin`.
+        .route("/api/mcp/servers", get(mcp::list_servers))
+        .route("/api/mcp/servers/{name}/status", get(mcp::status))
+        .route("/api/mcp/servers/{name}/login", post(mcp::login))
+        .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
+        // Config
+        .route("/api/config", get(config::get_config))
+        .route("/api/models", get(config::get_models))
+        // WebSocket
+        .route("/ws", get(websocket::ws_global))
+        .route("/ws/agents/{id}", get(websocket::ws_agent))
+}
+
 /// Core of [`execute`], with an optional shutdown signal so tests can stop
 /// the server gracefully and cover the `Ok(())` return path.
 ///
@@ -148,60 +210,7 @@ async fn execute_with_shutdown(
         }
     };
 
-    let app = Router::new()
-        // Blueprints
-        .route(
-            "/api/blueprints",
-            get(blueprints::list_blueprints).post(blueprints::create_blueprint),
-        )
-        .route(
-            "/api/blueprints/validate",
-            post(blueprints::validate_blueprint),
-        )
-        .route(
-            "/api/blueprints/{name}",
-            get(blueprints::get_blueprint)
-                .put(blueprints::update_blueprint)
-                .delete(blueprints::delete_blueprint),
-        )
-        // Agents
-        .route(
-            "/api/agents",
-            get(agents::list_agents).post(agents::spawn_agent),
-        )
-        .route("/api/agents/tree", get(tree::agents_tree))
-        .route(
-            "/api/agents/{id}",
-            get(agents::get_agent).delete(agents::kill_agent),
-        )
-        .route("/api/agents/{id}/children", get(agents::agent_children))
-        .route("/api/agents/{id}/context", get(agents::agent_context))
-        .route(
-            "/api/agents/{id}/context/history",
-            get(agents::agent_context_history),
-        )
-        .route("/api/agents/{id}/logs", get(agents::agent_logs))
-        .route("/api/agents/{id}/result", get(agents::agent_result))
-        .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
-        // Messages
-        .route("/api/agents/{id}/message", post(interactions::send_message))
-        // Interactions
-        .route(
-            "/api/agents/{id}/interaction",
-            get(interactions::get_interaction).post(interactions::submit_interaction),
-        )
-        // MCP servers — read-only surface. The mutating half is mounted below,
-        // behind `--allow-admin`.
-        .route("/api/mcp/servers", get(mcp::list_servers))
-        .route("/api/mcp/servers/{name}/status", get(mcp::status))
-        .route("/api/mcp/servers/{name}/login", post(mcp::login))
-        .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
-        // Config
-        .route("/api/config", get(config::get_config))
-        .route("/api/models", get(config::get_models))
-        // WebSocket
-        .route("/ws", get(websocket::ws_global))
-        .route("/ws/agents/{id}", get(websocket::ws_agent));
+    let app = api_router();
 
     // The MCP administration endpoints are remote code execution by
     // construction: `add_server` writes a `command` and `args` into
@@ -373,36 +382,10 @@ mod tests {
         }
     }
 
+    /// The production route table over a test state - auth, CORS, and the
+    /// admin routes are absent, exactly as `api_router` leaves them.
     fn test_app() -> Router {
-        let state = test_state();
-        Router::new()
-            .route("/api/blueprints", get(blueprints::list_blueprints))
-            .route(
-                "/api/blueprints/validate",
-                post(blueprints::validate_blueprint),
-            )
-            .route(
-                "/api/blueprints/{name}",
-                get(blueprints::get_blueprint).delete(blueprints::delete_blueprint),
-            )
-            .route("/api/agents", get(agents::list_agents))
-            .route("/api/agents/tree", get(tree::agents_tree))
-            .route("/api/agents/{id}", get(agents::get_agent))
-            .route("/api/agents/{id}/children", get(agents::agent_children))
-            .route("/api/agents/{id}/context", get(agents::agent_context))
-            .route(
-                "/api/agents/{id}/context/history",
-                get(agents::agent_context_history),
-            )
-            .route("/api/agents/{id}/logs", get(agents::agent_logs))
-            .route("/api/agents/{id}/result", get(agents::agent_result))
-            .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
-            .route(
-                "/api/agents/{id}/interaction",
-                get(interactions::get_interaction).post(interactions::submit_interaction),
-            )
-            .route("/api/config", get(config::get_config))
-            .with_state(state)
+        api_router().with_state(test_state())
     }
 
     #[tokio::test]
@@ -410,6 +393,20 @@ mod tests {
         let app = test_app();
         let req = Request::builder()
             .uri("/api/blueprints")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_router_serves_routes_the_old_hand_copy_missed() {
+        // /api/mcp/servers was one of the seven routes present in production
+        // but absent from the hand-copied test router; with the shared table
+        // it must be reachable here too.
+        let app = test_app();
+        let req = Request::builder()
+            .uri("/api/mcp/servers")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -680,54 +677,9 @@ model = "claude-sonnet-4-6"
         assert!(json2.contains("\"prompt_tokens\":5000"));
     }
 
-    fn full_app() -> Router {
-        let state = test_state();
-        Router::new()
-            .route(
-                "/api/blueprints",
-                get(blueprints::list_blueprints).post(blueprints::create_blueprint),
-            )
-            .route(
-                "/api/blueprints/validate",
-                post(blueprints::validate_blueprint),
-            )
-            .route(
-                "/api/blueprints/{name}",
-                get(blueprints::get_blueprint)
-                    .put(blueprints::update_blueprint)
-                    .delete(blueprints::delete_blueprint),
-            )
-            .route(
-                "/api/agents",
-                get(agents::list_agents).post(agents::spawn_agent),
-            )
-            .route("/api/agents/tree", get(tree::agents_tree))
-            .route(
-                "/api/agents/{id}",
-                get(agents::get_agent).delete(agents::kill_agent),
-            )
-            .route("/api/agents/{id}/children", get(agents::agent_children))
-            .route("/api/agents/{id}/context", get(agents::agent_context))
-            .route(
-                "/api/agents/{id}/context/history",
-                get(agents::agent_context_history),
-            )
-            .route("/api/agents/{id}/logs", get(agents::agent_logs))
-            .route("/api/agents/{id}/result", get(agents::agent_result))
-            .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
-            .route("/api/agents/{id}/message", post(interactions::send_message))
-            .route(
-                "/api/agents/{id}/interaction",
-                get(interactions::get_interaction).post(interactions::submit_interaction),
-            )
-            .route("/api/config", get(config::get_config))
-            .route("/api/models", get(config::get_models))
-            .with_state(state)
-    }
-
     #[tokio::test]
     async fn test_full_router_create_blueprint_invalid() {
-        let app = full_app();
+        let app = test_app();
         let body = serde_json::json!({
             "name": "bad-agent",
             "manifest": "not valid toml {{{"
@@ -744,7 +696,7 @@ model = "claude-sonnet-4-6"
 
     #[tokio::test]
     async fn test_full_router_update_blueprint_not_found() {
-        let app = full_app();
+        let app = test_app();
         let body = serde_json::json!({
             "manifest": r#"
 [agent]
@@ -768,7 +720,7 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_full_router_kill_agent_reaches_daemon() {
-        let app = full_app();
+        let app = test_app();
         let req = Request::builder()
             .method("DELETE")
             .uri("/api/agents/nonexistent-kill-id-xyz")
@@ -780,7 +732,7 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_full_router_send_message_reaches_daemon() {
-        let app = full_app();
+        let app = test_app();
         let body = serde_json::json!({"message": "hello"});
         let req = Request::builder()
             .method("POST")
@@ -794,7 +746,7 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_full_router_get_models() {
-        let app = full_app();
+        let app = test_app();
         let req = Request::builder()
             .uri("/api/models")
             .body(Body::empty())
@@ -805,7 +757,7 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_full_router_spawn_agent_blueprint_not_found() {
-        let app = full_app();
+        let app = test_app();
         let body = serde_json::json!({
             "blueprint": "nonexistent-blueprint-xyz",
             "task": "do something"
@@ -874,7 +826,7 @@ prompt = "Run"
         // The POST-interaction route is wired to the handler, which reaches the
         // (absent-in-test) daemon. The ACCEPTED path is covered by the
         // interactions handler's own tests against a fake daemon.
-        let app = full_app();
+        let app = test_app();
         let body = serde_json::json!({"request_id": "req-1", "value": "do it", "scope": "once"});
         let req = Request::builder()
             .method("POST")
@@ -1032,7 +984,7 @@ prompt = "Run"
 
     #[tokio::test]
     async fn test_agent_list_with_status_filter_full_router() {
-        let app = full_app();
+        let app = test_app();
         let req = Request::builder()
             .uri("/api/agents?status=running,complete")
             .body(Body::empty())

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -579,6 +579,7 @@ mod tests {
                     base_url: None,
                     model_capabilities: std::collections::HashMap::new(),
                     request_timeout_secs: Some(1),
+                    rate_limit: None,
                     options: std::collections::HashMap::new(),
                 },
             })

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -524,6 +524,7 @@ impl Wizard {
             base_url,
             model_capabilities: HashMap::new(),
             request_timeout_secs: Some(20),
+            rate_limit: None,
             options: HashMap::new(),
         };
         // A closed receiver means the background task is gone; the row simply

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -145,6 +145,7 @@ mod tests {
             base_url: None,
             model_capabilities: std::collections::HashMap::new(),
             request_timeout_secs: Some(1),
+            rate_limit: None,
             options: std::collections::HashMap::new(),
         }
     }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -158,6 +158,20 @@ pub struct Config {
     /// Default is None (no timeout).
     pub request_timeout_secs: Option<u64>,
 
+    /// Client-side rate limits for the built-in providers, keyed by provider
+    /// name (`anthropic`, `openai`, `google`, `openrouter`).
+    ///
+    /// ```toml
+    /// [rate_limits.anthropic]
+    /// requests_per_minute = 50
+    /// tokens_per_minute = 40000
+    /// ```
+    ///
+    /// Script providers configure theirs via
+    /// `[model_providers.<name>] rate_limit` instead.
+    #[serde(default)]
+    pub rate_limits: HashMap<String, leviath_providers::RateLimitConfig>,
+
     /// Global master switch for taint tracking / data-flow enforcement.
     ///
     /// **Off by default (opt-in).** When `true`, every agent enforces taint
@@ -557,6 +571,7 @@ impl Default for Config {
             agent_tool_permissions: HashMap::new(),
             title: TitleConfig::default(),
             request_timeout_secs: None,
+            rate_limits: HashMap::new(),
             taint_tracking: false,
             limits: LimitsConfig::default(),
             batch_tool_hint: true,
@@ -2613,6 +2628,7 @@ anthropic_api_key = "sk-ant-test-key"
                 model: Some("gpt-5-mini".to_string()),
             },
             request_timeout_secs: None,
+            rate_limits: HashMap::new(),
             taint_tracking: false,
             limits: LimitsConfig {
                 max_concurrent_inferences: Some(4),

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -751,9 +751,17 @@ fn build_agent_inner(
         blueprint.security.as_ref(),
         None,
     );
+    // The `[mcp_overrides]` from policy.toml (loaded into the world at daemon
+    // setup), applied to every gate this agent gets so a user's reclassified
+    // MCP tool is enforced, not just printed by `lev policy list`.
+    let mcp_overrides = world
+        .get_resource::<leviath_runtime::pipeline::PolicyGate>()
+        .map(|p| p.0.mcp_overrides.clone())
+        .unwrap_or_default();
     let tool_sensitivities: Option<HashMap<String, leviath_core::TaintLevel>> =
         security.taint_tracking.then(|| {
-            let gate = leviath_runtime::TaintGate::new(security.clone());
+            let mut gate = leviath_runtime::TaintGate::new(security.clone());
+            gate.apply_mcp_overrides(&mcp_overrides);
             all_tool_defs
                 .iter()
                 .map(|t| {
@@ -862,8 +870,10 @@ fn build_agent_inner(
         // taint tracking when the blueprint opts in (`Option`'s iterator keeps the
         // enforcement path region-free when taint is off).
         tool_sensitivities.into_iter().for_each(|sensitivities| {
+            let mut gate = leviath_runtime::TaintGate::new(security.clone());
+            gate.apply_mcp_overrides(&mcp_overrides);
             entity_mut.insert((
-                leviath_runtime::TaintGate::new(security.clone()),
+                gate,
                 leviath_runtime::pipeline::ToolSensitivities(sensitivities),
             ));
             // `--yolo` means run unattended: waive taint-gate prompts (the
@@ -1411,6 +1421,63 @@ mod tests {
                 .get::<leviath_runtime::components::GateAutoApprove>(entity)
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn build_agent_applies_policy_mcp_overrides_to_the_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"sec-ov\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [security]\ntaint_tracking = true\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        // The daemon loads policy.toml into this resource at setup; an
+        // [mcp_overrides] entry there must reach the gate attached at spawn,
+        // not just `lev policy list` output.
+        world
+            .world_mut()
+            .insert_resource(leviath_runtime::pipeline::PolicyGate(
+                leviath_core::PolicyConfig {
+                    allowlist: Vec::new(),
+                    mcp_overrides: HashMap::from([(
+                        "notes.share".to_string(),
+                        leviath_core::policy::McpToolOverride {
+                            sensitivity: None,
+                            direction: Some("outbound".to_string()),
+                            clearance: Some(leviath_core::TaintLevel::Private),
+                        },
+                    )]),
+                },
+            ));
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let gate = world
+            .world()
+            .get::<leviath_runtime::TaintGate>(entity)
+            .expect("gate attached");
+        let classification = gate.tool_classification("notes.share");
+        assert_eq!(
+            classification.direction,
+            leviath_core::taint::ToolDirection::Outbound
+        );
+        assert_eq!(classification.clearance, leviath_core::TaintLevel::Private);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -911,6 +911,11 @@ fn build_agent_inner(
         &config.tool_script_permissions,
         &content,
     );
+    // Same ceiling `build_tool_state` resolves for the built-in tools: the
+    // global `[tool_permissions]` with this agent's `[agent_tool_permissions]`
+    // grants overlaid. Passing the raw global map here would silently ignore a
+    // per-agent grant when a script tool's `inherit` defers to the built-in.
+    let agent_scoped_perms = config.permissions_for_agent(&agent_name);
     let script_allow = crate::daemon::script_host::resolve_script_permissions(
         &effective_script_perms,
         &|builtin| {
@@ -920,7 +925,7 @@ fn build_agent_inner(
                 &launch_overrides,
                 &entry_stage_perms,
                 &agent_perms,
-                &config.tool_permissions,
+                &agent_scoped_perms,
             )
         },
     );
@@ -1833,6 +1838,57 @@ mod tests {
         assert!(
             out[0].1.contains("[denied]"),
             "agent-level deny should block read_file"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_agent_script_host_honors_agent_level_grants() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"scriptperm\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+
+        // `write_file` defaults to Ask, and a script-permission `Inherit`
+        // permits the host function only on a hard Allow. The grant below
+        // lives solely in the user's per-agent block, so the script host can
+        // only see it through the agent-scoped ceiling — the raw global
+        // `[tool_permissions]` map is empty here.
+        let mut config = Config::default();
+        config.agent_tool_permissions.insert(
+            "scriptperm".to_string(),
+            HashMap::from([("write_file".to_string(), crate::config::ToolPolicy::Allow)]),
+        );
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mut args = spawn_args(&manifest.to_string_lossy());
+        args.workdir = dir.path().to_string_lossy().to_string();
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &config,
+            mcp,
+            &[],
+            &hub,
+            &args,
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let state = cli.take(entity).expect("tool state registered at spawn");
+        state
+            .script_host
+            .write_file("granted.txt", "ok")
+            .expect("agent-level write_file grant must reach the script host");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("granted.txt")).unwrap(),
+            "ok"
         );
     }
 

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -160,12 +160,13 @@ impl AnthropicProvider {
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
         timeout_secs: Option<u64>,
+        rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
             client: crate::provider::build_http_client(timeout_secs),
             api_key,
             base_url: "https://api.anthropic.com/v1".to_string(),
-            rate_limiter: None,
+            rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
             cache_ttl: CacheTtl::default(),
         }
@@ -1281,7 +1282,8 @@ mod tests {
                 max_output_tokens: 32_768,
             },
         );
-        let provider = AnthropicProvider::with_overrides("test-key".to_string(), overrides, None);
+        let provider =
+            AnthropicProvider::with_overrides("test-key".to_string(), overrides, None, None);
         let caps = provider.capabilities("claude-sonnet-4-6");
         // Override should take precedence over built-in
         assert!(!caps.supports_temperature);
@@ -1857,7 +1859,7 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = AnthropicProvider::with_overrides("key".to_string(), overrides, None);
+        let provider = AnthropicProvider::with_overrides("key".to_string(), overrides, None, None);
         let caps = provider.capabilities("custom-model");
         assert_eq!(caps.max_context_tokens, 42);
         assert!(!caps.supports_streaming);
@@ -1865,7 +1867,8 @@ mod tests {
 
     #[test]
     fn test_capabilities_falls_through_to_builtin() {
-        let provider = AnthropicProvider::with_overrides("key".to_string(), HashMap::new(), None);
+        let provider =
+            AnthropicProvider::with_overrides("key".to_string(), HashMap::new(), None, None);
         let caps = provider.capabilities("claude-sonnet-4-6");
         assert_eq!(caps.max_context_tokens, 1_000_000);
     }
@@ -3014,5 +3017,22 @@ mod tests {
         std::fs::write(&file, b"x").unwrap();
         dump_request(&serde_json::json!({ "a": 1 }), Some(file.to_str().unwrap()));
         let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn with_overrides_wires_the_rate_limiter() {
+        // The daemon path constructs providers exclusively through
+        // with_overrides, so a rate limit that stops here is a rate limit
+        // nobody gets.
+        let cfg = crate::provider::RateLimitConfig {
+            requests_per_minute: 5,
+            tokens_per_minute: 1_000,
+        };
+        let limited =
+            AnthropicProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        assert!(limited.rate_limiter.is_some());
+        let unlimited =
+            AnthropicProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -94,12 +94,13 @@ impl GeminiProvider {
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
         timeout_secs: Option<u64>,
+        rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
             client: crate::provider::build_http_client(timeout_secs),
             api_key,
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
-            rate_limiter: None,
+            rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
         }
     }
@@ -483,7 +484,8 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider = GeminiProvider::with_overrides("test-key".to_string(), overrides, None);
+        let provider =
+            GeminiProvider::with_overrides("test-key".to_string(), overrides, None, None);
         let caps = provider.capabilities("gemini-3.5-flash");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1);
@@ -736,7 +738,7 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = GeminiProvider::with_overrides("key".to_string(), overrides, None);
+        let provider = GeminiProvider::with_overrides("key".to_string(), overrides, None, None);
         let caps = provider.capabilities("gemini-custom");
         assert_eq!(caps.max_context_tokens, 42);
         assert!(!caps.supports_temperature);
@@ -744,7 +746,8 @@ mod tests {
 
     #[test]
     fn test_capabilities_builtin_fallthrough() {
-        let provider = GeminiProvider::with_overrides("key".to_string(), HashMap::new(), None);
+        let provider =
+            GeminiProvider::with_overrides("key".to_string(), HashMap::new(), None, None);
         let caps = provider.capabilities("gemini-3.5-flash");
         assert_eq!(caps.max_context_tokens, 1_048_576);
     }
@@ -1135,5 +1138,21 @@ mod tests {
             GeminiFamily::Flash
         );
         assert_eq!(GeminiFamily::classify("gemini-future"), GeminiFamily::Other);
+    }
+
+    #[test]
+    fn with_overrides_wires_the_rate_limiter() {
+        // The daemon path constructs providers exclusively through
+        // with_overrides, so a rate limit that stops here is a rate limit
+        // nobody gets.
+        let cfg = crate::provider::RateLimitConfig {
+            requests_per_minute: 5,
+            tokens_per_minute: 1_000,
+        };
+        let limited =
+            GeminiProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        assert!(limited.rate_limiter.is_some());
+        let unlimited = GeminiProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -65,12 +65,13 @@ impl OpenAIProvider {
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
         timeout_secs: Option<u64>,
+        rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
             client: crate::provider::build_http_client(timeout_secs),
             api_key,
             base_url: "https://api.openai.com/v1".to_string(),
-            rate_limiter: None,
+            rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
         }
     }
@@ -433,7 +434,8 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider = OpenAIProvider::with_overrides("test-key".to_string(), overrides, None);
+        let provider =
+            OpenAIProvider::with_overrides("test-key".to_string(), overrides, None, None);
         let caps = provider.capabilities("gpt-5.4-mini");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1);
@@ -563,7 +565,7 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider = OpenAIProvider::with_overrides("key".to_string(), overrides, None);
+        let provider = OpenAIProvider::with_overrides("key".to_string(), overrides, None, None);
         let caps = provider.capabilities("gpt-5.5");
         assert_eq!(caps.max_context_tokens, 1);
     }
@@ -839,5 +841,21 @@ mod tests {
         let provider = provider_with_url(url);
         let err = provider.list_models().await.unwrap_err();
         assert!(err.to_string().contains("unknown error"));
+    }
+
+    #[test]
+    fn with_overrides_wires_the_rate_limiter() {
+        // The daemon path constructs providers exclusively through
+        // with_overrides, so a rate limit that stops here is a rate limit
+        // nobody gets.
+        let cfg = crate::provider::RateLimitConfig {
+            requests_per_minute: 5,
+            tokens_per_minute: 1_000,
+        };
+        let limited =
+            OpenAIProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        assert!(limited.rate_limiter.is_some());
+        let unlimited = OpenAIProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -64,12 +64,13 @@ impl OpenRouterProvider {
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
         timeout_secs: Option<u64>,
+        rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
             client: crate::provider::build_http_client(timeout_secs),
             api_key,
             base_url: "https://openrouter.ai/api/v1".to_string(),
-            rate_limiter: None,
+            rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
         }
     }
@@ -697,7 +698,7 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = OpenRouterProvider::with_overrides("key".to_string(), overrides, None);
+        let provider = OpenRouterProvider::with_overrides("key".to_string(), overrides, None, None);
         let caps = provider.capabilities("custom/model");
         assert_eq!(caps.max_context_tokens, 99);
     }
@@ -1172,5 +1173,22 @@ mod tests {
         let provider = provider_with_url(url);
         let err = provider.list_models().await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
+    }
+
+    #[test]
+    fn with_overrides_wires_the_rate_limiter() {
+        // The daemon path constructs providers exclusively through
+        // with_overrides, so a rate limit that stops here is a rate limit
+        // nobody gets.
+        let cfg = crate::provider::RateLimitConfig {
+            requests_per_minute: 5,
+            tokens_per_minute: 1_000,
+        };
+        let limited =
+            OpenRouterProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        assert!(limited.rate_limiter.is_some());
+        let unlimited =
+            OpenRouterProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -27,6 +27,10 @@ pub struct ProviderCreds {
     pub model_capabilities: std::collections::HashMap<String, leviath_providers::ModelCapabilities>,
     /// HTTP request timeout in seconds (`None` uses the provider default).
     pub request_timeout_secs: Option<u64>,
+    /// Client-side rate limit (requests/tokens per minute) enforced before
+    /// each call. `None` sends requests unthrottled. Ignored by `ollama`
+    /// (a local server) and `claude-code` (a subprocess).
+    pub rate_limit: Option<leviath_providers::RateLimitConfig>,
     /// Provider-specific settings that don't fit the api-key / base-URL shape.
     ///
     /// Currently only `claude-code` reads this, for `binary` (path to the
@@ -55,6 +59,7 @@ impl std::fmt::Debug for ProviderCreds {
             .field("base_url", &self.base_url)
             .field("model_capabilities", &self.model_capabilities)
             .field("request_timeout_secs", &self.request_timeout_secs)
+            .field("rate_limit", &self.rate_limit)
             .field("options", &self.options)
             .finish()
     }
@@ -69,6 +74,7 @@ impl ProviderCreds {
             base_url: None,
             model_capabilities: std::collections::HashMap::new(),
             request_timeout_secs: None,
+            rate_limit: None,
             options: std::collections::HashMap::new(),
         }
     }
@@ -90,6 +96,7 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                             key.clone(),
                             caps,
                             timeout,
+                            c.rate_limit.as_ref(),
                         )),
                     );
                 }
@@ -102,6 +109,7 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                             key.clone(),
                             caps,
                             timeout,
+                            c.rate_limit.as_ref(),
                         )),
                     );
                 }
@@ -114,6 +122,7 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                             key.clone(),
                             caps,
                             timeout,
+                            c.rate_limit.as_ref(),
                         )),
                     );
                 }
@@ -126,6 +135,7 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                             key.clone(),
                             caps,
                             timeout,
+                            c.rate_limit.as_ref(),
                         )),
                     );
                 }
@@ -204,6 +214,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: Some(30),
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -212,6 +223,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -220,6 +232,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -228,6 +241,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -236,6 +250,7 @@ mod tests {
                 base_url: None, // exercise the default-URL fallback
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -244,6 +259,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
             ProviderCreds {
@@ -252,6 +268,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps,
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             },
         ];
@@ -279,6 +296,7 @@ mod tests {
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: None,
+                rate_limit: None,
                 options: Default::default(),
             })
             .collect();

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -101,6 +101,43 @@ impl TaintGate {
             .unwrap_or_else(|| builtin_tool_classification(tool_name))
     }
 
+    /// Apply the `[mcp_overrides]` section of policy.toml to this gate.
+    ///
+    /// Each override starts from the tool's current classification and
+    /// replaces only the fields it sets, keyed the same `server.tool` way MCP
+    /// tools are named at dispatch. An unrecognized `direction` string keeps
+    /// the existing direction and warns, rather than silently reclassifying
+    /// a security property.
+    ///
+    /// Called at gate construction. A later session-scoped "always allow"
+    /// writes the same map through [`Self::set_tool_classification`], so the
+    /// user's runtime decision still wins over the config file.
+    pub fn apply_mcp_overrides(
+        &mut self,
+        overrides: &HashMap<String, leviath_core::policy::McpToolOverride>,
+    ) {
+        for (tool_name, over) in overrides {
+            let mut classification = self.tool_classification(tool_name);
+            if let Some(sensitivity) = over.sensitivity {
+                classification.sensitivity = sensitivity;
+            }
+            if let Some(clearance) = over.clearance {
+                classification.clearance = clearance;
+            }
+            if let Some(direction) = over.direction.as_deref() {
+                match leviath_core::taint::ToolDirection::from_str_loose(direction) {
+                    Some(parsed) => classification.direction = parsed,
+                    None => tracing::warn!(
+                        tool = %tool_name,
+                        direction = %direction,
+                        "ignoring unrecognized direction in [mcp_overrides]"
+                    ),
+                }
+            }
+            self.set_tool_classification(tool_name.clone(), classification);
+        }
+    }
+
     /// Check the gate for a traditional-mode tool invocation.
     ///
     /// In traditional mode, the overall taint (max across all regions) is
@@ -432,6 +469,90 @@ mod tests {
         let window = make_window_with_taint(TaintLevel::Private);
         let decision = gate.check_traditional("agent-1", "shell", &window);
         assert!(decision.is_allowed());
+    }
+
+    #[test]
+    fn apply_mcp_overrides_replaces_only_the_set_fields() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let before = gate.tool_classification("srv.notify");
+        let overrides = std::collections::HashMap::from([(
+            "srv.notify".to_string(),
+            leviath_core::policy::McpToolOverride {
+                sensitivity: Some(TaintLevel::Private),
+                direction: None,
+                clearance: None,
+            },
+        )]);
+        gate.apply_mcp_overrides(&overrides);
+        let after = gate.tool_classification("srv.notify");
+        assert_eq!(after.sensitivity, TaintLevel::Private);
+        assert_eq!(after.direction, before.direction);
+        assert_eq!(after.clearance, before.clearance);
+    }
+
+    #[test]
+    fn apply_mcp_overrides_parses_direction_and_clearance() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let overrides = std::collections::HashMap::from([(
+            "srv.post".to_string(),
+            leviath_core::policy::McpToolOverride {
+                sensitivity: None,
+                direction: Some("outbound".to_string()),
+                clearance: Some(TaintLevel::Internal),
+            },
+        )]);
+        gate.apply_mcp_overrides(&overrides);
+        let after = gate.tool_classification("srv.post");
+        assert_eq!(after.direction, ToolDirection::Outbound);
+        assert_eq!(after.clearance, TaintLevel::Internal);
+    }
+
+    #[test]
+    fn apply_mcp_overrides_keeps_direction_on_unrecognized_string() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let before = gate.tool_classification("srv.odd");
+        let overrides = std::collections::HashMap::from([(
+            "srv.odd".to_string(),
+            leviath_core::policy::McpToolOverride {
+                sensitivity: None,
+                direction: Some("sideways".to_string()),
+                clearance: None,
+            },
+        )]);
+        gate.apply_mcp_overrides(&overrides);
+        // A typo must not silently reclassify a security property.
+        assert_eq!(
+            gate.tool_classification("srv.odd").direction,
+            before.direction
+        );
+    }
+
+    #[test]
+    fn session_approval_still_wins_over_an_mcp_override() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let overrides = std::collections::HashMap::from([(
+            "srv.send".to_string(),
+            leviath_core::policy::McpToolOverride {
+                sensitivity: None,
+                direction: Some("outbound".to_string()),
+                clearance: Some(TaintLevel::Public),
+            },
+        )]);
+        gate.apply_mcp_overrides(&overrides);
+        // The user's later "always allow" writes the same map and replaces
+        // the config-file entry.
+        gate.set_tool_classification(
+            "srv.send".to_string(),
+            ToolClassification::new(
+                TaintLevel::Public,
+                ToolDirection::Outbound,
+                TaintLevel::Private,
+            ),
+        );
+        assert_eq!(
+            gate.tool_classification("srv.send").clearance,
+            TaintLevel::Private
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Five wiring fixes found by a hooked-up audit; each commit is one fix with a test that discriminates it.

1. **Per-agent grants reach script tools** - `resolve_script_permissions` received the raw global `[tool_permissions]` map while the built-in path resolves the agent-scoped ceiling, so an `[agent_tool_permissions.<name>]` grant worked for the built-in tool but was silently ignored when a script tool's `inherit` deferred to it. Red/green proven: the new test fails on the old code.
2. **`[mcp_overrides]` is enforced** - it was parsed and printed by `lev policy list` but never consulted by the taint gate. `TaintGate::apply_mcp_overrides` overlays set fields at gate construction (both spawn sites), an invalid `direction` string warns instead of silently reclassifying, and a session-scoped "always allow" still wins.
3. **`lev policy test` runs the real gate** - it re-derived the verdict and had drifted (no scripted rules, no overrides), printing BLOCKED for calls the runtime allows. It now builds the same `TaintGate` and reports the decision with its source (clearance / allowlist rule # / scripted rule name).
4. **Rate limits reach the built-in providers** - the only production constructor hardcoded `rate_limiter: None` and `ProviderCreds` couldn't carry a limit, so nothing could throttle Anthropic/OpenAI/Gemini/OpenRouter. New `[rate_limits.<provider>]` config table plumbed through `ProviderCreds` into each keyed constructor.
5. **One route table for production and tests** - the hand-copied test router had drifted seven routes behind production; `api_router()` is now shared, and a test hits a route the old copy missed.

## Testing

- 13 new tests across the three crates; the permission fix is red/green proven against the old code.
- `cargo xtask coverage` green at 100% for leviath-cli, leviath-runtime, and leviath-providers.
- fmt, clippy `-D warnings`, full workspace test suite green per commit (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3