### PR TITLE
ci(docs): tokenless leviath.dev checkout for docs publish

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,12 +28,13 @@ jobs:
       - name: Checkout Leviath (docs content)
         uses: actions/checkout@v7
 
+      # leviath.dev is public, so the default token checks it out — no
+      # cross-repo PAT/deploy-key needed.
       - name: Checkout leviath.dev (docs-ssg)
         uses: actions/checkout@v7
         with:
           repository: Sun-Forge-AI/leviath.dev
           path: site
-          token: ${{ secrets.SITE_REPO_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Removes the `token: ${{ secrets.SITE_REPO_TOKEN }}` from the docs-publish job's
checkout of `Sun-Forge-AI/leviath.dev`. Since leviath.dev is going public, the
default `GITHUB_TOKEN` can clone it — no cross-repo PAT or deploy key needed,
and no dependency on a secret that was never set.

Once leviath.dev is public, triggering `Publish docs` (or any release workflow)
renders `docs/content` and syncs to `s3://…/docs/<channel>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)