### PR TITLE
fix(tui): select anywhere, display-row scrolling, setup blurb wrapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,10 @@ temp-env = "0.3"
 # wizard's generic bounds need `Send + Sync` added - small, but pointless until
 # tui-textarea moves.
 crossterm = "0.28"
-ratatui = "0.29"
+# unstable-rendered-line-info: `Paragraph::line_count`, which the dashboard
+# uses to scroll wrapped text by display rows ("unstable" = API may change
+# between ratatui versions; this workspace pins 0.29).
+ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 # Already in the tree via ratatui; named explicitly so the dashboard's mouse
 # selection can measure symbol display widths when reading cells back out of
 # the drawn frame (wide CJK/emoji symbols occupy continuation cells).

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The two coding agents can also detour through an optional **`prototype`** spike 
   <img src="docs/assets/dashboard-final.png" alt="lev dash - the Leviath terminal dashboard showing the agent list and live activity log" width="900">
 </p>
 
-`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, and full mouse support. Scroll with the wheel, or click-drag to select text in any pane; releasing the drag copies it to your clipboard (works over SSH via OSC52), and `y` still yanks a whole pane at once. Shift+drag reaches your terminal's native selection. Press **`m`** to open the MCP management screen - add, remove, log in to, and test tool servers without leaving the dashboard.
+`lev dash` is a full TUI for managing concurrent agents: stage tabs, context-window visualization, markdown rendering, search/filter, sub-agent tree view, and full mouse support. Scroll with the wheel, or click-drag to select text anywhere on screen, exactly like native terminal selection; releasing the drag copies it to your clipboard (works over SSH via OSC52), and `y` still yanks a whole pane at once. Shift+drag reaches your terminal's native selection. Press **`m`** to open the MCP management screen - add, remove, log in to, and test tool servers without leaving the dashboard.
 
 ## 🌐 API Server
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -178,15 +178,6 @@ impl Dashboard {
             return;
         }
 
-        // Read-only stage content accepts mouse selection; the rect excludes
-        // the borders (and with them the scrollbar track, which sits on the
-        // right border column). The editor branch above deliberately does not
-        // register: tui-textarea owns those cells.
-        self.selection_regions.push(content_area.inner(Margin {
-            vertical: 1,
-            horizontal: 1,
-        }));
-
         let inner_h = content_area.height.saturating_sub(2) as usize;
         let render_width = content_area.width.saturating_sub(2);
         let is_context = self.stage_content_mode == StageContentMode::Context;
@@ -250,20 +241,27 @@ impl Dashboard {
                 .collect()
         };
 
-        // Clamp search_match_idx and jump to current match
+        // Scrolling operates in *display rows*: long lines wrap at draw time,
+        // so counting logical lines undercounts what is on screen and leaves
+        // the wrapped tail clipped past the pane bottom. `line_count` measures
+        // exactly what `Paragraph` will render at this width.
+        let total_rows = wrapped_rows(&all_lines, render_width);
+
+        // Clamp search_match_idx and jump to current match (centred by the
+        // match's display row, since that is what the viewport scrolls by).
         if !match_indices.is_empty() {
             self.search_match_idx = self.search_match_idx.min(match_indices.len() - 1);
             let match_line = match_indices[self.search_match_idx];
-            let center_scroll = total.saturating_sub(match_line + inner_h / 2);
-            self.detail_scroll = center_scroll;
+            let rows_before = wrapped_rows(&all_lines[..match_line], render_width);
+            self.detail_scroll = total_rows.saturating_sub(rows_before + inner_h / 2);
         }
 
-        let max_scroll = total.saturating_sub(inner_h);
+        let max_scroll = total_rows.saturating_sub(inner_h);
         if self.detail_scroll > max_scroll {
             self.detail_scroll = max_scroll;
         }
-        let start = total.saturating_sub(inner_h + self.detail_scroll);
-        let end = (start + inner_h).min(total);
+        // Rows hidden above the viewport; 0 = top, max_scroll = bottom pinned.
+        let scroll_y = max_scroll - self.detail_scroll;
 
         let visible: Vec<Line> = if total == 0 {
             let stage_name = agent
@@ -281,11 +279,10 @@ impl Dashboard {
             ))]
         } else {
             let current_match_line = match_indices.get(self.search_match_idx).copied();
-            all_lines[start..end]
+            all_lines
                 .iter()
                 .enumerate()
-                .map(|(rel_idx, line)| {
-                    let abs_idx = start + rel_idx;
+                .map(|(abs_idx, line)| {
                     let is_current_match = current_match_line == Some(abs_idx);
                     let is_any_match = !query_lc.is_empty() && match_indices.contains(&abs_idx);
                     if is_current_match {
@@ -366,12 +363,12 @@ impl Dashboard {
                 format!(" Context Window  [o] output  [l] logs{} ", search_indicator)
             }
         };
-        let scroll_info = if total > inner_h {
+        let scroll_info = if total_rows > inner_h {
             let pct = 100
                 - (self.detail_scroll.min(max_scroll) * 100)
                     .checked_div(max_scroll)
                     .unwrap_or(0);
-            format!(" {}% ({}/{}) ", pct, end, total)
+            format!(" {}% ({}/{}) ", pct, scroll_y + inner_h, total_rows)
         } else {
             String::new()
         };
@@ -407,18 +404,21 @@ impl Dashboard {
             )
             .title_bottom(Span::styled(scroll_info, Style::default().fg(C_DIM)));
 
+        // The full text renders with a row offset (`scroll` applies after
+        // wrapping), so the viewport is exact: the bottom row of the pane is
+        // the bottom row of the document when detail_scroll is 0.
         let content_widget = Paragraph::new(visible)
             .block(content_block)
-            .wrap(Wrap { trim: false });
+            .wrap(Wrap { trim: false })
+            .scroll((scroll_y.min(u16::MAX as usize) as u16, 0));
         frame.render_widget(content_widget, content_area);
 
-        // Scrollbar
-        if total > inner_h {
+        // Scrollbar, in display rows.
+        if total_rows > inner_h {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓"));
-            let mut sb_state = ScrollbarState::new(max_scroll)
-                .position(max_scroll.saturating_sub(self.detail_scroll));
+            let mut sb_state = ScrollbarState::new(max_scroll).position(scroll_y);
             frame.render_stateful_widget(
                 scrollbar,
                 content_area.inner(Margin {
@@ -733,6 +733,15 @@ impl Dashboard {
     }
 }
 
+/// The number of display rows `lines` occupy at `width` once `Paragraph`
+/// wraps them - the same measurement the renderer itself uses, so the scroll
+/// math can never disagree with what is on screen.
+pub(in crate::commands::dashboard) fn wrapped_rows(lines: &[Line<'static>], width: u16) -> usize {
+    Paragraph::new(lines.to_vec())
+        .wrap(Wrap { trim: false })
+        .line_count(width)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -955,48 +964,6 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
-    }
-
-    #[test]
-    fn render_content_pane_registers_its_selection_region() {
-        let backend = TestBackend::new(120, 40);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent("run-selreg", AgentDisplayStatus::Active);
-        let area = Rect::new(0, 0, 100, 20);
-        terminal
-            .draw(|f| dash.render_content_pane(f, area, &agent, 100))
-            .unwrap();
-        // Borders excluded, so mouse selection can never grab the frame or
-        // the scrollbar track on the right border column.
-        assert_eq!(
-            dash.selection_regions,
-            vec![area.inner(ratatui::layout::Margin {
-                vertical: 1,
-                horizontal: 1,
-            })]
-        );
-    }
-
-    #[test]
-    fn render_content_pane_does_not_register_selection_while_editing() {
-        let backend = TestBackend::new(120, 40);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent("run-selreg-edit", AgentDisplayStatus::Waiting);
-        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::edit_text(
-            "et2", "Edit", "plan", "line A",
-        ));
-        dash.agents.push(agent.clone());
-        dash.update_display_indices();
-        dash.input_mode = true;
-        assert!(dash.editing_document());
-        terminal
-            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
-            .unwrap();
-        // tui-textarea owns those cells; a selection there would fight the
-        // editor's own cursor and highlighting.
-        assert!(dash.selection_regions.is_empty());
     }
 
     #[test]
@@ -1844,6 +1811,60 @@ mod tests {
     }
 
     // ─── render_content_pane: scroll at bottom (detail_scroll = 0) ────────
+
+    /// The reported bug: with lines longer than the pane, `Paragraph` wraps
+    /// them into more display rows than the logical-line scroll math counted,
+    /// and the document's tail was clipped past the pane bottom - at
+    /// detail_scroll 0 (bottom / auto-follow) the last line was simply not on
+    /// screen. Scrolling now counts display rows, so the bottom is the
+    /// bottom.
+    #[test]
+    fn wrapped_content_shows_its_last_line_at_the_bottom() {
+        let backend = TestBackend::new(50, 14);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.stage_content_mode = StageContentMode::Output;
+        dash.detail_scroll = 0;
+        let agent = setup_run_state_agent_with_logs(
+            "run-wrap-bottom",
+            &[],
+            Some(&format!(
+                "{}\n\n{}\n\nTHE-FINAL-LINE",
+                "wrapping ".repeat(40),
+                "more wrapping text here ".repeat(30),
+            )),
+        );
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 48, 14), &agent, 48))
+            .unwrap();
+        let screen: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            screen.contains("THE-FINAL-LINE"),
+            "the document tail must be visible at detail_scroll 0:\n{screen}"
+        );
+        let _ = std::fs::remove_dir_all(runstate::run_dir("run-wrap-bottom"));
+    }
+
+    #[test]
+    fn wrapped_rows_counts_display_rows_not_logical_lines() {
+        let lines = vec![
+            Line::from("a".repeat(100)),
+            Line::from("short"),
+            Line::from(""),
+        ];
+        // At width 40 the 100-char line wraps to 3 rows: 3 + 1 + 1 = 5.
+        assert_eq!(wrapped_rows(&lines, 40), 5);
+        // Wide enough for no wrapping: one row per logical line.
+        assert_eq!(wrapped_rows(&lines, 120), 3);
+        // Degenerate width renders nothing.
+        assert_eq!(wrapped_rows(&lines, 0), 0);
+    }
 
     #[test]
     fn render_content_pane_scrollbar_visible_when_overflow() {

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -22,32 +22,25 @@ impl Dashboard {
         review_lines: &[ratatui::text::Line<'static>],
         pending_req: &Option<interaction::InteractionRequest>,
     ) {
-        // The review document accepts mouse selection; borders (and the
-        // scrollbar track on the right border column) are excluded.
-        self.selection_regions.push(review_area.inner(Margin {
-            vertical: 1,
-            horizontal: 1,
-        }));
-
         let inner_h = review_area.height.saturating_sub(2) as usize;
+        let render_width = review_area.width.saturating_sub(2);
 
-        // Clamp scroll
-        let max_rv_scroll = review_lines.len().saturating_sub(inner_h);
+        // Scroll in display rows (long lines wrap at draw time), so the
+        // bottom of the document is genuinely reachable - the same fix as the
+        // content pane, measured the same way.
+        let total_rows = super::content::wrapped_rows(review_lines, render_width);
+        let max_rv_scroll = total_rows.saturating_sub(inner_h);
         if self.review_scroll > max_rv_scroll {
             self.review_scroll = max_rv_scroll;
         }
-        let rv_start = review_lines
-            .len()
-            .saturating_sub(inner_h + self.review_scroll);
-        let rv_end = (rv_start + inner_h).min(review_lines.len());
-        let visible_review: Vec<Line> = review_lines[rv_start..rv_end].to_vec();
+        let rv_scroll_y = max_rv_scroll - self.review_scroll;
 
         let rv_title = if let Some(req) = &pending_req {
             format!(" {} ", truncate(&req.prompt, 50))
         } else {
             " Review ".to_string()
         };
-        let rv_scroll_info = if review_lines.len() > inner_h {
+        let rv_scroll_info = if total_rows > inner_h {
             let pct = 100
                 - (self.review_scroll.min(max_rv_scroll) * 100)
                     .checked_div(max_rv_scroll)
@@ -56,7 +49,7 @@ impl Dashboard {
         } else {
             String::new()
         };
-        let review_widget = Paragraph::new(visible_review)
+        let review_widget = Paragraph::new(review_lines.to_vec())
             .block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -68,16 +61,16 @@ impl Dashboard {
                     ))
                     .title_bottom(Span::styled(rv_scroll_info, Style::default().fg(C_DIM))),
             )
-            .wrap(Wrap { trim: false });
+            .wrap(Wrap { trim: false })
+            .scroll((rv_scroll_y.min(u16::MAX as usize) as u16, 0));
         frame.render_widget(review_widget, review_area);
 
-        // Scrollbar for review body
-        if review_lines.len() > inner_h {
+        // Scrollbar for review body, in display rows.
+        if total_rows > inner_h {
             let rv_scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓"));
-            let mut rv_sb = ScrollbarState::new(max_rv_scroll)
-                .position(max_rv_scroll.saturating_sub(self.review_scroll));
+            let mut rv_sb = ScrollbarState::new(max_rv_scroll).position(rv_scroll_y);
             frame.render_stateful_widget(
                 rv_scrollbar,
                 review_area.inner(Margin {
@@ -315,6 +308,36 @@ mod tests {
             .unwrap();
     }
 
+    /// Same display-row fix as the content pane: a review document whose
+    /// lines wrap must still show its final line when scrolled to the bottom.
+    #[test]
+    fn wrapped_review_shows_its_last_line_at_the_bottom() {
+        let backend = TestBackend::new(50, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.review_scroll = 0;
+        let lines: Vec<ratatui::text::Line<'static>> = vec![
+            ratatui::text::Line::from("plan step ".repeat(30)),
+            ratatui::text::Line::from("detail text ".repeat(25)),
+            ratatui::text::Line::from("REVIEW-FINAL-LINE"),
+        ];
+        let pending: Option<interaction::InteractionRequest> = None;
+        terminal
+            .draw(|f| dash.render_review_body(f, Rect::new(0, 0, 48, 12), &lines, &pending))
+            .unwrap();
+        let screen: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            screen.contains("REVIEW-FINAL-LINE"),
+            "the review tail must be visible at review_scroll 0:\n{screen}"
+        );
+    }
+
     #[test]
     fn render_review_body_clamps_out_of_range_scroll() {
         let backend = TestBackend::new(120, 40);
@@ -334,15 +357,6 @@ mod tests {
             })
             .unwrap();
         assert!(dash.review_scroll < usize::MAX);
-        // The review pane accepts mouse selection: its inner rect (borders
-        // excluded) is registered for hit-testing.
-        assert_eq!(
-            dash.selection_regions,
-            vec![Rect::new(0, 0, 80, 10).inner(Margin {
-                vertical: 1,
-                horizontal: 1,
-            })]
-        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -18,15 +18,16 @@ use super::types::*;
 
 impl Dashboard {
     pub(super) fn draw(&mut self, frame: &mut Frame) {
-        // Selectable panes re-register their rects as they render; anything
-        // still selected in a pane that does not come back this frame is
-        // dropped by the overlay pass below.
+        // The whole frame accepts mouse selection, exactly like native
+        // terminal selection; re-registered per frame so a resize (the one
+        // event that moves text under a screen-anchored highlight without a
+        // scroll) drops the selection.
         self.selection_regions.clear();
+        self.selection_regions.push(frame.area());
 
         if self.mcp_screen {
             self.draw_mcp_screen(frame, frame.area());
-            // No pane registered a rect, so this drops any selection.
-            self.validate_selection();
+            self.apply_selection_overlay(frame);
             self.draw_toasts(frame);
             return;
         }
@@ -318,38 +319,41 @@ mod tests {
     }
 
     #[test]
-    fn draw_reregisters_selection_regions_every_frame() {
+    fn draw_registers_the_whole_frame_for_selection() {
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         terminal.draw(|f| dash.draw(f)).unwrap();
-        let first_frame = dash.selection_regions.clone();
-        assert!(!first_frame.is_empty());
-        // A second draw replaces the registrations instead of accumulating.
+        // One region, the frame itself: selection works anywhere, exactly
+        // like native terminal selection.
+        assert_eq!(
+            dash.selection_regions,
+            vec![ratatui::layout::Rect::new(0, 0, 120, 40)]
+        );
+        // A second draw replaces the registration instead of accumulating.
         terminal.draw(|f| dash.draw(f)).unwrap();
-        assert_eq!(dash.selection_regions, first_frame);
+        assert_eq!(dash.selection_regions.len(), 1);
     }
 
     #[test]
-    fn draw_mcp_screen_drops_any_selection() {
+    fn a_selection_survives_switching_to_the_mcp_screen() {
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
-        // Start a drag over the log panel on the normal screen.
         terminal.draw(|f| dash.draw(f)).unwrap();
-        let region = dash.selection_regions[0];
         dash.handle_mouse(crossterm::event::MouseEvent {
             kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
-            column: region.x,
-            row: region.y,
+            column: 2,
+            row: 2,
             modifiers: crossterm::event::KeyModifiers::NONE,
         });
         assert!(dash.selection.is_some());
-        // The MCP screen has no selectable panes; switching to it clears.
+        // The frame is the region, so a view switch keeps the drag alive -
+        // native terminal selection behaves the same way when content
+        // redraws underneath it.
         dash.mcp_screen = true;
         terminal.draw(|f| dash.draw(f)).unwrap();
-        assert!(dash.selection.is_none());
-        assert!(dash.selection_regions.is_empty());
+        assert!(dash.selection.is_some());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -1,7 +1,7 @@
 //! Agent table, log panel, and help bar rendering.
 
 use ratatui::Frame;
-use ratatui::layout::{Margin, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
@@ -164,13 +164,7 @@ impl Dashboard {
         frame.render_stateful_widget(table, area, &mut self.table_state);
     }
 
-    pub(in crate::commands::dashboard) fn draw_log_panel(&mut self, frame: &mut Frame, area: Rect) {
-        // The activity log accepts mouse selection (borders excluded).
-        self.selection_regions.push(area.inner(Margin {
-            vertical: 1,
-            horizontal: 1,
-        }));
-
+    pub(in crate::commands::dashboard) fn draw_log_panel(&self, frame: &mut Frame, area: Rect) {
         let log_lines: Vec<Line> = self
             .log
             .iter()
@@ -672,14 +666,6 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
-        // The activity log accepts mouse selection inside its borders.
-        assert_eq!(
-            dash.selection_regions,
-            vec![Rect::new(0, 0, 120, 40).inner(Margin {
-                vertical: 1,
-                horizontal: 1,
-            })]
-        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -7,11 +7,12 @@
 //! is read back from those same cells. This is the semantics of native
 //! terminal selection, which mouse capture otherwise takes away.
 //!
-//! Lifecycle: a left-button press inside a registered pane starts a drag,
-//! dragging extends the highlight (clamped to that pane), and release copies
-//! the highlighted cells through the same clipboard seam as `y` yank. A plain
-//! click, any scroll, or a frame that no longer draws the pane clears the
-//! selection - the highlight must never outlive the text it was drawn over.
+//! Lifecycle: a left-button press anywhere starts a drag (the whole frame is
+//! one selection region, exactly like native terminal selection - a
+//! multi-row drag spans panes and borders alike), dragging extends the
+//! highlight, and release copies the highlighted cells through the same
+//! clipboard seam as `y` yank. A plain click, any scroll, or a resize (which
+//! moves text under a screen-anchored highlight) clears the selection.
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::Frame;
@@ -28,8 +29,8 @@ use super::types::ToastLevel;
 /// Coordinates are absolute screen cells `(column, row)`, both endpoints
 /// inclusive and always inside `region`.
 pub(super) struct Selection {
-    /// The pane's inner rect (borders excluded) as registered by the pane's
-    /// renderer on the frame where the drag started.
+    /// The selectable region the drag started in - the whole frame, as
+    /// registered by `draw()` each frame.
     pub(super) region: Rect,
     /// Where the drag started.
     pub(super) anchor: (u16, u16),

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -149,6 +149,55 @@ fn draw_welcome(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
+/// Greedy word-wrap for plain text rendered inside `List` items, which
+/// (unlike `Paragraph`) cannot wrap. Words longer than `width` break at a
+/// character boundary rather than overflowing.
+fn wrap_plain(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        let mut word = word;
+        loop {
+            let need = if current.is_empty() {
+                word.chars().count()
+            } else {
+                current.chars().count() + 1 + word.chars().count()
+            };
+            if need <= width {
+                if !current.is_empty() {
+                    current.push(' ');
+                }
+                current.push_str(word);
+                break;
+            }
+            if current.is_empty() {
+                // A single word wider than the pane: hard-break it after
+                // `width` characters (a char boundary by construction).
+                // This branch is only reachable when the word has more than
+                // `width` chars (a shorter word takes the fits-branch above),
+                // so the boundary at char `width` always exists.
+                let cut = word
+                    .char_indices()
+                    .nth(width)
+                    .map(|(i, _)| i)
+                    .expect("infallible: the word is longer than width chars");
+                let (head, tail) = word.split_at(cut);
+                lines.push(head.to_string());
+                // The cut is strictly inside the word, so the tail is never
+                // empty; the loop re-tests it against the width.
+                word = tail;
+            } else {
+                lines.push(std::mem::take(&mut current));
+            }
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
 fn draw_providers(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     let items: Vec<ListItem> = wizard
         .providers
@@ -175,13 +224,17 @@ fn draw_providers(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             } else if !row.value.is_empty() {
                 spans.push(Span::styled("  (set)", Style::default().fg(C_MUTED)));
             }
-            ListItem::new(vec![
-                Line::from(spans),
-                Line::from(Span::styled(
-                    format!("    {}", row.provider.blurb),
+            let mut item_lines = vec![Line::from(spans)];
+            // Word-wrap the blurb to the pane: `List` does not wrap, so a
+            // long description on a narrow window would otherwise clip
+            // mid-sentence with nothing to say more text exists.
+            for chunk in wrap_plain(row.provider.blurb, area.width.saturating_sub(6) as usize) {
+                item_lines.push(Line::from(Span::styled(
+                    format!("    {chunk}"),
                     Style::default().fg(C_DIM),
-                )),
-            ])
+                )));
+            }
+            ListItem::new(item_lines)
         })
         .collect();
 
@@ -712,6 +765,40 @@ mod tests {
         let mut terminal = Terminal::new(TestBackendHarness::new(140, 44)).unwrap();
         terminal.draw(|frame| draw(frame, wizard)).unwrap();
         terminal.backend().text()
+    }
+
+    /// A provider blurb on a narrow window must wrap, not clip: the tail of
+    /// the sentence (here the transport's "cannot be disabled" caveat) has to
+    /// reach the screen.
+    #[test]
+    fn narrow_window_wraps_provider_blurbs_instead_of_clipping() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Providers);
+        let mut terminal = Terminal::new(TestBackendHarness::new(48, 44)).unwrap();
+        terminal.draw(|frame| draw(frame, &w)).unwrap();
+        let screen = terminal.backend().text();
+        assert!(
+            screen.contains("disabled"),
+            "the blurb tail must survive a 48-column window:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn wrap_plain_wraps_at_word_boundaries_and_hard_breaks_long_words() {
+        assert_eq!(
+            wrap_plain("alpha beta gamma", 11),
+            vec!["alpha beta", "gamma"]
+        );
+        // One word wider than the pane hard-breaks by characters.
+        assert_eq!(wrap_plain("abcdefghij", 4), vec!["abcd", "efgh", "ij"]);
+        // Multibyte characters break on char boundaries, never mid-character.
+        assert_eq!(
+            wrap_plain("\u{65e5}\u{672c}\u{8a9e}\u{3067}\u{3059}", 2),
+            vec!["\u{65e5}\u{672c}", "\u{8a9e}\u{3067}", "\u{3059}"]
+        );
+        assert!(wrap_plain("", 10).is_empty());
+        // A degenerate zero width still terminates and yields one char per line.
+        assert_eq!(wrap_plain("ab", 0), vec!["a", "b"]);
     }
 
     fn wizard() -> (tempfile::TempDir, Wizard) {


### PR DESCRIPTION
## What

Three reported TUI visibility issues, fixed and live-verified through a pty:

1. **Selection works anywhere.** The whole frame is now one selection region, exactly like native terminal selection - a drag can start on the agent table, header, stage tabs, or the MCP screen, and a multi-row drag spans panes and borders. A resize still clears the selection (the one event that moves text under a screen-anchored highlight without a scroll); a view switch keeps it, as native selection does when content redraws underneath.
2. **The bottom of wrapped documents is reachable.** Long lines wrap at draw time, so the old logical-line scroll math undercounted what was on screen and clipped the wrapped tail past the pane bottom - the "plan is cut off" report. The content and review panes now measure with `Paragraph::line_count` (ratatui's `unstable-rendered-line-info` feature, safe on our pinned 0.29) and render with a display-row offset: bottom means the document's last row, search recentering targets the match's display row, and the scrollbar/percent readout count rows.
3. **Setup wizard blurbs wrap on narrow windows.** `List` items cannot wrap, so long provider descriptions (the Claude Code transport's, notably) clipped mid-sentence. A word-wrap helper splits them to the pane width, hard-breaking on char boundaries only.

## Testing

- New regression tests pin each fix: wrapped content/review documents must show their final line at scroll 0, `wrapped_rows` counts display rows, the frame-wide region registration, selection surviving a view switch, and blurb wrapping at 48 columns.
- Full suite green (5,060 tests); clippy `--all-features -D warnings`; `cargo xtask coverage --package leviath-cli` at 100%.
- **Live pty run**: a real daemon run with long wrapped output shows `FINAL-MARKER-LINE` at the detail-view bottom, and a drag over the header/table rows (previously unselectable) copies an OSC52 payload byte-identical to the pyte screen cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3