### PR TITLE
test(sys): serialize every test that touches SystemRoot/USERNAME

### DIFF
--- a/crates/leviath-sys/src/perms.rs
+++ b/crates/leviath-sys/src/perms.rs
@@ -62,6 +62,16 @@ mod tests {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
     }
 
+    /// On Windows these calls shell out to `icacls`, resolved from `SystemRoot`
+    /// with a grant for `USERNAME` - and the platform tests mutate both
+    /// process-wide. Every test here that spawns it takes the same lock they
+    /// do, or a mutator's mid-flight environment turns a passing test into a
+    /// spawn failure.
+    #[cfg(windows)]
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::platform::ENV_LOCK.lock().expect("env lock")
+    }
+
     /// The point of `write_private` over `fs::write` + `chmod`: there is no
     /// moment where the file exists at the umask default. The absence of that
     /// window cannot be observed after the fact, so what is asserted is the mode
@@ -69,6 +79,8 @@ mod tests {
     /// only eventually.
     #[test]
     fn write_private_creates_an_owner_only_file_with_the_content() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
 
@@ -83,6 +95,8 @@ mod tests {
     /// permissive must tighten it again.
     #[test]
     fn write_private_retightens_an_existing_permissive_file() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, b"old").unwrap();
@@ -105,6 +119,8 @@ mod tests {
 
     #[test]
     fn secure_file_perms_restricts_on_unix_and_succeeds_everywhere() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, b"x").unwrap();
@@ -119,6 +135,8 @@ mod tests {
 
     #[test]
     fn secure_dir_perms_restricts_on_unix_and_succeeds_everywhere() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("d");
         std::fs::create_dir(&sub).unwrap();
@@ -133,6 +151,8 @@ mod tests {
 
     #[test]
     fn secure_file_perms_missing_path_behavior() {
+        #[cfg(windows)]
+        let _env = env_lock();
         // Unix `chmod` and Windows `icacls` both fail on a path that is not
         // there; only a platform with no permission model at all succeeds,
         // because it genuinely did nothing. Reporting the failure is the point:
@@ -149,6 +169,8 @@ mod tests {
 
     #[test]
     fn ensure_file_private_tightens_permissive_file_on_unix() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("cfg");
         std::fs::write(&path, b"x").unwrap();
@@ -169,6 +191,8 @@ mod tests {
 
     #[test]
     fn ensure_file_private_leaves_private_file_untouched() {
+        #[cfg(windows)]
+        let _env = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("cfg");
         std::fs::write(&path, b"x").unwrap();

--- a/crates/leviath-sys/src/platform/windows.rs
+++ b/crates/leviath-sys/src/platform/windows.rs
@@ -146,6 +146,33 @@ fn interpret_icacls(success: bool, stderr: &[u8], path: &Path) -> io::Result<()>
     )))
 }
 
+/// Serializes every test that touches the process environment this module
+/// reads: `USERNAME` (the account to grant) and `SystemRoot` (where
+/// `icacls.exe` is resolved from).
+///
+/// Some tests mutate those variables process-wide to prove errors propagate;
+/// others spawn the real `icacls`, which reads both. `cargo test` runs them in
+/// parallel threads of one process, so an unguarded spawner can catch a
+/// mutator's environment mid-flight. On CI that surfaced as `ensure_private`
+/// failing with "The system cannot find the path specified": `SystemRoot`
+/// momentarily pointed at `C:\definitely-not-windows` while another test was
+/// proving that a missing `icacls` is reported.
+///
+/// `temp_env` locks against its own calls, not against a test that reads the
+/// variable directly, so both sides have to take *this* guard. Same shape as
+/// the credential-store lesson: two guards are not a guard.
+///
+/// `pub(crate)` because the `perms` tests reach the same spawn through the
+/// public API and race identically.
+///
+/// Taken with `.expect`, not `unwrap_or_else(|e| e.into_inner())`: the
+/// recovery closure is a function that never runs while the tests pass, and
+/// the coverage gate reads that as an uncovered region. A poisoned guard only
+/// happens when a test holding it has already failed, and failing the others
+/// with "poisoned" alongside it is no loss.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,6 +195,7 @@ mod tests {
     /// place of the real one, during the step meant to be securing a secret.
     #[test]
     fn icacls_comes_from_the_system_directory() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         temp_env::with_var("SystemRoot", Some(r"C:\Windows"), || {
             assert_eq!(
                 icacls_program(),
@@ -178,26 +206,6 @@ mod tests {
             assert_eq!(icacls_program(), PathBuf::from("icacls.exe"));
         });
     }
-
-    /// Serializes the tests that depend on `USERNAME`.
-    ///
-    /// One of them unsets it process-wide to prove the error propagates, and
-    /// another reads it to restrict a real file. `cargo test` runs them in
-    /// parallel threads of one process, so without this the second sees the
-    /// first's unset environment and fails with "USERNAME is not set" - a real
-    /// CI failure on an unrelated PR, and a confusing one, because the code it
-    /// accuses is correct.
-    ///
-    /// `temp_env` locks against its own calls, not against a test that reads
-    /// the variable directly, so both sides have to take *this* guard. Same
-    /// shape as the credential-store lesson: two guards are not a guard.
-    ///
-    /// Taken with `.expect`, not `unwrap_or_else(|e| e.into_inner())`: the
-    /// recovery closure is a function that never runs while the tests pass, and
-    /// the coverage gate reads that as an uncovered region. A poisoned guard
-    /// only happens when one of these two tests has already failed, and failing
-    /// the other with "poisoned" alongside it is no loss.
-    static USERNAME_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn a_missing_username_is_an_explained_error() {
@@ -231,7 +239,7 @@ mod tests {
     /// your API keys.
     #[test]
     fn restricting_a_real_file_keeps_other_users_out() {
-        let _env = USERNAME_ENV.lock().expect("USERNAME guard");
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, b"the key").unwrap();
@@ -265,7 +273,7 @@ mod tests {
     /// is protected when it is not.
     #[test]
     fn restricting_fails_when_there_is_no_account_to_grant() {
-        let _env = USERNAME_ENV.lock().expect("USERNAME guard");
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, b"x").unwrap();
@@ -284,6 +292,7 @@ mod tests {
     /// silently skipping the hardening.
     #[test]
     fn a_missing_icacls_is_reported() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, b"x").unwrap();
@@ -298,6 +307,7 @@ mod tests {
 
     #[test]
     fn write_with_mode_writes_and_restricts() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         write_with_mode(&path, b"the key", 0o600).unwrap();
@@ -310,6 +320,7 @@ mod tests {
 
     #[test]
     fn ensure_private_restricts_an_existing_file_and_skips_a_missing_one() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("cfg");
         std::fs::write(&path, b"x").unwrap();
@@ -322,6 +333,7 @@ mod tests {
 
     #[test]
     fn set_mode_restricts_a_directory() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("d");
         std::fs::create_dir(&sub).unwrap();
@@ -332,6 +344,7 @@ mod tests {
 
     #[test]
     fn set_mode_reports_a_missing_path() {
+        let _env = ENV_LOCK.lock().expect("env lock");
         let dir = tempfile::tempdir().unwrap();
         assert!(set_mode(&dir.path().join("nope"), 0o600).is_err());
     }


### PR DESCRIPTION
## The failure

Windows CI on main has been failing intermittently (runs 30610274817, 30611157454):

```
platform::windows::tests::ensure_private_restricts_an_existing_file_and_skips_a_missing_one
panicked at crates\leviath-sys\src\platform\windows.rs:316:49:
called `Result::unwrap()` on an `Err` value: Os { code: 3, kind: NotFound,
message: "The system cannot find the path specified." }
```

## The cause

The test writes a real file, so the `NotFound` isn't the file — it's the `icacls` spawn. `a_missing_icacls_is_reported` points `SystemRoot` at `C:\definitely-not-windows` **process-wide** while it runs, and `cargo test` runs tests in parallel threads of one process. Any concurrent test that spawns the real `icacls` resolves it from the poisoned root and fails before the tool ever runs. In both failing logs the mutator finishes immediately before the victim fails.

The existing `USERNAME_ENV` mutex closed exactly this hole for `USERNAME`, but covered neither `SystemRoot` nor the icacls-spawning tests that took no guard at all — those could also catch the `USERNAME`-unset window of `restricting_fails_when_there_is_no_account_to_grant`.

## The fix

Generalize the mutex into a `pub(crate) ENV_LOCK` (still in `platform/windows.rs`, outside the tests module so siblings can reach it) and take it in every test that mutates **or** observes either variable:

- all the `platform::windows` tests that mutate env or spawn `icacls`
- the `perms` tests, which reach the same spawn through the public API on Windows (guard is `#[cfg(windows)]` so Unix keeps full parallelism)

Test-only change; no library code touched. Verified with `cargo test`/`clippy` on the host and `cargo check/clippy --tests --target x86_64-pc-windows-msvc` for the Windows cfg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGEgiRznp6gDcwYLpGRNKW