### PR TITLE
fix(serve): allow Authorization header in CORS (unblocks the browser console)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Ten agents ship out of the box, each a multi-stage directed graph with structure
 <table>
 <tr><th align="left">Agent</th><th align="left">Workflow</th></tr>
 <tr>
-<td valign="middle" width="30%"><b>software-engineer</b> <em>(default)</em><br>Full coding workflow: codebase discovery, human-approved planning, an optional prototype spike, stuck detection</td>
+<td valign="middle" width="30%"><b>software-engineer</b><br>Full coding workflow: codebase discovery, human-approved planning, an optional prototype spike, stuck detection</td>
 <td><picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/agents/software-engineer-dark.svg">
   <img src="docs/assets/agents/software-engineer.svg" alt="software-engineer workflow graph">

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -193,7 +193,14 @@ async fn execute_with_shutdown(
             CorsLayer::new()
                 .allow_origin(Any)
                 .allow_methods(Any)
-                .allow_headers(Any),
+                // `Access-Control-Allow-Headers: *` does NOT cover
+                // `Authorization` per the Fetch spec, so a browser sending the
+                // required bearer token would be blocked. List the headers the
+                // API actually needs explicitly.
+                .allow_headers([
+                    axum::http::header::AUTHORIZATION,
+                    axum::http::header::CONTENT_TYPE,
+                ]),
         ),
         Some(origin) => {
             // An unparseable value must not fall back to `*` - that silently
@@ -206,7 +213,14 @@ async fn execute_with_shutdown(
                 CorsLayer::new()
                     .allow_origin(value)
                     .allow_methods(Any)
-                    .allow_headers(Any),
+                    // `Access-Control-Allow-Headers: *` does NOT cover
+                    // `Authorization` per the Fetch spec, so a browser sending the
+                    // required bearer token would be blocked. List the headers the
+                    // API actually needs explicitly.
+                    .allow_headers([
+                        axum::http::header::AUTHORIZATION,
+                        axum::http::header::CONTENT_TYPE,
+                    ]),
             )
         }
     };
@@ -924,6 +938,64 @@ prompt = "Run"
                 assert!(
                     String::from_utf8_lossy(&resp2).starts_with("HTTP/1.1 401"),
                     "unauthenticated request should be 401"
+                );
+
+                handle.abort();
+            },
+        )
+        .await;
+    }
+
+    /// A browser preflight for a request carrying `Authorization` must be
+    /// allowed. `Access-Control-Allow-Headers: *` does NOT cover `Authorization`
+    /// per the Fetch spec, so the header has to be listed explicitly — without
+    /// it the console's authenticated requests are blocked by the browser. Also
+    /// covers the `Some("*")` CORS arm.
+    #[tokio::test]
+    async fn execute_cors_preflight_allows_authorization_header() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-cors-preflight",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: Some("*".to_string()),
+                    token: Some("test-token".to_string()),
+                    allow_admin: false,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                };
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let handle = tokio::spawn(execute_with_shutdown(
+                    args,
+                    no_daemon_control(),
+                    Box::pin(std::future::pending()),
+                    Some(ready_tx),
+                ));
+                let addr = ready_rx
+                    .await
+                    .expect("server should report its bound address");
+
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+                stream
+                    .write_all(
+                        b"OPTIONS /api/config HTTP/1.1\r\nHost: localhost\r\n\
+                          Origin: https://leviath.dev\r\n\
+                          Access-Control-Request-Method: GET\r\n\
+                          Access-Control-Request-Headers: authorization\r\n\
+                          Connection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+                let mut resp = Vec::new();
+                stream.read_to_end(&mut resp).await.unwrap();
+                let lower = String::from_utf8_lossy(&resp).to_lowercase();
+                assert!(
+                    lower.contains("access-control-allow-headers")
+                        && lower.contains("authorization"),
+                    "preflight must allow the Authorization header, got:\n{lower}"
                 );
 
                 handle.abort();


### PR DESCRIPTION
The leviath.dev console could connect to `lev serve` but every authenticated request failed at the browser.

**Root cause:** the CORS layer sent `Access-Control-Allow-Headers: *`, and per the Fetch spec the `*` wildcard does **not** cover the `Authorization` header — so the browser's preflight rejected every request carrying the required bearer token.

**Fix:** list `authorization` and `content-type` explicitly in both CORS arms (`--cors *` and `--cors <origin>`). Adds a preflight regression test; verified against a running server (`access-control-allow-headers: authorization,content-type`).

Also drops the meaningless "(default)" label on software-engineer in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183FsqU8fBBD3ajzDE2cvEe