### PR TITLE
feat: script-backed custom region kind (kind = "custom")

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
  "chrono",
  "leviath-core",
  "leviath-providers",
+ "leviath-scripting",
  "leviath-sys",
  "leviath-testkit",
  "leviath-tools",

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Ten agents ship out of the box, each a multi-stage directed graph with structure
 
 ### Structured context memory
 
-Seven region kinds with deterministic eviction: architecture stays pinned, tool results evict first, and conversation auto-compacts into summaries. Route reads to specific regions so a file dump can't push out your system prompt. Budgets can be percentages of the model's context window, so a blueprint's intent survives across models of different sizes. [Learn more →](https://leviath.dev/docs/context)
+Eight region kinds with deterministic eviction: architecture stays pinned, tool results evict first, and conversation auto-compacts into summaries. Route reads to specific regions so a file dump can't push out your system prompt. Budgets can be percentages of the model's context window, so a blueprint's intent survives across models of different sizes. And when the built-ins don't fit, a [`custom` region](docs/rhai-regions.md) hands one region's rendering, writes, and eviction to a Rhai script you control - up to owning the entire context window as a single scripted region. [Learn more →](https://leviath.dev/docs/context)
 
 ### Multi-stage workflows
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -1692,6 +1692,13 @@ mod tests {
                     entries: vec![],
                 },
                 runstate::RegionSnapshot {
+                    name: "brain".to_string(),
+                    kind: "custom".to_string(),
+                    current_tokens: 1000,
+                    max_tokens: 2000,
+                    entries: vec![],
+                },
+                runstate::RegionSnapshot {
                     name: "other".to_string(),
                     kind: "unknown_kind".to_string(),
                     current_tokens: 1000,

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -611,6 +611,7 @@ impl Dashboard {
                     "sliding" => C_SUCCESS,
                     "compacting" | "history" => C_WARN,
                     "temporary" | "clearable" => C_MUTED,
+                    "custom" => C_SCRIPT,
                     _ => C_DIM,
                 };
                 lines.push(Line::from(vec![

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -148,6 +148,13 @@ async fn execute_with_registry(
     let manifest_content = fs::read_to_string(&manifest_path)?;
     let blueprint = parse_manifest(&manifest_content)?;
 
+    // Custom regions' Rhai scripts, resolved exactly as a real spawn would
+    // (blueprint-dir-relative, compile-checked, hard error) - `lev test` is
+    // precisely the preview loop where a hook author wants the hook to run.
+    let region_scripts =
+        crate::daemon::spawn::resolve_region_scripts(&blueprint, &manifest_path.to_string_lossy())
+            .map_err(|e| anyhow::anyhow!(e))?;
+
     let registry = if !args.dry_run {
         let config = Config::load()?;
         Some(build_registry(&config))
@@ -203,7 +210,7 @@ async fn execute_with_registry(
                     let registry = registry
                         .as_ref()
                         .expect("registry should exist in non-dry-run");
-                    match run_test_case(&blueprint, registry, test_case).await {
+                    match run_test_case(&blueprint, registry, test_case, &region_scripts).await {
                         Ok(true) => {
                             passed += 1;
                             println!("  PASS: {}", test_case.name);
@@ -295,6 +302,10 @@ async fn run_test_case(
     blueprint: &leviath_core::Blueprint,
     registry: &ProviderRegistry,
     test: &TestCase,
+    region_scripts: &std::collections::HashMap<
+        String,
+        std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
+    >,
 ) -> anyhow::Result<bool> {
     // Model config comes from the first stage.
     let stage = blueprint
@@ -316,9 +327,16 @@ async fn run_test_case(
     // mirrors what the ECS pipeline's spawner does, without the shared world:
     // `lev test` only needs one inference to validate a stage's first response.
     let mut window = ContextWindow::new(blueprint.context_layout.total_budget_tokens);
+    window.region_scripts = region_scripts.clone();
     context_setup::init_window(&mut window, blueprint, &test.input);
 
-    let assembled = window.assemble();
+    // Assemble with real stage metadata so custom-region render hooks see
+    // what a live run's first inference would (iteration 0).
+    let assembled = window.assemble_with_meta(&leviath_runtime::custom_region::AssembleMeta {
+        stage_name: stage.name.clone(),
+        stage_iterations: 0,
+        model: model_name.to_string(),
+    });
     let caps = provider.capabilities(model_name);
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);
     let temperature = if caps.supports_temperature { 0.7 } else { 0.0 };
@@ -1290,6 +1308,112 @@ max_tokens = 5000
         parse_manifest(manifest).unwrap()
     }
 
+    /// A provider that records the request it receives, so a test can assert
+    /// what `lev test` actually assembled (e.g. a custom region's rendered
+    /// output).
+    struct RecordingProvider {
+        seen: std::sync::Arc<std::sync::Mutex<Option<InferenceRequest>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for RecordingProvider {
+        async fn infer(
+            &self,
+            request: InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            *self.seen.lock().unwrap() = Some(request);
+            Ok(InferenceResponse {
+                content: "recorded".to_string(),
+                tool_calls: vec![],
+                tokens_used: TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                },
+                finish_reason: FinishReason::Complete,
+            })
+        }
+
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+            text.len()
+        }
+
+        fn max_context_tokens(&self, _model: &str) -> usize {
+            8192
+        }
+
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        fn capabilities(&self, _model: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    /// `lev test` runs custom-region render hooks with the entry stage's real
+    /// metadata - the preview a hook author iterates against.
+    #[tokio::test]
+    async fn run_test_case_renders_custom_region_through_its_script() {
+        let manifest = r#"
+[agent]
+name = "custom-test-agent"
+version = "0.1.0"
+description = "test"
+
+[stages.main]
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+
+[context.regions.task]
+kind = "pinned"
+max_tokens = 4000
+
+[context.regions.brain]
+kind = "custom"
+script = "hooks/brain.rhai"
+max_tokens = 4000
+"#;
+        let blueprint = parse_manifest(manifest).unwrap();
+        let scripts = std::collections::HashMap::from([(
+            "hooks/brain.rhai".to_string(),
+            std::sync::Arc::new(
+                leviath_scripting::region_hook::compile(
+                    "hooks/brain.rhai",
+                    "fn render(ctx) { `<brain stage=${ctx.stage_name} model=${ctx.model}>` }",
+                )
+                .unwrap(),
+            ),
+        )]);
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let mut registry = ProviderRegistry::new();
+        registry.register(
+            "anthropic".to_string(),
+            Arc::new(RecordingProvider { seen: seen.clone() }),
+        );
+        let tc = TestCase {
+            name: "custom_render".to_string(),
+            input: "hi".to_string(),
+            expect_contains: Some("recorded".to_string()),
+            expect_tool_call: None,
+            max_tokens: None,
+        };
+        let passed = run_test_case(&blueprint, &registry, &tc, &scripts)
+            .await
+            .unwrap();
+        assert!(passed);
+        let request = seen.lock().unwrap().take().expect("provider saw a request");
+        assert!(
+            request
+                .system
+                .iter()
+                .any(|b| b.text == "<brain stage=main model=claude-sonnet-4-6>"),
+            "custom region rendered with stage metadata; system blocks: {:?}",
+            request.system.iter().map(|b| &b.text).collect::<Vec<_>>()
+        );
+    }
+
     // ── new coverage tests ────────────────────────────────────────────────────
 
     /// Covers the `map_err(|e| anyhow!("Inference failed: {}", e))` closure
@@ -1306,7 +1430,7 @@ max_tokens = 5000
             expect_tool_call: None,
             max_tokens: None,
         };
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Inference failed"));
     }
@@ -1329,7 +1453,7 @@ max_tokens = 5000
             expect_tool_call: None,
             max_tokens: None,
         };
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Blueprint has no stages"));
     }
@@ -1354,7 +1478,7 @@ max_tokens = 5000
             expect_tool_call: None,
             max_tokens: None,
         };
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(result.unwrap());
     }
 
@@ -1556,7 +1680,11 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             expect_tool_call: None,
             max_tokens: None,
         };
-        assert!(run_test_case(&blueprint, &registry, &tc).await.unwrap());
+        assert!(
+            run_test_case(&blueprint, &registry, &tc, &Default::default())
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -1579,7 +1707,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(result.unwrap());
     }
 
@@ -1603,7 +1731,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(!result.unwrap());
     }
 
@@ -1632,7 +1760,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(result.unwrap());
     }
 
@@ -1666,7 +1794,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(!result.unwrap());
     }
 
@@ -1690,7 +1818,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(!result.unwrap());
     }
 
@@ -1714,7 +1842,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(result.unwrap());
     }
 
@@ -1731,7 +1859,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not configured"));
     }
@@ -1756,7 +1884,11 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             expect_tool_call: None,
             max_tokens: None,
         };
-        assert!(run_test_case(&blueprint, &registry, &tc).await.unwrap());
+        assert!(
+            run_test_case(&blueprint, &registry, &tc, &Default::default())
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -1780,7 +1912,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             max_tokens: None,
         };
 
-        let result = run_test_case(&blueprint, &registry, &tc).await;
+        let result = run_test_case(&blueprint, &registry, &tc, &Default::default()).await;
         assert!(result.unwrap());
     }
 

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -1404,14 +1404,61 @@ max_tokens = 4000
             .unwrap();
         assert!(passed);
         let request = seen.lock().unwrap().take().expect("provider saw a request");
+        // Precompute the texts so the assert message costs no extra branch.
+        let system_texts: Vec<&String> = request.system.iter().map(|b| &b.text).collect();
+        let rendered = system_texts
+            .iter()
+            .any(|t| t.as_str() == "<brain stage=main model=claude-sonnet-4-6>");
         assert!(
-            request
-                .system
-                .iter()
-                .any(|b| b.text == "<brain stage=main model=claude-sonnet-4-6>"),
-            "custom region rendered with stage metadata; system blocks: {:?}",
-            request.system.iter().map(|b| &b.text).collect::<Vec<_>>()
+            rendered,
+            "custom region rendered with stage metadata; system blocks: {system_texts:?}"
         );
+
+        // Exercise the recording provider's remaining trait surface directly.
+        let provider = registry.get("anthropic").unwrap();
+        assert_eq!(provider.count_tokens("abcd", "m").await, 4);
+        assert_eq!(provider.max_context_tokens("m"), 8192);
+        assert_eq!(provider.name(), "recording");
+    }
+
+    /// The custom-region resolve error path in `execute` (a declared script
+    /// that doesn't exist fails before any provider setup, dry-run or not).
+    #[tokio::test]
+    async fn execute_fails_fast_on_a_broken_custom_region_script() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        std::fs::write(
+            project.join("agent.leviath"),
+            r#"
+[agent]
+name = "broken-custom"
+version = "0.1.0"
+description = "d"
+
+[stages.main]
+model = { provider = "anthropic", model = "m" }
+
+[context.regions.brain]
+kind = "custom"
+script = "hooks/missing.rhai"
+max_tokens = 4000
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir(project.join("tests")).unwrap();
+        std::fs::write(
+            project.join("tests/basic.toml"),
+            "[[test]]\nname = \"t\"\ninput = \"hi\"\n",
+        )
+        .unwrap();
+        let args = TestArgs {
+            path: Some(project.to_str().unwrap().to_string()),
+            filter: None,
+            dry_run: true,
+        };
+        let err = execute(args).await.unwrap_err().to_string();
+        assert!(err.contains("region 'brain'"), "{err}");
+        assert!(err.contains("hooks/missing.rhai"), "{err}");
     }
 
     // ── new coverage tests ────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -51,6 +51,13 @@ fn check_manifest(path: &std::path::Path) -> Result<leviath_core::Blueprint, Man
         .validate()
         .map_err(|e| ManifestCheckError::Validation(e.to_string()))?;
 
+    // Custom regions' Rhai scripts must resolve to readable, compilable
+    // files with a well-formed `fn render(ctx)` - the same check a spawn
+    // performs, surfaced here where a typo'd path or syntax error is cheap
+    // to find.
+    crate::daemon::spawn::resolve_region_scripts(&blueprint, &manifest_path.to_string_lossy())
+        .map_err(ManifestCheckError::Validation)?;
+
     Ok(blueprint)
 }
 
@@ -309,6 +316,48 @@ conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
 
     fn parse(toml: &str) -> leviath_core::Blueprint {
         leviath_core::manifest::parse_manifest(toml).unwrap()
+    }
+
+    #[test]
+    fn check_manifest_verifies_custom_region_scripts() {
+        // A custom region's script must exist and compile; the same failure a
+        // spawn would hit, surfaced by `lev validate`.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("agent.leviath");
+        let toml = r#"
+[agent]
+name = "custom-validate"
+version = "0.1.0"
+description = "d"
+
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+description = "Main stage"
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
+"#;
+        std::fs::write(&manifest_path, toml).unwrap();
+
+        // Missing script file → validation error naming region + path.
+        let err = check_manifest(&manifest_path).unwrap_err();
+        let ManifestCheckError::Validation(msg) = err else {
+            panic!("expected Validation, got {err:?}");
+        };
+        assert!(msg.contains("region 'brain'"), "{msg}");
+
+        // Present + compilable → passes.
+        std::fs::create_dir(dir.path().join("hooks")).unwrap();
+        std::fs::write(
+            dir.path().join("hooks/brain.rhai"),
+            "fn render(ctx) { \"ok\" }",
+        )
+        .unwrap();
+        let bp = check_manifest(&manifest_path).unwrap();
+        assert_eq!(bp.name, "custom-validate");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -343,11 +343,9 @@ brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
         std::fs::write(&manifest_path, toml).unwrap();
 
         // Missing script file → validation error naming region + path.
-        let err = check_manifest(&manifest_path).unwrap_err();
-        let ManifestCheckError::Validation(msg) = err else {
-            panic!("expected Validation, got {err:?}");
-        };
-        assert!(msg.contains("region 'brain'"), "{msg}");
+        let err = format!("{:?}", check_manifest(&manifest_path).unwrap_err());
+        assert!(err.starts_with("Validation"), "{err}");
+        assert!(err.contains("region 'brain'"), "{err}");
 
         // Present + compilable → passes.
         std::fs::create_dir(dir.path().join("hooks")).unwrap();

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1491,6 +1491,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_agent_fails_fast_on_a_broken_custom_region_script() {
+        // The resolve error propagates out of build_agent before any tokens
+        // are spent - a hook that silently never ran would change every
+        // inference with no signal.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(&manifest, custom_region_manifest()).unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let args = spawn_args(&manifest.to_string_lossy());
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &args,
+            100,
+            sub_tx(),
+        )
+        .unwrap_err();
+        assert!(err.contains("region 'brain'"), "got: {err}");
+        assert!(err.contains("hooks/brain.rhai"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn build_agent_rejects_a_workdir_that_is_missing_or_not_a_directory() {
         // `ToolContext::new` silently keeps a path it can't canonicalize, so
         // without this check a bogus workdir spawns a healthy-looking agent

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1395,6 +1395,101 @@ mod tests {
         }
     }
 
+    // ─── resolve_region_scripts ──────────────────────────────────────────
+
+    /// Manifest with a global custom region and a per-stage one, both
+    /// pointing into `hooks/` next to the manifest.
+    fn custom_region_manifest() -> &'static str {
+        "[agent]\nname = \"cr\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+         [context.regions.brain]\nkind = \"custom\"\nscript = \"hooks/brain.rhai\"\nmax_tokens = 4000\n\n\
+         [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+         [stages.main.context.regions.stage_view]\nkind = \"custom\"\nscript = \"hooks/stage.rhai\"\nmax_tokens = 2000\n"
+    }
+
+    #[test]
+    fn resolve_region_scripts_empty_without_custom_regions() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        let bp = leviath_core::manifest::parse_manifest(
+            "[agent]\nname = \"plain\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let scripts = resolve_region_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert!(scripts.is_empty());
+    }
+
+    #[test]
+    fn resolve_region_scripts_collects_global_and_per_stage_layouts() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::create_dir(dir.path().join("hooks")).unwrap();
+        std::fs::write(
+            dir.path().join("hooks/brain.rhai"),
+            "fn render(ctx) { \"b\" }",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("hooks/stage.rhai"),
+            "fn render(ctx) { \"s\" }",
+        )
+        .unwrap();
+        let bp = leviath_core::manifest::parse_manifest(custom_region_manifest()).unwrap();
+        let scripts = resolve_region_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert_eq!(scripts.len(), 2);
+        assert!(scripts.contains_key("hooks/brain.rhai"));
+        assert!(scripts.contains_key("hooks/stage.rhai"));
+    }
+
+    #[test]
+    fn resolve_region_scripts_reads_a_shared_path_once() {
+        // Two regions declaring the same script share one compiled Arc.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::create_dir(dir.path().join("hooks")).unwrap();
+        std::fs::write(
+            dir.path().join("hooks/shared.rhai"),
+            "fn render(ctx) { \"x\" }",
+        )
+        .unwrap();
+        let bp = leviath_core::manifest::parse_manifest(
+            "[agent]\nname = \"cr\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [context.regions.a]\nkind = \"custom\"\nscript = \"hooks/shared.rhai\"\nmax_tokens = 2000\n\n\
+             [context.regions.b]\nkind = \"custom\"\nscript = \"hooks/shared.rhai\"\nmax_tokens = 2000\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let scripts = resolve_region_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert_eq!(scripts.len(), 1);
+    }
+
+    #[test]
+    fn resolve_region_scripts_missing_file_is_a_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        let bp = leviath_core::manifest::parse_manifest(custom_region_manifest()).unwrap();
+        let err = resolve_region_scripts(&bp, &manifest.to_string_lossy()).unwrap_err();
+        assert!(err.contains("region 'brain'"), "{err}");
+        assert!(err.contains("hooks/brain.rhai"), "{err}");
+    }
+
+    #[test]
+    fn resolve_region_scripts_uncompilable_script_is_a_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::create_dir(dir.path().join("hooks")).unwrap();
+        std::fs::write(dir.path().join("hooks/brain.rhai"), "fn render(ctx) {").unwrap();
+        std::fs::write(
+            dir.path().join("hooks/stage.rhai"),
+            "fn render(ctx) { \"s\" }",
+        )
+        .unwrap();
+        let bp = leviath_core::manifest::parse_manifest(custom_region_manifest()).unwrap();
+        let err = resolve_region_scripts(&bp, &manifest.to_string_lossy()).unwrap_err();
+        assert!(err.contains("failed to compile"), "{err}");
+        assert!(err.contains("region 'brain'"), "{err}");
+    }
+
     #[tokio::test]
     async fn build_agent_rejects_a_workdir_that_is_missing_or_not_a_directory() {
         // `ToolContext::new` silently keeps a path it can't canonicalize, so

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -150,6 +150,62 @@ fn script_scan_dirs(
         .collect()
 }
 
+/// Read and compile every custom region's Rhai script declared by `blueprint`
+/// (global layout plus each stage's per-stage layout), keyed by the script
+/// path as written. Paths resolve relative to the blueprint's directory (the
+/// script-tool convention - the script travels with the agent), with absolute
+/// paths passing through `Path::join` unchanged. Each distinct path is read
+/// and compiled once; regions sharing a script share the compiled AST.
+///
+/// A missing or uncompilable script is a **hard spawn error** (fail fast,
+/// before any tokens are spent): a hook that silently never ran would change
+/// every inference with no signal. Runtime hook *eval* failures, by contrast,
+/// warn and fall back per hook.
+pub(crate) fn resolve_region_scripts(
+    blueprint: &Blueprint,
+    blueprint_path: &str,
+) -> Result<HashMap<String, Arc<leviath_scripting::region_hook::RegionScript>>, String> {
+    let base = std::path::Path::new(blueprint_path)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
+    let mut scripts = HashMap::new();
+
+    let layouts = std::iter::once(&blueprint.context_layout).chain(
+        blueprint
+            .stages
+            .iter()
+            .filter_map(|s| s.context_layout.as_ref()),
+    );
+    for layout in layouts {
+        for region in &layout.regions {
+            let leviath_core::RegionKind::Custom { script, .. } = &region.kind else {
+                continue;
+            };
+            if scripts.contains_key(script) {
+                continue;
+            }
+            let path = base.join(script);
+            let source = std::fs::read_to_string(&path).map_err(|e| {
+                format!(
+                    "region '{}': cannot read custom region script '{}': {e}",
+                    region.name,
+                    path.display()
+                )
+            })?;
+            let compiled =
+                leviath_scripting::region_hook::compile(script, &source).map_err(|e| {
+                    format!(
+                        "region '{}': custom region script failed to compile: {e}",
+                        region.name
+                    )
+                })?;
+            scripts.insert(script.clone(), Arc::new(compiled));
+        }
+    }
+    Ok(scripts)
+}
+
 /// Names already claimed by a built-in, sub-agent, or MCP tool - a discovered
 /// script tool colliding with one of these is dropped (never shadows a core tool).
 fn reserved_tool_names(builtin_names: &HashSet<String>, mcp_tool_defs: &[Tool]) -> HashSet<String> {
@@ -814,6 +870,12 @@ fn build_agent_inner(
         HashMap::new()
     };
 
+    // 5b. Read + compile-check custom regions' Rhai scripts (issue #152) -
+    // once per distinct path, blueprint-dir-relative. Runs on fresh spawns
+    // AND reloads (the hooks must work after a restart), and a broken script
+    // is a hard error either way.
+    let region_scripts = resolve_region_scripts(&blueprint, &args.blueprint_path)?;
+
     // 6. Spawn the agent.
     let entity = spawn_agent_seeded(
         world,
@@ -822,6 +884,7 @@ fn build_agent_inner(
         &seeds,
         stages,
         config.batch_tool_hint,
+        region_scripts,
     )?;
 
     // 7. Attach run metadata / token totals / persistence watermark (+ optional

--- a/crates/leviath-cli/src/tui/theme.rs
+++ b/crates/leviath-cli/src/tui/theme.rs
@@ -18,6 +18,8 @@ pub(crate) const C_DIM: Color = Color::DarkGray;
 pub(crate) const C_MUTED: Color = Color::Gray;
 pub(crate) const C_WHITE: Color = Color::White;
 pub(crate) const C_ACTIVE: Color = Color::Cyan;
+/// Script-backed (custom) region kind in the dashboard's region list.
+pub(crate) const C_SCRIPT: Color = Color::Magenta;
 pub(crate) const C_BORDER: Color = Color::DarkGray;
 pub(crate) const C_BORDER_FOCUS: Color = Color::Cyan;
 

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -176,18 +176,36 @@ impl ContextLayout {
             }
         }
 
+        // Reject a Custom region whose script path is empty - it could never
+        // resolve to a file, and the runtime would silently fall back to
+        // Temporary-style rendering on every inference.
+        for region in &self.regions {
+            if let RegionKind::Custom { script, .. } = &region.kind
+                && script.trim().is_empty()
+            {
+                return Err(ValidationError::Region {
+                    region: region.name.clone(),
+                    message: "custom region requires a non-empty script path".to_string(),
+                });
+            }
+        }
+
         // Warn if sum of max tokens exceeds budget (not necessarily an error,
         // since not all regions will be full simultaneously)
         // Warn if no SlidingWindow region exists - agents should have a
         // conversation region for typed message entries, but some agents
-        // (e.g., deep-researcher) use other region kinds exclusively.
-        let has_sliding_window = self
-            .regions
-            .iter()
-            .any(|r| matches!(r.kind, RegionKind::SlidingWindow { .. }));
-        if !has_sliding_window {
+        // (e.g., deep-researcher) use other region kinds exclusively. A Custom
+        // region counts: its script can render typed entries as messages.
+        let has_message_region = self.regions.iter().any(|r| {
+            matches!(
+                r.kind,
+                RegionKind::SlidingWindow { .. } | RegionKind::Custom { .. }
+            )
+        });
+        if !has_message_region {
             tracing::warn!(
-                "Layout has no SlidingWindow region - typed conversation entries require one"
+                "Layout has no SlidingWindow (or custom scripted) region - typed \
+                 conversation entries require one"
             );
         }
 
@@ -224,6 +242,10 @@ impl ContextLayout {
                     RegionKind::Pinned
                         | RegionKind::HashMap { .. }
                         | RegionKind::CompactHistory { .. }
+                        | RegionKind::Custom {
+                            persistent: true,
+                            ..
+                        }
                 )
             })
             .map(|r| r.max_tokens)
@@ -238,7 +260,8 @@ impl ContextLayout {
         {
             return Err(ValidationError::Layout(format!(
                 "context layout leaves only {working_tokens} working tokens after fixed \
-                 regions (pinned/hashmap/compact_history) consume {fixed_tokens} of the {} \
+                 regions (pinned/hashmap/compact_history/persistent custom) consume \
+                 {fixed_tokens} of the {} \
                  total budget; at least {} are needed for the agent to operate. Reduce the \
                  fixed regions' max_tokens or increase the total budget.",
                 self.total_budget_tokens,
@@ -700,6 +723,98 @@ mod tests {
         with_tracing(|| {
             assert!(layout.validate().is_ok());
         });
+    }
+
+    fn custom_kind(script: &str, persistent: bool) -> RegionKind {
+        RegionKind::Custom {
+            script: script.to_string(),
+            persistent,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_custom_region_with_empty_script() {
+        // Whitespace-only counts as empty: it could never resolve to a file
+        // and the runtime would silently fall back on every inference.
+        let regions = vec![RegionDefinition::new(
+            "brain".to_string(),
+            custom_kind("   ", false),
+            5000,
+        )];
+        let layout = ContextLayout::new(regions, 10_000);
+        let err = with_tracing(|| layout.validate().unwrap_err());
+        assert!(
+            err.to_string().contains("non-empty script path"),
+            "actionable error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_counts_persistent_custom_as_fixed_budget() {
+        // A persistent custom region is Pinned-like: protected from eviction,
+        // so it must count toward the fixed budget that can starve the
+        // working room.
+        let regions = vec![
+            RegionDefinition::new("vault".to_string(), custom_kind("v.rhai", true), 95_000),
+            RegionDefinition::new("work".to_string(), RegionKind::Temporary, 5_000),
+        ];
+        let layout = ContextLayout::new(regions, 100_000);
+        let err = with_tracing(|| layout.validate().unwrap_err());
+        assert!(err.to_string().contains("working tokens"), "{err}");
+    }
+
+    #[test]
+    fn validate_counts_non_persistent_custom_as_working_budget() {
+        // Same shape, but the custom region is evictable - it IS the working
+        // room, so validation passes.
+        let regions = vec![
+            RegionDefinition::new("brain".to_string(), custom_kind("b.rhai", false), 95_000),
+            RegionDefinition::new("task".to_string(), RegionKind::Pinned, 4_000),
+        ];
+        let layout = ContextLayout::new(regions, 100_000);
+        with_tracing(|| {
+            assert!(layout.validate().is_ok());
+        });
+    }
+
+    #[test]
+    fn custom_region_satisfies_the_message_region_check() {
+        // A layout whose only region is custom must not trip the "no
+        // SlidingWindow region" warning path - its script can render typed
+        // entries as messages. (Mirrors the sliding-window-present test: the
+        // skip branch is exercised, validation succeeds.)
+        let regions = vec![RegionDefinition::new(
+            "everything".to_string(),
+            custom_kind("all.rhai", false),
+            9_000,
+        )];
+        let layout = ContextLayout::new(regions, 10_000);
+        with_tracing(|| {
+            assert!(layout.validate().is_ok());
+        });
+    }
+
+    #[test]
+    fn resolved_percent_budget_applies_to_custom_region() {
+        // The "recreate built-ins in Rhai" guarantee: percentage budgets work
+        // on custom regions exactly as on built-in kinds, resolved against
+        // the stage model's context window at spawn.
+        let def = RegionDefinition::new("brain".to_string(), custom_kind("b.rhai", false), 0)
+            .with_budget(BudgetSpec::Percent {
+                percent: 0.40,
+                min: Some(10_000),
+                max: None,
+            });
+        let layout = ContextLayout::new(vec![def], 0);
+        let resolved = layout.resolved(200_000);
+        assert_eq!(resolved.regions[0].max_tokens, 80_000);
+        assert!(matches!(
+            resolved.regions[0].kind,
+            RegionKind::Custom { ref script, persistent: false } if script == "b.rhai"
+        ));
+        // The min floor wins on a small window.
+        let small = layout.resolved(8_192);
+        assert_eq!(small.regions[0].max_tokens, 10_000);
     }
 
     #[test]

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -983,7 +983,17 @@ fn parse_region_layout(
                     .unwrap_or(false);
                 RegionKind::Custom { script, persistent }
             }
-            _ => RegionKind::Temporary,
+            unknown => {
+                // A typo'd kind used to silently become Temporary - for a
+                // custom region that would mean the script never runs, with
+                // no signal anywhere. Fail at load instead; `lev validate`
+                // surfaces this immediately.
+                return Err(Error::Other(format!(
+                    "region '{region_name}': unknown kind \"{unknown}\" (valid kinds: \
+                     pinned, sliding_window, temporary, compacting, clearable, \
+                     compact_history, hashmap, custom)"
+                )));
+            }
         };
 
         // The effective compact_at fraction to store on the region: an explicit
@@ -3077,17 +3087,22 @@ name = "no-regions"
     }
 
     #[test]
-    fn parse_manifest_unknown_region_kind_defaults_to_temporary() {
+    fn parse_manifest_unknown_region_kind_is_a_hard_error() {
+        // A typo'd kind used to silently become Temporary - for a custom
+        // region that meant the script never ran, with no signal. The error
+        // names the region, the bad value, and the valid kinds.
         let toml = r#"
 [agent]
 name = "unknown-kind"
 
 [context.regions]
-test = { kind = "unknown_kind", max_tokens = 1000 }
+test = { kind = "cusotm", max_tokens = 1000 }
 "#;
-        let bp = parse_manifest(toml).unwrap();
-        let region = &bp.context_layout.regions[0];
-        assert_eq!(region.kind, RegionKind::Temporary);
+        let err = parse_manifest(toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("region 'test'"), "{msg}");
+        assert!(msg.contains("cusotm"), "{msg}");
+        assert!(msg.contains("valid kinds"), "{msg}");
     }
 
     #[test]

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -964,6 +964,25 @@ fn parse_region_layout(
                     .map(|v| v as usize);
                 RegionKind::HashMap { max_entries }
             }
+            "custom" => {
+                let script = region_value
+                    .get("script")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        Error::Other(format!(
+                            "region '{region_name}': kind = \"custom\" requires \
+                             script = \"<path>.rhai\""
+                        ))
+                    })?
+                    .to_string();
+                let persistent = region_value
+                    .get("persistent")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                RegionKind::Custom { script, persistent }
+            }
             _ => RegionKind::Temporary,
         };
 
@@ -1491,6 +1510,142 @@ mode = "autonomous"
         let err = parse_manifest(toml).unwrap_err().to_string();
         assert!(err.contains("unknown transform"), "got: {err}");
         assert!(err.contains("teleport"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_custom_region_kind() {
+        let toml = r#"
+[agent]
+name = "custom-region-test"
+
+[context.regions]
+brain = { kind = "custom", script = "context_hooks/brain.rhai", persistent = true, max_tokens = 5000 }
+scratch = { kind = "custom", script = "context_hooks/scratch.rhai", max_tokens = 2000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let brain = bp
+            .context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == "brain")
+            .unwrap();
+        assert_eq!(
+            brain.kind,
+            RegionKind::Custom {
+                script: "context_hooks/brain.rhai".to_string(),
+                persistent: true,
+            }
+        );
+        // persistent defaults to false when omitted.
+        let scratch = bp
+            .context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == "scratch")
+            .unwrap();
+        assert_eq!(
+            scratch.kind,
+            RegionKind::Custom {
+                script: "context_hooks/scratch.rhai".to_string(),
+                persistent: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_manifest_custom_region_requires_script() {
+        // Missing script is a load-time hard error, not a silent fallback.
+        let missing = r#"
+[agent]
+name = "bad"
+
+[context.regions]
+brain = { kind = "custom", max_tokens = 5000 }
+"#;
+        let err = parse_manifest(missing).unwrap_err();
+        assert!(
+            err.to_string().contains("requires"),
+            "actionable error: {err}"
+        );
+
+        // An empty/whitespace script path is equally dead - same error.
+        let empty = r#"
+[agent]
+name = "bad"
+
+[context.regions]
+brain = { kind = "custom", script = "  ", max_tokens = 5000 }
+"#;
+        let err = parse_manifest(empty).unwrap_err();
+        assert!(err.to_string().contains("requires"), "{err}");
+    }
+
+    #[test]
+    fn parse_manifest_custom_region_with_percent_budget() {
+        // Percentage budgets work on custom regions exactly as on built-ins.
+        let toml = r#"
+[agent]
+name = "pct-custom"
+
+[context.regions]
+brain = { kind = "custom", script = "b.rhai", budget = "40%", min_tokens = 10000 }
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let brain = bp
+            .context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == "brain")
+            .unwrap();
+        assert!(brain.budget.is_percent());
+        let resolved = bp.context_layout.resolved(200_000);
+        assert_eq!(
+            resolved
+                .regions
+                .iter()
+                .find(|r| r.name == "brain")
+                .unwrap()
+                .max_tokens,
+            80_000
+        );
+    }
+
+    #[test]
+    fn parse_manifest_per_stage_custom_region() {
+        // A per-stage layout can declare a custom region only that stage uses.
+        let toml = r#"
+[agent]
+name = "stage-custom"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000 }
+
+[stages.plan]
+[stages.plan.model]
+provider = "anthropic"
+model = "claude-sonnet-4"
+
+[stages.plan.context.regions]
+plan_view = { kind = "custom", script = "hooks/plan.rhai", max_tokens = 6000 }
+
+[stages.implement]
+[stages.implement.model]
+provider = "anthropic"
+model = "claude-sonnet-4"
+
+[stages.plan.transitions.implement]
+condition = "always"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let plan = bp.stages.iter().find(|s| s.name == "plan").unwrap();
+        let layout = plan.context_layout.as_ref().unwrap();
+        assert!(layout.regions.iter().any(|r| matches!(
+            &r.kind,
+            RegionKind::Custom { script, persistent: false } if script == "hooks/plan.rhai"
+        )));
+        // Sibling stage inherits the global layout (no per-stage override).
+        let implement = bp.stages.iter().find(|s| s.name == "implement").unwrap();
+        assert!(implement.context_layout.is_none());
     }
 
     #[test]

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -491,6 +491,37 @@ impl Region {
         Ok(())
     }
 
+    /// Carry an already-accepted entry into this region verbatim, preserving
+    /// its [`EntryKind`], metadata, key, and timestamp.
+    ///
+    /// Used when a stage-layout swap rebuilds a region and moves its surviving
+    /// content across: re-adding through [`add_entry`](Self::add_entry) would
+    /// stamp every carried entry [`EntryKind::Text`], destroying the typed
+    /// `tool_use`/`tool_result` pairing the assembler needs (the orphan
+    /// sanitizer would then strip the whole history). Skips schema validation
+    /// deliberately - the entry passed it when first accepted - but keeps the
+    /// budget check and sliding-window enforcement so the destination region's
+    /// limits still hold. Taint is not touched per entry: a carry copies the
+    /// region-level [`crate::taint::RegionTaint`] wholesale instead of
+    /// re-accumulating it.
+    pub fn carry_entry(&mut self, entry: RegionEntry) -> crate::error::Result<()> {
+        // Check token budget
+        if self.current_tokens + entry.tokens > self.max_tokens {
+            return Err(crate::error::Error::TokenBudgetExceeded {
+                used: self.current_tokens + entry.tokens,
+                max: self.max_tokens,
+            });
+        }
+
+        self.current_tokens += entry.tokens;
+        self.content.push(entry);
+
+        // Enforce SlidingWindow max_items limit
+        self.enforce_sliding_window();
+
+        Ok(())
+    }
+
     /// Upsert an entry by key. If key exists, replace content and update timestamp/tokens.
     /// If key doesn't exist, add new entry. Enforces max_tokens and max_entries via LRU eviction.
     pub fn upsert_by_key(
@@ -953,6 +984,77 @@ mod tests {
             }
         );
         assert_ne!(RegionKind::Pinned, RegionKind::Temporary);
+    }
+
+    #[test]
+    fn carry_entry_preserves_kind_metadata_key_and_timestamp() {
+        let mut source = Region::new("conversation".to_string(), RegionKind::Temporary, 10_000);
+        source
+            .add_typed_entry(
+                "result body".to_string(),
+                10,
+                EntryKind::ToolResult {
+                    tool_call_id: "call_1".to_string(),
+                    tool_name: "read_file".to_string(),
+                    is_error: false,
+                },
+            )
+            .unwrap();
+        let mut entry = source.content[0].clone();
+        entry.metadata = Some(serde_json::json!({"origin": "test"}));
+        entry.key = Some("k".to_string());
+        let stamped = entry.timestamp;
+
+        let mut dest = Region::new("conversation".to_string(), RegionKind::Temporary, 10_000);
+        dest.carry_entry(entry).unwrap();
+
+        let carried = &dest.content[0];
+        assert!(matches!(
+            &carried.kind,
+            EntryKind::ToolResult { tool_call_id, .. } if tool_call_id == "call_1"
+        ));
+        assert_eq!(
+            carried.metadata,
+            Some(serde_json::json!({"origin": "test"}))
+        );
+        assert_eq!(carried.key.as_deref(), Some("k"));
+        assert_eq!(carried.timestamp, stamped);
+        assert_eq!(dest.current_tokens, 10);
+    }
+
+    #[test]
+    fn carry_entry_rejects_over_budget() {
+        let mut dest = Region::new("small".to_string(), RegionKind::Temporary, 5);
+        let mut source = Region::new("src".to_string(), RegionKind::Temporary, 100);
+        source.add_entry("filler".to_string(), 10).unwrap();
+        let err = dest.carry_entry(source.content[0].clone()).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::TokenBudgetExceeded { used: 10, max: 5 }
+        ));
+        assert!(dest.content.is_empty());
+        assert_eq!(dest.current_tokens, 0);
+    }
+
+    #[test]
+    fn carry_entry_enforces_sliding_window_max_items() {
+        let mut source = Region::new("src".to_string(), RegionKind::Temporary, 10_000);
+        for i in 0..4 {
+            source.add_entry(format!("msg{i}"), 10).unwrap();
+        }
+        let mut dest = Region::new(
+            "conv".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 3,
+                eviction_strategy: EvictionStrategy::PerItem,
+            },
+            10_000,
+        );
+        for entry in &source.content {
+            dest.carry_entry(entry.clone()).unwrap();
+        }
+        assert_eq!(dest.content.len(), 3);
+        assert_eq!(dest.content[0].content, "msg1");
     }
 
     #[test]

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -142,6 +142,29 @@ pub enum RegionKind {
         /// Optional maximum number of keys
         max_entries: Option<usize>,
     },
+
+    /// Script-backed region: a user-authored Rhai script owns how the region
+    /// renders into the assembled context (`render`), may transform or reject
+    /// each incoming entry (`on_write`), and may choose what to drop under
+    /// budget pressure (`on_overflow`).
+    ///
+    /// `script` is the blueprint-dir-relative path to the `.rhai` file; path
+    /// resolution and compilation happen in the CLI spawner (this crate stays
+    /// filesystem-free), and the compiled script travels on the runtime's
+    /// context window keyed by this path. `persistent` regions behave like
+    /// [`Pinned`](Self::Pinned) for lifecycle - never evicted, immune to edge
+    /// `Clear` transforms, counted as fixed budget - while non-persistent
+    /// regions behave like [`Temporary`](Self::Temporary).
+    ///
+    /// Note: this kind is orthogonal to [`RegionSchema`]'s (unwired)
+    /// `custom_script` field, which is a content-*validation* concept.
+    Custom {
+        /// Blueprint-dir-relative path to the Rhai script backing this region
+        script: String,
+        /// Lifecycle: `true` = Pinned-like (protected, fixed budget),
+        /// `false` = Temporary-like (stage-specific, evictable)
+        persistent: bool,
+    },
 }
 
 impl PartialEq for RegionKind {
@@ -174,6 +197,16 @@ impl PartialEq for RegionKind {
                 Self::CompactHistory { source_region: b },
             ) => a == b,
             (Self::HashMap { max_entries: a }, Self::HashMap { max_entries: b }) => a == b,
+            (
+                Self::Custom {
+                    script: a,
+                    persistent: pa,
+                },
+                Self::Custom {
+                    script: b,
+                    persistent: pb,
+                },
+            ) => a == b && pa == pb,
             _ => false,
         }
     }
@@ -193,6 +226,16 @@ impl RegionKind {
             },
             RegionKind::HashMap { .. } => crate::cache::CacheHint::UntilChanged,
             RegionKind::Temporary | RegionKind::Clearable => crate::cache::CacheHint::Never,
+            // A persistent custom region is Pinned-like: its rendered output is
+            // expected to be stable. Non-persistent custom content changes on
+            // writes, like Compacting/HashMap.
+            RegionKind::Custom { persistent, .. } => {
+                if *persistent {
+                    crate::cache::CacheHint::Always
+                } else {
+                    crate::cache::CacheHint::UntilChanged
+                }
+            }
         }
     }
 }
@@ -984,6 +1027,64 @@ mod tests {
             }
         );
         assert_ne!(RegionKind::Pinned, RegionKind::Temporary);
+    }
+
+    #[test]
+    fn custom_kind_equality_compares_script_and_persistent() {
+        let a = RegionKind::Custom {
+            script: "conv.rhai".to_string(),
+            persistent: false,
+        };
+        assert_eq!(a, a.clone());
+        assert_ne!(
+            a,
+            RegionKind::Custom {
+                script: "other.rhai".to_string(),
+                persistent: false,
+            }
+        );
+        assert_ne!(
+            a,
+            RegionKind::Custom {
+                script: "conv.rhai".to_string(),
+                persistent: true,
+            }
+        );
+        assert_ne!(a, RegionKind::Temporary);
+    }
+
+    #[test]
+    fn custom_kind_serde_round_trips() {
+        let kind = RegionKind::Custom {
+            script: "hooks/conv.rhai".to_string(),
+            persistent: true,
+        };
+        let json = serde_json::to_string(&kind).unwrap();
+        let back: RegionKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(kind, back);
+        // Pre-existing serialized kinds still deserialize (additive variant).
+        let old: RegionKind = serde_json::from_str("\"Pinned\"").unwrap();
+        assert_eq!(old, RegionKind::Pinned);
+    }
+
+    #[test]
+    fn custom_kind_cache_hint_follows_persistent() {
+        assert_eq!(
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: true,
+            }
+            .cache_hint(),
+            crate::cache::CacheHint::Always
+        );
+        assert_eq!(
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            }
+            .cache_hint(),
+            crate::cache::CacheHint::UntilChanged
+        );
     }
 
     #[test]

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -1129,10 +1129,7 @@ mod tests {
         let mut source = Region::new("src".to_string(), RegionKind::Temporary, 100);
         source.add_entry("filler".to_string(), 10).unwrap();
         let err = dest.carry_entry(source.content[0].clone()).unwrap_err();
-        assert!(matches!(
-            err,
-            crate::error::Error::TokenBudgetExceeded { used: 10, max: 5 }
-        ));
+        assert_eq!(err.to_string(), "Content exceeds token budget: 10 > 5");
         assert!(dest.content.is_empty());
         assert_eq!(dest.current_tokens, 0);
     }

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -15,6 +15,9 @@ publish = false
 
 [dependencies]
 leviath-core = { workspace = true }
+# Custom-region Rhai hooks (render/on_write/on_overflow). The boundary is
+# JSON-in/JSON-out, so this crate needs no direct rhai dependency.
+leviath-scripting = { workspace = true }
 # Control-channel token generation.
 rand = { workspace = true }
 leviath-providers = { workspace = true }

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -306,10 +306,17 @@ impl ContextWindow {
         let initial_tokens = self.current_tokens;
 
         // Check if we have any evictable regions
-        let has_evictable = self
-            .regions
-            .iter()
-            .any(|r| matches!(r.kind, RegionKind::Clearable | RegionKind::Temporary));
+        let has_evictable = self.regions.iter().any(|r| {
+            matches!(
+                r.kind,
+                RegionKind::Clearable
+                    | RegionKind::Temporary
+                    | RegionKind::Custom {
+                        persistent: false,
+                        ..
+                    }
+            )
+        });
 
         if !has_evictable {
             tracing::warn!(
@@ -339,13 +346,23 @@ impl ContextWindow {
             }
         }
 
-        // Phase 2: Evict from Temporary regions (oldest first, one at a time)
+        // Phase 2: Evict from Temporary regions (oldest first, one at a time).
+        // Non-persistent Custom regions join this phase: their script's
+        // on_overflow hook (when present) has already had its say via
+        // `evict_custom_regions` before this cascade runs; oldest-first is
+        // the guaranteed-progress fallback.
         loop {
             let mut evicted_any = false;
 
             for region in &mut self.regions {
-                if matches!(region.kind, RegionKind::Temporary)
-                    && let Some(entry) = region.remove_oldest()
+                if matches!(
+                    region.kind,
+                    RegionKind::Temporary
+                        | RegionKind::Custom {
+                            persistent: false,
+                            ..
+                        }
+                ) && let Some(entry) = region.remove_oldest()
                 {
                     let freed = entry.tokens;
                     self.current_tokens -= freed;
@@ -391,7 +408,12 @@ impl ContextWindow {
             .filter(|r| {
                 matches!(
                     r.kind,
-                    RegionKind::Pinned | RegionKind::CompactHistory { .. }
+                    RegionKind::Pinned
+                        | RegionKind::CompactHistory { .. }
+                        | RegionKind::Custom {
+                            persistent: true,
+                            ..
+                        }
                 )
             })
             .map(|r| r.current_tokens)
@@ -587,6 +609,24 @@ impl ContextWindow {
                     });
                 }
                 leviath_core::RegionKind::Clearable => {
+                    let text = region
+                        .content
+                        .iter()
+                        .map(|e| e.content.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    system_blocks.push(leviath_providers::SystemBlock {
+                        text: format!("[{}]:\n{}", region.name, text),
+                        cache_hint: CacheHint::Never,
+                    });
+                }
+
+                // Custom (script-backed) regions render through their Rhai
+                // hook via `assemble_with_meta`; this plain-`assemble` arm is
+                // the hook-less fallback shape - a Temporary-style block - so
+                // a custom region is never silently dropped even when no
+                // compiled script is available.
+                leviath_core::RegionKind::Custom { .. } => {
                     let text = region
                         .content
                         .iter()
@@ -2190,6 +2230,74 @@ mod tests {
             assembled.system_blocks[0].cache_hint,
             leviath_core::CacheHint::Never
         );
+    }
+
+    fn custom_kind(script: &str, persistent: bool) -> RegionKind {
+        RegionKind::Custom {
+            script: script.to_string(),
+            persistent,
+        }
+    }
+
+    #[test]
+    fn test_assemble_custom_region_falls_back_to_temporary_style_block() {
+        // Plain `assemble()` has no compiled script available, so a custom
+        // region renders as the hook-less fallback: a Temporary-style block -
+        // never silently dropped.
+        let mut window = ContextWindow::new(100_000);
+        let mut region = Region::new("brain".to_string(), custom_kind("b.rhai", false), 10_000);
+        region.add_entry("thought one".to_string(), 10).unwrap();
+        region.add_entry("thought two".to_string(), 10).unwrap();
+        window.add_region(region);
+
+        let assembled = window.assemble();
+
+        assert_eq!(assembled.system_blocks.len(), 1);
+        assert_eq!(
+            assembled.system_blocks[0].text,
+            "[brain]:\nthought one\n\nthought two"
+        );
+        assert_eq!(
+            assembled.system_blocks[0].cache_hint,
+            leviath_core::CacheHint::Never
+        );
+    }
+
+    #[test]
+    fn try_evict_evicts_non_persistent_custom_regions_oldest_first() {
+        let mut window = ContextWindow::new(100);
+        let mut region = Region::new("brain".to_string(), custom_kind("b.rhai", false), 100);
+        region.add_entry("old".to_string(), 40).unwrap();
+        region.add_entry("new".to_string(), 40).unwrap();
+        window.add_region(region);
+        window.current_tokens = 80;
+
+        let result = with_tracing(|| window.try_evict(30).unwrap());
+        assert!(result.tokens_freed >= 40);
+        let brain = window.get_region("brain").unwrap();
+        assert_eq!(brain.content.len(), 1);
+        assert_eq!(brain.content[0].content, "new");
+    }
+
+    #[test]
+    fn try_evict_never_touches_persistent_custom_and_counts_it_as_pinned() {
+        // Persistent custom content survives eviction, and when it alone
+        // exceeds the whole window budget the pinned over-budget guard fires.
+        let mut window = ContextWindow::new(50);
+        let mut vault = Region::new("vault".to_string(), custom_kind("v.rhai", true), 100);
+        vault.add_entry("precious".to_string(), 60).unwrap();
+        window.add_region(vault);
+        window.current_tokens = 60;
+
+        let err = with_tracing(|| window.try_evict(10).unwrap_err());
+        assert!(matches!(
+            err,
+            leviath_core::Error::PinnedRegionsOverBudget {
+                pinned_tokens: 60,
+                total_budget: 50,
+            }
+        ));
+        assert_eq!(window.get_region("vault").unwrap().content.len(), 1);
     }
 
     // ─── assemble() EntryKind::Text prefix parsing ────────────────────────

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -263,7 +263,9 @@ impl ContextWindow {
             return Some((content, tokens));
         }
         // The region exists - custom_script_for resolved through it.
-        let region = self.get_region(region_name)?;
+        let region = self
+            .get_region(region_name)
+            .expect("custom_script_for resolved through this region");
         match crate::custom_region::apply_on_write(&script, region, content, tokens, kind) {
             crate::custom_region::OnWriteOutcome::Accept(content, tokens) => {
                 Some((content, tokens))
@@ -284,9 +286,9 @@ impl ContextWindow {
         if !script.has_on_overflow() {
             return false;
         }
-        let Some(region) = self.get_region_mut(region_name) else {
-            return false;
-        };
+        let region = self
+            .get_region_mut(region_name)
+            .expect("custom_script_for resolved through this region");
         let needed = (region.current_tokens + incoming_tokens).saturating_sub(region.max_tokens);
         let freed = crate::custom_region::apply_overflow(&script, region, needed);
         self.current_tokens = self.calculate_tokens();
@@ -2481,13 +2483,10 @@ mod tests {
         window.current_tokens = 60;
 
         let err = with_tracing(|| window.try_evict(10).unwrap_err());
-        assert!(matches!(
-            err,
-            leviath_core::Error::PinnedRegionsOverBudget {
-                pinned_tokens: 60,
-                total_budget: 50,
-            }
-        ));
+        assert_eq!(
+            err.to_string(),
+            "Pinned regions (60) exceed total budget (50)"
+        );
         assert_eq!(window.get_region("vault").unwrap().content.len(), 1);
     }
 
@@ -2584,6 +2583,109 @@ mod tests {
     }
 
     #[test]
+    fn custom_region_on_write_drop_covers_typed_and_tainted_methods() {
+        // Every write method's drop arm, not just add_to_region's.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { false }
+        "#;
+        let mut window = custom_window(src, false);
+        window
+            .add_typed_entry(
+                "brain",
+                leviath_core::EntryKind::UserMessage,
+                "a".to_string(),
+                1,
+            )
+            .unwrap();
+        window
+            .add_tainted_to_region(
+                "brain",
+                "b".to_string(),
+                1,
+                leviath_core::TaintLevel::Public,
+            )
+            .unwrap();
+        window
+            .add_typed_tainted_to_region(
+                "brain",
+                leviath_core::EntryKind::UserMessage,
+                "c".to_string(),
+                1,
+                leviath_core::TaintLevel::Public,
+            )
+            .unwrap();
+        assert!(window.get_region("brain").unwrap().content.is_empty());
+    }
+
+    #[test]
+    fn try_evict_skips_custom_region_whose_script_has_no_on_overflow() {
+        // Phase 1.5 leaves the choice to phase 2 (oldest-first) when the
+        // script defines no on_overflow.
+        let mut window = ContextWindow::new(100);
+        window.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            100,
+        ));
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(
+                leviath_scripting::region_hook::compile("s.rhai", "fn render(ctx) { \"\" }")
+                    .unwrap(),
+            ),
+        );
+        window
+            .add_to_region("brain", "old".to_string(), 40)
+            .unwrap();
+        window
+            .add_to_region("brain", "new".to_string(), 40)
+            .unwrap();
+
+        let result = with_tracing(|| window.try_evict(30).unwrap());
+        assert!(result.tokens_freed >= 40);
+        let brain = window.get_region("brain").unwrap();
+        assert_eq!(brain.content.len(), 1);
+        assert_eq!(brain.content[0].content, "new", "oldest-first fallback ran");
+    }
+
+    #[test]
+    fn try_evict_falls_to_oldest_first_when_script_frees_nothing() {
+        // on_overflow returns [] under pressure: phase 1.5 frees 0 and phase 2
+        // makes the progress.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) { [] }
+        "#;
+        let mut window = ContextWindow::new(100);
+        window.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            100,
+        ));
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(leviath_scripting::region_hook::compile("s.rhai", src).unwrap()),
+        );
+        window
+            .add_to_region("brain", "old".to_string(), 40)
+            .unwrap();
+        window
+            .add_to_region("brain", "new".to_string(), 40)
+            .unwrap();
+
+        let result = with_tracing(|| window.try_evict(30).unwrap());
+        assert!(result.tokens_freed >= 40);
+        assert_eq!(window.get_region("brain").unwrap().content.len(), 1);
+    }
+
+    #[test]
     fn non_custom_regions_bypass_the_on_write_seam() {
         // A script table entry exists, but the region is plain Temporary - the
         // hook must not fire for it.
@@ -2607,7 +2709,7 @@ mod tests {
         let err = window
             .add_to_region("ghost", "x".to_string(), 1)
             .unwrap_err();
-        assert!(matches!(err, leviath_core::Error::RegionNotFound(_)));
+        assert!(err.to_string().contains("ghost"), "{err}");
     }
 
     #[test]
@@ -2646,10 +2748,7 @@ mod tests {
             .unwrap();
         let err =
             with_tracing(|| window.add_to_region("brain", "too much".to_string(), 50)).unwrap_err();
-        assert!(matches!(
-            err,
-            leviath_core::Error::TokenBudgetExceeded { .. }
-        ));
+        assert_eq!(err.to_string(), "Content exceeds token budget: 140 > 100");
         assert_eq!(window.get_region("brain").unwrap().content.len(), 1);
     }
 
@@ -2662,10 +2761,7 @@ mod tests {
         let err = window
             .add_to_region("brain", "too much".to_string(), 50)
             .unwrap_err();
-        assert!(matches!(
-            err,
-            leviath_core::Error::TokenBudgetExceeded { .. }
-        ));
+        assert_eq!(err.to_string(), "Content exceeds token budget: 140 > 100");
     }
 
     #[test]
@@ -2813,11 +2909,8 @@ mod tests {
         assert!(assembled.system_blocks.is_empty());
         assert_eq!(assembled.messages.len(), 1);
         assert_eq!(assembled.messages[0].role, "user");
-        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
-            panic!("script emitted a text message");
-        };
         assert_eq!(
-            text,
+            assembled.messages[0].content.as_text(),
             "<context><event kind=\"user_message\">do the task</event>\
              <event kind=\"tool_result\">output</event></context>"
         );
@@ -2831,10 +2924,7 @@ mod tests {
         let assembled = window.assemble();
         assert!(assembled.system_blocks.is_empty());
         assert_eq!(assembled.messages.len(), 1);
-        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
-            panic!("Begin. fallback is text");
-        };
-        assert_eq!(text, "Begin.");
+        assert_eq!(assembled.messages[0].content.as_text(), "Begin.");
     }
 
     #[test]
@@ -2855,10 +2945,7 @@ mod tests {
         let window = custom_window(src, false);
         let assembled = window.assemble();
         assert_eq!(assembled.messages.len(), 1, "orphan tool_result stripped");
-        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
-            panic!("surviving message is the text one");
-        };
-        assert_eq!(text, "hello");
+        assert_eq!(assembled.messages[0].content.as_text(), "hello");
     }
 
     // ─── assemble() EntryKind::Text prefix parsing ────────────────────────

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -204,6 +204,18 @@ pub struct ContextWindow {
 
     /// Maximum token budget
     pub max_tokens: usize,
+
+    /// Compiled custom-region scripts, keyed by the script path each
+    /// `RegionKind::Custom` carries. Populated once at spawn by the CLI
+    /// (which resolves blueprint-dir-relative paths and compile-checks the
+    /// files); a stage-layout swap rebuilds `regions` but leaves this table
+    /// untouched, so per-stage custom regions keep working. Empty when no
+    /// custom regions exist - every hook lookup then misses and the region
+    /// renders its fallback shape.
+    pub region_scripts: std::collections::HashMap<
+        String,
+        std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
+    >,
 }
 
 impl ContextWindow {
@@ -213,7 +225,72 @@ impl ContextWindow {
             regions: Vec::new(),
             current_tokens: 0,
             max_tokens,
+            region_scripts: std::collections::HashMap::new(),
         }
+    }
+
+    /// The compiled script backing `region_name`, when it is a custom region
+    /// whose script path has an entry in [`Self::region_scripts`].
+    fn custom_script_for(
+        &self,
+        region_name: &str,
+    ) -> Option<std::sync::Arc<leviath_scripting::region_hook::RegionScript>> {
+        let region = self.get_region(region_name)?;
+        let leviath_core::RegionKind::Custom { script, .. } = &region.kind else {
+            return None;
+        };
+        self.region_scripts.get(script).cloned()
+    }
+
+    /// Run a custom region's `on_write` hook (when defined) for an incoming
+    /// entry. `None` means the script dropped the entry - the write reports
+    /// success without storing anything. Non-custom regions, missing scripts,
+    /// and hook failures all accept the entry unchanged.
+    ///
+    /// Deliberately NOT invoked by the layout-swap carry or restore overlay:
+    /// those re-add entries the hook already accepted once.
+    fn on_write_outcome(
+        &self,
+        region_name: &str,
+        content: String,
+        tokens: usize,
+        kind: &leviath_core::EntryKind,
+    ) -> Option<(String, usize)> {
+        let Some(script) = self.custom_script_for(region_name) else {
+            return Some((content, tokens));
+        };
+        if !script.has_on_write() {
+            return Some((content, tokens));
+        }
+        // The region exists - custom_script_for resolved through it.
+        let region = self.get_region(region_name)?;
+        match crate::custom_region::apply_on_write(&script, region, content, tokens, kind) {
+            crate::custom_region::OnWriteOutcome::Accept(content, tokens) => {
+                Some((content, tokens))
+            }
+            crate::custom_region::OnWriteOutcome::Drop => None,
+        }
+    }
+
+    /// Retry hook for a custom-region write that hit `TokenBudgetExceeded`:
+    /// let the script's `on_overflow` free room, then report whether a single
+    /// retry is worthwhile. Non-custom regions and hook failures leave the
+    /// original error standing (the callers' existing truncation ladders
+    /// apply).
+    fn try_custom_overflow(&mut self, region_name: &str, incoming_tokens: usize) -> bool {
+        let Some(script) = self.custom_script_for(region_name) else {
+            return false;
+        };
+        if !script.has_on_overflow() {
+            return false;
+        }
+        let Some(region) = self.get_region_mut(region_name) else {
+            return false;
+        };
+        let needed = (region.current_tokens + incoming_tokens).saturating_sub(region.max_tokens);
+        let freed = crate::custom_region::apply_overflow(&script, region, needed);
+        self.current_tokens = self.calculate_tokens();
+        freed >= needed && needed > 0
     }
 
     /// Get a region by name.
@@ -239,13 +316,14 @@ impl ContextWindow {
         content: String,
         tokens: usize,
     ) -> leviath_core::Result<()> {
-        if let Some(region) = self.get_region_mut(region_name) {
-            region.add_entry(content, tokens)?;
-            self.current_tokens = self.calculate_tokens();
-            Ok(())
-        } else {
-            Err(leviath_core::Error::RegionNotFound(region_name.to_string()))
-        }
+        let Some((content, tokens)) =
+            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
+        else {
+            return Ok(()); // the region's script dropped the entry
+        };
+        self.write_to_region(region_name, tokens, &mut |region, tokens| {
+            region.add_entry(content.clone(), tokens)
+        })
     }
 
     /// Replace a region's entire content with a single entry (clear, then add).
@@ -253,6 +331,14 @@ impl ContextWindow {
     /// authoritative document region (e.g. the plan) holding only its current
     /// version, so revisions build on it instead of accumulating stale copies.
     pub fn replace_region(&mut self, region_name: &str, content: String, tokens: usize) -> bool {
+        // The replacement passes through on_write like any incoming entry - a
+        // custom region's script sees (and may transform or refuse) it.
+        let Some((content, tokens)) =
+            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
+        else {
+            // Dropped by the script: the region keeps its current content.
+            return self.get_region(region_name).is_some();
+        };
         if let Some(region) = self.get_region_mut(region_name) {
             region.clear();
             let _ = region.add_entry(content, tokens);
@@ -275,12 +361,46 @@ impl ContextWindow {
         content: String,
         tokens: usize,
     ) -> leviath_core::Result<()> {
-        if let Some(region) = self.get_region_mut(region_name) {
-            region.add_typed_entry(content, tokens, kind)?;
-            self.current_tokens = self.calculate_tokens();
-            Ok(())
-        } else {
-            Err(leviath_core::Error::RegionNotFound(region_name.to_string()))
+        let Some((content, tokens)) = self.on_write_outcome(region_name, content, tokens, &kind)
+        else {
+            return Ok(());
+        };
+        self.write_to_region(region_name, tokens, &mut |region, tokens| {
+            region.add_typed_entry(content.clone(), tokens, kind.clone())
+        })
+    }
+
+    /// Shared tail of every region write: run the insert, give a custom
+    /// region's `on_overflow` one shot at freeing room when the budget
+    /// rejects it, and recount the window. A `&mut dyn FnMut` (not generic)
+    /// keeps one instantiation for the coverage gate.
+    fn write_to_region(
+        &mut self,
+        region_name: &str,
+        tokens: usize,
+        insert: &mut dyn FnMut(&mut Region, usize) -> leviath_core::Result<()>,
+    ) -> leviath_core::Result<()> {
+        if self.get_region(region_name).is_none() {
+            return Err(leviath_core::Error::RegionNotFound(region_name.to_string()));
+        }
+        let first = {
+            let region = self.get_region_mut(region_name).expect("checked above");
+            insert(region, tokens)
+        };
+        match first {
+            Ok(()) => {
+                self.current_tokens = self.calculate_tokens();
+                Ok(())
+            }
+            Err(leviath_core::Error::TokenBudgetExceeded { .. })
+                if self.try_custom_overflow(region_name, tokens) =>
+            {
+                let region = self.get_region_mut(region_name).expect("checked above");
+                let retried = insert(region, tokens);
+                self.current_tokens = self.calculate_tokens();
+                retried
+            }
+            Err(e) => Err(e),
         }
     }
 
@@ -346,11 +466,65 @@ impl ContextWindow {
             }
         }
 
+        // Phase 1.5: Give each non-persistent custom region's on_overflow
+        // hook first say over what IT loses, before the indiscriminate
+        // oldest-first cascade below. A script that keeps errors and drops
+        // successes only works if it runs before oldest-first does. Hook
+        // absent/failing/insufficient → phase 2 makes the guaranteed
+        // progress.
+        let mut custom_freed = 0usize;
+        for i in 0..self.regions.len() {
+            let needed = target_free_tokens
+                .saturating_sub(self.max_tokens.saturating_sub(self.current_tokens));
+            if needed == 0 {
+                break;
+            }
+            let region = &self.regions[i];
+            if !matches!(
+                region.kind,
+                RegionKind::Custom {
+                    persistent: false,
+                    ..
+                }
+            ) || region.content.is_empty()
+            {
+                continue;
+            }
+            let Some(script) = self.custom_script_for(&region.name.clone()) else {
+                continue;
+            };
+            if !script.has_on_overflow() {
+                continue;
+            }
+            let freed = crate::custom_region::apply_overflow(&script, &mut self.regions[i], needed);
+            self.current_tokens = self.current_tokens.saturating_sub(freed);
+            custom_freed += freed;
+            if freed > 0 {
+                tracing::debug!(
+                    region = %self.regions[i].name,
+                    tokens_freed = freed,
+                    "custom region's on_overflow chose its own evictions"
+                );
+            }
+        }
+        // Return early ONLY when a script's own drops satisfied the target -
+        // otherwise phase 2 would immediately evict one more entry (it checks
+        // the target *after* each eviction), overriding the script's
+        // retention choice. Windows with no custom drops (custom_freed == 0)
+        // fall through with phase 2's pre-existing behavior, byte-identical.
+        if custom_freed > 0
+            && self.max_tokens.saturating_sub(self.current_tokens) >= target_free_tokens
+        {
+            return Ok(EvictionResult {
+                tokens_freed: initial_tokens - self.current_tokens,
+                needs_compaction: Vec::new(),
+            });
+        }
+
         // Phase 2: Evict from Temporary regions (oldest first, one at a time).
         // Non-persistent Custom regions join this phase: their script's
-        // on_overflow hook (when present) has already had its say via
-        // `evict_custom_regions` before this cascade runs; oldest-first is
-        // the guaranteed-progress fallback.
+        // on_overflow hook (when present) has already had its say in phase
+        // 1.5; oldest-first is the guaranteed-progress fallback.
         loop {
             let mut evicted_any = false;
 
@@ -436,14 +610,31 @@ impl ContextWindow {
     ///
     /// System-bound regions become `system_blocks`; the messages region
     /// becomes `messages` with proper typed entries (no text-prefix parsing).
+    ///
+    /// Thin wrapper over [`assemble_with_meta`](Self::assemble_with_meta) with
+    /// no stage metadata - custom-region scripts see empty stage fields.
     pub fn assemble(&self) -> AssembledContext {
+        self.assemble_with_meta(&crate::custom_region::AssembleMeta::default())
+    }
+
+    /// [`assemble`](Self::assemble) with stage metadata for custom-region
+    /// `render(ctx)` hooks (stage name, per-stage iteration count, model).
+    /// The inference path (`build_request`) threads real values; other
+    /// callers use the default.
+    pub fn assemble_with_meta(
+        &self,
+        meta: &crate::custom_region::AssembleMeta,
+    ) -> AssembledContext {
         use leviath_core::{CacheHint, EntryKind};
 
         let mut system_blocks = Vec::new();
         let mut messages: Vec<leviath_providers::Message> = Vec::new();
 
         for region in &self.regions {
-            if region.content.is_empty() {
+            // Custom regions render even when empty - a script may emit
+            // static scaffolding. Every other kind skips an empty region.
+            let is_custom = matches!(region.kind, leviath_core::RegionKind::Custom { .. });
+            if region.content.is_empty() && !is_custom {
                 continue;
             }
 
@@ -622,21 +813,20 @@ impl ContextWindow {
                 }
 
                 // Custom (script-backed) regions render through their Rhai
-                // hook via `assemble_with_meta`; this plain-`assemble` arm is
-                // the hook-less fallback shape - a Temporary-style block - so
-                // a custom region is never silently dropped even when no
-                // compiled script is available.
-                leviath_core::RegionKind::Custom { .. } => {
-                    let text = region
-                        .content
-                        .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: format!("[{}]:\n{}", region.name, text),
-                        cache_hint: CacheHint::Never,
-                    });
+                // hook; a missing script or any hook failure falls back to
+                // the Temporary-style block inside `render_custom_region`,
+                // so a custom region is never silently dropped.
+                leviath_core::RegionKind::Custom { script, persistent } => {
+                    crate::custom_region::render_custom_region(
+                        region,
+                        self.region_scripts.get(script),
+                        *persistent,
+                        meta,
+                        self.current_tokens,
+                        self.max_tokens,
+                        &mut system_blocks,
+                        &mut messages,
+                    );
                 }
 
                 // HashMap regions → system blocks with key headers
@@ -803,13 +993,14 @@ impl ContextWindow {
         tokens: usize,
         taint_level: leviath_core::TaintLevel,
     ) -> leviath_core::Result<()> {
-        if let Some(region) = self.get_region_mut(region_name) {
-            region.add_tainted_entry(content, tokens, taint_level)?;
-            self.current_tokens = self.calculate_tokens();
-            Ok(())
-        } else {
-            Err(leviath_core::Error::RegionNotFound(region_name.to_string()))
-        }
+        let Some((content, tokens)) =
+            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
+        else {
+            return Ok(());
+        };
+        self.write_to_region(region_name, tokens, &mut |region, tokens| {
+            region.add_tainted_entry(content.clone(), tokens, taint_level)
+        })
     }
 
     /// Add a typed entry to a region with a specific taint level.
@@ -826,13 +1017,13 @@ impl ContextWindow {
         tokens: usize,
         taint_level: leviath_core::TaintLevel,
     ) -> leviath_core::Result<()> {
-        if let Some(region) = self.get_region_mut(region_name) {
-            region.add_typed_tainted_entry(content, tokens, kind, taint_level)?;
-            self.current_tokens = self.calculate_tokens();
-            Ok(())
-        } else {
-            Err(leviath_core::Error::RegionNotFound(region_name.to_string()))
-        }
+        let Some((content, tokens)) = self.on_write_outcome(region_name, content, tokens, &kind)
+        else {
+            return Ok(());
+        };
+        self.write_to_region(region_name, tokens, &mut |region, tokens| {
+            region.add_typed_tainted_entry(content.clone(), tokens, kind.clone(), taint_level)
+        })
     }
 
     /// Get the overall taint level (max across all regions).
@@ -2298,6 +2489,376 @@ mod tests {
             }
         ));
         assert_eq!(window.get_region("vault").unwrap().content.len(), 1);
+    }
+
+    /// A window with one custom region (`brain`, budget 100) backed by `src`,
+    /// compiled and installed in the script table under "s.rhai".
+    fn custom_window(src: &str, persistent: bool) -> ContextWindow {
+        let mut window = ContextWindow::new(10_000);
+        window.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent,
+            },
+            100,
+        ));
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(leviath_scripting::region_hook::compile("s.rhai", src).unwrap()),
+        );
+        window
+    }
+
+    #[test]
+    fn custom_region_on_write_fires_across_all_write_methods() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { `${ctx.entry.kind}:${ctx.entry.content}` }
+        "#;
+        let mut window = custom_window(src, false);
+
+        window.add_to_region("brain", "a".to_string(), 1).unwrap();
+        window
+            .add_typed_entry(
+                "brain",
+                leviath_core::EntryKind::UserMessage,
+                "b".to_string(),
+                1,
+            )
+            .unwrap();
+        window
+            .add_tainted_to_region(
+                "brain",
+                "c".to_string(),
+                1,
+                leviath_core::TaintLevel::Public,
+            )
+            .unwrap();
+        window
+            .add_typed_tainted_to_region(
+                "brain",
+                leviath_core::EntryKind::UserMessage,
+                "d".to_string(),
+                1,
+                leviath_core::TaintLevel::Public,
+            )
+            .unwrap();
+
+        let contents: Vec<_> = window
+            .get_region("brain")
+            .unwrap()
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["text:a", "user_message:b", "text:c", "user_message:d"],
+            "every write method passes through on_write with the entry kind visible"
+        );
+        // Token counts were re-estimated for the replacements.
+        assert_eq!(window.current_tokens, window.calculate_tokens());
+
+        assert!(window.replace_region("brain", "e".to_string(), 1));
+        let region = window.get_region("brain").unwrap();
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content, "text:e");
+    }
+
+    #[test]
+    fn custom_region_on_write_drop_reports_success_without_storing() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { false }
+        "#;
+        let mut window = custom_window(src, false);
+        window
+            .add_to_region("brain", "spam".to_string(), 1)
+            .unwrap();
+        assert!(window.get_region("brain").unwrap().content.is_empty());
+
+        // A dropped replacement leaves existing content in place.
+        assert!(window.replace_region("brain", "more spam".to_string(), 1));
+        assert!(window.get_region("brain").unwrap().content.is_empty());
+    }
+
+    #[test]
+    fn non_custom_regions_bypass_the_on_write_seam() {
+        // A script table entry exists, but the region is plain Temporary - the
+        // hook must not fire for it.
+        let mut window = custom_window(
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { \"MANGLED\" }",
+            false,
+        );
+        window.add_region(Region::new("plain".to_string(), RegionKind::Temporary, 100));
+        window
+            .add_to_region("plain", "untouched".to_string(), 2)
+            .unwrap();
+        assert_eq!(
+            window.get_region("plain").unwrap().content[0].content,
+            "untouched"
+        );
+    }
+
+    #[test]
+    fn write_to_missing_region_still_errors() {
+        let mut window = custom_window("fn render(ctx) { \"\" }", false);
+        let err = window
+            .add_to_region("ghost", "x".to_string(), 1)
+            .unwrap_err();
+        assert!(matches!(err, leviath_core::Error::RegionNotFound(_)));
+    }
+
+    #[test]
+    fn custom_region_add_time_overflow_retries_after_script_drops() {
+        // Region budget 100: fill with 90, then add 20 - over budget. The
+        // script drops entry 0 (90 tokens), freeing room; the retry succeeds.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) { [0] }
+        "#;
+        let mut window = custom_window(src, false);
+        window
+            .add_to_region("brain", "big".to_string(), 90)
+            .unwrap();
+        window
+            .add_to_region("brain", "next".to_string(), 20)
+            .unwrap();
+
+        let region = window.get_region("brain").unwrap();
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content, "next");
+        assert_eq!(window.current_tokens, 20);
+    }
+
+    #[test]
+    fn custom_region_add_time_overflow_propagates_when_still_too_big() {
+        // The script frees nothing, so the retry path never runs and the
+        // original budget error propagates to the caller's ladders.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) { [] }
+        "#;
+        let mut window = custom_window(src, false);
+        window
+            .add_to_region("brain", "big".to_string(), 90)
+            .unwrap();
+        let err =
+            with_tracing(|| window.add_to_region("brain", "too much".to_string(), 50)).unwrap_err();
+        assert!(matches!(
+            err,
+            leviath_core::Error::TokenBudgetExceeded { .. }
+        ));
+        assert_eq!(window.get_region("brain").unwrap().content.len(), 1);
+    }
+
+    #[test]
+    fn custom_region_without_on_overflow_gets_no_retry() {
+        let mut window = custom_window("fn render(ctx) { \"\" }", false);
+        window
+            .add_to_region("brain", "big".to_string(), 90)
+            .unwrap();
+        let err = window
+            .add_to_region("brain", "too much".to_string(), 50)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            leviath_core::Error::TokenBudgetExceeded { .. }
+        ));
+    }
+
+    #[test]
+    fn try_evict_lets_custom_script_choose_what_to_drop() {
+        // The script keeps errors, drops successes - the retention choice the
+        // oldest-first cascade could never make. Window is small so eviction
+        // has real pressure.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) {
+                let drops = [];
+                for (entry, i) in ctx.entries {
+                    if !entry.content.contains("ERROR") { drops.push(i); }
+                }
+                drops
+            }
+        "#;
+        let mut window = ContextWindow::new(100);
+        window.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            100,
+        ));
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(leviath_scripting::region_hook::compile("s.rhai", src).unwrap()),
+        );
+        window
+            .add_to_region("brain", "ok one".to_string(), 30)
+            .unwrap();
+        window
+            .add_to_region("brain", "ERROR two".to_string(), 30)
+            .unwrap();
+        window
+            .add_to_region("brain", "ok three".to_string(), 30)
+            .unwrap();
+
+        let result = with_tracing(|| window.try_evict(40)).unwrap();
+        assert!(result.tokens_freed >= 40);
+        let contents: Vec<_> = window
+            .get_region("brain")
+            .unwrap()
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["ERROR two"],
+            "script retention choice honored"
+        );
+    }
+
+    // ─── assemble(): custom regions ──────────────────────────────────────
+
+    #[test]
+    fn assemble_custom_region_renders_through_script() {
+        let src = r#"fn render(ctx) { `<brain iter=${ctx.stage_iterations}>` }"#;
+        let mut window = custom_window(src, false);
+        window
+            .add_to_region("brain", "note".to_string(), 2)
+            .unwrap();
+
+        // Default meta via plain assemble().
+        let assembled = window.assemble();
+        assert_eq!(assembled.system_blocks.len(), 1);
+        assert_eq!(assembled.system_blocks[0].text, "<brain iter=0>");
+        assert_eq!(
+            assembled.system_blocks[0].cache_hint,
+            leviath_core::CacheHint::UntilChanged
+        );
+
+        // Real meta via assemble_with_meta.
+        let assembled = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
+            stage_name: "plan".to_string(),
+            stage_iterations: 7,
+            model: "m".to_string(),
+        });
+        assert_eq!(assembled.system_blocks[0].text, "<brain iter=7>");
+    }
+
+    #[test]
+    fn assemble_custom_region_renders_even_when_empty() {
+        // Static scaffolding: the script emits structure with no entries.
+        let src = r#"fn render(ctx) { `<empty count=${ctx.entries.len()}>` }"#;
+        let window = custom_window(src, false);
+        let assembled = window.assemble();
+        assert_eq!(assembled.system_blocks.len(), 1);
+        assert_eq!(assembled.system_blocks[0].text, "<empty count=0>");
+    }
+
+    #[test]
+    fn assemble_custom_conversation_takeover_renders_single_user_message() {
+        // The 12-factor case: a custom region NAMED conversation holds the
+        // typed history and renders it as one XML user message. No sliding
+        // window exists; the request's only message is the script's.
+        let src = r#"
+            fn render(ctx) {
+                let xml = "<context>";
+                for entry in ctx.entries {
+                    xml += `<event kind="${entry.kind}">${entry.content}</event>`;
+                }
+                xml += "</context>";
+                #{ messages: [ #{ role: "user", content: xml } ] }
+            }
+        "#;
+        let mut window = ContextWindow::new(10_000);
+        window.add_region(Region::new(
+            "conversation".to_string(),
+            RegionKind::Custom {
+                script: "conv.rhai".to_string(),
+                persistent: false,
+            },
+            5_000,
+        ));
+        window.region_scripts.insert(
+            "conv.rhai".to_string(),
+            std::sync::Arc::new(leviath_scripting::region_hook::compile("conv.rhai", src).unwrap()),
+        );
+        window
+            .add_typed_entry(
+                "conversation",
+                leviath_core::EntryKind::UserMessage,
+                "do the task".to_string(),
+                4,
+            )
+            .unwrap();
+        window
+            .add_typed_entry(
+                "conversation",
+                leviath_core::EntryKind::ToolResult {
+                    tool_call_id: "c1".to_string(),
+                    tool_name: "shell".to_string(),
+                    is_error: false,
+                },
+                "output".to_string(),
+                2,
+            )
+            .unwrap();
+
+        let assembled = window.assemble();
+        assert!(assembled.system_blocks.is_empty());
+        assert_eq!(assembled.messages.len(), 1);
+        assert_eq!(assembled.messages[0].role, "user");
+        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
+            panic!("script emitted a text message");
+        };
+        assert_eq!(
+            text,
+            "<context><event kind=\"user_message\">do the task</event>\
+             <event kind=\"tool_result\">output</event></context>"
+        );
+    }
+
+    #[test]
+    fn assemble_custom_script_emitting_nothing_gets_begin_fallback() {
+        // A script that emits no messages leaves the request message-less;
+        // the shared finalization injects the "Begin." user message.
+        let window = custom_window("fn render(ctx) { \"\" }", false);
+        let assembled = window.assemble();
+        assert!(assembled.system_blocks.is_empty());
+        assert_eq!(assembled.messages.len(), 1);
+        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
+            panic!("Begin. fallback is text");
+        };
+        assert_eq!(text, "Begin.");
+    }
+
+    #[test]
+    fn assemble_custom_unpaired_tool_blocks_are_sanitized() {
+        // A buggy script emits a tool_result with no matching tool_use; the
+        // orphan sanitizer strips it instead of sending a provider-invalid
+        // request.
+        let src = r#"
+            fn render(ctx) {
+                #{ messages: [
+                    #{ role: "user", content: "hello" },
+                    #{ role: "user", tool_results: [
+                        #{ tool_call_id: "ghost", content: "orphan" },
+                    ] },
+                ] }
+            }
+        "#;
+        let window = custom_window(src, false);
+        let assembled = window.assemble();
+        assert_eq!(assembled.messages.len(), 1, "orphan tool_result stripped");
+        let leviath_providers::MessageContent::Text(text) = &assembled.messages[0].content else {
+            panic!("surviving message is the text one");
+        };
+        assert_eq!(text, "hello");
     }
 
     // ─── assemble() EntryKind::Text prefix parsing ────────────────────────

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -147,9 +147,17 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         );
 
         if let Some(existing) = window.get_region(&region_def.name) {
+            // Carry entries verbatim - kind, metadata, key, timestamp survive
+            // the swap. Rebuilding via `add_entry` flattened every carried
+            // entry to `EntryKind::Text`, which destroyed the typed tool_use/
+            // tool_result pairing of any message-bearing region and left the
+            // assembler's orphan sanitizer to strip the whole history.
             for entry in &existing.content {
-                let _ = new_region.add_entry(entry.content.clone(), entry.tokens);
+                let _ = new_region.carry_entry(entry.clone());
             }
+            // The region-level taint state carries wholesale too; the rebuild
+            // used to silently reset it.
+            new_region.taint = existing.taint.clone();
         }
 
         kept.insert(region_def.name.as_str());
@@ -171,9 +179,12 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
                 existing.kind.clone(),
                 existing.max_tokens,
             );
+            // Same verbatim carry as above: these are exactly the regions whose
+            // typed turns the transition must not flatten.
             for entry in &existing.content {
-                let _ = carried.add_entry(entry.content.clone(), entry.tokens);
+                let _ = carried.carry_entry(entry.clone());
             }
+            carried.taint = existing.taint.clone();
             new_regions.push(carried);
         }
     }
@@ -488,6 +499,100 @@ mod tests {
         // Token total recomputed from the surviving content.
         assert_eq!(window.current_tokens, window.calculate_tokens());
         assert!(window.current_tokens > 0);
+    }
+
+    #[test]
+    fn apply_layout_preserves_entry_kinds_and_taint_across_swap() {
+        // Regression: the carry used to rebuild entries via `add_entry`, which
+        // stamped every carried entry `EntryKind::Text` (destroying tool_use/
+        // tool_result pairing) and silently reset region-level taint.
+        let bp = blueprint_with(vec![RegionDefinition::new(
+            "task".to_string(),
+            RegionKind::Pinned,
+            5000,
+        )]);
+        let mut window = seeded_window(&bp, "the task");
+        window
+            .add_typed_entry(
+                "conversation",
+                leviath_core::EntryKind::AssistantTurn {
+                    tool_calls: vec![leviath_core::SerializedToolCall {
+                        id: "call_9".to_string(),
+                        name: "shell".to_string(),
+                        arguments: serde_json::json!({"command": "ls"}),
+                        thought_signature: None,
+                    }],
+                },
+                "running ls".to_string(),
+                10,
+            )
+            .unwrap();
+        window
+            .add_typed_entry(
+                "conversation",
+                leviath_core::EntryKind::ToolResult {
+                    tool_call_id: "call_9".to_string(),
+                    tool_name: "shell".to_string(),
+                    is_error: false,
+                },
+                "file_a\nfile_b".to_string(),
+                10,
+            )
+            .unwrap();
+        window
+            .get_region_mut("conversation")
+            .unwrap()
+            .enable_taint_tracking();
+
+        // Swap 1: layout omits conversation (the infra-carry loop).
+        let omitting = ContextLayout::new(
+            vec![RegionDefinition::new(
+                "task".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            8000,
+        );
+        apply_layout(&mut window, &omitting);
+
+        // Swap 2: layout declares conversation (the by-name carry loop).
+        let declaring = ContextLayout::new(
+            vec![
+                RegionDefinition::new("task".to_string(), RegionKind::Pinned, 5000),
+                RegionDefinition::new(
+                    "conversation".to_string(),
+                    RegionKind::SlidingWindow {
+                        max_items: 10,
+                        eviction_strategy: EvictionStrategy::PerItem,
+                    },
+                    10_000,
+                ),
+            ],
+            20_000,
+        );
+        apply_layout(&mut window, &declaring);
+
+        let conv = window.get_region("conversation").unwrap();
+        assert!(
+            conv.content.iter().any(|e| matches!(
+                &e.kind,
+                leviath_core::EntryKind::AssistantTurn { tool_calls }
+                    if tool_calls.iter().any(|c| c.id == "call_9")
+            )),
+            "assistant turn must keep its typed tool_calls through both carry paths"
+        );
+        assert!(
+            conv.content.iter().any(|e| matches!(
+                &e.kind,
+                leviath_core::EntryKind::ToolResult { tool_call_id, .. }
+                    if tool_call_id == "call_9"
+            )),
+            "tool result must keep its typed pairing through both carry paths"
+        );
+        assert!(
+            conv.taint.is_some(),
+            "region-level taint state must carry across layout swaps"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -588,8 +588,17 @@ mod tests {
             },
             100,
         ));
+        w.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "b.rhai".to_string(),
+                persistent: false,
+            },
+            100,
+        ));
         let all = call(&mut w, "context_list", json!({}));
         assert!(all.contains("temporary") && all.contains("summarized when full"));
+        assert!(all.contains("scripted"), "custom region label: {all}");
 
         // No regions configured.
         let mut empty = ContextWindow::new(100_000);

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -213,6 +213,7 @@ pub fn handle_context_tool(
                         RegionKind::Clearable => "temporary",
                         RegionKind::CompactHistory { .. } => "summary archive",
                         RegionKind::HashMap { .. } => "key-value store",
+                        RegionKind::Custom { .. } => "scripted",
                     };
                     lines.push(format!(
                         "  {} ({}): {} entries, {}/{} tokens",

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -65,8 +65,11 @@ pub fn handle_context_tool(
                     Err(e) => format!("[error] {e}"),
                 }
             } else {
+                // Through the window method (not region.add_entry directly)
+                // so a custom region's on_write hook sees the write.
                 region.clear();
-                match region.add_entry(content.to_string(), tokens) {
+                window.current_tokens = window.calculate_tokens();
+                match window.add_to_region(region_name, content.to_string(), tokens) {
                     Ok(()) => format!("Stored in '{region_name}' section."),
                     Err(e) => format!("[error] {e}"),
                 }
@@ -110,7 +113,8 @@ pub fn handle_context_tool(
                     }
                 }
             } else {
-                match region.add_entry(content.to_string(), tokens) {
+                // Same routing rationale as context_write above.
+                match window.add_to_region(region_name, content.to_string(), tokens) {
                     Ok(()) => format!("Appended to '{region_name}' section."),
                     Err(e) => format!("[error] {e}"),
                 }

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -658,26 +658,18 @@ mod tests {
         );
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[0].role, "user");
-        let leviath_providers::MessageContent::Blocks(assistant) = &messages[1].content else {
-            panic!("assistant tool_calls message must be block content");
-        };
-        assert!(matches!(
-            &assistant[0],
-            leviath_providers::ContentBlock::Text { text } if text == "thinking"
-        ));
-        assert!(matches!(
-            &assistant[1],
-            leviath_providers::ContentBlock::ToolUse { id, name, .. }
-                if id == "c1" && name == "shell"
-        ));
-        let leviath_providers::MessageContent::Blocks(results) = &messages[2].content else {
-            panic!("tool_results message must be block content");
-        };
-        assert!(matches!(
-            &results[0],
-            leviath_providers::ContentBlock::ToolResult { tool_use_id, content, is_error }
-                if tool_use_id == "c1" && content == "file_a" && !is_error
-        ));
+        // Assert the wire shapes through serde - no enum destructuring, so
+        // there are no never-taken match arms for the coverage gate.
+        let assistant = serde_json::to_value(&messages[1].content).unwrap();
+        assert_eq!(assistant[0], json!({ "type": "text", "text": "thinking" }));
+        assert_eq!(assistant[1]["type"], json!("tool_use"));
+        assert_eq!(assistant[1]["id"], json!("c1"));
+        assert_eq!(assistant[1]["name"], json!("shell"));
+        let results = serde_json::to_value(&messages[2].content).unwrap();
+        assert_eq!(results[0]["type"], json!("tool_result"));
+        assert_eq!(results[0]["tool_use_id"], json!("c1"));
+        assert_eq!(results[0]["content"], json!("file_a"));
+        assert_eq!(results[0]["is_error"], json!(false));
     }
 
     #[test]
@@ -796,6 +788,71 @@ mod tests {
     }
 
     #[test]
+    fn render_invalid_shape_on_empty_region_emits_nothing() {
+        // The invalid-shape fallback has nothing to fall back TO when the
+        // region is empty - no block at all.
+        let region = region_with(&[]);
+        let (blocks, messages) = render(&region, Some(&script("fn render(ctx) { 42 }")), false);
+        assert!(blocks.is_empty());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn render_empty_single_system_string_is_skipped() {
+        let src = r#"fn render(ctx) { #{ system: "" } }"#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (blocks, messages) = render(&region, Some(&script(src)), false);
+        assert!(blocks.is_empty());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn render_tool_call_passes_thought_signature_through() {
+        let src = r#"
+            fn render(ctx) {
+                #{ messages: [#{ role: "assistant", tool_calls: [
+                    #{ id: "c", name: "n", thought_signature: "sig123" },
+                ] }] }
+            }
+        "#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (_, messages) = render(&region, Some(&script(src)), false);
+        let blocks = serde_json::to_value(&messages[0].content).unwrap();
+        assert_eq!(blocks[0]["thought_signature"], json!("sig123"));
+    }
+
+    #[test]
+    fn on_write_ctx_reports_every_entry_kind() {
+        // The kind string the script sees matches the entry's typed kind.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { ctx.entry.kind }
+        "#;
+        for (kind, expected) in [
+            (EntryKind::Text, "text"),
+            (EntryKind::UserMessage, "user_message"),
+            (
+                EntryKind::AssistantTurn { tool_calls: vec![] },
+                "assistant_turn",
+            ),
+            (
+                EntryKind::ToolResult {
+                    tool_call_id: "c".to_string(),
+                    tool_name: "t".to_string(),
+                    is_error: false,
+                },
+                "tool_result",
+            ),
+        ] {
+            let replaced = on_write_kind(src, "x", &kind);
+            assert_eq!(
+                replaced.map(|(content, _)| content),
+                Some(expected.to_string())
+            );
+        }
+    }
+
+    #[test]
     fn render_assistant_tool_call_defaults_arguments_and_signature() {
         let src = r#"
             fn render(ctx) {
@@ -804,29 +861,31 @@ mod tests {
         "#;
         let region = region_with(&[("x", EntryKind::Text)]);
         let (_, messages) = render(&region, Some(&script(src)), false);
-        let leviath_providers::MessageContent::Blocks(blocks) = &messages[0].content else {
-            panic!("blocks expected");
-        };
-        assert!(matches!(
-            &blocks[0],
-            leviath_providers::ContentBlock::ToolUse { input, thought_signature, .. }
-                if input == &json!({}) && thought_signature.is_none()
-        ));
+        let blocks = serde_json::to_value(&messages[0].content).unwrap();
+        assert_eq!(blocks[0]["type"], json!("tool_use"));
+        assert_eq!(blocks[0]["input"], json!({}));
+        // Indexing a missing key yields Null, so this covers absent-or-null
+        // without a short-circuit branch the coverage gate can't see taken.
+        assert_eq!(blocks[0]["thought_signature"], serde_json::Value::Null);
     }
 
     // ─── on_write ────────────────────────────────────────────────────────
 
-    fn on_write_of(src: &str, content: &str) -> OnWriteOutcome {
+    /// Run `apply_on_write` and collapse the outcome to an Option - both
+    /// enum arms are exercised across this suite (through this one shared
+    /// mapping), so it has no never-taken branch.
+    fn on_write_kind(src: &str, content: &str, kind: &EntryKind) -> Option<(String, usize)> {
         let region = region_with(&[]);
-        with_tracing(|| {
-            apply_on_write(
-                &script(src),
-                &region,
-                content.to_string(),
-                5,
-                &EntryKind::Text,
-            )
-        })
+        let outcome =
+            with_tracing(|| apply_on_write(&script(src), &region, content.to_string(), 5, kind));
+        match outcome {
+            OnWriteOutcome::Accept(content, tokens) => Some((content, tokens)),
+            OnWriteOutcome::Drop => None,
+        }
+    }
+
+    fn on_write_of(src: &str, content: &str) -> Option<(String, usize)> {
+        on_write_kind(src, content, &EntryKind::Text)
     }
 
     #[test]
@@ -835,25 +894,25 @@ mod tests {
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { ctx.entry.content.to_upper() }",
             "hi",
         );
-        let OnWriteOutcome::Accept(content, tokens) = replaced else {
-            panic!("expected accept");
-        };
-        assert_eq!(content, "HI");
-        assert_eq!(tokens, leviath_core::estimate_tokens("HI"));
+        assert_eq!(
+            replaced,
+            Some(("HI".to_string(), leviath_core::estimate_tokens("HI")))
+        );
 
         for accept_body in ["true", ""] {
             let src = format!("fn render(ctx) {{ \"\" }}\nfn on_write(ctx) {{ {accept_body} }}");
-            let OnWriteOutcome::Accept(content, tokens) = on_write_of(&src, "orig") else {
-                panic!("expected accept for body {accept_body:?}");
-            };
-            assert_eq!(content, "orig");
-            assert_eq!(tokens, 5, "original token count preserved");
+            assert_eq!(
+                on_write_of(&src, "orig"),
+                Some(("orig".to_string(), 5)),
+                "body {accept_body:?} accepts unchanged with original tokens"
+            );
         }
 
-        assert!(matches!(
+        assert_eq!(
             on_write_of("fn render(ctx) { \"\" }\nfn on_write(ctx) { false }", "x"),
-            OnWriteOutcome::Drop
-        ));
+            None,
+            "false drops the entry"
+        );
     }
 
     #[test]
@@ -862,11 +921,11 @@ mod tests {
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { 42 }",
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { throw \"bad\" }",
         ] {
-            let OnWriteOutcome::Accept(content, tokens) = on_write_of(src, "keep") else {
-                panic!("expected accept for {src}");
-            };
-            assert_eq!(content, "keep");
-            assert_eq!(tokens, 5);
+            assert_eq!(
+                on_write_of(src, "keep"),
+                Some(("keep".to_string(), 5)),
+                "src: {src}"
+            );
         }
     }
 

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -1,0 +1,918 @@
+//! Runtime side of script-backed custom regions (`RegionKind::Custom`).
+//!
+//! The scripting layer ([`leviath_scripting::region_hook`]) compiles and runs
+//! the hooks; this module owns everything on the runtime side of that JSON
+//! boundary: building the `ctx` objects a hook receives, interpreting each
+//! hook's returned value, and every fallback. The contract is that a hook
+//! failure can never fail an inference or lose a write:
+//!
+//! - `render` failure → the region renders as a Temporary-style block
+//!   (`[{name}]:\n…`, `Never` cache hint) and a warning names the script.
+//! - `on_write` failure → the entry is accepted unchanged.
+//! - `on_overflow` failure or invalid indices → oldest-first eviction.
+
+use std::sync::Arc;
+
+use leviath_core::{EntryKind, Region, RegionEntry};
+use leviath_scripting::region_hook::{RegionScript, run_on_overflow, run_on_write, run_render};
+
+/// Stage-level metadata threaded into `render(ctx)`. `Default` (empty name,
+/// zero iterations, empty model) is used by callers with no stage context -
+/// the transition-choice request and plain `assemble()` in tests.
+#[derive(Debug, Clone, Default)]
+pub struct AssembleMeta {
+    /// Current stage name (`AgentState::current_stage`).
+    pub stage_name: String,
+    /// Inference count within the current stage (`StageProgress::iterations`).
+    pub stage_iterations: usize,
+    /// Model id serving this stage.
+    pub model: String,
+}
+
+/// What `on_write` decided about an incoming entry.
+pub(crate) enum OnWriteOutcome {
+    /// Store the entry with this (possibly replaced) content and token count.
+    Accept(String, usize),
+    /// The script declined the entry; report success to the writer.
+    Drop,
+}
+
+/// Serialize one region entry for a hook ctx. Typed metadata crosses as plain
+/// data so a script can key decisions off tool ids/names, but it is read-only:
+/// hooks return instructions (drop indices, replacement text), never entries.
+fn entry_to_json(entry: &RegionEntry) -> serde_json::Value {
+    let mut obj = serde_json::json!({
+        "content": entry.content,
+        "tokens": entry.tokens,
+        "timestamp": entry.timestamp,
+        "key": entry.key,
+    });
+    let (kind, extra) = match &entry.kind {
+        EntryKind::Text => ("text", None),
+        EntryKind::UserMessage => ("user_message", None),
+        EntryKind::AssistantTurn { tool_calls } => (
+            "assistant_turn",
+            Some((
+                "tool_calls",
+                serde_json::to_value(tool_calls).unwrap_or_default(),
+            )),
+        ),
+        EntryKind::ToolResult {
+            tool_call_id,
+            tool_name,
+            is_error,
+        } => {
+            obj["tool_call_id"] = serde_json::json!(tool_call_id);
+            obj["tool_name"] = serde_json::json!(tool_name);
+            obj["is_error"] = serde_json::json!(is_error);
+            ("tool_result", None)
+        }
+    };
+    obj["kind"] = serde_json::json!(kind);
+    if let Some((k, v)) = extra {
+        obj[k] = v;
+    }
+    obj
+}
+
+/// The `region` sub-object shared by all three hook ctx shapes.
+fn region_to_json(region: &Region) -> serde_json::Value {
+    serde_json::json!({
+        "name": region.name,
+        "budget": region.max_tokens,
+        "current_tokens": region.current_tokens,
+        "entry_count": region.content.len(),
+    })
+}
+
+/// The Temporary-style block a custom region falls back to whenever its hook
+/// can't run or misbehaves - identical to the plain-`assemble` arm, so the
+/// region is never silently dropped.
+fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
+    let text = region
+        .content
+        .iter()
+        .map(|e| e.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    leviath_providers::SystemBlock {
+        text: format!("[{}]:\n{}", region.name, text),
+        cache_hint: leviath_core::CacheHint::Never,
+    }
+}
+
+/// Render a custom region through its script, appending the results to the
+/// caller's block/message accumulators. Any failure falls back to the
+/// Temporary-style block with a warning; success is followed by a warn-only
+/// token re-check against the region's budget (no truncation - the opt-in
+/// exact-token preflight remains the hard guard).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn render_custom_region(
+    region: &Region,
+    script: Option<&Arc<RegionScript>>,
+    persistent: bool,
+    meta: &AssembleMeta,
+    window_current: usize,
+    window_max: usize,
+    system_blocks: &mut Vec<leviath_providers::SystemBlock>,
+    messages: &mut Vec<leviath_providers::Message>,
+) {
+    let Some(script) = script else {
+        // No compiled script on the window (plain `assemble()` callers, or a
+        // spawn path that skipped resolution). Same shape as a hook failure.
+        if !region.content.is_empty() {
+            tracing::warn!(
+                region = %region.name,
+                "custom region has no compiled script; rendering fallback block"
+            );
+            system_blocks.push(fallback_block(region));
+        }
+        return;
+    };
+
+    let ctx = serde_json::json!({
+        "region": region_to_json(region),
+        "entries": region.content.iter().map(entry_to_json).collect::<Vec<_>>(),
+        "stage_name": meta.stage_name,
+        "stage_iterations": meta.stage_iterations,
+        "model": meta.model,
+        "window": { "total_tokens": window_current, "max_tokens": window_max },
+    });
+
+    let rendered = match run_render(script, ctx) {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(
+                region = %region.name,
+                script = %script.path,
+                error = %e,
+                "custom region render failed; using fallback block"
+            );
+            if !region.content.is_empty() {
+                system_blocks.push(fallback_block(region));
+            }
+            return;
+        }
+    };
+
+    match parse_render_output(&rendered, persistent) {
+        Ok((blocks, msgs)) => {
+            let emitted_tokens: usize = blocks
+                .iter()
+                .map(|b| leviath_core::estimate_tokens(&b.text))
+                .chain(msgs.iter().map(|m| {
+                    match &m.content {
+                        leviath_providers::MessageContent::Text(t) => {
+                            leviath_core::estimate_tokens(t)
+                        }
+                        leviath_providers::MessageContent::Blocks(bs) => bs
+                            .iter()
+                            .map(|b| match b {
+                                leviath_providers::ContentBlock::Text { text } => {
+                                    leviath_core::estimate_tokens(text)
+                                }
+                                leviath_providers::ContentBlock::ToolUse { input, .. } => {
+                                    leviath_core::estimate_tokens(&input.to_string())
+                                }
+                                leviath_providers::ContentBlock::ToolResult { content, .. } => {
+                                    leviath_core::estimate_tokens(content)
+                                }
+                            })
+                            .sum(),
+                    }
+                }))
+                .sum();
+            if emitted_tokens > region.max_tokens {
+                tracing::warn!(
+                    region = %region.name,
+                    script = %script.path,
+                    emitted_tokens,
+                    budget = region.max_tokens,
+                    "custom region render exceeds its budget; sending anyway \
+                     (enable exact_token_counting for a hard guard)"
+                );
+            }
+            system_blocks.extend(blocks);
+            messages.extend(msgs);
+        }
+        Err(reason) => {
+            tracing::warn!(
+                region = %region.name,
+                script = %script.path,
+                reason = %reason,
+                "custom region render returned an invalid shape; using fallback block"
+            );
+            if !region.content.is_empty() {
+                system_blocks.push(fallback_block(region));
+            }
+        }
+    }
+}
+
+/// Interpret `render`'s returned value: a string (one system block) or an
+/// object with optional `system` (string or array of strings) and `messages`
+/// (array of message objects). Strict on shape - any surprise is an `Err`,
+/// which the caller turns into the fallback block.
+fn parse_render_output(
+    value: &serde_json::Value,
+    persistent: bool,
+) -> Result<
+    (
+        Vec<leviath_providers::SystemBlock>,
+        Vec<leviath_providers::Message>,
+    ),
+    String,
+> {
+    // A persistent region's rendered output is expected stable → cacheable.
+    let hint = if persistent {
+        leviath_core::CacheHint::Always
+    } else {
+        leviath_core::CacheHint::UntilChanged
+    };
+    let block = |text: &str| leviath_providers::SystemBlock {
+        text: text.to_string(),
+        cache_hint: hint,
+    };
+
+    match value {
+        serde_json::Value::String(s) => {
+            let blocks = if s.is_empty() { vec![] } else { vec![block(s)] };
+            Ok((blocks, vec![]))
+        }
+        serde_json::Value::Object(obj) => {
+            let mut blocks = Vec::new();
+            match obj.get("system") {
+                None | Some(serde_json::Value::Null) => {}
+                Some(serde_json::Value::String(s)) => {
+                    if !s.is_empty() {
+                        blocks.push(block(s));
+                    }
+                }
+                Some(serde_json::Value::Array(items)) => {
+                    for item in items {
+                        match item {
+                            serde_json::Value::String(s) if !s.is_empty() => blocks.push(block(s)),
+                            serde_json::Value::String(_) => {}
+                            other => {
+                                return Err(format!(
+                                    "system array items must be strings, found {other}"
+                                ));
+                            }
+                        }
+                    }
+                }
+                Some(other) => {
+                    return Err(format!(
+                        "system must be a string or array of strings, found {other}"
+                    ));
+                }
+            }
+            let mut messages = Vec::new();
+            match obj.get("messages") {
+                None | Some(serde_json::Value::Null) => {}
+                Some(serde_json::Value::Array(items)) => {
+                    for item in items {
+                        messages.push(message_from_json(item)?);
+                    }
+                }
+                Some(other) => return Err(format!("messages must be an array, found {other}")),
+            }
+            Ok((blocks, messages))
+        }
+        other => Err(format!(
+            "render must return a string or #{{ system, messages }} map, found {other}"
+        )),
+    }
+}
+
+/// Build one provider message from a script-emitted message object. Three
+/// accepted shapes, constructed with the same wire types the built-in
+/// SlidingWindow arm emits (so a Rhai recreation of it is byte-identical):
+///
+/// - `{ role, content }` - plain text, role `user` or `assistant`
+/// - `{ role: "assistant", content?, tool_calls: [{id, name, arguments}] }`
+/// - `{ role: "user", tool_results: [{tool_call_id, content, is_error?}] }`
+fn message_from_json(value: &serde_json::Value) -> Result<leviath_providers::Message, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| format!("each message must be a map, found {value}"))?;
+    let role = obj
+        .get("role")
+        .and_then(|r| r.as_str())
+        .ok_or("each message needs a role of \"user\" or \"assistant\"")?;
+    if role != "user" && role != "assistant" {
+        return Err(format!(
+            "message role must be user or assistant, found {role}"
+        ));
+    }
+
+    let content_str = match obj.get("content") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(other) => return Err(format!("message content must be a string, found {other}")),
+    };
+
+    if let Some(calls) = obj.get("tool_calls") {
+        if role != "assistant" {
+            return Err("tool_calls are only valid on an assistant message".to_string());
+        }
+        let calls = calls
+            .as_array()
+            .ok_or_else(|| format!("tool_calls must be an array, found {calls}"))?;
+        let mut blocks = Vec::new();
+        if let Some(text) = content_str.filter(|s| !s.is_empty()) {
+            blocks.push(leviath_providers::ContentBlock::Text { text });
+        }
+        for call in calls {
+            let call = call
+                .as_object()
+                .ok_or_else(|| format!("each tool_call must be a map, found {call}"))?;
+            let id = call
+                .get("id")
+                .and_then(|v| v.as_str())
+                .ok_or("each tool_call needs a string id")?;
+            let name = call
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or("each tool_call needs a string name")?;
+            blocks.push(leviath_providers::ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: name.to_string(),
+                input: call
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Object(Default::default())),
+                thought_signature: call
+                    .get("thought_signature")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+            });
+        }
+        return Ok(leviath_providers::Message {
+            role: "assistant".to_string(),
+            content: leviath_providers::MessageContent::Blocks(blocks),
+            cache_breakpoint: false,
+        });
+    }
+
+    if let Some(results) = obj.get("tool_results") {
+        if role != "user" {
+            return Err("tool_results are only valid on a user message".to_string());
+        }
+        let results = results
+            .as_array()
+            .ok_or_else(|| format!("tool_results must be an array, found {results}"))?;
+        let mut blocks = Vec::new();
+        for result in results {
+            let result = result
+                .as_object()
+                .ok_or_else(|| format!("each tool_result must be a map, found {result}"))?;
+            let id = result
+                .get("tool_call_id")
+                .and_then(|v| v.as_str())
+                .ok_or("each tool_result needs a string tool_call_id")?;
+            let content = result
+                .get("content")
+                .and_then(|v| v.as_str())
+                .ok_or("each tool_result needs string content")?;
+            blocks.push(leviath_providers::ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: content.to_string(),
+                is_error: result
+                    .get("is_error")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            });
+        }
+        return Ok(leviath_providers::Message {
+            role: "user".to_string(),
+            content: leviath_providers::MessageContent::Blocks(blocks),
+            cache_breakpoint: false,
+        });
+    }
+
+    let content =
+        content_str.ok_or("a message without tool_calls/tool_results needs string content")?;
+    Ok(leviath_providers::Message {
+        role: role.to_string(),
+        content: content.into(),
+        cache_breakpoint: false,
+    })
+}
+
+/// Run `on_write` for an entry headed into a custom region. Failure of any
+/// kind accepts the entry unchanged - a script bug must not lose writes.
+pub(crate) fn apply_on_write(
+    script: &RegionScript,
+    region: &Region,
+    content: String,
+    tokens: usize,
+    kind: &EntryKind,
+) -> OnWriteOutcome {
+    let kind_str = match kind {
+        EntryKind::Text => "text",
+        EntryKind::UserMessage => "user_message",
+        EntryKind::AssistantTurn { .. } => "assistant_turn",
+        EntryKind::ToolResult { .. } => "tool_result",
+    };
+    let ctx = serde_json::json!({
+        "region": region_to_json(region),
+        "entry": { "content": content, "kind": kind_str, "tokens": tokens },
+    });
+    match run_on_write(script, ctx) {
+        Ok(serde_json::Value::String(replacement)) => {
+            let tokens = leviath_core::estimate_tokens(&replacement);
+            OnWriteOutcome::Accept(replacement, tokens)
+        }
+        Ok(serde_json::Value::Bool(false)) => OnWriteOutcome::Drop,
+        Ok(serde_json::Value::Bool(true)) | Ok(serde_json::Value::Null) => {
+            OnWriteOutcome::Accept(content, tokens)
+        }
+        Ok(other) => {
+            tracing::warn!(
+                region = %region.name,
+                script = %script.path,
+                returned = %other,
+                "on_write must return a string, true/false, or unit; accepting entry unchanged"
+            );
+            OnWriteOutcome::Accept(content, tokens)
+        }
+        Err(e) => {
+            tracing::warn!(
+                region = %region.name,
+                script = %script.path,
+                error = %e,
+                "on_write failed; accepting entry unchanged"
+            );
+            OnWriteOutcome::Accept(content, tokens)
+        }
+    }
+}
+
+/// Ask `on_overflow` which entries to drop, validate the answer, and apply it.
+/// Returns the tokens freed (0 when the hook is absent, fails, or returns an
+/// invalid/empty answer - callers fall back to oldest-first for the rest).
+pub(crate) fn apply_overflow(
+    script: &RegionScript,
+    region: &mut Region,
+    needed_tokens: usize,
+) -> usize {
+    let ctx = serde_json::json!({
+        "region": region_to_json(region),
+        "entries": region.content.iter().map(entry_to_json).collect::<Vec<_>>(),
+        "needed_tokens": needed_tokens,
+    });
+    let value = match run_on_overflow(script, ctx) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                region = %region.name,
+                script = %script.path,
+                error = %e,
+                "on_overflow failed; falling back to oldest-first eviction"
+            );
+            return 0;
+        }
+    };
+    let Some(indices) = valid_drop_indices(&value, region.content.len()) else {
+        tracing::warn!(
+            region = %region.name,
+            script = %script.path,
+            returned = %value,
+            "on_overflow must return an array of in-range entry indices; \
+             falling back to oldest-first eviction"
+        );
+        return 0;
+    };
+
+    let mut freed = 0;
+    // Descending order keeps earlier indices valid while removing.
+    for index in indices.into_iter().rev() {
+        let entry = region.content.remove(index);
+        freed += entry.tokens;
+    }
+    region.current_tokens = region.current_tokens.saturating_sub(freed);
+    freed
+}
+
+/// Validate an `on_overflow` return value into a sorted, deduped index list.
+/// `None` when the shape is wrong or any index is out of range.
+fn valid_drop_indices(value: &serde_json::Value, len: usize) -> Option<Vec<usize>> {
+    let items = value.as_array()?;
+    let mut indices = Vec::with_capacity(items.len());
+    for item in items {
+        let index = item.as_u64()? as usize;
+        if index >= len {
+            return None;
+        }
+        indices.push(index);
+    }
+    indices.sort_unstable();
+    indices.dedup();
+    Some(indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_tracing;
+    use leviath_core::RegionKind;
+    use leviath_scripting::region_hook::compile;
+    use serde_json::json;
+
+    fn script(src: &str) -> Arc<RegionScript> {
+        Arc::new(compile("test.rhai", src).unwrap())
+    }
+
+    fn region_with(entries: &[(&str, EntryKind)]) -> Region {
+        let mut region = Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "test.rhai".to_string(),
+                persistent: false,
+            },
+            1000,
+        );
+        for (content, kind) in entries {
+            region
+                .add_typed_entry(content.to_string(), 10, kind.clone())
+                .unwrap();
+        }
+        region
+    }
+
+    fn render(
+        region: &Region,
+        script: Option<&Arc<RegionScript>>,
+        persistent: bool,
+    ) -> (
+        Vec<leviath_providers::SystemBlock>,
+        Vec<leviath_providers::Message>,
+    ) {
+        let mut blocks = Vec::new();
+        let mut messages = Vec::new();
+        with_tracing(|| {
+            render_custom_region(
+                region,
+                script,
+                persistent,
+                &AssembleMeta {
+                    stage_name: "plan".to_string(),
+                    stage_iterations: 2,
+                    model: "m1".to_string(),
+                },
+                50,
+                2000,
+                &mut blocks,
+                &mut messages,
+            )
+        });
+        (blocks, messages)
+    }
+
+    // ─── entry_to_json ───────────────────────────────────────────────────
+
+    #[test]
+    fn entry_to_json_serializes_all_kinds() {
+        let mut region = region_with(&[
+            ("plain", EntryKind::Text),
+            ("hi", EntryKind::UserMessage),
+            (
+                "calling",
+                EntryKind::AssistantTurn {
+                    tool_calls: vec![leviath_core::SerializedToolCall {
+                        id: "c1".to_string(),
+                        name: "shell".to_string(),
+                        arguments: json!({"command": "ls"}),
+                        thought_signature: None,
+                    }],
+                },
+            ),
+            (
+                "result",
+                EntryKind::ToolResult {
+                    tool_call_id: "c1".to_string(),
+                    tool_name: "shell".to_string(),
+                    is_error: true,
+                },
+            ),
+        ]);
+        region.content[0].key = Some("k".to_string());
+
+        let entries: Vec<_> = region.content.iter().map(entry_to_json).collect();
+        assert_eq!(entries[0]["kind"], json!("text"));
+        assert_eq!(entries[0]["key"], json!("k"));
+        assert_eq!(entries[0]["tokens"], json!(10));
+        assert_eq!(entries[1]["kind"], json!("user_message"));
+        assert_eq!(entries[2]["kind"], json!("assistant_turn"));
+        assert_eq!(entries[2]["tool_calls"][0]["id"], json!("c1"));
+        assert_eq!(entries[3]["kind"], json!("tool_result"));
+        assert_eq!(entries[3]["tool_call_id"], json!("c1"));
+        assert_eq!(entries[3]["is_error"], json!(true));
+    }
+
+    // ─── render: happy paths ─────────────────────────────────────────────
+
+    #[test]
+    fn render_string_becomes_one_block_with_persistence_hint() {
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let s = script("fn render(ctx) { `<${ctx.region.name}>` }");
+
+        let (blocks, messages) = render(&region, Some(&s), false);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, "<brain>");
+        assert_eq!(blocks[0].cache_hint, leviath_core::CacheHint::UntilChanged);
+        assert!(messages.is_empty());
+
+        let (blocks, _) = render(&region, Some(&s), true);
+        assert_eq!(blocks[0].cache_hint, leviath_core::CacheHint::Always);
+    }
+
+    #[test]
+    fn render_map_emits_system_array_and_typed_messages() {
+        // A script that recreates the SlidingWindow wire shapes: assistant
+        // text+tool_use, then a user tool_result message - built-ins parity.
+        let src = r#"
+            fn render(ctx) {
+                #{
+                    system: ["s1", "", "s2"],
+                    messages: [
+                        #{ role: "user", content: "hello" },
+                        #{ role: "assistant", content: "thinking", tool_calls: [
+                            #{ id: "c1", name: "shell", arguments: #{ command: "ls" } },
+                        ] },
+                        #{ role: "user", tool_results: [
+                            #{ tool_call_id: "c1", content: "file_a", is_error: false },
+                        ] },
+                    ],
+                }
+            }
+        "#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (blocks, messages) = render(&region, Some(&script(src)), false);
+
+        assert_eq!(
+            blocks.iter().map(|b| b.text.as_str()).collect::<Vec<_>>(),
+            vec!["s1", "s2"],
+            "empty system strings are skipped"
+        );
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].role, "user");
+        let leviath_providers::MessageContent::Blocks(assistant) = &messages[1].content else {
+            panic!("assistant tool_calls message must be block content");
+        };
+        assert!(matches!(
+            &assistant[0],
+            leviath_providers::ContentBlock::Text { text } if text == "thinking"
+        ));
+        assert!(matches!(
+            &assistant[1],
+            leviath_providers::ContentBlock::ToolUse { id, name, .. }
+                if id == "c1" && name == "shell"
+        ));
+        let leviath_providers::MessageContent::Blocks(results) = &messages[2].content else {
+            panic!("tool_results message must be block content");
+        };
+        assert!(matches!(
+            &results[0],
+            leviath_providers::ContentBlock::ToolResult { tool_use_id, content, is_error }
+                if tool_use_id == "c1" && content == "file_a" && !is_error
+        ));
+    }
+
+    #[test]
+    fn render_map_accepts_single_system_string_and_null_fields() {
+        let src = r#"fn render(ctx) { #{ system: "solo", messages: () } }"#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (blocks, messages) = render(&region, Some(&script(src)), false);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, "solo");
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn render_empty_map_and_empty_string_emit_nothing() {
+        let region = region_with(&[("x", EntryKind::Text)]);
+        for src in ["fn render(ctx) { #{} }", "fn render(ctx) { \"\" }"] {
+            let (blocks, messages) = render(&region, Some(&script(src)), false);
+            assert!(blocks.is_empty(), "src: {src}");
+            assert!(messages.is_empty());
+        }
+    }
+
+    #[test]
+    fn render_sees_stage_meta_and_window_fields() {
+        let src = r#"
+            fn render(ctx) {
+                `${ctx.stage_name}|${ctx.stage_iterations}|${ctx.model}|${ctx.window.total_tokens}|${ctx.window.max_tokens}`
+            }
+        "#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (blocks, _) = render(&region, Some(&script(src)), false);
+        assert_eq!(blocks[0].text, "plan|2|m1|50|2000");
+    }
+
+    #[test]
+    fn render_over_budget_warns_but_still_emits() {
+        // Budget is 1000 tokens; the script emits ~2000 tokens of output. The
+        // result is kept (warn-only per the design), not truncated.
+        let src = r#"fn render(ctx) { let s = "x"; s.pad(8000, 'x'); s }"#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (blocks, _) = render(&region, Some(&script(src)), false);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text.len(), 8000);
+    }
+
+    // ─── render: fallbacks ───────────────────────────────────────────────
+
+    #[test]
+    fn render_missing_script_falls_back_to_temporary_style() {
+        let region = region_with(&[("a", EntryKind::Text), ("b", EntryKind::Text)]);
+        let (blocks, messages) = render(&region, None, false);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, "[brain]:\na\n\nb");
+        assert_eq!(blocks[0].cache_hint, leviath_core::CacheHint::Never);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn render_missing_script_on_empty_region_emits_nothing() {
+        let region = region_with(&[]);
+        let (blocks, messages) = render(&region, None, false);
+        assert!(blocks.is_empty());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn render_runtime_error_falls_back() {
+        let region = region_with(&[("kept", EntryKind::Text)]);
+        let s = script("fn render(ctx) { throw \"broken\" }");
+        let (blocks, _) = render(&region, Some(&s), false);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, "[brain]:\nkept");
+        assert_eq!(blocks[0].cache_hint, leviath_core::CacheHint::Never);
+    }
+
+    #[test]
+    fn render_error_on_empty_region_emits_nothing() {
+        let region = region_with(&[]);
+        let s = script("fn render(ctx) { throw \"broken\" }");
+        let (blocks, _) = render(&region, Some(&s), false);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn render_invalid_shapes_fall_back() {
+        let region = region_with(&[("kept", EntryKind::Text)]);
+        for src in [
+            "fn render(ctx) { 42 }",
+            "fn render(ctx) { true }",
+            "fn render(ctx) { [1, 2] }",
+            "fn render(ctx) { }",
+            "fn render(ctx) { #{ system: 42 } }",
+            "fn render(ctx) { #{ system: [1] } }",
+            "fn render(ctx) { #{ messages: \"not an array\" } }",
+            "fn render(ctx) { #{ messages: [42] } }",
+            "fn render(ctx) { #{ messages: [#{ content: \"no role\" }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"system\", content: \"bad role\" }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", content: 42 }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\" }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", tool_calls: [] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"assistant\", tool_calls: 42 }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"assistant\", tool_calls: [42] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"assistant\", tool_calls: [#{ name: \"n\" }] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"assistant\", tool_calls: [#{ id: \"i\" }] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"assistant\", tool_results: [] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", tool_results: 42 }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", tool_results: [42] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", tool_results: [#{ content: \"c\" }] }] } }",
+            "fn render(ctx) { #{ messages: [#{ role: \"user\", tool_results: [#{ tool_call_id: \"i\" }] }] } }",
+        ] {
+            let (blocks, messages) = render(&region, Some(&script(src)), false);
+            assert_eq!(blocks.len(), 1, "src must fall back: {src}");
+            assert_eq!(blocks[0].text, "[brain]:\nkept", "src: {src}");
+            assert!(messages.is_empty(), "src: {src}");
+        }
+    }
+
+    #[test]
+    fn render_assistant_tool_call_defaults_arguments_and_signature() {
+        let src = r#"
+            fn render(ctx) {
+                #{ messages: [#{ role: "assistant", tool_calls: [#{ id: "c", name: "n" }] }] }
+            }
+        "#;
+        let region = region_with(&[("x", EntryKind::Text)]);
+        let (_, messages) = render(&region, Some(&script(src)), false);
+        let leviath_providers::MessageContent::Blocks(blocks) = &messages[0].content else {
+            panic!("blocks expected");
+        };
+        assert!(matches!(
+            &blocks[0],
+            leviath_providers::ContentBlock::ToolUse { input, thought_signature, .. }
+                if input == &json!({}) && thought_signature.is_none()
+        ));
+    }
+
+    // ─── on_write ────────────────────────────────────────────────────────
+
+    fn on_write_of(src: &str, content: &str) -> OnWriteOutcome {
+        let region = region_with(&[]);
+        with_tracing(|| {
+            apply_on_write(
+                &script(src),
+                &region,
+                content.to_string(),
+                5,
+                &EntryKind::Text,
+            )
+        })
+    }
+
+    #[test]
+    fn on_write_replaces_accepts_and_drops() {
+        let replaced = on_write_of(
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { ctx.entry.content.to_upper() }",
+            "hi",
+        );
+        let OnWriteOutcome::Accept(content, tokens) = replaced else {
+            panic!("expected accept");
+        };
+        assert_eq!(content, "HI");
+        assert_eq!(tokens, leviath_core::estimate_tokens("HI"));
+
+        for accept_body in ["true", ""] {
+            let src = format!("fn render(ctx) {{ \"\" }}\nfn on_write(ctx) {{ {accept_body} }}");
+            let OnWriteOutcome::Accept(content, tokens) = on_write_of(&src, "orig") else {
+                panic!("expected accept for body {accept_body:?}");
+            };
+            assert_eq!(content, "orig");
+            assert_eq!(tokens, 5, "original token count preserved");
+        }
+
+        assert!(matches!(
+            on_write_of("fn render(ctx) { \"\" }\nfn on_write(ctx) { false }", "x"),
+            OnWriteOutcome::Drop
+        ));
+    }
+
+    #[test]
+    fn on_write_invalid_return_and_error_accept_unchanged() {
+        for src in [
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { 42 }",
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { throw \"bad\" }",
+        ] {
+            let OnWriteOutcome::Accept(content, tokens) = on_write_of(src, "keep") else {
+                panic!("expected accept for {src}");
+            };
+            assert_eq!(content, "keep");
+            assert_eq!(tokens, 5);
+        }
+    }
+
+    // ─── on_overflow / apply_overflow ────────────────────────────────────
+
+    #[test]
+    fn apply_overflow_drops_chosen_indices() {
+        let mut region = region_with(&[
+            ("a", EntryKind::Text),
+            ("b", EntryKind::Text),
+            ("c", EntryKind::Text),
+        ]);
+        // Duplicate + unordered indices are deduped and applied safely.
+        let s = script("fn render(ctx) { \"\" }\nfn on_overflow(ctx) { [2, 0, 2] }");
+        let freed = with_tracing(|| apply_overflow(&s, &mut region, 15));
+        assert_eq!(freed, 20);
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content, "b");
+        assert_eq!(region.current_tokens, 10);
+    }
+
+    #[test]
+    fn apply_overflow_error_and_invalid_shapes_free_nothing() {
+        for src in [
+            "fn render(ctx) { \"\" }\nfn on_overflow(ctx) { throw \"bad\" }",
+            "fn render(ctx) { \"\" }\nfn on_overflow(ctx) { \"not an array\" }",
+            "fn render(ctx) { \"\" }\nfn on_overflow(ctx) { [\"x\"] }",
+            "fn render(ctx) { \"\" }\nfn on_overflow(ctx) { [99] }",
+        ] {
+            let mut region = region_with(&[("a", EntryKind::Text)]);
+            let freed = with_tracing(|| apply_overflow(&script(src), &mut region, 5));
+            assert_eq!(freed, 0, "src: {src}");
+            assert_eq!(region.content.len(), 1, "content untouched: {src}");
+        }
+    }
+
+    #[test]
+    fn overflow_ctx_carries_needed_tokens_and_entries() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) {
+                if ctx.needed_tokens == 7 && ctx.entries.len() == 2 { [0] } else { [] }
+            }
+        "#;
+        let mut region = region_with(&[("a", EntryKind::Text), ("b", EntryKind::Text)]);
+        let freed = with_tracing(|| apply_overflow(&script(src), &mut region, 7));
+        assert_eq!(freed, 10);
+    }
+}

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -13,6 +13,7 @@ pub mod context_setup;
 pub(crate) mod context_tools;
 pub(crate) mod context_transform;
 pub mod control_socket;
+pub mod custom_region;
 pub mod dynamic_interaction;
 pub mod fanout;
 pub(crate) mod gate_prompt;

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -115,6 +115,7 @@ fn region_kind_str(kind: &RegionKind) -> &'static str {
         RegionKind::Compacting { .. } => "compacting",
         RegionKind::CompactHistory { .. } => "history",
         RegionKind::HashMap { .. } => "hashmap",
+        RegionKind::Custom { .. } => "custom",
     }
 }
 

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -482,6 +482,14 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             100,
         ));
+        w.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "b.rhai".to_string(),
+                persistent: false,
+            },
+            100,
+        ));
         let _ = w.add_to_region("pin", "hello".to_string(), 3);
         w.current_tokens = w.calculate_tokens();
 
@@ -498,7 +506,8 @@ mod tests {
                 "sliding",
                 "compacting",
                 "history",
-                "hashmap"
+                "hashmap",
+                "custom"
             ]
         );
         // The pinned region's entry is captured.

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -205,13 +205,17 @@ pub struct PendingEdgeCompact(pub Vec<String>);
 
 /// Whether a region kind is "stage-specific" - eligible for an edge transform to
 /// clear or compact. The always-preserved kinds (pinned identity, compaction
-/// history, hashmap stores) are never touched.
+/// history, hashmap stores, persistent custom regions) are never touched.
 pub(crate) fn is_stage_specific(kind: &leviath_core::RegionKind) -> bool {
     !matches!(
         kind,
         leviath_core::RegionKind::Pinned
             | leviath_core::RegionKind::CompactHistory { .. }
             | leviath_core::RegionKind::HashMap { .. }
+            | leviath_core::RegionKind::Custom {
+                persistent: true,
+                ..
+            }
     )
 }
 

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -15,15 +15,25 @@ one response to cut round trips. Do NOT batch when a call depends on a previous 
 call's result, or when you must see a command's output before deciding the next step.";
 
 /// Build the [`InferenceRequest`] for an agent from its context window + stage
-/// data. Pure; no `.await`. (Ported from `AgentEngine::build_inference_request`,
+/// data. Pure; no `.await` - a custom region's render hook is a bounded,
+/// synchronous Rhai eval. (Ported from `AgentEngine::build_inference_request`,
 /// with provider resolution lifted into the caller so this stays query-friendly.)
+///
+/// `stage_name` / `stage_iterations` feed custom-region `render(ctx)` hooks;
+/// they change nothing when the window has no custom regions.
 pub(crate) fn build_request(
     window: &ContextWindow,
     config: Option<&InferenceConfig>,
     stage: &StageInference,
     provider: &Arc<dyn Provider>,
+    stage_name: &str,
+    stage_iterations: usize,
 ) -> InferenceRequest {
-    let assembled = window.assemble();
+    let assembled = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
+        stage_name: stage_name.to_string(),
+        stage_iterations,
+        model: stage.model.clone(),
+    });
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);
     let caps = provider.capabilities(&stage.model);
     let output_cap = config
@@ -157,6 +167,7 @@ pub fn dispatch_inference(
             Option<&InferenceConfig>,
             &StageInference,
             Option<&InFlightWork>,
+            Option<&StageProgress>,
         ),
         With<ReadyToInfer>,
     >,
@@ -179,7 +190,7 @@ pub fn dispatch_inference(
     crate::tick_scope::clear();
     agents
         .par_iter()
-        .for_each(|(entity, state, window, config, si, in_flight)| {
+        .for_each(|(entity, state, window, config, si, in_flight, progress)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
                     return; // paused / waiting / cancelled - don't start new work
@@ -203,7 +214,14 @@ pub fn dispatch_inference(
                     );
                     return;
                 };
-                let request = build_request(window, config, si, &provider);
+                let request = build_request(
+                    window,
+                    config,
+                    si,
+                    &provider,
+                    &state.current_stage,
+                    progress.map(|p| p.iterations).unwrap_or(0),
+                );
                 let job = InferenceJob {
                     entity,
                     provider,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4321,6 +4321,38 @@ fn apply_edge_transform_clear_wipes_stage_specific_keeps_pinned() {
 }
 
 #[test]
+fn edge_transforms_respect_custom_region_persistence() {
+    // Non-persistent custom is stage-specific (wiped by Clear); persistent is
+    // protected alongside Pinned/HashMap/CompactHistory.
+    let mut w = transform_window();
+    let mut scratch_custom = Region::new(
+        "scratch_custom".to_string(),
+        RegionKind::Custom {
+            script: "s.rhai".to_string(),
+            persistent: false,
+        },
+        500,
+    );
+    let _ = scratch_custom.add_entry("wipe me".to_string(), 10);
+    w.add_region(scratch_custom);
+    let mut vault = Region::new(
+        "vault".to_string(),
+        RegionKind::Custom {
+            script: "v.rhai".to_string(),
+            persistent: true,
+        },
+        500,
+    );
+    let _ = vault.add_entry("keep me".to_string(), 10);
+    w.add_region(vault);
+    w.current_tokens = w.calculate_tokens();
+
+    assert!(apply_edge_transform(&mut w, &EdgeTransform::Clear).is_empty());
+    assert_eq!(w.get_region("scratch_custom").unwrap().current_tokens, 0);
+    assert!(w.get_region("vault").unwrap().current_tokens > 0);
+}
+
+#[test]
 fn apply_edge_transform_compact_returns_stage_specific_with_content() {
     let mut w = transform_window();
     // Pinned excluded; scratch (stage-specific, has content) returned; not cleared.

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -82,6 +82,39 @@ fn provider(supports_temperature: bool, max_output: usize) -> Arc<dyn Provider> 
 // ── build_request branch coverage ──
 
 #[test]
+fn build_request_threads_stage_meta_into_custom_region_render() {
+    // The custom region's script echoes the stage metadata build_request
+    // passes - proving the dispatch wiring (stage name, per-stage iteration,
+    // model) reaches render(ctx).
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new(
+        "brain".to_string(),
+        RegionKind::Custom {
+            script: "meta.rhai".to_string(),
+            persistent: false,
+        },
+        1_000,
+    ));
+    w.region_scripts.insert(
+        "meta.rhai".to_string(),
+        Arc::new(
+            leviath_scripting::region_hook::compile(
+                "meta.rhai",
+                "fn render(ctx) { `${ctx.stage_name}#${ctx.stage_iterations}@${ctx.model}` }",
+            )
+            .unwrap(),
+        ),
+    );
+    let si = stage("model-x", vec![], None);
+    let req = build_request(&w, None, &si, &provider(true, 500), "implement", 4);
+    assert!(
+        req.system.iter().any(|b| b.text == "implement#4@model-x"),
+        "system blocks: {:?}",
+        req.system.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn build_request_filters_tools_and_uses_config_overrides() {
     let cfg = InferenceConfig {
         temperature: Some(0.1),
@@ -95,7 +128,14 @@ fn build_request_filters_tools_and_uses_config_overrides() {
         vec![tool("keep"), tool("drop")],
         Some(vec!["keep".into()]),
     );
-    let req = build_request(&window(), Some(&cfg), &si, &provider(true, 9999));
+    let req = build_request(
+        &window(),
+        Some(&cfg),
+        &si,
+        &provider(true, 9999),
+        "test-stage",
+        0,
+    );
     assert_eq!(req.tools.len(), 1); // filtered to "keep"
     assert_eq!(req.tools[0].name, "keep");
     assert_eq!(req.max_tokens, 42); // config output cap wins
@@ -113,10 +153,17 @@ fn build_request_threads_per_stage_timeout() {
         ..Default::default()
     };
     let si = stage("m", vec![], None);
-    let req = build_request(&window(), Some(&cfg), &si, &provider(true, 500));
+    let req = build_request(
+        &window(),
+        Some(&cfg),
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
     assert_eq!(req.request_timeout_secs, Some(120));
 
-    let req_none = build_request(&window(), None, &si, &provider(true, 500));
+    let req_none = build_request(&window(), None, &si, &provider(true, 500), "test-stage", 0);
     assert_eq!(req_none.request_timeout_secs, None);
 }
 
@@ -132,7 +179,14 @@ fn build_request_passes_through_extra_params() {
         request_timeout_secs: None,
     };
     let si = stage("m", vec![], None);
-    let req = build_request(&window(), Some(&cfg), &si, &provider(true, 500));
+    let req = build_request(
+        &window(),
+        Some(&cfg),
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
     assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
 }
 
@@ -156,7 +210,14 @@ fn build_request_prepends_batch_hint_when_enabled() {
         request_timeout_secs: None,
     };
     let si = stage("m", vec![], None);
-    let req = build_request(&window_with_sys(), Some(&cfg), &si, &provider(true, 500));
+    let req = build_request(
+        &window_with_sys(),
+        Some(&cfg),
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
     // The hint is prepended ahead of the stage's own system block(s).
     assert_eq!(
         req.system.first().map(|b| b.text.as_str()),
@@ -182,11 +243,25 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         batch_tool_hint: false,
         request_timeout_secs: None,
     };
-    let req = build_request(&window_with_sys(), Some(&cfg), &si, &provider(true, 500));
+    let req = build_request(
+        &window_with_sys(),
+        Some(&cfg),
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
     assert!(!req.system.is_empty());
     assert!(req.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
     // Absent config → no hint.
-    let req_none = build_request(&window_with_sys(), None, &si, &provider(true, 500));
+    let req_none = build_request(
+        &window_with_sys(),
+        None,
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
     assert!(!req_none.system.is_empty());
     assert!(req_none.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
 }
@@ -194,7 +269,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
 #[test]
 fn build_request_all_tools_default_temperature_no_config() {
     let si = stage("m", vec![tool("a"), tool("b")], None); // None filter = all
-    let req = build_request(&window(), None, &si, &provider(true, 500));
+    let req = build_request(&window(), None, &si, &provider(true, 500), "test-stage", 0);
     assert_eq!(req.tools.len(), 2);
     assert_eq!(req.temperature, 0.7); // default when supported and no config
     assert_eq!(req.max_tokens, 500); // capability cap when no config override
@@ -203,7 +278,7 @@ fn build_request_all_tools_default_temperature_no_config() {
 #[test]
 fn build_request_empty_filter_is_all_and_no_temperature_when_unsupported() {
     let si = stage("m", vec![tool("a")], Some(vec![])); // empty filter = all
-    let req = build_request(&window(), None, &si, &provider(false, 500));
+    let req = build_request(&window(), None, &si, &provider(false, 500), "test-stage", 0);
     assert_eq!(req.tools.len(), 1);
     assert_eq!(req.temperature, 0.0); // model doesn't support temperature
 }

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1258,6 +1258,9 @@ pub fn spawn_agent(
     global_batch_tool_hint: bool,
 ) -> Result<Entity, String> {
     let seeds = std::collections::HashMap::from([("task".to_string(), task.to_string())]);
+    // No compiled custom-region scripts on this path: script-backed regions
+    // require the seeded spawn (the CLI resolves and compiles them). A custom
+    // region spawned through here renders its fallback shape.
     spawn_agent_seeded(
         world,
         agent_id,
@@ -1265,6 +1268,7 @@ pub fn spawn_agent(
         &seeds,
         stages,
         global_batch_tool_hint,
+        std::collections::HashMap::new(),
     )
 }
 
@@ -1279,6 +1283,10 @@ pub fn spawn_agent_seeded(
     seeds: &std::collections::HashMap<String, String>,
     stages: Vec<ResolvedStage>,
     global_batch_tool_hint: bool,
+    region_scripts: std::collections::HashMap<
+        String,
+        std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
+    >,
 ) -> Result<Entity, String> {
     // Resolve any percentage region budgets against each stage's model context
     // window (the only place the model - and hence the window - is known). The
@@ -1327,6 +1335,9 @@ pub fn spawn_agent_seeded(
     // context setup (layout swap + system-prompt injection) just as entering any
     // later stage would.
     let mut window = ContextWindow::new(blueprint.context_layout.total_budget_tokens);
+    // Attach compiled custom-region scripts BEFORE seeding, so seed writes
+    // pass through each region's on_write hook like any other entry.
+    window.region_scripts = region_scripts;
     crate::context_setup::init_window_seeded(&mut window, &blueprint, seeds);
     apply_stage_context(&setups[0], &mut window)?;
 
@@ -1563,6 +1574,10 @@ pub fn dispatch_transition_choice(
             tokens,
         );
 
+        // Plain `assemble()` (default meta): this is the deterministic
+        // 256-token routing call, not stage inference - custom regions still
+        // render (they may hold the whole context), just with empty stage
+        // fields in their ctx.
         let assembled = window.assemble();
         let remaining = window.max_tokens.saturating_sub(window.current_tokens);
         let request = InferenceRequest {

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod engine;
 pub mod functions;
+pub mod region_hook;
 pub mod sandbox;
 pub mod tool;
 pub mod types;

--- a/crates/leviath-scripting/src/region_hook.rs
+++ b/crates/leviath-scripting/src/region_hook.rs
@@ -123,9 +123,10 @@ fn call(
     ctx: serde_json::Value,
 ) -> crate::Result<serde_json::Value> {
     let engine = build_engine();
-    let ctx_dyn = rhai::serde::to_dynamic(ctx).map_err(|e| {
-        crate::Error::ExecutionFailed(format!("{}: building {fn_name} ctx: {e}", script.path))
-    })?;
+    // Total conversion: every JSON value has a Dynamic representation, so a
+    // failure here is a programmer error, not a script error (same stance as
+    // the provider layer's request_to_dynamic).
+    let ctx_dyn = rhai::serde::to_dynamic(ctx).expect("JSON always converts to Dynamic");
     let result: Dynamic = engine
         .call_fn(&mut Scope::new(), &script.ast, fn_name, (ctx_dyn,))
         .map_err(|e| crate::Error::ExecutionFailed(format!("{}: {fn_name}: {e}", script.path)))?;
@@ -206,14 +207,20 @@ mod tests {
     #[test]
     fn compile_rejects_syntax_errors() {
         let err = compile("bad.rhai", "fn render(ctx) {").unwrap_err();
-        assert!(matches!(err, crate::Error::CompilationFailed(_)), "{err}");
+        assert!(
+            err.to_string().starts_with("Script compilation failed"),
+            "{err}"
+        );
         assert!(err.to_string().contains("bad.rhai"));
     }
 
     #[test]
     fn compile_rejects_missing_render() {
         let err = compile("no.rhai", "fn on_write(ctx) { true }").unwrap_err();
-        assert!(matches!(err, crate::Error::ValidationFailed(_)));
+        assert!(
+            err.to_string().starts_with("Script validation failed"),
+            "{err}"
+        );
         assert!(err.to_string().contains("must define fn render"));
     }
 
@@ -279,7 +286,10 @@ mod tests {
     fn render_runtime_throw_is_execution_error() {
         let s = compile("r.rhai", "fn render(ctx) { throw \"boom\" }").unwrap();
         let err = run_render(&s, ctx()).unwrap_err();
-        assert!(matches!(err, crate::Error::ExecutionFailed(_)));
+        assert!(
+            err.to_string().starts_with("Script execution failed"),
+            "{err}"
+        );
         assert!(err.to_string().contains("boom"), "{err}");
     }
 
@@ -287,7 +297,10 @@ mod tests {
     fn render_infinite_loop_hits_operation_limit() {
         let s = compile("r.rhai", "fn render(ctx) { loop { } }").unwrap();
         let err = run_render(&s, ctx()).unwrap_err();
-        assert!(matches!(err, crate::Error::ExecutionFailed(_)), "{err}");
+        assert!(
+            err.to_string().starts_with("Script execution failed"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -295,7 +308,10 @@ mod tests {
         // A function pointer cannot cross the JSON boundary.
         let s = compile("r.rhai", "fn render(ctx) { Fn(\"render\") }").unwrap();
         let err = run_render(&s, ctx()).unwrap_err();
-        assert!(matches!(err, crate::Error::ValidationFailed(_)), "{err}");
+        assert!(
+            err.to_string().starts_with("Script validation failed"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -303,7 +319,10 @@ mod tests {
         // The sandbox holds for hooks: `eval` is disabled outright, so a
         // script trying to use it never even compiles.
         let err = compile("r.rhai", "fn render(ctx) { eval(\"1+1\") }").unwrap_err();
-        assert!(matches!(err, crate::Error::CompilationFailed(_)), "{err}");
+        assert!(
+            err.to_string().starts_with("Script compilation failed"),
+            "{err}"
+        );
         assert!(err.to_string().contains("eval"), "{err}");
     }
 
@@ -374,6 +393,9 @@ mod tests {
         let s = compile("r.rhai", "fn render(ctx) { \"\" }").unwrap();
         assert!(!s.has_on_write());
         let err = run_on_write(&s, json!({})).unwrap_err();
-        assert!(matches!(err, crate::Error::ExecutionFailed(_)));
+        assert!(
+            err.to_string().starts_with("Script execution failed"),
+            "{err}"
+        );
     }
 }

--- a/crates/leviath-scripting/src/region_hook.rs
+++ b/crates/leviath-scripting/src/region_hook.rs
@@ -1,0 +1,379 @@
+//! Script-backed custom region hooks (`RegionKind::Custom`).
+//!
+//! A custom region's `.rhai` script owns the region's behavior through up to
+//! three functions, each a **return-value contract** (Rhai passes arguments by
+//! value, so mutating the `ctx` argument in place has no effect - the script
+//! must return its result):
+//!
+//! - `render(ctx)` - **required**. Shapes the region's contribution to the
+//!   assembled context. Returns a string (one system block) or a map
+//!   `#{ system: ..., messages: [...] }`.
+//! - `on_write(ctx)` - optional. Sees each incoming entry; returns a string
+//!   (replace the content), `true`/`()` (accept unchanged), or `false` (drop).
+//! - `on_overflow(ctx)` - optional. Chooses what to evict under budget
+//!   pressure; returns an array of entry indices to drop.
+//!
+//! This module owns compilation (once, at agent spawn - the CLI resolves the
+//! blueprint-dir-relative path and reads the file) and the three call
+//! entry points. Interpretation of the returned values - block/message
+//! construction, index validation, fallbacks - lives with the caller
+//! (`leviath-runtime`), which receives plain [`serde_json::Value`]s so it
+//! needs no `rhai` dependency of its own.
+//!
+//! Execution runs on a fresh hardened engine per call (see [`crate::harden`])
+//! over the precompiled AST: no filesystem, no network, no `eval`, operation-
+//! bounded. The registered helpers are the same pure function/type sets every
+//! Leviath script engine gets.
+
+use rhai::{AST, Dynamic, Engine, Scope};
+
+/// Operation budget for region hooks: pure data transforms, same policy as
+/// `ScriptEngine` validators/transforms (not the 500k the IO-driving script
+/// tools/providers get).
+const REGION_HOOK_MAX_OPERATIONS: u64 = 100_000;
+
+/// A compiled custom-region script, ready to call. Compiled once at spawn and
+/// shared via `Arc` on the runtime's context window, keyed by `path`.
+#[derive(Debug, Clone)]
+pub struct RegionScript {
+    /// The script path as written in the blueprint - log/error context only.
+    pub path: String,
+    ast: AST,
+    has_on_write: bool,
+    has_on_overflow: bool,
+}
+
+impl RegionScript {
+    /// Whether the script defines `on_write(ctx)`.
+    pub fn has_on_write(&self) -> bool {
+        self.has_on_write
+    }
+
+    /// Whether the script defines `on_overflow(ctx)`.
+    pub fn has_on_overflow(&self) -> bool {
+        self.has_on_overflow
+    }
+}
+
+/// Build the hardened engine every region-hook call runs on.
+fn build_engine() -> Engine {
+    let mut engine = Engine::new();
+    crate::harden(&mut engine, REGION_HOOK_MAX_OPERATIONS);
+    crate::functions::register_functions(&mut engine);
+    crate::types::register_types(&mut engine);
+    engine
+}
+
+/// Compile a custom-region script and verify its shape: `render(ctx)` must
+/// exist with exactly one parameter; `on_write`/`on_overflow` are recorded
+/// when present (also arity 1). Used by the CLI at spawn (fail-fast: a
+/// missing or broken script is a spawn error, not a silent runtime fallback)
+/// and by `lev validate`.
+pub fn compile(path: &str, source: &str) -> crate::Result<RegionScript> {
+    let engine = build_engine();
+    let ast = engine
+        .compile(source)
+        .map_err(|e| crate::Error::CompilationFailed(format!("{path}: {e}")))?;
+
+    let arity_of = |name: &str| -> Option<usize> {
+        ast.iter_functions()
+            .find(|f| f.name == name)
+            .map(|f| f.params.len())
+    };
+
+    match arity_of("render") {
+        Some(1) => {}
+        Some(n) => {
+            return Err(crate::Error::ValidationFailed(format!(
+                "{path}: fn render must take exactly one parameter (ctx), found {n}"
+            )));
+        }
+        None => {
+            return Err(crate::Error::ValidationFailed(format!(
+                "{path}: script must define fn render(ctx)"
+            )));
+        }
+    }
+    // Optional hooks: present-but-wrong-arity is an authoring error worth
+    // failing on at spawn, not a silent "hook never fires".
+    for optional in ["on_write", "on_overflow"] {
+        if let Some(n) = arity_of(optional)
+            && n != 1
+        {
+            return Err(crate::Error::ValidationFailed(format!(
+                "{path}: fn {optional} must take exactly one parameter (ctx), found {n}"
+            )));
+        }
+    }
+
+    Ok(RegionScript {
+        path: path.to_string(),
+        has_on_write: arity_of("on_write").is_some(),
+        has_on_overflow: arity_of("on_overflow").is_some(),
+        ast,
+    })
+}
+
+/// Call one of the script's functions with `ctx` and hand back the raw result
+/// as JSON. The caller interprets the shape; a value that cannot be
+/// represented as JSON (a function pointer, say) is a validation error.
+fn call(
+    script: &RegionScript,
+    fn_name: &str,
+    ctx: serde_json::Value,
+) -> crate::Result<serde_json::Value> {
+    let engine = build_engine();
+    let ctx_dyn = rhai::serde::to_dynamic(ctx).map_err(|e| {
+        crate::Error::ExecutionFailed(format!("{}: building {fn_name} ctx: {e}", script.path))
+    })?;
+    let result: Dynamic = engine
+        .call_fn(&mut Scope::new(), &script.ast, fn_name, (ctx_dyn,))
+        .map_err(|e| crate::Error::ExecutionFailed(format!("{}: {fn_name}: {e}", script.path)))?;
+    rhai::serde::from_dynamic::<serde_json::Value>(&result).map_err(|e| {
+        crate::Error::ValidationFailed(format!(
+            "{}: {fn_name} returned a value that is not plain data: {e}",
+            script.path
+        ))
+    })
+}
+
+/// Run `render(ctx)`. The result is a JSON string (one system block) or an
+/// object with optional `system` / `messages` fields - shape validation is the
+/// caller's job.
+pub fn run_render(
+    script: &RegionScript,
+    ctx: serde_json::Value,
+) -> crate::Result<serde_json::Value> {
+    call(script, "render", ctx)
+}
+
+/// Run `on_write(ctx)`. Callers must check [`RegionScript::has_on_write`]
+/// first - calling a missing function is an execution error.
+pub fn run_on_write(
+    script: &RegionScript,
+    ctx: serde_json::Value,
+) -> crate::Result<serde_json::Value> {
+    call(script, "on_write", ctx)
+}
+
+/// Run `on_overflow(ctx)`. Callers must check
+/// [`RegionScript::has_on_overflow`] first.
+pub fn run_on_overflow(
+    script: &RegionScript,
+    ctx: serde_json::Value,
+) -> crate::Result<serde_json::Value> {
+    call(script, "on_overflow", ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx() -> serde_json::Value {
+        json!({
+            "region": { "name": "brain", "budget": 1000, "current_tokens": 10, "entry_count": 1 },
+            "entries": [ { "content": "hello", "tokens": 2, "kind": "text" } ],
+            "stage_name": "plan",
+            "stage_iterations": 3,
+            "model": "test-model",
+            "window": { "total_tokens": 10, "max_tokens": 2000 },
+        })
+    }
+
+    // ─── compile ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn compile_accepts_render_only_script() {
+        let s = compile("r.rhai", "fn render(ctx) { \"out\" }").unwrap();
+        assert_eq!(s.path, "r.rhai");
+        assert!(!s.has_on_write());
+        assert!(!s.has_on_overflow());
+    }
+
+    #[test]
+    fn compile_detects_optional_hooks() {
+        let src = r#"
+            fn render(ctx) { "out" }
+            fn on_write(ctx) { true }
+            fn on_overflow(ctx) { [] }
+        "#;
+        let s = compile("r.rhai", src).unwrap();
+        assert!(s.has_on_write());
+        assert!(s.has_on_overflow());
+    }
+
+    #[test]
+    fn compile_rejects_syntax_errors() {
+        let err = compile("bad.rhai", "fn render(ctx) {").unwrap_err();
+        assert!(matches!(err, crate::Error::CompilationFailed(_)), "{err}");
+        assert!(err.to_string().contains("bad.rhai"));
+    }
+
+    #[test]
+    fn compile_rejects_missing_render() {
+        let err = compile("no.rhai", "fn on_write(ctx) { true }").unwrap_err();
+        assert!(matches!(err, crate::Error::ValidationFailed(_)));
+        assert!(err.to_string().contains("must define fn render"));
+    }
+
+    #[test]
+    fn compile_rejects_wrong_render_arity() {
+        let err = compile("a.rhai", "fn render(a, b) { \"x\" }").unwrap_err();
+        assert!(err.to_string().contains("exactly one parameter"), "{err}");
+    }
+
+    #[test]
+    fn compile_rejects_wrong_optional_hook_arity() {
+        let src = "fn render(ctx) { \"x\" }\nfn on_write() { true }";
+        let err = compile("w.rhai", src).unwrap_err();
+        assert!(err.to_string().contains("on_write"), "{err}");
+        let src = "fn render(ctx) { \"x\" }\nfn on_overflow(a, b) { [] }";
+        let err = compile("o.rhai", src).unwrap_err();
+        assert!(err.to_string().contains("on_overflow"), "{err}");
+    }
+
+    // ─── render ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_returns_string() {
+        let s = compile("r.rhai", "fn render(ctx) { `[${ctx.region.name}] ok` }").unwrap();
+        let out = run_render(&s, ctx()).unwrap();
+        assert_eq!(out, json!("[brain] ok"));
+    }
+
+    #[test]
+    fn render_sees_full_ctx() {
+        // The script reads every advertised ctx field and echoes them back -
+        // locks the ctx schema from the script's point of view.
+        let src = r#"
+            fn render(ctx) {
+                #{
+                    system: `${ctx.stage_name}/${ctx.stage_iterations}/${ctx.model}`,
+                    messages: [
+                        #{ role: "user", content: ctx.entries[0].content },
+                    ],
+                    budget: ctx.region.budget,
+                    window_max: ctx.window.max_tokens,
+                }
+            }
+        "#;
+        let s = compile("r.rhai", src).unwrap();
+        let out = run_render(&s, ctx()).unwrap();
+        assert_eq!(out["system"], json!("plan/3/test-model"));
+        assert_eq!(out["messages"][0]["content"], json!("hello"));
+        assert_eq!(out["budget"], json!(1000));
+        assert_eq!(out["window_max"], json!(2000));
+    }
+
+    #[test]
+    fn render_returns_unit_as_null() {
+        // The caller treats non-string/non-map as a hook error; the scripting
+        // layer just reports it faithfully.
+        let s = compile("r.rhai", "fn render(ctx) { }").unwrap();
+        let out = run_render(&s, ctx()).unwrap();
+        assert_eq!(out, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn render_runtime_throw_is_execution_error() {
+        let s = compile("r.rhai", "fn render(ctx) { throw \"boom\" }").unwrap();
+        let err = run_render(&s, ctx()).unwrap_err();
+        assert!(matches!(err, crate::Error::ExecutionFailed(_)));
+        assert!(err.to_string().contains("boom"), "{err}");
+    }
+
+    #[test]
+    fn render_infinite_loop_hits_operation_limit() {
+        let s = compile("r.rhai", "fn render(ctx) { loop { } }").unwrap();
+        let err = run_render(&s, ctx()).unwrap_err();
+        assert!(matches!(err, crate::Error::ExecutionFailed(_)), "{err}");
+    }
+
+    #[test]
+    fn render_unrepresentable_return_is_validation_error() {
+        // A function pointer cannot cross the JSON boundary.
+        let s = compile("r.rhai", "fn render(ctx) { Fn(\"render\") }").unwrap();
+        let err = run_render(&s, ctx()).unwrap_err();
+        assert!(matches!(err, crate::Error::ValidationFailed(_)), "{err}");
+    }
+
+    #[test]
+    fn hooks_cannot_reach_disabled_engine_surface() {
+        // The sandbox holds for hooks: `eval` is disabled outright, so a
+        // script trying to use it never even compiles.
+        let err = compile("r.rhai", "fn render(ctx) { eval(\"1+1\") }").unwrap_err();
+        assert!(matches!(err, crate::Error::CompilationFailed(_)), "{err}");
+        assert!(err.to_string().contains("eval"), "{err}");
+    }
+
+    // ─── on_write / on_overflow ──────────────────────────────────────────
+
+    #[test]
+    fn on_write_returns_replacement_string() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { ctx.entry.content.to_upper() }
+        "#;
+        let s = compile("w.rhai", src).unwrap();
+        let out = run_on_write(
+            &s,
+            json!({ "region": { "name": "brain" }, "entry": { "content": "hi", "kind": "text", "tokens": 1 }, "stage_name": "plan" }),
+        )
+        .unwrap();
+        assert_eq!(out, json!("HI"));
+    }
+
+    #[test]
+    fn on_write_returns_booleans_and_unit() {
+        for (body, expected) in [
+            ("true", json!(true)),
+            ("false", json!(false)),
+            ("", serde_json::Value::Null),
+        ] {
+            let src = format!("fn render(ctx) {{ \"\" }}\nfn on_write(ctx) {{ {body} }}");
+            let s = compile("w.rhai", &src).unwrap();
+            let out = run_on_write(&s, json!({"entry": {"content": "x"}})).unwrap();
+            assert_eq!(out, expected, "body: {body}");
+        }
+    }
+
+    #[test]
+    fn on_overflow_returns_index_array() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) {
+                let drops = [];
+                for (entry, i) in ctx.entries {
+                    if entry.kind != "tool_result" { drops.push(i); }
+                }
+                drops
+            }
+        "#;
+        let s = compile("o.rhai", src).unwrap();
+        let out = run_on_overflow(
+            &s,
+            json!({
+                "region": { "name": "brain" },
+                "entries": [
+                    { "content": "a", "kind": "text" },
+                    { "content": "b", "kind": "tool_result" },
+                    { "content": "c", "kind": "text" },
+                ],
+                "needed_tokens": 10,
+            }),
+        )
+        .unwrap();
+        assert_eq!(out, json!([0, 2]));
+    }
+
+    #[test]
+    fn calling_a_missing_hook_is_an_execution_error() {
+        // Callers gate on has_on_write/has_on_overflow; if they get it wrong
+        // the failure is an ordinary error, not a panic.
+        let s = compile("r.rhai", "fn render(ctx) { \"\" }").unwrap();
+        assert!(!s.has_on_write());
+        let err = run_on_write(&s, json!({})).unwrap_err();
+        assert!(matches!(err, crate::Error::ExecutionFailed(_)));
+    }
+}

--- a/crates/leviath-scripting/src/types.rs
+++ b/crates/leviath-scripting/src/types.rs
@@ -28,6 +28,17 @@ pub fn register_types(engine: &mut Engine) {
         map
     });
 
+    engine.register_fn(
+        "region_custom",
+        |script: String, persistent: bool| -> rhai::Map {
+            let mut map = rhai::Map::new();
+            map.insert("kind".into(), rhai::Dynamic::from("custom".to_string()));
+            map.insert("script".into(), rhai::Dynamic::from(script));
+            map.insert("persistent".into(), rhai::Dynamic::from(persistent));
+            map
+        },
+    );
+
     // Region entry constructor
     engine.register_fn(
         "region_entry",
@@ -144,6 +155,27 @@ mod tests {
             result.get("threshold_tokens").unwrap().clone_cast::<i64>(),
             5000
         );
+    }
+
+    // --- region_custom ---
+
+    #[test]
+    fn region_custom_returns_map_with_script_and_persistent() {
+        let e = engine();
+        let result: rhai::Map = e.eval(r#"region_custom("hooks/conv.rhai", true)"#).unwrap();
+        assert_eq!(result.get("kind").unwrap().clone_cast::<String>(), "custom");
+        assert_eq!(
+            result.get("script").unwrap().clone_cast::<String>(),
+            "hooks/conv.rhai"
+        );
+        assert!(result.get("persistent").unwrap().clone_cast::<bool>());
+    }
+
+    #[test]
+    fn region_custom_non_persistent() {
+        let e = engine();
+        let result: rhai::Map = e.eval(r#"region_custom("r.rhai", false)"#).unwrap();
+        assert!(!result.get("persistent").unwrap().clone_cast::<bool>());
     }
 
     // --- region_entry ---

--- a/docs/rhai-regions.md
+++ b/docs/rhai-regions.md
@@ -1,0 +1,186 @@
+# Rhai custom regions
+
+Leviath's built-in region kinds (`pinned`, `sliding_window`, `temporary`,
+`compacting`, `clearable`, `compact_history`, `hashmap`) cover most context
+layouts. When they don't, `kind = "custom"` hands one region's behavior to a
+Rhai script you write: how the region renders into the model's context, what
+happens to each incoming entry, and what gets dropped under budget pressure.
+
+Custom regions mix freely with built-in ones - or, as a single region named
+`conversation`, own the entire context window (the
+[12-Factor Agents](https://github.com/humanlayer/12-factor-agents) "own your
+context window" pattern). Message and tool-result routing in Leviath is by
+region *name*, so a custom region named `conversation` receives the full typed
+history and its script decides what the model sees.
+
+## Declaring one
+
+```toml
+[context.regions.brain]
+kind = "custom"
+script = "context_hooks/brain.rhai"   # required, relative to the agent dir
+persistent = false                    # optional, default false
+budget = "40%"                        # budgets work exactly as on built-ins
+min_tokens = 10000
+```
+
+- `script` resolves relative to the directory containing `agent.leviath`, so
+  the script travels with the agent (`lev add`, bundles, and the embedded
+  defaults all carry `.rhai` files). Absolute paths pass through unchanged.
+- `persistent = true` makes the region Pinned-like: never evicted, immune to
+  edge `Clear` transforms, counted as fixed budget, `Always` cache hint.
+  `persistent = false` (default) behaves like Temporary: stage-specific,
+  evicted under pressure (the script gets first say - see `on_overflow`).
+- Percentage budgets resolve at spawn against the stage model's context
+  window; the script sees the resolved absolute number in `ctx.region.budget`.
+- Per-stage layouts (`[stages.<name>.context.regions.<region>]`) may declare
+  custom regions too.
+
+The script is read and compile-checked **once, at spawn**. A missing or broken
+file is a hard spawn error (and `lev validate` reports it); editing the script
+takes effect on the next run.
+
+## Script contract
+
+Three functions, each receiving one `ctx` argument. Rhai passes arguments by
+value, so mutating `ctx` in place does nothing - **return** your result.
+
+### `render(ctx)` - required
+
+Runs on every inference (even when the region is empty, so a script can emit
+static scaffolding). Shapes the region's contribution to the assembled
+request.
+
+`ctx`:
+
+```jsonc
+{
+  "region":  { "name": "brain", "budget": 80000, "current_tokens": 1234, "entry_count": 7 },
+  "entries": [ {
+      "content": "...", "tokens": 12, "timestamp": 1710000000, "key": null,
+      "kind": "text" | "user_message" | "assistant_turn" | "tool_result",
+      // assistant_turn only:
+      "tool_calls": [ { "id": "...", "name": "...", "arguments": { ... } } ],
+      // tool_result only:
+      "tool_call_id": "...", "tool_name": "...", "is_error": false
+  } ],
+  "stage_name": "plan", "stage_iterations": 2, "model": "claude-...",
+  "window": { "total_tokens": 9000, "max_tokens": 200000 }
+}
+```
+
+Return either a **string** (one system block; empty string = nothing) or a
+**map**:
+
+```rhai
+fn render(ctx) {
+    #{
+        system: "one block",            // or an array of strings
+        messages: [
+            #{ role: "user", content: "plain text" },
+            #{ role: "assistant", content: "thinking", tool_calls: [
+                #{ id: "c1", name: "shell", arguments: #{ command: "ls" } },
+            ] },
+            #{ role: "user", tool_results: [
+                #{ tool_call_id: "c1", content: "file_a", is_error: false },
+            ] },
+        ],
+    }
+}
+```
+
+Typed `tool_calls` / `tool_results` messages are built with the same wire
+shapes as the built-in `sliding_window` kind, so a Rhai recreation of it is
+byte-identical. The assembler's orphan sanitizer still strips unpaired tool
+blocks a buggy script emits - you can't produce a provider-invalid request.
+
+The 12-Factor "everything as one XML user message" case:
+
+```rhai
+fn render(ctx) {
+    let xml = "<context>";
+    for entry in ctx.entries {
+        xml += `<event kind="${entry.kind}">${entry.content}</event>`;
+    }
+    xml += "</context>";
+    #{ messages: [ #{ role: "user", content: xml } ] }
+}
+```
+
+### `on_write(ctx)` - optional
+
+Sees every entry headed into the region.
+`ctx = { region, entry: { content, kind, tokens } }`.
+
+Return a **string** to replace the content (tokens re-estimated, entry kind
+preserved), `true` or `()` to accept unchanged, `false` to drop the entry
+(the write still reports success to the writer - note a dropped tool result
+may leave a pointer in `conversation` referencing content that no longer
+exists; that's your call to make).
+
+### `on_overflow(ctx)` - optional
+
+Runs when the region must shrink: at window eviction, and when a single write
+overflows the region's budget (the write is retried once after your drops).
+`ctx = { region, entries, needed_tokens }`. Return an array of entry indices
+to drop:
+
+```rhai
+fn on_overflow(ctx) {
+    // Keep errors, drop successes.
+    let drops = [];
+    for (entry, i) in ctx.entries {
+        if !entry.content.contains("ERROR") { drops.push(i); }
+    }
+    drops
+}
+```
+
+Absent hook = oldest-first (Temporary semantics). If your drops don't free
+enough, oldest-first eviction makes up the difference.
+
+## Failure semantics
+
+Load-time problems fail fast; runtime problems never break an inference:
+
+| Failure | Behavior |
+|---|---|
+| Script file missing / doesn't compile / no `fn render(ctx)` | **Hard spawn error** (also caught by `lev validate`) |
+| `render` errors or returns an invalid shape | Warning + the region renders as a plain `[name]:` block |
+| `on_write` errors or returns an invalid type | Warning + entry accepted unchanged |
+| `on_overflow` errors or returns invalid indices | Warning + oldest-first eviction |
+| Rendered output exceeds the region's budget | Warning only - sent anyway (enable `[limits] exact_token_counting` for a hard guard) |
+
+Hooks run in the standard Leviath Rhai sandbox: no filesystem, no network, no
+`eval`/`import`, operation-bounded. They are pure data transforms.
+
+## Recreating the built-ins
+
+The point of the escape hatch is that you *could* write the built-ins
+yourself:
+
+- **pinned** - `persistent = true`, render joins entries. Exact.
+- **temporary / clearable** - defaults + a `[name]:`-style render. Exact.
+- **sliding_window** - `on_overflow` implementing your retention window,
+  render emitting typed messages. Exact (this is why typed message emission
+  exists).
+- **compacting** - approximable with deterministic condensing in
+  `on_overflow`; the LLM summarization lane is not script-accessible.
+- **hashmap** - not recreatable yet: keyed upsert is built-in-only
+  (`on_write` can't modify existing entries).
+
+## Previewing
+
+`lev test` assembles with your hooks active and real stage metadata, so you
+can see exactly what the provider would receive before a live run.
+`lev validate` checks the script parses and defines `render`.
+
+## Known limits
+
+- Stage-instruction injection targets the first `pinned` region, never a
+  custom one; file tracking (`[context.file_tracking]`) requires a `hashmap`
+  region.
+- The per-render cache hint is fixed by `persistent` (Always vs UntilChanged);
+  render can't override it per call.
+- Reordering or reshaping content across inferences can reduce provider
+  prompt-cache hits - the script owns that tradeoff.


### PR DESCRIPTION
Closes #152.

## What

A new region kind whose behavior is owned by a user Rhai script:

```toml
[context.regions.conversation]
kind = "custom"
script = "context_hooks/conv.rhai"   # blueprint-dir-relative; travels with the agent
persistent = false                    # true = Pinned-like lifecycle
budget = "40%"                        # percentage budgets work exactly as on built-ins
```

The script defines `render(ctx)` (required - shapes the region's contribution to the assembled request: a string system block, or `{system, messages}` including **typed tool_calls/tool_results messages** built with the same wire shapes as the built-in sliding window), plus optional `on_write(ctx)` (transform/reject each incoming entry) and `on_overflow(ctx)` (choose what to drop under budget pressure).

Because message/tool-result routing is by region *name*, a custom region named `conversation` suppresses the built-in sliding-window injection and receives the full typed history - one scripted region can own the entire context window (the 12-Factor Agents "own your context window" pattern), or mix freely with built-in regions. Docs: `docs/rhai-regions.md`, including an honest parity checklist for recreating each built-in kind in Rhai.

## Semantics

- **Fail fast at spawn, never at inference**: scripts are read + compile-checked once at spawn (missing/broken file = spawn error, also surfaced by `lev validate`); runtime hook failures warn and fall back (render → Temporary-style block, on_write → accept unchanged, on_overflow → oldest-first). Over-budget render output warns and sends (`exact_token_counting` stays the hard guard).
- **`persistent` flag**: true = protected from eviction and edge `Clear` transforms, fixed budget, `Always` cache hint; false = Temporary-like, with the script's `on_overflow` getting first say before the oldest-first cascade (new try_evict phase 1.5; windows without custom drops keep phase 2's pre-existing behavior byte-identical).
- **on_write seam** covers all five ContextWindow write methods and the `context_write`/`context_append` tools; the layout-swap carry and restore overlay are deliberately exempt (they re-add already-accepted entries).
- **`lev test`** assembles with hooks active and real stage metadata; **`lev validate`** checks scripts resolve and compile.

## Also in this PR

- **fix(runtime)**: `apply_layout`'s carry rebuilt entries via `add_entry`, flattening every carried entry to `EntryKind::Text` - destroying typed tool_use/tool_result pairing across per-stage layout swaps for ALL kinds (the orphan sanitizer then stripped the history) and silently resetting region-level taint. New `Region::carry_entry` preserves entries verbatim; both carry loops use it. This is a behavior improvement for existing agents with per-stage layouts.
- **feat(core)! (behavior change)**: unknown `kind = "..."` strings are now a load-time hard error instead of silently becoming Temporary - with `custom` in the mix, a typo'd kind would otherwise mean the script never runs with no signal anywhere.

## Verification

- `cargo xtask coverage`: **all 11 packages at 100%** lines/regions/functions.
- Full workspace test suite green; rebased onto current main (post-OTEL).
- **Live-verified** against a real daemon with a deterministic Rhai echo provider:
  - XML takeover: a custom `conversation` region rendered the entire typed history as one user message, with the resolved 40% budget (80000 of the mock's 200k window) visible in ctx;
  - broken render: run completed, warning named region+script+error, Temporary-style fallback block sent;
  - on_write: nudge entries dropped by the script never entered the region;
  - on_overflow: script-chosen drops let new writes land inside a 250-token budget;
  - control agent with only built-in regions: byte-normal behavior, zero warnings;
  - `lev validate`: passes the good agent, names region+path on a missing script, and rejects a typo'd kind listing the valid kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V64U61Rx6QZGM4sFhfhz5