### PR TITLE
Hot-reload daemon config so config.toml edits take effect on the next run

### DIFF
--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -1,0 +1,278 @@
+//! Hot-reloading of the daemon's spawn-time config.
+//!
+//! The daemon loads `~/.leviath/config.toml` once at startup and would
+//! otherwise serve that snapshot for its whole life - so a user who granted a
+//! `[read_paths]` path, flipped a tool permission, or changed a limit had to
+//! restart the daemon before the next `lev run` saw it. That is a surprising
+//! loop to be stuck in: the spawn warning tells you to edit the config, and
+//! editing it appears to do nothing.
+//!
+//! [`ConfigReloader`] closes that gap for the config an agent reads *at spawn*
+//! (permissions, `[read_paths]`, sandbox defaults, limits, taint). It reloads
+//! the file when its mtime changes, mirroring the script-provider hot-reload
+//! (`leviath_runtime::script_provider`), and keeps the last good config if a
+//! reload fails so an edit saved mid-keystroke never breaks a spawn.
+//!
+//! What it deliberately does **not** reload is the infrastructure established
+//! once at boot: the provider registry, MCP connections, the outbound-network
+//! policy, and the telemetry sink. Those hold live connections and
+//! process-wide state; re-initializing them on a file write is a much larger
+//! change with its own failure modes. Adding a provider key or an MCP server
+//! still needs a daemon restart; see `daemon.md`.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::SystemTime;
+
+use crate::config::Config;
+
+/// The config as of a given file mtime.
+struct Cached {
+    /// The file mtime this config was loaded from. `None` means the file did
+    /// not exist at load time (defaults in use); it reloads if the file later
+    /// appears.
+    mtime: Option<SystemTime>,
+    config: Arc<Config>,
+}
+
+/// Serves the freshest spawn-time [`Config`], reloading `config.toml` when it
+/// changes on disk.
+pub struct ConfigReloader {
+    /// The file watched for changes - [`Config::config_path`] at construction.
+    /// `None` for a [`fixed`](Self::fixed) reloader that never watches a file.
+    path: Option<PathBuf>,
+    cache: Mutex<Cached>,
+}
+
+impl ConfigReloader {
+    /// Wrap the boot-loaded `initial` config, watching `path` (normally
+    /// [`Config::config_path`]). The file's current mtime is recorded so the
+    /// first [`current`](Self::current) call does not reload a config that has
+    /// not changed.
+    pub fn new(path: PathBuf, initial: Config) -> Self {
+        let mtime = file_mtime(&path);
+        Self {
+            path: Some(path),
+            cache: Mutex::new(Cached {
+                mtime,
+                config: Arc::new(initial),
+            }),
+        }
+    }
+
+    /// A reloader that never watches a file: [`current`](Self::current) always
+    /// returns `config`. For contexts that hold a config snapshot but do not
+    /// hot-reload (tests, and any caller that wants a fixed config).
+    pub fn fixed(config: Config) -> Self {
+        Self {
+            path: None,
+            cache: Mutex::new(Cached {
+                mtime: None,
+                config: Arc::new(config),
+            }),
+        }
+    }
+
+    /// The current spawn-time config: the cached copy when `config.toml` is
+    /// unchanged, or a freshly loaded one when its mtime moved.
+    ///
+    /// A reload that fails to parse (an edit saved half-written, a syntax
+    /// error) does not fail the caller - it logs a warning and returns the
+    /// last good config, so a broken file degrades to "your last saved config"
+    /// rather than a broken spawn. The stale mtime is retained, so the next
+    /// successful save is picked up.
+    pub fn current(&self) -> Arc<Config> {
+        let Some(path) = &self.path else {
+            // A fixed reloader: nothing to watch.
+            return self
+                .cache
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .config
+                .clone();
+        };
+        let mtime = file_mtime(path);
+        let mut cached = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
+        if mtime == cached.mtime {
+            return cached.config.clone();
+        }
+        // Bind the displayed path in a plain statement rather than as a lazy
+        // `%path.display()` tracing field: the method-call region inside a
+        // structured field is only reached when the callsite is enabled, and
+        // tracing caches callsite interest process-globally, so it is
+        // unreachable under a coverage run whose other tests hit it with no
+        // subscriber. A pre-bound value sidesteps that.
+        let displayed = path.display();
+        match Config::load_from_path_public(path) {
+            Ok(config) => {
+                let config = Arc::new(config);
+                cached.mtime = mtime;
+                cached.config = config.clone();
+                tracing::info!(path = %displayed, "reloaded config after an on-disk change");
+                config
+            }
+            Err(e) => {
+                // Keep the last-good config AND its mtime: retrying the same
+                // broken file every spawn would spam the log, and we want the
+                // *next* good save (a new mtime) to reload.
+                tracing::warn!(
+                    path = %displayed,
+                    error = %e,
+                    "config changed on disk but failed to reload; keeping the last good config"
+                );
+                cached.config.clone()
+            }
+        }
+    }
+}
+
+/// The file's modification time, or `None` if it does not exist or cannot be
+/// stat'd (treated as "no file" - a missing config means defaults).
+fn file_mtime(path: &std::path::Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn write(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// Force a file's mtime strictly newer, so a reload is observable even when
+    /// two writes land in the same clock tick (mirrors the script-provider
+    /// hot-reload test helper).
+    fn bump_mtime(path: &std::path::Path) {
+        let later = SystemTime::now() + Duration::from_secs(5);
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(later).unwrap();
+    }
+
+    /// A complete, valid config TOML (several top-level fields have no serde
+    /// default, so a partial document would not parse) granting `agent` one
+    /// read path.
+    fn config_with_grant(agent: &str, path: &str) -> String {
+        let mut c = Config::default();
+        c.agent_read_paths.insert(
+            agent.to_string(),
+            crate::config::ReadPathGrants {
+                allow: vec![path.to_string()],
+            },
+        );
+        toml::to_string(&c).unwrap()
+    }
+
+    fn empty_config() -> String {
+        toml::to_string(&Config::default()).unwrap()
+    }
+
+    #[test]
+    fn an_unchanged_file_returns_the_cached_config_without_reloading() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &empty_config());
+        let reloader = ConfigReloader::new(path.clone(), Config::default());
+
+        let a = reloader.current();
+        let b = reloader.current();
+        // Same Arc: no reload happened.
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn an_edited_file_is_reloaded_on_the_next_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &empty_config());
+        let reloader = ConfigReloader::new(path.clone(), Config::default());
+        assert!(
+            reloader
+                .current()
+                .read_path_grants_for_agent("cto")
+                .is_empty()
+        );
+
+        // The user grants a read path and saves.
+        write(&path, &config_with_grant("cto", "~/.leviath/runs"));
+        bump_mtime(&path);
+
+        // Subscriber active so the "reloaded config" info-log field evaluates.
+        let reloaded = reloader.current();
+        assert_eq!(
+            reloaded.read_path_grants_for_agent("cto"),
+            vec!["~/.leviath/runs".to_string()],
+            "the new grant must be visible without a restart"
+        );
+    }
+
+    #[test]
+    fn a_config_that_appears_after_boot_is_picked_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        // No file at construction: defaults, mtime None.
+        let reloader = ConfigReloader::new(path.clone(), Config::default());
+        assert!(
+            reloader
+                .current()
+                .read_path_grants_for_agent("cto")
+                .is_empty()
+        );
+
+        write(&path, &config_with_grant("cto", "~/docs"));
+        let reloaded = reloader.current();
+        assert_eq!(
+            reloaded.read_path_grants_for_agent("cto"),
+            vec!["~/docs".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_broken_edit_keeps_the_last_good_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &config_with_grant("cto", "~/good"));
+        // Mirror boot: the reloader is seeded with the config already on disk.
+        let reloader =
+            ConfigReloader::new(path.clone(), Config::load_from_path_public(&path).unwrap());
+        assert_eq!(
+            reloader.current().read_path_grants_for_agent("cto"),
+            vec!["~/good".to_string()]
+        );
+
+        // A half-saved, unparseable edit.
+        write(&path, "this is not valid : : toml");
+        bump_mtime(&path);
+
+        // Subscriber active so the "failed to reload" warn-log field evaluates.
+        let after = reloader.current();
+        assert_eq!(
+            after.read_path_grants_for_agent("cto"),
+            vec!["~/good".to_string()],
+            "a broken file must not break the spawn - keep the last good config"
+        );
+    }
+
+    #[test]
+    fn a_good_save_after_a_broken_one_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &config_with_grant("cto", "~/good"));
+        let reloader =
+            ConfigReloader::new(path.clone(), Config::load_from_path_public(&path).unwrap());
+        let _ = reloader.current();
+
+        write(&path, "broken : :");
+        bump_mtime(&path);
+        let _ = reloader.current(); // keeps last-good
+
+        // The user fixes it.
+        write(&path, &config_with_grant("cto", "~/fixed"));
+        bump_mtime(&path);
+        assert_eq!(
+            reloader.current().read_path_grants_for_agent("cto"),
+            vec!["~/fixed".to_string()]
+        );
+    }
+}

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -23,7 +23,6 @@ use leviath_runtime::pipeline::{AgentBlueprint, force_transition};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::config::Config;
 use crate::daemon::client::resolve_spawn_args;
 use crate::daemon::spawn::build_agent;
 use crate::daemon::tool_service::CliToolService;
@@ -32,7 +31,9 @@ use crate::daemon::tool_service::CliToolService;
 /// from inside a world-system (which has no access to the daemon's context).
 #[derive(Clone)]
 pub struct DaemonFanOutSpawner {
-    pub config: Config,
+    /// Spawn-time config, read fresh per worker so a `config.toml` edit reaches
+    /// fan-out workers too (shared with the daemon's main spawner).
+    pub config: Arc<crate::daemon::config_reload::ConfigReloader>,
     pub shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
     pub mcp_tool_defs: Vec<Tool>,
     /// Shared MCP pool for per-agent `[[mcp_servers]]` - a fan-out worker
@@ -118,10 +119,11 @@ impl FanOutSpawner for DaemonFanOutSpawner {
         // `worker_agent`/`worker_query` worker warms them here for its siblings).
         let mcp_defs = self.worker_mcp_defs(&args.blueprint_path);
 
+        let config = self.config.current();
         let child = build_agent(
             world,
             self.tool_service.as_ref(),
-            &self.config,
+            &config,
             self.shared_mcp.clone(),
             &mcp_defs,
             &self.hub,
@@ -203,6 +205,7 @@ fn discover_worker(agents_dir: Option<&Path>, query: &str) -> Result<PathBuf, St
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
     use leviath_core::blueprint::WorkerFailurePolicy;
 
     fn cfg(stage: Option<&str>, agent: Option<&str>, query: Option<&str>) -> FanOutConfig {
@@ -345,7 +348,9 @@ mod tests {
     fn spawner_with(tool_service: Arc<CliToolService>) -> DaemonFanOutSpawner {
         let shared_mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
         DaemonFanOutSpawner {
-            config: Config::default(),
+            config: Arc::new(crate::daemon::config_reload::ConfigReloader::fixed(
+                Config::default(),
+            )),
             shared_mcp: shared_mcp.clone(),
             mcp_tool_defs: vec![],
             mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(shared_mcp, &[]),
@@ -433,7 +438,7 @@ mod tests {
         let parent = build_agent(
             world.world_mut(),
             cli.as_ref(),
-            &spawner.config,
+            &spawner.config.current(),
             spawner.shared_mcp.clone(),
             &spawner.mcp_tool_defs,
             &spawner.hub,

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -5,6 +5,7 @@
 //! to the built-in / MCP executors and the interaction hub.
 
 pub mod client;
+pub mod config_reload;
 pub mod fanout_spawner;
 pub mod gate_rules;
 pub mod mcp_pool;

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -185,11 +185,22 @@ pub fn build_host(
         host.register(run_id, entity);
     }
 
+    // Config hot-reload: after boot, spawn-time config (permissions,
+    // `[read_paths]`, sandbox, limits, taint) is served from here, reloaded
+    // when `config.toml` changes on disk. The boot infrastructure (provider
+    // registry, MCP pool, network policy, telemetry) keeps the boot snapshot -
+    // those hold live connections and need a restart - so the reloader takes a
+    // clone and the boot snapshot stays usable below.
+    let reloader = std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+        Config::config_path(),
+        config.clone(),
+    ));
+
     // Install the fan-out spawner as a world resource so the runtime's fan-out
     // systems can start workers (it captures the same context as the spawner
     // below, cloned before those move into the closure).
     let fanout_spawner = DaemonFanOutSpawner {
-        config: config.clone(),
+        config: reloader.clone(),
         shared_mcp: shared_mcp.clone(),
         mcp_tool_defs: mcp_tool_defs.clone(),
         mcp_pool: mcp_pool.clone(),
@@ -243,13 +254,16 @@ pub fn build_host(
     // disk. Capture the shared context (cloned before the spawner moves the
     // originals below).
     let reload_tools = tool_service.clone();
-    let reload_config = config.clone();
+    let reload_reloader = reloader.clone();
     let reload_mcp = shared_mcp.clone();
     let reload_defs = mcp_tool_defs.clone();
     let reload_hub = hub.clone();
     let reload_tx = subagent_tx.clone();
     let reload_runs = runs_dir.clone();
     host.set_reloader(Box::new(move |world, run_id| {
+        // Pages a run back in with the current on-disk config, matching what a
+        // real restart would restore it with.
+        let reload_config = reload_reloader.current();
         crate::daemon::recovery::reload_run(
             world,
             reload_tools.as_ref(),
@@ -305,6 +319,7 @@ pub fn build_host(
     // servers' defs plus this blueprint's declared servers' defs (warmed above).
     let spawn_pool = mcp_pool.clone();
     let spawn_runs_dir = runs_dir.clone();
+    let spawn_reloader = reloader.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -314,6 +329,10 @@ pub fn build_host(
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
         let defs = per_agent_mcp_defs(&spawn_pool, &mcp_tool_defs, &args.blueprint_path);
+        // Fresh config per spawn: a `config.toml` edit (a new `[read_paths]`
+        // grant, a permission change) takes effect on the next `lev run`
+        // without a daemon restart.
+        let config = spawn_reloader.current();
         build_agent(
             world.world_mut(),
             tool_service.as_ref(),

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -67,6 +67,21 @@ lev daemon uninstall
 > An installed daemon plus [`lev serve`](/docs/api) is all you need to drive Leviath from the
 > browser [console](/app), no terminal required.
 
+## Config changes take effect on the next run
+
+The daemon watches `~/.leviath/config.toml` and picks up your edits automatically. When you change
+per-run policy - a tool permission, a `[read_paths]` grant, a sandbox default, a limit, taint - the
+**next `lev run` uses the new value with no restart**. If a save leaves the file briefly unparseable
+(a half-typed edit), the daemon keeps serving your last good config and reloads on the next clean
+save, so an in-progress edit never breaks a spawn.
+
+Two kinds of change still need `lev daemon restart`, because they set up connections and
+process-wide state once at startup rather than per run:
+
+- provider keys and `[model_providers]` (the provider registry)
+- `[[mcp_servers]]` (live MCP connections), `[observability]` (the telemetry pipeline), and
+  `[security] allow_local_network` (the outbound-network policy)
+
 ## Control surface
 
 The daemon is reached over a local **control socket**: a Unix socket / Windows pipe guarded by a

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -72,6 +72,11 @@ directory in your config does not open it to agents that never asked. When an ag
 paths nothing grants, it still runs; the reads are refused and a spawn warning shows the exact
 stanza to add. `lev add` and `lev validate` both report what an agent asks for.
 
+You do not need to restart the daemon after editing the grant: it reloads `config.toml` on
+change, so the **next `lev run` picks up the new grant automatically** (see
+[the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run)). An agent that just
+failed on a refused read succeeds the next time you run it, once you have added the grant.
+
 The rules that keep this safe:
 
 - **Read-only.** Only `read_file`, `read_files`, and `list_dir` can leave the workdir.


### PR DESCRIPTION
## Motivation

The daemon loaded `~/.leviath/config.toml` once at startup and served that snapshot for its whole life. So the scenario a user hits right after the `[read_paths]` feature (#178) — an agent's read is refused, you edit the config to grant the path, you re-run — **still failed**, because the running daemon never re-read the file. The spawn warning told you to edit the config, and editing it appeared to do nothing until a manual `lev daemon restart`.

## What this does

Adds a `ConfigReloader` (`crates/leviath-cli/src/daemon/config_reload.rs`) that mirrors the existing script-provider hot-reload: it reloads `config.toml` when its mtime changes, and keeps the last good config if a reload fails so a half-saved edit never breaks a spawn. The main spawner, the fan-out worker spawner, and the reload-on-demand path all read spawn-time config through it, so any agent **run or resumed after an edit uses the new config — no restart**.

## Scope

Hot-reload covers the **spawn-time policy config**: tool permissions, `[read_paths]`, sandbox defaults, limits, taint. Boot infrastructure keeps its startup snapshot, because those establish live connections / process-wide state once and re-initializing them on a file write is a much larger, riskier change:

- provider keys / `[model_providers]` (the provider registry)
- `[[mcp_servers]]` (MCP connections), `[observability]` (telemetry), `[security] allow_local_network` (network policy)

Those still need `lev daemon restart`, documented in `daemon.md` and the read_paths section of `security.md`.

## Verification

- Full workspace coverage gate at 100%; clippy + fmt clean.
- Unit tests for the reloader: unchanged file (no reload), edited file (reloads), config appearing after boot, broken edit keeps last-good, good save after a broken one recovers.
- **Live**: with the daemon running, an agent's read is refused; the config is edited to grant the path *without restarting the daemon*; the next `lev run` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)