### PR TITLE
Promote docs by the binaries' commit, not main's head

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -157,6 +157,8 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
           echo "sha_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          # For the release title. Same line-anchored extraction prod.yml uses.
+          echo "version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -203,7 +205,7 @@ jobs:
         with:
           tag_name: alpha
           target_commitish: ${{ steps.info.outputs.sha_full }}
-          name: "Alpha · ${{ steps.info.outputs.date }} · ${{ steps.info.outputs.sha_short }}"
+          name: "Leviath v${{ steps.info.outputs.version }}-Alpha"
           body: |
             **Nightly alpha build** from `main` at ${{ steps.info.outputs.sha_full }}
 

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -243,4 +243,6 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       channel: alpha
+      # The same commit the binaries in this run were built from.
+      ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Handed to the docs job so beta docs render the promoted alpha commit,
+    # exactly like the binaries.
+    outputs:
+      sha: ${{ steps.alpha.outputs.sha }}
+      skip: ${{ steps.alpha.outputs.skip }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -128,10 +133,15 @@ jobs:
   docs:
     name: Publish docs (beta)
     needs: promote
+    # `promote` exits 0 when there is no alpha to promote; no new binaries
+    # means no docs refresh either.
+    if: needs.promote.outputs.skip != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/publish-docs.yml
     with:
       channel: beta
+      # The promoted alpha commit, so beta docs match the beta binaries.
+      ref: ${{ needs.promote.outputs.sha }}
     secrets: inherit

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -54,6 +54,9 @@ jobs:
             fi
             echo "sha=$sha" >> $GITHUB_OUTPUT
             echo "sha_short=${sha:0:7}" >> $GITHUB_OUTPUT
+            # Version at the promoted commit, for the release title. Same
+            # extraction prod.yml applies to the beta SHA.
+            echo "version=$(git show "$sha:Cargo.toml" | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
           else
             echo "No COMMIT_SHA in alpha release. Skipping."
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -99,7 +102,7 @@ jobs:
         with:
           tag_name: beta
           target_commitish: ${{ steps.alpha.outputs.sha }}
-          name: "Beta · ${{ steps.alpha.outputs.date }} · ${{ steps.alpha.outputs.sha_short }}"
+          name: "Leviath v${{ steps.alpha.outputs.version }}-Beta"
           body: |
             **Weekly beta build** promoted from alpha.
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -224,11 +224,15 @@ jobs:
 
   docs:
     name: Publish docs (stable)
-    needs: deploy
+    # check-beta is only here for its `sha` output; deploy is the real gate
+    # (it inherits check-beta's skip condition).
+    needs: [deploy, check-beta]
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/publish-docs.yml
     with:
       channel: stable
+      # The promoted beta commit, so stable docs match the stable binaries.
+      ref: ${{ needs.check-beta.outputs.sha }}
     secrets: inherit

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,12 +9,25 @@ on:
       channel:
         required: true
         type: string
+      # The leviath commit whose docs/content gets rendered. The release
+      # workflows pass the SHA their binaries were built from, so a channel's
+      # docs always describe that channel's binary rather than whatever main
+      # happens to be when the promotion runs. Empty means the triggering SHA.
+      ref:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       channel:
         description: alpha | beta | stable
         required: true
         default: alpha
+        type: string
+      ref:
+        description: leviath commit to render (empty = current main)
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -27,6 +40,8 @@ jobs:
     steps:
       - name: Checkout Leviath (docs content)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       # leviath.dev is a private repo, so the default GITHUB_TOKEN (scoped to
       # this repo) cannot read it — a fine-grained PAT with Contents: read on


### PR DESCRIPTION
Beta and prod promote binaries built from an older alpha SHA, but their docs jobs rendered `docs/content` from main's head at promotion time, so a channel's docs could describe features its binary does not have yet.

`publish-docs.yml` now accepts a `ref` input (default: the triggering SHA, so manual dispatches behave as before), and each channel passes the commit its binaries came from:

- alpha: `github.sha` (the build commit, explicit now)
- beta: the promoted alpha SHA (already computed and 40-hex validated in the promote job, now exposed as a job output)
- prod: the promoted beta SHA (already a check-beta output)

The beta docs job also gains `if: skip != 'true'` so a no-op promotion (no alpha release) no longer refreshes docs; prod already had that gate via deploy.

Live test after merge: rerun beta.yml and confirm docs/beta renders the alpha SHA rather than main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2