### PR TITLE
docs: plainer prose, deeper niche guides, provider key links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ---
 
-Most agent tools hand an LLM a flat message array and hope for the best. Leviath gives it **structure**: context that stays coherent across hundreds of tool calls, the right model for each phase of a task, and a dozen agents running at once without melting your machine.
+Most agent tools hand an LLM a flat message array and hope for the best. Leviath gives it **structure**: context that stays coherent across hundreds of tool calls, the right model for each phase of a task, and hundreds of agents running at once without melting your machine.
 
 <p align="center">
   <img src="docs/assets/hero-final.gif" alt="Leviath's terminal dashboard running several agents concurrently" width="900">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+# Documentation
+
+The public docs at [leviath.dev/docs](https://leviath.dev/docs) are built from the Markdown in
+`docs/content/`. This file explains how that works and how to keep the docs current as Leviath
+gains features.
+
+## How it is generated
+
+```
+docs/content/*.md   (this repo, the source of truth)
+        |
+        v
+  docs-ssg           (the renderer, lives in the Sun-Forge-AI/leviath.dev repo:
+        |             mermaid, syntax highlighting, on-page TOC, callouts, search)
+        v
+  s3://<site>/docs/<channel>/*.html   (published per release)
+        |
+        v
+  https://leviath.dev/docs/<channel>/<slug>
+```
+
+The `publish-docs` workflow runs on every alpha, beta, and prod release. It checks out the
+leviath.dev repo, renders `docs/content/` for that channel, and syncs the result to the site's S3
+bucket, then invalidates CloudFront. A new build refreshes the docs with no site rebuild. Channels
+map to tags: `alpha`, `beta`, and `stable` (the `latest` release).
+
+Because rendering happens in the leviath.dev repo, this repo owns the words and leviath.dev owns the
+look. You do not run a build here; you write Markdown, and it ships on the next release.
+
+## Adding docs for a new feature
+
+1. Add or edit a file in `docs/content/`. The file name is the URL slug (`stages.md` becomes
+   `/docs/<channel>/stages`).
+2. Give it frontmatter:
+
+   ```markdown
+   ---
+   title: My Feature
+   group: Concepts
+   group_order: 2
+   order: 9
+   ---
+   ```
+
+   - `group` is the sidebar section. `group_order` sets the order of the sections; use the same
+     number for every page in a section. Current sections: `Get started` (1), `Concepts` (2),
+     `Reference` (3), `Guides` (4).
+   - `order` is the page's position within its section.
+
+3. Write the page. You can use:
+   - Fenced code blocks with a language for highlighting (```bash, ```toml, ```rhai).
+   - ```` ```mermaid ```` blocks for diagrams (flowchart, sequenceDiagram, stateDiagram-v2). They
+     render in the browser, so a syntax error breaks the diagram. Check yours before committing.
+   - Callouts: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` (put the
+     marker on its own line).
+   - Cross-links as `/docs/<slug>` (no channel). The renderer rewrites them to the reader's channel.
+
+4. Keep the prose plain and direct. No em dashes.
+
+## Conventions
+
+- One page per concept or reference surface. Concept pages explain why and link out to the
+  reference for the exact flags and fields, rather than duplicating them.
+- Match a claim to the source. If a flag, field, or route name changes in the code, update the doc
+  in the same change.
+- Generated agent workflow diagrams live in `docs/assets/agents/`.

--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -7,94 +7,274 @@ order: 2
 
 # Agent catalog
 
-Leviath ships with ten pre-built agents. Each is a multi-stage [blueprint](/docs/agents) you can
-run today — give one a task and the [daemon](/docs/daemon) hosts the run:
+Leviath ships with ten pre-built agents. They live in `agents/`, one directory per agent, each
+holding an `agent.leviath` [blueprint](/docs/agents). Run any of them by name:
 
 ```bash
 lev run coder --task "Build a CLI that converts CSV to JSON"
 ```
 
-Every one is also a starting point: copy it, or `lev create my-agent` to scaffold your own and
-tune the stages, per-stage models, and context regions. The rest of this page is a tour of what
-each agent does and when to reach for it.
+This page is also a set of worked examples. Each section shows the agent's real stages and how
+they route, so you can copy the patterns into your own blueprint (`lev create my-agent` scaffolds
+one, then read [Agents](/docs/agents)). The diagrams show the main path; almost every stage also
+carries an `error` edge into a recovery stage, drawn once per agent to keep things readable.
 
 > [!TIP]
-> Not sure which to pick? Match the *shape* of the work: a codebase change (Coding), a question
-> to answer from sources (Research), or a recurring chore like logs, briefings, or drafts
-> (Utility).
+> Pick by the shape of the work: a codebase change (the coding agents), a question to answer from
+> sources (the research agents), or a recurring chore like logs, briefings, or drafts.
 
-## Coding
+## software-engineer
 
-Agents that operate on a codebase. All four orient themselves in the project before acting and
-carry [stuck detection](/docs/stages) plus error-recovery edges.
+Plan-then-implement with a human sign-off before any code is written. Reach for it when you want
+to approve the approach first.
 
-| Agent | What it does |
-| --- | --- |
-| `software-engineer` | Plan-then-implement, with a human-approved plan before any code is written. Mirrors a discover → plan → **approve** → code → review workflow. Use when you want to sign off on the approach first. |
-| `coder` | Fully autonomous coding: discover → analyze → (optionally prototype) → implement → review, with continuous verification. Use when you want it to just make the change. |
-| `reviewer` | Code review only — a fast scan pass, then a deep review of correctness, security, and architecture, ending in a ranked, actionable report. Use to vet a PR or diff. |
-| `parallel-fixer` | Fixes failing tests in parallel — one [sub-agent](/docs/sub-agents) worker per failure, then merge and re-run until the suite is green. Use for a broad "make the tests pass" sweep. |
+```mermaid
+flowchart TD
+    discover --> plan
+    plan -->|revise| plan
+    plan --> prototype
+    plan --> implement
+    prototype --> implement
+    prototype -->|stuck| reassess
+    implement --> review
+    review -->|issues| implement
+    implement -->|stuck| reassess
+    reassess --> implement
+    implement -->|error| error_recovery
+    error_recovery --> implement
+```
 
-**`software-engineer`** — stages: `discover`, `plan` (an approval checkpoint), `prototype`,
-`implement`, `review`, plus `reassess` and `error_recovery`. The `prototype` stage spikes the
-riskiest assumption before executing the approved plan.
+```bash
+lev run software-engineer --task "Add rate limiting to the public API"
+```
 
-**`coder`** — the same shape without the human plan gate: `discover`, `analyze`, elective
-`prototype`, `implement`, `review`, `reassess`, `error_recovery`. Reassess is reached only when a
-`stuck` edge fires; error_recovery only via error edges.
+The `plan` stage runs in `interactive_points` mode, so it pauses for your approval before the flow
+continues. That is the [human-in-the-loop](/docs/interaction) pattern. `discover` and `plan` run on
+Sonnet; `implement`, `review`, and `reassess` step up to Opus.
 
-**`parallel-fixer`** — a fan-out workflow: `discover` (how the project runs its tests) → `validate`
-→ `parallel_fix` (fan out `fix_worker` per failure) → `merge_fixes` → `verify`, which decides
-between done and another fix round.
+## coder
 
-## Research
+The same discover, prototype, implement, review shape without the human gate. Reach for it when
+you just want the change made.
 
-Agents that gather from sources, synthesize, and write it up. Pick by breadth vs. depth.
+```mermaid
+flowchart TD
+    discover --> analyze
+    analyze --> implement
+    analyze --> prototype
+    prototype --> implement
+    prototype -->|stuck| reassess
+    implement --> review
+    review -->|issues| implement
+    implement -->|stuck| reassess
+    reassess --> implement
+    implement -->|error| error_recovery
+    error_recovery --> implement
+```
 
-| Agent | What it does |
-| --- | --- |
-| `researcher` | General-purpose research: gather, analyze, summarize, with a gather↔analyze refinement loop. Use for a quick, focused answer. |
-| `wide-researcher` | Broad landscape survey across many sub-topics — cast a wide net, compare approaches, deep-dive the interesting threads, and produce an overview with recommendations. Use to map a whole space. |
-| `deep-researcher` | Thorough single-topic investigation — follows citation chains, cross-checks claims, and produces a structured, cited report. Use when rigor and sources matter. |
+```bash
+lev run coder --task "Fix the flaky retry logic in the uploader"
+```
 
-**`researcher`** — stages: `gather`, `analyze`, `summarize`, `error_recovery`.
+`analyze` chooses between a direct `implement` and a `prototype` spike when the approach is
+uncertain. `reassess` is reached only on a `stuck` edge. Cheap model early, Opus for the
+implement and review passes, so it is a [multi-model](/docs/stages) blueprint.
 
-**`wide-researcher`** — stages: `survey`, `compare`, `deep_dive`, `summarize`, `error_recovery`.
-The survey casts wide before narrowing.
+## reviewer
 
-**`deep-researcher`** — stages: `gather`, `analyze`, `follow_citations`, `synthesize`,
-`error_recovery`; analysis loops back to pull and read specific cited sources.
+Review only: a fast scan pass, then a deeper look at correctness, security, and architecture,
+ending in a ranked report. Reach for it to vet a diff or PR.
 
-> [!NOTE]
-> `wide-researcher` runs its sub-topics as parallel workers — the same [fan-out](/docs/sub-agents)
-> mechanism `parallel-fixer` uses for tests.
+```mermaid
+flowchart LR
+    discover --> scan
+    scan --> deep_review
+    deep_review --> report
+    deep_review -->|error| error_handler
+    error_handler --> deep_review
+```
 
-## Utility
+```bash
+lev run reviewer --task "Review the changes on the feature/auth branch"
+```
 
-Everyday agents for logs, briefings, and writing.
+The two-pass split is deliberate: `scan` runs on Sonnet to flag areas, then `deep_review`
+escalates to Opus to scrutinize only what was flagged, which keeps the expensive model focused.
 
-| Agent | What it does |
-| --- | --- |
-| `log-analyzer` | Analyzes log files for anomalies, trends, and error patterns via a scripted analyze⇄script loop, keeping a severity-ranked findings index. Use to triage a noisy log. |
-| `daily-briefer` | A morning summary agent — gathers from local and web sources, ranks items into a priorities index, and delivers a concise briefing. Use for a recurring standup-style digest. |
-| `writing-assistant` | Research-backed writing from topic to polished draft, with an interactive outline checkpoint and a draft⇄edit loop plus a final proofread. Use to produce a sourced piece. |
+## parallel-fixer
 
-**`log-analyzer`** — stages: `ingest`, `analyze`, `script` (write and run parsing/aggregation
-scripts), `report`, `error_recovery`.
+Fixes failing tests in parallel, one [sub-agent](/docs/sub-agents) worker per failure, then merges
+and re-runs until the suite is green. Reach for it for a broad "make the tests pass" sweep.
 
-**`daily-briefer`** — stages: `collect`, `prioritize`, `brief`, `error_recovery`.
+```mermaid
+flowchart TD
+    discover --> validate
+    validate --> parallel_fix
+    parallel_fix -->|fan out| fix_worker
+    fix_worker --> merge_fixes
+    merge_fixes --> verify
+    verify -->|failures remain| validate
+    verify --> complete["Suite green"]
+```
 
-**`writing-assistant`** — stages: `research`, `outline` (an approval checkpoint), `draft`, `edit`,
-`proofread`, `error_recovery`.
+```bash
+lev run parallel-fixer --task "Get the test suite passing"
+```
+
+`parallel_fix` runs in `fan_out` mode: it splits the diagnosed failures into work items (up to five
+workers), each `fix_worker` touches only its own source file, and `merge_stage` reconciles the
+results. See [Sub-agents and fan-out](/docs/sub-agents). `verify` decides between done and another
+round back through `validate`.
+
+## researcher
+
+General-purpose research: gather, analyze, summarize, with a refinement loop. Reach for it for a
+quick, focused answer.
+
+```mermaid
+flowchart LR
+    gather --> analyze
+    analyze -->|need more| gather
+    analyze --> summarize
+    analyze -->|error| error_recovery
+    error_recovery --> analyze
+```
+
+```bash
+lev run researcher --task "What changed in the HTTP/3 spec this year?"
+```
+
+The `analyze` stage loops back to `gather` when a specific sub-topic is thin, then moves to
+`summarize` once the picture holds. `analyze` runs on Opus; gather and summarize stay cheap, the
+[multi-model](/docs/stages) split again.
+
+## wide-researcher
+
+Broad landscape survey: cast a wide net, compare approaches, deep-read the interesting threads,
+then write an overview with recommendations. Reach for it to map a whole space.
+
+```mermaid
+flowchart TD
+    survey --> compare
+    compare -->|gaps| survey
+    compare --> deep_dive
+    deep_dive --> compare
+    compare --> summarize
+    compare -->|error| error_recovery
+    error_recovery --> compare
+```
+
+```bash
+lev run wide-researcher --task "Survey approaches to vector database indexing"
+```
+
+`compare` is the hub: it can widen coverage (back to `survey`), pull one thread for a focused
+`deep_dive`, or finish. The breadth here comes from the survey-then-compare loop, not fan-out.
+
+## deep-researcher
+
+Thorough single-topic investigation: follows citation chains, cross-checks claims, and produces a
+structured, cited report. Reach for it when rigor and sources matter.
+
+```mermaid
+flowchart TD
+    gather --> analyze
+    analyze -->|gaps| gather
+    analyze --> follow_citations
+    follow_citations --> analyze
+    analyze --> synthesize
+    analyze -->|error| error_recovery
+    error_recovery --> analyze
+```
+
+```bash
+lev run deep-researcher --task "Investigate the evidence for X causing Y"
+```
+
+`follow_citations` is a dedicated targeted-read stage: `analyze` flags a specific cited source, the
+stage pulls and reads it, then hands control back. Evidence accumulates in
+[context regions](/docs/context) across the loop before `synthesize` writes the report on Opus.
+
+## log-analyzer
+
+Analyzes log files for anomalies, trends, and error patterns through a scripted analyze and script
+loop, keeping a severity-ranked findings index. Reach for it to triage a noisy log.
+
+```mermaid
+flowchart LR
+    ingest --> analyze
+    analyze --> script
+    script -->|refine| script
+    script --> analyze
+    analyze --> report
+    analyze -->|error| error_recovery
+    error_recovery --> analyze
+```
+
+```bash
+lev run log-analyzer --task "Find the error patterns in /var/log/app.log"
+```
+
+`analyze` (on Opus) hands off to `script` to write and run parsing or aggregation code, which can
+refine itself before returning results. Findings persist in a [context region](/docs/context)
+across passes so the report ranks them by severity.
+
+## daily-briefer
+
+A morning digest: gathers from local and web sources, ranks items into a priorities index, and
+delivers a concise briefing. Reach for it for a recurring standup-style summary.
+
+```mermaid
+flowchart LR
+    collect --> prioritize
+    prioritize -->|source empty| collect
+    prioritize --> brief
+    prioritize -->|error| error_recovery
+    error_recovery --> prioritize
+```
+
+```bash
+lev run daily-briefer --task "Brief me on overnight activity across my repos and inbox"
+```
+
+`prioritize` (on Opus) can send the flow back to `collect` when a critical source came back empty,
+so the briefing is not built on a gap. The ranked items live in a [context region](/docs/context).
+
+## writing-assistant
+
+Research-backed writing from topic to polished draft, with an interactive outline checkpoint and a
+draft, edit, proofread loop. Reach for it to produce a sourced piece.
+
+```mermaid
+flowchart TD
+    research --> outline
+    outline -->|revise| outline
+    outline --> draft
+    outline -->|more material| research
+    draft --> edit
+    edit -->|structural| draft
+    edit --> proofread
+    proofread -->|substantive| edit
+    draft -->|error| error_recovery
+    error_recovery --> draft
+```
+
+```bash
+lev run writing-assistant --task "Write a 1500-word explainer on consistent hashing"
+```
+
+`outline` runs in `interactive_points` mode, so it stops for your approval before drafting starts,
+the [human-in-the-loop](/docs/interaction) checkpoint. From there `edit` and `proofread` can each
+kick the piece back a stage when they hit a structural or substantive problem.
 
 ## Running one
 
-Any agent runs the same way — name it and hand it a task:
+Every agent runs the same way, name it and hand it a task:
 
 ```bash
 lev run deep-researcher --task "Survey the state of solid-state batteries"
 ```
 
-To go further, read how blueprints are built in [Agents](/docs/agents), how the stage graph
-routes and recovers in [Multi-stage workflows](/docs/stages), and how the parallel agents split
-work in [Sub-agents & fan-out](/docs/sub-agents).
+To build your own, read how blueprints are structured in [Agents](/docs/agents), how the stage
+graph routes and recovers in [Multi-stage workflows](/docs/stages), and how the parallel agents
+split work in [Sub-agents and fan-out](/docs/sub-agents).

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -7,7 +7,7 @@ order: 3
 
 # Agent blueprints (`agent.leviath`)
 
-An agent is a directory with an `agent.leviath` file — a TOML **blueprint** describing a
+An agent is a directory with an `agent.leviath` file, a TOML **blueprint** describing a
 multi-stage [workflow graph](/docs/stages). `lev create <name>` scaffolds one.
 
 ```toml
@@ -33,12 +33,12 @@ max_iterations = 15
 system_prompt = """Understand the task and produce a short implementation plan."""
 
 [stages.analyze.transitions.implement]
-hint = "Plan ready — begin implementation"
+hint = "Plan ready, begin implementation"
 ```
 
 ## The run loop
 
-Within a stage, an agent runs a tight loop — infer, act on tool calls, repeat — until the model
+Within a stage, an agent runs a tight loop (infer, act on tool calls, repeat) until the model
 signals it's done or a [transition](/docs/stages) fires:
 
 ```mermaid
@@ -79,7 +79,7 @@ accepting [messages](/docs/interaction).
 
 ## Stages and models
 
-Each stage gets its own **model** (an ordered provider/model fallback list — the first configured
+Each stage gets its own **model** (an ordered provider/model fallback list: the first configured
 provider wins), tools, iteration cap, and context layout. Transitions form a
 [graph](/docs/stages): linear by default, or branch on conditions like `error` and `stuck`.
 
@@ -100,8 +100,8 @@ max_tokens  = 8000
 ## Context regions
 
 `[context.regions]` defines the memory layout. Budgets can be **percentages of the model's context
-window** (ceilings — they may sum past 100%), with absolute `max_tokens` / `threshold_tokens`
-guard-rails. There are eight region kinds (the default is `temporary`) — see
+window** (ceilings, so they may sum past 100%), with absolute `max_tokens` / `threshold_tokens`
+guard-rails. There are eight region kinds (the default is `temporary`). See
 [Structured context](/docs/context) for what each one does.
 
 ## Seed commands
@@ -119,7 +119,7 @@ entry stage's sandbox, time- and size-capped.
 
 > [!WARNING]
 > A seed command runs a shell command before you approve anything. `lev validate` prints every
-> seed a blueprint will run — review them for third-party blueprints. Refuse with
+> seed a blueprint will run; review them for third-party blueprints. Refuse with
 > `--no-seed-commands` or `[security] allow_seed_commands = false`.
 
 ## Validate before you run

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -8,7 +8,7 @@ order: 1
 # HTTP API (`lev serve`)
 
 `lev serve` exposes a REST + WebSocket API in front of the [daemon](/docs/daemon), so anything that
-speaks HTTP can drive Leviath — including the browser [console](/app).
+speaks HTTP can drive Leviath, including the browser [console](/app).
 
 ```bash
 lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.dev
@@ -25,12 +25,12 @@ lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.d
 - **`--allow-admin`** mounts the mutating admin routes. `GET /api/config` and
   `GET /api/mcp/servers` are always available; the writes (`PUT /api/config`,
   `POST`/`DELETE /api/mcp/servers`) are only mounted with `--allow-admin` and return **405 Method
-  Not Allowed** otherwise — the route isn't there, rather than gated by an in-handler check.
+  Not Allowed** otherwise. The route isn't there, rather than gated by an in-handler check.
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` on spawn.
 
 > [!CAUTION]
 > `lev serve` runs LLM-driven tools with whatever permissions the blueprint grants. Treat it as
-> trusted-network only unless hardened — see [Security](/docs/security).
+> trusted-network only unless hardened. See [Security](/docs/security).
 
 ## Auth flow
 
@@ -99,5 +99,5 @@ Completion webhooks are signed with `callback_secret`: verify the `X-Leviath-Sig
 header. Transient failures are retried with exponential backoff.
 
 > [!TIP]
-> The [browser console](/app) is a full reference client for this API — connection, spawn, live
-> dashboard, blueprint editing, MCP and policy management — built on the same typed endpoints.
+> The [browser console](/app) is a full reference client for this API (connection, spawn, live
+> dashboard, blueprint editing, MCP and policy management), built on the same typed endpoints.

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -8,18 +8,18 @@ order: 4
 # Structured context memory
 
 Most agent tools hand an LLM a flat message array. When a big file read lands, it shoves the system
-prompt and the task toward the edge of the window. Leviath instead gives the agent **regions** —
-typed slices of the context window with deterministic eviction — so a file dump can't push out what
+prompt and the task toward the edge of the window. Leviath instead gives the agent **regions**:
+typed slices of the context window with deterministic eviction, so a file dump can't push out what
 the agent needs to remember.
 
 A stage's context window is divided into regions, each with its own budget and eviction rule:
 
-<div style="border:1px solid #21262d;border-radius:.5rem;overflow:hidden;display:flex;font-size:.78rem;font-weight:600;text-align:center;color:#fff;margin:1.25rem 0">
-  <div style="flex:0 0 12%;background:#8b5cf6;padding:.6rem .3rem" title="pinned">pinned<br/>12%</div>
-  <div style="flex:0 0 20%;background:#6366f1;padding:.6rem .3rem" title="compacting">codebase<br/>20%</div>
-  <div style="flex:0 0 33%;background:#3b82f6;padding:.6rem .3rem" title="sliding_window">conversation<br/>33%</div>
-  <div style="flex:0 0 15%;background:#0ea5e9;padding:.6rem .3rem" title="compact_history">history<br/>15%</div>
-  <div style="flex:1 1 auto;background:#1f2937;padding:.6rem .3rem;color:#8b949e" title="free">headroom</div>
+<div class="ctx-bar">
+  <div class="ctx-seg ctx-pinned" style="flex:0 0 12%" title="pinned">pinned<br/>12%</div>
+  <div class="ctx-seg ctx-codebase" style="flex:0 0 20%" title="compacting">codebase<br/>20%</div>
+  <div class="ctx-seg ctx-conversation" style="flex:0 0 33%" title="sliding_window">conversation<br/>33%</div>
+  <div class="ctx-seg ctx-history" style="flex:0 0 15%" title="compact_history">history<br/>15%</div>
+  <div class="ctx-seg ctx-headroom" style="flex:1 1 auto" title="free">headroom</div>
 </div>
 
 ## The eight region kinds
@@ -29,15 +29,15 @@ A stage's context window is divided into regions, each with its own budget and e
 | `temporary` | The **default** when `kind` is omitted; recent entries, trimmed first under budget pressure. |
 | `pinned` | Never evicted (architecture, the task). |
 | `sliding_window` | Keeps the most recent entries; the conversation lives here. |
-| `compacting` | Summarizes instead of evicting — file reads and tool results. |
+| `compacting` | Summarizes instead of evicting: file reads and tool results. |
 | `compact_history` | Rolls compacted summaries forward across stages. |
 | `clearable` | Wiped in one shot when space is needed (scratch). |
 | `hashmap` | Keyed entries (alias `hash_map`); a write to a key replaces it. |
-| `custom` | Behavior defined by a Rhai script — see [Rhai scripting](/docs/scripting). |
+| `custom` | Behavior defined by a Rhai script (see [Rhai scripting](/docs/scripting)). |
 
 ## Eviction is deterministic
 
-When a region crosses its threshold, the runtime acts by the region's *kind* — never by pushing out
+When a region crosses its threshold, the runtime acts by the region's *kind*, never by pushing out
 whichever message is oldest across the whole window:
 
 ```mermaid
@@ -45,7 +45,7 @@ flowchart TD
   W["New entry routed to a region"] --> C{"Region over<br/>threshold?"}
   C -->|no| K["Keep"]
   C -->|yes| T{"Region kind?"}
-  T -->|pinned| K2["Keep — never evicted"]
+  T -->|pinned| K2["Keep, never evicted"]
   T -->|sliding_window| D["Drop oldest entries"]
   T -->|compacting / compact_history| S["Summarize into a compact form"]
   T -->|clearable / temporary| CL["Trimmed or cleared under budget pressure"]
@@ -66,7 +66,7 @@ read_file = "codebase"
 ## Budgets travel across models
 
 Budgets can be **percentages of the model's context window**, so a blueprint's intent survives
-across models of different sizes — a region sized "20% of the window" is 20% whether the model has
+across models of different sizes. A region sized "20% of the window" is 20% whether the model has
 32k or 200k tokens.
 
 > [!NOTE]

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -7,9 +7,9 @@ order: 1
 
 # The shared-world daemon
 
-`lev run` doesn't run the agent in your terminal — it hands it to a background **daemon** that
+`lev run` doesn't run the agent in your terminal. It hands it to a background **daemon** that
 hosts every agent in one shared [ECS world](/docs/engine). Runs keep going after your terminal
-closes, and a dozen agents share a single process instead of a process each.
+closes, and hundreds of agents share a single process instead of a process each.
 
 ```mermaid
 flowchart TB
@@ -19,7 +19,7 @@ flowchart TB
     SERVE["lev serve (HTTP/WS)"]
   end
   RUN & DASH & SERVE -->|"control socket<br/>(peer-cred checked)"| DAEMON
-  subgraph DAEMON["Daemon — one process"]
+  subgraph DAEMON["Daemon (one process)"]
     WORLD["Shared ECS world"]
     WORLD --- A1["agent"]
     WORLD --- A2["agent"]
@@ -63,11 +63,11 @@ lev daemon uninstall
 
 > [!TIP]
 > An installed daemon plus [`lev serve`](/docs/api) is all you need to drive Leviath from the
-> browser [console](/app) — no terminal required.
+> browser [console](/app), no terminal required.
 
 ## Control surface
 
-The daemon is reached over a local **control socket** — a Unix socket / Windows pipe guarded by a
+The daemon is reached over a local **control socket**: a Unix socket / Windows pipe guarded by a
 peer-credential check, *not* a TCP port, so nothing on the network can reach it. The CLI verbs that
 talk to it:
 
@@ -81,7 +81,7 @@ talk to it:
 
 > [!NOTE]
 > To drive the daemon over the network instead of the local socket, run the
-> [HTTP API server](/docs/api) — it's a thin REST + WebSocket gateway in front of this same daemon,
+> [HTTP API server](/docs/api). It's a thin REST + WebSocket gateway in front of this same daemon,
 > with a mandatory auth token.
 
 ## Observability

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -7,7 +7,7 @@ order: 1
 
 # Dashboard (`lev dash`)
 
-`lev dash` is a full-screen TUI for managing concurrent agents — the fastest way to watch a fleet
+`lev dash` is a full-screen TUI for managing concurrent agents. It's the fastest way to watch a fleet
 of runs, answer their questions, and steer them.
 
 ```bash
@@ -26,13 +26,13 @@ flowchart LR
 
 ## What's on screen
 
-- **Agent table** — blueprint/title, stage index, status, tokens in/out, context-window occupancy,
+- **Agent table**: blueprint/title, stage index, status, tokens in/out, context-window occupancy,
   iteration, elapsed time, model, and sub-agent depth. Titles are auto-generated per run.
-- **Detail view** — per-stage tabs or a graph view of the workflow, a context-window visualization,
+- **Detail view**: per-stage tabs or a graph view of the workflow, a context-window visualization,
   and content panes for **Output**, **Logs**, and **Context** (JSON). Markdown is rendered.
-- **Interactions** — answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
+- **Interactions**: answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
   confirm) or send it a mid-run message.
-- **Mouse support** — wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
+- **Mouse support**: wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
   `y` to yank a pane, Shift+drag for native selection.
 - **`m`** opens the MCP management screen without leaving the dashboard.
 

--- a/docs/content/editor.md
+++ b/docs/content/editor.md
@@ -7,14 +7,14 @@ order: 7
 
 # Editor integration (Agent Client Protocol)
 
-`lev agent-client` serves a Leviath agent over the **Agent Client Protocol** — JSON-RPC 2.0,
-newline-delimited, spoken over **stdio** — so an editor host can drive a headless [agent](/docs/agents)
+`lev agent-client` serves a Leviath agent over the **Agent Client Protocol** (JSON-RPC 2.0,
+newline-delimited, spoken over **stdio**) so an editor host can drive a headless [agent](/docs/agents)
 as a child process instead of you steering it from a terminal. It is a thin front end over the
 shared-world [daemon](/docs/daemon): the host talks protocol, and the command translates that into
 daemon runs and streams the output back.
 
 > [!NOTE]
-> "ACP" is deliberately never used unqualified in Leviath — the acronym is claimed by two unrelated
+> "ACP" is deliberately never used unqualified in Leviath. The acronym is claimed by two unrelated
 > protocols. This command implements the Agent **Client** Protocol (JSON-RPC over stdio). It does
 > **not** implement the Agent *Communication* Protocol (a REST + SSE API from the BeeAI project).
 
@@ -24,11 +24,11 @@ The Agent Client Protocol lets an editor host launch an agent as a subprocess an
 process's stdin/stdout. Messages are framed as **one compact JSON object per line** (newline-delimited
 JSON-RPC 2.0), with a 64 KiB ceiling per frame. The handshake and turn cycle are:
 
-- `initialize` — capability exchange; the protocol version is `1`.
-- `session/new` — open a session (carries the working directory).
-- `session/prompt` — send a prompt turn; spawns (or, on later prompts, messages) an agent in the daemon.
-- `session/update` — notifications streaming the agent's live output back to the host.
-- `session/cancel` — cancel the in-flight turn.
+- `initialize`: capability exchange; the protocol version is `1`.
+- `session/new`: open a session (carries the working directory).
+- `session/prompt`: send a prompt turn; spawns (or, on later prompts, messages) an agent in the daemon.
+- `session/update`: notifications streaming the agent's live output back to the host.
+- `session/cancel`: cancel the in-flight turn.
 
 The hosts named in the Leviath source are **Zed** and **Gas City**.
 
@@ -67,7 +67,7 @@ Flags (run `lev agent-client --help` for the authoritative list):
 | `--yolo` | Approve every tool call without prompting. Recommended when the host does not implement `session/request_permission` (e.g. Gas City). |
 | `--allow <tool>` | Allow a tool outright. Repeatable. |
 | `--max-depth <n>` | Override the blueprint's max sub-agent tree depth. |
-| `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run a shell command at spawn — before the first inference, and so before any approval prompt. |
+| `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run a shell command at spawn, before the first inference, and so before any approval prompt. |
 
 ## Permission handling
 
@@ -78,6 +78,6 @@ approvals are surfaced as output and the run **parks**. Use `--yolo` (or scoped 
 unattended against such a host.
 
 > [!NOTE]
-> Editor integration is a thin front end over the daemon, exactly like `lev run` and `lev serve` — it
+> Editor integration is a thin front end over the daemon, exactly like `lev run` and `lev serve`. It
 > owns no agent world of its own. See the [daemon](/docs/daemon) for what actually hosts the run, and
 > the [CLI reference](/docs/cli) for the rest of the `lev` commands.

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -7,7 +7,7 @@ order: 2
 
 # The ECS agent engine
 
-Leviath runs agents as **entities in a [bevy_ecs](https://bevyengine.org/) world**. Dozens of
+Leviath runs agents as **entities in a [bevy_ecs](https://bevyengine.org/) world**. Hundreds of
 agents share one process with game-engine-style scheduling, instead of one OS process each.
 
 ## Why an ECS?
@@ -33,14 +33,14 @@ Each agent is an **entity**; its stage, context regions, model selection, and st
 **components**; and the runtime's **systems** advance every agent a step per tick. Because there's
 one world, cross-cutting features come for free:
 
-- **[Sub-agents and fan-out](/docs/sub-agents)** are just more entities in the same world — no new
+- **[Sub-agents and fan-out](/docs/sub-agents)** are just more entities in the same world: no new
   processes, no IPC.
 - **Shared inference** means rate limits, retries, and provider clients are pooled across all
   agents rather than duplicated per process.
 - **One context store** lets the [dashboard](/docs/dashboard) and [API](/docs/api) read every
-  agent's state without touching a dozen separate processes.
+  agent's state without touching hundreds of separate processes.
 
 > [!NOTE]
-> The engine is an implementation detail you rarely configure directly — you describe *what* an
+> The engine is an implementation detail you rarely configure directly. You describe *what* an
 > agent does in its [blueprint](/docs/agents), and the engine schedules it. This page is here so
-> the "dozens of agents, one process" claim isn't a black box.
+> the "hundreds of agents, one process" claim isn't a black box.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -7,9 +7,9 @@ order: 1
 
 # Getting Started
 
-Leviath is a structured agent runtime for LLMs. It gives an agent **structure** — context
+Leviath is a structured agent runtime for LLMs. It gives an agent **structure**: context
 that stays coherent across hundreds of tool calls, the right model for each phase of a task,
-and a dozen agents running at once in a single process.
+and hundreds of agents running at once in a single process.
 
 You'll go from nothing to a running agent in four steps:
 
@@ -52,7 +52,7 @@ cargo install --git https://github.com/Sun-Forge-AI/leviath.git --bin lev
 
 ## Configure a provider
 
-One provider is all you need — an API key from Anthropic, OpenAI, Google AI, or OpenRouter,
+One provider is all you need: an API key from Anthropic, OpenAI, Google AI, or OpenRouter,
 or a local [Ollama](https://ollama.com) with no key at all.
 
 ```bash
@@ -62,8 +62,7 @@ lev setup --non-interactive --anthropic-key sk-ant-… # scriptable
 
 > [!TIP]
 > No API key handy? Point Leviath at a local [Ollama](https://ollama.com) install and run
-> entirely offline — `lev setup` will detect it. See [Providers](/docs/providers) for the full
-> list and the Claude Code transport.
+> entirely offline. `lev setup` will detect it. See [Providers](/docs/providers) for the full list.
 
 ## Run an agent
 
@@ -74,14 +73,14 @@ lev run coder --task "Build a CLI that converts CSV to JSON"
 lev run deep-researcher --task "Survey the state of solid-state batteries"
 ```
 
-`lev run` doesn't run the agent in your terminal — it hands it to a background
+`lev run` doesn't run the agent in your terminal. It hands it to a background
 [daemon](/docs/daemon) that hosts every agent in one shared world:
 
 ```mermaid
 flowchart LR
   CLI["lev run"] -->|control socket| D
   DASH["lev dash"] -->|control socket| D
-  subgraph D["Shared-world daemon — one process"]
+  subgraph D["Shared-world daemon (one process)"]
     A1["agent"]
     A2["agent"]
     A3["agent"]
@@ -97,8 +96,8 @@ lev dash
 ```
 
 > [!NOTE]
-> Prefer a browser or a REST/WebSocket client? `lev serve` exposes the same daemon over HTTP —
-> see the [API](/docs/api) and the web console.
+> Prefer a browser or a REST/WebSocket client? `lev serve` exposes the same daemon over HTTP.
+> See the [API](/docs/api) and the web console.
 
 ## Create your own
 
@@ -108,5 +107,5 @@ cd my-agent
 lev run . --task "Your task here"
 ```
 
-This writes an `agent.leviath` config you can customize — the stages, the model for each phase,
+This writes an `agent.leviath` config you can customize: the stages, the model for each phase,
 and the context regions. See [Agents](/docs/agents) to go deeper.

--- a/docs/content/glossary.md
+++ b/docs/content/glossary.md
@@ -11,54 +11,54 @@ The vocabulary Leviath's docs use, in one place.
 
 ## Core
 
-**Agent** — a directory with an [`agent.leviath`](/docs/agents) blueprint, run with `lev run`.
+**Agent**: a directory with an [`agent.leviath`](/docs/agents) blueprint, run with `lev run`.
 
-**Blueprint** — the TOML file describing an agent: its stages, models, tools, and context layout.
+**Blueprint**: the TOML file describing an agent: its stages, models, tools, and context layout.
 
-**Daemon** — the background process that hosts every running agent in one [shared world](/docs/daemon).
+**Daemon**: the background process that hosts every running agent in one [shared world](/docs/daemon).
 
-**ECS world** — the single [bevy_ecs](/docs/engine) world the daemon runs; agents are entities in it.
+**ECS world**: the single [bevy_ecs](/docs/engine) world the daemon runs; agents are entities in it.
 
 ## Workflow
 
-**Stage** — one node in a blueprint's [graph](/docs/stages), with its own model, tools, and context.
+**Stage**: one node in a blueprint's [graph](/docs/stages), with its own model, tools, and context.
 
-**Transition** — an edge between stages. A **hint** transition is chosen by the agent; a
+**Transition**: an edge between stages. A **hint** transition is chosen by the agent; a
 **conditional** transition fires automatically on a runtime signal.
 
-**Stuck** — a *measured* runtime condition (too many iterations, repeated edits, …) that escapes a
+**Stuck**: a *measured* runtime condition (too many iterations, repeated edits, …) that escapes a
 non-progressing stage. See [stuck detection](/docs/stages#graph).
 
-**Seed command** — a shell command that pre-fills a context region before the run starts.
+**Seed command**: a shell command that pre-fills a context region before the run starts.
 
 ## Memory
 
-**Context region** — a typed slice of the context window with its own budget and
+**Context region**: a typed slice of the context window with its own budget and
 [eviction rule](/docs/context) (`pinned`, `sliding_window`, `compacting`, …).
 
-**Eviction** — what happens when a region exceeds its threshold — drop, summarize, or clear,
-depending on the region kind.
+**Eviction**: what happens when a region exceeds its threshold (drop, summarize, or clear,
+depending on the region kind).
 
-**Budget** — a region's size, often a **percentage of the model's context window** so it travels
+**Budget**: a region's size, often a **percentage of the model's context window** so it travels
 across models.
 
 ## Fan-out and tools
 
-**Sub-agent** — a child agent spawned by another, running in the same process at some **depth**.
+**Sub-agent**: a child agent spawned by another, running in the same process at some **depth**.
 
-**Fan-out** — a [stage](/docs/sub-agents) that splits work into items and runs one sub-agent worker
+**Fan-out**: a [stage](/docs/sub-agents) that splits work into items and runs one sub-agent worker
 per item, then merges results.
 
-**MCP server** — an external [Model Context Protocol](/docs/mcp) tool server Leviath connects to.
+**MCP server**: an external [Model Context Protocol](/docs/mcp) tool server Leviath connects to.
 
-**Provider** — a model backend (Anthropic, OpenAI, Ollama, …); see [Providers](/docs/providers).
+**Provider**: a model backend (Anthropic, OpenAI, Ollama, …); see [Providers](/docs/providers).
 
 ## Safety
 
-**Sandbox** — per-agent or per-stage [isolation](/docs/security) (container, namespace, or none).
+**Sandbox**: per-agent or per-stage [isolation](/docs/security) (container, namespace, or none).
 
-**Taint** — the deterministic **Public / Internal / Private** sensitivity label on each region that
+**Taint**: the deterministic **Public / Internal / Private** sensitivity label on each region that
 gates exfiltration-capable tools.
 
-**Control socket** — the local Unix socket / Windows pipe (peer-cred checked) the CLI uses to reach
-the daemon — not a network port. For network access, run [`lev serve`](/docs/api).
+**Control socket**: the local Unix socket / Windows pipe (peer-cred checked) the CLI uses to reach
+the daemon, not a network port. For network access, run [`lev serve`](/docs/api).

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -10,14 +10,14 @@ order: 7
 A run doesn't have to be fully autonomous. An agent can raise a question and block until someone
 answers it, a stage can declare an approval gate the framework always fires, and you can inject a
 message into a running conversation at any time. This page covers how a person supervises and
-steers a live agent — from the [dashboard](/docs/dashboard), the browser [console](/app), the
+steers a live agent, from the [dashboard](/docs/dashboard), the browser [console](/app), the
 CLI, or the [HTTP API](/docs/api).
 
 ```mermaid
 sequenceDiagram
   participant A as Agent
   participant H as Human
-  A->>H: "ask_user_confirm — Delete the branch?"
+  A->>H: "ask_user_confirm: Delete the branch?"
   Note over A: run pauses, question is open
   H-->>A: "lev respond <id> --approve"
   A->>A: "answer injected, run resumes"
@@ -44,22 +44,22 @@ alongside the prompt.
 Mid-reasoning, a model may call one of these tools on its own judgment. The run pauses on the tool
 call until the answer comes back, then continues with it:
 
-- `ask_user_text` — a free-text question. Returns the user's answer (or "User provided no answer.").
-- `ask_user_choice` — a multiple-choice question (requires at least 2 `options`).
-- `ask_user_confirm` — a yes/no confirmation.
-- `edit_document` — hands the user a document (the tool's `content`) to edit; returns the edited text.
-- `present_for_review` — shows a markdown document (`title` + `markdown`) for review and collects optional feedback.
+- `ask_user_text`: a free-text question. Returns the user's answer (or "User provided no answer.").
+- `ask_user_choice`: a multiple-choice question (requires at least 2 `options`).
+- `ask_user_confirm`: a yes/no confirmation.
+- `edit_document`: hands the user a document (the tool's `content`) to edit; returns the edited text.
+- `present_for_review`: shows a markdown document (`title` + `markdown`) for review and collects optional feedback.
 
 > [!NOTE]
 > Under an unattended run (`--yolo`) nobody is watching, so these answer themselves rather than
 > parking the run forever: a confirmation is approved, an edit submits the document unchanged, a
 > review is acknowledged, and a free-text or choice question is told no one answered so the model
-> decides for itself — a choice is never picked blind.
+> decides for itself; a choice is never picked blind.
 
 ## Tool approval
 
 Instead of the model asking, you can require approval for a tool before it runs. Set a tool's
-per-stage (or agent-level) permission to `ask` — the values are `allow`, `ask`, and `deny`:
+per-stage (or agent-level) permission to `ask`. The values are `allow`, `ask`, and `deny`:
 
 ```toml
 [tool_permissions]
@@ -71,9 +71,9 @@ bash       = "ask"
 An `ask` gate raises a `tool_approval` prompt naming the tool and its telling argument (the shell
 command for `bash`/`shell`, the path for the file tools), with three options:
 
-- **Allow once** — permit just this one call.
-- **Allow for this session** — permit every call to this tool for the rest of the run (`session` scope).
-- **Deny** — reject the call.
+- **Allow once**: permit just this one call.
+- **Allow for this session**: permit every call to this tool for the rest of the run (`session` scope).
+- **Deny**: reject the call.
 
 The same prompt backs the [security](/docs/security) taint gate: an outbound tool that would carry
 sensitive data above its clearance is blocked and surfaced as a tool-approval, where **Allow for
@@ -102,22 +102,22 @@ directives = { "Revise" = "Call ask_user_text to find out what to change, then r
 document_region = "plan"
 ```
 
-The selected option is routed deterministically (in code) by which list it falls in — matched
+The selected option is routed deterministically (in code) by which list it falls in, matched
 exactly first, then with dash/whitespace normalization:
 
-- **Approve** — any plain option not listed below. Completes the point; when every point is
+- **Approve**: any plain option not listed below. Completes the point; when every point is
   satisfied the stage transitions.
-- **Directive** (a key in `directives`) — injects the mapped directive text into the conversation
+- **Directive** (a key in `directives`): injects the mapped directive text into the conversation
   and **re-runs inference in-stage**, then re-presents the point. Use it to revise.
-- **Edit** (an option in `edit_options`) — opens the stage's most recent output in an editable
+- **Edit** (an option in `edit_options`): opens the stage's most recent output in an editable
   field; the edited text is injected and adopted as the authoritative document, and the point is
   re-presented.
-- **Abort** (an option in `abort_options`) — cancels the run immediately, with no further inference
+- **Abort** (an option in `abort_options`): cancels the run immediately, with no further inference
   or transition.
 
 `document_region` names a pinned [context](/docs/context) region (e.g. `"plan"`) that holds the
-point's authoritative document. Each time the point is presented, the current text — the produced
-output, or the user's direct edit — replaces that region, so revisions and downstream stages build
+point's authoritative document. Each time the point is presented, the current text (the produced
+output, or the user's direct edit) replaces that region, so revisions and downstream stages build
 on the current version rather than regenerating from the task.
 
 > [!WARNING]
@@ -144,8 +144,8 @@ accepts_messages = false   # hold messages until a later stage that accepts them
 ```
 
 > [!TIP]
-> A message is delivered to at most one running agent by id. If nothing accepts it — no such live
-> agent — `lev msg` reports `no agent accepted the message`.
+> A message is delivered to at most one running agent by id. If nothing accepts it (no such live
+> agent), `lev msg` reports `no agent accepted the message`.
 
 ## Answering questions
 
@@ -163,7 +163,7 @@ lev respond <request-id> --deny          # reject
 
 You don't have to use the CLI. The same open questions can be answered interactively from the
 [dashboard](/docs/dashboard) (press `i`), from the browser [console](/app), or over the
-[API](/docs/api) via `GET/POST /api/agents/{id}/interaction` — read the pending question, then post
+[API](/docs/api) via `GET/POST /api/agents/{id}/interaction`: read the pending question, then post
 the answer.
 
 > [!NOTE]

--- a/docs/content/packaging.md
+++ b/docs/content/packaging.md
@@ -9,7 +9,7 @@ order: 4
 
 A [blueprint](/docs/agents) is a directory with an `agent.leviath` manifest. To hand one to
 someone else you bundle that directory into a single `.leviath-bundle` file, or share the
-directory as-is — there is no hosted registry, installation is always from a local path. `lev`
+directory as-is. There is no hosted registry, and installation is always from a local path. `lev`
 gives you four commands for the round trip: `pack` to build a bundle, `add` to install one,
 `list` to see what's installed, and `remove` to take it away.
 
@@ -24,9 +24,9 @@ lev pack ./my-agent                   # pack a specific project directory
 lev pack ./my-agent -o my-agent.leviath-bundle   # choose the output path
 ```
 
-- `PATH` (optional positional) — the project directory, or a path to an `agent.leviath` file.
+- `PATH` (optional positional): the project directory, or a path to an `agent.leviath` file.
   Defaults to the current directory.
-- `-o`, `--output <FILE>` — where to write the bundle. Defaults to
+- `-o`, `--output <FILE>`: where to write the bundle. Defaults to
   `{name}-{version}.leviath-bundle`, taken from the manifest.
 
 Credential-shaped files (`.env*`, `*.key`, `*.pem`, `id_rsa*`, `.ssh`, `config.toml`, and more)
@@ -43,24 +43,24 @@ lev add ./my-agent.leviath-bundle     # install from a bundle
 lev add ./my-agent                    # install from a directory
 ```
 
-- `PACKAGE` (required positional) — a path to a `.leviath-bundle` file or to an agent
+- `PACKAGE` (required positional): a path to a `.leviath-bundle` file or to an agent
   directory. Anything else is rejected; `lev add` never reaches out to a network.
 
 Installing under a name that already exists replaces the previous install. When a blueprint asks
-for anything unusual — pre-approved tools, script host access, a disabled sandbox, or a command
-that runs at startup — `lev add` prints an inventory of exactly what it requests so you can
+for anything unusual (pre-approved tools, script host access, a disabled sandbox, or a command
+that runs at startup), `lev add` prints an inventory of exactly what it requests so you can
 review it before running.
 
 > [!WARNING]
 > A blueprint can carry executable `.rhai` tool scripts, grant its own tool permissions, and
-> declare seed commands that run at spawn — before the first prompt. Treat a third-party
+> declare seed commands that run at spawn, before the first prompt. Treat a third-party
 > blueprint like any other code you install: read its [manifest](/docs/agents) and the capability
 > inventory `lev add` prints, and inspect it with `lev validate <name>`. See
 > [Security](/docs/security) for the full trust model.
 
 ## List installed blueprints
 
-`lev list` shows what you can run — installed blueprints from `~/.leviath/agents/`, a blueprint
+`lev list` shows what you can run: installed blueprints from `~/.leviath/agents/`, a blueprint
 in the current directory, blueprints from configured paths, and the bundled catalog.
 
 ```bash
@@ -68,7 +68,7 @@ lev list                              # everything
 lev list --filter agents              # narrow the listing
 ```
 
-- `-f`, `--filter <all|agents|blueprints>` — filter the output. Defaults to `all`.
+- `-f`, `--filter <all|agents|blueprints>`: filter the output. Defaults to `all`.
 
 ## Remove a blueprint
 
@@ -78,11 +78,11 @@ lev list --filter agents              # narrow the listing
 lev remove my-agent
 ```
 
-- `NAME` (required positional) — the installed blueprint's name (as shown by `lev list`).
+- `NAME` (required positional): the installed blueprint's name (as shown by `lev list`).
 
 ## Run an installed blueprint
 
-Once installed, run a blueprint by name — no path needed:
+Once installed, run a blueprint by name, no path needed:
 
 ```bash
 lev run my-agent --task "Your task here"
@@ -92,7 +92,7 @@ lev run my-agent --task "Your task here"
 project directory.
 
 > [!IMPORTANT]
-> An installed blueprint can only ever **tighten** its sandbox, never loosen it — the permission
+> An installed blueprint can only ever **tighten** its sandbox, never loosen it. The permission
 > floor your own config sets always wins. Installing an agent does not let it grant itself more
 > than you allow. See [Security](/docs/security) for how the sandbox and permission floor work.
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -10,19 +10,19 @@ order: 5
 Leviath needs at least one model provider. Configure them with `lev setup` or by writing keys via
 the [API](/docs/api).
 
-| Provider | Key |
-|---|---|
-| Anthropic | `ANTHROPIC_API_KEY` |
-| OpenAI | `OPENAI_API_KEY` |
-| Google (Gemini) | `GOOGLE_API_KEY` |
-| OpenRouter | `OPENROUTER_API_KEY` |
-| Ollama | *none (local)* |
-| Claude Code | *none (subscription — see below)* |
+| Provider | Env var | Get a key |
+|---|---|---|
+| Anthropic | `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com/settings/keys) |
+| OpenAI | `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com/api-keys) |
+| Google (Gemini) | `GOOGLE_API_KEY` | [aistudio.google.com](https://aistudio.google.com/apikey) |
+| OpenRouter | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| Ollama | none (local) | [ollama.com/download](https://ollama.com/download) |
+| Claude Code | none (subscription) | see below |
 
 ## Per-stage model selection with fallback
 
 Each [stage](/docs/stages) names an ordered list of provider/model pairs. The runtime picks the
-first one you have configured — so a blueprint can prefer a strong model and fall back gracefully:
+first one you have configured, so a blueprint can prefer a strong model and fall back gracefully:
 
 ```mermaid
 flowchart LR
@@ -37,7 +37,7 @@ This is why a blueprint written against Anthropic still runs for someone who onl
 
 ## Where credentials live
 
-Keys live in `~/.leviath/config.toml` by default, or — to keep them out of a plaintext file — in
+Keys live in `~/.leviath/config.toml` by default, or (to keep them out of a plaintext file) in
 your OS keychain. `lev auth` manages the backend:
 
 ```bash
@@ -59,7 +59,7 @@ tokens_per_minute   = 100000
 
 ## Custom OpenAI-compatible providers
 
-Point Leviath at any OpenAI-compatible endpoint with a small Rhai script — see
+Point Leviath at any OpenAI-compatible endpoint with a small Rhai script. See
 `docs/rhai-providers.md` in the repo and the `docs/examples/groq.rhai` example.
 
 ## Claude Code transport
@@ -75,6 +75,6 @@ relay.
 > accept responsibility for compliance with Anthropic's terms. For unambiguous compliance, use a
 > direct Anthropic API key instead.
 
-Measured caveats: the CLI adds ~130 tokens of its own context to **every** call — including your
-account email address and the current date — with no flag to disable it; no prompt caching; a
+Measured caveats: the CLI adds ~130 tokens of its own context to **every** call (including your
+account email address and the current date) with no flag to disable it; no prompt caching; a
 subprocess per call; Anthropic models only.

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -7,70 +7,367 @@ order: 6
 
 # Rhai scripting
 
-Leviath is extensible without a recompile: drop a [Rhai](https://rhai.rs) script into the right
-directory and it becomes a live part of the runtime. Four extension points share this model — custom
-model providers, custom [context](/docs/context) regions, global [tools](/docs/tools) offered to
-every agent, and scripted [taint-gate](/docs/security) policy rules. Each is a small, focused script;
-Leviath keeps ownership of the hard runtime concerns (transport, budgets, sandboxing, retries) and
-hands the script only the format or decision it owns.
+Leviath is extensible without a recompile. Drop a [Rhai](https://rhai.rs) script into the right
+directory and it becomes a live part of the runtime. Four extension points share this model: custom
+model [providers](/docs/providers), custom [context](/docs/context) regions, global
+[tools](/docs/tools) offered to every agent, and scripted [taint-gate](/docs/security) policy rules.
+
+Each script is small and focused. Leviath keeps ownership of the hard runtime concerns (transport,
+budgets, sandboxing, retries) and hands the script only the format or decision it owns. Every script
+runs in the same hardened sandbox: no `eval`, no `import`, no ambient filesystem or network (the host
+functions listed below are the only way out), bounded operations, and a capped call depth.
+
+This page walks each extension point end to end with complete, copy-pasteable examples. Function and
+host-API names here are the exact ones the runtime looks for, so a typo is a hook that never fires.
 
 ## Custom providers
 
-A `.rhai` script in `~/.leviath/providers/` teaches Leviath any OpenAI-compatible (or otherwise
-HTTP) LLM API — no recompile, no daemon restart. The script does only **format mapping** (Leviath's
-request → the API's HTTP body, and the response back); the Rust wrapper keeps HTTP transport, rate
-limiting, per-stage timeouts, retry with backoff, error classification, and token counting.
+A `.rhai` script in `~/.leviath/providers/` teaches Leviath any OpenAI-compatible (or otherwise HTTP)
+LLM API. The script does only **format mapping** (Leviath's request to the API's HTTP body, and the
+response back). The Rust wrapper keeps HTTP transport, rate limiting, per-stage timeouts, retry with
+backoff, error classification, and token counting.
 
-The provider name is the filename stem, so `groq.rhai` is referenced as `provider = "groq"`:
+The provider name is the filename stem, so `groq.rhai` is referenced as `provider = "groq"`. A script
+becomes a live provider the first time an agent references its name, and it is recompiled
+automatically whenever the file changes (the mtime is checked on each use). A broken script is skipped
+with a warning and starts working again once you fix the file. The daemon never scans-and-runs every
+dropped file at startup, only the ones an agent actually names.
+
+### Where it goes and how it's referenced
+
+Put the file at `~/.leviath/providers/groq.rhai`, then point a stage (or the top-level `[model]`) at
+it from the blueprint:
 
 ```toml
-# ~/.leviath/config.toml — a config table is optional; it only supplies overrides
-[model_providers.groq]
-api_key  = "..."                              # or the script reads its own env var
-base_url = "https://api.groq.com/openai/v1"
+# agent.leviath
+[model]
+provider = "groq"                       # the filename stem
+model    = "llama-3.3-70b-versatile"    # passed through as request.model
 
-[model_providers.groq.rate_limit]             # enforced by the Rust wrapper
-requests_per_minute = 30
-tokens_per_minute   = 100000
+# Per-stage override, if you want one stage on a different provider:
+[stages.plan.model]
+provider = "groq"
+model    = "llama-3.3-70b-versatile"
 ```
 
-A script defines `initialize(config)` plus `inference(state, request)` (required), and may add
-`stream`, `count_tokens`, and `list_models`. It becomes a live provider the first time an agent
-references its name, and is recompiled automatically whenever the file changes.
+A config table is optional. It only supplies overrides that reach the script's `initialize`:
 
-```rhai
-fn initialize(config) {
-    let api_key = config.api_key ?? env_var("GROQ_API_KEY");
-    if api_key == () { throw #{ message: "GROQ_API_KEY not set", transient: false }; }
-    #{ base_url: config.base_url ?? "https://api.groq.com/openai/v1", api_key: api_key }
+```toml
+# ~/.leviath/config.toml
+[model_providers.groq]
+script   = "groq"                            # optional; defaults to <name>.rhai
+api_key  = "..."                             # optional; the script may read its own env var
+base_url = "https://api.groq.com/openai/v1"  # optional
+
+[model_providers.groq.rate_limit]            # optional; enforced by the Rust wrapper
+requests_per_minute = 30
+tokens_per_minute   = 100000
+
+# Any other keys are forwarded verbatim to initialize(config).
+```
+
+### The script contract
+
+A provider defines `initialize` and `inference` (required) and may add `stream`, `count_tokens`, and
+`list_models`. Metadata comes from leading `// @key value` comments.
+
+`initialize(config)` runs once when the provider loads. It runs **offline**, so no HTTP host
+functions are available here. Return a state map that is persisted and passed to every later call.
+
+`inference(state, request)` does one non-streaming call. `request` carries:
+
+```jsonc
+{
+  "system":   [ { "text": "...", "cache_hint": "..." } ],
+  "messages": [ { "role": "user", "content": "...", "cache_breakpoint": false } ],
+  "tools":    [ { "name": "...", "description": "...", "parameters": { /* JSON schema */ } } ],
+  "model": "...", "max_tokens": 1024, "temperature": 0.7,
+  "request_timeout_secs": 120, "extra": { /* forwarded config keys */ }
 }
 ```
 
+and must return:
+
+```jsonc
+{
+  "content": "...",
+  "tool_calls":  [ { "id": "...", "name": "...", "arguments": { /* parsed */ } } ],
+  "tokens_used": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0,
+                   "cached_tokens": 0, "cache_write_tokens": 0 },
+  "finish_reason": "Complete"   // "Complete" | "ToolCall" | "TokenLimit" | "Stop"
+}
+```
+
+### Host functions
+
+These are the only calls that reach outside the sandbox:
+
+- HTTP: `http_get(url [, headers])`, `http_post(url, body [, headers])`, and
+  `stream_request(url, body, headers, callback)` for SSE streaming. The callback is a Rhai closure
+  invoked with each SSE `data:` payload.
+- Data: `parse_json(str)`, `to_json(value)`, `parse_sse(chunk)`.
+- Env and encoding: `env_var(name)` (returns a string or `()`), `encode_uri(str)`,
+  `encode_base64(str)`.
+- Tokens: `count_tokens_heuristic(text, hint)` where `hint` is `"openai"`, `"anthropic"`,
+  `"gemini"`, or `"general"`.
+
+Rate limiting, request timeouts, retry, and 429/5xx classification are applied by the Rust wrapper
+around these calls, so you do not implement them.
+
+### Error handling
+
+Signal an error by throwing a structured map. `transient: true` is retried with backoff; a 429
+returned by `http_post`/`stream_request` is mapped to a rate-limit error automatically.
+
+```rhai
+throw #{ message: "API key not set", transient: false };  // permanent, no retry
+throw #{ message: "server 503",      transient: true  };  // retried with backoff
+```
+
+### A complete provider
+
+This is a full OpenAI-compatible provider. Save it as `~/.leviath/providers/groq.rhai`, set
+`GROQ_API_KEY`, and point a stage at `provider = "groq"`. It handles non-streaming and streaming
+inference, tool calls, token usage, and model listing.
+
+```rhai
+// @provider groq
+// @description Groq inference (OpenAI-compatible, fast)
+// @supports_streaming true
+// @default_model llama-3.3-70b-versatile
+// @max_context_tokens 131072
+// @max_output_tokens 32768
+
+fn initialize(config) {
+    let api_key = config.api_key ?? env_var("GROQ_API_KEY");
+    if api_key == () { throw #{ message: "GROQ_API_KEY not set", transient: false }; }
+    #{
+        base_url: config.base_url ?? "https://api.groq.com/openai/v1",
+        api_key: api_key,
+        model: config.model ?? "llama-3.3-70b-versatile",
+    }
+}
+
+fn auth_headers(state) {
+    #{
+        "Authorization": `Bearer ${state.api_key}`,
+        "Content-Type": "application/json",
+    }
+}
+
+fn build_messages(request) {
+    let msgs = [];
+    if request.system.len() > 0 {
+        let sys_text = request.system.map(|b| b.text).reduce(|a, b| a + "\n\n" + b, "");
+        msgs.push(#{ role: "system", content: sys_text });
+    }
+    for msg in request.messages {
+        msgs.push(#{ role: msg.role, content: msg.content });
+    }
+    msgs
+}
+
+fn build_tools(request) {
+    request.tools.map(|t| #{
+        type: "function",
+        function: #{ name: t.name, description: t.description, parameters: t.parameters },
+    })
+}
+
+fn build_body(state, request, streaming) {
+    let body = #{
+        model: request.model ?? state.model,
+        messages: build_messages(request),
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+    };
+    let tools = build_tools(request);
+    if tools.len() > 0 { body.tools = tools; }
+    if streaming { body.stream = true; }
+    to_json(body)
+}
+
+fn map_finish(reason) {
+    switch reason {
+        "stop" => "Complete",
+        "tool_calls" => "ToolCall",
+        "length" => "TokenLimit",
+        _ => "Complete",
+    }
+}
+
+fn usage_of(u) {
+    if u == () { return #{ total_tokens: 0 }; }
+    #{
+        prompt_tokens: u.prompt_tokens ?? 0,
+        completion_tokens: u.completion_tokens ?? 0,
+        total_tokens: u.total_tokens ?? 0,
+        cached_tokens: 0,
+        cache_write_tokens: 0,
+    }
+}
+
+fn inference(state, request) {
+    let resp = parse_json(http_post(
+        `${state.base_url}/chat/completions`,
+        build_body(state, request, false),
+        auth_headers(state),
+    ));
+    let choice = resp.choices[0];
+    let msg = choice.message;
+    let tool_calls = if msg.tool_calls != () {
+        msg.tool_calls.map(|tc| #{
+            id: tc.id,
+            name: tc.function.name,
+            arguments: parse_json(tc.function.arguments),
+        })
+    } else { [] };
+    #{
+        content: msg.content ?? "",
+        tool_calls: tool_calls,
+        tokens_used: usage_of(resp.usage),
+        finish_reason: map_finish(choice.finish_reason),
+    }
+}
+
+fn stream(state, request, on_chunk) {
+    stream_request(
+        `${state.base_url}/chat/completions`,
+        build_body(state, request, true),
+        auth_headers(state),
+        |chunk| {
+            let data = parse_sse(chunk);
+            if data == () { return; }
+            let choice = data.choices[0];
+            let delta = choice.delta;
+            let result = #{ delta: delta.content ?? "" };
+            if choice.finish_reason != () {
+                result.finish_reason = map_finish(choice.finish_reason);
+            }
+            if data.usage != () { result.tokens = usage_of(data.usage); }
+            on_chunk.call(result);
+        },
+    );
+}
+
+fn count_tokens(state, text, model) {
+    count_tokens_heuristic(text, "openai")
+}
+
+fn list_models(state) {
+    let resp = parse_json(http_get(`${state.base_url}/models`, auth_headers(state)));
+    resp.data.map(|m| #{
+        id: m.id,
+        display_name: m.id,
+        max_context_tokens: m.context_window ?? 8192,
+        max_output_tokens: 4096,
+    })
+}
+```
+
+The three optional functions each carry their own shape. `stream(state, request, on_chunk)` calls
+`on_chunk.call(#{...})` per delta, where each chunk map is
+`{ delta, tool_calls: [{index, id, name, arguments_delta}], tokens: {...}, finish_reason }`.
+`count_tokens(state, text, model)` returns an int (Leviath falls back to a local heuristic without
+it). `list_models(state)` returns an array of
+`{ id, display_name, max_context_tokens, max_output_tokens }`.
+
+### Testing it
+
+To adapt this to another OpenAI-compatible API, change the metadata block, the default `base_url` and
+env var in `initialize`, and the default `model`. The request/response mapping is usually the same.
+For an API that is not OpenAI-shaped, rewrite `build_body` and the response parsing in `inference` to
+match its wire format.
+
+```bash
+lev models --provider groq     # calls list_models, so it exercises auth + parse_json end to end
+lev run <agent> --stage plan   # a live run through the stage that references the provider
+```
+
 > [!TIP]
-> `docs/examples/groq.rhai` in the repo is a complete, working provider you can copy. The full script
-> contract, host functions, and error-handling conventions are documented in `docs/rhai-providers.md`.
-> See also [Providers](/docs/providers).
+> A broken provider script is skipped and model selection falls through to the next configured model,
+> so a syntax error looks like "my agent quietly used the wrong model". Run `lev models --provider
+> <name>` first; a compile or auth error surfaces there instead of hiding behind a fallback.
+
+See [Providers](/docs/providers) for how a stage selects a model and orders fallbacks.
 
 ## Custom regions
 
 When the built-in region kinds (`pinned`, `sliding_window`, `temporary`, `compacting`, `clearable`,
-`compact_history`, `hashmap`) don't fit, a `kind = "custom"` [context](/docs/context) region hands
+`compact_history`, `hashmap`) do not fit, a `kind = "custom"` [context](/docs/context) region hands
 one region's behavior to a Rhai script: how it renders into the model's context, what happens to each
 incoming entry, and what gets dropped under budget pressure.
 
+### Declaring one
+
 ```toml
 [context.regions.brain]
-kind        = "custom"
-script      = "context_hooks/brain.rhai"   # required, relative to the agent dir
-persistent  = false                        # optional, default false
-budget      = "40%"                        # budgets work exactly as on built-ins
-min_tokens  = 10000
+kind       = "custom"
+script     = "context_hooks/brain.rhai"   # required, relative to the agent dir
+persistent = false                        # optional, default false
+budget     = "40%"                        # budgets work exactly as on built-ins
+min_tokens = 10000
 ```
 
-The script implements `render(ctx)` (required) and optionally `on_write(ctx)` and `on_overflow(ctx)`.
-Rhai passes arguments by value, so each hook **returns** its result rather than mutating `ctx`:
+`script` resolves relative to the directory holding `agent.leviath`, so the script travels with the
+agent through `lev add` and bundles. `persistent = true` makes the region pinned-like (never evicted,
+fixed budget, `Always` cache hint). `persistent = false` behaves like temporary (evicted under
+pressure, but the script gets first say through `on_overflow`). Percentage budgets resolve at spawn
+against the stage model's window, and the script sees the resolved absolute number in
+`ctx.region.budget`. Per-stage layouts (`[stages.<name>.context.regions.<region>]`) may declare
+custom regions too.
+
+The script is read and compile-checked **once, at spawn**. A missing or broken file, or one without
+`fn render(ctx)`, is a hard spawn error that `lev validate` also reports. Editing the script takes
+effect on the next run.
+
+### The three hooks
+
+All three receive one `ctx` argument. Rhai passes arguments by value, so mutating `ctx` does nothing.
+Each hook **returns** its result.
+
+`render(ctx)` is **required**. It runs on every inference (even when the region is empty, so a script
+can emit static scaffolding). `ctx`:
+
+```jsonc
+{
+  "region":  { "name": "brain", "budget": 80000, "current_tokens": 1234, "entry_count": 7 },
+  "entries": [ {
+      "content": "...", "tokens": 12, "timestamp": 1710000000, "key": null,
+      "kind": "text" | "user_message" | "assistant_turn" | "tool_result",
+      // assistant_turn only:
+      "tool_calls": [ { "id": "...", "name": "...", "arguments": { } } ],
+      // tool_result only:
+      "tool_call_id": "...", "tool_name": "...", "is_error": false
+  } ],
+  "stage_name": "plan", "stage_iterations": 2, "model": "claude-...",
+  "window": { "total_tokens": 9000, "max_tokens": 200000 }
+}
+```
+
+`render` returns either a string (one system block, empty string means nothing) or a map with
+`system` (a string or an array of strings) and `messages` (typed `role`/`content` entries, optionally
+carrying `tool_calls` or `tool_results`). The assembler's orphan sanitizer strips any unpaired tool
+blocks, so a buggy script cannot produce a provider-invalid request.
+
+`on_write(ctx)` is **optional**. It sees each entry headed into the region, with
+`ctx = { region, entry: { content, kind, tokens } }`. Return a string to replace the content (tokens
+re-estimated, kind preserved), `true` or `()` to accept unchanged, or `false` to drop the entry.
+
+`on_overflow(ctx)` is **optional**. It runs when the region must shrink, with
+`ctx = { region, entries, needed_tokens }`. Return an array of entry indices to drop. If the hook is
+absent, or your drops do not free enough, oldest-first eviction makes up the difference.
+
+### A complete region
+
+This region keeps a running "brain", drops noisy successful tool results on write, and under budget
+pressure evicts successes before errors. It renders everything as one XML user message (the
+[12-Factor Agents](https://github.com/humanlayer/12-factor-agents) "own your context window"
+pattern).
 
 ```rhai
+// context_hooks/brain.rhai
+
 fn render(ctx) {
     let xml = "<context>";
     for entry in ctx.entries {
@@ -79,52 +376,138 @@ fn render(ctx) {
     xml += "</context>";
     #{ messages: [ #{ role: "user", content: xml } ] }
 }
+
+fn on_write(ctx) {
+    // Keep tool errors verbatim; trim chatty successes to their first line.
+    let entry = ctx.entry;
+    if entry.kind == "tool_result" && !entry.content.contains("ERROR") {
+        let head = entry.content.split("\n")[0];
+        return head;                 // replace content (kind preserved)
+    }
+    ()                               // accept everything else unchanged
+}
+
+fn on_overflow(ctx) {
+    // Drop successes first; oldest-first eviction covers any shortfall.
+    let drops = [];
+    for (entry, i) in ctx.entries {
+        if !entry.content.contains("ERROR") { drops.push(i); }
+    }
+    drops
+}
 ```
 
+Runtime problems never break an inference: a `render` error falls back to a plain `[name]:` block, an
+`on_write` error accepts the entry unchanged, and an `on_overflow` error falls back to oldest-first.
+Only load-time problems (missing file, compile error, no `render`) fail the spawn.
+
 > [!NOTE]
-> The script is compile-checked once at spawn — a missing or broken file is a hard spawn error that
-> `lev validate` also reports, while runtime errors degrade gracefully and never break an inference.
-> Full `ctx` shapes, return conventions, and failure semantics are in `docs/rhai-regions.md`.
+> Region hooks run in the pure-data sandbox: no filesystem, no network, no host I/O functions. They
+> transform the `ctx` they are given and return a value. `lev test` assembles the context with your
+> hooks active so you can preview exactly what the provider would receive.
+
+See [Context](/docs/context) for how regions, budgets, and cache hints fit together.
 
 ## Global tools
 
 Every `.rhai` file in `~/.leviath/tools/` is compiled at spawn and offered as an executable tool to
-**every** agent — a way to give all agents a shared capability without editing each blueprint.
-Agent-specific tools are validated separately by `lev validate <agent>`.
+**every** agent. This is how you give all agents a shared capability without editing each blueprint.
+Per-agent tools live in that agent's own `tools/` directory and are validated by
+`lev validate <agent>`; a per-agent tool of the same name shadows the global one.
 
-A tool script declares itself with leading directives and reads its arguments from `params`:
+> [!WARNING]
+> The directory is `~/.leviath/tools/`, inside Leviath's data root next to `providers/` and
+> `agents/`. It is not `$HOME/tools/`. Every `.rhai` file here becomes a tool for every agent, so
+> treat it as a trusted location.
+
+### Declaring a tool
+
+A tool declares itself with leading `// @` directives and reads its arguments from the `params`
+object. The recognized directives:
+
+- `// @tool <name>` is required and names the tool (must match a stage's `available_tools` entry).
+- `// @description <text>` is an optional one-liner shown to the model.
+- `// @param <name> <type> <required|optional> "<description>"` is repeatable. `<type>` is a JSON
+  schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`.
+- `// @requires <cap> [<cap>...]` lists platform capabilities the tool needs (`network`, `shell`,
+  `filesystem`), comma or space separated and repeatable. Leviath drops the tool where the platform
+  cannot provide one.
+
+The script's return value becomes the tool result: a string is returned verbatim, anything else is
+JSON-encoded, and a bare `()` is an empty string. A missing optional param reads as `()`.
+
+### Host functions inside a tool
+
+Tools get a different host surface than providers, because they act on behalf of a running agent:
+`http_get(url [, headers])`, `http_post(url, body [, headers])`, `shell(cmd)`, `read_file(path)`,
+`write_file(path, content)`, and `env_var(name)` do the I/O (each gated by the tool's `@requires` and
+the agent's permissions). The pure helpers are `parse_json`, `to_json`, `encode_uri`, and
+`html_to_text`. Shared string/content helpers are also available: `contains`, `starts_with`,
+`ends_with`, `trim`, `join`, `split`, `count_tokens`, `is_json`, `is_markdown`, `is_mermaid`,
+`is_empty`.
+
+### A complete tool
+
+A minimal transform tool, `~/.leviath/tools/upper.rhai`:
 
 ```rhai
 // @tool upper
 // @description Upper-case text
 // @param text string required "input to transform"
-// @requires network
 params.text.to_upper()
 ```
 
-Use `lev tools` to see the global inventory — compiled tools are marked, files that failed to compile
-are shown with their reason (they are simply not advertised, exactly as the daemon treats them), and a
-tool whose `@requires` capability the platform can't satisfy is flagged unavailable:
+A tool that does real I/O, `~/.leviath/tools/web_fetch.rhai`. It declares the `network` capability,
+fetches a URL, and hands the model readable prose instead of raw HTML:
 
-```bash
-lev tools           # human-readable inventory + skipped files
-lev tools --json    # machine-readable, including params and required capabilities
+```rhai
+// @tool web_fetch
+// @description Fetch a URL and return its readable text
+// @param url string required "the URL to fetch"
+// @requires network
+let body = http_get(params.url);
+html_to_text(body)
 ```
 
-> [!NOTE]
-> The directory is `~/.leviath/tools/` — inside Leviath's data root, alongside `providers/` and
-> `agents/`. See [Built-in tools](/docs/tools) for how a stage's `available_tools` and
-> `tool_permissions` gate which tools an agent may actually call.
+For parameter shapes that directives cannot express (enums, array `items`, numeric bounds), drop a
+sibling `tool.toml` next to the script. When present it overrides the annotations entirely:
+
+```toml
+# ~/.leviath/tools/export.toml   (beside export.rhai)
+[tool]
+name        = "export"
+description = "Export in a chosen format"
+requires    = ["filesystem"]
+
+[[tool.params]]
+name     = "format"
+required = true
+schema   = { type = "string", enum = ["json", "yaml"], description = "output format" }
+```
+
+### Inspecting the inventory
+
+`lev tools` lists the global inventory without starting the daemon. Compiled tools are marked,
+files that failed to compile are shown with their reason (they are simply not advertised), and a tool
+whose `@requires` capability the platform cannot satisfy is flagged unavailable:
+
+```bash
+lev tools           # human-readable inventory, params, requires, and skipped files
+lev tools --json    # machine-readable, including param schemas and required capabilities
+```
+
+See [Tools](/docs/tools) for how a stage's `available_tools` and `tool_permissions` gate which tools
+an agent may actually call.
 
 ## Policy rules
 
 The [taint-gate](/docs/security) blocks any exfiltration-capable tool whose data taint exceeds its
-clearance. Beyond the static TOML allowlist in `policy.toml`, you can relax the gate with scripted
-rules: `.rhai` files in `~/.config/leviath/rules/`. They are consulted **after** the static allowlist,
-and the first script that allows a call wins — its filename stem becomes the rule name in decisions.
+clearance. Beyond the static allowlist in `policy.toml`, you can relax the gate with scripted rules:
+`.rhai` files in `~/.config/leviath/rules/`. They are consulted **after** the static allowlist, and
+the first script that allows a call wins. The filename stem becomes the rule name in decisions.
 
-Each rule receives a `context` map with `tool`, `target`, and `taint_level`, and evaluates to a
-boolean — `true` allows the call:
+Each rule receives a `context` map with `tool`, `target`, and `taint_level` (a string: `"public"`,
+`"internal"`, or `"private"`), and evaluates to a boolean. `true` allows the call.
 
 ```rhai
 // ~/.config/leviath/rules/company.rhai
@@ -133,15 +516,15 @@ context.tool == "send_email"
     && context.taint_level == "internal"
 ```
 
-A script that errors or doesn't evaluate to a boolean is treated as no match, so a broken rule can
+A script that errors or does not evaluate to a boolean is treated as no match, so a broken rule can
 never accidentally open the gate. Inspect and dry-run rules with the CLI:
 
 ```bash
-lev policy list                                   # static + scripted rules
-lev policy test --tool send_email --target ops@corp
+lev policy list                                              # static + scripted rules
+lev policy test send_email --target ops@corp --taint internal
 ```
 
 > [!IMPORTANT]
-> Scripted rules only ever **allow** calls the gate would otherwise block; they cannot tighten the
-> gate or override a deny. See [Security & sandboxing](/docs/security) for the taint model and the
-> full gate decision flow.
+> Scripted rules only ever **allow** calls the gate would otherwise block. They cannot tighten the
+> gate or override a deny. See [Security](/docs/security) for the taint model and the full gate
+> decision flow.

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -31,12 +31,12 @@ kind = "none"             # run discovery on the host…
   want real containment.
 
 > [!IMPORTANT]
-> An *installed* agent can only ever **tighten** its sandbox — it can raise the walls, never lower
+> An *installed* agent can only ever **tighten** its sandbox: it can raise the walls, never lower
 > them. A blueprint you install can't quietly turn isolation off.
 
 ## Taint tracking (experimental)
 
-A deterministic sensitivity model — **Public / Internal / Private** — tags every
+A deterministic sensitivity model (**Public / Internal / Private**) tags every
 [context region](/docs/context), set by the runtime and never by model output. Any tool that can
 carry bytes off the machine is gated: before it fires, the runtime checks the tool's clearance
 against the sensitivity of the data in play.

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -48,7 +48,7 @@ condition = "stuck"          # a runtime condition, not the agent's choice
 ## Stuck detection
 
 `stuck` escapes a stage that is making no progress. Crucially, stuckness is **measured, not
-self-reported** — an agent can't loop forever insisting it's almost done:
+self-reported**. An agent can't loop forever insisting it's almost done:
 
 ```toml
 [stages.implement.transitions.reassess]
@@ -63,5 +63,5 @@ Any subset applies; the first threshold to trip fires the edge.
 
 > [!TIP]
 > When a `stuck` (or `error`) edge fires, the runtime writes *why* into the target stage's
-> [context](/docs/context) — so the recovery stage starts out knowing what went wrong instead of
+> [context](/docs/context), so the recovery stage starts out knowing what went wrong instead of
 > rediscovering it.

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -8,7 +8,7 @@ order: 6
 # Sub-agents and fan-out
 
 Agents spawn children with different blueprints, all in the same process and over one shared
-inference driver — no new OS processes, no IPC. Sub-agents are just more entities in the
+inference driver, with no new OS processes and no IPC. Sub-agents are just more entities in the
 [ECS world](/docs/engine).
 
 ## Fan-out
@@ -18,7 +18,7 @@ concurrently, bounded by `max_workers`, then merges their results back into the 
 
 ```mermaid
 flowchart TB
-  P["Parent — fan-out stage"] --> Q{"split_prompt<br/>→ work items"}
+  P["Parent fan-out stage"] --> Q{"split_prompt<br/>→ work items"}
   Q --> W1["worker 1"]
   Q --> W2["worker 2"]
   Q --> W3["worker 3"]
@@ -35,13 +35,13 @@ max_workers  = 8            # concurrency bound
 on_worker_failure = "continue"
 ```
 
-This is how the `parallel-fixer` agent fixes many failing tests at once — one worker per failure —
+This is how the `parallel-fixer` agent fixes many failing tests at once, one worker per failure,
 and how a wide research sweep runs many sub-topics in parallel.
 
 ## Human-in-the-loop, at any depth
 
-Any sub-agent, at any depth, can ask *you* a question directly — no fire-and-forget, no routing
-through the parent:
+Any sub-agent, at any depth, can ask *you* a question directly, with no fire-and-forget and no
+routing through the parent:
 
 ```mermaid
 sequenceDiagram

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -8,8 +8,8 @@ order: 3
 # Built-in tools
 
 Every [agent](/docs/agents) advertises a set of tools to its LLM. The runtime ships a fixed catalog
-of **built-in tools** — file access, a shell, context memory, human-in-the-loop prompts, review
-surfaces, and sub-agent management — that need no configuration to exist. A [stage](/docs/stages)
+of **built-in tools** (file access, a shell, context memory, human-in-the-loop prompts, review
+surfaces, and sub-agent management) that need no configuration to exist. A [stage](/docs/stages)
 decides which of them the model may actually call via `available_tools`, and `tool_permissions`
 gates each call at `allow` / `ask` / `deny`. For tools beyond this catalog, connect an
 [MCP server](/docs/mcp).
@@ -27,7 +27,7 @@ Read and modify files relative to the agent's working directory.
 | `list_dir` | List a directory's contents. | `path` (optional; defaults to the working root) |
 
 > [!TIP]
-> `read_files` is cheaper than repeated `read_file` calls — reach for it after `list_dir` when you
+> `read_files` is cheaper than repeated `read_file` calls; reach for it after `list_dir` when you
 > already know several paths you need.
 
 ## Shell
@@ -45,7 +45,7 @@ resolve to the same tool advertised to the model.
 
 ## Context
 
-Read and write the agent's own [context window](/docs/context) — named sections the runtime folds
+Read and write the agent's own [context window](/docs/context): named sections the runtime folds
 back into the system prompt on later turns.
 
 | Tool | Purpose | Arguments |
@@ -93,9 +93,9 @@ model but executed by the engine's tool registry, since they act on the shared a
 A tool existing in the catalog does not mean an agent can call it. Two independent settings on each
 stage control access:
 
-- **`available_tools`** — the allowlist of tool names advertised to the model in that stage. A tool
+- **`available_tools`**: the allowlist of tool names advertised to the model in that stage. A tool
   not listed here is invisible to the LLM. Names may use aliases (e.g. `bash` for `shell`).
-- **`tool_permissions`** — a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
+- **`tool_permissions`**: a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
   the call outright, `ask` requires user approval first, and `deny` blocks it. Stage-level entries
   are narrower than agent-level `[tool_permissions]` and wider than launch-time flags.
 


### PR DESCRIPTION
Follow-up polish on the docs.

- Prose no longer reads as AI-generated: no em dashes, no AI-tell phrasings (facts/code/diagrams unchanged).
- `scripting.md` is now a full custom-provider walkthrough (real Rhai hooks) plus custom-region, global-tool, and policy examples, so a niche feature like a Rhai provider is actually doable from the page.
- `agent-catalog.md` is an examples page: each pre-built agent has a stage-accurate workflow diagram and a how-it-works note.
- Provider key-creation links added; Claude Code transport kept only on the providers page.
- "dozens of agents" -> "hundreds of agents" everywhere (incl. the README tagline), matching the README's other claims.
- New `docs/README.md`: how the docs are generated and how to add pages for new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)