### PR TITLE
Correct the lev run hint; migrate the daemon service label off sunforge

### DIFF
--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -19,7 +19,33 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 /// The reverse-DNS label both platforms key the service by.
-pub const SERVICE_LABEL: &str = "ai.sunforge.leviath";
+pub const SERVICE_LABEL: &str = "dev.leviath.daemon";
+
+/// Labels earlier releases registered the launchd agent under (the project
+/// predates its move off the Sun Forge organization). Install and uninstall
+/// also deregister these, so upgrading across the rename cannot leave a
+/// second supervised daemon running under the old name.
+#[cfg(target_os = "macos")]
+pub const LEGACY_SERVICE_LABELS: &[&str] = &["ai.sunforge.leviath"];
+
+/// The cleanup a legacy label needs: the unit file it wrote and the
+/// `launchctl bootout` that deregisters it. Pure data - running the commands
+/// is the caller's subprocess I/O, same split as [`ServiceUnit`].
+#[cfg(target_os = "macos")]
+pub fn legacy_cleanup(config_home: &Path, uid: u32) -> Vec<(PathBuf, (String, Vec<String>))> {
+    LEGACY_SERVICE_LABELS
+        .iter()
+        .map(|label| {
+            (
+                config_home.join(format!("{label}.plist")),
+                (
+                    "launchctl".to_string(),
+                    vec!["bootout".to_string(), format!("gui/{uid}/{label}")],
+                ),
+            )
+        })
+        .collect()
+}
 
 /// Where a supervised daemon's stdout/stderr are appended, under the leviath
 /// home directory. Only the platforms with a supervisor render a unit file.
@@ -424,6 +450,23 @@ mod tests {
                     .unwrap()
                     .ends_with("LaunchAgents")
             );
+        }
+
+        #[test]
+        fn legacy_cleanup_covers_every_old_label_with_a_bootout_and_a_plist() {
+            let actions = legacy_cleanup(Path::new("/tmp/lev-units"), 501);
+            assert_eq!(actions.len(), LEGACY_SERVICE_LABELS.len());
+            let (path, (cmd, args)) = &actions[0];
+            assert_eq!(
+                path.file_name().unwrap().to_string_lossy(),
+                "ai.sunforge.leviath.plist"
+            );
+            assert_eq!(cmd, "launchctl");
+            assert_eq!(args[0], "bootout");
+            assert_eq!(args[1], "gui/501/ai.sunforge.leviath");
+            // The rename is only safe because the old label is cleaned up;
+            // the current label must never appear in the legacy list.
+            assert!(!LEGACY_SERVICE_LABELS.contains(&SERVICE_LABEL));
         }
     }
 

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -179,7 +179,7 @@ impl RiskyExecutors for RealExecutors {
 /// the un-unit-testable slivers kept here.
 async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
     let path = args.path.ok_or_else(|| {
-        anyhow::anyhow!("a blueprint path is required (e.g. `lev run agents/coder \"task\"`)")
+        anyhow::anyhow!("a blueprint name or path is required (e.g. `lev run coder -t \"task\"`)")
     })?;
     let task = args
         .task
@@ -371,6 +371,7 @@ fn real_daemon_install() -> anyhow::Result<()> {
     // Re-registering a live service is an error on both platforms; drop any
     // previous registration first so `install` is idempotent.
     let _ = run_supervisor(&unit.deactivate);
+    remove_legacy_services();
     run_supervisor(&unit.activate)?;
     println!("the leviath daemon is now supervised and will restart automatically");
     Ok(())
@@ -382,6 +383,7 @@ fn real_daemon_uninstall() -> anyhow::Result<()> {
     // Deregistration fails when nothing is registered; that's the desired end
     // state either way, so only the file removal is reported.
     let _ = run_supervisor(&unit.deactivate);
+    remove_legacy_services();
     if commands::daemon_service::uninstall(&unit)? {
         println!("removed {}", unit.path.display());
     } else {
@@ -389,6 +391,33 @@ fn real_daemon_uninstall() -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+/// Deregister and delete any service registration left under a previous
+/// label (`daemon_service::LEGACY_SERVICE_LABELS`), so a rename never leaves
+/// a second supervised daemon behind. Best-effort by design: on a machine
+/// that never had the old label, every step is a no-op.
+#[cfg(target_os = "macos")]
+fn remove_legacy_services() {
+    let Some(user_home) = dirs::home_dir() else {
+        return;
+    };
+    let Ok(config_home) = commands::daemon_service::config_home(&user_home) else {
+        return;
+    };
+    for (path, bootout) in
+        commands::daemon_service::legacy_cleanup(&config_home, leviath_sys::current_uid())
+    {
+        let _ = run_supervisor(&bootout);
+        if std::fs::remove_file(&path).is_ok() {
+            println!("removed legacy service file {}", path.display());
+        }
+    }
+}
+
+/// Only macOS ever shipped under a different label; elsewhere there is
+/// nothing legacy to clean up.
+#[cfg(not(target_os = "macos"))]
+fn remove_legacy_services() {}
 
 /// Real `lev daemon`: bind the platform control socket and drive the shared world
 /// until Ctrl-C. Wiring only - the world, host, tool service, and spawner it


### PR DESCRIPTION
Two user-visible code fixes from the launch audit.

**`lev run` error hint** (`main.rs`): suggested `lev run agents/coder "task"` — the `agents/` path form no longer resolves from a checkout, and the task is a `-t` flag, not positional. Now `lev run coder -t "task"`. This is the reason for the `allow-main-rs-change` label.

**Daemon service label**: `ai.sunforge.leviath` was the last user-visible Sun-Forge string (the launchd plist name and `launchctl` target from `lev daemon install`). Renamed to `dev.leviath.daemon`, with a migration: install/uninstall also boot out and remove any registration under `LEGACY_SERVICE_LABELS`, so upgrading across the rename cannot leave a second supervised daemon running under the old name. The cleanup actions are pure data in the tested `daemon_service` core (covered by a new macOS test, including the invariant that the current label never appears in the legacy list); executing them lives in the binary with the rest of the subprocess I/O. Linux always used `leviath.service` and is untouched.

Verified: `cargo xtask coverage --package leviath-cli` green locally on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2