### PR TITLE
Fix invalid workflows permission; use RELEASE_TOKEN for channel releases

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -18,14 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Creating the beta release creates a tag at the promoted alpha commit.
-      # When workflow files changed on main since that commit, GitHub requires
-      # `workflows: write` on top of `contents: write` to create a ref whose
-      # workflow tree differs (the 403 says so in
-      # x-accepted-github-permissions: "contents=write;
-      # contents=write,workflows=write"). Without it, promotion only works in
-      # the accidental case where no workflow edits landed in between.
-      workflows: write
     # Handed to the docs job so beta docs render the promoted alpha commit,
     # exactly like the binaries.
     outputs:
@@ -108,6 +100,14 @@ jobs:
         if: steps.alpha.outputs.skip != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # Promotion tags an OLDER commit whose .github/workflows can differ
+          # from main's current tree, and GITHUB_TOKEN is never allowed to
+          # create such a ref (the 403's x-accepted-github-permissions wants
+          # contents+workflows, and workflow permissions blocks cannot grant
+          # workflows). RELEASE_TOKEN is a fine-grained PAT with Contents +
+          # Workflows read/write on this repo; the fallback keeps the
+          # no-workflow-drift case working without the secret.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
           tag_name: beta
           target_commitish: ${{ steps.alpha.outputs.sha }}
           name: "Leviath v${{ steps.alpha.outputs.version }}-Beta"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -103,10 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Same reason as beta.yml's promote job: tagging the promoted beta
-      # commit needs `workflows: write` whenever workflow files changed on
-      # main since that commit.
-      workflows: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -156,6 +152,9 @@ jobs:
       - name: Publish prod release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # See beta.yml: tagging the promoted (older) commit needs a token
+          # that may create refs with workflow-file drift; GITHUB_TOKEN cannot.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
           tag_name: ${{ env.VERSION }}
           target_commitish: ${{ needs.check-beta.outputs.sha }}
           name: "Leviath ${{ env.VERSION }}"
@@ -210,6 +209,8 @@ jobs:
       - name: Publish latest channel release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # Same as the prod release above.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
           tag_name: latest
           target_commitish: ${{ needs.check-beta.outputs.sha }}
           name: "Leviath ${{ env.VERSION }} (stable channel)"


### PR DESCRIPTION
PR #172's `workflows: write` is not a legal key in a workflow permissions block — beta.yml and prod.yml currently fail to parse on main (dispatch returns 422), so this needs to land promptly.

The diagnosis behind #172 still stands: promotion creates a tag at an older commit, and when workflow files changed on main since that commit, GitHub requires the contents+workflows permission set — which GITHUB_TOKEN cannot carry at all. The durable fix is a `RELEASE_TOKEN` secret (fine-grained PAT: Contents + Workflows, read/write, scoped to this repo) used by the three softprops release-creation steps, with `|| github.token` fallback so promotion keeps working without the secret whenever no workflow drift exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2