### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ in [the release docs](https://leviath.dev/docs/releases); each versioned
 GitHub release also carries auto-generated notes listing the merged pull
 requests since the previous version.
 
+## 0.1.1 - 2026-07-31
+
+Post-launch cleanup.
+
+- The daemon's launchd service label is now `dev.leviath.daemon`;
+  `lev daemon install`/`uninstall` also remove any registration under the old
+  `ai.sunforge.leviath` label, so upgrading cannot leave a stale supervised
+  daemon behind.
+- The `lev run` error hint shows a working invocation.
+- Removed the outdated per-agent READMEs bundled with the CLI (the
+  [agent catalog](https://leviath.dev/docs/agent-catalog) is the maintained
+  reference); improved the crates.io pages with inline install steps and a
+  runnable library example.
+- crates.io releases are now published automatically from each stable deploy,
+  from the same commit the binaries are built at.
+
 ## 0.1.0 - 2026-07-31
 
 First public release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,7 +2174,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "keyring",
  "keyring-core",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tokio",
  "tracing",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "leviath-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -60,17 +60,17 @@ string_slice = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.1.0" }
-leviath-core = { path = "crates/leviath-core", version = "0.1.0" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.1.0" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.1.0" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.1.0" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.1.0" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.1.0" }
-leviath-package = { path = "crates/leviath-package", version = "0.1.0" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.1.0" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.1.0" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.1.0" }
+leviath = { path = "crates/leviath", version = "0.1.1" }
+leviath-core = { path = "crates/leviath-core", version = "0.1.1" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.1.1" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.1.1" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.1.1" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.1.1" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.1.1" }
+leviath-package = { path = "crates/leviath-package", version = "0.1.1" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.1.1" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.1.1" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.1.1" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies


### PR DESCRIPTION
Bumps `[workspace.package] version` and the 11 internal dependency version fields to 0.1.1, refreshes Cargo.lock, and adds the CHANGELOG entry.

This is the first version to exercise the full automated pipeline: once merged, alpha builds it, beta and prod promote it, and prod's `publish-crates` job publishes all twelve crates to crates.io from the promoted commit — carrying the launch cleanup (service label migration, corrected `lev run` hint, refreshed crates.io pages, facade example) to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km9mfcU1ezK2HgB9SJa2R2