### PR TITLE
feat: single-container Docker deployment (daemon + API)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the build context to sources: the target dir alone is gigabytes.
+# agents/ must stay complete - build.rs embeds every file of every bundled
+# blueprint, including their READMEs.
+target/
+coverage/
+.git/
+.github/
+.claude/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Leviath in a container: the shared-world daemon plus its REST/WebSocket API.
+#
+# `lev serve` auto-starts the daemon inside the container and routes agent
+# actions through its control socket, so this single process is the whole
+# deployment. Agent tools (shell, file I/O) run INSIDE the container - which
+# is the isolation most deployments want. The `[sandbox]` feature spawns
+# sibling containers and would need the Docker socket mounted; on this image
+# leave sandboxing unset and let the container itself be the boundary.
+#
+#   docker build -t leviath .
+#   docker run -d -p 3000:3000 \
+#     -e LEVIATH_API_TOKEN=change-me \
+#     -v leviath-data:/data \
+#     leviath
+#
+# Configuration lives in the volume at /data/.leviath/config.toml (LEVIATH_HOME
+# is /data). Provider keys can go there or in the environment, e.g.
+# `-e ANTHROPIC_API_KEY=...`.
+
+FROM rust:1.97.1-slim-bookworm AS builder
+WORKDIR /src
+COPY . .
+# The release profile (fat LTO, one codegen unit) is what ships everywhere
+# else; the image gets the same binary users install.
+RUN cargo build --release -p leviath-cli
+
+FROM debian:bookworm-slim
+# ca-certificates: provider APIs and MCP servers are HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/target/release/lev /usr/local/bin/lev
+
+# All persistent state (config, runs, agents, providers) under one volume.
+ENV LEVIATH_HOME=/data
+VOLUME /data
+WORKDIR /data
+
+EXPOSE 3000
+ENTRYPOINT ["lev"]
+# 0.0.0.0 is correct inside the container: Docker's port mapping is the
+# boundary, and the API refuses to start without LEVIATH_API_TOKEN anyway.
+CMD ["serve", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
## What

Answers "can users run the ECS daemon through Docker and not worry": previously no - the repo had no Dockerfile at all (the only container integration was the tool sandbox). Now yes:

- **Multi-stage Dockerfile**: rust builder producing the same release binary users install everywhere else, on debian-slim with ca-certificates (190 MB image). `lev serve` is the entrypoint and auto-starts the shared-world daemon inside, so one container is the whole deployment. All state lives under a `/data` volume (`LEVIATH_HOME`); the API refuses to start without `LEVIATH_API_TOKEN`.
- **.dockerignore** keeps the build context lean while deliberately keeping `agents/` complete - build.rs embeds every file of every bundled blueprint, and excluding markdown would silently thin the bundles inside the image.
- **README gains a Docker section** with the run command and the honest sandbox caveat: agent tools run inside the container (the isolation most deployments want); `[sandbox]` spawns sibling containers and would need the Docker socket, so in this image the container itself is the boundary.

## Verified live

- Image builds from a clean context; container starts; an agent spawned through the authenticated REST API ran to completion with state persisted to the volume; a container **restart** came back with run history intact; re-verified after the dockerignore fix (fresh run completed alongside the surviving old one).
- Also live-verified in this pass: `[sandbox] kind = "container"` genuinely routes an agent's shell into Docker - on a macOS host, the sandboxed `uname -s` wrote `Linux` into the bind-mounted workdir.

Possible follow-up (not included): a CI job building the image per PR to prevent Dockerfile rot - it adds ~10 minutes per run, so it felt like an owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3