### PR TITLE
docs: top-tier content — Diátaxis IA, diagrams, callouts

### DIFF
--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -1,13 +1,14 @@
 ---
 title: Agent blueprints
-group: Guides
-order: 2
+group: Concepts
+group_order: 2
+order: 3
 ---
 
 # Agent blueprints (`agent.leviath`)
 
 An agent is a directory with an `agent.leviath` file — a TOML **blueprint** describing a
-multi-stage workflow graph. `lev create <name>` scaffolds one.
+multi-stage [workflow graph](/docs/stages). `lev create <name>` scaffolds one.
 
 ```toml
 [agent]
@@ -35,6 +36,41 @@ system_prompt = """Understand the task and produce a short implementation plan."
 hint = "Plan ready — begin implementation"
 ```
 
+## The run loop
+
+Within a stage, an agent runs a tight loop — infer, act on tool calls, repeat — until the model
+signals it's done or a [transition](/docs/stages) fires:
+
+```mermaid
+flowchart LR
+  I["Infer<br/>(stage model)"] --> T{"Tool calls?"}
+  T -->|yes| X["Execute tools<br/>route output to regions"]
+  X --> I
+  T -->|no| D{"Transition?"}
+  D -->|hint / error / stuck| N["Next stage"]
+  D -->|none, done| E["Finish"]
+  N --> I
+```
+
+## Lifecycle
+
+A run moves through a handful of states the [dashboard](/docs/dashboard) and [API](/docs/api)
+report on:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Running
+  Running --> AwaitingInput: ask_user / tool approval
+  AwaitingInput --> Running: you respond
+  Running --> Done
+  Running --> Failed: unrecoverable error
+  Running --> Cancelled: lev cancel
+  Done --> [*]
+  Failed --> [*]
+  Cancelled --> [*]
+```
+
 ## Stages and models
 
 Each stage gets its own **model** (an ordered provider/model fallback list — the first configured
@@ -46,7 +82,7 @@ provider wins), tools, iteration cap, and context layout. Transitions form a
 `[context.regions]` defines the memory layout. Budgets can be **percentages of the model's context
 window** (ceilings — they may sum past 100%), with absolute `max_tokens` / `threshold_tokens`
 guard-rails. Region kinds: `pinned`, `sliding_window`, `compacting`, `compact_history`, `clearable`,
-`hashmap`. See [Context regions](/docs/context).
+`hashmap`. See [Structured context](/docs/context) for what each one does.
 
 ## Seed commands
 
@@ -59,12 +95,16 @@ seed = { command = "git ls-files" }
 ```
 
 Seeds run at spawn **before any approval prompt**, confined to the workdir and routed through the
-entry stage's sandbox, time- and size-capped. `lev validate` prints them; refuse with
-`--no-seed-commands` or `[security] allow_seed_commands = false`.
+entry stage's sandbox, time- and size-capped.
 
-Validate and test a blueprint before running it:
+> [!WARNING]
+> A seed command runs a shell command before you approve anything. `lev validate` prints every
+> seed a blueprint will run — review them for third-party blueprints. Refuse with
+> `--no-seed-commands` or `[security] allow_seed_commands = false`.
+
+## Validate before you run
 
 ```bash
-lev validate .
-lev test .
+lev validate .             # check the graph, print seeds + permissions
+lev test .                 # dry-run the blueprint
 ```

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -1,13 +1,14 @@
 ---
 title: HTTP API
-group: Guides
+group: Reference
+group_order: 3
 order: 1
 ---
 
 # HTTP API (`lev serve`)
 
-`lev serve` exposes a REST + WebSocket API in front of the daemon, so anything that speaks HTTP
-can drive Leviath — including the [agent console](/app).
+`lev serve` exposes a REST + WebSocket API in front of the [daemon](/docs/daemon), so anything that
+speaks HTTP can drive Leviath — including the browser [console](/app).
 
 ```bash
 lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.dev
@@ -24,6 +25,27 @@ lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.d
 - **`--allow-admin`** mounts the mutating admin routes (write config, add/remove MCP servers).
   Off by default, so those routes 404 rather than relying on an in-handler check.
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` on spawn.
+
+> [!CAUTION]
+> `lev serve` runs LLM-driven tools with whatever permissions the blueprint grants. Treat it as
+> trusted-network only unless hardened — see [Security](/docs/security).
+
+## Auth flow
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Serve as lev serve
+  participant Daemon
+  Client->>Serve: request + Authorization: Bearer <token>
+  alt token missing / wrong
+    Serve-->>Client: 401 Unauthorized
+  else authorized
+    Serve->>Daemon: control-socket call
+    Daemon-->>Serve: result
+    Serve-->>Client: 200 JSON
+  end
+```
 
 ## Endpoints
 
@@ -43,7 +65,26 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/mcp/servers` · `/{name}/status` · `/login` · `/test` | MCP servers (add/remove need admin) |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
 
-## Spawning with a webhook
+## Live updates over WebSocket
+
+Connect to `/ws` (all agents) or `/ws/agents/{id}` (one run) with `?token=<t>`; the server streams
+`ServerEvent` frames as the run progresses:
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Serve as lev serve
+  Browser->>Serve: GET /ws/agents/{id}?token=…
+  Serve-->>Browser: 101 Switching Protocols
+  loop while the run is live
+    Serve-->>Browser: {stage changed}
+    Serve-->>Browser: {tokens updated}
+    Serve-->>Browser: {awaiting input}
+  end
+  Serve-->>Browser: {done}
+```
+
+## Spawning with a signed webhook
 
 ```bash
 curl -X POST http://localhost:3000/api/agents \
@@ -54,3 +95,7 @@ curl -X POST http://localhost:3000/api/agents \
 
 Completion webhooks are signed with `callback_secret`: verify the `X-Leviath-Signature: sha256=<hex>`
 header. Transient failures are retried with exponential backoff.
+
+> [!TIP]
+> The [browser console](/app) is a full reference client for this API — connection, spawn, live
+> dashboard, blueprint editing, MCP and policy management — built on the same typed endpoints.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -1,0 +1,52 @@
+---
+title: CLI reference
+group: Reference
+group_order: 3
+order: 2
+---
+
+# CLI reference (`lev`)
+
+Everything Leviath does is one binary, `lev`. This is a map of the commands the docs reference;
+run `lev <command> --help` for the full, authoritative flag list.
+
+## Running agents
+
+| Command | Purpose |
+|---|---|
+| `lev run <agent> --task "…"` | Start an agent (built-in name or a blueprint path) |
+| `lev create <name>` | Scaffold a new [`agent.leviath` blueprint](/docs/agents) |
+| `lev validate <path>` | Check a blueprint's graph, seeds, and permissions |
+| `lev test <path>` | Dry-run a blueprint |
+
+## Watching and steering
+
+| Command | Purpose |
+|---|---|
+| `lev dash` | Full-screen TUI [dashboard](/docs/dashboard) |
+| `lev ps` | List running agents and their status |
+| `lev msg <id> "…"` | Send a message to a running agent |
+| `lev respond` | Answer a pending `ask_user` question |
+| `lev cancel <run-id>` | Cancel a run |
+| `lev context <run-id>` | Show a run's context-window history |
+
+## The daemon and API
+
+| Command | Purpose |
+|---|---|
+| `lev daemon [status\|stop]` | Run / inspect / stop the [shared-world daemon](/docs/daemon) |
+| `lev daemon install` | Install it as a launchd / systemd service |
+| `lev serve …` | Expose the [HTTP + WebSocket API](/docs/api) |
+
+## Configuration and tools
+
+| Command | Purpose |
+|---|---|
+| `lev setup` | Interactive [provider](/docs/providers) setup wizard |
+| `lev mcp [add\|list\|login\|test\|remove]` | Manage [MCP tool servers](/docs/mcp) |
+| `lev policy [list\|add\|test]` | Manage [taint policy](/docs/security) rules |
+
+> [!TIP]
+> Two flags worth knowing on `lev serve`: `--allow-admin` (mounts the config-write and MCP-write
+> routes) and `--cors https://leviath.dev` (lets the browser [console](/app) reach it). See the
+> [API](/docs/api) for the full security model.

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -1,15 +1,28 @@
 ---
 title: Structured context
 group: Concepts
-order: 1
+group_order: 2
+order: 4
 ---
 
 # Structured context memory
 
-Most agent tools hand an LLM a flat message array. Leviath gives it **regions** — typed slices of
-the context window with deterministic eviction, so a file dump can't push out your system prompt.
+Most agent tools hand an LLM a flat message array. When a big file read lands, it shoves the system
+prompt and the task toward the edge of the window. Leviath instead gives the agent **regions** —
+typed slices of the context window with deterministic eviction — so a file dump can't push out what
+the agent needs to remember.
 
-Six region kinds:
+A stage's context window is divided into regions, each with its own budget and eviction rule:
+
+<div style="border:1px solid #21262d;border-radius:.5rem;overflow:hidden;display:flex;font-size:.78rem;font-weight:600;text-align:center;color:#fff;margin:1.25rem 0">
+  <div style="flex:0 0 12%;background:#8b5cf6;padding:.6rem .3rem" title="pinned">pinned<br/>12%</div>
+  <div style="flex:0 0 20%;background:#6366f1;padding:.6rem .3rem" title="compacting">codebase<br/>20%</div>
+  <div style="flex:0 0 33%;background:#3b82f6;padding:.6rem .3rem" title="sliding_window">conversation<br/>33%</div>
+  <div style="flex:0 0 15%;background:#0ea5e9;padding:.6rem .3rem" title="compact_history">history<br/>15%</div>
+  <div style="flex:1 1 auto;background:#1f2937;padding:.6rem .3rem;color:#8b949e" title="free">headroom</div>
+</div>
+
+## The six region kinds
 
 | Kind | Behavior |
 |---|---|
@@ -19,6 +32,24 @@ Six region kinds:
 | `compact_history` | Rolls compacted summaries forward across stages. |
 | `clearable` | Dropped wholesale at a stage boundary (scratch). |
 | `hashmap` | Keyed entries; a write to a key replaces it. |
+
+## Eviction is deterministic
+
+When a region crosses its threshold, the runtime acts by the region's *kind* — never by pushing out
+whichever message is oldest across the whole window:
+
+```mermaid
+flowchart TD
+  W["New entry routed to a region"] --> C{"Region over<br/>threshold?"}
+  C -->|no| K["Keep"]
+  C -->|yes| T{"Region kind?"}
+  T -->|pinned| K2["Keep — never evicted"]
+  T -->|sliding_window| D["Drop oldest entries"]
+  T -->|compacting / compact_history| S["Summarize into a compact form"]
+  T -->|clearable| CL["Cleared at next stage boundary"]
+```
+
+## Routing tool output
 
 Tool output is **routed** to a region, so exploration lands in a persistent codebase region rather
 than scratch:
@@ -30,6 +61,12 @@ default_region = "scratch"
 read_file = "codebase"
 ```
 
+## Budgets travel across models
+
 Budgets can be **percentages of the model's context window**, so a blueprint's intent survives
-across models of different sizes. Percentages are ceilings and may sum past 100%; absolute
-`max_tokens` and `threshold_tokens` are hard guard-rails.
+across models of different sizes — a region sized "20% of the window" is 20% whether the model has
+32k or 200k tokens.
+
+> [!NOTE]
+> Percentages are ceilings and may sum past 100% (regions rarely fill at once). Absolute
+> `max_tokens` and `threshold_tokens` are hard guard-rails when you need them.

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -1,16 +1,49 @@
 ---
 title: The daemon
-group: Start
-order: 2
+group: Concepts
+group_order: 2
+order: 1
 ---
 
 # The shared-world daemon
 
 `lev run` doesn't run the agent in your terminal — it hands it to a background **daemon** that
-hosts every agent in one shared ECS world. Runs keep going after your terminal closes, and a
-dozen agents share a single process instead of a process each.
+hosts every agent in one shared [ECS world](/docs/engine). Runs keep going after your terminal
+closes, and a dozen agents share a single process instead of a process each.
 
-The daemon starts automatically the first time you need it. You can also run it yourself:
+```mermaid
+flowchart TB
+  subgraph clients["Clients"]
+    RUN["lev run / ps / msg"]
+    DASH["lev dash"]
+    SERVE["lev serve (HTTP/WS)"]
+  end
+  RUN & DASH & SERVE -->|"control socket<br/>(peer-cred checked)"| DAEMON
+  subgraph DAEMON["Daemon — one process"]
+    WORLD["Shared ECS world"]
+    WORLD --- A1["agent"]
+    WORLD --- A2["agent"]
+    WORLD --- A3["sub-agent"]
+  end
+  DAEMON -->|inference| PROV["LLM providers"]
+```
+
+## Lifecycle
+
+The daemon starts automatically the first time a command needs it, and on start it **reloads runs
+that were interrupted** so nothing is lost across a restart.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Starting
+  Starting --> Ready: reload interrupted runs
+  Ready --> Ready: accept commands / host agents
+  Ready --> Draining: stop requested
+  Draining --> Stopped: finish in-flight work
+  Stopped --> [*]
+```
+
+You can also drive it directly:
 
 ```bash
 lev daemon                 # run in the foreground (with logs)
@@ -28,10 +61,15 @@ lev daemon install         # launchd (macOS) / systemd --user (Linux)
 lev daemon uninstall
 ```
 
+> [!TIP]
+> An installed daemon plus [`lev serve`](/docs/api) is all you need to drive Leviath from the
+> browser [console](/app) — no terminal required.
+
 ## Control surface
 
-The daemon is reached over a local control socket (a Unix socket / Windows pipe, guarded by a
-peer-credential check — not a TCP port). The CLI verbs that talk to it:
+The daemon is reached over a local **control socket** — a Unix socket / Windows pipe guarded by a
+peer-credential check, *not* a TCP port, so nothing on the network can reach it. The CLI verbs that
+talk to it:
 
 | Command | Does |
 |---|---|
@@ -41,4 +79,7 @@ peer-credential check — not a TCP port). The CLI verbs that talk to it:
 | `lev cancel <run-id>` | Cancel a run |
 | `lev context <run-id>` | Show a run's context-window history |
 
-To drive the daemon over HTTP instead, run the [API server](/docs/api).
+> [!NOTE]
+> To drive the daemon over the network instead of the local socket, run the
+> [HTTP API server](/docs/api) — it's a thin REST + WebSocket gateway in front of this same daemon,
+> with a mandatory auth token.

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -1,15 +1,33 @@
 ---
 title: Dashboard
 group: Guides
-order: 5
+group_order: 4
+order: 1
 ---
 
 # Dashboard (`lev dash`)
 
-`lev dash` is a full TUI for managing concurrent agents.
+`lev dash` is a full-screen TUI for managing concurrent agents — the fastest way to watch a fleet
+of runs, answer their questions, and steer them.
+
+```bash
+lev dash
+```
+
+It reads the same [daemon](/docs/daemon) the browser [console](/app) does, just over the local
+control socket instead of HTTP:
+
+```mermaid
+flowchart LR
+  DASH["lev dash (TUI)"] -->|control socket| D["Daemon"]
+  CONSOLE["Browser console"] -->|"HTTP + WS"| SERVE["lev serve"] --> D
+  D --> AG["live agent state"]
+```
+
+## What's on screen
 
 - **Agent table** — blueprint/title, stage index, status, tokens in/out, context-window occupancy,
-  iteration, elapsed time, model, and sub-agent depth. Auto-generated run titles.
+  iteration, elapsed time, model, and sub-agent depth. Titles are auto-generated per run.
 - **Detail view** — per-stage tabs or a graph view of the workflow, a context-window visualization,
   and content panes for **Output**, **Logs**, and **Context** (JSON). Markdown is rendered.
 - **Interactions** — answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
@@ -18,7 +36,18 @@ order: 5
   `y` to yank a pane, Shift+drag for native selection.
 - **`m`** opens the MCP management screen without leaving the dashboard.
 
-Common keys: `1`–`9` select · Enter/Esc open/close detail · `/` search · `l`/`o`/`c` switch
-Logs/Output/Context · `i` respond or message · `k` kill · `?` help.
+## Keys
 
-Prefer a browser? The [agent console](/app) mirrors the dashboard over the [HTTP API](/docs/api).
+| Key | Action |
+|---|---|
+| `1`–`9` | Select an agent |
+| `Enter` / `Esc` | Open / close detail |
+| `l` / `o` / `c` | Switch Logs / Output / Context |
+| `i` | Respond to or message the agent |
+| `/` | Search |
+| `k` | Kill the run |
+| `?` | Help |
+
+> [!TIP]
+> Prefer a browser, or want to drive Leviath from another machine? The [agent console](/app)
+> mirrors the dashboard over the [HTTP API](/docs/api).

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -1,18 +1,46 @@
 ---
 title: ECS engine
 group: Concepts
-order: 3
+group_order: 2
+order: 2
 ---
 
 # The ECS agent engine
 
-Leviath runs agents as **entities in a [bevy_ecs](https://bevyengine.org/) world**. Dozens of agents
-share one process with game-engine-style scheduling, instead of one OS process each.
+Leviath runs agents as **entities in a [bevy_ecs](https://bevyengine.org/) world**. Dozens of
+agents share one process with game-engine-style scheduling, instead of one OS process each.
 
-Why it matters: orchestration tools that spawn a separate process per agent carry the full weight of
-a Node/Go runtime per agent, and each manages its own flat context window. Leviath's engine runs
-them all over one shared, lock-free inference driver, so spinning up ten agents doesn't mean ten
-times the device RAM.
+## Why an ECS?
 
-Sub-agents and fan-out workers are just more entities in the same world — see
-[Sub-agents](/docs/sub-agents).
+Orchestration tools that spawn a separate process per agent carry the full weight of a Node or Go
+runtime per agent, and each manages its own flat context window. Leviath's engine runs them all
+over one shared, lock-free inference driver, so spinning up ten agents doesn't mean ten times the
+device RAM.
+
+```mermaid
+flowchart LR
+  subgraph tick["Each scheduler tick"]
+    direction TB
+    S1["advance stages"] --> S2["dispatch inference"]
+    S2 --> S3["route tool output<br/>to context regions"]
+    S3 --> S4["evaluate transitions<br/>(error / stuck / hint)"]
+  end
+  tick -->|systems run over| ents["Agent entities<br/>(components: stage, context, model, status)"]
+  ents --> tick
+```
+
+Each agent is an **entity**; its stage, context regions, model selection, and status are
+**components**; and the runtime's **systems** advance every agent a step per tick. Because there's
+one world, cross-cutting features come for free:
+
+- **[Sub-agents and fan-out](/docs/sub-agents)** are just more entities in the same world — no new
+  processes, no IPC.
+- **Shared inference** means rate limits, retries, and provider clients are pooled across all
+  agents rather than duplicated per process.
+- **One context store** lets the [dashboard](/docs/dashboard) and [API](/docs/api) read every
+  agent's state without touching a dozen separate processes.
+
+> [!NOTE]
+> The engine is an implementation detail you rarely configure directly — you describe *what* an
+> agent does in its [blueprint](/docs/agents), and the engine schedules it. This page is here so
+> the "dozens of agents, one process" claim isn't a black box.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
-group: Start
+group: Get started
+group_order: 1
 order: 1
 ---
 
@@ -10,9 +11,20 @@ Leviath is a structured agent runtime for LLMs. It gives an agent **structure** 
 that stays coherent across hundreds of tool calls, the right model for each phase of a task,
 and a dozen agents running at once in a single process.
 
+You'll go from nothing to a running agent in four steps:
+
+```mermaid
+flowchart LR
+  A["Install<br/>lev"] --> B["Configure<br/>a provider"]
+  B --> C["Run<br/>an agent"]
+  C --> D["Daemon hosts<br/>the run"]
+  D --> E["Watch in<br/>lev dash"]
+```
+
 ## Install
 
-> **Private alpha.** Installing needs a GitHub Personal Access Token (`repo` scope):
+> [!IMPORTANT]
+> Private alpha. Installing needs a GitHub Personal Access Token (`repo` scope):
 > `GITHUB_TOKEN` for the scripts and `HOMEBREW_GITHUB_API_TOKEN` for Homebrew. One-time setup
 > lives in the [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist).
 
@@ -55,21 +67,45 @@ lev setup                                            # interactive wizard
 lev setup --non-interactive --anthropic-key sk-ant-… # scriptable
 ```
 
-See [Providers](/docs/providers) for the full list and the Claude Code transport.
+> [!TIP]
+> No API key handy? Point Leviath at a local [Ollama](https://ollama.com) install and run
+> entirely offline — `lev setup` will detect it. See [Providers](/docs/providers) for the full
+> list and the Claude Code transport.
 
 ## Run an agent
+
+Pick one of the ten [pre-built agents](/docs/agents) and give it a task:
 
 ```bash
 lev run coder --task "Build a CLI that converts CSV to JSON"
 lev run deep-researcher --task "Survey the state of solid-state batteries"
 ```
 
-`lev run` hands the agent to a background [daemon](/docs/daemon), so runs keep going after your
-terminal closes. Watch everything with the TUI [dashboard](/docs/dashboard):
+`lev run` doesn't run the agent in your terminal — it hands it to a background
+[daemon](/docs/daemon) that hosts every agent in one shared world:
+
+```mermaid
+flowchart LR
+  CLI["lev run"] -->|control socket| D
+  DASH["lev dash"] -->|control socket| D
+  subgraph D["Shared-world daemon — one process"]
+    A1["agent"]
+    A2["agent"]
+    A3["agent"]
+  end
+  D -->|provider API| P["LLM provider"]
+```
+
+Because the daemon owns the run, it keeps going after your terminal closes. Watch everything
+live with the TUI [dashboard](/docs/dashboard):
 
 ```bash
 lev dash
 ```
+
+> [!NOTE]
+> Prefer a browser or a REST/WebSocket client? `lev serve` exposes the same daemon over HTTP —
+> see the [API](/docs/api) and the web console.
 
 ## Create your own
 
@@ -79,4 +115,5 @@ cd my-agent
 lev run . --task "Your task here"
 ```
 
-This writes an `agent.leviath` config you can customize — see [Agents](/docs/agents).
+This writes an `agent.leviath` config you can customize — the stages, the model for each phase,
+and the context regions. See [Agents](/docs/agents) to go deeper.

--- a/docs/content/glossary.md
+++ b/docs/content/glossary.md
@@ -1,0 +1,64 @@
+---
+title: Glossary
+group: Guides
+group_order: 4
+order: 3
+---
+
+# Glossary
+
+The vocabulary Leviath's docs use, in one place.
+
+## Core
+
+**Agent** — a directory with an [`agent.leviath`](/docs/agents) blueprint, run with `lev run`.
+
+**Blueprint** — the TOML file describing an agent: its stages, models, tools, and context layout.
+
+**Daemon** — the background process that hosts every running agent in one [shared world](/docs/daemon).
+
+**ECS world** — the single [bevy_ecs](/docs/engine) world the daemon runs; agents are entities in it.
+
+## Workflow
+
+**Stage** — one node in a blueprint's [graph](/docs/stages), with its own model, tools, and context.
+
+**Transition** — an edge between stages. A **hint** transition is chosen by the agent; a
+**conditional** transition fires automatically on a runtime signal.
+
+**Stuck** — a *measured* runtime condition (too many iterations, repeated edits, …) that escapes a
+non-progressing stage. See [stuck detection](/docs/stages#graph).
+
+**Seed command** — a shell command that pre-fills a context region before the run starts.
+
+## Memory
+
+**Context region** — a typed slice of the context window with its own budget and
+[eviction rule](/docs/context) (`pinned`, `sliding_window`, `compacting`, …).
+
+**Eviction** — what happens when a region exceeds its threshold — drop, summarize, or clear,
+depending on the region kind.
+
+**Budget** — a region's size, often a **percentage of the model's context window** so it travels
+across models.
+
+## Fan-out and tools
+
+**Sub-agent** — a child agent spawned by another, running in the same process at some **depth**.
+
+**Fan-out** — a [stage](/docs/sub-agents) that splits work into items and runs one sub-agent worker
+per item, then merges results.
+
+**MCP server** — an external [Model Context Protocol](/docs/mcp) tool server Leviath connects to.
+
+**Provider** — a model backend (Anthropic, OpenAI, Ollama, …); see [Providers](/docs/providers).
+
+## Safety
+
+**Sandbox** — per-agent or per-stage [isolation](/docs/security) (container, namespace, or none).
+
+**Taint** — the deterministic **Public / Internal / Private** sensitivity label on each region that
+gates exfiltration-capable tools.
+
+**Control socket** — the local Unix socket / Windows pipe (peer-cred checked) the CLI uses to reach
+the daemon — not a network port. For network access, run [`lev serve`](/docs/api).

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -1,13 +1,26 @@
 ---
 title: MCP tool servers
-group: Guides
-order: 6
+group: Reference
+group_order: 3
+order: 3
 ---
 
 # MCP tool servers
 
 Leviath connects to [Model Context Protocol](https://modelcontextprotocol.io) servers over stdio or
-HTTP (streamable, with a legacy HTTP+SSE fallback), giving agents extra tools.
+HTTP (streamable, with a legacy HTTP+SSE fallback), giving agents extra tools beyond the built-ins.
+
+```mermaid
+flowchart LR
+  subgraph D["Daemon"]
+    A["agent"]
+  end
+  A -->|tool call| B["MCP broker"]
+  B -->|stdio| S1["filesystem<br/>(npx server)"]
+  B -->|HTTP| S2["remote<br/>(mcp.example.com)"]
+```
+
+## Managing servers
 
 ```bash
 lev mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path
@@ -31,7 +44,30 @@ url = "https://mcp.example.com"
 headers = { Authorization = "Bearer ${MY_TOKEN}" }   # ${VAR} is expanded
 ```
 
+## Discovery and invocation
+
+On connect, Leviath discovers the server's tools and exposes them to any stage whose
+`available_tools` includes them:
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant Broker as MCP broker
+  participant Server as MCP server
+  Broker->>Server: initialize + list tools
+  Server-->>Broker: tool schemas
+  Agent->>Broker: call tool(args)
+  Broker->>Server: invoke
+  Server-->>Broker: result
+  Broker-->>Agent: routed to a context region
+```
+
+## OAuth, safely
+
 `lev mcp add` detects OAuth servers, binds tokens to the server origin (RFC 8414 issuer check,
 HTTPS-only, capped redirects), and stores them in `~/.leviath/mcp-auth.json` (`0600`), refreshing
-non-interactively. Manage servers from the [dashboard](/docs/dashboard) with `m`, or over the
-[API](/docs/api) under `/api/mcp/servers`.
+non-interactively.
+
+> [!NOTE]
+> Manage servers from the [dashboard](/docs/dashboard) with `m`, or over the [API](/docs/api) under
+> `/api/mcp/servers` (add/remove need `--allow-admin`).

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -1,7 +1,8 @@
 ---
 title: Providers
-group: Guides
-order: 3
+group: Reference
+group_order: 3
+order: 4
 ---
 
 # Providers
@@ -17,6 +18,22 @@ the [API](/docs/api).
 | OpenRouter | `OPENROUTER_API_KEY` |
 | Ollama | *none (local)* |
 | Claude Code | *none (subscription — see below)* |
+
+## Per-stage model selection with fallback
+
+Each [stage](/docs/stages) names an ordered list of provider/model pairs. The runtime picks the
+first one you have configured — so a blueprint can prefer a strong model and fall back gracefully:
+
+```mermaid
+flowchart LR
+  ST["stage: analyze"] --> M1{"anthropic<br/>configured?"}
+  M1 -->|yes| U1["use claude-sonnet"]
+  M1 -->|no| M2{"openai<br/>configured?"}
+  M2 -->|yes| U2["use gpt-mini"]
+  M2 -->|no| M3["… next fallback"]
+```
+
+This is why a blueprint written against Anthropic still runs for someone who only has OpenAI keys.
 
 ## Rate limits
 
@@ -39,11 +56,12 @@ If you have Claude Code installed and signed in, you can run Leviath on your Cla
 with no API key. Leviath's structured regions still work; the CLI is driven as a plain inference
 relay.
 
-> **⚠️ Terms of service:** Anthropic's terms state that third-party developers may not offer
-> claude.ai login or subscription rate limits for their products without prior approval. Using this
-> transport routes inference through your Claude subscription via the CLI's OAuth session. **By
-> enabling it, you accept responsibility for compliance with Anthropic's terms.** For unambiguous
-> compliance, use a direct Anthropic API key instead.
+> [!CAUTION]
+> **Terms of service.** Anthropic's terms state that third-party developers may not offer claude.ai
+> login or subscription rate limits for their products without prior approval. Using this transport
+> routes inference through your Claude subscription via the CLI's OAuth session. By enabling it, you
+> accept responsibility for compliance with Anthropic's terms. For unambiguous compliance, use a
+> direct Anthropic API key instead.
 
 Measured caveats: the CLI adds ~130 tokens of its own context to **every** call — including your
 account email address and the current date — with no flag to disable it; no prompt caching; a

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -1,7 +1,8 @@
 ---
 title: Security & sandboxing
-group: Guides
-order: 4
+group: Concepts
+group_order: 2
+order: 7
 ---
 
 # Security: sandboxed execution and taint tracking
@@ -29,17 +30,31 @@ kind = "none"             # run discovery on the host…
   `network = false`) connectivity. It shares the host filesystem, so reach for a container when you
   want real containment.
 
-An installed agent can *tighten* its sandbox but never turn one off.
+> [!IMPORTANT]
+> An *installed* agent can only ever **tighten** its sandbox — it can raise the walls, never lower
+> them. A blueprint you install can't quietly turn isolation off.
 
 ## Taint tracking (experimental)
 
-A deterministic sensitivity model — **Public / Internal / Private** — tags every context region,
-set by the runtime and never by model output. Any tool that can carry bytes off the machine is
-gated: if it carries data above its clearance, the call is blocked before it fires, or surfaced as
-an *allow once / allow for session / deny* prompt. Taint recovers as entries evict, and unrecognized
-tools fail closed.
+A deterministic sensitivity model — **Public / Internal / Private** — tags every
+[context region](/docs/context), set by the runtime and never by model output. Any tool that can
+carry bytes off the machine is gated: before it fires, the runtime checks the tool's clearance
+against the sensitivity of the data in play.
 
-Configure with a `[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool:
+```mermaid
+flowchart TD
+  C["Tool call<br/>(e.g. http_post)"] --> E{"Can it exfiltrate?"}
+  E -->|no| RUN["Run"]
+  E -->|yes| L{"Data taint ≤<br/>tool clearance?"}
+  L -->|yes| RUN
+  L -->|no| P{"Policy?"}
+  P -->|allow| RUN
+  P -->|deny| BLK["Blocked before it fires"]
+  P -->|ask| Q["Prompt: allow once /<br/>for session / deny"]
+```
+
+Taint recovers as entries evict, and an unrecognized tool **fails closed**. Configure with a
+`[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool:
 
 ```bash
 lev policy list

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -1,14 +1,38 @@
 ---
 title: Multi-stage workflows
 group: Concepts
-order: 2
+group_order: 2
+order: 5
 ---
 
 # Multi-stage workflows
 
 A blueprint is a **graph of stages**. Each stage has its own model, tools, and context layout. Run
 them linearly, or branch with conditional transitions, LLM-driven routing, and error recovery.
-Check the graph with `lev validate`.
+
+```mermaid
+flowchart LR
+  analyze -->|hint: plan ready| implement
+  implement -->|hint: ready for review| review
+  implement -->|condition: stuck| reassess
+  review -->|condition: error| implement
+  reassess -->|hint| implement
+  review --> done["done"]
+```
+
+Every blueprint's graph is checkable before you run it:
+
+```bash
+lev validate .             # verifies the graph is well-formed and reachable
+```
+
+## Transitions
+
+Each edge is one of two kinds:
+
+- **hint** transitions are chosen by the agent (LLM-routed) when it decides the stage's goal is met.
+- **conditional** transitions fire automatically on a runtime signal — `error`, or `stuck` — no
+  matter what the model wants.
 
 ```toml
 [stages.implement.transitions.review]
@@ -18,14 +42,10 @@ hint = "Implementation complete, ready for review"
 condition = "stuck"          # a runtime condition, not the agent's choice
 ```
 
-## Transitions
-
-- **hint** transitions are chosen by the agent (LLM-routed).
-- **conditional** transitions fire automatically on a runtime signal: `error`, or `stuck`.
-
 ## Stuck detection {#graph}
 
-`stuck` escapes a stage that is making no progress. Stuckness is *measured*, not self-reported:
+`stuck` escapes a stage that is making no progress. Crucially, stuckness is **measured, not
+self-reported** — an agent can't loop forever insisting it's almost done:
 
 ```toml
 [stages.implement.transitions.reassess]
@@ -36,5 +56,9 @@ stuck_after_tool_calls      = 100
 stuck_after_minutes         = 30
 ```
 
-Any subset applies; the first threshold to trip fires the edge, and the runtime writes *why* into
-the target stage's context so the next stage knows what happened.
+Any subset applies; the first threshold to trip fires the edge.
+
+> [!TIP]
+> When a `stuck` (or `error`) edge fires, the runtime writes *why* into the target stage's
+> [context](/docs/context) — so the recovery stage starts out knowing what went wrong instead of
+> rediscovering it.

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -1,18 +1,30 @@
 ---
 title: Sub-agents & fan-out
 group: Concepts
-order: 4
+group_order: 2
+order: 6
 ---
 
 # Sub-agents and fan-out
 
 Agents spawn children with different blueprints, all in the same process and over one shared
-inference driver.
+inference driver — no new OS processes, no IPC. Sub-agents are just more entities in the
+[ECS world](/docs/engine).
 
 ## Fan-out
 
 A **fan-out** stage splits a task into work items and runs one sub-agent worker per item
-concurrently, bounded by `max_workers`, then merges their results back into the parent.
+concurrently, bounded by `max_workers`, then merges their results back into the parent:
+
+```mermaid
+flowchart TB
+  P["Parent — fan-out stage"] --> Q{"split by query"}
+  Q --> W1["worker 1"]
+  Q --> W2["worker 2"]
+  Q --> W3["worker 3"]
+  W1 & W2 & W3 --> M["merge_stage<br/>(aggregate results)"]
+  M --> P2["Parent continues"]
+```
 
 ```toml
 [stages.fix.fan_out]
@@ -23,6 +35,25 @@ merge_stage  = "verify"
 on_worker_failure = "continue"
 ```
 
-Any sub-agent, at any depth, can ask the user a question directly — no fire-and-forget, no routing
-through the parent. The [dashboard](/docs/dashboard) and the API's `/api/agents/tree` show the full
-sub-agent tree with per-subtree token roll-ups.
+This is how the `parallel-fixer` agent fixes many failing tests at once — one worker per failure —
+and how a wide research sweep runs many sub-topics in parallel.
+
+## Human-in-the-loop, at any depth
+
+Any sub-agent, at any depth, can ask *you* a question directly — no fire-and-forget, no routing
+through the parent:
+
+```mermaid
+sequenceDiagram
+  participant You
+  participant Parent
+  participant Worker as Sub-agent (depth 2)
+  Parent->>Worker: spawn with a work item
+  Worker->>You: ask_user "which API version?"
+  You-->>Worker: "v2"
+  Worker-->>Parent: result
+```
+
+> [!TIP]
+> The [dashboard](/docs/dashboard) and the API's `GET /api/agents/tree` show the full sub-agent
+> tree with per-subtree token roll-ups, so you can see exactly where the budget is going.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -1,0 +1,65 @@
+---
+title: Troubleshooting
+group: Guides
+group_order: 4
+order: 2
+---
+
+# Troubleshooting
+
+Common snags and how to clear them.
+
+## The console can't reach my server
+
+The browser [console](/app) talks straight to your `lev serve` endpoint, so three things must line
+up:
+
+1. **The server is running** with a token: `lev serve --token <t>`.
+2. **CORS allows the site's origin**: add `--cors https://leviath.dev` (or `--cors "*"`). Without
+   it, the browser blocks the request before your server ever sees it.
+3. **The token matches** the one you entered in the console.
+
+```bash
+lev serve --token 6618… --cors https://leviath.dev --allow-admin
+```
+
+> [!WARNING]
+> A page served over **https** can't call an **http** endpoint (mixed content). `http://127.0.0.1`
+> is exempt, so localhost works; for a remote box use TLS, an SSH tunnel, or the Docker image.
+
+## I get `401 Unauthorized`
+
+The token is missing or wrong. REST clients send `Authorization: Bearer <token>`; WebSocket clients
+pass `?token=<token>` in the URL (browsers can't set WS headers). Confirm the value matches what you
+passed to `--token`.
+
+## An admin action returns `404`
+
+Config-write and MCP add/remove live behind `--allow-admin`. Without that flag those routes don't
+exist (they 404 rather than 403). Restart with `lev serve … --allow-admin`.
+
+## No provider configured
+
+An agent needs at least one [provider](/docs/providers). Run `lev setup`, or point Leviath at a
+local [Ollama](https://ollama.com) for a no-key start.
+
+## An agent seems stuck in a loop
+
+That's what [stuck detection](/docs/stages#graph) is for. Add a `condition = "stuck"` transition
+with thresholds (`stuck_after_iterations`, `stuck_after_same_file_edits`, …) so the runtime escapes
+the stage automatically instead of burning tokens.
+
+## A run vanished when I closed my terminal
+
+It didn't — `lev run` hands the agent to the [daemon](/docs/daemon), which keeps hosting it. Bring
+it back with `lev ps` or `lev dash`. If the daemon itself was stopped, it reloads interrupted runs
+on its next start.
+
+## Install fails with an auth error
+
+During the private alpha, installing needs a GitHub token with `repo` scope (`GITHUB_TOKEN` for the
+scripts, `HOMEBREW_GITHUB_API_TOKEN` for Homebrew) — see [Getting Started](/docs/getting-started).
+
+> [!NOTE]
+> Still stuck? Open an issue or a private security advisory on
+> [GitHub](https://github.com/Sun-Forge-AI/leviath).


### PR DESCRIPTION
Rewrites `docs/content` into a top-tier docs experience, paired with the new
leviath.dev renderer (mermaid, syntax highlighting, on-page TOC, callouts,
prev/next, version switcher, search).

## What changed
- **Diátaxis IA** via a new `group_order` frontmatter field: **Get started → Concepts → Reference → Guides**.
- **18 Mermaid diagrams** across the pages — architecture, agent & daemon lifecycle state machines, the run loop, context eviction flow, workflow graph, fan-out/fan-in, taint-check flow, auth & WebSocket sequences, MCP topology, model routing. All validated against mermaid's parser.
- **A custom token-budget region visualization** on the context page — the "regions with budgets" diagram no competitor has.
- **Callouts** (note/tip/important/warning/caution) throughout.
- **New pages**: CLI reference, Troubleshooting, Glossary.

Live now on every channel (rendered from this content):
- https://leviath.dev/docs/stable/getting-started
- https://leviath.dev/docs/stable/context

🤖 Generated with [Claude Code](https://claude.com/claude-code)