### PR TITLE
Add [read_paths] allowlist for C-suite agent file access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,6 +2254,8 @@ version = "0.1.1"
 dependencies = [
  "chrono",
  "dirs",
+ "glob",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,10 @@ anyhow = "1.0"
 chrono = "0.4"
 rhai = { version = "1.20", features = ["sync", "serde"] }
 glob = "0.3"
+# Compiled once per [read_paths] entry at spawn; already in the lock file
+# transitively, named here so the allowlist matcher in `leviath-core` uses the
+# same version everywhere.
+regex = "1"
 # Already in the tree via reqwest; named explicitly so `leviath-core` can hold
 # the outbound-URL policy (`leviath_core::net`) without depending on reqwest.
 # `reqwest::Url` IS this crate's `Url`, so the two interoperate directly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,11 @@ a vulnerability:
   owner-only too.
 - **A repository the agent is pointed at.** File tools resolve symlinks and
   refuse paths that leave the workspace, so a checked-in symlink cannot read
-  your `~/.ssh`.
+  your `~/.ssh`. The one exception is deliberate and yours to make: an agent
+  may declare extra directories under `[read_paths]`, and those declarations
+  are inert until your config grants them. When granted they are read-only,
+  and every access is checked against the symlink-resolved real path, so a
+  planted symlink inside a granted directory still cannot reach outside it.
 - **The supply chain.** `Cargo.lock` is committed, `cargo-deny` gates advisories
   and licences on every PR, all GitHub Actions are SHA-pinned, and release
   binaries carry signed build provenance. Every install path - the shell

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -182,6 +182,27 @@ pub(crate) fn describe_capabilities(manifest_toml: &str, script_tools: &[String]
         findings.push("asks to run tools directly on the host (sandbox = none)".to_string());
     }
 
+    // Read paths beyond the workdir. Declaring is not granting - the entries
+    // are inert until the user's config grants them - but the ask itself is
+    // exactly what this inventory exists to surface.
+    if let Some(entries) = value
+        .get("read_paths")
+        .and_then(|v| v.get("allow"))
+        .and_then(|v| v.as_array())
+        && !entries.is_empty()
+    {
+        let listed: Vec<String> = entries
+            .iter()
+            .filter_map(|e| e.as_str().map(str::to_string))
+            .collect();
+        findings.push(format!(
+            "asks to read outside its workdir (read-only): {}; inert unless you grant it \
+             via [security] read_paths / allow_blueprint_read_paths or \
+             [agent_read_paths.<name>] in your config",
+            listed.join(", ")
+        ));
+    }
+
     // Command seeds run at spawn, before the first inference and therefore
     // before any approval prompt - the one place a manifest executes something
     // without being asked.
@@ -446,6 +467,37 @@ mod capability_tests {
     #[test]
     fn opting_into_a_sandbox_is_not_reported() {
         let manifest = "[agent]\nname = \"x\"\n\n[sandbox]\nkind = \"container\"\n";
+        assert!(describe_capabilities(manifest, &[]).is_empty());
+    }
+
+    /// `[read_paths]` is an ask to see beyond the workdir - listed verbatim,
+    /// with the reminder that it stays inert until the user's config grants it.
+    #[test]
+    fn read_path_declarations_are_reported() {
+        let manifest = "[agent]\nname = \"x\"\n\n\
+                        [read_paths]\n\
+                        allow = [\"~/.leviath/runs\", \"glob:~/design-docs/**\"]\n";
+        let findings = describe_capabilities(manifest, &[]);
+        assert_eq!(findings.len(), 1);
+        assert!(
+            findings[0].contains("read outside its workdir"),
+            "{findings:?}"
+        );
+        assert!(findings[0].contains("~/.leviath/runs"), "{findings:?}");
+        assert!(
+            findings[0].contains("glob:~/design-docs/**"),
+            "{findings:?}"
+        );
+        assert!(
+            findings[0].contains("inert unless you grant it"),
+            "{findings:?}"
+        );
+    }
+
+    /// An empty `allow` array asks for nothing - stay quiet.
+    #[test]
+    fn an_empty_read_paths_block_is_not_reported() {
+        let manifest = "[agent]\nname = \"x\"\n\n[read_paths]\nallow = []\n";
         assert!(describe_capabilities(manifest, &[]).is_empty());
     }
 

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -53,6 +53,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_seed_commands: bool,
 
+    /// Working directory for the run (default: the directory `lev run` is
+    /// invoked from). The agent's file tools are confined to it, and relative
+    /// `[read_paths]` entries resolve against it.
+    #[arg(long, value_name = "DIR")]
+    pub workdir: Option<std::path::PathBuf>,
+
     /// Dynamic per-region seed flags (`--<region> <text|@file>`), collected by an
     /// argv pre-scan in the binary since region names are blueprint-defined.
     /// clap skips this field; it is populated after parsing.
@@ -69,10 +75,37 @@ const KNOWN_RUN_FLAGS: &[&str] = &[
     "allow",
     "max-depth",
     "no-seed-commands",
+    "workdir",
     "verbose",
     "help",
     "version",
 ];
+
+/// The run's effective working directory: the `--workdir` flag when given
+/// (canonicalized, and refused early when it does not exist - a bad workdir
+/// would otherwise spawn an agent whose every tool call fails), else `cwd`
+/// (the directory the command was invoked from, resolved by the caller).
+pub fn effective_workdir(
+    flag: Option<std::path::PathBuf>,
+    cwd: std::path::PathBuf,
+) -> anyhow::Result<String> {
+    let dir = match flag {
+        Some(dir) => {
+            let canonical = std::fs::canonicalize(&dir).map_err(|e| {
+                anyhow::anyhow!(
+                    "--workdir '{}' is not a usable directory: {e}",
+                    dir.display()
+                )
+            })?;
+            if !canonical.is_dir() {
+                anyhow::bail!("--workdir '{}' is not a directory", dir.display());
+            }
+            canonical
+        }
+        None => cwd,
+    };
+    Ok(dir.to_string_lossy().to_string())
+}
 
 /// Pre-scan a full argv (program name first) for dynamic `--<region>` flags on
 /// the `run` subcommand, since region names are blueprint-defined and clap can't
@@ -219,5 +252,58 @@ mod tests {
     fn global_verbose_before_run_still_activates() {
         let (_out, regions) = extract_region_flags(argv(&["lev", "-v", "run", "a", "--spec", "x"]));
         assert_eq!(regions.get("spec").map(String::as_str), Some("x"));
+    }
+
+    /// `--workdir` is a real run flag: the pre-scan must pass it through to
+    /// clap, not swallow it as a region seed named "workdir".
+    #[test]
+    fn workdir_flag_is_not_eaten_as_a_region() {
+        let input = argv(&["lev", "run", "a", "--workdir", "/elsewhere", "--task", "t"]);
+        let (out, regions) = extract_region_flags(input.clone());
+        assert_eq!(out, input);
+        assert!(regions.is_empty());
+    }
+
+    #[test]
+    fn effective_workdir_uses_the_flag_canonicalized() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = effective_workdir(
+            Some(dir.path().to_path_buf()),
+            std::path::PathBuf::from("/unused"),
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            std::fs::canonicalize(dir.path())
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn effective_workdir_defaults_to_the_supplied_cwd() {
+        let cwd = tempfile::tempdir().unwrap();
+        let got = effective_workdir(None, cwd.path().to_path_buf()).unwrap();
+        assert_eq!(got, cwd.path().to_string_lossy().to_string());
+    }
+
+    /// A bad `--workdir` fails before the daemon is contacted - otherwise it
+    /// spawns an agent whose every tool call fails.
+    #[test]
+    fn effective_workdir_refuses_a_missing_or_non_directory_path() {
+        let cwd = std::path::PathBuf::from("/unused");
+        let err = effective_workdir(
+            Some(std::path::PathBuf::from("/definitely/not/a/real/dir")),
+            cwd.clone(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not a usable directory"), "{err}");
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, "x").unwrap();
+        let err = effective_workdir(Some(file), cwd).unwrap_err();
+        assert!(err.to_string().contains("not a directory"), "{err}");
     }
 }

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -217,6 +217,51 @@ fn print_script_tool_report(path: &std::path::Path) {
     }
 }
 
+/// Report `[read_paths]` declarations: what the agent asks to read beyond its
+/// workdir, plus a sharper warning for entries so broad they amount to "my
+/// whole home directory" or "any absolute path". Pure over the blueprint so
+/// the wording is testable without capturing stdout.
+fn read_path_warning_lines(blueprint: &leviath_core::Blueprint) -> Vec<String> {
+    let Some(rp) = blueprint
+        .read_paths
+        .as_ref()
+        .filter(|rp| !rp.allow.is_empty())
+    else {
+        return Vec::new();
+    };
+    let mut lines = vec![format!(
+        "  ⚠ Note: declares [read_paths] (reads outside the run workdir): {} - refused \
+         unless your config grants them",
+        rp.allow.join(", ")
+    )];
+    for entry in &rp.allow {
+        if read_path_entry_is_broad(entry) {
+            lines.push(format!(
+                "  ⚠ Warning: read_paths entry '{entry}' is very broad - it can match your \
+                 entire home directory or any path on this machine"
+            ));
+        }
+    }
+    lines
+}
+
+/// Whether a `[read_paths]` entry grants effectively unlimited read access:
+/// the home directory itself, a filesystem root, or a pattern whose first
+/// component already matches anything.
+fn read_path_entry_is_broad(entry: &str) -> bool {
+    let pattern = entry
+        .strip_prefix("glob:")
+        .or_else(|| entry.strip_prefix("regex:"))
+        .unwrap_or(entry);
+    let pattern = pattern.replace('\\', "/");
+    let trimmed = pattern.trim_end_matches('/');
+    matches!(trimmed, "~" | "")
+        || trimmed == "/**"
+        || pattern.starts_with("**")
+        || pattern.starts_with("/.*")
+        || trimmed == "/.+"
+}
+
 pub async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
     match execute_reporting_outcome(&args)? {
         ValidateOutcome::Success => Ok(()),
@@ -226,6 +271,12 @@ pub async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
 }
 
 fn print_warnings(blueprint: &leviath_core::Blueprint) {
+    // Before the graph-only checks below: `[read_paths]` applies to any
+    // blueprint shape, so it is reported ahead of the `is_graph` early return.
+    for line in read_path_warning_lines(blueprint) {
+        println!("{line}");
+    }
+
     let stage_names: std::collections::HashSet<&str> =
         blueprint.stages.iter().map(|s| s.name.as_str()).collect();
 
@@ -318,6 +369,67 @@ conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
         leviath_core::manifest::parse_manifest(toml).unwrap()
     }
 
+    /// The `[read_paths]` note fires for any blueprint shape - including the
+    /// linear ones the graph warnings skip - and lists the entries verbatim.
+    #[test]
+    fn read_path_declarations_are_noted_for_linear_blueprints() {
+        let toml = format!(
+            "{}\n[read_paths]\nallow = [\"~/.leviath/runs\"]\n",
+            make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"")
+        );
+        let lines = read_path_warning_lines(&parse(&toml));
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("~/.leviath/runs"), "{lines:?}");
+        assert!(
+            lines[0].contains("refused unless your config grants"),
+            "{lines:?}"
+        );
+    }
+
+    #[test]
+    fn no_read_paths_means_no_note() {
+        let toml = make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"");
+        assert!(read_path_warning_lines(&parse(&toml)).is_empty());
+    }
+
+    /// Entries that amount to "everything" get the sharper warning; scoped
+    /// ones do not.
+    #[test]
+    fn broad_read_path_entries_get_their_own_warning() {
+        let toml = format!(
+            "{}\n[read_paths]\nallow = [\"~\", \"~/.leviath/runs\"]\n",
+            make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"")
+        );
+        let lines = read_path_warning_lines(&parse(&toml));
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert!(lines[1].contains("very broad"), "{lines:?}");
+        assert!(lines[1].contains("'~'"), "{lines:?}");
+    }
+
+    #[test]
+    fn broad_entry_heuristic_covers_each_shape() {
+        for entry in [
+            "~",
+            "~/",
+            "/",
+            "glob:**",
+            "glob:/**",
+            "regex:/.*",
+            "regex:/.+",
+        ] {
+            assert!(read_path_entry_is_broad(entry), "{entry}");
+        }
+        for entry in [
+            "~/.leviath/runs",
+            "glob:~/docs/**",
+            "regex:/data/.*",
+            "../shared",
+            r"C:\data",
+        ] {
+            assert!(!read_path_entry_is_broad(entry), "{entry}");
+        }
+    }
+
     #[test]
     fn check_manifest_verifies_custom_region_scripts() {
         // A custom region's script must exist and compile; the same failure a
@@ -404,17 +516,22 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
 
     #[test]
     fn print_warnings_linear_mode_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
+        let toml = format!(
+            "{}\n[read_paths]\nallow = [\"~/.leviath/runs\", \"~\"]\n",
+            make_blueprint_toml(
+                r#"
 [stages.main]
 mode = "autonomous"
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 description = "Main stage"
 max_iterations = 10
 "#,
+            )
         );
         let bp = parse(&toml);
-        // Should not panic even though there's no graph
+        // Should not panic even though there's no graph, and the read_paths
+        // note (plus the broad-entry warning for "~") is printed before the
+        // graph-only checks bail.
         print_warnings(&bp);
     }
 

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -231,6 +231,30 @@ pub struct Config {
     /// [`Self::taint_tracking`] key for back-compat.)
     #[serde(default)]
     pub security: SecurityConfig,
+
+    /// Per-agent read grants, keyed by agent name - the itemized counterpart
+    /// of [`SecurityConfig::allow_blueprint_read_paths`], analogous to
+    /// [`Self::agent_tool_permissions`]:
+    ///
+    /// ```toml
+    /// [agent_read_paths.cto]
+    /// allow = ["~/.leviath/runs", "glob:~/design-docs/**"]
+    /// ```
+    ///
+    /// Naming the agent here is the user saying "I trust this one to read
+    /// these" - a decision that lives in the user's config, not the
+    /// downloaded manifest. As with `[security] read_paths`, a grant only
+    /// takes effect for a path the blueprint also declares.
+    #[serde(default)]
+    pub agent_read_paths: HashMap<String, ReadPathGrants>,
+}
+
+/// One agent's entry in `[agent_read_paths.<name>]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadPathGrants {
+    /// Granted entries, same forms as a blueprint's `[read_paths] allow`.
+    #[serde(default)]
+    pub allow: Vec<String>,
 }
 
 /// `[security]` in `~/.leviath/config.toml`.
@@ -292,6 +316,40 @@ pub struct SecurityConfig {
     #[serde(default)]
     pub allow_env_vars: Vec<String>,
 
+    /// Whether a blueprint's `[read_paths]` declarations are honored as-is.
+    ///
+    /// **Off by default.** A `[read_paths]` block travels inside the
+    /// `agent.leviath` you installed, and a manifest may only *tighten* what
+    /// your config allows, never widen it - otherwise any agent package could
+    /// read `~/.ssh`, this very config file (your API keys), or a password
+    /// store by shipping one TOML line. With this off, an agent's declared
+    /// read paths are inert until you grant them via [`Self::read_paths`] or
+    /// `[agent_read_paths.<name>]`. Turning it on says "any blueprint I run
+    /// may read every path it declares" - reads only, each access still
+    /// resolves symlinks and must land inside a declared entry, but prefer
+    /// the per-agent grant for anything you did not author yourself.
+    #[serde(default)]
+    pub allow_blueprint_read_paths: bool,
+
+    /// Machine-wide read grants for agents that declare `[read_paths]`.
+    ///
+    /// Entries use the same three forms as a blueprint's `[read_paths] allow`:
+    /// an exact path (grants its subtree), `glob:` and `regex:` patterns
+    /// (matched against the symlink-resolved real path, written with `/` on
+    /// every OS, regex auto-anchored). `~/` expands to your home; a relative
+    /// entry resolves against the run's workdir.
+    ///
+    /// ```toml
+    /// [security]
+    /// read_paths = ["~/.leviath/runs", "glob:~/design-docs/**"]
+    /// ```
+    ///
+    /// A grant only takes effect for a path the running blueprint *also*
+    /// declares - by itself it grants nothing, so listing a directory here
+    /// does not open it to agents that never asked.
+    #[serde(default)]
+    pub read_paths: Vec<String>,
+
     /// Where provider API keys and MCP OAuth tokens are kept.
     ///
     /// **`file` by default** - `~/.leviath/config.toml` and
@@ -325,6 +383,8 @@ impl Default for SecurityConfig {
             allow_seed_commands: true,
             allow_local_network: false,
             allow_env_vars: Vec::new(),
+            allow_blueprint_read_paths: false,
+            read_paths: Vec::new(),
             credential_store: leviath_core::CredentialStoreKind::File,
         }
     }
@@ -591,6 +651,7 @@ impl Default for Config {
             sandbox: None,
             tool_script_permissions: ScriptToolPermissions::default(),
             security: SecurityConfig::default(),
+            agent_read_paths: HashMap::new(),
         }
     }
 }
@@ -609,6 +670,18 @@ impl Config {
             merged.extend(per_agent.iter().map(|(k, v)| (k.clone(), *v)));
         }
         merged
+    }
+
+    /// Every read-path grant that applies to `agent_name`: the machine-wide
+    /// `[security] read_paths` list plus that agent's
+    /// `[agent_read_paths.<name>]` entries. Resolved once at spawn, mirroring
+    /// [`Self::permissions_for_agent`].
+    pub fn read_path_grants_for_agent(&self, agent_name: &str) -> Vec<String> {
+        let mut grants = self.security.read_paths.clone();
+        if let Some(per_agent) = self.agent_read_paths.get(agent_name) {
+            grants.extend(per_agent.allow.iter().cloned());
+        }
+        grants
     }
 
     /// Load configuration from the default location (~/.leviath/config.toml).
@@ -1889,6 +1962,39 @@ google_api_key = "AIza-existing"
         assert_eq!(other.get("shell"), Some(&ToolPolicy::Ask));
     }
 
+    /// Read-path grants mirror the tool-permission shape: a machine-wide list
+    /// plus per-agent additions, resolved once per agent.
+    #[test]
+    fn read_path_grants_merge_global_and_per_agent() {
+        let mut config = Config::default();
+        assert!(
+            !config.security.allow_blueprint_read_paths,
+            "blueprint read paths must be opt-in"
+        );
+        assert!(config.read_path_grants_for_agent("cto").is_empty());
+
+        config.security.read_paths = vec!["~/.leviath/runs".to_string()];
+        config.agent_read_paths.insert(
+            "cto".to_string(),
+            ReadPathGrants {
+                allow: vec!["glob:~/design-docs/**".to_string()],
+            },
+        );
+
+        assert_eq!(
+            config.read_path_grants_for_agent("cto"),
+            vec![
+                "~/.leviath/runs".to_string(),
+                "glob:~/design-docs/**".to_string(),
+            ]
+        );
+        // Any other agent gets the machine-wide grants only.
+        assert_eq!(
+            config.read_path_grants_for_agent("researcher"),
+            vec!["~/.leviath/runs".to_string()]
+        );
+    }
+
     /// One `tracing::debug!(?config)` would otherwise put every provider key in
     /// the logs.
     #[test]
@@ -2663,8 +2769,16 @@ anthropic_api_key = "sk-ant-test-key"
                 allow_seed_commands: false,
                 allow_local_network: true,
                 allow_env_vars: vec!["MY_PROVIDER_KEY".to_string()],
+                allow_blueprint_read_paths: true,
+                read_paths: vec!["~/.leviath/runs".to_string()],
                 credential_store: leviath_core::CredentialStoreKind::Keychain,
             },
+            agent_read_paths: HashMap::from([(
+                "cto".to_string(),
+                ReadPathGrants {
+                    allow: vec!["glob:~/design-docs/**".to_string()],
+                },
+            )]),
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();
@@ -2687,6 +2801,14 @@ anthropic_api_key = "sk-ant-test-key"
             ScriptPermission::Deny
         );
         assert!(!deserialized.security.allow_seed_commands);
+        assert!(deserialized.security.allow_blueprint_read_paths);
+        assert_eq!(deserialized.security.read_paths, vec!["~/.leviath/runs"]);
+        assert_eq!(
+            deserialized.agent_read_paths.get("cto"),
+            Some(&ReadPathGrants {
+                allow: vec!["glob:~/design-docs/**".to_string()],
+            })
+        );
         assert_eq!(deserialized.webhook.max_retries, 5);
         assert_eq!(deserialized.webhook.base_delay_ms, 250);
         assert_eq!(deserialized.webhook.max_delay_ms, 10_000);

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -581,6 +581,81 @@ fn read_and_concat(
     Ok((!parts.is_empty()).then(|| parts.join("\n\n")))
 }
 
+/// Resolve an agent's `[read_paths]` declarations against the user's config
+/// into the policy its file tools enforce, plus a warning to surface when the
+/// declarations exist but nothing grants them.
+///
+/// A declared-but-ungranted agent still spawns - its out-of-workdir reads are
+/// refused per path with the same guidance - but the warning fires once here
+/// so the user learns about it at spawn rather than from a mid-run tool error.
+/// A malformed entry (in the blueprint or in the user's own grant list) is a
+/// hard spawn error: silently dropping it would either under-grant or run the
+/// agent with less vision than its author designed for.
+fn build_read_path_policy(
+    blueprint: &leviath_core::Blueprint,
+    config: &crate::config::Config,
+    workdir: &std::path::Path,
+) -> Result<(leviath_core::ReadPathPolicy, Option<String>), String> {
+    let Some(rp) = blueprint
+        .read_paths
+        .as_ref()
+        .filter(|rp| !rp.allow.is_empty())
+    else {
+        return Ok((leviath_core::ReadPathPolicy::inactive(), None));
+    };
+    let home = leviath_core::home_dir();
+    let declared =
+        leviath_core::ReadPathSet::compile(&rp.allow, workdir, home.as_deref(), cfg!(windows))
+            .map_err(|e| format!("agent '{}' [read_paths]: {e}", blueprint.name))?;
+    let grant_entries = config.read_path_grants_for_agent(&blueprint.name);
+    let grants =
+        leviath_core::ReadPathSet::compile(&grant_entries, workdir, home.as_deref(), cfg!(windows))
+            .map_err(|e| format!("read_paths grant in your config.toml: {e}"))?;
+    let allow_blueprint = config.security.allow_blueprint_read_paths;
+    let warning = (!allow_blueprint && grants.is_empty()).then(|| {
+        let entries = rp
+            .allow
+            .iter()
+            .map(|e| format!("\"{e}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "agent '{name}' declares [read_paths] but nothing grants them; reads outside \
+             the workdir will be refused. To grant them, add to your config.toml either:\n\
+             [security]\nallow_blueprint_read_paths = true\n\
+             or the specific paths:\n[agent_read_paths.{name}]\nallow = [{entries}]",
+            name = blueprint.name,
+        )
+    });
+    Ok((
+        leviath_core::ReadPathPolicy {
+            agent: blueprint.name.clone(),
+            blueprint: declared,
+            grants,
+            allow_blueprint,
+        },
+        warning,
+    ))
+}
+
+/// Raise the read tools to `Private` for an agent whose `[read_paths]` are
+/// actually granted: they can pull in content from outside the workdir -
+/// design docs, run archives, whatever else was granted - which the default
+/// `Internal` classification (written for workdir files) understates.
+fn bump_read_sensitivities(
+    map: &mut HashMap<String, leviath_core::TaintLevel>,
+    read_paths_granted: bool,
+) {
+    if !read_paths_granted {
+        return;
+    }
+    for tool in ["read_file", "read_files", "list_dir"] {
+        if let Some(level) = map.get_mut(tool) {
+            *level = (*level).max(leviath_core::TaintLevel::Private);
+        }
+    }
+}
+
 /// Load the blueprint at `args.blueprint_path`, spawn the agent into `world`,
 /// register its tool state, and return the new entity. Operates on the raw ECS
 /// [`World`] so it is callable both from the host's spawner (via
@@ -736,37 +811,20 @@ fn build_agent_inner(
     .map(Arc::new);
 
     // 2b. Per-agent built-in tools (over the agent's workdir), routing shell
-    // execution through the sandbox when one is configured. Build with
-    // read_paths from the blueprint for C-suite agents.
-    let read_path_entries: Vec<leviath_core::ReadPathEntry> = blueprint
-        .read_paths
-        .as_ref()
-        .map(|rp| {
-            rp.allow
-                .iter()
-                .filter_map(|raw| match leviath_core::ReadPathEntry::parse(raw) {
-                    Ok(entry) => Some(entry),
-                    Err(e) => {
-                        tracing::warn!(
-                            agent_name = %blueprint.name,
-                            raw = %raw,
-                            error = %e,
-                            "skipping invalid read_paths entry"
-                        );
-                        None
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    let tool_ctx = if read_path_entries.is_empty() {
-        leviath_tools::ToolContext::new(std::path::PathBuf::from(&args.workdir))
-    } else {
-        leviath_tools::ToolContext::with_read_paths(
-            std::path::PathBuf::from(&args.workdir),
-            read_path_entries,
-        )
-    };
+    // execution through the sandbox when one is configured. The blueprint's
+    // `[read_paths]` declarations are resolved against the user's config here -
+    // declared AND granted, or the read tools never leave the workdir.
+    let (read_path_policy, read_path_warning) =
+        build_read_path_policy(&blueprint, config, std::path::Path::new(&args.workdir))?;
+    if let Some(warning) = &read_path_warning {
+        tracing::warn!(agent_name = %blueprint.name, "{warning}");
+    }
+    // Whether the agent can actually read outside its workdir - feeds the
+    // taint bump below, captured before the policy moves into the context.
+    let read_paths_granted = read_path_policy.is_active()
+        && (read_path_policy.allow_blueprint || !read_path_policy.grants.is_empty());
+    let tool_ctx = leviath_tools::ToolContext::new(std::path::PathBuf::from(&args.workdir))
+        .with_read_paths(read_path_policy);
     let mut builtins = leviath_tools::BuiltinTools::new(tool_ctx);
     if let Some(mgr) = &sandbox {
         builtins =
@@ -846,7 +904,7 @@ fn build_agent_inner(
         security.taint_tracking.then(|| {
             let mut gate = leviath_runtime::TaintGate::new(security.clone());
             gate.apply_mcp_overrides(&mcp_overrides);
-            all_tool_defs
+            let mut map: HashMap<String, leviath_core::TaintLevel> = all_tool_defs
                 .iter()
                 .map(|t| {
                     (
@@ -854,7 +912,9 @@ fn build_agent_inner(
                         gate.tool_classification(&t.name).sensitivity,
                     )
                 })
-                .collect()
+                .collect();
+            bump_read_sensitivities(&mut map, read_paths_granted);
+            map
         });
     // Per-stage tool permissions (in stage order) + the entry stage's index, for
     // the tool state's stage-scoped policy layer.
@@ -2397,6 +2457,123 @@ mod tests {
         );
     }
 
+    // ── [read_paths] policy resolution ────────────────────────────────────
+
+    use std::path::Path;
+
+    fn blueprint_declaring(read_paths: &[&str]) -> Blueprint {
+        let stage = leviath_core::Stage::new("s".to_string(), model_cfg(vec![("anthropic", "m")]));
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let mut bp = Blueprint::new("cto".to_string(), "d".to_string(), vec![stage], layout);
+        if !read_paths.is_empty() {
+            bp.read_paths = Some(leviath_core::ReadPathsConfig {
+                allow: read_paths.iter().map(|s| s.to_string()).collect(),
+            });
+        }
+        bp
+    }
+
+    #[test]
+    fn read_path_policy_is_inactive_without_declarations() {
+        let bp = blueprint_declaring(&[]);
+        let (policy, warning) =
+            build_read_path_policy(&bp, &Config::default(), Path::new("/w")).unwrap();
+        assert!(!policy.is_active());
+        assert!(warning.is_none());
+
+        // An explicitly empty `[read_paths]` block is the same as none.
+        let mut bp = blueprint_declaring(&[]);
+        bp.read_paths = Some(leviath_core::ReadPathsConfig { allow: vec![] });
+        let (policy, warning) =
+            build_read_path_policy(&bp, &Config::default(), Path::new("/w")).unwrap();
+        assert!(!policy.is_active());
+        assert!(warning.is_none());
+    }
+
+    /// Declared but ungranted: the agent still spawns, and the warning names
+    /// the agent and shows both config stanzas that would grant the paths.
+    #[test]
+    fn read_path_policy_warns_when_nothing_grants() {
+        let bp = blueprint_declaring(&["/data/runs", "glob:/data/docs/**"]);
+        let (policy, warning) =
+            build_read_path_policy(&bp, &Config::default(), Path::new("/w")).unwrap();
+        assert!(policy.is_active());
+        assert!(!policy.allow_blueprint);
+        assert!(policy.grants.is_empty());
+        let warning = warning.expect("ungranted declarations must warn");
+        assert!(warning.contains("allow_blueprint_read_paths"), "{warning}");
+        assert!(warning.contains("[agent_read_paths.cto]"), "{warning}");
+        assert!(warning.contains("\"/data/runs\""), "{warning}");
+        assert!(warning.contains("\"glob:/data/docs/**\""), "{warning}");
+    }
+
+    #[test]
+    fn read_path_policy_is_quiet_when_granted() {
+        let bp = blueprint_declaring(&["/data/runs"]);
+        let mut config = Config::default();
+        config.agent_read_paths.insert(
+            "cto".to_string(),
+            crate::config::ReadPathGrants {
+                allow: vec!["/data/runs".to_string()],
+            },
+        );
+        let (policy, warning) = build_read_path_policy(&bp, &config, Path::new("/w")).unwrap();
+        assert!(policy.is_active());
+        assert!(!policy.grants.is_empty());
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn read_path_policy_is_quiet_under_the_override() {
+        let bp = blueprint_declaring(&["/data/runs"]);
+        let mut config = Config::default();
+        config.security.allow_blueprint_read_paths = true;
+        let (policy, warning) = build_read_path_policy(&bp, &config, Path::new("/w")).unwrap();
+        assert!(policy.allow_blueprint);
+        assert!(warning.is_none());
+    }
+
+    /// A malformed entry is a hard spawn error naming its source - the
+    /// blueprint's section or the user's own grant list.
+    #[test]
+    fn read_path_policy_rejects_bad_entries_loudly() {
+        let bp = blueprint_declaring(&["glob:["]);
+        let err = build_read_path_policy(&bp, &Config::default(), Path::new("/w")).unwrap_err();
+        assert!(err.contains("agent 'cto' [read_paths]"), "{err}");
+
+        let bp = blueprint_declaring(&["/data/runs"]);
+        let mut config = Config::default();
+        config.security.read_paths = vec!["regex:(".to_string()];
+        let err = build_read_path_policy(&bp, &config, Path::new("/w")).unwrap_err();
+        assert!(err.contains("config.toml"), "{err}");
+    }
+
+    /// Granted read paths raise the read tools to `Private`; nothing else
+    /// moves, and an ungranted or missing tool entry is left alone.
+    #[test]
+    fn read_sensitivities_bump_only_the_read_tools_when_granted() {
+        use leviath_core::TaintLevel;
+        let base = || {
+            HashMap::from([
+                ("read_file".to_string(), TaintLevel::Internal),
+                ("list_dir".to_string(), TaintLevel::Public),
+                ("write_file".to_string(), TaintLevel::Internal),
+            ])
+        };
+
+        let mut map = base();
+        bump_read_sensitivities(&mut map, true);
+        assert_eq!(map.get("read_file"), Some(&TaintLevel::Private));
+        assert_eq!(map.get("list_dir"), Some(&TaintLevel::Private));
+        assert_eq!(map.get("write_file"), Some(&TaintLevel::Internal));
+        // `read_files` was absent from the map: no entry invented for it.
+        assert!(!map.contains_key("read_files"));
+
+        let mut map = base();
+        bump_read_sensitivities(&mut map, false);
+        assert_eq!(map, base(), "no grant, no change");
+    }
+
     #[test]
     fn resolve_stages_empty_available_tools_gets_none() {
         let mut stage =
@@ -2609,6 +2786,115 @@ system_prompt = "be brief"
         assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
         // Compaction settings were attached.
         assert!(world.world().get::<CompactionSettings>(entity).is_some());
+    }
+
+    /// A manifest that returns `[agent] name` and `write` a `read_paths.leviath`
+    /// declaring an out-of-workdir read. Used by the wiring tests below.
+    fn write_read_paths_manifest(dir: &std::path::Path, allow: &str) -> std::path::PathBuf {
+        let manifest = dir.join("reader.leviath");
+        std::fs::write(
+            &manifest,
+            format!(
+                r#"
+[agent]
+name = "reader"
+version = "0.1.0"
+description = "d"
+
+[read_paths]
+allow = [{allow}]
+
+[context.regions]
+task = {{ kind = "pinned", max_tokens = 4000 }}
+
+[stages.main]
+mode = "autonomous"
+model = {{ models = [{{ provider = "anthropic", model = "m" }}] }}
+description = "d"
+available_tools = []
+system_prompt = "be brief"
+"#
+            ),
+        )
+        .unwrap();
+        manifest
+    }
+
+    /// A granted `[read_paths]` spawns cleanly, with taint on so the read-tool
+    /// sensitivity bump path runs end to end.
+    #[tokio::test]
+    async fn build_agent_wires_granted_read_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_read_paths_manifest(dir.path(), "\"/tmp\"");
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mut config = Config::default();
+        config.security.allow_blueprint_read_paths = true;
+        config.taint_tracking = true;
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &config,
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+    }
+
+    /// A declared-but-ungranted `[read_paths]` still spawns; the warning-logging
+    /// branch fires.
+    #[tokio::test]
+    async fn build_agent_wires_ungranted_read_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_read_paths_manifest(dir.path(), "\"/tmp\"");
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds even when nothing grants the declaration");
+        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+    }
+
+    /// A malformed grant entry in the user's own config fails the spawn - the
+    /// error propagates out of `build_read_path_policy`.
+    #[tokio::test]
+    async fn build_agent_rejects_a_malformed_config_grant() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_read_paths_manifest(dir.path(), "\"/tmp\"");
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mut config = Config::default();
+        config.security.read_paths = vec!["glob:[".to_string()];
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &config,
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect_err("a broken config grant must fail the spawn");
+        assert!(err.contains("config.toml"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -736,10 +736,38 @@ fn build_agent_inner(
     .map(Arc::new);
 
     // 2b. Per-agent built-in tools (over the agent's workdir), routing shell
-    // execution through the sandbox when one is configured.
-    let mut builtins = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
-        std::path::PathBuf::from(&args.workdir),
-    ));
+    // execution through the sandbox when one is configured. Build with
+    // read_paths from the blueprint for C-suite agents.
+    let read_path_entries: Vec<leviath_core::ReadPathEntry> = blueprint
+        .read_paths
+        .as_ref()
+        .map(|rp| {
+            rp.allow
+                .iter()
+                .filter_map(|raw| match leviath_core::ReadPathEntry::parse(raw) {
+                    Ok(entry) => Some(entry),
+                    Err(e) => {
+                        tracing::warn!(
+                            agent_name = %blueprint.name,
+                            raw = %raw,
+                            error = %e,
+                            "skipping invalid read_paths entry"
+                        );
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let tool_ctx = if read_path_entries.is_empty() {
+        leviath_tools::ToolContext::new(std::path::PathBuf::from(&args.workdir))
+    } else {
+        leviath_tools::ToolContext::with_read_paths(
+            std::path::PathBuf::from(&args.workdir),
+            read_path_entries,
+        )
+    };
+    let mut builtins = leviath_tools::BuiltinTools::new(tool_ctx);
     if let Some(mgr) = &sandbox {
         builtins =
             builtins.with_shell_executor(mgr.clone() as Arc<dyn leviath_tools::ShellExecutor>);

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -186,7 +186,7 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("a task is required (e.g. `-t \"do the thing\"`)"))?;
 
     ensure_daemon_running().await?;
-    let workdir = std::env::current_dir()?.to_string_lossy().to_string();
+    let workdir = commands::run::effective_workdir(args.workdir, std::env::current_dir()?)?;
     let spawn_args = leviath_cli::daemon::client::resolve_spawn_args(
         &path,
         &task,

--- a/crates/leviath-core/Cargo.toml
+++ b/crates/leviath-core/Cargo.toml
@@ -25,6 +25,8 @@ dirs = { workspace = true }
 # every outbound client in the workspace starts from one timeout + redirect
 # policy instead of a bare `Client::new()` with neither.
 reqwest = { workspace = true }
+glob = "0.3"
+regex = "1"
 
 [dev-dependencies]
 # A redirecting server, so the redirect policy is verified by following one

--- a/crates/leviath-core/Cargo.toml
+++ b/crates/leviath-core/Cargo.toml
@@ -25,8 +25,10 @@ dirs = { workspace = true }
 # every outbound client in the workspace starts from one timeout + redirect
 # policy instead of a bare `Client::new()` with neither.
 reqwest = { workspace = true }
-glob = "0.3"
-regex = "1"
+# The `[read_paths]` allowlist matcher (`leviath_core::read_paths`): glob and
+# regex entries compile at spawn and match against symlink-resolved paths.
+glob = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 # A redirecting server, so the redirect policy is verified by following one

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -78,6 +78,27 @@ pub struct Blueprint {
     /// discovered once at spawn and an agent cannot grow its own toolchain.
     #[serde(default)]
     pub dynamic_tools: bool,
+
+    /// Additional directories (or glob/regex patterns) this agent may read from
+    /// beyond its workdir. C-suite agents (CTO, TL) need this to read design
+    /// docs, run archives, and other agent blueprints. Read-only; `write_file`
+    /// and `edit_file` remain sandboxed to the workdir.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_paths: Option<ReadPathsConfig>,
+}
+
+/// Additional read paths an agent can access beyond its workdir.
+///
+/// Entries may be exact paths, glob patterns (`glob:` prefix), or regex
+/// patterns (`regex:` prefix). No prefix = exact match.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadPathsConfig {
+    /// Directories / patterns to allow. Each entry may be:
+    /// - An exact path: `"C:\\Users\\...\\.leviath\\runs"`
+    /// - A glob: `"glob:C:\\Users\\...\\.leviath\\runs\\**"`
+    /// - A regex: `"regex:^C:\\\\Users\\\\...\\\\.leviath\\\\runs\\\\.*"`
+    #[serde(default)]
+    pub allow: Vec<String>,
 }
 
 impl Blueprint {

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -79,24 +79,30 @@ pub struct Blueprint {
     #[serde(default)]
     pub dynamic_tools: bool,
 
-    /// Additional directories (or glob/regex patterns) this agent may read from
-    /// beyond its workdir. C-suite agents (CTO, TL) need this to read design
-    /// docs, run archives, and other agent blueprints. Read-only; `write_file`
-    /// and `edit_file` remain sandboxed to the workdir.
+    /// Read paths this agent *declares* beyond its workdir - directories a
+    /// planner-style agent needs to see, like run archives or design docs.
+    /// Declaring is not granting: entries only take effect when the user's
+    /// config also grants them (`[security] read_paths`,
+    /// `[agent_read_paths.<name>]`, or `allow_blueprint_read_paths = true`),
+    /// so an installed manifest cannot widen its own sandbox. Read-only in
+    /// every case; `write_file` and `edit_file` stay confined to the workdir.
+    /// Semantics live in [`crate::read_paths`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_paths: Option<ReadPathsConfig>,
 }
 
-/// Additional read paths an agent can access beyond its workdir.
-///
-/// Entries may be exact paths, glob patterns (`glob:` prefix), or regex
-/// patterns (`regex:` prefix). No prefix = exact match.
+/// The `[read_paths]` section of a manifest: raw declared entries, compiled
+/// against the run's workdir and home at spawn.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadPathsConfig {
-    /// Directories / patterns to allow. Each entry may be:
-    /// - An exact path: `"C:\\Users\\...\\.leviath\\runs"`
-    /// - A glob: `"glob:C:\\Users\\...\\.leviath\\runs\\**"`
-    /// - A regex: `"regex:^C:\\\\Users\\\\...\\\\.leviath\\\\runs\\\\.*"`
+    /// Declared entries. Each may be:
+    /// - an exact path, granting its subtree: `"~/.leviath/runs"` or
+    ///   `"../shared-docs"` (relative to the run's workdir)
+    /// - a glob: `"glob:~/.leviath/runs/**"`
+    /// - a regex, auto-anchored: `"regex:/data/design-docs/.*"`
+    ///
+    /// Patterns are written with `/` separators on every OS and match the
+    /// symlink-resolved real path.
     #[serde(default)]
     pub allow: Vec<String>,
 }
@@ -126,6 +132,7 @@ impl Blueprint {
             file_tracking: None,
             sandbox: None,
             dynamic_tools: false,
+            read_paths: None,
         }
     }
 

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -33,9 +33,11 @@ pub mod telemetry;
 pub mod text;
 
 pub use blueprint::{
-    Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, RepetitionDetectionConfig,
-    Stage, StuckConfig, ToolResultRouting, TransitionCondition, TransitionEdge,
+    Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, ReadPathsConfig,
+    RepetitionDetectionConfig, Stage, StuckConfig, ToolResultRouting,
+    TransitionCondition, TransitionEdge,
 };
+pub use paths::ReadPathEntry;
 pub use cache::CacheHint;
 pub use credentials::{
     CredentialStore, CredentialStoreKind, MemoryStore, mcp_account, provider_account,

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod net;
 pub mod panic_payload;
 pub mod paths;
 pub mod policy;
+pub mod read_paths;
 pub mod region;
 pub mod run_archive;
 pub mod run_meta;
@@ -34,10 +35,9 @@ pub mod text;
 
 pub use blueprint::{
     Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, ReadPathsConfig,
-    RepetitionDetectionConfig, Stage, StuckConfig, ToolResultRouting,
-    TransitionCondition, TransitionEdge,
+    RepetitionDetectionConfig, Stage, StuckConfig, ToolResultRouting, TransitionCondition,
+    TransitionEdge,
 };
-pub use paths::ReadPathEntry;
 pub use cache::CacheHint;
 pub use credentials::{
     CredentialStore, CredentialStoreKind, MemoryStore, mcp_account, provider_account,
@@ -51,10 +51,13 @@ pub use net::{
 };
 pub use panic_payload::panic_message;
 pub use paths::{
-    agents_dir, data_dir, home_dir, is_safe_path_component, providers_dir, resolves_within,
-    tools_dir,
+    agents_dir, canonicalize_for_match, data_dir, home_dir, is_safe_path_component, providers_dir,
+    resolves_within, tools_dir,
 };
 pub use policy::{AllowlistRule, McpToolOverride, PolicyConfig};
+pub use read_paths::{
+    ReadPathDecision, ReadPathEntry, ReadPathPolicy, ReadPathSet, validate_entry_syntax,
+};
 pub use region::{
     ContentFormat, EntryKind, EvictionStrategy, Region, RegionEntry, RegionKind, RegionSchema,
     SerializedToolCall,

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -685,6 +685,25 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         blueprint.sandbox = Some(parse_sandbox_config(sandbox_table)?);
     }
 
+    // Parse agent-level read-path declarations: [read_paths]. Entries are
+    // syntax-checked here so a broken one fails `lev validate`/`lev add`/spawn
+    // loudly, instead of degrading the agent at its first out-of-workdir read.
+    if let Some(rp_table) = parsed.get("read_paths").and_then(|v| v.as_table()) {
+        let mut allow = Vec::new();
+        if let Some(entries) = rp_table.get("allow").and_then(|v| v.as_array()) {
+            for entry in entries {
+                let Some(raw) = entry.as_str() else {
+                    return Err(Error::Other(format!(
+                        "[read_paths] allow entries must be strings, got: {entry}"
+                    )));
+                };
+                crate::read_paths::validate_entry_syntax(raw).map_err(Error::Other)?;
+                allow.push(raw.to_string());
+            }
+        }
+        blueprint.read_paths = Some(crate::blueprint::ReadPathsConfig { allow });
+    }
+
     // Parse agent-level tool permissions: [tool_permissions]
     if let Some(tp_table) = parsed.get("tool_permissions").and_then(|v| v.as_table()) {
         for (tool_name, policy_val) in tp_table {
@@ -2650,6 +2669,87 @@ mode = "autonomous"
         // A stage with no [security] inherits (None).
         let build = bp.find_stage("build").unwrap();
         assert!(build.security.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_read_paths_declarations() {
+        let toml = r#"
+[agent]
+name = "rp-test"
+
+[read_paths]
+allow = ["~/.leviath/runs", "glob:~/design-docs/**", "regex:/data/archives/.*"]
+
+[stages.plan]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        let rp = bp.read_paths.as_ref().unwrap();
+        assert_eq!(
+            rp.allow,
+            vec![
+                "~/.leviath/runs".to_string(),
+                "glob:~/design-docs/**".to_string(),
+                "regex:/data/archives/.*".to_string(),
+            ]
+        );
+    }
+
+    /// A `[read_paths]` section without an `allow` key parses as an empty
+    /// declaration list - present but granting nothing to ask for.
+    #[test]
+    fn parse_manifest_read_paths_without_allow_is_empty() {
+        let toml = r#"
+[agent]
+name = "rp-empty"
+
+[read_paths]
+
+[stages.plan]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert!(bp.read_paths.as_ref().unwrap().allow.is_empty());
+    }
+
+    /// No `[read_paths]` section means no declarations at all - the field
+    /// stays `None` and the workdir sandbox is unchanged.
+    #[test]
+    fn parse_manifest_without_read_paths_leaves_none() {
+        let toml = r#"
+[agent]
+name = "rp-none"
+
+[stages.plan]
+mode = "autonomous"
+"#;
+        assert!(parse_manifest(toml).unwrap().read_paths.is_none());
+    }
+
+    /// A malformed entry fails the whole parse - a skipped entry would
+    /// degrade the agent silently at its first out-of-workdir read.
+    #[test]
+    fn parse_manifest_refuses_invalid_read_path_entries() {
+        for (entry, expect) in [
+            (r#""glob:[""#, "invalid glob"),
+            (r#""regex:relative/.*""#, "must start with"),
+            (r#"42"#, "must be strings"),
+        ] {
+            let toml = format!(
+                r#"
+[agent]
+name = "rp-bad"
+
+[read_paths]
+allow = [{entry}]
+
+[stages.plan]
+mode = "autonomous"
+"#
+            );
+            let err = parse_manifest(&toml).unwrap_err().to_string();
+            assert!(err.contains(expect), "{entry}: {err}");
+        }
     }
 
     #[test]

--- a/crates/leviath-core/src/paths.rs
+++ b/crates/leviath-core/src/paths.rs
@@ -2,59 +2,6 @@
 
 use std::path::{Path, PathBuf};
 
-/// A single entry in the `[read_paths]` allowlist.
-///
-/// Supports three kinds of path matching:
-/// - `Exact` — literal directory prefix match
-/// - `Glob` — glob pattern (e.g. `**/*.md`)
-/// - `Regex` — compiled regex pattern
-#[derive(Debug, Clone)]
-pub enum ReadPathEntry {
-    /// Exact path — matched via canonicalized starts_with
-    Exact(PathBuf),
-    /// Glob pattern — matched via glob::Pattern
-    Glob(glob::Pattern),
-    /// Regex pattern — matched via regex::Regex
-    Regex(regex::Regex),
-}
-
-impl ReadPathEntry {
-    /// Parse a raw string from the `[read_paths].allow` TOML array into
-    /// the appropriate variant. No prefix = Exact, `glob:` = Glob,
-    /// `regex:` = Regex.
-    pub fn parse(raw: &str) -> Result<Self, String> {
-        if let Some(rest) = raw.strip_prefix("regex:") {
-            regex::Regex::new(rest)
-                .map(ReadPathEntry::Regex)
-                .map_err(|e| format!("invalid regex '{}': {}", rest, e))
-        } else if let Some(rest) = raw.strip_prefix("glob:") {
-            glob::Pattern::new(rest)
-                .map(ReadPathEntry::Glob)
-                .map_err(|e| format!("invalid glob '{}': {}", rest, e))
-        } else {
-            Ok(ReadPathEntry::Exact(PathBuf::from(raw)))
-        }
-    }
-
-    /// Check whether `canonicalized` matches this allowlist entry.
-    ///
-    /// `canonicalized` has already been through `canonicalize_existing_prefix`
-    /// and `..`/`.` folding. On Windows, matching is case-insensitive.
-    pub fn matches(&self, canonicalized: &Path) -> bool {
-        match self {
-            ReadPathEntry::Exact(root) => {
-                let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
-                canonicalized.starts_with(&root)
-            }
-            ReadPathEntry::Glob(pattern) => pattern.matches_path(canonicalized),
-            ReadPathEntry::Regex(re) => {
-                let s = canonicalized.to_string_lossy();
-                re.is_match(&s)
-            }
-        }
-    }
-}
-
 /// The user's home directory, honoring the `LEVIATH_HOME` override.
 ///
 /// `dirs::home_dir()` cannot be redirected by `$HOME` on macOS
@@ -163,6 +110,17 @@ pub fn resolves_within(path: &Path, root: &Path) -> bool {
         // is not a safe one.
         None => false,
     }
+}
+
+/// Canonicalize a path for allowlist matching, failing closed.
+///
+/// The same machinery [`resolves_within`] uses, exposed for the `[read_paths]`
+/// resolver in `leviath-tools`: the deepest existing ancestor is
+/// canonicalized (which is where any symlink lives) and the unresolved tail
+/// re-appended. `None` means nothing along the path could be verified, and an
+/// unverifiable path must be refused, never matched.
+pub fn canonicalize_for_match(path: &Path) -> Option<PathBuf> {
+    canonicalize_existing_prefix(path)
 }
 
 /// Canonicalize the deepest existing ancestor of `path` and re-append whatever
@@ -338,6 +296,23 @@ mod tests {
         // `dir.path()` is already whatever the OS handed us; canonicalizing the
         // path alone would diverge from it on macOS.
         assert!(resolves_within(&root.join("f.txt"), root));
+    }
+
+    /// The `[read_paths]` resolver's canonicalizer is the same machinery as
+    /// `resolves_within`, exposed fail-closed: a real path resolves (symlinks
+    /// and all), an unverifiable one is `None`.
+    #[test]
+    fn canonicalize_for_match_resolves_real_paths_and_refuses_unverifiable_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), b"x").unwrap();
+        assert_eq!(
+            canonicalize_for_match(&dir.path().join("f.txt")),
+            Some(std::fs::canonicalize(dir.path().join("f.txt")).unwrap())
+        );
+        assert_eq!(
+            canonicalize_for_match(Path::new("no-such-relative-name")),
+            None
+        );
     }
 
     #[test]

--- a/crates/leviath-core/src/paths.rs
+++ b/crates/leviath-core/src/paths.rs
@@ -2,6 +2,59 @@
 
 use std::path::{Path, PathBuf};
 
+/// A single entry in the `[read_paths]` allowlist.
+///
+/// Supports three kinds of path matching:
+/// - `Exact` — literal directory prefix match
+/// - `Glob` — glob pattern (e.g. `**/*.md`)
+/// - `Regex` — compiled regex pattern
+#[derive(Debug, Clone)]
+pub enum ReadPathEntry {
+    /// Exact path — matched via canonicalized starts_with
+    Exact(PathBuf),
+    /// Glob pattern — matched via glob::Pattern
+    Glob(glob::Pattern),
+    /// Regex pattern — matched via regex::Regex
+    Regex(regex::Regex),
+}
+
+impl ReadPathEntry {
+    /// Parse a raw string from the `[read_paths].allow` TOML array into
+    /// the appropriate variant. No prefix = Exact, `glob:` = Glob,
+    /// `regex:` = Regex.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        if let Some(rest) = raw.strip_prefix("regex:") {
+            regex::Regex::new(rest)
+                .map(ReadPathEntry::Regex)
+                .map_err(|e| format!("invalid regex '{}': {}", rest, e))
+        } else if let Some(rest) = raw.strip_prefix("glob:") {
+            glob::Pattern::new(rest)
+                .map(ReadPathEntry::Glob)
+                .map_err(|e| format!("invalid glob '{}': {}", rest, e))
+        } else {
+            Ok(ReadPathEntry::Exact(PathBuf::from(raw)))
+        }
+    }
+
+    /// Check whether `canonicalized` matches this allowlist entry.
+    ///
+    /// `canonicalized` has already been through `canonicalize_existing_prefix`
+    /// and `..`/`.` folding. On Windows, matching is case-insensitive.
+    pub fn matches(&self, canonicalized: &Path) -> bool {
+        match self {
+            ReadPathEntry::Exact(root) => {
+                let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+                canonicalized.starts_with(&root)
+            }
+            ReadPathEntry::Glob(pattern) => pattern.matches_path(canonicalized),
+            ReadPathEntry::Regex(re) => {
+                let s = canonicalized.to_string_lossy();
+                re.is_match(&s)
+            }
+        }
+    }
+}
+
 /// The user's home directory, honoring the `LEVIATH_HOME` override.
 ///
 /// `dirs::home_dir()` cannot be redirected by `$HOME` on macOS

--- a/crates/leviath-core/src/read_paths.rs
+++ b/crates/leviath-core/src/read_paths.rs
@@ -1,0 +1,806 @@
+//! The `[read_paths]` allowlist: how an agent is granted read access outside
+//! its workdir, and how each access is checked.
+//!
+//! A blueprint's `[read_paths] allow` array *declares* what the agent wants to
+//! read. Declaring is not granting: the user's config must either name the
+//! same paths (`[security] read_paths` / `[agent_read_paths.<name>]`) or set
+//! `allow_blueprint_read_paths = true`. That keeps the manifest tighten-only -
+//! an `agent.leviath` someone downloaded cannot ship one TOML line that reads
+//! `~/.ssh`. [`ReadPathPolicy::decide`] is that double check, applied per path
+//! at resolve time.
+//!
+//! Three entry forms:
+//! - an exact path: grants the whole subtree under it, checked with the same
+//!   canonicalize-then-prefix containment as the workdir sandbox
+//! - `glob:` - a glob pattern, `*` stays inside one path component, `**`
+//!   crosses them
+//! - `regex:` - a regex, auto-anchored as `^(?:pattern)$` so `regex:runs`
+//!   cannot quietly match `/etc/runs-anything`
+//!
+//! Patterns match the **symlink-resolved real path** of the file, never the
+//! path the agent asked for. That is what makes them safe: a symlink planted
+//! inside an allowlisted directory resolves to its real target, and the real
+//! target must itself match an entry. The matched string uses `/` separators
+//! on every OS and, on Windows, has the `\\?\` verbatim prefix stripped and is
+//! compared case-insensitively (see [`normalize_match_str`]).
+//!
+//! Portability: `~/` expands to the home directory (honoring `LEVIATH_HOME`),
+//! and a bare relative entry resolves against the run's workdir. A relative
+//! `regex:` is refused - there is no way to splice a workdir into a regex
+//! safely, and `glob:` covers that case.
+
+use std::path::{Path, PathBuf};
+
+/// One compiled allowlist entry. Only [`ReadPathSet`] constructs these; the
+/// enum is public so a set's contents are inspectable, not so callers build
+/// entries by hand (compilation is where `~`/relative resolution and
+/// anchoring happen).
+#[derive(Debug, Clone)]
+pub enum ReadPathEntry {
+    /// An exact root: grants the subtree under it. Stored as resolved at
+    /// compile time (tilde/workdir applied) but *uncanonicalized* - the root
+    /// is canonicalized at match time so a root created after spawn still
+    /// works, and a root that cannot be verified never matches.
+    Exact(PathBuf),
+    /// A glob over the normalized real path.
+    Glob {
+        /// The compiled pattern, already `/`-separated and prefixed with the
+        /// escaped home or workdir when the source entry was `~/` or relative.
+        pattern: glob::Pattern,
+        /// Match options: `require_literal_separator` always, case sensitivity
+        /// per platform semantics.
+        options: glob::MatchOptions,
+    },
+    /// A regex over the normalized real path, anchored at compile time.
+    Regex(regex::Regex),
+}
+
+impl ReadPathEntry {
+    /// Whether the already-canonicalized `canonical` path (and its
+    /// pre-normalized string form) lands inside this entry.
+    fn matches(&self, canonical: &Path, normalized: &str) -> bool {
+        match self {
+            ReadPathEntry::Exact(root) => match std::fs::canonicalize(root) {
+                Ok(real_root) => canonical.starts_with(&real_root),
+                // The root itself cannot be verified (it does not exist, or a
+                // parent is unreadable). `canonical` exists - it was
+                // canonicalized by the caller - so it cannot really live under
+                // an unverifiable root. Refuse.
+                Err(_) => false,
+            },
+            ReadPathEntry::Glob { pattern, options } => pattern.matches_with(normalized, *options),
+            ReadPathEntry::Regex(re) => re.is_match(normalized),
+        }
+    }
+}
+
+/// Normalize a canonicalized path string for glob/regex matching.
+///
+/// With `windows` set (production: `cfg!(windows)`, injected so both branches
+/// are testable everywhere):
+/// - `\\?\UNC\server\share\..` becomes `\\server\share\..`
+/// - `\\?\C:\..` (a drive-letter verbatim path, which is what
+///   `fs::canonicalize` returns on Windows) loses the `\\?\` prefix
+/// - any other `\\?\` form (`\\?\Volume{..}`) is left alone; such a path
+///   simply never matches a drive-letter pattern, which fails closed
+/// - every `\` becomes `/`, so patterns are written with `/` on every OS
+///
+/// Without it the string is returned unchanged - a Unix filename may legally
+/// contain `\`.
+pub fn normalize_match_str(s: &str, windows: bool) -> String {
+    if !windows {
+        return s.to_string();
+    }
+    let stripped = if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
+        let bytes = rest.as_bytes();
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            rest.to_string()
+        } else {
+            s.to_string()
+        }
+    } else {
+        s.to_string()
+    };
+    stripped.replace('\\', "/")
+}
+
+/// A compiled set of allowlist entries, bound to the run they were compiled
+/// for (tilde and relative entries were resolved at compile time).
+#[derive(Debug, Clone, Default)]
+pub struct ReadPathSet {
+    entries: Vec<ReadPathEntry>,
+    /// Windows path semantics for matching (separator normalization and case
+    /// folding). Injected rather than read from `cfg!` inside so every branch
+    /// runs under test on every OS.
+    windows: bool,
+}
+
+impl ReadPathSet {
+    /// Compile raw `[read_paths] allow` strings against a run's workdir and
+    /// home. `windows` selects Windows path semantics: `/`-normalization of
+    /// the matched string and case-insensitive glob/regex matching
+    /// (production passes `cfg!(windows)`).
+    ///
+    /// Any invalid entry is a hard error naming the entry - a skipped entry
+    /// would degrade the agent silently mid-run, and refusing loudly at
+    /// compile (spawn) time is the same posture the sandbox config takes.
+    pub fn compile(
+        raw: &[String],
+        workdir: &Path,
+        home: Option<&Path>,
+        windows: bool,
+    ) -> Result<Self, String> {
+        let entries = raw
+            .iter()
+            .map(|entry| compile_entry(entry, workdir, home, windows))
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(Self { entries, windows })
+    }
+
+    /// Whether the set has no entries at all.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The compiled entries, for callers that report or display them.
+    pub fn entries(&self) -> &[ReadPathEntry] {
+        &self.entries
+    }
+
+    /// Whether the already-canonicalized `canonical` path matches any entry.
+    pub fn matches(&self, canonical: &Path) -> bool {
+        let normalized = normalize_match_str(&canonical.to_string_lossy(), self.windows);
+        self.entries
+            .iter()
+            .any(|e| e.matches(canonical, &normalized))
+    }
+}
+
+/// The outcome of checking one path against a [`ReadPathPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadPathDecision {
+    /// Declared by the blueprint and granted by the user (or the user opted
+    /// into honoring blueprints wholesale).
+    Allowed,
+    /// The blueprint never asked for this path; the ordinary workdir refusal
+    /// stands.
+    NotDeclared,
+    /// The blueprint asked, but nothing in the user's config grants it.
+    NotGranted,
+}
+
+/// Everything read-path enforcement needs, resolved once at spawn.
+///
+/// `blueprint` is what the manifest declares; `grants` is what the user's
+/// config allows (`[security] read_paths` plus `[agent_read_paths.<name>]`);
+/// `allow_blueprint` is the `[security] allow_blueprint_read_paths` override
+/// that honors declarations without itemized grants.
+#[derive(Debug, Clone, Default)]
+pub struct ReadPathPolicy {
+    /// The agent's name, for error and warning text.
+    pub agent: String,
+    /// Entries the blueprint declares.
+    pub blueprint: ReadPathSet,
+    /// Entries the user's config grants.
+    pub grants: ReadPathSet,
+    /// Whether declarations are honored without itemized grants.
+    pub allow_blueprint: bool,
+}
+
+impl ReadPathPolicy {
+    /// A policy that allows nothing beyond the workdir - the default for
+    /// every agent whose blueprint has no `[read_paths]`.
+    pub fn inactive() -> Self {
+        Self::default()
+    }
+
+    /// Whether the blueprint declares any read paths at all. When false, the
+    /// resolver never consults this policy and the workdir sandbox behaves
+    /// exactly as it always has.
+    pub fn is_active(&self) -> bool {
+        !self.blueprint.is_empty()
+    }
+
+    /// The double check: the blueprint must declare the path AND the user
+    /// must grant it (itemized, or via the blanket override).
+    pub fn decide(&self, canonical: &Path) -> ReadPathDecision {
+        if !self.blueprint.matches(canonical) {
+            return ReadPathDecision::NotDeclared;
+        }
+        if self.allow_blueprint || self.grants.matches(canonical) {
+            ReadPathDecision::Allowed
+        } else {
+            ReadPathDecision::NotGranted
+        }
+    }
+}
+
+/// Validate one entry's syntax without binding it to a run: bad glob/regex,
+/// a relative `regex:`, an empty entry. Called from manifest parsing so a
+/// broken entry fails `lev validate`/`lev add`/spawn loudly instead of
+/// degrading the agent at its first out-of-workdir read.
+///
+/// Environment problems (`~` with no resolvable home) are not syntax and are
+/// only caught when the real compile runs at spawn.
+pub fn validate_entry_syntax(raw: &str) -> Result<(), String> {
+    // The dummy workdir is deep enough that a reasonable `../` prefix in a
+    // relative glob validates; how far up a real run can climb is bound to the
+    // real workdir at spawn.
+    let workdir = Path::new("/validate/a/b/c/d/e/f/g/h");
+    compile_entry(raw, workdir, Some(Path::new("/validate-home")), false).map(|_| ())
+}
+
+/// Compile one raw entry. `windows` is the same injected platform-semantics
+/// flag as [`ReadPathSet::compile`].
+fn compile_entry(
+    raw: &str,
+    workdir: &Path,
+    home: Option<&Path>,
+    windows: bool,
+) -> Result<ReadPathEntry, String> {
+    if raw.trim().is_empty() {
+        return Err("read_paths entry is empty".to_string());
+    }
+    if let Some(rest) = raw.strip_prefix("regex:") {
+        compile_regex(raw, rest, home, windows)
+    } else if let Some(rest) = raw.strip_prefix("glob:") {
+        compile_glob(raw, rest, workdir, home, windows)
+    } else {
+        compile_exact(raw, workdir, home)
+    }
+}
+
+/// Whether pattern text starts like an absolute path: `/..`, `//server/..`,
+/// or a drive letter `C:/..`. Deliberately literal - a pattern opening with a
+/// character class (`[A-Z]:/..`) is refused rather than guessed at.
+fn absolute_shaped(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    text.starts_with('/')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+fn compile_regex(
+    raw: &str,
+    rest: &str,
+    home: Option<&Path>,
+    windows: bool,
+) -> Result<ReadPathEntry, String> {
+    if rest.is_empty() {
+        return Err(format!("read_paths entry '{raw}': regex pattern is empty"));
+    }
+    let body = if let Some(after_tilde) = rest.strip_prefix('~') {
+        if !(after_tilde.is_empty() || after_tilde.starts_with('/')) {
+            return Err(format!(
+                "read_paths entry '{raw}': only '~/' home expansion is supported"
+            ));
+        }
+        let home = home.ok_or_else(|| {
+            format!("read_paths entry '{raw}': no home directory resolved for '~' expansion")
+        })?;
+        let prefix = regex::escape(&normalize_match_str(&home.to_string_lossy(), windows));
+        format!("{prefix}{after_tilde}")
+    } else if absolute_shaped(rest) {
+        rest.to_string()
+    } else {
+        return Err(format!(
+            "read_paths entry '{raw}': regex entries must start with '/', a drive letter, or '~/'; \
+             use 'glob:' for workdir-relative patterns"
+        ));
+    };
+    regex::RegexBuilder::new(&format!("^(?:{body})$"))
+        .case_insensitive(windows)
+        .build()
+        .map(ReadPathEntry::Regex)
+        .map_err(|e| format!("read_paths entry '{raw}': invalid regex: {e}"))
+}
+
+fn compile_glob(
+    raw: &str,
+    rest: &str,
+    workdir: &Path,
+    home: Option<&Path>,
+    windows: bool,
+) -> Result<ReadPathEntry, String> {
+    if rest.is_empty() {
+        return Err(format!("read_paths entry '{raw}': glob pattern is empty"));
+    }
+    // Glob has no backslash-escape syntax, so this is lossless and makes
+    // Windows-style patterns portable.
+    let text = rest.replace('\\', "/");
+    let text = if let Some(after_tilde) = text.strip_prefix('~') {
+        if !(after_tilde.is_empty() || after_tilde.starts_with('/')) {
+            return Err(format!(
+                "read_paths entry '{raw}': only '~/' home expansion is supported"
+            ));
+        }
+        let home = home.ok_or_else(|| {
+            format!("read_paths entry '{raw}': no home directory resolved for '~' expansion")
+        })?;
+        // The home directory is data, not pattern: escape any glob
+        // metacharacters it happens to contain.
+        let prefix = glob::Pattern::escape(&normalize_match_str(&home.to_string_lossy(), windows));
+        format!("{prefix}{after_tilde}")
+    } else if absolute_shaped(&text) {
+        text
+    } else {
+        resolve_relative_glob(raw, &text, workdir, windows)?
+    };
+    // A `.` or `..` component anywhere in the final pattern can never match a
+    // canonicalized path, so it is always a mistake - refuse it rather than
+    // let the entry silently match nothing.
+    if text.split('/').any(|c| c == "." || c == "..") {
+        return Err(format!(
+            "read_paths entry '{raw}': glob patterns cannot contain '.' or '..' components \
+             (relative entries fold them against the workdir at the start only)"
+        ));
+    }
+    let pattern = glob::Pattern::new(&text)
+        .map_err(|e| format!("read_paths entry '{raw}': invalid glob: {e}"))?;
+    let options = glob::MatchOptions {
+        case_sensitive: !windows,
+        // `*` must not cross a `/`; `**` is the explicit way to.
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+    Ok(ReadPathEntry::Glob { pattern, options })
+}
+
+/// Anchor a relative glob at the workdir, folding any *leading* `./` and
+/// `../` components into the workdir prefix so `glob:../shared/**` means the
+/// workdir's sibling.
+fn resolve_relative_glob(
+    raw: &str,
+    text: &str,
+    workdir: &Path,
+    windows: bool,
+) -> Result<String, String> {
+    let base_str = normalize_match_str(&workdir.to_string_lossy(), windows);
+    let mut base: Vec<&str> = base_str.split('/').collect();
+    // "/" splits to ["", ""]; keep the leading "" (it restores the root `/`
+    // on rejoin) and drop trailing empties.
+    while base.len() > 1 && base.last().is_some_and(|s| s.is_empty()) {
+        base.pop();
+    }
+    let mut rest = text;
+    loop {
+        if let Some(r) = rest.strip_prefix("./") {
+            rest = r;
+        } else if let Some(r) = rest.strip_prefix("../") {
+            if base.len() <= 1 {
+                return Err(format!(
+                    "read_paths entry '{raw}': relative pattern escapes the filesystem root"
+                ));
+            }
+            base.pop();
+            rest = r;
+        } else {
+            break;
+        }
+    }
+    // The workdir is data, not pattern.
+    let prefix = glob::Pattern::escape(&base.join("/"));
+    Ok(if rest.is_empty() {
+        prefix
+    } else {
+        format!("{prefix}/{rest}")
+    })
+}
+
+fn compile_exact(raw: &str, workdir: &Path, home: Option<&Path>) -> Result<ReadPathEntry, String> {
+    let path = if let Some(after_tilde) = raw.strip_prefix('~') {
+        let sub = after_tilde
+            .strip_prefix('/')
+            .or_else(|| after_tilde.strip_prefix('\\'));
+        let sub = match (sub, after_tilde.is_empty()) {
+            (_, true) => "",
+            (Some(sub), _) => sub,
+            (None, false) => {
+                return Err(format!(
+                    "read_paths entry '{raw}': only '~/' home expansion is supported"
+                ));
+            }
+        };
+        let home = home.ok_or_else(|| {
+            format!("read_paths entry '{raw}': no home directory resolved for '~' expansion")
+        })?;
+        if sub.is_empty() {
+            home.to_path_buf()
+        } else {
+            home.join(sub)
+        }
+    } else if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        workdir.join(raw)
+    };
+    Ok(ReadPathEntry::Exact(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(entries: &[&str], workdir: &str, home: Option<&str>, windows: bool) -> ReadPathSet {
+        let raw: Vec<String> = entries.iter().map(|s| s.to_string()).collect();
+        ReadPathSet::compile(&raw, Path::new(workdir), home.map(Path::new), windows)
+            .expect("entries compile")
+    }
+
+    fn compile_err(entry: &str, workdir: &str, home: Option<&str>) -> String {
+        ReadPathSet::compile(
+            &[entry.to_string()],
+            Path::new(workdir),
+            home.map(Path::new),
+            false,
+        )
+        .expect_err("entry must be refused")
+    }
+
+    // -- compile errors ----------------------------------------------------
+
+    #[test]
+    fn empty_and_whitespace_entries_are_refused() {
+        assert!(compile_err("", "/w", None).contains("empty"));
+        assert!(compile_err("   ", "/w", None).contains("empty"));
+        assert!(compile_err("glob:", "/w", None).contains("glob pattern is empty"));
+        assert!(compile_err("regex:", "/w", None).contains("regex pattern is empty"));
+    }
+
+    #[test]
+    fn invalid_patterns_are_refused() {
+        assert!(compile_err("glob:/a/[", "/w", None).contains("invalid glob"));
+        assert!(compile_err("regex:/a/(", "/w", None).contains("invalid regex"));
+    }
+
+    /// There is no safe way to splice a workdir into a regex, so a relative
+    /// regex is a hard error pointing at glob.
+    #[test]
+    fn a_relative_regex_is_refused() {
+        let err = compile_err("regex:etc/passwd", "/w", None);
+        assert!(err.contains("must start with"), "got: {err}");
+        assert!(err.contains("glob:"), "got: {err}");
+    }
+
+    /// `~user` expansion is not supported in any entry kind - only `~/`.
+    #[test]
+    fn tilde_user_forms_are_refused() {
+        for entry in ["~other/x", "glob:~other/**", "regex:~other/.*"] {
+            let err = compile_err(entry, "/w", Some("/home/me"));
+            assert!(err.contains("only '~/'"), "{entry}: {err}");
+        }
+    }
+
+    /// `~` without a resolvable home is an environment error at compile time,
+    /// for every entry kind.
+    #[test]
+    fn tilde_without_a_home_is_refused() {
+        for entry in ["~/docs", "glob:~/docs/**", "regex:~/docs/.*"] {
+            let err = compile_err(entry, "/w", None);
+            assert!(err.contains("no home directory"), "{entry}: {err}");
+        }
+    }
+
+    /// A dot component in the middle of a glob can never match a canonical
+    /// path, so it is refused instead of silently matching nothing.
+    #[test]
+    fn interior_dot_components_in_globs_are_refused() {
+        for entry in ["glob:/a/../b/**", "glob:/a/./b", "glob:a/../../b"] {
+            let err = compile_err(entry, "/w/x", None);
+            assert!(err.contains("cannot contain"), "{entry}: {err}");
+        }
+    }
+
+    #[test]
+    fn a_relative_glob_cannot_climb_past_the_root() {
+        let err = compile_err("glob:../../../x/**", "/w", None);
+        assert!(err.contains("escapes the filesystem root"), "got: {err}");
+    }
+
+    // -- exact entries -----------------------------------------------------
+
+    #[test]
+    fn an_exact_root_grants_its_subtree_and_nothing_else() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        std::fs::create_dir(root.join("sub")).unwrap();
+        std::fs::write(root.join("sub/f.txt"), b"x").unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("f.txt");
+        std::fs::write(&outside_file, b"x").unwrap();
+
+        let s = set(&[root.to_str().unwrap()], "/w", None, false);
+        assert!(s.matches(&root.join("sub/f.txt")));
+        assert!(!s.matches(&std::fs::canonicalize(&outside_file).unwrap()));
+    }
+
+    /// The entry itself may be uncanonicalized (macOS `/tmp` vs
+    /// `/private/tmp`); the root is canonicalized at match time.
+    #[test]
+    fn an_uncanonicalized_exact_root_still_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), b"x").unwrap();
+        let s = set(&[dir.path().to_str().unwrap()], "/w", None, false);
+        assert!(s.matches(&std::fs::canonicalize(dir.path().join("f.txt")).unwrap()));
+    }
+
+    /// A root that cannot be verified never matches - the canonicalized
+    /// candidate exists, so it cannot really live under a nonexistent root.
+    #[test]
+    fn a_nonexistent_exact_root_never_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = std::fs::canonicalize(dir.path()).unwrap();
+        let s = set(&["/definitely/not/a/real/root"], "/w", None, false);
+        assert!(!s.matches(&real));
+    }
+
+    #[test]
+    fn a_relative_exact_entry_resolves_against_the_workdir() {
+        let parent = tempfile::tempdir().unwrap();
+        let workdir = parent.path().join("work");
+        let sibling = parent.path().join("shared");
+        std::fs::create_dir_all(&workdir).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        std::fs::write(sibling.join("doc.md"), b"x").unwrap();
+
+        let s = set(&["../shared"], workdir.to_str().unwrap(), None, false);
+        assert!(s.matches(&std::fs::canonicalize(sibling.join("doc.md")).unwrap()));
+    }
+
+    #[test]
+    fn tilde_exact_entries_expand_to_the_home_argument() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir(home.path().join("docs")).unwrap();
+        std::fs::write(home.path().join("docs/a.md"), b"x").unwrap();
+        let home_str = home.path().to_str().unwrap();
+
+        let bare = set(&["~"], "/w", Some(home_str), false);
+        let scoped = set(&["~/docs"], "/w", Some(home_str), false);
+        let canonical = std::fs::canonicalize(home.path().join("docs/a.md")).unwrap();
+        assert!(bare.matches(&canonical));
+        assert!(scoped.matches(&canonical));
+    }
+
+    // -- glob entries (matching is pure string work, no filesystem) --------
+
+    #[test]
+    fn star_stays_within_one_component_and_doublestar_crosses() {
+        let s = set(&["glob:/data/runs/*"], "/w", None, false);
+        assert!(s.matches(Path::new("/data/runs/r1")));
+        assert!(!s.matches(Path::new("/data/runs/r1/log.txt")));
+
+        let deep = set(&["glob:/data/runs/**"], "/w", None, false);
+        assert!(deep.matches(Path::new("/data/runs/r1/log.txt")));
+        assert!(!deep.matches(Path::new("/data/other/x")));
+    }
+
+    #[test]
+    fn a_relative_glob_is_anchored_at_the_workdir() {
+        let s = set(&["glob:../shared/**"], "/w/agent", None, false);
+        assert!(s.matches(Path::new("/w/shared/notes/a.md")));
+        assert!(!s.matches(Path::new("/w/agent/own.md")));
+        assert!(!s.matches(Path::new("/elsewhere/shared/a.md")));
+    }
+
+    /// A relative glob anchored at the filesystem root itself: the root's
+    /// trailing-empty split segment must not double the separator.
+    #[test]
+    fn a_relative_glob_works_from_a_root_workdir() {
+        let s = set(&["glob:docs/**"], "/", None, false);
+        assert!(s.matches(Path::new("/docs/a.md")));
+        assert!(!s.matches(Path::new("/other/a.md")));
+    }
+
+    /// A pattern that is nothing but dot components (`glob:../`) reduces to
+    /// the folded prefix alone and matches exactly that directory.
+    #[test]
+    fn a_dots_only_glob_matches_the_folded_directory_itself() {
+        let s = set(&["glob:../"], "/a/b", None, false);
+        assert!(s.matches(Path::new("/a")));
+        assert!(!s.matches(Path::new("/a/b")));
+    }
+
+    /// The workdir is data: glob metacharacters in it must match literally.
+    #[test]
+    fn a_metachar_workdir_is_escaped_in_relative_globs() {
+        let s = set(&["glob:./docs/**"], "/we[ird]/w", None, false);
+        assert!(s.matches(Path::new("/we[ird]/w/docs/a.md")));
+        // If the workdir were spliced in unescaped, `[ird]` would be a class
+        // and this single-character variant would match.
+        assert!(!s.matches(Path::new("/wei/w/docs/a.md")));
+    }
+
+    /// The home directory is data too.
+    #[test]
+    fn a_metachar_home_is_escaped_in_tilde_globs() {
+        let s = set(&["glob:~/docs/**"], "/w", Some("/ho[me]"), false);
+        assert!(s.matches(Path::new("/ho[me]/docs/a.md")));
+        assert!(!s.matches(Path::new("/hom/docs/a.md")));
+    }
+
+    /// Windows-style pattern text is normalized to `/` so blueprints written
+    /// with backslashes keep working.
+    #[test]
+    fn backslash_glob_patterns_are_normalized() {
+        let s = set(&[r"glob:C:\data\runs\**"], "/w", None, true);
+        assert!(s.matches(Path::new(r"C:\data\runs\r1\log.txt")));
+    }
+
+    #[test]
+    fn glob_case_sensitivity_follows_the_platform_flag() {
+        let insensitive = set(&["glob:/Data/**"], "/w", None, true);
+        assert!(insensitive.matches(Path::new("/data/x")));
+        let sensitive = set(&["glob:/Data/**"], "/w", None, false);
+        assert!(!sensitive.matches(Path::new("/data/x")));
+    }
+
+    // -- regex entries -----------------------------------------------------
+
+    /// The anchor is the point: an unanchored `regex:/etc/runs` must not
+    /// match `/etc/runs-anything` or `/prefix/etc/runs`.
+    #[test]
+    fn regexes_are_anchored_to_the_whole_path() {
+        let s = set(&["regex:/etc/runs"], "/w", None, false);
+        assert!(s.matches(Path::new("/etc/runs")));
+        assert!(!s.matches(Path::new("/etc/runs-anything")));
+        assert!(!s.matches(Path::new("/prefix/etc/runs")));
+
+        let subtree = set(&["regex:/etc/runs/.*"], "/w", None, false);
+        assert!(subtree.matches(Path::new("/etc/runs/deep/file")));
+    }
+
+    #[test]
+    fn regex_case_sensitivity_follows_the_platform_flag() {
+        let insensitive = set(&["regex:/Data/.*"], "/w", None, true);
+        assert!(insensitive.matches(Path::new("/data/x")));
+        let sensitive = set(&["regex:/Data/.*"], "/w", None, false);
+        assert!(!sensitive.matches(Path::new("/data/x")));
+    }
+
+    /// The home is spliced in escaped, so a metacharacter in the home path
+    /// matches itself and nothing else.
+    #[test]
+    fn a_metachar_home_is_escaped_in_tilde_regexes() {
+        let s = set(&["regex:~/docs/.*"], "/w", Some("/ho.me"), false);
+        assert!(s.matches(Path::new("/ho.me/docs/a")));
+        assert!(!s.matches(Path::new("/hoXme/docs/a")));
+    }
+
+    /// A drive-letter regex is accepted as absolute-shaped.
+    #[test]
+    fn a_drive_letter_regex_is_accepted() {
+        let s = set(&["regex:C:/data/.*"], "/w", None, true);
+        assert!(s.matches(Path::new(r"C:\data\x")));
+    }
+
+    // -- normalize_match_str ----------------------------------------------
+
+    #[test]
+    fn unix_strings_pass_through_untouched() {
+        assert_eq!(
+            normalize_match_str(r"/a/weird\name", false),
+            r"/a/weird\name"
+        );
+    }
+
+    #[test]
+    fn windows_verbatim_prefixes_are_stripped_for_matching() {
+        assert_eq!(normalize_match_str(r"\\?\C:\Users\x", true), "C:/Users/x");
+        assert_eq!(
+            normalize_match_str(r"\\?\UNC\srv\share\x", true),
+            "//srv/share/x"
+        );
+        // Unrecognized verbatim forms are left alone (they fail to match
+        // drive-letter patterns, which is the safe direction).
+        assert_eq!(
+            normalize_match_str(r"\\?\Volume{abc}\x", true),
+            "//?/Volume{abc}/x"
+        );
+        assert_eq!(normalize_match_str(r"C:\plain\x", true), "C:/plain/x");
+    }
+
+    // -- policy ------------------------------------------------------------
+
+    fn policy(blueprint: &[&str], grants: &[&str], allow_blueprint: bool) -> ReadPathPolicy {
+        ReadPathPolicy {
+            agent: "tester".into(),
+            blueprint: set(blueprint, "/w", None, false),
+            grants: set(grants, "/w", None, false),
+            allow_blueprint,
+        }
+    }
+
+    #[test]
+    fn an_inactive_policy_declares_nothing() {
+        let p = ReadPathPolicy::inactive();
+        assert!(!p.is_active());
+        assert_eq!(
+            p.decide(Path::new("/anything")),
+            ReadPathDecision::NotDeclared
+        );
+    }
+
+    #[test]
+    fn a_path_the_blueprint_never_declared_is_not_declared() {
+        let p = policy(&["glob:/data/**"], &["glob:/data/**"], false);
+        assert!(p.is_active());
+        assert_eq!(
+            p.decide(Path::new("/etc/passwd")),
+            ReadPathDecision::NotDeclared
+        );
+    }
+
+    /// Declared but ungranted: the blueprint alone grants nothing. This is
+    /// the tighten-only invariant.
+    #[test]
+    fn a_declared_but_ungranted_path_is_not_granted() {
+        let p = policy(&["glob:/data/**"], &[], false);
+        assert_eq!(p.decide(Path::new("/data/x")), ReadPathDecision::NotGranted);
+    }
+
+    #[test]
+    fn a_granted_path_is_allowed() {
+        let p = policy(&["glob:/data/**"], &["glob:/data/**"], false);
+        assert_eq!(p.decide(Path::new("/data/x")), ReadPathDecision::Allowed);
+    }
+
+    /// The grant need not be textually identical - it is a second predicate,
+    /// so a broad user grant covers a narrow blueprint declaration.
+    #[test]
+    fn a_broader_grant_covers_a_narrow_declaration() {
+        let p = policy(&["glob:/data/runs/**"], &["glob:/data/**"], false);
+        assert_eq!(
+            p.decide(Path::new("/data/runs/r1")),
+            ReadPathDecision::Allowed
+        );
+    }
+
+    /// A grant that does not cover the declared path does nothing: both
+    /// predicates must hold for the same path.
+    #[test]
+    fn a_nonoverlapping_grant_does_not_help() {
+        let p = policy(&["glob:/data/**"], &["glob:/other/**"], false);
+        assert_eq!(p.decide(Path::new("/data/x")), ReadPathDecision::NotGranted);
+    }
+
+    #[test]
+    fn the_blanket_override_honors_declarations_without_grants() {
+        let p = policy(&["glob:/data/**"], &[], true);
+        assert_eq!(p.decide(Path::new("/data/x")), ReadPathDecision::Allowed);
+        // The override does not widen beyond what is declared.
+        assert_eq!(p.decide(Path::new("/etc/x")), ReadPathDecision::NotDeclared);
+    }
+
+    #[test]
+    fn an_empty_set_matches_nothing() {
+        let s = set(&[], "/w", None, false);
+        assert!(s.is_empty());
+        assert!(s.entries().is_empty());
+        assert!(!s.matches(Path::new("/anything")));
+    }
+
+    // -- validate_entry_syntax --------------------------------------------
+
+    #[test]
+    fn syntax_validation_accepts_well_formed_entries() {
+        for entry in [
+            "/abs/dir",
+            "relative/dir",
+            "~/docs",
+            "glob:~/runs/**",
+            "glob:../shared/**",
+            "regex:/data/.*",
+            r"C:\Users\me\docs",
+        ] {
+            assert!(validate_entry_syntax(entry).is_ok(), "{entry}");
+        }
+    }
+
+    #[test]
+    fn syntax_validation_refuses_malformed_entries() {
+        for entry in ["", "glob:[", "regex:(", "regex:relative/.*", "~oops"] {
+            assert!(validate_entry_syntax(entry).is_err(), "{entry}");
+        }
+    }
+}

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -6,6 +6,10 @@ use super::*;
 pub struct ToolContext {
     /// Absolute working directory. All file operations are confined here.
     pub workdir: PathBuf,
+    /// Additional directories/patterns this agent may read from beyond its
+    /// workdir. C-suite agents use this to read design docs and run archives.
+    /// Read-only; write operations are always sandboxed to `workdir`.
+    pub read_paths: Vec<leviath_core::ReadPathEntry>,
     /// Per-path advisory locks serializing concurrent mutating file operations
     /// (`write_file`/`edit_file`) on the *same* file. Fan-out sub-agent workers
     /// share one process and one workdir, so an in-process lock map keyed by
@@ -21,6 +25,17 @@ impl ToolContext {
         let workdir = std::fs::canonicalize(&workdir).unwrap_or(workdir);
         Self {
             workdir,
+            read_paths: Vec::new(),
+            file_locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Create a new context with additional read paths for the allowlist.
+    pub fn with_read_paths(workdir: PathBuf, read_paths: Vec<leviath_core::ReadPathEntry>) -> Self {
+        let workdir = std::fs::canonicalize(&workdir).unwrap_or(workdir);
+        Self {
+            workdir,
+            read_paths,
             file_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -6,10 +6,12 @@ use super::*;
 pub struct ToolContext {
     /// Absolute working directory. All file operations are confined here.
     pub workdir: PathBuf,
-    /// Additional directories/patterns this agent may read from beyond its
-    /// workdir. C-suite agents use this to read design docs and run archives.
-    /// Read-only; write operations are always sandboxed to `workdir`.
-    pub read_paths: Vec<leviath_core::ReadPathEntry>,
+    /// The `[read_paths]` policy: which paths outside the workdir the
+    /// *read-only* file tools may fall back to, and only when both the
+    /// blueprint declares them and the user's config grants them. Inactive by
+    /// default, and never consulted by `write_file`/`edit_file` - writes are
+    /// confined to `workdir` unconditionally.
+    pub(crate) read_paths: leviath_core::ReadPathPolicy,
     /// Per-path advisory locks serializing concurrent mutating file operations
     /// (`write_file`/`edit_file`) on the *same* file. Fan-out sub-agent workers
     /// share one process and one workdir, so an in-process lock map keyed by
@@ -25,19 +27,16 @@ impl ToolContext {
         let workdir = std::fs::canonicalize(&workdir).unwrap_or(workdir);
         Self {
             workdir,
-            read_paths: Vec::new(),
+            read_paths: leviath_core::ReadPathPolicy::inactive(),
             file_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Create a new context with additional read paths for the allowlist.
-    pub fn with_read_paths(workdir: PathBuf, read_paths: Vec<leviath_core::ReadPathEntry>) -> Self {
-        let workdir = std::fs::canonicalize(&workdir).unwrap_or(workdir);
-        Self {
-            workdir,
-            read_paths,
-            file_locks: Arc::new(Mutex::new(HashMap::new())),
-        }
+    /// Attach a `[read_paths]` policy resolved at spawn. Builder-style, like
+    /// [`BuiltinTools::with_shell_executor`].
+    pub fn with_read_paths(mut self, policy: leviath_core::ReadPathPolicy) -> Self {
+        self.read_paths = policy;
+        self
     }
 
     /// Get (or create) the advisory lock for `path`. The map mutex is held only

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -70,7 +70,47 @@ impl BuiltinTools {
     /// throughout, which is a larger change; this stops the planted-symlink case,
     /// which is the one an agent can actually arrange.
     pub(crate) fn resolve(&self, requested: &str) -> anyhow::Result<PathBuf> {
-        Self::resolve_within(requested, &self.ctx.workdir, resolves_within)
+        // 1. Try the workdir first — this is the normal, sandboxed path.
+        match Self::resolve_within(requested, &self.ctx.workdir, resolves_within) {
+            Ok(path) => return Ok(path),
+            Err(_workdir_err) => {
+                // 2. If the workdir check fails, try each read_paths allowlist entry.
+                //    Only absolute paths are checked against read_paths — relative
+                //    paths are always confined to the workdir.
+                if !Path::new(requested).is_absolute() || self.ctx.read_paths.is_empty() {
+                    // No fallback — return the original workdir error.
+                    return Self::resolve_within(requested, &self.ctx.workdir, resolves_within);
+                }
+                let raw = PathBuf::from(requested);
+                // Normalize .. and .
+                let mut normalized = PathBuf::new();
+                for component in raw.components() {
+                    match component {
+                        Component::ParentDir => {
+                            if !normalized.pop() {
+                                anyhow::bail!("path '{}' escapes the working directory", requested);
+                            }
+                        }
+                        Component::CurDir => {}
+                        other => normalized.push(other),
+                    }
+                }
+                for entry in &self.ctx.read_paths {
+                    if entry.matches(&normalized) {
+                        // Symlink check against the matched entry's root.
+                        let root = match entry {
+                            leviath_core::ReadPathEntry::Exact(root) => root.clone(),
+                            _ => normalized.clone(),
+                        };
+                        if resolves_within(&normalized, &root) {
+                            return Ok(normalized);
+                        }
+                    }
+                }
+                // No allowlist entry matched — return the original error.
+                Self::resolve_within(requested, &self.ctx.workdir, resolves_within)
+            }
+        }
     }
 
     /// Core of [`resolve`](Self::resolve) with the containment check injected.

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -70,46 +70,99 @@ impl BuiltinTools {
     /// throughout, which is a larger change; this stops the planted-symlink case,
     /// which is the one an agent can actually arrange.
     pub(crate) fn resolve(&self, requested: &str) -> anyhow::Result<PathBuf> {
-        // 1. Try the workdir first — this is the normal, sandboxed path.
+        Self::resolve_within(requested, &self.ctx.workdir, resolves_within)
+    }
+
+    /// Resolve a requested path for a *read-only* tool.
+    ///
+    /// Identical to [`resolve`](Self::resolve) - same two checks, same
+    /// errors - until the workdir refuses. Only then, and only when the
+    /// agent's `[read_paths]` policy is active, the path is checked against
+    /// that policy: canonicalized first (fail closed), then both predicates
+    /// of [`leviath_core::ReadPathPolicy::decide`] must hold - the blueprint
+    /// declared it AND the user's config grants it.
+    ///
+    /// This function is deliberately not called by `write_file`/`edit_file`.
+    /// `[read_paths]` grants reads; the write tools stay on
+    /// [`resolve`](Self::resolve) so an allowlisted directory can be read but
+    /// never written.
+    pub(crate) fn resolve_read(&self, requested: &str) -> anyhow::Result<PathBuf> {
         match Self::resolve_within(requested, &self.ctx.workdir, resolves_within) {
-            Ok(path) => return Ok(path),
-            Err(_workdir_err) => {
-                // 2. If the workdir check fails, try each read_paths allowlist entry.
-                //    Only absolute paths are checked against read_paths — relative
-                //    paths are always confined to the workdir.
-                if !Path::new(requested).is_absolute() || self.ctx.read_paths.is_empty() {
-                    // No fallback — return the original workdir error.
-                    return Self::resolve_within(requested, &self.ctx.workdir, resolves_within);
+            Ok(path) => Ok(path),
+            Err(workdir_err) => {
+                if !self.ctx.read_paths.is_active() {
+                    return Err(workdir_err);
                 }
-                let raw = PathBuf::from(requested);
-                // Normalize .. and .
-                let mut normalized = PathBuf::new();
-                for component in raw.components() {
-                    match component {
-                        Component::ParentDir => {
-                            if !normalized.pop() {
-                                anyhow::bail!("path '{}' escapes the working directory", requested);
-                            }
-                        }
-                        Component::CurDir => {}
-                        other => normalized.push(other),
-                    }
-                }
-                for entry in &self.ctx.read_paths {
-                    if entry.matches(&normalized) {
-                        // Symlink check against the matched entry's root.
-                        let root = match entry {
-                            leviath_core::ReadPathEntry::Exact(root) => root.clone(),
-                            _ => normalized.clone(),
-                        };
-                        if resolves_within(&normalized, &root) {
-                            return Ok(normalized);
-                        }
-                    }
-                }
-                // No allowlist entry matched — return the original error.
-                Self::resolve_within(requested, &self.ctx.workdir, resolves_within)
+                Self::resolve_outside(
+                    requested,
+                    &self.ctx.workdir,
+                    &self.ctx.read_paths,
+                    leviath_core::canonicalize_for_match,
+                )
             }
+        }
+    }
+
+    /// The out-of-workdir arm of [`resolve_read`](Self::resolve_read), with
+    /// the canonicalizer injected (`fn` pointer, same seam idiom as
+    /// [`resolve_within`](Self::resolve_within)) so the fail-closed refusal is
+    /// testable on every platform.
+    ///
+    /// The returned path is the *canonicalized* one - the path that was
+    /// actually vetted - so the subsequent `open` operates on what the policy
+    /// approved rather than re-walking any symlinks.
+    pub(crate) fn resolve_outside(
+        requested: &str,
+        workdir: &Path,
+        policy: &leviath_core::ReadPathPolicy,
+        canon: fn(&Path) -> Option<PathBuf>,
+    ) -> anyhow::Result<PathBuf> {
+        // Relative requests resolve against the workdir here too, so a
+        // relative `[read_paths]` entry like "../shared" is reachable by the
+        // matching relative request. Canonicalization below is what decides
+        // containment; the workdir join is just the base.
+        let raw = if Path::new(requested).is_absolute() {
+            PathBuf::from(requested)
+        } else {
+            workdir.join(requested)
+        };
+
+        // Fold `..` lexically; popping past the filesystem root is
+        // unresolvable no matter what any allowlist says. `Path::components`
+        // already drops interior `.`, and `raw` is absolute here (an absolute
+        // request, or a relative one joined onto the canonicalized workdir),
+        // so no `CurDir` survives to this loop - the catch-all mirrors
+        // `resolve_within`.
+        let mut normalized = PathBuf::new();
+        for component in raw.components() {
+            match component {
+                Component::ParentDir => {
+                    if !normalized.pop() {
+                        anyhow::bail!("path '{requested}' cannot be resolved");
+                    }
+                }
+                other => normalized.push(other),
+            }
+        }
+
+        // The policy only ever sees the real, symlink-resolved path. A path
+        // that cannot be verified is refused, never matched.
+        let Some(canonical) = canon(&normalized) else {
+            anyhow::bail!("path '{requested}' cannot be verified against [read_paths]");
+        };
+
+        match policy.decide(&canonical) {
+            leviath_core::ReadPathDecision::Allowed => Ok(canonical),
+            leviath_core::ReadPathDecision::NotDeclared => anyhow::bail!(
+                "path '{requested}' is outside the working directory and not in this \
+                 agent's [read_paths]"
+            ),
+            leviath_core::ReadPathDecision::NotGranted => anyhow::bail!(
+                "path '{requested}' matches this agent's [read_paths], but your config \
+                 does not grant it; add it under [agent_read_paths.{agent}] (or set \
+                 allow_blueprint_read_paths = true under [security]) in your config.toml",
+                agent = policy.agent
+            ),
         }
     }
 
@@ -165,7 +218,7 @@ impl BuiltinTools {
             None => return "[error] missing 'path' argument".to_string(),
         };
 
-        let path = match self.resolve(path_str) {
+        let path = match self.resolve_read(path_str) {
             Ok(p) => p,
             Err(e) => return format!("[error] {}", e),
         };
@@ -196,7 +249,7 @@ impl BuiltinTools {
                 }
             };
 
-            let path = match self.resolve(path_str) {
+            let path = match self.resolve_read(path_str) {
                 Ok(p) => p,
                 Err(e) => {
                     results.push(format!("### [{}]\n[error] {}", path_str, e));
@@ -316,7 +369,7 @@ impl BuiltinTools {
     pub(crate) async fn list_dir(&self, args: &Value) -> String {
         let path_str = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
 
-        let path = match self.resolve(path_str) {
+        let path = match self.resolve_read(path_str) {
             Ok(p) => p,
             Err(e) => return format!("[error] {}", e),
         };

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -606,8 +606,10 @@ mod tests {
         assert_eq!(out, "outside contents");
     }
 
-    /// Folding `..` past the filesystem root is unresolvable no matter what
-    /// any allowlist says.
+    /// Folding `..` past the top is unresolvable no matter what any allowlist
+    /// says. A leading `..` against an empty base leaves nothing to pop on
+    /// every platform - `/..` would not, since it is not absolute on Windows
+    /// and gets reshaped by the workdir join there.
     #[test]
     fn folding_past_the_root_is_unresolvable() {
         let policy = leviath_core::ReadPathPolicy {
@@ -616,12 +618,12 @@ mod tests {
             ..Default::default()
         };
         let err = BuiltinTools::resolve_outside(
-            "/..",
-            Path::new("/w"),
+            "../x",
+            Path::new(""),
             &policy,
             leviath_core::canonicalize_for_match,
         )
-        .expect_err("popping past the root must be refused");
+        .expect_err("popping past the top must be refused");
         assert!(err.to_string().contains("cannot be resolved"), "{err}");
     }
 

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -428,6 +428,302 @@ mod tests {
         );
     }
 
+    // ── [read_paths]: reads may be granted outside the workdir ────────────
+
+    /// Tools whose context carries a `[read_paths]` policy compiled for
+    /// `workdir` (no home, unix path semantics - the platform seams have
+    /// their own tests in `leviath_core::read_paths`).
+    fn make_tools_with_read_paths(
+        workdir: &std::path::Path,
+        blueprint: &[&str],
+        grants: &[&str],
+        allow_blueprint: bool,
+    ) -> BuiltinTools {
+        let compile = |entries: &[&str]| {
+            let raw: Vec<String> = entries.iter().map(|s| s.to_string()).collect();
+            leviath_core::ReadPathSet::compile(&raw, workdir, None, false)
+                .expect("test entries compile")
+        };
+        let policy = leviath_core::ReadPathPolicy {
+            agent: "tester".into(),
+            blueprint: compile(blueprint),
+            grants: compile(grants),
+            allow_blueprint,
+        };
+        BuiltinTools::new(ToolContext::new(workdir.to_path_buf()).with_read_paths(policy))
+    }
+
+    /// The whole point of the feature: a declared-and-granted directory is
+    /// readable, through every read-only tool.
+    #[tokio::test]
+    async fn read_tools_reach_a_declared_and_granted_outside_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "outside contents").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[entry], false);
+
+        let target = outside.path().join("doc.md");
+        let target = target.to_str().unwrap();
+        let out = tools.read_file(&json!({ "path": target })).await;
+        assert_eq!(out, "outside contents");
+
+        let listed = tools
+            .list_dir(&json!({ "path": outside.path().to_str().unwrap() }))
+            .await;
+        assert!(listed.contains("doc.md"), "got: {listed}");
+
+        // `read_files` mixes inside and outside paths per element.
+        fs::write(dir.path().join("inside.txt"), "inside contents").unwrap();
+        let out = tools
+            .read_files(&json!({ "paths": ["inside.txt", target] }))
+            .await;
+        assert!(out.contains("inside contents"), "got: {out}");
+        assert!(out.contains("outside contents"), "got: {out}");
+    }
+
+    /// `[read_paths]` grants reads and nothing else: the same fully granted
+    /// path is still refused for `write_file` and `edit_file`, which never
+    /// consult the policy.
+    #[tokio::test]
+    async fn write_and_edit_stay_confined_despite_read_grants() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "original").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[entry], false);
+
+        let target = outside.path().join("doc.md");
+        let target = target.to_str().unwrap();
+        let out = tools
+            .write_file(&json!({ "path": target, "content": "clobbered" }))
+            .await;
+        assert!(out.contains("[error]"), "got: {out}");
+        let out = tools
+            .edit_file(&json!({ "path": target, "old_str": "original", "new_str": "x" }))
+            .await;
+        assert!(out.contains("[error]"), "got: {out}");
+        assert_eq!(
+            fs::read_to_string(outside.path().join("doc.md")).unwrap(),
+            "original",
+            "a read grant must never permit a write"
+        );
+    }
+
+    /// Declared by the blueprint but granted by nothing: refused, and the
+    /// error says exactly which config stanza would grant it.
+    #[tokio::test]
+    async fn an_ungranted_declaration_is_refused_with_guidance() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "secret").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[], false);
+
+        let target = outside.path().join("doc.md");
+        let out = tools
+            .read_file(&json!({ "path": target.to_str().unwrap() }))
+            .await;
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(out.contains("does not grant"), "got: {out}");
+        assert!(out.contains("[agent_read_paths.tester]"), "got: {out}");
+        assert!(!out.contains("secret"), "content must not leak");
+    }
+
+    /// The `allow_blueprint_read_paths` override honors declarations without
+    /// itemized grants - and still nothing beyond what is declared.
+    #[tokio::test]
+    async fn the_blanket_override_honors_declarations() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "outside contents").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[], true);
+
+        let target = outside.path().join("doc.md");
+        let out = tools
+            .read_file(&json!({ "path": target.to_str().unwrap() }))
+            .await;
+        assert_eq!(out, "outside contents");
+
+        // Undeclared stays undeclared: the override widens nothing.
+        let undeclared = tempfile::tempdir().unwrap();
+        fs::write(undeclared.path().join("x.txt"), "x").unwrap();
+        let out = tools
+            .read_file(&json!({ "path": undeclared.path().join("x.txt").to_str().unwrap() }))
+            .await;
+        assert!(
+            out.contains("not in this agent's [read_paths]"),
+            "got: {out}"
+        );
+    }
+
+    /// With no `[read_paths]` at all, an outside read gets the original
+    /// workdir refusal, word for word - the policy is never consulted.
+    #[tokio::test]
+    async fn an_inactive_policy_keeps_the_workdir_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let out = tools.read_file(&json!({ "path": "/etc/hosts" })).await;
+        assert!(
+            out.contains("would escape the working directory"),
+            "got: {out}"
+        );
+    }
+
+    /// A relative request resolves against the workdir in the fallback too,
+    /// so a workdir-relative entry like `../shared` is reachable by the
+    /// matching relative request.
+    #[tokio::test]
+    async fn a_relative_request_reaches_a_relative_grant() {
+        let parent = tempfile::tempdir().unwrap();
+        let workdir = parent.path().join("work");
+        let shared = parent.path().join("shared");
+        fs::create_dir_all(&workdir).unwrap();
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(shared.join("doc.md"), "shared contents").unwrap();
+        let tools = make_tools_with_read_paths(&workdir, &["../shared"], &["../shared"], false);
+
+        let out = tools
+            .read_file(&json!({ "path": "../shared/doc.md" }))
+            .await;
+        assert_eq!(out, "shared contents");
+    }
+
+    /// An interior `.` in a fallback request is folded away (`Path::components`
+    /// drops it), so `<granted>/./doc.md` resolves the same as
+    /// `<granted>/doc.md`.
+    #[tokio::test]
+    async fn a_dot_component_is_folded_in_the_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "outside contents").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[entry], false);
+
+        let target = format!("{}/./doc.md", outside.path().to_str().unwrap());
+        let out = tools.read_file(&json!({ "path": target })).await;
+        assert_eq!(out, "outside contents");
+    }
+
+    /// Folding `..` past the filesystem root is unresolvable no matter what
+    /// any allowlist says.
+    #[test]
+    fn folding_past_the_root_is_unresolvable() {
+        let policy = leviath_core::ReadPathPolicy {
+            agent: "tester".into(),
+            allow_blueprint: true,
+            ..Default::default()
+        };
+        let err = BuiltinTools::resolve_outside(
+            "/..",
+            Path::new("/w"),
+            &policy,
+            leviath_core::canonicalize_for_match,
+        )
+        .expect_err("popping past the root must be refused");
+        assert!(err.to_string().contains("cannot be resolved"), "{err}");
+    }
+
+    /// The fail-closed arm, driven through the injected canonicalizer so it
+    /// runs on every platform: a path nothing can verify is refused, never
+    /// matched.
+    #[test]
+    fn an_unverifiable_path_is_refused() {
+        fn unverifiable(_: &Path) -> Option<PathBuf> {
+            None
+        }
+        let policy = leviath_core::ReadPathPolicy {
+            agent: "tester".into(),
+            allow_blueprint: true,
+            ..Default::default()
+        };
+        let err =
+            BuiltinTools::resolve_outside("/outside/x", Path::new("/w"), &policy, unverifiable)
+                .expect_err("an unverifiable path must be refused");
+        assert!(err.to_string().contains("cannot be verified"), "{err}");
+    }
+
+    /// The attack the policy exists to stop: a symlink planted *inside* a
+    /// granted directory, pointing outside it. The policy sees the real
+    /// target, which no entry declares.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_inside_a_granted_directory_cannot_escape_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let granted = tempfile::tempdir().unwrap();
+        let secret_home = tempfile::tempdir().unwrap();
+        fs::write(secret_home.path().join("id_rsa"), "PRIVATE KEY").unwrap();
+        std::os::unix::fs::symlink(
+            secret_home.path().join("id_rsa"),
+            granted.path().join("innocent.md"),
+        )
+        .unwrap();
+        let entry = granted.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[entry], false);
+
+        let out = tools
+            .read_file(&json!({ "path": granted.path().join("innocent.md").to_str().unwrap() }))
+            .await;
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(!out.contains("PRIVATE KEY"), "content must not leak");
+    }
+
+    /// The same attack against a glob entry - the variant the original PR
+    /// missed entirely. The pattern is matched against the symlink-resolved
+    /// real path, and the real target does not match it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_glob_grant_is_symlink_safe() {
+        let dir = tempfile::tempdir().unwrap();
+        let granted = tempfile::tempdir().unwrap();
+        let secret_home = tempfile::tempdir().unwrap();
+        fs::write(secret_home.path().join("id_rsa"), "PRIVATE KEY").unwrap();
+        std::os::unix::fs::symlink(
+            secret_home.path().join("id_rsa"),
+            granted.path().join("innocent.md"),
+        )
+        .unwrap();
+        // Patterns match the canonical real path, so build the entry from it.
+        let canonical = fs::canonicalize(granted.path()).unwrap();
+        let entry = format!("glob:{}/**", canonical.display());
+        let tools = make_tools_with_read_paths(dir.path(), &[&entry], &[&entry], false);
+
+        let out = tools
+            .read_file(&json!({ "path": granted.path().join("innocent.md").to_str().unwrap() }))
+            .await;
+        assert!(out.contains("[error]"), "got: {out}");
+        assert!(!out.contains("PRIVATE KEY"), "content must not leak");
+
+        // The positive pair: a real file under the same glob is readable, so
+        // the refusal above is the symlink and not the pattern.
+        fs::write(granted.path().join("real.md"), "real contents").unwrap();
+        let out = tools
+            .read_file(&json!({ "path": granted.path().join("real.md").to_str().unwrap() }))
+            .await;
+        assert_eq!(out, "real contents");
+    }
+
+    /// A symlink whose target stays inside the granted subtree is fine - the
+    /// rule is about where the path lands, exactly as in the workdir.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_within_a_granted_directory_is_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let granted = tempfile::tempdir().unwrap();
+        fs::create_dir(granted.path().join("real")).unwrap();
+        fs::write(granted.path().join("real/doc.md"), "granted contents").unwrap();
+        std::os::unix::fs::symlink(granted.path().join("real"), granted.path().join("link"))
+            .unwrap();
+        let entry = granted.path().to_str().unwrap();
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[entry], false);
+
+        let out = tools
+            .read_file(&json!({ "path": granted.path().join("link/doc.md").to_str().unwrap() }))
+            .await;
+        assert_eq!(out, "granted contents");
+    }
+
     /// A symlink that stays *inside* the workdir keeps working - the rule is
     /// about where the path lands, not whether a symlink was involved. Agents
     /// operate on real repositories, which contain plenty of internal symlinks.

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -607,9 +607,13 @@ mod tests {
     }
 
     /// Folding `..` past the top is unresolvable no matter what any allowlist
-    /// says. A leading `..` against an empty base leaves nothing to pop on
-    /// every platform - `/..` would not, since it is not absolute on Windows
-    /// and gets reshaped by the workdir join there.
+    /// says. Mirrors `resolve_rejects_excessive_parent_dir_traversal`: a
+    /// *relative* base (`wd`) gives the accumulator exactly one leading
+    /// `Normal` component and no platform-specific root/drive/prefix, so the
+    /// first `..` pops `wd` and the second calls `pop()` on an empty
+    /// accumulator - firing the bail on every OS. `/..` or an empty base does
+    /// not: neither is absolute on Windows, and the join reshapes them so the
+    /// `pop()` never fails there.
     #[test]
     fn folding_past_the_root_is_unresolvable() {
         let policy = leviath_core::ReadPathPolicy {
@@ -618,8 +622,8 @@ mod tests {
             ..Default::default()
         };
         let err = BuiltinTools::resolve_outside(
-            "../x",
-            Path::new(""),
+            "../../x",
+            Path::new("wd"),
             &policy,
             leviath_core::canonicalize_for_match,
         )

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -148,6 +148,20 @@ entry stage's sandbox, time- and size-capped.
 > seed a blueprint will run; review them for third-party blueprints. Refuse with
 > `--no-seed-commands` or `[security] allow_seed_commands = false`.
 
+## Read paths
+
+An agent that needs to *read* beyond its workdir - run archives, design docs, sibling
+directories - declares them:
+
+```toml
+[read_paths]
+allow = ["~/.leviath/runs", "../shared-docs", "glob:~/design-docs/**"]
+```
+
+The declarations do nothing on their own: the user's config must grant them, they are
+read-only, and every access is checked against the symlink-resolved real path. See
+[Security](/docs/security) for the grant stanzas and the full matching rules.
+
 ## How the coding agents verify their work
 
 The bundled coding agents (`software-engineer`, `coder`) treat verification as workflow, not

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -15,6 +15,7 @@ run `lev <command> --help` for the full, authoritative flag list.
 | Command | Purpose |
 |---|---|
 | `lev run <agent> --task "…"` | Start an agent (built-in name or a blueprint path) |
+| `lev run <agent> --workdir <dir>` | Run the agent over a different directory (default: where you ran the command) |
 | `lev create <name>` | Scaffold a new [`agent.leviath` blueprint](/docs/agents) |
 | `lev validate <path>` | Check a blueprint's graph, seeds, and permissions |
 | `lev test <path>` | Dry-run a blueprint |

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -34,6 +34,65 @@ kind = "none"             # run discovery on the host…
 > An *installed* agent can only ever **tighten** its sandbox: it can raise the walls, never lower
 > them. A blueprint you install can't quietly turn isolation off.
 
+## Reading outside the workdir
+
+An agent's file tools are confined to its workdir. Some agents legitimately need to see more:
+a planner that reads run archives, a reviewer that reads design docs kept next to the repo. For
+that, a blueprint can declare extra read paths:
+
+```toml
+[read_paths]
+allow = [
+    "~/.leviath/runs",          # an exact path grants its whole subtree
+    "../shared-docs",           # relative entries resolve against the run's workdir
+    "glob:~/design-docs/**",    # glob patterns; * stays in one component, ** crosses
+    "regex:/data/archives/.*",  # regex patterns, auto-anchored (^...$)
+]
+```
+
+Declaring is not granting. The manifest travels with the agent package, and a package can only
+tighten what your config allows. Declared paths stay inert until your `config.toml` grants them:
+
+```toml
+# Grant specific paths, for one agent...
+[agent_read_paths.cto]
+allow = ["~/.leviath/runs", "glob:~/design-docs/**"]
+
+# ...or machine-wide, for any agent that declares them:
+[security]
+read_paths = ["~/.leviath/runs"]
+
+# Or trust every blueprint's declarations wholesale (off by default):
+[security]
+allow_blueprint_read_paths = true
+```
+
+A grant applies to a path only when the running blueprint also declares it, so listing a
+directory in your config does not open it to agents that never asked. When an agent declares
+paths nothing grants, it still runs; the reads are refused and a spawn warning shows the exact
+stanza to add. `lev add` and `lev validate` both report what an agent asks for.
+
+The rules that keep this safe:
+
+- **Read-only.** Only `read_file`, `read_files`, and `list_dir` can leave the workdir.
+  `write_file` and `edit_file` are confined to the workdir no matter what is granted.
+- **Symlinks cannot widen a grant.** Every access is resolved to its real path first, and the
+  real path must match a declared and granted entry. A symlink planted inside a granted
+  directory that points at `~/.ssh` is refused.
+- **Patterns match the real path**, written with `/` on every OS (on Windows, matching is
+  case-insensitive and the `\\?\` prefix is handled for you). On macOS note that `/tmp` is
+  really `/private/tmp`; `~/` entries avoid the problem since the home directory is stable.
+- **Regexes are anchored.** `regex:/data/runs` matches exactly that path, not
+  `/data/runs-anything`; end a pattern with `/.*` to grant a subtree. A relative regex is
+  refused; use `glob:` for workdir-relative patterns.
+- **Taint rises.** When a grant is active, the read tools are classified `Private` for that
+  agent, so taint tracking treats out-of-workdir content with more suspicion, not less.
+- Rhai script tools have their own `read_file` and it stays workdir-confined; `[read_paths]`
+  applies to the built-in file tools only.
+
+Pick the run's workdir itself with `lev run <agent> --workdir <dir>` (defaults to the directory
+you ran the command from).
+
 ## Taint tracking (experimental)
 
 A deterministic sensitivity model (**Public / Internal / Private**) tags every


### PR DESCRIPTION
## Summary

Adds a `[read_paths]` section to agent blueprints that allows agents (especially C-suite) to read files from additional directories beyond their workdir. Supports exact paths, glob patterns, and regex patterns.

## Motivation

C-suite agents (CTO, TL, bottleneck-investigator) need to read files anywhere on the filesystem — design docs, run archives, other agent blueprints — to scope work and make decisions.

**Without this**, C-suite agents must either:
- Use `shell` to `Get-Content` files outside the workdir (defeats the file sandbox)
- Have `workdir` set to filesystem root (defeats the sandbox entirely)
- Copy all referenced files into workdir before every run (operational friction)

**With this**, agents declare exactly what they can see. Explicit, auditable, secure.

## Usage

```toml
[read_paths]
allow = [
    # Exact paths
    "C:\\Users\\jlear\\.leviath\\runs",
    # Glob patterns
    "glob:C:\\Users\\jlear\\.leviath\\runs\\**",
    # Regex patterns  
    "regex:^C:\\\\Users\\\\jlear\\\\.leviath\\\\agents\\\\.*",
]
```

## Implementation

| File | Change |
|------|--------|
| `leviath-core/src/blueprint.rs` | Added `ReadPathsConfig` struct deserialized from `[read_paths]` |
| `leviath-core/src/paths.rs` | Added `ReadPathEntry` enum (Exact/Glob/Regex) with `parse()` and `matches()` |
| `leviath-core/Cargo.toml` | Added `glob` and `regex` dependencies |
| `leviath-core/src/lib.rs` | Exported `ReadPathsConfig` and `ReadPathEntry` |
| `leviath-tools/src/context.rs` | Added `read_paths` field and `with_read_paths()` constructor to `ToolContext` |
| `leviath-tools/src/exec.rs` | Modified `resolve()` to check `read_paths` allowlist when workdir check fails |
| `leviath-cli/src/daemon/spawn.rs` | Parse `read_paths` from blueprint and pass to `ToolContext` |

## Security

- **Read-only**: Only applies to `read_file`/`read_files`. `write_file` and `edit_file` remain sandboxed to workdir.
- **Symlink validation**: Exact-path entries get `resolves_within()` check against their canonicalized root.
- **No traversal**: All `..` and `.` are normalized before matching.
- **Invalid entries**: Skipped at spawn time with a warning, not a fatal error.

## Design decision

We chose `[read_paths]` over a `c_suite: true` boolean or `read_file = "allow-anywhere"` permission because it is granular, explicit, and auditable. Each agent declares exactly what it can see.
