### PR TITLE
ci: run required checks in the merge queue (merge_group trigger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     # `labeled`/`unlabeled` are included so the `guard-main-rs` job re-runs when
     # a maintainer applies/removes the `allow-main-rs-change` override label.
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  # The merge queue runs required checks against a temporary `merge_group` ref.
+  # Without this trigger those checks never run, so queued PRs block forever.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
`main`'s merge queue runs required checks against a temporary `merge_group` ref, but `ci.yml` only triggered on `push`/`pull_request`. So queued PRs waited forever for merge-group checks that never ran, blocking every merge to `main`.

This adds the `merge_group:` trigger. PR-only jobs (`guard-main-rs`) already gate on `github.event_name == 'pull_request'` and skip on merge-group events.

**This PR hits the same deadlock**, so it needs a one-time admin merge to land (see instructions from the assistant). After it merges, the queue works for everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)