### PR TITLE
serve: config-write API + docs content/publishing for leviath.dev

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -225,3 +225,14 @@ jobs:
             ```
           prerelease: true
           files: release/*
+
+  docs:
+    name: Publish docs (alpha)
+    needs: release
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      channel: alpha
+    secrets: inherit

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -124,3 +124,14 @@ jobs:
             ```
           prerelease: true
           files: release/*
+
+  docs:
+    name: Publish docs (beta)
+    needs: promote
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      channel: beta
+    secrets: inherit

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -221,3 +221,14 @@ jobs:
           files: release/*
 
 
+
+  docs:
+    name: Publish docs (stable)
+    needs: deploy
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      channel: stable
+    secrets: inherit

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,66 @@
+name: Publish docs
+
+# Renders docs/content to themed, crawlable HTML with leviath.dev's docs-ssg and
+# publishes it to the site's S3 docs/<channel>/ prefix. Called by the release
+# workflows (alpha/beta/prod) so a new build refreshes docs with no site rebuild.
+on:
+  workflow_call:
+    inputs:
+      channel:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: alpha | beta | stable
+        required: true
+        default: alpha
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Leviath (docs content)
+        uses: actions/checkout@v7
+
+      - name: Checkout leviath.dev (docs-ssg)
+        uses: actions/checkout@v7
+        with:
+          repository: Sun-Forge-AI/leviath.dev
+          path: site
+          token: ${{ secrets.SITE_REPO_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Build the docs renderer
+        working-directory: site
+        run: |
+          npm ci
+          npm run build --workspace @leviath-dev/docs-ssg
+
+      - name: Render docs
+        run: node site/packages/docs-ssg/dist/cli.mjs docs/content docs-out "${{ inputs.channel }}"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DOCS_PUBLISH_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Publish to S3
+        run: aws s3 sync docs-out "s3://${{ vars.SITE_BUCKET }}/docs/${{ inputs.channel }}" --delete
+
+      - name: Invalidate CloudFront
+        run: >
+          aws cloudfront create-invalidation
+          --distribution-id "${{ vars.CF_DISTRIBUTION_ID }}"
+          --paths "/docs/${{ inputs.channel }}/*"

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1,22 +1,111 @@
 //! Config and models endpoints.
 
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::Json;
 
 use super::types::*;
 use crate::commands::run::build_provider_registry_from_config;
+use crate::config::Config;
 
-pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
-    let c = &*state.config;
-    Json(RedactedConfig {
+/// Redacted view of a config — booleans for keys, never their values.
+fn redact(c: &Config) -> RedactedConfig {
+    RedactedConfig {
         default_provider: c.default_provider.clone(),
         has_anthropic_key: c.providers.anthropic_api_key.is_some(),
         has_openai_key: c.providers.openai_api_key.is_some(),
+        has_google_key: c.providers.google_api_key.is_some(),
         has_openrouter_key: c.openrouter_api_key.is_some(),
         ollama_base_url: c.ollama_base_url.clone(),
         agent_paths: c.agent_paths.clone(),
         mcp_server_count: c.mcp_servers.len(),
-    })
+    }
+}
+
+pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
+    Json(redact(&state.config))
+}
+
+/// `PUT /api/config` (admin-only). Loads the on-disk config, applies every
+/// present field, and writes it back with the file's `0600` permissions — the
+/// same file `lev setup` and MCP admin edits. Returns the new redacted config.
+pub(super) async fn put_config(
+    State(state): State<AppState>,
+    Json(req): Json<WriteConfigReq>,
+) -> Result<Json<RedactedConfig>, (StatusCode, Json<ErrorResponse>)> {
+    let path = &state.mcp.config_path;
+    let mut config = Config::load_from_path_public(path).map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to read config: {e}"),
+        )
+    })?;
+
+    if let Some(v) = req.default_provider {
+        config.default_provider = v;
+    }
+    if let Some(v) = req.default_model {
+        config.default_model = Some(v);
+    }
+    if let Some(v) = req.anthropic_key {
+        config.providers.anthropic_api_key = Some(v);
+    }
+    if let Some(v) = req.openai_key {
+        config.providers.openai_api_key = Some(v);
+    }
+    if let Some(v) = req.google_key {
+        config.providers.google_api_key = Some(v);
+    }
+    if let Some(v) = req.openrouter_key {
+        config.openrouter_api_key = Some(v);
+    }
+    if let Some(v) = req.ollama_base_url {
+        config.ollama_base_url = Some(v);
+    }
+
+    config.save_to_path_public(path).map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to write config: {e}"),
+        )
+    })?;
+    Ok(Json(redact(&config)))
+}
+
+/// Format-only validation of a provider key (no network call, no persistence).
+fn validate_key_format(provider: &str, key: &str) -> (bool, Option<String>) {
+    match provider {
+        "anthropic" => {
+            if key.starts_with("sk-ant-") {
+                (true, None)
+            } else {
+                (
+                    false,
+                    Some("Anthropic keys start with `sk-ant-`.".to_string()),
+                )
+            }
+        }
+        "openai" => {
+            if key.starts_with("sk-") {
+                (true, None)
+            } else {
+                (false, Some("OpenAI keys start with `sk-`.".to_string()))
+            }
+        }
+        "google" | "openrouter" => {
+            if key.trim().is_empty() {
+                (false, Some("Key must not be empty.".to_string()))
+            } else {
+                (true, None)
+            }
+        }
+        other => (false, Some(format!("Unknown provider `{other}`."))),
+    }
+}
+
+pub(super) async fn validate_config_key(Json(req): Json<ValidateKeyReq>) -> Json<ValidateKeyResp> {
+    let (valid, message) = validate_key_format(&req.provider, &req.key);
+    Json(ValidateKeyResp { valid, message })
 }
 
 pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelEntry>> {
@@ -246,6 +335,7 @@ mod tests {
             default_provider: "anthropic".to_string(),
             has_anthropic_key: true,
             has_openai_key: false,
+            has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
             agent_paths: vec![],
@@ -265,6 +355,7 @@ mod tests {
             default_provider: "ollama".to_string(),
             has_anthropic_key: false,
             has_openai_key: false,
+            has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: Some("http://localhost:11434".to_string()),
             agent_paths: vec![],
@@ -272,5 +363,166 @@ mod tests {
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"ollama_base_url\":\"http://localhost:11434\""));
+    }
+
+    // ─── put_config endpoint ──────────────────────────────────────────────────
+
+    fn state_with_config_path(path: std::path::PathBuf) -> AppState {
+        let (tx, _) = broadcast::channel::<ServerEvent>(64);
+        AppState {
+            config: Arc::new(Config::default()),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin {
+                config_path: path,
+                ..Default::default()
+            },
+            limits: Default::default(),
+        }
+    }
+
+    async fn put_config_request(state: AppState, body: &str) -> axum::http::Response<Body> {
+        let app = Router::new()
+            .route("/api/config", axum::routing::put(put_config))
+            .with_state(state);
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/config")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.oneshot(req).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn put_config_writes_all_present_fields_and_redacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        let body = serde_json::json!({
+            "default_provider": "openai",
+            "default_model": "gpt-5",
+            "anthropic_key": "sk-ant-x",
+            "openai_key": "sk-openai-x",
+            "google_key": "g-x",
+            "openrouter_key": "or-x",
+            "ollama_base_url": "http://ollama:11434"
+        })
+        .to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        assert!(!raw.contains("sk-ant-x"), "must not leak key values");
+        let rc: RedactedConfig = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            rc.has_anthropic_key && rc.has_openai_key && rc.has_google_key && rc.has_openrouter_key
+        );
+        assert_eq!(rc.default_provider, "openai");
+
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(
+            saved.providers.anthropic_api_key.as_deref(),
+            Some("sk-ant-x")
+        );
+        assert_eq!(
+            saved.providers.openai_api_key.as_deref(),
+            Some("sk-openai-x")
+        );
+        assert_eq!(saved.providers.google_api_key.as_deref(), Some("g-x"));
+        assert_eq!(saved.openrouter_api_key.as_deref(), Some("or-x"));
+        assert_eq!(saved.default_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            saved.ollama_base_url.as_deref(),
+            Some("http://ollama:11434")
+        );
+    }
+
+    #[tokio::test]
+    async fn put_config_empty_body_leaves_existing_config_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let base = Config {
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some("sk-ant-keep".to_string()),
+                openai_api_key: None,
+                google_api_key: None,
+                claude_code_enabled: false,
+                claude_code_binary: None,
+                claude_code_effort: None,
+            },
+            ..Default::default()
+        };
+        base.save_to_path_public(&path).unwrap();
+
+        let resp = put_config_request(state_with_config_path(path.clone()), "{}").await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(
+            saved.providers.anthropic_api_key.as_deref(),
+            Some("sk-ant-keep")
+        );
+    }
+
+    #[tokio::test]
+    async fn put_config_read_failure_is_500() {
+        // config_path points at a directory, so reading it as a file fails.
+        let dir = tempfile::tempdir().unwrap();
+        let resp = put_config_request(state_with_config_path(dir.path().to_path_buf()), "{}").await;
+        assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn put_config_write_failure_is_500() {
+        // The config file's parent is itself a file, so saving fails while
+        // reading (a non-existent file) succeeds as defaults.
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        let path = blocker.join("config.toml");
+        let resp = put_config_request(state_with_config_path(path), "{}").await;
+        assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // ─── config key validation ────────────────────────────────────────────────
+
+    #[test]
+    fn validate_key_format_covers_every_provider() {
+        assert_eq!(validate_key_format("anthropic", "sk-ant-1"), (true, None));
+        assert!(!validate_key_format("anthropic", "nope").0);
+        assert_eq!(validate_key_format("openai", "sk-1"), (true, None));
+        assert!(!validate_key_format("openai", "nope").0);
+        assert_eq!(validate_key_format("google", "g"), (true, None));
+        assert!(!validate_key_format("google", "  ").0);
+        assert_eq!(validate_key_format("openrouter", "or"), (true, None));
+        assert!(!validate_key_format("unknown", "x").0);
+    }
+
+    #[tokio::test]
+    async fn validate_config_key_endpoint_returns_result() {
+        let app = Router::new().route(
+            "/api/config/validate",
+            axum::routing::post(validate_config_key),
+        );
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/config/validate")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({"provider":"anthropic","key":"bad"}).to_string(),
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let v: ValidateKeyResp = serde_json::from_slice(&bytes).unwrap();
+        assert!(!v.valid);
+        assert!(v.message.is_some());
     }
 }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -23,7 +23,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, put};
 use tokio::sync::broadcast;
 use tower_http::cors::{Any, CorsLayer};
 
@@ -105,6 +105,7 @@ fn api_router() -> Router<AppState> {
         .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
         // Config
         .route("/api/config", get(config::get_config))
+        .route("/api/config/validate", post(config::validate_config_key))
         .route("/api/models", get(config::get_models))
         // WebSocket
         .route("/ws", get(websocket::ws_global))
@@ -222,7 +223,10 @@ async fn execute_with_shutdown(
     let app = match args.allow_admin {
         true => app
             .route("/api/mcp/servers", post(mcp::add_server))
-            .route("/api/mcp/servers/{name}", delete(mcp::remove_server)),
+            .route("/api/mcp/servers/{name}", delete(mcp::remove_server))
+            // Config-write persists provider secrets to disk, so it is gated the
+            // same way as MCP admin: unmounted (404) unless --allow-admin.
+            .route("/api/config", put(config::put_config)),
         false => app,
     };
 

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -361,10 +361,40 @@ pub(super) struct RedactedConfig {
     pub(super) default_provider: String,
     pub(super) has_anthropic_key: bool,
     pub(super) has_openai_key: bool,
+    pub(super) has_google_key: bool,
     pub(super) has_openrouter_key: bool,
     pub(super) ollama_base_url: Option<String>,
     pub(super) agent_paths: Vec<PathBuf>,
     pub(super) mcp_server_count: usize,
+}
+
+/// Body of `PUT /api/config` (admin-only). Every field is optional; a present
+/// field is written, an absent one is left untouched. Mirrors what `lev setup`
+/// writes, so a newcomer can configure providers entirely from the browser.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct WriteConfigReq {
+    pub(super) default_provider: Option<String>,
+    pub(super) default_model: Option<String>,
+    pub(super) anthropic_key: Option<String>,
+    pub(super) openai_key: Option<String>,
+    pub(super) google_key: Option<String>,
+    pub(super) openrouter_key: Option<String>,
+    pub(super) ollama_base_url: Option<String>,
+}
+
+/// Body of `POST /api/config/validate` — a format-only key check (no network,
+/// no persistence), mirroring the `lev setup` wizard's inline validation.
+#[derive(Debug, Deserialize)]
+pub(super) struct ValidateKeyReq {
+    pub(super) provider: String,
+    pub(super) key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ValidateKeyResp {
+    pub(super) valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) message: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -507,6 +537,7 @@ mod tests {
             default_provider: "anthropic".to_string(),
             has_anthropic_key: true,
             has_openai_key: false,
+            has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
             agent_paths: vec![],

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -1,0 +1,70 @@
+---
+title: Agent blueprints
+group: Guides
+order: 2
+---
+
+# Agent blueprints (`agent.leviath`)
+
+An agent is a directory with an `agent.leviath` file — a TOML **blueprint** describing a
+multi-stage workflow graph. `lev create <name>` scaffolds one.
+
+```toml
+[agent]
+name = "coder"
+version = "0.2.0"
+description = "Analyze, implement, and review with graph-based recovery"
+entry_stage = "analyze"
+
+[tool_permissions]           # global defaults; per-stage overrides allowed
+read_file  = "allow"
+write_file = "ask"
+bash       = "ask"
+
+[stages.analyze]
+mode = "autonomous"
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-4-6" },
+  { provider = "openai",    model = "gpt-5.4-mini" },
+] }
+available_tools = ["read_file", "list_dir"]
+max_iterations = 15
+system_prompt = """Understand the task and produce a short implementation plan."""
+
+[stages.analyze.transitions.implement]
+hint = "Plan ready — begin implementation"
+```
+
+## Stages and models
+
+Each stage gets its own **model** (an ordered provider/model fallback list — the first configured
+provider wins), tools, iteration cap, and context layout. Transitions form a
+[graph](/docs/stages): linear by default, or branch on conditions like `error` and `stuck`.
+
+## Context regions
+
+`[context.regions]` defines the memory layout. Budgets can be **percentages of the model's context
+window** (ceilings — they may sum past 100%), with absolute `max_tokens` / `threshold_tokens`
+guard-rails. Region kinds: `pinned`, `sliding_window`, `compacting`, `compact_history`, `clearable`,
+`hashmap`. See [Context regions](/docs/context).
+
+## Seed commands
+
+A region can be seeded before the run starts:
+
+```toml
+[context.regions.codebase]
+kind = "compacting"
+seed = { command = "git ls-files" }
+```
+
+Seeds run at spawn **before any approval prompt**, confined to the workdir and routed through the
+entry stage's sandbox, time- and size-capped. `lev validate` prints them; refuse with
+`--no-seed-commands` or `[security] allow_seed_commands = false`.
+
+Validate and test a blueprint before running it:
+
+```bash
+lev validate .
+lev test .
+```

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -1,0 +1,56 @@
+---
+title: HTTP API
+group: Guides
+order: 1
+---
+
+# HTTP API (`lev serve`)
+
+`lev serve` exposes a REST + WebSocket API in front of the daemon, so anything that speaks HTTP
+can drive Leviath — including the [agent console](/app).
+
+```bash
+lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.dev
+```
+
+## Security model
+
+- **A token is required.** The server refuses to start without `--token <t>` (or
+  `LEVIATH_API_TOKEN`). Every request must send `Authorization: Bearer <t>`; WebSocket clients
+  pass it as `?token=<t>` because browsers can't set WS headers.
+- **CORS is closed by default.** Pass `--cors <origin>` (e.g. `https://leviath.dev`) or `--cors "*"`
+  to allow a browser to call it cross-origin.
+- **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network.
+- **`--allow-admin`** mounts the mutating admin routes (write config, add/remove MCP servers).
+  Off by default, so those routes 404 rather than relying on an in-handler check.
+- **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` on spawn.
+
+## Endpoints
+
+Base path `/api`; all JSON unless noted.
+
+| Method · Path | Purpose |
+|---|---|
+| `GET /api/agents` · `POST /api/agents` | List runs · spawn an agent |
+| `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
+| `GET /api/agents/{id}/result` · `/logs` · `/context` · `/context/history` | Run output, logs, context |
+| `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
+| `POST /api/agents/{id}/message` | Steer a running agent |
+| `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
+| `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation |
+| `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
+| `GET /api/models` | Enumerate models |
+| `GET /api/mcp/servers` · `/{name}/status` · `/login` · `/test` | MCP servers (add/remove need admin) |
+| `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
+
+## Spawning with a webhook
+
+```bash
+curl -X POST http://localhost:3000/api/agents \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"blueprint":"coder","task":"Add input validation",
+       "callback_url":"https://example.com/hook","callback_secret":"whsec_…"}'
+```
+
+Completion webhooks are signed with `callback_secret`: verify the `X-Leviath-Signature: sha256=<hex>`
+header. Transient failures are retried with exponential backoff.

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -1,0 +1,35 @@
+---
+title: Structured context
+group: Concepts
+order: 1
+---
+
+# Structured context memory
+
+Most agent tools hand an LLM a flat message array. Leviath gives it **regions** — typed slices of
+the context window with deterministic eviction, so a file dump can't push out your system prompt.
+
+Six region kinds:
+
+| Kind | Behavior |
+|---|---|
+| `pinned` | Never evicted (architecture, the task). |
+| `sliding_window` | Keeps the most recent entries; the conversation lives here. |
+| `compacting` | Summarizes instead of evicting — file reads and tool results. |
+| `compact_history` | Rolls compacted summaries forward across stages. |
+| `clearable` | Dropped wholesale at a stage boundary (scratch). |
+| `hashmap` | Keyed entries; a write to a key replaces it. |
+
+Tool output is **routed** to a region, so exploration lands in a persistent codebase region rather
+than scratch:
+
+```toml
+[stages.analyze.tool_routing]
+default_region = "scratch"
+[stages.analyze.tool_routing.overrides]
+read_file = "codebase"
+```
+
+Budgets can be **percentages of the model's context window**, so a blueprint's intent survives
+across models of different sizes. Percentages are ceilings and may sum past 100%; absolute
+`max_tokens` and `threshold_tokens` are hard guard-rails.

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -1,0 +1,44 @@
+---
+title: The daemon
+group: Start
+order: 2
+---
+
+# The shared-world daemon
+
+`lev run` doesn't run the agent in your terminal — it hands it to a background **daemon** that
+hosts every agent in one shared ECS world. Runs keep going after your terminal closes, and a
+dozen agents share a single process instead of a process each.
+
+The daemon starts automatically the first time you need it. You can also run it yourself:
+
+```bash
+lev daemon                 # run in the foreground (with logs)
+lev daemon status          # is it running?
+lev daemon stop
+```
+
+## Run it unattended
+
+For an always-on setup, install the daemon under your OS service manager so it starts at login,
+restarts if it dies, and reloads interrupted runs on start:
+
+```bash
+lev daemon install         # launchd (macOS) / systemd --user (Linux)
+lev daemon uninstall
+```
+
+## Control surface
+
+The daemon is reached over a local control socket (a Unix socket / Windows pipe, guarded by a
+peer-credential check — not a TCP port). The CLI verbs that talk to it:
+
+| Command | Does |
+|---|---|
+| `lev ps` | List running agents and their status |
+| `lev msg <id> <text>` | Send a message to a running agent |
+| `lev respond` | Answer a pending `ask_user` question |
+| `lev cancel <run-id>` | Cancel a run |
+| `lev context <run-id>` | Show a run's context-window history |
+
+To drive the daemon over HTTP instead, run the [API server](/docs/api).

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -1,0 +1,24 @@
+---
+title: Dashboard
+group: Guides
+order: 5
+---
+
+# Dashboard (`lev dash`)
+
+`lev dash` is a full TUI for managing concurrent agents.
+
+- **Agent table** — blueprint/title, stage index, status, tokens in/out, context-window occupancy,
+  iteration, elapsed time, model, and sub-agent depth. Auto-generated run titles.
+- **Detail view** — per-stage tabs or a graph view of the workflow, a context-window visualization,
+  and content panes for **Output**, **Logs**, and **Context** (JSON). Markdown is rendered.
+- **Interactions** — answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
+  confirm) or send it a mid-run message.
+- **Mouse support** — wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
+  `y` to yank a pane, Shift+drag for native selection.
+- **`m`** opens the MCP management screen without leaving the dashboard.
+
+Common keys: `1`–`9` select · Enter/Esc open/close detail · `/` search · `l`/`o`/`c` switch
+Logs/Output/Context · `i` respond or message · `k` kill · `?` help.
+
+Prefer a browser? The [agent console](/app) mirrors the dashboard over the [HTTP API](/docs/api).

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -1,0 +1,18 @@
+---
+title: ECS engine
+group: Concepts
+order: 3
+---
+
+# The ECS agent engine
+
+Leviath runs agents as **entities in a [bevy_ecs](https://bevyengine.org/) world**. Dozens of agents
+share one process with game-engine-style scheduling, instead of one OS process each.
+
+Why it matters: orchestration tools that spawn a separate process per agent carry the full weight of
+a Node/Go runtime per agent, and each manages its own flat context window. Leviath's engine runs
+them all over one shared, lock-free inference driver, so spinning up ten agents doesn't mean ten
+times the device RAM.
+
+Sub-agents and fan-out workers are just more entities in the same world — see
+[Sub-agents](/docs/sub-agents).

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,0 +1,82 @@
+---
+title: Getting Started
+group: Start
+order: 1
+---
+
+# Getting Started
+
+Leviath is a structured agent runtime for LLMs. It gives an agent **structure** — context
+that stays coherent across hundreds of tool calls, the right model for each phase of a task,
+and a dozen agents running at once in a single process.
+
+## Install
+
+> **Private alpha.** Installing needs a GitHub Personal Access Token (`repo` scope):
+> `GITHUB_TOKEN` for the scripts and `HOMEBREW_GITHUB_API_TOKEN` for Homebrew. One-time setup
+> lives in the [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist).
+
+**macOS (Homebrew)**
+
+```bash
+brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+brew trust sun-forge-ai/leviath
+brew install leviath            # or: leviath-beta, leviath-alpha
+```
+
+**Linux**
+
+```bash
+curl -fsSL -H "Authorization: token $GITHUB_TOKEN" \
+  https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh \
+  | bash -s -- --channel stable
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm -Headers @{Authorization="token $env:GITHUB_TOKEN"} `
+  https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.ps1 | iex
+```
+
+**From source** (any platform, needs [Rust](https://rustup.rs/)):
+
+```bash
+cargo install --git https://github.com/Sun-Forge-AI/leviath.git --bin lev
+```
+
+## Configure a provider
+
+One provider is all you need — an API key from Anthropic, OpenAI, Google AI, or OpenRouter,
+or a local [Ollama](https://ollama.com) with no key at all.
+
+```bash
+lev setup                                            # interactive wizard
+lev setup --non-interactive --anthropic-key sk-ant-… # scriptable
+```
+
+See [Providers](/docs/providers) for the full list and the Claude Code transport.
+
+## Run an agent
+
+```bash
+lev run coder --task "Build a CLI that converts CSV to JSON"
+lev run deep-researcher --task "Survey the state of solid-state batteries"
+```
+
+`lev run` hands the agent to a background [daemon](/docs/daemon), so runs keep going after your
+terminal closes. Watch everything with the TUI [dashboard](/docs/dashboard):
+
+```bash
+lev dash
+```
+
+## Create your own
+
+```bash
+lev create my-agent        # scaffolds an agent directory
+cd my-agent
+lev run . --task "Your task here"
+```
+
+This writes an `agent.leviath` config you can customize — see [Agents](/docs/agents).

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -1,0 +1,37 @@
+---
+title: MCP tool servers
+group: Guides
+order: 6
+---
+
+# MCP tool servers
+
+Leviath connects to [Model Context Protocol](https://modelcontextprotocol.io) servers over stdio or
+HTTP (streamable, with a legacy HTTP+SSE fallback), giving agents extra tools.
+
+```bash
+lev mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path
+lev mcp list
+lev mcp login <name>        # OAuth servers: opens your browser
+lev mcp test <name>
+lev mcp remove <name>
+```
+
+Or configure in `~/.leviath/config.toml`:
+
+```toml
+[[mcp_servers]]
+name = "filesystem"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+
+[[mcp_servers]]
+name = "remote"
+url = "https://mcp.example.com"
+headers = { Authorization = "Bearer ${MY_TOKEN}" }   # ${VAR} is expanded
+```
+
+`lev mcp add` detects OAuth servers, binds tokens to the server origin (RFC 8414 issuer check,
+HTTPS-only, capped redirects), and stores them in `~/.leviath/mcp-auth.json` (`0600`), refreshing
+non-interactively. Manage servers from the [dashboard](/docs/dashboard) with `m`, or over the
+[API](/docs/api) under `/api/mcp/servers`.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -1,0 +1,50 @@
+---
+title: Providers
+group: Guides
+order: 3
+---
+
+# Providers
+
+Leviath needs at least one model provider. Configure them with `lev setup` or by writing keys via
+the [API](/docs/api).
+
+| Provider | Key |
+|---|---|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Google (Gemini) | `GOOGLE_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| Ollama | *none (local)* |
+| Claude Code | *none (subscription — see below)* |
+
+## Rate limits
+
+Optional per-provider client-side rate limits, enforced before each call:
+
+```toml
+[rate_limits.anthropic]
+requests_per_minute = 50
+tokens_per_minute   = 100000
+```
+
+## Custom OpenAI-compatible providers
+
+Point Leviath at any OpenAI-compatible endpoint with a small Rhai script — see
+`docs/rhai-providers.md` in the repo and the `docs/examples/groq.rhai` example.
+
+## Claude Code transport
+
+If you have Claude Code installed and signed in, you can run Leviath on your Claude subscription
+with no API key. Leviath's structured regions still work; the CLI is driven as a plain inference
+relay.
+
+> **⚠️ Terms of service:** Anthropic's terms state that third-party developers may not offer
+> claude.ai login or subscription rate limits for their products without prior approval. Using this
+> transport routes inference through your Claude subscription via the CLI's OAuth session. **By
+> enabling it, you accept responsibility for compliance with Anthropic's terms.** For unambiguous
+> compliance, use a direct Anthropic API key instead.
+
+Measured caveats: the CLI adds ~130 tokens of its own context to **every** call — including your
+account email address and the current date — with no flag to disable it; no prompt caching; a
+subprocess per call; Anthropic models only.

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -1,0 +1,54 @@
+---
+title: Security & sandboxing
+group: Guides
+order: 4
+---
+
+# Security: sandboxed execution and taint tracking
+
+By default an agent's shell commands run directly on your machine. When you want isolation, opt in
+per agent or per stage.
+
+## Sandboxes
+
+```toml
+[sandbox]
+kind    = "container"     # "container" | "namespace" | "none"
+engine  = "docker"        # docker | podman | any Docker-CLI-compatible
+image   = "debian:bookworm-slim"
+network = false
+
+[stages.analyze.sandbox]  # per-stage override
+kind = "none"             # run discovery on the host…
+```
+
+- **Containers** (Docker/Podman): the daemon keeps a warm container per agent and tears it down at
+  reap. Every capability is dropped, privilege regain is forbidden, processes and memory are bounded,
+  and file tools keep working over the bind-mounted workdir.
+- **Namespaces**: a lighter option with no container runtime; isolates PIDs and (with
+  `network = false`) connectivity. It shares the host filesystem, so reach for a container when you
+  want real containment.
+
+An installed agent can *tighten* its sandbox but never turn one off.
+
+## Taint tracking (experimental)
+
+A deterministic sensitivity model — **Public / Internal / Private** — tags every context region,
+set by the runtime and never by model output. Any tool that can carry bytes off the machine is
+gated: if it carries data above its clearance, the call is blocked before it fires, or surfaced as
+an *allow once / allow for session / deny* prompt. Taint recovers as entries evict, and unrecognized
+tools fail closed.
+
+Configure with a `[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool:
+
+```bash
+lev policy list
+lev policy add
+lev policy test --tool bash --target example.com
+```
+
+## Threat model
+
+`lev serve` runs LLM-driven tools, so treat it as trusted-network only unless hardened. See
+[SECURITY.md](https://github.com/Sun-Forge-AI/leviath/blob/main/SECURITY.md) for the full threat
+model, what Leviath defends against, and how to report a vulnerability (GitHub private advisories).

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -1,0 +1,40 @@
+---
+title: Multi-stage workflows
+group: Concepts
+order: 2
+---
+
+# Multi-stage workflows
+
+A blueprint is a **graph of stages**. Each stage has its own model, tools, and context layout. Run
+them linearly, or branch with conditional transitions, LLM-driven routing, and error recovery.
+Check the graph with `lev validate`.
+
+```toml
+[stages.implement.transitions.review]
+hint = "Implementation complete, ready for review"
+
+[stages.implement.transitions.reassess]
+condition = "stuck"          # a runtime condition, not the agent's choice
+```
+
+## Transitions
+
+- **hint** transitions are chosen by the agent (LLM-routed).
+- **conditional** transitions fire automatically on a runtime signal: `error`, or `stuck`.
+
+## Stuck detection {#graph}
+
+`stuck` escapes a stage that is making no progress. Stuckness is *measured*, not self-reported:
+
+```toml
+[stages.implement.transitions.reassess]
+condition = "stuck"
+stuck_after_iterations      = 20   # inferences in this stage
+stuck_after_same_file_edits = 5    # write/edit calls against one path
+stuck_after_tool_calls      = 100
+stuck_after_minutes         = 30
+```
+
+Any subset applies; the first threshold to trip fires the edge, and the runtime writes *why* into
+the target stage's context so the next stage knows what happened.

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -1,0 +1,28 @@
+---
+title: Sub-agents & fan-out
+group: Concepts
+order: 4
+---
+
+# Sub-agents and fan-out
+
+Agents spawn children with different blueprints, all in the same process and over one shared
+inference driver.
+
+## Fan-out
+
+A **fan-out** stage splits a task into work items and runs one sub-agent worker per item
+concurrently, bounded by `max_workers`, then merges their results back into the parent.
+
+```toml
+[stages.fix.fan_out]
+worker_agent = "."          # blueprint for each worker
+query        = "..."        # how to split the work
+max_workers  = 8
+merge_stage  = "verify"
+on_worker_failure = "continue"
+```
+
+Any sub-agent, at any depth, can ask the user a question directly — no fire-and-forget, no routing
+through the parent. The [dashboard](/docs/dashboard) and the API's `/api/agents/tree` show the full
+sub-agent tree with per-subtree token roll-ups.


### PR DESCRIPTION
Support for the new leviath.dev site + browser console.

## API
- **`PUT /api/config`** (admin-only, behind `--allow-admin`): writes provider keys, default provider/model, and the Ollama URL to the config file with its `0600` perms — so a newcomer can configure a fresh instance entirely from the browser console. Never echoes key values.
- **`POST /api/config/validate`**: format-only key validation (mirrors `lev setup`).
- `RedactedConfig` gains `has_google_key`.

## Docs
- `docs/content/*.md`: the 12-page source of truth for leviath.dev/docs, rendered per release by the site's docs-ssg into crawlable HTML.
- `publish-docs.yml` + wiring into alpha/beta/prod: each release publishes docs to the site's S3 `docs/<channel>/` prefix via keyless OIDC — no site rebuild.

Fully unit-tested and clippy-clean; the 100% coverage gate holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183FsqU8fBBD3ajzDE2cvEe