### PR TITLE
Point every repo reference at github.com/GEMISIS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Thanks for the report! For suspected **security vulnerabilities**, please use
-        [private vulnerability reporting](https://github.com/Sun-Forge-AI/leviath/security/advisories/new)
+        [private vulnerability reporting](https://github.com/GEMISIS/leviath/security/advisories/new)
         instead of a public issue — see [SECURITY.md](../blob/main/SECURITY.md).
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/Sun-Forge-AI/leviath/security/advisories/new
+    url: https://github.com/GEMISIS/leviath/security/advisories/new
     about: Please report vulnerabilities privately, never in a public issue.
   - name: Documentation
     url: https://leviath.dev/docs

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -192,7 +192,7 @@ jobs:
       # forged by someone who merely holds a repo token.
       #
       # Users verify with:
-      #   gh attestation verify <file> --repo Sun-Forge-AI/leviath
+      #   gh attestation verify <file> --repo GEMISIS/leviath
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
@@ -216,13 +216,13 @@ jobs:
 
             **Homebrew (macOS):**
             ```bash
-            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew tap gemisis/leviath https://github.com/GEMISIS/leviath-dist.git
             brew install leviath
             ```
 
             **Linux:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.sh | bash
             ```
 
             **Manual:**

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -108,13 +108,13 @@ jobs:
 
             **Homebrew (macOS):**
             ```bash
-            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew tap gemisis/leviath https://github.com/GEMISIS/leviath-dist.git
             brew install leviath
             ```
 
             **Linux:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.sh | bash
             ```
 
             **Manual:**

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -164,18 +164,18 @@ jobs:
 
             **Homebrew (macOS):**
             ```bash
-            brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            brew tap gemisis/leviath https://github.com/GEMISIS/leviath-dist.git
             brew install leviath
             ```
 
             **Linux:**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.sh | bash
             ```
 
             **Windows (Scoop):**
             ```powershell
-            scoop bucket add leviath https://github.com/Sun-Forge-AI/leviath-dist.git
+            scoop bucket add leviath https://github.com/GEMISIS/leviath-dist.git
             scoop install leviath
             ```
 
@@ -188,7 +188,7 @@ jobs:
 
             **From source:**
             ```bash
-            cargo install --git https://github.com/Sun-Forge-AI/leviath.git --tag ${{ env.VERSION }} --bin lev
+            cargo install --git https://github.com/GEMISIS/leviath.git --tag ${{ env.VERSION }} --bin lev
             ```
           prerelease: false
           make_latest: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout leviath.dev (docs-ssg)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          repository: Sun-Forge-AI/leviath.dev
+          repository: GEMISIS/leviath.dev
           token: ${{ secrets.DOCS_SSG_TOKEN }}
           path: site
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the maintainers by opening an issue, or — for reports that should
 stay private — through GitHub's
-[private vulnerability reporting](https://github.com/Sun-Forge-AI/leviath/security/advisories/new)
+[private vulnerability reporting](https://github.com/GEMISIS/leviath/security/advisories/new)
 form on this repository (it reaches the maintainers privately even for
 non-vulnerability reports).
 All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,13 @@ flowchart LR
   repository's [MIT license](LICENSE). There is no CLA.
 - **Conduct**: we follow the [Contributor Covenant](CODE_OF_CONDUCT.md).
 - **Security issues** go through
-  [private vulnerability reporting](https://github.com/Sun-Forge-AI/leviath/security/advisories/new),
+  [private vulnerability reporting](https://github.com/GEMISIS/leviath/security/advisories/new),
   never public issues — see [SECURITY.md](SECURITY.md).
 
 ## Getting the code building
 
 ```bash
-git clone https://github.com/Sun-Forge-AI/leviath.git
+git clone https://github.com/GEMISIS/leviath.git
 cd leviath
 cargo build
 cargo test --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
-repository = "https://github.com/Sun-Forge-AI/leviath"
+repository = "https://github.com/GEMISIS/leviath"
 homepage = "https://leviath.dev"
 description = "A structured agent runtime for LLMs - context memory, multi-stage workflows, and ECS-based orchestration"
 # crates.io metadata. `rust-version` is the toolchain releases are built and

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 **Right-sized.** Each phase of a task gets its own model, tools, and context layout, so you aren't paying frontier prices for file reads.<br>
 **Light.** Hundreds of agents in one [bevy_ecs](https://bevyengine.org/) process, from a single binary. No Node, Python, or Docker.
 
-[![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-test-all.json)](https://github.com/Sun-Forge-AI/leviath/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-coverage-lines.json)](https://github.com/Sun-Forge-AI/leviath/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Sun-Forge-AI/leviath/blob/main/LICENSE)
+[![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-test-all.json)](https://github.com/GEMISIS/leviath/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-coverage-lines.json)](https://github.com/GEMISIS/leviath/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/GEMISIS/leviath/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-leviath.dev-8b5cf6)](https://leviath.dev)
 
 **[Quick Start](#quick-start) · [Agents](#pre-built-agents) · [Features](#features) · [Dashboard](#dashboard) · [API](#api-server) · [Agent Client Protocol](#agent-client-protocol) · [Comparison](#how-it-compares) · [Why not Leviath](#why-you-might-not-want-leviath) · [Contributing](#contributing)**
@@ -54,21 +54,21 @@ lev create my-agent              # scaffold your own agent
 **macOS (Homebrew, recommended):**
 
 ```bash
-brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
-brew trust sun-forge-ai/leviath          # Homebrew 6 requires trusting third-party taps
+brew tap gemisis/leviath https://github.com/GEMISIS/leviath-dist.git
+brew trust gemisis/leviath          # Homebrew 6 requires trusting third-party taps
 brew install leviath                     # stable - or: leviath-beta, leviath-alpha
 ```
 
 **Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh | bash -s -- --channel stable
+curl -fsSL https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.sh | bash -s -- --channel stable
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.ps1 | iex
 ```
 
 All three install prebuilt binaries; no Rust toolchain needed.
@@ -77,7 +77,7 @@ All three install prebuilt binaries; no Rust toolchain needed.
 
 ```bash
 cargo install leviath-cli                # released version from crates.io
-cargo install --git https://github.com/Sun-Forge-AI/leviath.git --bin lev   # latest development build
+cargo install --git https://github.com/GEMISIS/leviath.git --bin lev   # latest development build
 ```
 
 Leviath is also a library: add the [`leviath`](https://crates.io/crates/leviath) crate to embed the runtime in your own application.
@@ -437,7 +437,7 @@ Optional client-side rate limits per provider (requests and tokens per minute), 
 | **Beta** | Weekly (Monday) | `beta` | Tested |
 | **Stable** | Weekly (Thursday, approval-gated) | `latest` | Production |
 
-Channel tags roll with every publish; each stable deploy also cuts an immutable `vX.Y.Z` release, which is what Homebrew and Scoop pin to. Install commands per channel: [distribution repo](https://github.com/Sun-Forge-AI/leviath-dist).
+Channel tags roll with every publish; each stable deploy also cuts an immutable `vX.Y.Z` release, which is what Homebrew and Scoop pin to. Install commands per channel: [distribution repo](https://github.com/GEMISIS/leviath-dist).
 
 ## Security
 
@@ -446,7 +446,7 @@ Leviath runs LLM-driven tools on your machine, so [SECURITY.md](SECURITY.md) sta
 ## Contributing
 
 ```bash
-git clone https://github.com/Sun-Forge-AI/leviath.git
+git clone https://github.com/GEMISIS/leviath.git
 cd leviath
 cargo build
 cargo test --workspace
@@ -499,6 +499,6 @@ graph TD
 <p align="center">
   <a href="https://leviath.dev">Website</a> ·
   <a href="https://leviath.dev/docs">Docs</a> ·
-  <a href="https://github.com/Sun-Forge-AI/leviath">GitHub</a> ·
-  <a href="https://github.com/Sun-Forge-AI/leviath/issues">Issues</a>
+  <a href="https://github.com/GEMISIS/leviath">GitHub</a> ·
+  <a href="https://github.com/GEMISIS/leviath/issues">Issues</a>
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Report privately, not as a public issue: use [GitHub's private vulnerability
-reporting](https://github.com/Sun-Forge-AI/leviath/security/advisories/new).
+reporting](https://github.com/GEMISIS/leviath/security/advisories/new).
 Everything about a report happens there - filing, discussion, the fix, and
 the advisory.
 
@@ -194,7 +194,7 @@ the attestation as well:
 
 ```bash
 # Asset names are `leviath-<platform>-<arch>.<ext>`, e.g.:
-gh attestation verify leviath-linux-x64.tar.gz --repo Sun-Forge-AI/leviath
+gh attestation verify leviath-linux-x64.tar.gz --repo GEMISIS/leviath
 sha256sum -c SHA256SUMS
 ```
 

--- a/crates/leviath-agent-client/README.md
+++ b/crates/leviath-agent-client/README.md
@@ -3,7 +3,7 @@
 Wire types and Leviath mappings for the Agent Client Protocol (JSON-RPC
 over stdio), which lets editors host a Leviath agent as a session.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-cli/README.md
+++ b/crates/leviath-cli/README.md
@@ -1,6 +1,6 @@
 # leviath-cli
 
-The `lev` command-line tool for [Leviath](https://github.com/Sun-Forge-AI/leviath),
+The `lev` command-line tool for [Leviath](https://github.com/GEMISIS/leviath),
 a structured agent runtime for LLMs: context memory laid out in regions with
 token budgets, multi-stage workflows described by blueprints, and an ECS-based
 execution engine.
@@ -12,7 +12,7 @@ cargo install leviath-cli
 ```
 
 Prebuilt binaries, a Homebrew tap, and install scripts are listed in the
-[main README](https://github.com/Sun-Forge-AI/leviath#readme).
+[main README](https://github.com/GEMISIS/leviath#readme).
 
 ## Quick start
 

--- a/crates/leviath-core/README.md
+++ b/crates/leviath-core/README.md
@@ -4,7 +4,7 @@ Core types and traits for Leviath: context regions and memory layouts, token
 budgets, blueprint manifests, tool and network policy, sandbox configuration,
 and lifecycle rules. Every other crate in the runtime builds on this one.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-mcp/README.md
+++ b/crates/leviath-mcp/README.md
@@ -4,7 +4,7 @@ Model Context Protocol support for Leviath: server discovery, tool listing
 and execution over stdio or HTTP transports, and OAuth for servers that
 need it.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-package/README.md
+++ b/crates/leviath-package/README.md
@@ -3,7 +3,7 @@
 Packaging and installation for Leviath agent blueprints: bundling an agent
 directory for sharing, and installing one into the local data root.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-providers/README.md
+++ b/crates/leviath-providers/README.md
@@ -4,7 +4,7 @@ LLM provider integrations for Leviath: Anthropic, OpenAI, Gemini, Ollama,
 OpenRouter, and drop-in providers written in Rhai. Also holds the shared
 retry, rate-limit, and tokenizer plumbing the providers have in common.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-runtime/README.md
+++ b/crates/leviath-runtime/README.md
@@ -4,7 +4,7 @@ Leviath's execution engine. Agents live as entities in an ECS world, and the
 stage pipeline, persistence, fan-out to sub-agents, provider wiring, and
 taint tracking are systems that run over them.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-scripting/README.md
+++ b/crates/leviath-scripting/README.md
@@ -4,7 +4,7 @@ Rhai scripting for Leviath. Blueprints can ship custom validators,
 transforms, script tools, and even whole context region implementations as
 scripts, and this crate is the engine that runs them.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-sys/README.md
+++ b/crates/leviath-sys/README.md
@@ -5,7 +5,7 @@ process control and signals, socket peer credentials, terminal handling,
 and the OS keychain. Despite the -sys suffix, this is not an FFI binding
 crate; it is where Leviath's OS-specific code is quarantined.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-telemetry/README.md
+++ b/crates/leviath-telemetry/README.md
@@ -3,7 +3,7 @@
 OpenTelemetry export for Leviath's telemetry event stream. Traces, metrics,
 and logs go out as OTLP over HTTP.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath-tools/README.md
+++ b/crates/leviath-tools/README.md
@@ -4,7 +4,7 @@ The native tools Leviath agents can call: shell, file reads and writes, web
 fetch and search, and the ask-user interaction tools, all gated by the
 policy and sandbox types from leviath-core.
 
-Part of [Leviath](https://github.com/Sun-Forge-AI/leviath), a structured
+Part of [Leviath](https://github.com/GEMISIS/leviath), a structured
 agent runtime for LLMs. Most applications should depend on the
 [`leviath`](https://crates.io/crates/leviath) facade crate rather than this
 one, and if you want the `lev` command-line tool, install

--- a/crates/leviath/README.md
+++ b/crates/leviath/README.md
@@ -26,7 +26,7 @@ If you want the `lev` command-line tool rather than a library, install
 [`leviath-cli`](https://crates.io/crates/leviath-cli).
 
 Source, documentation, and issue tracker live at
-[github.com/Sun-Forge-AI/leviath](https://github.com/Sun-Forge-AI/leviath).
+[github.com/GEMISIS/leviath](https://github.com/GEMISIS/leviath).
 See also [leviath.dev](https://leviath.dev).
 
 Licensed under the MIT license.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ gains features.
 docs/content/*.md   (this repo, the source of truth)
         |
         v
-  docs-ssg           (the renderer, lives in the Sun-Forge-AI/leviath.dev repo:
+  docs-ssg           (the renderer, lives in the GEMISIS/leviath.dev repo:
         |             mermaid, syntax highlighting, on-page TOC, callouts, search)
         v
   s3://<site>/docs/<channel>/*.html   (published per release)

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -26,22 +26,22 @@ flowchart LR
 **macOS (Homebrew, recommended)**
 
 ```bash
-brew tap sun-forge-ai/leviath https://github.com/Sun-Forge-AI/leviath-dist.git
-brew trust sun-forge-ai/leviath # Homebrew 6 requires trusting third-party taps
+brew tap gemisis/leviath https://github.com/GEMISIS/leviath-dist.git
+brew trust gemisis/leviath # Homebrew 6 requires trusting third-party taps
 brew install leviath            # or: leviath-beta, leviath-alpha
 ```
 
 **Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.sh \
+curl -fsSL https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.sh \
   | bash -s -- --channel stable
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/Sun-Forge-AI/leviath-dist/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/GEMISIS/leviath-dist/main/install.ps1 | iex
 ```
 
 The three options above install prebuilt binaries; no Rust toolchain needed.
@@ -50,7 +50,7 @@ The three options above install prebuilt binaries; no Rust toolchain needed.
 
 ```bash
 cargo install leviath-cli                # released version from crates.io
-cargo install --git https://github.com/Sun-Forge-AI/leviath.git --bin lev   # latest development build
+cargo install --git https://github.com/GEMISIS/leviath.git --bin lev   # latest development build
 ```
 
 To embed the runtime in your own application instead, add the [`leviath`](https://crates.io/crates/leviath) crate as a dependency.

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -68,5 +68,5 @@ lev policy test bash --target example.com
 ## Threat model
 
 `lev serve` runs LLM-driven tools, so treat it as trusted-network only unless hardened. See
-[SECURITY.md](https://github.com/Sun-Forge-AI/leviath/blob/main/SECURITY.md) for the full threat
+[SECURITY.md](https://github.com/GEMISIS/leviath/blob/main/SECURITY.md) for the full threat
 model, what Leviath defends against, and how to report a vulnerability (GitHub private advisories).

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -60,10 +60,10 @@ on its next start.
 
 No token is needed — the repos and release assets are public. A 401/403 during install usually
 means leftovers from the private alpha: remove any
-`url."https://…@github.com/Sun-Forge-AI/".insteadOf` rewrite from `~/.gitconfig`, unset stale
+`url."https://…@github.com/GEMISIS/".insteadOf` rewrite from `~/.gitconfig`, unset stale
 `GITHUB_TOKEN` / `HOMEBREW_GITHUB_API_TOKEN` exports (an expired token *fails* requests that
 would succeed anonymously), and retry.
 
 > [!NOTE]
 > Still stuck? Open an issue or a private security advisory on
-> [GitHub](https://github.com/Sun-Forge-AI/leviath).
+> [GitHub](https://github.com/GEMISIS/leviath).


### PR DESCRIPTION
The leviath, leviath-dist, leviath-benchmarks, and leviath.dev repos moved from the Sun-Forge-AI organization to the GEMISIS personal account. Redirects cover old URLs for now, but the crates.io publish is about to bake these into immutable crate versions, so they get fixed at the source first.

52 references across 27 files: the workspace `repository` field, all per-crate READMEs, install instructions (the brew tap is now `gemisis/leviath`), workflow release-note bodies, issue templates, community files, and docs content. `publish-docs.yml` now checks out `GEMISIS/leviath.dev`.

No code changes; `git diff --stat` is 52 insertions, 52 deletions, all string URL/name swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2