### PR TITLE
fix(setup): a Gemini-only install now has models to run and a live key

### DIFF
--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -201,6 +201,42 @@ fn builtin_table() -> Vec<BuiltinEntry> {
             ctx = 400_000,
             out = 128_000
         ),
+        // ── Google (Gemini) ────────────────────────────────────────────────────
+        // Native Google provider entries. Without these, a user whose only key
+        // is a Gemini key saw no model they could run: every Gemini row in this
+        // table routed through OpenRouter, which needs a different key.
+        entry!(
+            "google",
+            "gemini-3.5-flash",
+            "Gemini 3.5 Flash",
+            temp = true,
+            ctx = 1_048_576,
+            out = 65_535
+        ),
+        entry!(
+            "google",
+            "gemini-3.1-pro-preview",
+            "Gemini 3.1 Pro (preview)",
+            temp = true,
+            ctx = 1_048_576,
+            out = 65_535
+        ),
+        entry!(
+            "google",
+            "gemini-3-flash",
+            "Gemini 3 Flash",
+            temp = true,
+            ctx = 1_048_576,
+            out = 65_535
+        ),
+        entry!(
+            "google",
+            "gemini-3.1-flash-lite",
+            "Gemini 3.1 Flash Lite",
+            temp = true,
+            ctx = 1_048_576,
+            out = 65_535
+        ),
         // ── OpenRouter: Google Gemini ──────────────────────────────────────────
         entry!(
             "openrouter",
@@ -820,6 +856,31 @@ mod tests {
             if entry.provider == "openai" {
                 assert!(entry.caps.supports_temperature);
             }
+        }
+    }
+
+    /// A user whose only key is a Gemini key must find models they can run.
+    /// Every Gemini row in this table used to route through OpenRouter, which
+    /// needs a different key, so `lev models list` showed that user nothing
+    /// their key could reach.
+    #[test]
+    fn builtin_table_offers_native_google_models() {
+        let table = builtin_table();
+        let native: Vec<&str> = table
+            .iter()
+            .filter(|e| e.provider == "google")
+            .map(|e| e.model_id)
+            .collect();
+        assert!(
+            !native.is_empty(),
+            "the native google provider must offer models of its own"
+        );
+        // Native ids are bare (`gemini-3.5-flash`), never OpenRouter-prefixed.
+        for id in &native {
+            assert!(
+                !id.contains('/'),
+                "native google model id must not be vendor-prefixed: {id}"
+            );
         }
     }
 

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -365,16 +365,19 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
     let mut creds = Vec::new();
 
     let keyed = [
-        ("anthropic", config.providers.anthropic_api_key.as_ref()),
-        ("openai", config.providers.openai_api_key.as_ref()),
-        ("google", config.providers.google_api_key.as_ref()),
-        ("openrouter", config.openrouter_api_key.as_ref()),
+        ("anthropic", config.providers.anthropic_api_key.as_deref()),
+        ("openai", config.providers.openai_api_key.as_deref()),
+        ("google", config.providers.google_api_key.as_deref()),
+        ("openrouter", config.openrouter_api_key.as_deref()),
     ];
     for (name, key) in keyed {
-        if let Some(key) = key {
+        // A blank key is not a key: `lev setup` writes empty strings for
+        // providers the user skipped, and registering one produces a provider
+        // that authenticates as nobody and fails at the first call.
+        if let Some(key) = key.map(str::trim).filter(|k| !k.is_empty()) {
             creds.push(ProviderCreds {
                 name: name.to_string(),
-                api_key: Some(key.clone()),
+                api_key: Some(key.to_string()),
                 base_url: None,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: timeout,
@@ -875,6 +878,34 @@ mod tests {
         let ollama = creds.iter().find(|c| c.name == "ollama").unwrap();
         assert_eq!(ollama.base_url.as_deref(), Some("http://custom:11434"));
         assert!(ollama.api_key.is_none());
+    }
+
+    /// `lev setup` writes an empty string for a provider the user skipped, so
+    /// a blank key must not register one: doing so produced a provider that
+    /// authenticates as nobody and fails at the first call, and it crowded out
+    /// the provider the user actually configured.
+    #[test]
+    fn provider_creds_from_config_ignores_blank_keys() {
+        let config = Config {
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some(String::new()),
+                openai_api_key: Some("   ".to_string()),
+                google_api_key: Some("AIza-real".to_string()),
+                ..Config::default().providers
+            },
+            ..Config::default()
+        };
+        let creds = provider_creds_from_config(&config);
+        let names: Vec<&str> = creds.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            names.contains(&"google"),
+            "the configured provider must register: {names:?}"
+        );
+        assert!(!names.contains(&"anthropic"), "empty key must not register");
+        assert!(
+            !names.contains(&"openai"),
+            "whitespace-only key must not register"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -887,15 +887,21 @@ impl Config {
 
     /// Validate API key formats and return warnings for suspicious keys.
     pub fn validate_keys(&self) -> Vec<String> {
+        // A blank key means "not configured" (that is what `lev setup` writes
+        // for a provider the user skipped), so it earns no warning - warning
+        // about the shape of a key nobody set is noise that trains users to
+        // ignore the ones that matter.
         let mut warnings = Vec::new();
-        if let Some(ref key) = self.providers.anthropic_api_key
+        if let Some(key) = self.providers.anthropic_api_key.as_deref()
+            && !key.trim().is_empty()
             && !key.starts_with("sk-ant-")
         {
             warnings.push(
                 "Anthropic API key doesn't start with 'sk-ant-' - verify it's correct".to_string(),
             );
         }
-        if let Some(ref key) = self.providers.openai_api_key
+        if let Some(key) = self.providers.openai_api_key.as_deref()
+            && !key.trim().is_empty()
             && !key.starts_with("sk-")
         {
             warnings
@@ -2234,6 +2240,20 @@ max_output_tokens = 2048
     }
 
     // ─── validate_keys with both keys ──────────────────────────────────────
+
+    /// A blank key means "not configured" (what `lev setup` writes for a
+    /// skipped provider), so it must not draw a shape warning - noise about
+    /// keys nobody set trains users to ignore the warnings that matter.
+    #[test]
+    fn validate_keys_is_quiet_about_blank_keys() {
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some(String::new());
+        config.providers.openai_api_key = Some("   ".to_string());
+        assert!(config.validate_keys().is_empty());
+        // A genuinely wrong-looking key still warns.
+        config.providers.anthropic_api_key = Some("nope".to_string());
+        assert_eq!(config.validate_keys().len(), 1);
+    }
 
     #[test]
     fn validate_keys_both_bad() {


### PR DESCRIPTION
## What

Chasing the "Gemini key didn't get hooked up" report found two real bugs (the transport itself was fine - see below):

1. **No native Google models existed in the model table.** Every Gemini row in `builtin_table()` was an `openrouter` entry (`google/gemini-2.5-pro` etc.), which needs an OpenRouter key. A user whose only key was a Gemini key ran `lev models list` and saw **zero** models their key could reach - indistinguishable from "my key was ignored". The four models the Gemini provider's own capability table already documents are now listed under the `google` provider with bare ids.
2. **Empty keys registered as providers.** `provider_creds_from_config` accepted any `Some(key)`, and `lev setup` writes empty strings for providers the user skipped - so a Gemini-only install registered anthropic + openai + openrouter with blank keys (each failing at first call) and printed bogus "key doesn't start with sk-" warnings. Blank/whitespace-only keys no longer register, and `validate_keys` is quiet about them.

## What was NOT broken

The credential path itself. A live run pinned to `google/gemini-3.5-flash` with a deliberately fake key resolved the provider, reached Google's API, and returned `"Please pass a valid API key"` - the key was read from config, wired into the provider, and transmitted. The user-visible failure was discovery, not transport, which is why it looked Anthropic-only (Anthropic's models were the ones the table listed).

## Testing

Three regression tests: the table must offer native, non-vendor-prefixed `google` models; blank and whitespace-only keys must not register while a real key does; `validate_keys` stays quiet about blanks but still warns on a genuinely malformed key. Full workspace suite green (5,074), clippy `--all-features -D warnings`, and `cargo xtask coverage --package leviath-cli` at 100%.

Verified by hand: with only a Gemini key configured, `lev models list` now shows 4 google models and no spurious warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnnF9RWB5huyguHxrrCsx3