### PR TITLE
ci: temporary probe for release-create 403

### DIFF
--- a/.github/workflows/debug-release-perms.yml
+++ b/.github/workflows/debug-release-perms.yml
@@ -1,0 +1,34 @@
+# Temporary probe: release creation via GITHUB_TOKEN started returning 403
+# "Resource not accessible by integration" after the org -> personal transfer,
+# with Contents: write granted. The 403's x-accepted-github-permissions header
+# names the permission the endpoint actually wants; this prints it. Remove
+# once the release workflows are fixed.
+name: Debug release perms
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Probe releases API
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl -isS -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases" \
+            -d "{\"tag_name\":\"debug-perm-check\",\"target_commitish\":\"${{ github.sha }}\",\"name\":\"debug perm check\",\"prerelease\":true}" \
+            | grep -iE "^HTTP|x-accepted-github-permissions|\"message\"" || true
+      - name: Probe tag creation via git
+        run: |
+          git push origin "HEAD:refs/tags/debug-perm-check-git" && echo "git tag push: OK" || echo "git tag push: DENIED"
+      - name: Cleanup probes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete debug-perm-check --yes --cleanup-tag --repo "${{ github.repository }}" || true
+          git push origin --delete refs/tags/debug-perm-check-git || true


### PR DESCRIPTION
Temporary: prints the x-accepted-github-permissions header from the 403 the release workflows hit post-transfer. Will be removed in the fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2