### PR TITLE
ci(alpha): install the pinned toolchain's std for the cross target

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -66,9 +66,17 @@ jobs:
             ext: zip
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: ${{ matrix.target }}
+      # `rust-toolchain.toml` pins the compiler, and rustup resolves that pin
+      # per directory - so a cross target handed to a "stable" toolchain action
+      # lands on a *different* toolchain installation than the one `cargo build`
+      # actually uses, and the cross builds fail with "can't find crate for
+      # `core`". Install the pinned toolchain itself (no-arg install reads the
+      # pin) and add the target to it.
+      - name: Install the pinned toolchain with the build target
+        shell: bash
+        run: |
+          rustup toolchain install
+          rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}


### PR DESCRIPTION
## The failure

Alpha (Nightly) has failed three nights running (since 2026-07-29), on exactly the two cross-compiled builds — `Build (x86_64-apple-darwin)` and `Build (aarch64-unknown-linux-gnu)`:

```
error[E0463]: can't find crate for `core`
error: could not compile `libc` (lib) due to 1 previous error
```

Prod (Weekly Thursday)'s failure is downstream of this: beta/prod promote alpha's artifacts.

## The cause

cbfffc4 (2026-07-28, part of the supply-chain work) added `rust-toolchain.toml` pinning `channel = "1.97.1"` — and the first failing nightly is the next morning. The build job passes the cross target to `dtolnay/rust-toolchain`, which installs it into the **`stable`** toolchain. But the moment `cargo build` runs inside the checkout, rustup resolves the directory pin and uses the **`1.97.1`** toolchain instead — a separate installation that rustup auto-installs with only the host's std. rustup treats `stable-…` and `1.97.1-…` as distinct toolchains even when they're the same compiler, so the target std never reaches the toolchain doing the building.

The native-target jobs (and all of regular CI) kept passing because the host std is always present, which is why this only ever showed in the nightly cross builds.

## The fix

Replace the toolchain action in the build job with an explicit install of the pinned toolchain plus `rustup target add` for the matrix target — both resolved against the pin, so a future toolchain bump keeps working with no second place to edit.

Verification: this changes a `schedule`/`workflow_dispatch` workflow, so PR CI can't exercise it; after merge I'll trigger `Alpha (Nightly)` manually via `workflow_dispatch` and confirm all five targets build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGEgiRznp6gDcwYLpGRNKW