### PR TITLE
docs: accuracy fixes + full feature coverage

### DIFF
--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -1,0 +1,100 @@
+---
+title: Agent catalog
+group: Get started
+group_order: 1
+order: 2
+---
+
+# Agent catalog
+
+Leviath ships with ten pre-built agents. Each is a multi-stage [blueprint](/docs/agents) you can
+run today — give one a task and the [daemon](/docs/daemon) hosts the run:
+
+```bash
+lev run coder --task "Build a CLI that converts CSV to JSON"
+```
+
+Every one is also a starting point: copy it, or `lev create my-agent` to scaffold your own and
+tune the stages, per-stage models, and context regions. The rest of this page is a tour of what
+each agent does and when to reach for it.
+
+> [!TIP]
+> Not sure which to pick? Match the *shape* of the work: a codebase change (Coding), a question
+> to answer from sources (Research), or a recurring chore like logs, briefings, or drafts
+> (Utility).
+
+## Coding
+
+Agents that operate on a codebase. All four orient themselves in the project before acting and
+carry [stuck detection](/docs/stages) plus error-recovery edges.
+
+| Agent | What it does |
+| --- | --- |
+| `software-engineer` | Plan-then-implement, with a human-approved plan before any code is written. Mirrors a discover → plan → **approve** → code → review workflow. Use when you want to sign off on the approach first. |
+| `coder` | Fully autonomous coding: discover → analyze → (optionally prototype) → implement → review, with continuous verification. Use when you want it to just make the change. |
+| `reviewer` | Code review only — a fast scan pass, then a deep review of correctness, security, and architecture, ending in a ranked, actionable report. Use to vet a PR or diff. |
+| `parallel-fixer` | Fixes failing tests in parallel — one [sub-agent](/docs/sub-agents) worker per failure, then merge and re-run until the suite is green. Use for a broad "make the tests pass" sweep. |
+
+**`software-engineer`** — stages: `discover`, `plan` (an approval checkpoint), `prototype`,
+`implement`, `review`, plus `reassess` and `error_recovery`. The `prototype` stage spikes the
+riskiest assumption before executing the approved plan.
+
+**`coder`** — the same shape without the human plan gate: `discover`, `analyze`, elective
+`prototype`, `implement`, `review`, `reassess`, `error_recovery`. Reassess is reached only when a
+`stuck` edge fires; error_recovery only via error edges.
+
+**`parallel-fixer`** — a fan-out workflow: `discover` (how the project runs its tests) → `validate`
+→ `parallel_fix` (fan out `fix_worker` per failure) → `merge_fixes` → `verify`, which decides
+between done and another fix round.
+
+## Research
+
+Agents that gather from sources, synthesize, and write it up. Pick by breadth vs. depth.
+
+| Agent | What it does |
+| --- | --- |
+| `researcher` | General-purpose research: gather, analyze, summarize, with a gather↔analyze refinement loop. Use for a quick, focused answer. |
+| `wide-researcher` | Broad landscape survey across many sub-topics — cast a wide net, compare approaches, deep-dive the interesting threads, and produce an overview with recommendations. Use to map a whole space. |
+| `deep-researcher` | Thorough single-topic investigation — follows citation chains, cross-checks claims, and produces a structured, cited report. Use when rigor and sources matter. |
+
+**`researcher`** — stages: `gather`, `analyze`, `summarize`, `error_recovery`.
+
+**`wide-researcher`** — stages: `survey`, `compare`, `deep_dive`, `summarize`, `error_recovery`.
+The survey casts wide before narrowing.
+
+**`deep-researcher`** — stages: `gather`, `analyze`, `follow_citations`, `synthesize`,
+`error_recovery`; analysis loops back to pull and read specific cited sources.
+
+> [!NOTE]
+> `wide-researcher` runs its sub-topics as parallel workers — the same [fan-out](/docs/sub-agents)
+> mechanism `parallel-fixer` uses for tests.
+
+## Utility
+
+Everyday agents for logs, briefings, and writing.
+
+| Agent | What it does |
+| --- | --- |
+| `log-analyzer` | Analyzes log files for anomalies, trends, and error patterns via a scripted analyze⇄script loop, keeping a severity-ranked findings index. Use to triage a noisy log. |
+| `daily-briefer` | A morning summary agent — gathers from local and web sources, ranks items into a priorities index, and delivers a concise briefing. Use for a recurring standup-style digest. |
+| `writing-assistant` | Research-backed writing from topic to polished draft, with an interactive outline checkpoint and a draft⇄edit loop plus a final proofread. Use to produce a sourced piece. |
+
+**`log-analyzer`** — stages: `ingest`, `analyze`, `script` (write and run parsing/aggregation
+scripts), `report`, `error_recovery`.
+
+**`daily-briefer`** — stages: `collect`, `prioritize`, `brief`, `error_recovery`.
+
+**`writing-assistant`** — stages: `research`, `outline` (an approval checkpoint), `draft`, `edit`,
+`proofread`, `error_recovery`.
+
+## Running one
+
+Any agent runs the same way — name it and hand it a task:
+
+```bash
+lev run deep-researcher --task "Survey the state of solid-state batteries"
+```
+
+To go further, read how blueprints are built in [Agents](/docs/agents), how the stage graph
+routes and recovers in [Multi-stage workflows](/docs/stages), and how the parallel agents split
+work in [Sub-agents & fan-out](/docs/sub-agents).

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -59,17 +59,23 @@ report on:
 
 ```mermaid
 stateDiagram-v2
-  [*] --> Queued
-  Queued --> Running
-  Running --> AwaitingInput: ask_user / tool approval
-  AwaitingInput --> Running: you respond
-  Running --> Done
-  Running --> Failed: unrecoverable error
+  [*] --> Starting
+  Starting --> Running
+  Running --> WaitingInput: ask_user / tool approval
+  WaitingInput --> Running: you respond
+  Running --> Complete
+  Running --> CompleteInteractive: done, still accepting messages
+  Running --> Error: unrecoverable error
   Running --> Cancelled: lev cancel
-  Done --> [*]
-  Failed --> [*]
+  Complete --> [*]
+  CompleteInteractive --> [*]
+  Error --> [*]
   Cancelled --> [*]
 ```
+
+These are the exact `RunStatus` values the [dashboard](/docs/dashboard) and [API](/docs/api)
+report. `CompleteInteractive` means every required stage finished but the agent is still
+accepting [messages](/docs/interaction).
 
 ## Stages and models
 
@@ -77,12 +83,26 @@ Each stage gets its own **model** (an ordered provider/model fallback list — t
 provider wins), tools, iteration cap, and context layout. Transitions form a
 [graph](/docs/stages): linear by default, or branch on conditions like `error` and `stuck`.
 
+```toml
+[stages.analyze.model]
+allow_user_default = true          # fall back to the user's default model, else fail closed
+models = [
+  { provider = "anthropic", model = "claude-sonnet-4-6" },
+  { provider = "openai",    model = "gpt-5.4-mini" },
+]
+request_timeout_secs = 120         # per-stage inference wall-clock cap
+
+[stages.analyze.model.parameters]  # free-form, passed through to the provider
+temperature = 0.2
+max_tokens  = 8000
+```
+
 ## Context regions
 
 `[context.regions]` defines the memory layout. Budgets can be **percentages of the model's context
 window** (ceilings — they may sum past 100%), with absolute `max_tokens` / `threshold_tokens`
-guard-rails. Region kinds: `pinned`, `sliding_window`, `compacting`, `compact_history`, `clearable`,
-`hashmap`. See [Structured context](/docs/context) for what each one does.
+guard-rails. There are eight region kinds (the default is `temporary`) — see
+[Structured context](/docs/context) for what each one does.
 
 ## Seed commands
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -22,8 +22,10 @@ lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.d
 - **CORS is closed by default.** Pass `--cors <origin>` (e.g. `https://leviath.dev`) or `--cors "*"`
   to allow a browser to call it cross-origin.
 - **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network.
-- **`--allow-admin`** mounts the mutating admin routes (write config, add/remove MCP servers).
-  Off by default, so those routes 404 rather than relying on an in-handler check.
+- **`--allow-admin`** mounts the mutating admin routes. `GET /api/config` and
+  `GET /api/mcp/servers` are always available; the writes (`PUT /api/config`,
+  `POST`/`DELETE /api/mcp/servers`) are only mounted with `--allow-admin` and return **405 Method
+  Not Allowed** otherwise — the route isn't there, rather than gated by an in-handler check.
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` on spawn.
 
 > [!CAUTION]

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -18,6 +18,17 @@ run `lev <command> --help` for the full, authoritative flag list.
 | `lev create <name>` | Scaffold a new [`agent.leviath` blueprint](/docs/agents) |
 | `lev validate <path>` | Check a blueprint's graph, seeds, and permissions |
 | `lev test <path>` | Dry-run a blueprint |
+| `lev models` | List the models available from your configured [providers](/docs/providers) |
+| `lev agent-client …` | Serve an agent to an [editor host over ACP](/docs/editor) |
+
+## Blueprints and packaging
+
+| Command | Purpose |
+|---|---|
+| `lev list` | List installed blueprints and agents |
+| `lev add <package>` | Install a blueprint from a directory or `.leviath-bundle` |
+| `lev remove <name>` | Remove an installed blueprint |
+| `lev pack [path]` | Bundle a project for [sharing](/docs/packaging) |
 
 ## Watching and steering
 
@@ -43,7 +54,9 @@ run `lev <command> --help` for the full, authoritative flag list.
 | Command | Purpose |
 |---|---|
 | `lev setup` | Interactive [provider](/docs/providers) setup wizard |
+| `lev auth [status\|migrate]` | Move keys between `config.toml` and the [OS keychain](/docs/providers) |
 | `lev mcp [add\|list\|login\|test\|remove]` | Manage [MCP tool servers](/docs/mcp) |
+| `lev tools` | List and validate your global [Rhai tool scripts](/docs/scripting) |
 | `lev policy [list\|add\|test]` | Manage [taint policy](/docs/security) rules |
 
 > [!TIP]

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -22,16 +22,18 @@ A stage's context window is divided into regions, each with its own budget and e
   <div style="flex:1 1 auto;background:#1f2937;padding:.6rem .3rem;color:#8b949e" title="free">headroom</div>
 </div>
 
-## The six region kinds
+## The eight region kinds
 
 | Kind | Behavior |
 |---|---|
+| `temporary` | The **default** when `kind` is omitted; recent entries, trimmed first under budget pressure. |
 | `pinned` | Never evicted (architecture, the task). |
 | `sliding_window` | Keeps the most recent entries; the conversation lives here. |
 | `compacting` | Summarizes instead of evicting — file reads and tool results. |
 | `compact_history` | Rolls compacted summaries forward across stages. |
-| `clearable` | Dropped wholesale at a stage boundary (scratch). |
-| `hashmap` | Keyed entries; a write to a key replaces it. |
+| `clearable` | Wiped in one shot when space is needed (scratch). |
+| `hashmap` | Keyed entries (alias `hash_map`); a write to a key replaces it. |
+| `custom` | Behavior defined by a Rhai script — see [Rhai scripting](/docs/scripting). |
 
 ## Eviction is deterministic
 
@@ -46,7 +48,7 @@ flowchart TD
   T -->|pinned| K2["Keep — never evicted"]
   T -->|sliding_window| D["Drop oldest entries"]
   T -->|compacting / compact_history| S["Summarize into a compact form"]
-  T -->|clearable| CL["Cleared at next stage boundary"]
+  T -->|clearable / temporary| CL["Trimmed or cleared under budget pressure"]
 ```
 
 ## Routing tool output

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -83,3 +83,16 @@ talk to it:
 > To drive the daemon over the network instead of the local socket, run the
 > [HTTP API server](/docs/api) — it's a thin REST + WebSocket gateway in front of this same daemon,
 > with a mandatory auth token.
+
+## Observability
+
+The daemon can export its telemetry event stream over OpenTelemetry (OTLP/HTTP) to any collector.
+Enable it in `~/.leviath/config.toml`:
+
+```toml
+[observability]
+enabled      = true
+exporter     = "otlp"
+endpoint     = "http://localhost:4318"
+service_name = "leviath"
+```

--- a/docs/content/editor.md
+++ b/docs/content/editor.md
@@ -1,0 +1,83 @@
+---
+title: Editor integration
+group: Reference
+group_order: 3
+order: 7
+---
+
+# Editor integration (Agent Client Protocol)
+
+`lev agent-client` serves a Leviath agent over the **Agent Client Protocol** — JSON-RPC 2.0,
+newline-delimited, spoken over **stdio** — so an editor host can drive a headless [agent](/docs/agents)
+as a child process instead of you steering it from a terminal. It is a thin front end over the
+shared-world [daemon](/docs/daemon): the host talks protocol, and the command translates that into
+daemon runs and streams the output back.
+
+> [!NOTE]
+> "ACP" is deliberately never used unqualified in Leviath — the acronym is claimed by two unrelated
+> protocols. This command implements the Agent **Client** Protocol (JSON-RPC over stdio). It does
+> **not** implement the Agent *Communication* Protocol (a REST + SSE API from the BeeAI project).
+
+## What it is
+
+The Agent Client Protocol lets an editor host launch an agent as a subprocess and drive it over the
+process's stdin/stdout. Messages are framed as **one compact JSON object per line** (newline-delimited
+JSON-RPC 2.0), with a 64 KiB ceiling per frame. The handshake and turn cycle are:
+
+- `initialize` — capability exchange; the protocol version is `1`.
+- `session/new` — open a session (carries the working directory).
+- `session/prompt` — send a prompt turn; spawns (or, on later prompts, messages) an agent in the daemon.
+- `session/update` — notifications streaming the agent's live output back to the host.
+- `session/cancel` — cancel the in-flight turn.
+
+The hosts named in the Leviath source are **Zed** and **Gas City**.
+
+## How a host connects
+
+The host launches `lev agent-client` and speaks JSON-RPC over the process's own stdin/stdout. Every
+prompt is forwarded to the daemon over its control socket; the daemon's live event stream and each
+run's per-stage output are translated into `session/update` notifications until the run finishes or parks.
+
+```mermaid
+flowchart LR
+  HOST["Editor host<br/>(Zed / Gas City)"]
+  HOST -->|"stdin: JSON-RPC requests"| CLI["lev agent-client"]
+  CLI -->|"stdout: session/update"| HOST
+  CLI -->|"control socket"| DAEMON["Shared-world daemon"]
+  DAEMON -->|"WorldEvent stream"| CLI
+```
+
+> [!NOTE]
+> stdout is reserved for the JSON-RPC channel. All logs and diagnostics go to **stderr** so they
+> can't corrupt the protocol stream.
+
+## Starting it
+
+```bash
+lev agent-client --agent my-agent
+```
+
+With no `--agent`, each session's working directory is searched for an `agent.leviath` blueprint.
+
+Flags (run `lev agent-client --help` for the authoritative list):
+
+| Flag | Purpose |
+|---|---|
+| `--agent <name-or-path>` | Blueprint to serve: an installed [agent](/docs/agents) name, or a path to one. When omitted, the session's working directory is searched for an `agent.leviath`. |
+| `--yolo` | Approve every tool call without prompting. Recommended when the host does not implement `session/request_permission` (e.g. Gas City). |
+| `--allow <tool>` | Allow a tool outright. Repeatable. |
+| `--max-depth <n>` | Override the blueprint's max sub-agent tree depth. |
+| `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run a shell command at spawn — before the first inference, and so before any approval prompt. |
+
+## Permission handling
+
+Hosts that implement the client-side methods advertise capabilities at `initialize`, and the agent
+surfaces tool approvals as `session/request_permission` requests the host answers. Hosts that send no
+capabilities (Gas City sends none) cannot answer such a request, so instead of deadlocking, tool
+approvals are surfaced as output and the run **parks**. Use `--yolo` (or scoped `--allow` flags) to run
+unattended against such a host.
+
+> [!NOTE]
+> Editor integration is a thin front end over the daemon, exactly like `lev run` and `lev serve` — it
+> owns no agent world of its own. See the [daemon](/docs/daemon) for what actually hosts the run, and
+> the [CLI reference](/docs/cli) for the rest of the `lev` commands.

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -1,0 +1,172 @@
+---
+title: Human-in-the-loop
+group: Concepts
+group_order: 2
+order: 7
+---
+
+# Human-in-the-loop
+
+A run doesn't have to be fully autonomous. An agent can raise a question and block until someone
+answers it, a stage can declare an approval gate the framework always fires, and you can inject a
+message into a running conversation at any time. This page covers how a person supervises and
+steers a live agent — from the [dashboard](/docs/dashboard), the browser [console](/app), the
+CLI, or the [HTTP API](/docs/api).
+
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant H as Human
+  A->>H: "ask_user_confirm — Delete the branch?"
+  Note over A: run pauses, question is open
+  H-->>A: "lev respond <id> --approve"
+  A->>A: "answer injected, run resumes"
+```
+
+## Interaction kinds
+
+Every prompt an agent puts to a person is one of five kinds (`InteractionKind`). The kind decides
+what the client renders and what a valid answer looks like:
+
+| Kind | Wire value | What the user does |
+|---|---|---|
+| Free-text | `free_text` | Types a free-form answer |
+| Multiple-choice | `multiple_choice` | Picks one option from a list |
+| Confirm | `confirm` | Answers yes / no |
+| Tool-approval | `tool_approval` | Allows or denies a specific tool call |
+| Edit-text | `edit_text` | Edits a document in place and submits the modified text |
+
+A request may also carry a rich `body` (a markdown plan or document) for the user to review
+alongside the prompt.
+
+## Agent-raised questions
+
+Mid-reasoning, a model may call one of these tools on its own judgment. The run pauses on the tool
+call until the answer comes back, then continues with it:
+
+- `ask_user_text` — a free-text question. Returns the user's answer (or "User provided no answer.").
+- `ask_user_choice` — a multiple-choice question (requires at least 2 `options`).
+- `ask_user_confirm` — a yes/no confirmation.
+- `edit_document` — hands the user a document (the tool's `content`) to edit; returns the edited text.
+- `present_for_review` — shows a markdown document (`title` + `markdown`) for review and collects optional feedback.
+
+> [!NOTE]
+> Under an unattended run (`--yolo`) nobody is watching, so these answer themselves rather than
+> parking the run forever: a confirmation is approved, an edit submits the document unchanged, a
+> review is acknowledged, and a free-text or choice question is told no one answered so the model
+> decides for itself — a choice is never picked blind.
+
+## Tool approval
+
+Instead of the model asking, you can require approval for a tool before it runs. Set a tool's
+per-stage (or agent-level) permission to `ask` — the values are `allow`, `ask`, and `deny`:
+
+```toml
+[tool_permissions]
+read_file  = "allow"
+write_file = "ask"     # pause and ask before each write
+bash       = "ask"
+```
+
+An `ask` gate raises a `tool_approval` prompt naming the tool and its telling argument (the shell
+command for `bash`/`shell`, the path for the file tools), with three options:
+
+- **Allow once** — permit just this one call.
+- **Allow for this session** — permit every call to this tool for the rest of the run (`session` scope).
+- **Deny** — reject the call.
+
+The same prompt backs the [security](/docs/security) taint gate: an outbound tool that would carry
+sensitive data above its clearance is blocked and surfaced as a tool-approval, where **Allow for
+this session** maps to always-allow and **Deny** blocks it.
+
+## Interaction points
+
+An interaction point is an approval gate declared **statically** on a stage. Unlike the `ask_user`
+tools (which fire only if the model chooses to call them), the framework fires an interaction point
+at the stage boundary *always*, before the stage may transition. Set the stage's mode to
+`interactive_points` and list one or more points:
+
+```toml
+[stages.plan]
+mode = "interactive_points"
+
+[[stages.plan.interaction_points]]
+name     = "plan_approval"
+prompt   = "Approve the plan?"
+required = true
+style    = "multiple_choice"          # free_text | multiple_choice | confirm
+options  = ["Approve", "Revise", "Edit", "Abort"]
+abort_options = ["Abort"]
+edit_options  = ["Edit"]
+directives = { "Revise" = "Call ask_user_text to find out what to change, then re-plan." }
+document_region = "plan"
+```
+
+The selected option is routed deterministically (in code) by which list it falls in — matched
+exactly first, then with dash/whitespace normalization:
+
+- **Approve** — any plain option not listed below. Completes the point; when every point is
+  satisfied the stage transitions.
+- **Directive** (a key in `directives`) — injects the mapped directive text into the conversation
+  and **re-runs inference in-stage**, then re-presents the point. Use it to revise.
+- **Edit** (an option in `edit_options`) — opens the stage's most recent output in an editable
+  field; the edited text is injected and adopted as the authoritative document, and the point is
+  re-presented.
+- **Abort** (an option in `abort_options`) — cancels the run immediately, with no further inference
+  or transition.
+
+`document_region` names a pinned [context](/docs/context) region (e.g. `"plan"`) that holds the
+point's authoritative document. Each time the point is presented, the current text — the produced
+output, or the user's direct edit — replaces that region, so revisions and downstream stages build
+on the current version rather than regenerating from the task.
+
+> [!WARNING]
+> The revise and edit loops are bounded: after 4 revision rounds at a single point (`MAX_REVISION_ROUNDS`),
+> the stage proceeds regardless, so a revise/edit loop can never run forever.
+
+## Mid-run messages
+
+You can steer a running agent without waiting for it to ask. A message is injected into the
+conversation region between inference calls, as if the user had spoken mid-turn:
+
+```bash
+lev msg <agent-id> "Focus on the auth module first, skip the migrations for now."
+```
+
+Whether a message lands right away is per-stage. `accepts_messages` defaults to `true`; set it to
+`false` on a stage that shouldn't be interrupted (e.g. a final report), and messages stay queued in
+the agent's inbox until it reaches a stage that accepts them:
+
+```toml
+[stages.report]
+mode = "autonomous"
+accepts_messages = false   # hold messages until a later stage that accepts them
+```
+
+> [!TIP]
+> A message is delivered to at most one running agent by id. If nothing accepts it — no such live
+> agent — `lev msg` reports `no agent accepted the message`.
+
+## Answering questions
+
+When a run is waiting on a question, answer it with `lev respond`. Run it with no arguments to list
+the interactions the daemon is currently holding, then answer one by its request id:
+
+```bash
+lev respond                              # list open interactions
+lev respond <request-id> "your answer"   # free-text / edited value
+lev respond <request-id> --choice 1      # multiple-choice, 0-based index
+lev respond <request-id> --approve       # tool-approval / confirm
+lev respond <request-id> --approve --session   # allow for the rest of the run
+lev respond <request-id> --deny          # reject
+```
+
+You don't have to use the CLI. The same open questions can be answered interactively from the
+[dashboard](/docs/dashboard) (press `i`), from the browser [console](/app), or over the
+[API](/docs/api) via `GET/POST /api/agents/{id}/interaction` — read the pending question, then post
+the answer.
+
+> [!NOTE]
+> Interaction state survives a daemon restart. An agent parked at a stage-boundary interaction
+> point is re-presented with the exact same prompt when the daemon comes back, rather than dropping
+> the question and re-running inference.

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -2,7 +2,7 @@
 title: MCP tool servers
 group: Reference
 group_order: 3
-order: 3
+order: 4
 ---
 
 # MCP tool servers
@@ -23,12 +23,17 @@ flowchart LR
 ## Managing servers
 
 ```bash
-lev mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path
+lev mcp add filesystem --command npx \
+  --arg -y --arg @modelcontextprotocol/server-filesystem --arg /path
+lev mcp add remote --url https://mcp.example.com --header "Authorization: Bearer $TOK"
 lev mcp list
 lev mcp login <name>        # OAuth servers: opens your browser
 lev mcp test <name>
 lev mcp remove <name>
 ```
+
+`lev mcp add <name>` takes `--command` + repeatable `--arg` for a stdio server, or `--url`
+(with optional `--header`/`--env`) for an HTTP one; `--no-login` skips the OAuth handshake.
 
 Or configure in `~/.leviath/config.toml`:
 

--- a/docs/content/packaging.md
+++ b/docs/content/packaging.md
@@ -1,0 +1,99 @@
+---
+title: Packaging blueprints
+group: Guides
+group_order: 4
+order: 4
+---
+
+# Packaging & sharing blueprints
+
+A [blueprint](/docs/agents) is a directory with an `agent.leviath` manifest. To hand one to
+someone else you bundle that directory into a single `.leviath-bundle` file, or share the
+directory as-is — there is no hosted registry, installation is always from a local path. `lev`
+gives you four commands for the round trip: `pack` to build a bundle, `add` to install one,
+`list` to see what's installed, and `remove` to take it away.
+
+## Pack a blueprint
+
+`lev pack` bundles a blueprint project into a distributable `.leviath-bundle` archive (a
+gzip-compressed tarball of the manifest, scripts, tests, and docs).
+
+```bash
+lev pack                              # pack the current directory
+lev pack ./my-agent                   # pack a specific project directory
+lev pack ./my-agent -o my-agent.leviath-bundle   # choose the output path
+```
+
+- `PATH` (optional positional) — the project directory, or a path to an `agent.leviath` file.
+  Defaults to the current directory.
+- `-o`, `--output <FILE>` — where to write the bundle. Defaults to
+  `{name}-{version}.leviath-bundle`, taken from the manifest.
+
+Credential-shaped files (`.env*`, `*.key`, `*.pem`, `id_rsa*`, `.ssh`, `config.toml`, and more)
+are excluded from the archive automatically, so a stray secret in the project directory is not
+shipped.
+
+## Install a blueprint
+
+`lev add` installs a blueprint into your local agents directory, `~/.leviath/agents/`. It
+accepts either a bundle file or a plain agent directory.
+
+```bash
+lev add ./my-agent.leviath-bundle     # install from a bundle
+lev add ./my-agent                    # install from a directory
+```
+
+- `PACKAGE` (required positional) — a path to a `.leviath-bundle` file or to an agent
+  directory. Anything else is rejected; `lev add` never reaches out to a network.
+
+Installing under a name that already exists replaces the previous install. When a blueprint asks
+for anything unusual — pre-approved tools, script host access, a disabled sandbox, or a command
+that runs at startup — `lev add` prints an inventory of exactly what it requests so you can
+review it before running.
+
+> [!WARNING]
+> A blueprint can carry executable `.rhai` tool scripts, grant its own tool permissions, and
+> declare seed commands that run at spawn — before the first prompt. Treat a third-party
+> blueprint like any other code you install: read its [manifest](/docs/agents) and the capability
+> inventory `lev add` prints, and inspect it with `lev validate <name>`. See
+> [Security](/docs/security) for the full trust model.
+
+## List installed blueprints
+
+`lev list` shows what you can run — installed blueprints from `~/.leviath/agents/`, a blueprint
+in the current directory, blueprints from configured paths, and the bundled catalog.
+
+```bash
+lev list                              # everything
+lev list --filter agents              # narrow the listing
+```
+
+- `-f`, `--filter <all|agents|blueprints>` — filter the output. Defaults to `all`.
+
+## Remove a blueprint
+
+`lev remove` deletes an installed blueprint from `~/.leviath/agents/`.
+
+```bash
+lev remove my-agent
+```
+
+- `NAME` (required positional) — the installed blueprint's name (as shown by `lev list`).
+
+## Run an installed blueprint
+
+Once installed, run a blueprint by name — no path needed:
+
+```bash
+lev run my-agent --task "Your task here"
+```
+
+`lev run` hands the agent to the background [daemon](/docs/daemon), the same as running a local
+project directory.
+
+> [!IMPORTANT]
+> An installed blueprint can only ever **tighten** its sandbox, never loosen it — the permission
+> floor your own config sets always wins. Installing an agent does not let it grant itself more
+> than you allow. See [Security](/docs/security) for how the sandbox and permission floor work.
+
+See the [CLI reference](/docs/cli) for every command and flag.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -2,7 +2,7 @@
 title: Providers
 group: Reference
 group_order: 3
-order: 4
+order: 5
 ---
 
 # Providers
@@ -34,6 +34,18 @@ flowchart LR
 ```
 
 This is why a blueprint written against Anthropic still runs for someone who only has OpenAI keys.
+
+## Where credentials live
+
+Keys live in `~/.leviath/config.toml` by default, or — to keep them out of a plaintext file — in
+your OS keychain. `lev auth` manages the backend:
+
+```bash
+lev auth status                 # which backend holds your secrets
+lev auth migrate                # move keys into the OS keychain
+lev auth migrate --reverse      # move them back to config.toml
+lev auth migrate --dry-run      # preview without moving anything
+```
 
 ## Rate limits
 

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -1,0 +1,147 @@
+---
+title: Rhai scripting
+group: Reference
+group_order: 3
+order: 6
+---
+
+# Rhai scripting
+
+Leviath is extensible without a recompile: drop a [Rhai](https://rhai.rs) script into the right
+directory and it becomes a live part of the runtime. Four extension points share this model — custom
+model providers, custom [context](/docs/context) regions, global [tools](/docs/tools) offered to
+every agent, and scripted [taint-gate](/docs/security) policy rules. Each is a small, focused script;
+Leviath keeps ownership of the hard runtime concerns (transport, budgets, sandboxing, retries) and
+hands the script only the format or decision it owns.
+
+## Custom providers
+
+A `.rhai` script in `~/.leviath/providers/` teaches Leviath any OpenAI-compatible (or otherwise
+HTTP) LLM API — no recompile, no daemon restart. The script does only **format mapping** (Leviath's
+request → the API's HTTP body, and the response back); the Rust wrapper keeps HTTP transport, rate
+limiting, per-stage timeouts, retry with backoff, error classification, and token counting.
+
+The provider name is the filename stem, so `groq.rhai` is referenced as `provider = "groq"`:
+
+```toml
+# ~/.leviath/config.toml — a config table is optional; it only supplies overrides
+[model_providers.groq]
+api_key  = "..."                              # or the script reads its own env var
+base_url = "https://api.groq.com/openai/v1"
+
+[model_providers.groq.rate_limit]             # enforced by the Rust wrapper
+requests_per_minute = 30
+tokens_per_minute   = 100000
+```
+
+A script defines `initialize(config)` plus `inference(state, request)` (required), and may add
+`stream`, `count_tokens`, and `list_models`. It becomes a live provider the first time an agent
+references its name, and is recompiled automatically whenever the file changes.
+
+```rhai
+fn initialize(config) {
+    let api_key = config.api_key ?? env_var("GROQ_API_KEY");
+    if api_key == () { throw #{ message: "GROQ_API_KEY not set", transient: false }; }
+    #{ base_url: config.base_url ?? "https://api.groq.com/openai/v1", api_key: api_key }
+}
+```
+
+> [!TIP]
+> `docs/examples/groq.rhai` in the repo is a complete, working provider you can copy. The full script
+> contract, host functions, and error-handling conventions are documented in `docs/rhai-providers.md`.
+> See also [Providers](/docs/providers).
+
+## Custom regions
+
+When the built-in region kinds (`pinned`, `sliding_window`, `temporary`, `compacting`, `clearable`,
+`compact_history`, `hashmap`) don't fit, a `kind = "custom"` [context](/docs/context) region hands
+one region's behavior to a Rhai script: how it renders into the model's context, what happens to each
+incoming entry, and what gets dropped under budget pressure.
+
+```toml
+[context.regions.brain]
+kind        = "custom"
+script      = "context_hooks/brain.rhai"   # required, relative to the agent dir
+persistent  = false                        # optional, default false
+budget      = "40%"                        # budgets work exactly as on built-ins
+min_tokens  = 10000
+```
+
+The script implements `render(ctx)` (required) and optionally `on_write(ctx)` and `on_overflow(ctx)`.
+Rhai passes arguments by value, so each hook **returns** its result rather than mutating `ctx`:
+
+```rhai
+fn render(ctx) {
+    let xml = "<context>";
+    for entry in ctx.entries {
+        xml += `<event kind="${entry.kind}">${entry.content}</event>`;
+    }
+    xml += "</context>";
+    #{ messages: [ #{ role: "user", content: xml } ] }
+}
+```
+
+> [!NOTE]
+> The script is compile-checked once at spawn — a missing or broken file is a hard spawn error that
+> `lev validate` also reports, while runtime errors degrade gracefully and never break an inference.
+> Full `ctx` shapes, return conventions, and failure semantics are in `docs/rhai-regions.md`.
+
+## Global tools
+
+Every `.rhai` file in `~/.leviath/tools/` is compiled at spawn and offered as an executable tool to
+**every** agent — a way to give all agents a shared capability without editing each blueprint.
+Agent-specific tools are validated separately by `lev validate <agent>`.
+
+A tool script declares itself with leading directives and reads its arguments from `params`:
+
+```rhai
+// @tool upper
+// @description Upper-case text
+// @param text string required "input to transform"
+// @requires network
+params.text.to_upper()
+```
+
+Use `lev tools` to see the global inventory — compiled tools are marked, files that failed to compile
+are shown with their reason (they are simply not advertised, exactly as the daemon treats them), and a
+tool whose `@requires` capability the platform can't satisfy is flagged unavailable:
+
+```bash
+lev tools           # human-readable inventory + skipped files
+lev tools --json    # machine-readable, including params and required capabilities
+```
+
+> [!NOTE]
+> The directory is `~/.leviath/tools/` — inside Leviath's data root, alongside `providers/` and
+> `agents/`. See [Built-in tools](/docs/tools) for how a stage's `available_tools` and
+> `tool_permissions` gate which tools an agent may actually call.
+
+## Policy rules
+
+The [taint-gate](/docs/security) blocks any exfiltration-capable tool whose data taint exceeds its
+clearance. Beyond the static TOML allowlist in `policy.toml`, you can relax the gate with scripted
+rules: `.rhai` files in `~/.config/leviath/rules/`. They are consulted **after** the static allowlist,
+and the first script that allows a call wins — its filename stem becomes the rule name in decisions.
+
+Each rule receives a `context` map with `tool`, `target`, and `taint_level`, and evaluates to a
+boolean — `true` allows the call:
+
+```rhai
+// ~/.config/leviath/rules/company.rhai
+context.tool == "send_email"
+    && context.target == "ops@corp"
+    && context.taint_level == "internal"
+```
+
+A script that errors or doesn't evaluate to a boolean is treated as no match, so a broken rule can
+never accidentally open the gate. Inspect and dry-run rules with the CLI:
+
+```bash
+lev policy list                                   # static + scripted rules
+lev policy test --tool send_email --target ops@corp
+```
+
+> [!IMPORTANT]
+> Scripted rules only ever **allow** calls the gate would otherwise block; they cannot tighten the
+> gate or override a deny. See [Security & sandboxing](/docs/security) for the taint model and the
+> full gate decision flow.

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -2,7 +2,7 @@
 title: Security & sandboxing
 group: Concepts
 group_order: 2
-order: 7
+order: 8
 ---
 
 # Security: sandboxed execution and taint tracking
@@ -58,9 +58,12 @@ Taint recovers as entries evict, and an unrecognized tool **fails closed**. Conf
 
 ```bash
 lev policy list
-lev policy add
-lev policy test --tool bash --target example.com
+lev policy add send_email --target "*.example.com" --max-sensitivity internal
+lev policy test bash --target example.com
 ```
+
+`lev policy add` and `lev policy test` take the tool name as a **positional** argument
+(`lev policy add <tool> …`, `lev policy test <tool> --target …`).
 
 ## Threat model
 

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -31,8 +31,9 @@ lev validate .             # verifies the graph is well-formed and reachable
 Each edge is one of two kinds:
 
 - **hint** transitions are chosen by the agent (LLM-routed) when it decides the stage's goal is met.
-- **conditional** transitions fire automatically on a runtime signal — `error`, or `stuck` — no
-  matter what the model wants.
+- **conditional** transitions fire automatically on a runtime signal rather than the agent's
+  choice: `error`, `stuck`, `max_iterations` (the stage's iteration cap is hit), or `always` (an
+  unconditional edge).
 
 ```toml
 [stages.implement.transitions.review]
@@ -42,7 +43,9 @@ hint = "Implementation complete, ready for review"
 condition = "stuck"          # a runtime condition, not the agent's choice
 ```
 
-## Stuck detection {#graph}
+<a id="graph"></a>
+
+## Stuck detection
 
 `stuck` escapes a stage that is making no progress. Crucially, stuckness is **measured, not
 self-reported** — an agent can't loop forever insisting it's almost done:

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -18,7 +18,7 @@ concurrently, bounded by `max_workers`, then merges their results back into the 
 
 ```mermaid
 flowchart TB
-  P["Parent — fan-out stage"] --> Q{"split by query"}
+  P["Parent — fan-out stage"] --> Q{"split_prompt<br/>→ work items"}
   Q --> W1["worker 1"]
   Q --> W2["worker 2"]
   Q --> W3["worker 3"]
@@ -28,10 +28,10 @@ flowchart TB
 
 ```toml
 [stages.fix.fan_out]
-worker_agent = "."          # blueprint for each worker
-query        = "..."        # how to split the work
-max_workers  = 8
-merge_stage  = "verify"
+worker_agent = "."          # blueprint each worker runs
+split_prompt = "..."        # prompt that produces the JSON array of work items
+merge_stage  = "verify"     # stage the parent resumes at once workers finish
+max_workers  = 8            # concurrency bound
 on_worker_failure = "continue"
 ```
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -1,0 +1,114 @@
+---
+title: Built-in tools
+group: Reference
+group_order: 3
+order: 3
+---
+
+# Built-in tools
+
+Every [agent](/docs/agents) advertises a set of tools to its LLM. The runtime ships a fixed catalog
+of **built-in tools** — file access, a shell, context memory, human-in-the-loop prompts, review
+surfaces, and sub-agent management — that need no configuration to exist. A [stage](/docs/stages)
+decides which of them the model may actually call via `available_tools`, and `tool_permissions`
+gates each call at `allow` / `ask` / `deny`. For tools beyond this catalog, connect an
+[MCP server](/docs/mcp).
+
+## Files
+
+Read and modify files relative to the agent's working directory.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `read_file` | Read one file's complete contents. | `path` |
+| `read_files` | Read several files in one call, separated by path headers. | `paths` (array) |
+| `write_file` | Write content to a file, creating parent directories as needed. | `path`, `content` |
+| `edit_file` | Replace an exact string that occurs exactly once in a file. | `path`, `old_str`, `new_str` |
+| `list_dir` | List a directory's contents. | `path` (optional; defaults to the working root) |
+
+> [!TIP]
+> `read_files` is cheaper than repeated `read_file` calls — reach for it after `list_dir` when you
+> already know several paths you need.
+
+## Shell
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `shell` | Run a shell command in the working directory using the system shell (bash/zsh on Unix, cmd on Windows). Has a 60-second timeout. | `command` |
+
+`bash` is an accepted alias for `shell`: a stage's `available_tools` may name either, and both
+resolve to the same tool advertised to the model.
+
+> [!WARNING]
+> `shell` requires the platform's process-spawn capability. On platforms that don't provide it, the
+> tool (and its `bash` alias) is filtered out and never advertised.
+
+## Context
+
+Read and write the agent's own [context window](/docs/context) — named sections the runtime folds
+back into the system prompt on later turns.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `context_write` | Store or replace a keyed entry in a named section. | `region`, `content`, `key` (optional) |
+| `context_append` | Add to a section without replacing existing content. | `region`, `content`, `key` (optional) |
+| `context_read` | Read a section, or a specific keyed entry within it. | `region`, `key` (optional) |
+| `context_delete` | Remove a specific keyed entry from a section. | `region`, `key` |
+| `context_list` | List sections with their token counts and entry counts. | `region` (optional) |
+
+## Human-in-the-loop
+
+Pause the run and hand control to the user. Each of these blocks until the user responds.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `ask_user_text` | Ask a free-form question and wait for a written answer. | `prompt` |
+| `ask_user_choice` | Ask the user to pick one option from a list. | `prompt`, `options` (array, at least two) |
+| `ask_user_confirm` | Ask a yes/no question. | `prompt` |
+
+## Review
+
+Present work to the user for approval or direct editing.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `present_for_review` | Pause and display a markdown document (plan, design, report) for the user to read and approve. | `title`, `markdown` |
+| `edit_document` | Show a document in an editable field pre-filled with its current text; the returned text is the user's authoritative edit. | `content`, `prompt` (optional) |
+
+## Sub-agents
+
+Spawn and coordinate [child agents](/docs/sub-agents) from within a run. These are advertised to the
+model but executed by the engine's tool registry, since they act on the shared agent world.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `spawn_agent` | Spawn a sub-agent from a blueprint; returns its ID (blocks and returns the result when `wait` is true). | `blueprint`, `task`, `wait` (default false), `seed_context` (optional), `max_child_depth` (optional) |
+| `check_agent` | Non-blocking status check; returns the result if complete. | `agent_id` |
+| `wait_for_agent` | Block until a sub-agent completes, then return its final result. | `agent_id` |
+| `send_to_agent` | Send a message into a running sub-agent's context. | `agent_id`, `message`, `target_region` (optional; defaults to the conversation) |
+| `kill_agent` | Kill a sub-agent and all its descendants. | `agent_id` |
+
+## Granting tools per stage
+
+A tool existing in the catalog does not mean an agent can call it. Two independent settings on each
+stage control access:
+
+- **`available_tools`** — the allowlist of tool names advertised to the model in that stage. A tool
+  not listed here is invisible to the LLM. Names may use aliases (e.g. `bash` for `shell`).
+- **`tool_permissions`** — a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
+  the call outright, `ask` requires user approval first, and `deny` blocks it. Stage-level entries
+  are narrower than agent-level `[tool_permissions]` and wider than launch-time flags.
+
+```toml
+[stages.implement]
+available_tools = ["read_file", "read_files", "edit_file", "shell"]
+
+[stages.implement.tool_permissions]
+shell     = "ask"      # require approval before running commands
+edit_file = "allow"    # apply edits without prompting
+```
+
+> [!NOTE]
+> `available_tools` and `tool_permissions` are separate gates: a tool must be listed in
+> `available_tools` to be offered at all, and its `tool_permissions` value then decides whether a
+> call is allowed, prompted, or refused.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -33,10 +33,11 @@ The token is missing or wrong. REST clients send `Authorization: Bearer <token>`
 pass `?token=<token>` in the URL (browsers can't set WS headers). Confirm the value matches what you
 passed to `--token`.
 
-## An admin action returns `404`
+## An admin action returns `405`
 
-Config-write and MCP add/remove live behind `--allow-admin`. Without that flag those routes don't
-exist (they 404 rather than 403). Restart with `lev serve … --allow-admin`.
+Config-write and MCP add/remove live behind `--allow-admin`. Without that flag the mutating method
+isn't mounted, so it returns **405 Method Not Allowed** (the read routes still work). Restart with
+`lev serve … --allow-admin`.
 
 ## No provider configured
 


### PR DESCRIPTION
Follow-up to the top-tier docs pass: audited every page against source, fixed inaccuracies, and added the missing core + niche features.

**Accuracy** (verified against Rust source): `lev mcp add` flag form, `lev policy add/test` positional tool arg, fan_out `split_prompt` (not `query`), eight context region kinds incl. the default `temporary`, real `RunStatus` lifecycle states, 405-not-404 for admin routes, `clearable` eviction trigger, extra transition conditions.

**New pages**: Built-in tools · Human-in-the-loop · Agent catalog · Packaging blueprints · Editor integration (ACP) · Rhai scripting. Plus `cli.md` gains list/add/remove/pack/models/tools/agent-client/auth; `agents.md` model parameters; `providers.md` `lev auth`; `daemon.md` observability.

Diátaxis sidebar order (Get started → Concepts → Reference → Guides); all 20 mermaid diagrams validated; every internal link target checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)