### PR TITLE
Publish crates.io automatically from each stable deploy

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -230,6 +230,64 @@ jobs:
 
 
 
+  # crates.io tracks the stable channel: same commit as the binaries, so
+  # `cargo install leviath-cli` means "the current stable line". Alpha and
+  # beta are deliberately NOT published - registry versions are immutable and
+  # nightly prereleases would be permanent clutter that `cargo install`
+  # ignores by default anyway; developers who want the bleeding edge use
+  # `cargo install --git`. Publishing per crate (not --workspace) because
+  # cargo hard-errors on partially-published workspaces, and the per-crate
+  # already-on-crates.io check makes the whole job idempotent: a same-version
+  # re-promotion (the +date tag case) skips every crate cleanly.
+  publish-crates:
+    name: Publish crates.io
+    needs: [deploy, check-beta]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The promoted beta commit, so the crates match the binaries.
+          ref: ${{ needs.check-beta.outputs.sha }}
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - name: Publish unpublished crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.check-beta.outputs.version }}
+        run: |
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "::warning::CARGO_REGISTRY_TOKEN is not set; skipping the crates.io publish."
+            exit 0
+          fi
+          # Dependency order: cargo publish verifies each crate against the
+          # registry, so dependencies must land before their dependents.
+          for c in leviath-core leviath-sys leviath-agent-client leviath-mcp \
+                   leviath-package leviath-scripting leviath-telemetry \
+                   leviath-providers leviath-tools leviath-runtime \
+                   leviath leviath-cli; do
+            if curl -fsS -A "leviath-ci (github.com/GEMISIS/leviath)" \
+                 "https://crates.io/api/v1/crates/$c/$VERSION" >/dev/null 2>&1; then
+              echo "$c@$VERSION already on crates.io, skipping"
+              continue
+            fi
+            # Retry with a delay: crates.io rate-limits bursts of publishes,
+            # and the sparse index takes a moment to serve a just-published
+            # dependency to the next crate's verify build.
+            tries=0
+            until cargo publish -p "$c"; do
+              tries=$((tries + 1))
+              if [ "$tries" -ge 15 ]; then
+                echo "::error::giving up on $c after $tries attempts"
+                exit 1
+              fi
+              echo "publish of $c failed (attempt $tries); retrying in 2m"
+              sleep 120
+            done
+          done
+
   docs:
     name: Publish docs (stable)
     # check-beta is only here for its `sha` output; deploy is the real gate

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -50,8 +50,9 @@ scoop bucket add leviath https://github.com/GEMISIS/leviath-dist.git
 scoop install leviath            # or leviath-beta, leviath-alpha
 ```
 
-**Cargo** installs the released crates.io version, which corresponds to the
-current stable line:
+**Cargo** installs the released crates.io version, which tracks the stable
+channel: each stable deploy publishes any crate version not yet on crates.io,
+from the same commit the binaries were built at.
 
 ```bash
 cargo install leviath-cli


### PR DESCRIPTION
crates.io now tracks the stable channel. After a successful prod deploy, a `publish-crates` job checks out the promoted beta commit (so crates match the binaries exactly) and publishes, in dependency order, every workspace crate whose version is not already on the registry.

Design notes:
- **Idempotent by construction**: the per-crate crates.io existence check means a same-version re-promotion (the `+date` tag case) skips all 12 crates cleanly, and a partial publish resumes where it stopped. Per-crate `cargo publish -p` rather than `--workspace`, which hard-errors on partially published workspaces.
- **Rate-limit tolerant**: retry loop with a 2-minute backoff absorbs crates.io publish limits and sparse-index propagation between a dependency landing and its dependent's verify build.
- **Degrades safely**: without a `CARGO_REGISTRY_TOKEN` secret the job warns and exits 0 instead of failing the deploy.
- **Why stable, not alpha**: registry versions are immutable, so nightly publishes would be permanent clutter; `cargo install`/`cargo add` ignore prereleases by default so users would not see them anyway; and `cargo install --git` already serves the development channel.

Requires a `CARGO_REGISTRY_TOKEN` Actions secret (crates.io API token, publish-update scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2