### PR TITLE
refactor(providers): standard child-module layout for the rhai test files

### DIFF
--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -205,5 +205,4 @@ pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
 }
 
 #[cfg(test)]
-#[path = "convert_tests.rs"]
 mod tests;

--- a/crates/leviath-providers/src/rhai_provider/convert/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert/tests.rs
@@ -1,6 +1,7 @@
-//! Tests for [`super::super::convert`]. Kept in a separate file so this test
-//! code is not measured by the coverage gate (only production code must be
-//! 100%), matching the crate's `tests.rs` convention.
+//! Tests for the parent module. The standard child-module file name
+//! (`tests.rs`) keeps this scaffolding outside the coverage report:
+//! cargo-llvm-cov's default ignore regex excludes `tests.rs` and
+//! `*_tests.rs` files, so only production code answers to the 100% gate.
 use super::{
     chunk_from_dynamic, finish_reason_from_str, host_err_to_rhai, map_rhai_err,
     parse_inference_dynamic, runtime_error,

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -312,5 +312,4 @@ fn register_emit_chunk(
 }
 
 #[cfg(test)]
-#[path = "engine_tests.rs"]
 mod tests;

--- a/crates/leviath-providers/src/rhai_provider/engine/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine/tests.rs
@@ -1,5 +1,7 @@
-//! Tests for [`super::engine`]. Separate file → excluded from the coverage
-//! gate (only production code must hit 100%).
+//! Tests for the parent module. The standard child-module file name
+//! (`tests.rs`) keeps this scaffolding outside the coverage report:
+//! cargo-llvm-cov's default ignore regex excludes `tests.rs` and
+//! `*_tests.rs` files, so only production code answers to the 100% gate.
 use super::*;
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -281,5 +281,4 @@ fn parse_sse_block(block: &str) -> Option<SseEvent> {
 }
 
 #[cfg(test)]
-#[path = "host_tests.rs"]
 mod tests;

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -1,5 +1,7 @@
-//! Tests for [`super::host`]. Separate file → excluded from the coverage
-//! gate (only production code must hit 100%).
+//! Tests for the parent module. The standard child-module file name
+//! (`tests.rs`) keeps this scaffolding outside the coverage report:
+//! cargo-llvm-cov's default ignore regex excludes `tests.rs` and
+//! `*_tests.rs` files, so only production code answers to the 100% gate.
 use super::*;
 
 fn ev(kind: &SseEvent) -> String {


### PR DESCRIPTION
## What

Answers "can the `#[path]` sibling test files be cleaned up without breaking the coverage gate and without touching the gate's exclusions" - yes, because the exclusion was never local configuration in the first place.

cargo-llvm-cov's built-in default ignore regex (in `report.rs`, disable-able only via `--no-default-ignore-filename-regex`) excludes any file named `tests.rs` or `*_tests.rs`, plus `tests/`/`benches/`/`examples/` directories. The sibling files were relying on that tool convention; only the `#[path]` attribute was nonstandard. Each file now lives at its module's standard child location (`host/tests.rs` etc.) where a plain `mod tests;` finds it:

- same parent module, so `use super::*` and private-item access are byte-for-byte untouched;
- same filename convention, so the tool's default exclusion still applies;
- zero changes to xtask, CI, or any ignore list.

## Testing

Full providers suite green (626 tests, same count); clippy `--all-features -D warnings`; `cargo xtask coverage --package leviath-providers` green at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3