### PR TITLE
feat(setup): Anthropic ToS disclosure and confirmation for Claude Code transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Pick a pre-built agent or write your own, run it, and watch it actually remember
 
 > **Claude Code transport (opt-in):** if you have [Claude Code](https://claude.com/claude-code) installed and signed in, enable it in `lev setup` to run Leviath on your Claude subscription with no API key. Leviath's structured regions work normally - it drives the CLI as a plain inference relay, keeping the context window, the tool loop, and the iteration count on Leviath's side.
 >
-> Caveats, measured rather than estimated: the CLI adds ~130 tokens of its own context to **every** call, including **your account email address** and the current date. This cannot be disabled - every flag that suppresses it also disables subscription auth. There is no prompt caching, and each call spawns a subprocess (~200 ms). Anthropic models only. For full control over what reaches the model, use a direct provider.
+> **⚠️ Terms of service:** Anthropic's terms [state](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) that third-party developers may not offer claude.ai login or subscription rate limits for their products without prior approval. Using this transport routes inference through your Claude subscription via the CLI's OAuth session. **By enabling it, you accept responsibility for compliance with Anthropic's terms.** For unambiguous compliance, use a direct Anthropic API key instead.
+>
+> Technical caveats, measured rather than estimated: the CLI adds ~130 tokens of its own context to **every** call, including **your account email address** and the current date. This cannot be disabled - every flag that suppresses it also disables subscription auth. There is no prompt caching, and each call spawns a subprocess (~200 ms). Anthropic models only. For full control over what reaches the model, use a direct provider.
 
 ## 🚀 Quick Start
 

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -97,8 +97,9 @@ pub fn providers() -> Vec<Provider> {
             id: "claude-code",
             display: "Claude Code transport",
             blurb: "Runs on your Claude subscription instead of an API key. \
-                    The CLI adds ~130 tokens of its own context to every call, \
-                    including your account email and the date. This cannot be \
+                    ⚠️ May conflict with Anthropic's terms for third-party \
+                    apps. The CLI adds ~130 tokens of its own context to every \
+                    call, including your account email. This cannot be \
                     disabled.",
             credential: Credential::None,
             hint: "",
@@ -242,6 +243,8 @@ mod tests {
             .expect("the transport is offered");
         assert!(cc.blurb.contains("email"));
         assert!(cc.blurb.contains("cannot be disabled"));
+        // Enabling it is a terms decision as much as a privacy one.
+        assert!(cc.blurb.contains("terms"));
         assert_eq!(cc.credential, Credential::None);
         assert!(!Config::default().providers.claude_code_enabled);
     }

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -35,8 +35,7 @@ impl Wizard {
         }
         if self.show_tos_confirm {
             // A hard gate: nothing else means anything until it is answered.
-            self.handle_tos_key(key);
-            return Action::Continue;
+            return self.handle_tos_key(key);
         }
         if self.show_help {
             // Any key dismisses the help overlay.
@@ -176,15 +175,17 @@ impl Wizard {
 
     /// Handle a key while the ToS confirmation overlay is showing.
     ///
-    /// Y accepts the terms and goes back one screen so the user can review
-    /// their choices with the acknowledgment recorded. Any other key
-    /// dismisses the overlay and goes back without recording acceptance.
-    fn handle_tos_key(&mut self, key: KeyEvent) {
+    /// Y accepts the terms and lets the interrupted save proceed - the user
+    /// already asked to save; confirming is the last word, not a detour. Any
+    /// other key dismisses the overlay and stays put, leaving the transport
+    /// selected but unsaveable until it is either confirmed or deselected.
+    fn handle_tos_key(&mut self, key: KeyEvent) -> Action {
         self.show_tos_confirm = false;
         if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
             self.claude_code_tos_accepted = true;
+            return Action::Save;
         }
-        self.back();
+        Action::Continue
     }
 
     /// `Space`: toggle whatever the cursor is on.
@@ -1062,42 +1063,48 @@ mod tests {
     }
 
     #[test]
-    fn pressing_y_on_tos_confirmation_accepts_and_goes_back() {
+    fn pressing_y_on_tos_confirmation_accepts_and_saves() {
         let (_dir, mut w) = wizard_with_claude_code();
         w.enter(Step::Review);
         w.handle_key(press(KeyCode::Enter));
         assert!(w.show_tos_confirm);
 
-        w.handle_key(press(KeyCode::Char('y')));
+        let action = w.handle_key(press(KeyCode::Char('y')));
 
         assert!(w.claude_code_tos_accepted);
         assert!(!w.show_tos_confirm);
-        assert_ne!(w.step, Step::Review, "should have gone back");
+        assert_eq!(
+            action,
+            Action::Save,
+            "confirming is the last word on the save the user already asked for"
+        );
     }
 
     #[test]
-    fn pressing_uppercase_y_also_accepts() {
+    fn pressing_uppercase_y_also_accepts_and_saves() {
         let (_dir, mut w) = wizard_with_claude_code();
         w.enter(Step::Review);
         w.handle_key(press(KeyCode::Enter));
 
-        w.handle_key(press(KeyCode::Char('Y')));
+        let action = w.handle_key(press(KeyCode::Char('Y')));
 
         assert!(w.claude_code_tos_accepted);
         assert!(!w.show_tos_confirm);
+        assert_eq!(action, Action::Save);
     }
 
     #[test]
-    fn pressing_n_on_tos_confirmation_goes_back_without_accepting() {
+    fn dismissing_the_tos_confirmation_stays_put_without_accepting() {
         let (_dir, mut w) = wizard_with_claude_code();
         w.enter(Step::Review);
         w.handle_key(press(KeyCode::Enter));
 
-        w.handle_key(press(KeyCode::Char('n')));
+        let action = w.handle_key(press(KeyCode::Char('n')));
 
         assert!(!w.claude_code_tos_accepted);
         assert!(!w.show_tos_confirm);
-        assert_ne!(w.step, Step::Review);
+        assert_eq!(action, Action::Continue, "the save stays blocked");
+        assert_eq!(w.step, Step::Review, "declining must not navigate away");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -33,6 +33,11 @@ impl Wizard {
             self.handle_edit_key(key, edit);
             return Action::Continue;
         }
+        if self.show_tos_confirm {
+            // A hard gate: nothing else means anything until it is answered.
+            self.handle_tos_key(key);
+            return Action::Continue;
+        }
         if self.show_help {
             // Any key dismisses the help overlay.
             self.show_help = false;
@@ -74,7 +79,13 @@ impl Wizard {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
         match key.code {
-            KeyCode::Char('s') if ctrl => return Action::Save,
+            KeyCode::Char('s') if ctrl => {
+                if self.needs_tos_confirmation() {
+                    self.show_tos_confirm = true;
+                    return Action::Continue;
+                }
+                return Action::Save;
+            }
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Char('?') => self.show_help = true,
             KeyCode::Char('r') if ctrl => {
@@ -109,7 +120,13 @@ impl Wizard {
     /// always the key that moves forward.
     fn activate(&mut self) -> Action {
         let opened = match self.step {
-            Step::Review => return Action::Save,
+            Step::Review => {
+                if self.needs_tos_confirmation() {
+                    self.show_tos_confirm = true;
+                    return Action::Continue;
+                }
+                return Action::Save;
+            }
             Step::ProviderDetail => self.open_credential_editor(),
             Step::Defaults | Step::Limits => self.open_field_editor(),
             _ => false,
@@ -157,12 +174,31 @@ impl Wizard {
         true
     }
 
+    /// Handle a key while the ToS confirmation overlay is showing.
+    ///
+    /// Y accepts the terms and goes back one screen so the user can review
+    /// their choices with the acknowledgment recorded. Any other key
+    /// dismisses the overlay and goes back without recording acceptance.
+    fn handle_tos_key(&mut self, key: KeyEvent) {
+        self.show_tos_confirm = false;
+        if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
+            self.claude_code_tos_accepted = true;
+        }
+        self.back();
+    }
+
     /// `Space`: toggle whatever the cursor is on.
     fn toggle(&mut self) {
         match self.step {
             Step::Providers => {
                 if let Some(row) = self.providers.get_mut(self.cursor) {
                     row.selected = !row.selected;
+                    // Deselecting the Claude Code transport withdraws the
+                    // terms acceptance so it must be re-confirmed if
+                    // re-enabled.
+                    if row.provider.id == "claude-code" && !row.selected {
+                        self.claude_code_tos_accepted = false;
+                    }
                 }
                 // The credential screen walks selected providers, so its
                 // position is only meaningful relative to the current
@@ -984,5 +1020,135 @@ mod tests {
 
         assert_eq!(w.step, before);
         assert!(!w.should_quit);
+    }
+
+    // ─── Claude Code ToS confirmation gate ──────────────────────────────────
+
+    fn wizard_with_claude_code() -> (tempfile::TempDir, Wizard) {
+        let (dir, mut w) = wizard();
+        let index = w
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "claude-code")
+            .expect("the transport is offered");
+        w.providers[index].selected = true;
+        (dir, w)
+    }
+
+    #[test]
+    fn enter_on_review_with_claude_code_shows_tos_confirmation() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+
+        let action = w.handle_key(press(KeyCode::Enter));
+
+        assert_eq!(
+            action,
+            Action::Continue,
+            "must not save without ToS acceptance"
+        );
+        assert!(w.show_tos_confirm, "the overlay should be showing");
+    }
+
+    #[test]
+    fn ctrl_s_with_claude_code_shows_tos_confirmation() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Providers);
+
+        let action = w.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+
+        assert_eq!(action, Action::Continue);
+        assert!(w.show_tos_confirm);
+    }
+
+    #[test]
+    fn pressing_y_on_tos_confirmation_accepts_and_goes_back() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+        w.handle_key(press(KeyCode::Enter));
+        assert!(w.show_tos_confirm);
+
+        w.handle_key(press(KeyCode::Char('y')));
+
+        assert!(w.claude_code_tos_accepted);
+        assert!(!w.show_tos_confirm);
+        assert_ne!(w.step, Step::Review, "should have gone back");
+    }
+
+    #[test]
+    fn pressing_uppercase_y_also_accepts() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+        w.handle_key(press(KeyCode::Enter));
+
+        w.handle_key(press(KeyCode::Char('Y')));
+
+        assert!(w.claude_code_tos_accepted);
+        assert!(!w.show_tos_confirm);
+    }
+
+    #[test]
+    fn pressing_n_on_tos_confirmation_goes_back_without_accepting() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+        w.handle_key(press(KeyCode::Enter));
+
+        w.handle_key(press(KeyCode::Char('n')));
+
+        assert!(!w.claude_code_tos_accepted);
+        assert!(!w.show_tos_confirm);
+        assert_ne!(w.step, Step::Review);
+    }
+
+    #[test]
+    fn second_enter_on_review_after_accepting_saves() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+        w.handle_key(press(KeyCode::Enter)); // shows overlay
+        w.handle_key(press(KeyCode::Char('y'))); // accept, goes back
+
+        w.enter(Step::Review);
+        let action = w.handle_key(press(KeyCode::Enter));
+
+        assert_eq!(action, Action::Save, "should save after ToS accepted");
+    }
+
+    #[test]
+    fn deselecting_claude_code_resets_tos_acceptance() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.claude_code_tos_accepted = true;
+
+        let index = w
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "claude-code")
+            .unwrap();
+        w.enter(Step::Providers);
+        w.cursor = index;
+        w.handle_key(press(KeyCode::Char(' '))); // deselect
+
+        assert!(!w.claude_code_tos_accepted);
+    }
+
+    #[test]
+    fn tos_overlay_blocks_all_other_keys() {
+        let (_dir, mut w) = wizard_with_claude_code();
+        w.enter(Step::Review);
+        w.handle_key(press(KeyCode::Enter));
+        assert!(w.show_tos_confirm);
+
+        // q should NOT quit - the overlay eats it
+        w.handle_key(press(KeyCode::Char('q')));
+        assert!(!w.should_quit, "q must not quit while overlay is showing");
+        assert!(!w.show_tos_confirm, "overlay dismissed");
+    }
+
+    #[test]
+    fn without_claude_code_review_saves_immediately() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Review);
+
+        let action = w.handle_key(press(KeyCode::Enter));
+        assert_eq!(action, Action::Save, "no claude-code means no gate");
     }
 }

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -249,6 +249,19 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
                 "← / → to change.  Sign in with `claude` if you have not already.",
                 Style::default().fg(C_DIM),
             )));
+            // The transport is opt-in, so the terms risk has to be on the
+            // screen where it is opted into - not only in the README.
+            for warning in [
+                "⚠️  Anthropic's terms prohibit third-party use of subscription auth",
+                "    without prior approval. By enabling this transport you accept",
+                "    responsibility for compliance with their terms.",
+                "    For unambiguous compliance, use a direct Anthropic API key.",
+            ] {
+                lines.push(Line::from(Span::styled(
+                    warning,
+                    Style::default().fg(C_WARN),
+                )));
+            }
         }
     }
 
@@ -498,6 +511,24 @@ fn draw_review(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             lines.push(Line::from(Span::styled(
                 format!("  • {failure}"),
                 Style::default().fg(C_ERROR),
+            )));
+        }
+    }
+
+    if wizard
+        .providers
+        .iter()
+        .any(|r| r.selected && r.provider.id == "claude-code")
+    {
+        lines.push(Line::from(""));
+        for warning in [
+            "Claude Code transport: Anthropic's terms may prohibit third-party use of",
+            "subscription auth without prior approval. By enabling it you accept",
+            "responsibility for compliance with their terms.",
+        ] {
+            lines.push(Line::from(Span::styled(
+                warning,
+                Style::default().fg(C_WARN),
             )));
         }
     }
@@ -819,6 +850,33 @@ mod tests {
             screen.contains("email"),
             "the privacy cost must be on screen"
         );
+        assert!(
+            screen.contains("terms"),
+            "the terms-of-service risk must be on screen:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn the_review_screen_warns_about_the_claude_code_terms() {
+        let (_dir, mut w) = wizard();
+        let index = w
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "claude-code")
+            .expect("the transport is offered");
+        w.enter(Step::Review);
+        assert!(
+            !rendered(&w).contains("Claude Code transport: Anthropic"),
+            "the warning is only for a setup that enables it"
+        );
+
+        w.providers[index].selected = true;
+        let screen = rendered(&w);
+        assert!(
+            screen.contains("Claude Code transport: Anthropic"),
+            "{screen}"
+        );
+        assert!(screen.contains("responsibility for compliance"), "{screen}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -33,7 +33,9 @@ pub fn draw(frame: &mut Frame, wizard: &Wizard) {
     draw_body(frame, chunks[1], wizard);
     draw_footer(frame, chunks[2], wizard);
 
-    if wizard.show_help {
+    if wizard.show_tos_confirm {
+        draw_tos_confirm(frame, frame.area());
+    } else if wizard.show_help {
         draw_help(frame, frame.area());
     }
 }
@@ -608,6 +610,65 @@ fn draw_help(frame: &mut Frame, area: Rect) {
     );
 }
 
+/// Confirmation overlay for the Claude Code transport's terms risk.
+fn draw_tos_confirm(frame: &mut Frame, area: Rect) {
+    let popup = centered(70, 50, area);
+    frame.render_widget(Clear, popup);
+    let lines = vec![
+        Line::from(Span::styled(
+            "⚠️  Terms of Service",
+            Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Anthropic's terms prohibit third-party developers from offering",
+            Style::default().fg(C_WARN),
+        )),
+        Line::from(Span::styled(
+            "claude.ai subscription auth for their products without prior",
+            Style::default().fg(C_WARN),
+        )),
+        Line::from(Span::styled(
+            "approval. The Claude Code transport routes inference through your",
+            Style::default().fg(C_WARN),
+        )),
+        Line::from(Span::styled(
+            "subscription via the CLI's OAuth session.",
+            Style::default().fg(C_WARN),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "For unambiguous compliance, use a direct Anthropic API key.",
+            Style::default().fg(C_WHITE),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Press ", Style::default().fg(C_DIM)),
+            Span::styled(
+                "Y",
+                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " to accept responsibility for compliance,",
+                Style::default().fg(C_DIM),
+            ),
+        ]),
+        Line::from(Span::styled(
+            "or any other key to go back.",
+            Style::default().fg(C_DIM),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(C_WARN))
+                .title(" Confirm "),
+        ),
+        popup,
+    );
+}
+
 /// A centred rectangle covering `percent_x`/`percent_y` of `area`.
 fn centered(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let vertical = Layout::default()
@@ -877,6 +938,33 @@ mod tests {
             "{screen}"
         );
         assert!(screen.contains("responsibility for compliance"), "{screen}");
+    }
+
+    #[test]
+    fn the_tos_confirmation_overlay_draws_over_the_review_screen() {
+        let (_dir, mut w) = wizard();
+        let index = w
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "claude-code")
+            .expect("the transport is offered");
+        w.providers[index].selected = true;
+        w.show_tos_confirm = true;
+        w.enter(Step::Review);
+
+        let screen = rendered(&w);
+        assert!(
+            screen.contains("Terms of Service"),
+            "overlay title missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("Press"),
+            "call to action missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("any other key"),
+            "dismissal hint missing:\n{screen}"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -654,7 +654,7 @@ fn draw_tos_confirm(frame: &mut Frame, area: Rect) {
             ),
         ]),
         Line::from(Span::styled(
-            "or any other key to go back.",
+            "or any other key to cancel.",
             Style::default().fg(C_DIM),
         )),
     ];

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -209,6 +209,13 @@ pub struct Wizard {
     /// Show credentials in clear text.
     pub reveal: bool,
     pub show_help: bool,
+    /// The Claude Code terms-of-service confirmation is on screen, and is the
+    /// only thing keys mean until it is answered.
+    pub show_tos_confirm: bool,
+    /// The user has acknowledged the Claude Code transport's terms risk. A
+    /// hard gate on saving: the transport cannot be written to the config
+    /// without it, and deselecting the transport withdraws it.
+    pub claude_code_tos_accepted: bool,
     pub should_quit: bool,
     /// Set once the plan has been applied, so the loop knows to stop.
     pub finished: bool,
@@ -326,6 +333,8 @@ impl Wizard {
             edit: None,
             reveal: false,
             show_help: false,
+            show_tos_confirm: false,
+            claude_code_tos_accepted: false,
             should_quit: false,
             finished: false,
             message: None,
@@ -368,6 +377,21 @@ impl Wizard {
     /// The provider row the credential screen is currently showing.
     pub fn detail_row(&self) -> Option<usize> {
         self.selected_providers().get(self.detail).copied()
+    }
+
+    /// Whether the Claude Code transport is one of the picked providers.
+    pub fn claude_code_selected(&self) -> bool {
+        self.providers
+            .iter()
+            .any(|r| r.selected && r.provider.id == "claude-code")
+    }
+
+    /// Whether saving must first ask the user to acknowledge Anthropic's
+    /// terms. Enabling the transport routes inference through a subscription
+    /// session, so the risk is confirmed once, explicitly, rather than being
+    /// buried in a paragraph nobody reads.
+    pub fn needs_tos_confirmation(&self) -> bool {
+        self.claude_code_selected() && !self.claude_code_tos_accepted
     }
 
     /// The fields the current step edits, if it edits fields.


### PR DESCRIPTION
## Summary

Adds clear Terms of Service disclosure and a hard confirmation gate when users enable the Claude Code transport, which routes inference through a Claude subscription via the CLI's OAuth session.

Anthropic's terms [state](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) that third-party developers may not offer claude.ai login or subscription rate limits for their products without prior approval.

## Changes

### README.md
- Added a **⚠️ Terms of service** paragraph to the Claude Code transport blockquote, linking to Anthropic's Agent SDK plan article
- Separated technical caveats into their own paragraph

### Setup wizard (TUI)

**Catalog blurb** — Now flags potential terms conflict when browsing providers

**Detail screen** — 4-line `C_WARN` warning block shown when configuring the Claude Code transport

**Review screen** — Terms warning shown before saving when Claude Code is selected

**Hard confirmation gate:**
- When saving (Enter on Review or Ctrl-S from anywhere) with Claude Code selected, an overlay blocks the save
- User must press **Y** to accept responsibility for compliance
- Any other key dismisses without accepting
- After pressing Y, wizard goes back one screen so user can review with acknowledgment recorded
- Next save attempt proceeds normally
- Deselecting the transport resets the acceptance

### Tests
- 10 new tests covering the confirmation gate (input: 9, render: 1)
- Existing detail/review tests extended for terms assertions
- All 230 setup tests pass