### PR TITLE
feat: intern region entry content at the runtime boundary

### DIFF
--- a/crates/leviath-core/src/intern.rs
+++ b/crates/leviath-core/src/intern.rs
@@ -1,0 +1,229 @@
+//! Content interning for region entry text.
+//!
+//! [`ContentInterner`] is a **shareable handle** (`Clone` is cheap and shares the
+//! table). The runtime inserts one as a Bevy `Resource` and clones that handle
+//! into every [`crate::region`]-backing context window so agents in the same
+//! World deduplicate identical entry text.
+//!
+//! This module has no process-global state: two independently constructed
+//! interners never share allocations. That keeps tests isolated and matches
+//! multi-World / multi-daemon deployment.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex, Weak};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Handle to a content-addressed string table.
+///
+/// `Clone` shares the underlying table (via `Arc`). Construct once per ECS
+/// World (as a resource) and clone into each agent context.
+#[derive(Clone, Default)]
+pub struct ContentInterner {
+    inner: Arc<Mutex<InternerState>>,
+}
+
+#[derive(Default)]
+struct InternerState {
+    /// Hash → weak handles still (or recently) live under that hash.
+    buckets: HashMap<u64, Vec<Weak<str>>>,
+}
+
+impl ContentInterner {
+    /// Empty interner with its own private table.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(InternerState::default())),
+        }
+    }
+
+    /// Intern `s`, reusing an existing allocation when this interner already
+    /// holds identical text.
+    pub fn intern(&self, s: impl AsRef<str>) -> InternedString {
+        let s = s.as_ref();
+        let hash = {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            s.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let bucket = guard.buckets.entry(hash).or_default();
+        bucket.retain(|w| w.strong_count() > 0);
+
+        for weak in bucket.iter() {
+            if let Some(arc) = weak.upgrade()
+                && arc.as_ref() == s
+            {
+                return InternedString(arc);
+            }
+        }
+
+        let arc: Arc<str> = Arc::from(s);
+        bucket.push(Arc::downgrade(&arc));
+        InternedString(arc)
+    }
+
+    /// True when `self` and `other` share the same underlying table.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl fmt::Debug for ContentInterner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ContentInterner(..)")
+    }
+}
+
+/// Interned, reference-counted entry text.
+///
+/// Opaque outside this module's constructors. Callers read plain `&str` via
+/// [`crate::region::RegionEntry::content`].
+#[derive(Clone, Eq)]
+pub struct InternedString(Arc<str>);
+
+impl InternedString {
+    /// Allocate without consulting any interner table (no cross-entry sharing).
+    #[inline]
+    pub fn unique(s: impl AsRef<str>) -> Self {
+        Self(Arc::from(s.as_ref()))
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl PartialEq for InternedString {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.0.as_ref() == other.0.as_ref()
+    }
+}
+
+impl PartialEq<str> for InternedString {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl PartialEq<&str> for InternedString {
+    fn eq(&self, other: &&str) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
+impl PartialEq<String> for InternedString {
+    fn eq(&self, other: &String) -> bool {
+        self.0.as_ref() == other.as_str()
+    }
+}
+
+impl Hash for InternedString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ref().hash(state);
+    }
+}
+
+impl Deref for InternedString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for InternedString {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.0.as_ref(), f)
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for InternedString {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for InternedString {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Deserialization has no interner in scope (snapshots are pure data).
+        // Use a unique Arc; restore paths re-intern via [`ContentInterner`].
+        let s = String::deserialize(deserializer)?;
+        Ok(InternedString(Arc::from(s.as_str())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_interner_shares_allocation() {
+        let i = ContentInterner::new();
+        let a = i.intern("pinned");
+        let b = i.intern("pinned");
+        assert!(a.ptr_eq(&b));
+    }
+
+    #[test]
+    fn distinct_interners_do_not_share() {
+        let a = ContentInterner::new().intern("pinned");
+        let b = ContentInterner::new().intern("pinned");
+        assert!(!a.ptr_eq(&b));
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn clone_handle_shares_table() {
+        let i1 = ContentInterner::new();
+        let i2 = i1.clone();
+        assert!(i1.ptr_eq(&i2));
+        let a = i1.intern("x");
+        let b = i2.intern("x");
+        assert!(a.ptr_eq(&b));
+    }
+
+    #[test]
+    fn unique_never_shares_with_interned() {
+        let i = ContentInterner::new();
+        let a = InternedString::unique("same");
+        let b = i.intern("same");
+        assert!(!a.ptr_eq(&b));
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_text() {
+        let i = ContentInterner::new();
+        let a = i.intern("hello");
+        let json = serde_json::to_string(&a).unwrap();
+        let b: InternedString = serde_json::from_str(&json).unwrap();
+        assert_eq!(a.as_str(), b.as_str());
+        // deserialize has no interner — unique Arc
+        assert!(!a.ptr_eq(&b));
+    }
+}

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod credentials;
 pub mod error;
 pub mod interaction;
+pub mod intern;
 pub mod layout;
 pub mod lifecycle;
 pub mod manifest;
@@ -43,6 +44,7 @@ pub use credentials::{
     CredentialStore, CredentialStoreKind, MemoryStore, mcp_account, provider_account,
 };
 pub use error::{Error, Result, ValidationError};
+pub use intern::ContentInterner;
 pub use layout::{BudgetSpec, ContextLayout, RegionDefinition};
 pub use lifecycle::CompactionConfig;
 pub use net::{

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -6,6 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::intern::{ContentInterner, InternedString};
+
 /// The kind of content stored in a region entry.
 ///
 /// Entries carry typed metadata instead of relying on text-prefix parsing
@@ -311,43 +313,11 @@ impl Region {
     /// Add an entry with a taint level. Used when taint tracking is enabled.
     pub fn add_tainted_entry(
         &mut self,
-        content: String,
+        content: impl AsRef<str>,
         tokens: usize,
         taint_level: crate::taint::TaintLevel,
     ) -> crate::error::Result<()> {
-        // Validate against schema if present
-        if let Some(schema) = &self.schema {
-            schema.validate(&content)?;
-        }
-
-        // Check token budget
-        if self.current_tokens + tokens > self.max_tokens {
-            return Err(crate::error::Error::TokenBudgetExceeded {
-                used: self.current_tokens + tokens,
-                max: self.max_tokens,
-            });
-        }
-
-        // Add entry
-        self.content.push(RegionEntry {
-            content,
-            tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: None,
-            kind: EntryKind::default(),
-            key: None,
-        });
-        self.current_tokens += tokens;
-
-        // Update taint tracking
-        if let Some(taint) = &mut self.taint {
-            taint.add_entry(taint_level);
-        }
-
-        // Enforce SlidingWindow max_items limit
-        self.enforce_sliding_window();
-
-        Ok(())
+        self.insert_tainted_entry(RegionEntry::new(content, tokens), taint_level)
     }
 
     /// Add a typed entry with a taint level.
@@ -360,44 +330,14 @@ impl Region {
     /// both keeps its `ToolResult` kind and raises the region's taint level.
     pub fn add_typed_tainted_entry(
         &mut self,
-        content: String,
+        content: impl AsRef<str>,
         tokens: usize,
         kind: EntryKind,
         taint_level: crate::taint::TaintLevel,
     ) -> crate::error::Result<()> {
-        // Validate against schema if present
-        if let Some(schema) = &self.schema {
-            schema.validate(&content)?;
-        }
-
-        // Check token budget
-        if self.current_tokens + tokens > self.max_tokens {
-            return Err(crate::error::Error::TokenBudgetExceeded {
-                used: self.current_tokens + tokens,
-                max: self.max_tokens,
-            });
-        }
-
-        // Add entry
-        self.content.push(RegionEntry {
-            content,
-            tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: None,
-            kind,
-            key: None,
-        });
-        self.current_tokens += tokens;
-
-        // Update taint tracking with the supplied level
-        if let Some(taint) = &mut self.taint {
-            taint.add_entry(taint_level);
-        }
-
-        // Enforce SlidingWindow max_items limit
-        self.enforce_sliding_window();
-
-        Ok(())
+        let mut entry = RegionEntry::new(content, tokens);
+        entry.kind = kind;
+        self.insert_tainted_entry(entry, taint_level)
     }
 
     /// Add a validation schema to this region.
@@ -406,86 +346,80 @@ impl Region {
         self
     }
 
-    /// Add an entry to this region.
+    /// Insert a pre-built entry (runtime boundary).
     ///
-    /// Validates content against schema if present, checks token budget,
-    /// and adds the entry to the region.
-    pub fn add_entry(&mut self, content: String, tokens: usize) -> crate::error::Result<()> {
-        // Validate against schema if present
+    /// Validates the entry's content against schema if present, checks the
+    /// token budget, and pushes. Used by context windows that have already
+    /// interned the text — domain code should prefer [`Self::add_entry`].
+    pub fn insert_entry(&mut self, entry: RegionEntry) -> crate::error::Result<()> {
         if let Some(schema) = &self.schema {
-            schema.validate(&content)?;
+            schema.validate(entry.content())?;
         }
-
-        // Check token budget
-        if self.current_tokens + tokens > self.max_tokens {
+        if self.current_tokens + entry.tokens > self.max_tokens {
             return Err(crate::error::Error::TokenBudgetExceeded {
-                used: self.current_tokens + tokens,
+                used: self.current_tokens + entry.tokens,
                 max: self.max_tokens,
             });
         }
-
-        // Add entry
-        self.content.push(RegionEntry {
-            content,
-            tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: None,
-            kind: EntryKind::default(),
-            key: None,
-        });
+        let tokens = entry.tokens;
+        self.content.push(entry);
         self.current_tokens += tokens;
-
-        // Track taint as Public for untagged entries
         if let Some(taint) = &mut self.taint {
             taint.add_entry(crate::taint::TaintLevel::Public);
         }
-
-        // Enforce SlidingWindow max_items limit
         self.enforce_sliding_window();
-
         Ok(())
+    }
+
+    /// Like [`Self::insert_entry`] but records `taint_level` when tracking is on.
+    pub fn insert_tainted_entry(
+        &mut self,
+        entry: RegionEntry,
+        taint_level: crate::taint::TaintLevel,
+    ) -> crate::error::Result<()> {
+        if let Some(schema) = &self.schema {
+            schema.validate(entry.content())?;
+        }
+        if self.current_tokens + entry.tokens > self.max_tokens {
+            return Err(crate::error::Error::TokenBudgetExceeded {
+                used: self.current_tokens + entry.tokens,
+                max: self.max_tokens,
+            });
+        }
+        let tokens = entry.tokens;
+        self.content.push(entry);
+        self.current_tokens += tokens;
+        if let Some(taint) = &mut self.taint {
+            taint.add_entry(taint_level);
+        }
+        self.enforce_sliding_window();
+        Ok(())
+    }
+
+    /// Add an entry to this region.
+    ///
+    /// Validates content against schema if present, checks token budget,
+    /// and adds the entry to the region. Allocates uniquely — no interner
+    /// required. Runtime paths that need cross-agent sharing should build a
+    /// [`RegionEntry::interned`] value and call [`Self::insert_entry`].
+    pub fn add_entry(
+        &mut self,
+        content: impl AsRef<str>,
+        tokens: usize,
+    ) -> crate::error::Result<()> {
+        self.insert_entry(RegionEntry::new(content, tokens))
     }
 
     /// Add an entry with metadata.
     pub fn add_entry_with_metadata(
         &mut self,
-        content: String,
+        content: impl AsRef<str>,
         tokens: usize,
         metadata: serde_json::Value,
     ) -> crate::error::Result<()> {
-        // Validate against schema if present
-        if let Some(schema) = &self.schema {
-            schema.validate(&content)?;
-        }
-
-        // Check token budget
-        if self.current_tokens + tokens > self.max_tokens {
-            return Err(crate::error::Error::TokenBudgetExceeded {
-                used: self.current_tokens + tokens,
-                max: self.max_tokens,
-            });
-        }
-
-        // Add entry
-        self.content.push(RegionEntry {
-            content,
-            tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: Some(metadata),
-            kind: EntryKind::default(),
-            key: None,
-        });
-        self.current_tokens += tokens;
-
-        // Track taint as Public for untagged entries
-        if let Some(taint) = &mut self.taint {
-            taint.add_entry(crate::taint::TaintLevel::Public);
-        }
-
-        // Enforce SlidingWindow max_items limit
-        self.enforce_sliding_window();
-
-        Ok(())
+        let mut entry = RegionEntry::new(content, tokens);
+        entry.metadata = Some(metadata);
+        self.insert_entry(entry)
     }
 
     /// Add an entry with a specific [`EntryKind`] to this region.
@@ -495,43 +429,13 @@ impl Region {
     /// text-prefix parsing.
     pub fn add_typed_entry(
         &mut self,
-        content: String,
+        content: impl AsRef<str>,
         tokens: usize,
         kind: EntryKind,
     ) -> crate::error::Result<()> {
-        // Validate against schema if present
-        if let Some(schema) = &self.schema {
-            schema.validate(&content)?;
-        }
-
-        // Check token budget
-        if self.current_tokens + tokens > self.max_tokens {
-            return Err(crate::error::Error::TokenBudgetExceeded {
-                used: self.current_tokens + tokens,
-                max: self.max_tokens,
-            });
-        }
-
-        // Add entry
-        self.content.push(RegionEntry {
-            content,
-            tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: None,
-            kind,
-            key: None,
-        });
-        self.current_tokens += tokens;
-
-        // Track taint as Public for untagged entries
-        if let Some(taint) = &mut self.taint {
-            taint.add_entry(crate::taint::TaintLevel::Public);
-        }
-
-        // Enforce SlidingWindow max_items limit
-        self.enforce_sliding_window();
-
-        Ok(())
+        let mut entry = RegionEntry::new(content, tokens);
+        entry.kind = kind;
+        self.insert_entry(entry)
     }
 
     /// Carry an already-accepted entry into this region verbatim, preserving
@@ -570,9 +474,10 @@ impl Region {
     pub fn upsert_by_key(
         &mut self,
         key: &str,
-        content: String,
+        content: impl AsRef<str>,
         tokens: usize,
     ) -> Result<(), String> {
+        let content = content.as_ref();
         // If key exists, update in place
         if let Some(pos) = self
             .content
@@ -581,7 +486,7 @@ impl Region {
         {
             let old_tokens = self.content[pos].tokens;
             self.current_tokens -= old_tokens;
-            self.content[pos].content = content;
+            self.content[pos].set_content(content);
             self.content[pos].tokens = tokens;
             self.content[pos].timestamp = chrono::Utc::now().timestamp();
             self.current_tokens += tokens;
@@ -615,14 +520,14 @@ impl Region {
             ));
         }
 
-        self.content.push(RegionEntry {
+        self.content.push(RegionEntry::make_unique(
             content,
             tokens,
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: None,
-            kind: EntryKind::default(),
-            key: Some(key.to_string()),
-        });
+            EntryKind::default(),
+            None,
+            Some(key.to_string()),
+            None,
+        ));
         self.current_tokens += tokens;
         Ok(())
     }
@@ -836,10 +741,16 @@ impl Region {
 /// A single entry within a region.
 ///
 /// Each entry has content and metadata tracking its token usage.
+///
+/// Text is stored as a reference-counted string. Callers only see plain `&str`
+/// through [`Self::content`]. Sharing across agents is a *runtime* concern:
+/// construct with [`Self::interned`] at the window/restore boundary; domain
+/// code uses [`Self::new`] / the region convenience writers, which allocate
+/// uniquely and never require an interner parameter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegionEntry {
-    /// The actual content of this entry
-    pub content: String,
+    /// Interned payload. Private: only constructors / [`Self::set_content`] intern.
+    content: InternedString,
 
     /// Token count for this entry
     pub tokens: usize,
@@ -859,6 +770,131 @@ pub struct RegionEntry {
     /// Optional key for HashMap regions. When set, upsert semantics apply.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+}
+
+impl RegionEntry {
+    /// Unique allocation — no interner, no cross-entry sharing.
+    ///
+    /// Domain code and tests use this. Runtime paths that need sharing use
+    /// [`Self::interned`] instead.
+    pub fn new(content: impl AsRef<str>, tokens: usize) -> Self {
+        Self::make_unique(content, tokens, EntryKind::default(), None, None, None)
+    }
+
+    /// Intern through `interner` so identical text shares one allocation.
+    ///
+    /// Used at the runtime boundary (context window writes, restore).
+    pub fn interned(interner: &ContentInterner, content: impl AsRef<str>, tokens: usize) -> Self {
+        Self::make_interned(
+            interner,
+            content,
+            tokens,
+            EntryKind::default(),
+            None,
+            None,
+            None,
+        )
+    }
+
+    /// Full constructor with unique allocation (tests, offline rebuilds).
+    pub fn from_parts(
+        content: impl AsRef<str>,
+        tokens: usize,
+        timestamp: i64,
+        metadata: Option<serde_json::Value>,
+        kind: EntryKind,
+        key: Option<String>,
+    ) -> Self {
+        Self::make_unique(content, tokens, kind, metadata, key, Some(timestamp))
+    }
+
+    /// Full constructor that interns through `interner` (restore / window writes).
+    pub fn from_parts_interned(
+        interner: &ContentInterner,
+        content: impl AsRef<str>,
+        tokens: usize,
+        timestamp: i64,
+        metadata: Option<serde_json::Value>,
+        kind: EntryKind,
+        key: Option<String>,
+    ) -> Self {
+        Self::make_interned(
+            interner,
+            content,
+            tokens,
+            kind,
+            metadata,
+            key,
+            Some(timestamp),
+        )
+    }
+
+    /// Borrow the entry text as plain `&str`.
+    #[inline]
+    pub fn content(&self) -> &str {
+        self.content.as_str()
+    }
+
+    /// Replace text with a unique allocation.
+    #[inline]
+    pub fn set_content(&mut self, content: impl AsRef<str>) {
+        self.content = InternedString::unique(content);
+    }
+
+    /// Replace text, re-interning through `interner`.
+    #[inline]
+    pub fn set_content_interned(&mut self, interner: &ContentInterner, content: impl AsRef<str>) {
+        self.content = interner.intern(content);
+    }
+
+    /// Owned copy for snapshots / provider payloads.
+    #[inline]
+    pub fn content_owned(&self) -> String {
+        self.content.as_str().to_owned()
+    }
+
+    /// True when both entries share the same heap allocation.
+    #[inline]
+    pub fn shares_content_with(&self, other: &Self) -> bool {
+        self.content.ptr_eq(&other.content)
+    }
+
+    fn make_unique(
+        content: impl AsRef<str>,
+        tokens: usize,
+        kind: EntryKind,
+        metadata: Option<serde_json::Value>,
+        key: Option<String>,
+        timestamp: Option<i64>,
+    ) -> Self {
+        Self {
+            content: InternedString::unique(content),
+            tokens,
+            timestamp: timestamp.unwrap_or_else(|| chrono::Utc::now().timestamp()),
+            metadata,
+            kind,
+            key,
+        }
+    }
+
+    fn make_interned(
+        interner: &ContentInterner,
+        content: impl AsRef<str>,
+        tokens: usize,
+        kind: EntryKind,
+        metadata: Option<serde_json::Value>,
+        key: Option<String>,
+        timestamp: Option<i64>,
+    ) -> Self {
+        Self {
+            content: interner.intern(content),
+            tokens,
+            timestamp: timestamp.unwrap_or_else(|| chrono::Utc::now().timestamp()),
+            metadata,
+            kind,
+            key,
+        }
+    }
 }
 
 /// Validation schema for a region's content.
@@ -987,6 +1023,8 @@ pub trait Validator: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    use super::ContentInterner;
+
     use super::*;
 
     #[test]
@@ -1092,7 +1130,7 @@ mod tests {
         let mut source = Region::new("conversation".to_string(), RegionKind::Temporary, 10_000);
         source
             .add_typed_entry(
-                "result body".to_string(),
+                "result body",
                 10,
                 EntryKind::ToolResult {
                     tool_call_id: "call_1".to_string(),
@@ -1127,7 +1165,7 @@ mod tests {
     fn carry_entry_rejects_over_budget() {
         let mut dest = Region::new("small".to_string(), RegionKind::Temporary, 5);
         let mut source = Region::new("src".to_string(), RegionKind::Temporary, 100);
-        source.add_entry("filler".to_string(), 10).unwrap();
+        source.add_entry("filler", 10).unwrap();
         let err = dest.carry_entry(source.content[0].clone()).unwrap_err();
         assert_eq!(err.to_string(), "Content exceeds token budget: 10 > 5");
         assert!(dest.content.is_empty());
@@ -1152,7 +1190,7 @@ mod tests {
             dest.carry_entry(entry.clone()).unwrap();
         }
         assert_eq!(dest.content.len(), 3);
-        assert_eq!(dest.content[0].content, "msg1");
+        assert_eq!(dest.content[0].content(), "msg1");
     }
 
     #[test]
@@ -1166,23 +1204,23 @@ mod tests {
             50000,
         );
 
-        region.add_entry("msg1".to_string(), 10).unwrap();
-        region.add_entry("msg2".to_string(), 20).unwrap();
-        region.add_entry("msg3".to_string(), 30).unwrap();
+        region.add_entry("msg1", 10).unwrap();
+        region.add_entry("msg2", 20).unwrap();
+        region.add_entry("msg3", 30).unwrap();
         assert_eq!(region.entry_count(), 3);
         assert_eq!(region.current_tokens, 60);
 
         // Adding a 4th entry should evict the oldest
-        region.add_entry("msg4".to_string(), 40).unwrap();
+        region.add_entry("msg4", 40).unwrap();
         assert_eq!(region.entry_count(), 3);
-        assert_eq!(region.content[0].content, "msg2");
-        assert_eq!(region.content[2].content, "msg4");
+        assert_eq!(region.content[0].content(), "msg2");
+        assert_eq!(region.content[2].content(), "msg4");
         assert_eq!(region.current_tokens, 90); // 20 + 30 + 40
 
         // Adding a 5th entry should evict again
-        region.add_entry("msg5".to_string(), 50).unwrap();
+        region.add_entry("msg5", 50).unwrap();
         assert_eq!(region.entry_count(), 3);
-        assert_eq!(region.content[0].content, "msg3");
+        assert_eq!(region.content[0].content(), "msg3");
         assert_eq!(region.current_tokens, 120); // 30 + 40 + 50
     }
 
@@ -1198,18 +1236,18 @@ mod tests {
         );
 
         region
-            .add_entry_with_metadata("a".to_string(), 10, serde_json::json!({"idx": 1}))
+            .add_entry_with_metadata("a", 10, serde_json::json!({"idx": 1}))
             .unwrap();
         region
-            .add_entry_with_metadata("b".to_string(), 20, serde_json::json!({"idx": 2}))
+            .add_entry_with_metadata("b", 20, serde_json::json!({"idx": 2}))
             .unwrap();
         region
-            .add_entry_with_metadata("c".to_string(), 30, serde_json::json!({"idx": 3}))
+            .add_entry_with_metadata("c", 30, serde_json::json!({"idx": 3}))
             .unwrap();
 
         assert_eq!(region.entry_count(), 2);
-        assert_eq!(region.content[0].content, "b");
-        assert_eq!(region.content[1].content, "c");
+        assert_eq!(region.content[0].content(), "b");
+        assert_eq!(region.content[1].content(), "c");
         assert_eq!(region.current_tokens, 50);
     }
 
@@ -1280,7 +1318,7 @@ mod tests {
         let schema = RegionSchema::new(ContentFormat::Json);
         let mut region =
             Region::new("data".to_string(), RegionKind::Temporary, 1000).with_schema(schema);
-        let result = region.add_entry("not json".to_string(), 10);
+        let result = region.add_entry("not json", 10);
         assert!(result.is_err());
         assert_eq!(region.entry_count(), 0);
     }
@@ -1290,7 +1328,7 @@ mod tests {
         let schema = RegionSchema::new(ContentFormat::Json);
         let mut region =
             Region::new("data".to_string(), RegionKind::Temporary, 1000).with_schema(schema);
-        let result = region.add_entry("{\"a\":1}".to_string(), 10);
+        let result = region.add_entry("{\"a\":1}", 10);
         assert!(result.is_ok());
         assert_eq!(region.entry_count(), 1);
     }
@@ -1298,7 +1336,7 @@ mod tests {
     #[test]
     fn test_add_entry_rejects_over_budget() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 10);
-        let result = region.add_entry("too much".to_string(), 20);
+        let result = region.add_entry("too much", 20);
         assert_eq!(
             result.unwrap_err().to_string(),
             "Content exceeds token budget: 20 > 10"
@@ -1311,16 +1349,14 @@ mod tests {
         let schema = RegionSchema::new(ContentFormat::Json);
         let mut region =
             Region::new("data".to_string(), RegionKind::Temporary, 1000).with_schema(schema);
-        let result =
-            region.add_entry_with_metadata("not json".to_string(), 10, serde_json::json!({}));
+        let result = region.add_entry_with_metadata("not json", 10, serde_json::json!({}));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_add_entry_with_metadata_rejects_over_budget() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 10);
-        let result =
-            region.add_entry_with_metadata("too much".to_string(), 20, serde_json::json!({}));
+        let result = region.add_entry_with_metadata("too much", 20, serde_json::json!({}));
         assert_eq!(
             result.unwrap_err().to_string(),
             "Content exceeds token budget: 20 > 10"
@@ -1331,7 +1367,7 @@ mod tests {
     fn test_add_entry_with_metadata_stores_metadata() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 1000);
         region
-            .add_entry_with_metadata("hello".to_string(), 5, serde_json::json!({"k": "v"}))
+            .add_entry_with_metadata("hello", 5, serde_json::json!({"k": "v"}))
             .unwrap();
         assert_eq!(
             region.content[0].metadata,
@@ -1344,8 +1380,8 @@ mod tests {
     #[test]
     fn test_clear_removes_all_content_and_resets_tokens() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 1000);
-        region.add_entry("a".to_string(), 10).unwrap();
-        region.add_entry("b".to_string(), 20).unwrap();
+        region.add_entry("a", 10).unwrap();
+        region.add_entry("b", 20).unwrap();
         assert_eq!(region.entry_count(), 2);
 
         region.clear();
@@ -1356,11 +1392,11 @@ mod tests {
     #[test]
     fn test_remove_oldest_returns_and_removes_first_entry() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 1000);
-        region.add_entry("first".to_string(), 10).unwrap();
-        region.add_entry("second".to_string(), 20).unwrap();
+        region.add_entry("first", 10).unwrap();
+        region.add_entry("second", 20).unwrap();
 
         let removed = region.remove_oldest().unwrap();
-        assert_eq!(removed.content, "first");
+        assert_eq!(removed.content(), "first");
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.current_tokens, 20);
     }
@@ -1380,7 +1416,7 @@ mod tests {
             },
             1000,
         );
-        region.add_entry("x".to_string(), 20).unwrap();
+        region.add_entry("x", 20).unwrap();
         assert!(region.needs_compaction());
     }
 
@@ -1393,7 +1429,7 @@ mod tests {
             },
             1000,
         );
-        region.add_entry("x".to_string(), 20).unwrap();
+        region.add_entry("x", 20).unwrap();
         assert!(!region.needs_compaction());
     }
 
@@ -1551,11 +1587,7 @@ mod tests {
         let mut region =
             Region::new("test".to_string(), RegionKind::Temporary, 1000).with_taint_tracking();
         region
-            .add_tainted_entry(
-                "secret data".to_string(),
-                10,
-                crate::taint::TaintLevel::Private,
-            )
+            .add_tainted_entry("secret data", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         assert_eq!(
             region.taint_level(),
@@ -1569,11 +1601,7 @@ mod tests {
         let mut region = Region::new("test".to_string(), RegionKind::Temporary, 1000)
             .with_taint_tracking()
             .with_schema(RegionSchema::new(ContentFormat::Json));
-        let result = region.add_tainted_entry(
-            "not json".to_string(),
-            10,
-            crate::taint::TaintLevel::Internal,
-        );
+        let result = region.add_tainted_entry("not json", 10, crate::taint::TaintLevel::Internal);
         assert!(result.is_err());
         assert_eq!(region.entry_count(), 0);
     }
@@ -1582,11 +1610,7 @@ mod tests {
     fn test_add_tainted_entry_checks_budget() {
         let mut region =
             Region::new("test".to_string(), RegionKind::Temporary, 10).with_taint_tracking();
-        let result = region.add_tainted_entry(
-            "too much".to_string(),
-            20,
-            crate::taint::TaintLevel::Internal,
-        );
+        let result = region.add_tainted_entry("too much", 20, crate::taint::TaintLevel::Internal);
         assert!(result.is_err());
     }
 
@@ -1594,7 +1618,7 @@ mod tests {
     fn test_add_entry_tracks_taint_as_public() {
         let mut region =
             Region::new("test".to_string(), RegionKind::Temporary, 1000).with_taint_tracking();
-        region.add_entry("public data".to_string(), 10).unwrap();
+        region.add_entry("public data", 10).unwrap();
         assert_eq!(region.taint_level(), Some(crate::taint::TaintLevel::Public));
     }
 
@@ -1603,10 +1627,10 @@ mod tests {
         let mut region =
             Region::new("test".to_string(), RegionKind::Temporary, 1000).with_taint_tracking();
         region
-            .add_tainted_entry("private".to_string(), 10, crate::taint::TaintLevel::Private)
+            .add_tainted_entry("private", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         region
-            .add_tainted_entry("public".to_string(), 10, crate::taint::TaintLevel::Public)
+            .add_tainted_entry("public", 10, crate::taint::TaintLevel::Public)
             .unwrap();
         assert_eq!(
             region.taint_level(),
@@ -1622,7 +1646,7 @@ mod tests {
         let mut region =
             Region::new("test".to_string(), RegionKind::Temporary, 1000).with_taint_tracking();
         region
-            .add_tainted_entry("private".to_string(), 10, crate::taint::TaintLevel::Private)
+            .add_tainted_entry("private", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         region.clear();
         assert_eq!(region.taint_level(), Some(crate::taint::TaintLevel::Public));
@@ -1641,10 +1665,10 @@ mod tests {
         .with_taint_tracking();
 
         region
-            .add_tainted_entry("private".to_string(), 10, crate::taint::TaintLevel::Private)
+            .add_tainted_entry("private", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         region
-            .add_tainted_entry("public1".to_string(), 10, crate::taint::TaintLevel::Public)
+            .add_tainted_entry("public1", 10, crate::taint::TaintLevel::Public)
             .unwrap();
         assert_eq!(
             region.taint_level(),
@@ -1653,7 +1677,7 @@ mod tests {
 
         // Third entry evicts the private one
         region
-            .add_tainted_entry("public2".to_string(), 10, crate::taint::TaintLevel::Public)
+            .add_tainted_entry("public2", 10, crate::taint::TaintLevel::Public)
             .unwrap();
         assert_eq!(region.entry_count(), 2);
         assert_eq!(region.taint_level(), Some(crate::taint::TaintLevel::Public));
@@ -1687,7 +1711,7 @@ mod tests {
 
         region
             .add_typed_tainted_entry(
-                "secret data".to_string(),
+                "secret data",
                 10,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -1761,7 +1785,7 @@ mod tests {
         .with_taint_tracking();
 
         let result = region.add_typed_tainted_entry(
-            "too large".to_string(),
+            "too large",
             100,
             EntryKind::ToolResult {
                 tool_call_id: "tc_1".to_string(),
@@ -1781,7 +1805,7 @@ mod tests {
 
         // Non-JSON content should fail validation
         let result = region.add_typed_tainted_entry(
-            "not json".to_string(),
+            "not json",
             5,
             EntryKind::Text,
             crate::taint::TaintLevel::Public,
@@ -1805,7 +1829,7 @@ mod tests {
 
         region
             .add_typed_tainted_entry(
-                "data".to_string(),
+                "data",
                 10,
                 EntryKind::Text,
                 crate::taint::TaintLevel::Private,
@@ -1823,7 +1847,7 @@ mod tests {
         let mut region = Region::new("conv".to_string(), RegionKind::Temporary, 50000);
         region
             .add_typed_entry(
-                "assistant response".to_string(),
+                "assistant response",
                 10,
                 EntryKind::AssistantTurn {
                     tool_calls: vec![
@@ -1845,7 +1869,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "result 1".to_string(),
+                "result 1",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -1856,7 +1880,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "result 2".to_string(),
+                "result 2",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_2".to_string(),
@@ -1874,7 +1898,7 @@ mod tests {
         let mut region = Region::new("conv".to_string(), RegionKind::Temporary, 50000);
         region
             .add_typed_entry(
-                "assistant with no tools".to_string(),
+                "assistant with no tools",
                 10,
                 EntryKind::AssistantTurn { tool_calls: vec![] },
             )
@@ -1893,15 +1917,13 @@ mod tests {
     #[test]
     fn test_turn_group_size_at_non_assistant_entries() {
         let mut region = Region::new("conv".to_string(), RegionKind::Temporary, 50000);
+        region.add_typed_entry("hello", 5, EntryKind::Text).unwrap();
         region
-            .add_typed_entry("hello".to_string(), 5, EntryKind::Text)
-            .unwrap();
-        region
-            .add_typed_entry("hi".to_string(), 5, EntryKind::UserMessage)
+            .add_typed_entry("hi", 5, EntryKind::UserMessage)
             .unwrap();
         region
             .add_typed_entry(
-                "orphan result".to_string(),
+                "orphan result",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_x".to_string(),
@@ -1924,7 +1946,7 @@ mod tests {
         // AssistantTurn with 2 tool calls
         region
             .add_typed_entry(
-                "assistant".to_string(),
+                "assistant",
                 100,
                 EntryKind::AssistantTurn {
                     tool_calls: vec![
@@ -1946,7 +1968,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "result 1".to_string(),
+                "result 1",
                 30,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -1957,7 +1979,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "result 2".to_string(),
+                "result 2",
                 20,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_2".to_string(),
@@ -1968,7 +1990,7 @@ mod tests {
             .unwrap();
         // A trailing user message that should survive
         region
-            .add_typed_entry("user msg".to_string(), 10, EntryKind::UserMessage)
+            .add_typed_entry("user msg", 10, EntryKind::UserMessage)
             .unwrap();
 
         assert_eq!(region.entry_count(), 4);
@@ -1977,11 +1999,11 @@ mod tests {
         let removed = region.remove_oldest().unwrap();
         // The returned entry is the AssistantTurn, with tokens adjusted to
         // include the extra tokens from the 2 ToolResult entries.
-        assert_eq!(removed.content, "assistant");
+        assert_eq!(removed.content(), "assistant");
         assert_eq!(removed.tokens, 100 + 30 + 20); // 150
         // Only the user message remains
         assert_eq!(region.entry_count(), 1);
-        assert_eq!(region.content[0].content, "user msg");
+        assert_eq!(region.content[0].content(), "user msg");
         assert_eq!(region.current_tokens, 10);
     }
 
@@ -1995,7 +2017,7 @@ mod tests {
         // AssistantTurn (Private) + 1 ToolResult (Internal) + 1 trailing Public entry
         region
             .add_typed_tainted_entry(
-                "assistant".to_string(),
+                "assistant",
                 10,
                 EntryKind::AssistantTurn {
                     tool_calls: vec![SerializedToolCall {
@@ -2010,7 +2032,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_tainted_entry(
-                "result".to_string(),
+                "result",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -2021,11 +2043,7 @@ mod tests {
             )
             .unwrap();
         region
-            .add_tainted_entry(
-                "public stuff".to_string(),
-                5,
-                crate::taint::TaintLevel::Public,
-            )
+            .add_tainted_entry("public stuff", 5, crate::taint::TaintLevel::Public)
             .unwrap();
 
         assert_eq!(
@@ -2036,7 +2054,7 @@ mod tests {
 
         // Evict the turn group (AssistantTurn + ToolResult)
         let removed = region.remove_oldest().unwrap();
-        assert_eq!(removed.content, "assistant");
+        assert_eq!(removed.content(), "assistant");
         assert_eq!(region.entry_count(), 1);
         // Taint should have called remove_oldest twice (once per group member),
         // leaving only the Public entry's taint.
@@ -2060,7 +2078,7 @@ mod tests {
         // Add an AssistantTurn + 2 ToolResults = 3 entries (fills the window)
         region
             .add_typed_entry(
-                "assistant".to_string(),
+                "assistant",
                 10,
                 EntryKind::AssistantTurn {
                     tool_calls: vec![
@@ -2082,7 +2100,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "r1".to_string(),
+                "r1",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -2093,7 +2111,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "r2".to_string(),
+                "r2",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc_2".to_string(),
@@ -2108,12 +2126,12 @@ mod tests {
         // Adding a 4th entry should evict the entire turn group (3 entries)
         // because the group at index 0 is an AssistantTurn with 2 ToolResults.
         region
-            .add_typed_entry("user msg".to_string(), 15, EntryKind::UserMessage)
+            .add_typed_entry("user msg", 15, EntryKind::UserMessage)
             .unwrap();
 
         // After eviction: only the new user message remains
         assert_eq!(region.entry_count(), 1);
-        assert_eq!(region.content[0].content, "user msg");
+        assert_eq!(region.content[0].content(), "user msg");
         assert_eq!(region.current_tokens, 15);
     }
 
@@ -2125,7 +2143,7 @@ mod tests {
             Region::new("data".to_string(), RegionKind::Temporary, 1000).with_taint_tracking();
 
         region
-            .add_entry_with_metadata("content".to_string(), 10, serde_json::json!({"key": "val"}))
+            .add_entry_with_metadata("content", 10, serde_json::json!({"key": "val"}))
             .unwrap();
 
         assert_eq!(region.taint_level(), Some(crate::taint::TaintLevel::Public));
@@ -2145,7 +2163,7 @@ mod tests {
 
         region
             .add_typed_entry(
-                "assistant response".to_string(),
+                "assistant response",
                 10,
                 EntryKind::AssistantTurn { tool_calls: vec![] },
             )
@@ -2175,9 +2193,9 @@ mod tests {
             region.add_entry(format!("msg{}", i), 10).unwrap();
         }
         assert_eq!(region.entry_count(), 3);
-        assert_eq!(region.content[0].content, "msg2");
-        assert_eq!(region.content[1].content, "msg3");
-        assert_eq!(region.content[2].content, "msg4");
+        assert_eq!(region.content[0].content(), "msg2");
+        assert_eq!(region.content[1].content(), "msg3");
+        assert_eq!(region.content[2].content(), "msg4");
     }
 
     #[test]
@@ -2198,9 +2216,9 @@ mod tests {
         assert_eq!(region.entry_count(), 8);
 
         // Adding one more (9 total > 5+3=8) triggers bulk eviction → down to 5
-        region.add_entry("msg8".to_string(), 10).unwrap();
+        region.add_entry("msg8", 10).unwrap();
         assert_eq!(region.entry_count(), 5);
-        assert_eq!(region.content[0].content, "msg4");
+        assert_eq!(region.content[0].content(), "msg4");
     }
 
     #[test]
@@ -2216,7 +2234,7 @@ mod tests {
         // Add AssistantTurn + ToolResult (turn group of 2)
         region
             .add_typed_entry(
-                "assistant".to_string(),
+                "assistant",
                 10,
                 EntryKind::AssistantTurn {
                     tool_calls: vec![SerializedToolCall {
@@ -2230,7 +2248,7 @@ mod tests {
             .unwrap();
         region
             .add_typed_entry(
-                "result".to_string(),
+                "result",
                 5,
                 EntryKind::ToolResult {
                     tool_call_id: "tc1".to_string(),
@@ -2240,18 +2258,18 @@ mod tests {
             )
             .unwrap();
         // Add more entries to exceed overflow
-        region.add_entry("msg2".to_string(), 10).unwrap();
-        region.add_entry("msg3".to_string(), 10).unwrap();
-        region.add_entry("msg4".to_string(), 10).unwrap();
+        region.add_entry("msg2", 10).unwrap();
+        region.add_entry("msg3", 10).unwrap();
+        region.add_entry("msg4", 10).unwrap();
         // 5 entries, under overflow (5 < 3+2=5 is not >), no eviction yet
         assert_eq!(region.entry_count(), 5);
 
         // Adding 6th entry: 6 > 5 triggers bulk eviction
-        region.add_entry("msg5".to_string(), 10).unwrap();
+        region.add_entry("msg5", 10).unwrap();
         // Turn group (assistant+result=2) evicted together, then msg2 evicted
         // to get down to max_items=3
         assert_eq!(region.entry_count(), 3);
-        assert_eq!(region.content[0].content, "msg3");
+        assert_eq!(region.content[0].content(), "msg3");
     }
 
     #[test]
@@ -2310,7 +2328,7 @@ mod tests {
         }
         // Should have bulk-evicted down to max_items=5
         assert_eq!(region.entry_count(), 5);
-        assert_eq!(region.content[0].content, "msg7");
+        assert_eq!(region.content[0].content(), "msg7");
         // Compaction flag should be cleared after fallback
         assert!(!region.needs_message_compaction);
     }
@@ -2324,19 +2342,17 @@ mod tests {
     fn test_remove_entries_by_prefix() {
         let mut region = Region::new("system".to_string(), RegionKind::Pinned, 50000);
         region
-            .add_entry("[Stage instructions: Be terse.]".to_string(), 10)
+            .add_entry("[Stage instructions: Be terse.]", 10)
             .unwrap();
+        region.add_entry("Core identity block", 20).unwrap();
         region
-            .add_entry("Core identity block".to_string(), 20)
-            .unwrap();
-        region
-            .add_entry("[Stage instructions: Be verbose.]".to_string(), 15)
+            .add_entry("[Stage instructions: Be verbose.]", 15)
             .unwrap();
 
         assert_eq!(region.entry_count(), 3);
         region.remove_entries_by_prefix("[Stage instructions:");
         assert_eq!(region.entry_count(), 1);
-        assert_eq!(region.content[0].content, "Core identity block");
+        assert_eq!(region.content[0].content(), "Core identity block");
         assert_eq!(region.current_tokens, 20);
     }
 
@@ -2346,21 +2362,17 @@ mod tests {
             Region::new("system".to_string(), RegionKind::Pinned, 50000).with_taint_tracking();
         region
             .add_tainted_entry(
-                "[Stage instructions: Be terse.]".to_string(),
+                "[Stage instructions: Be terse.]",
                 10,
                 crate::taint::TaintLevel::Private,
             )
             .unwrap();
         region
-            .add_tainted_entry(
-                "Core identity block".to_string(),
-                20,
-                crate::taint::TaintLevel::Public,
-            )
+            .add_tainted_entry("Core identity block", 20, crate::taint::TaintLevel::Public)
             .unwrap();
         region
             .add_tainted_entry(
-                "[Stage instructions: Be verbose.]".to_string(),
+                "[Stage instructions: Be verbose.]",
                 15,
                 crate::taint::TaintLevel::Internal,
             )
@@ -2374,7 +2386,7 @@ mod tests {
 
         region.remove_entries_by_prefix("[Stage instructions:");
         assert_eq!(region.entry_count(), 1);
-        assert_eq!(region.content[0].content, "Core identity block");
+        assert_eq!(region.content[0].content(), "Core identity block");
         assert_eq!(region.current_tokens, 20);
         // After removing Private and Internal entries, only Public remains
         assert_eq!(region.taint_level(), Some(crate::taint::TaintLevel::Public));
@@ -2414,7 +2426,7 @@ mod tests {
 
         // Add 5 entries (3+2): at threshold, no eviction
         region
-            .add_tainted_entry("private".to_string(), 10, crate::taint::TaintLevel::Private)
+            .add_tainted_entry("private", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         for i in 1..5 {
             region
@@ -2425,7 +2437,7 @@ mod tests {
 
         // 6th entry triggers bulk eviction to max_items=3
         region
-            .add_tainted_entry("pub5".to_string(), 10, crate::taint::TaintLevel::Public)
+            .add_tainted_entry("pub5", 10, crate::taint::TaintLevel::Public)
             .unwrap();
         assert_eq!(region.entry_count(), 3);
         // Private entry was evicted, only public remain
@@ -2486,7 +2498,7 @@ mod tests {
     fn test_add_typed_entry_validates_schema() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 1000)
             .with_schema(RegionSchema::new(ContentFormat::Json));
-        let result = region.add_typed_entry("not json".to_string(), 5, EntryKind::Text);
+        let result = region.add_typed_entry("not json", 5, EntryKind::Text);
         assert!(result.is_err());
         assert_eq!(region.entry_count(), 0);
     }
@@ -2494,7 +2506,7 @@ mod tests {
     #[test]
     fn test_add_typed_entry_checks_budget() {
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 10);
-        let result = region.add_typed_entry("too big".to_string(), 20, EntryKind::UserMessage);
+        let result = region.add_typed_entry("too big", 20, EntryKind::UserMessage);
         assert!(result.is_err());
         assert_eq!(region.entry_count(), 0);
     }
@@ -2504,7 +2516,7 @@ mod tests {
         // When taint tracking is NOT enabled, the taint level is silently ignored.
         let mut region = Region::new("data".to_string(), RegionKind::Temporary, 1000);
         region
-            .add_tainted_entry("data".to_string(), 10, crate::taint::TaintLevel::Private)
+            .add_tainted_entry("data", 10, crate::taint::TaintLevel::Private)
             .unwrap();
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.taint_level(), None);
@@ -2513,8 +2525,8 @@ mod tests {
     #[test]
     fn test_remove_entries_by_prefix_no_match() {
         let mut region = Region::new("system".to_string(), RegionKind::Pinned, 50000);
-        region.add_entry("Keep this".to_string(), 10).unwrap();
-        region.add_entry("And this".to_string(), 20).unwrap();
+        region.add_entry("Keep this", 10).unwrap();
+        region.add_entry("And this", 20).unwrap();
         region.remove_entries_by_prefix("[Stage instructions:");
         assert_eq!(region.entry_count(), 2);
         assert_eq!(region.current_tokens, 30);
@@ -2530,17 +2542,17 @@ mod tests {
             10000,
         );
         region
-            .upsert_by_key("src/main.rs", "fn main() {}".to_string(), 10)
+            .upsert_by_key("src/main.rs", "fn main() {}", 10)
             .unwrap();
         region
-            .upsert_by_key("src/lib.rs", "pub mod foo;".to_string(), 8)
+            .upsert_by_key("src/lib.rs", "pub mod foo;", 8)
             .unwrap();
 
         assert_eq!(region.entry_count(), 2);
         assert_eq!(region.current_tokens, 18);
 
         let entry = region.get_by_key("src/main.rs").unwrap();
-        assert_eq!(entry.content, "fn main() {}");
+        assert_eq!(entry.content(), "fn main() {}");
         assert_eq!(entry.key.as_deref(), Some("src/main.rs"));
     }
 
@@ -2551,17 +2563,13 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             10000,
         );
-        region
-            .upsert_by_key("file.rs", "version 1".to_string(), 10)
-            .unwrap();
+        region.upsert_by_key("file.rs", "version 1", 10).unwrap();
         assert_eq!(region.current_tokens, 10);
 
-        region
-            .upsert_by_key("file.rs", "version 2".to_string(), 15)
-            .unwrap();
+        region.upsert_by_key("file.rs", "version 2", 15).unwrap();
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.current_tokens, 15);
-        assert_eq!(region.get_by_key("file.rs").unwrap().content, "version 2");
+        assert_eq!(region.get_by_key("file.rs").unwrap().content(), "version 2");
     }
 
     #[test]
@@ -2571,8 +2579,8 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             10000,
         );
-        region.upsert_by_key("a.rs", "aaa".to_string(), 10).unwrap();
-        region.upsert_by_key("b.rs", "bbb".to_string(), 20).unwrap();
+        region.upsert_by_key("a.rs", "aaa", 10).unwrap();
+        region.upsert_by_key("b.rs", "bbb", 20).unwrap();
 
         assert!(region.remove_by_key("a.rs"));
         assert_eq!(region.entry_count(), 1);
@@ -2588,8 +2596,8 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             10000,
         );
-        region.upsert_by_key("x.rs", "x".to_string(), 5).unwrap();
-        region.upsert_by_key("y.rs", "y".to_string(), 5).unwrap();
+        region.upsert_by_key("x.rs", "x", 5).unwrap();
+        region.upsert_by_key("y.rs", "y", 5).unwrap();
 
         let keys = region.keys();
         assert_eq!(keys.len(), 2);
@@ -2604,16 +2612,16 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             30, // tight budget
         );
-        region.upsert_by_key("a.rs", "aaa".to_string(), 10).unwrap();
+        region.upsert_by_key("a.rs", "aaa", 10).unwrap();
         // Make 'a' older by manually adjusting timestamp
         region.content[0].timestamp -= 100;
-        region.upsert_by_key("b.rs", "bbb".to_string(), 10).unwrap();
-        region.upsert_by_key("c.rs", "ccc".to_string(), 10).unwrap();
+        region.upsert_by_key("b.rs", "bbb", 10).unwrap();
+        region.upsert_by_key("c.rs", "ccc", 10).unwrap();
         assert_eq!(region.entry_count(), 3);
         assert_eq!(region.current_tokens, 30);
 
         // Adding d.rs should evict a.rs (oldest timestamp)
-        region.upsert_by_key("d.rs", "ddd".to_string(), 10).unwrap();
+        region.upsert_by_key("d.rs", "ddd", 10).unwrap();
         assert_eq!(region.entry_count(), 3);
         assert!(region.get_by_key("a.rs").is_none());
         assert!(region.get_by_key("d.rs").is_some());
@@ -2628,13 +2636,13 @@ mod tests {
             },
             10000,
         );
-        region.upsert_by_key("a.rs", "aaa".to_string(), 10).unwrap();
+        region.upsert_by_key("a.rs", "aaa", 10).unwrap();
         region.content[0].timestamp -= 100; // make oldest
-        region.upsert_by_key("b.rs", "bbb".to_string(), 10).unwrap();
+        region.upsert_by_key("b.rs", "bbb", 10).unwrap();
         assert_eq!(region.entry_count(), 2);
 
         // Adding c.rs should evict a.rs (oldest, max_entries=2)
-        region.upsert_by_key("c.rs", "ccc".to_string(), 10).unwrap();
+        region.upsert_by_key("c.rs", "ccc", 10).unwrap();
         assert_eq!(region.entry_count(), 2);
         assert!(region.get_by_key("a.rs").is_none());
         assert!(region.get_by_key("c.rs").is_some());
@@ -2647,7 +2655,7 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             5, // very small
         );
-        let result = region.upsert_by_key("big.rs", "huge content".to_string(), 100);
+        let result = region.upsert_by_key("big.rs", "huge content", 100);
         assert!(result.is_err());
     }
 
@@ -2684,34 +2692,27 @@ mod tests {
     #[test]
     fn test_region_entry_key_default_none() {
         let mut region = Region::new("test".to_string(), RegionKind::Temporary, 1000);
-        region.add_entry("content".to_string(), 10).unwrap();
+        region.add_entry("content", 10).unwrap();
         assert!(region.content[0].key.is_none());
     }
 
     #[test]
     fn test_region_entry_key_serde_skip_when_none() {
-        let entry = RegionEntry {
-            content: "test".to_string(),
-            tokens: 5,
-            timestamp: 0,
-            metadata: None,
-            kind: EntryKind::default(),
-            key: None,
-        };
+        let entry = RegionEntry::from_parts("test", 5, 0, None, EntryKind::default(), None);
         let json = serde_json::to_string(&entry).unwrap();
         assert!(!json.contains("key"));
     }
 
     #[test]
     fn test_region_entry_key_serde_roundtrip() {
-        let entry = RegionEntry {
-            content: "test".to_string(),
-            tokens: 5,
-            timestamp: 0,
-            metadata: None,
-            kind: EntryKind::default(),
-            key: Some("mykey".to_string()),
-        };
+        let entry = RegionEntry::from_parts(
+            "test",
+            5,
+            0,
+            None,
+            EntryKind::default(),
+            Some("mykey".to_string()),
+        );
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("mykey"));
         let back: RegionEntry = serde_json::from_str(&json).unwrap();
@@ -2752,14 +2753,14 @@ mod tests {
             5000,
         );
         region
-            .upsert_by_key("config.toml", "[package]\nname = \"foo\"".to_string(), 12)
+            .upsert_by_key("config.toml", "[package]\nname = \"foo\"", 12)
             .unwrap();
 
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.current_tokens, 12);
 
         let entry = region.get_by_key("config.toml").unwrap();
-        assert_eq!(entry.content, "[package]\nname = \"foo\"");
+        assert_eq!(entry.content(), "[package]\nname = \"foo\"");
         assert_eq!(entry.tokens, 12);
         assert_eq!(entry.key.as_deref(), Some("config.toml"));
     }
@@ -2771,19 +2772,17 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             5000,
         );
-        region
-            .upsert_by_key("readme.md", "# Old".to_string(), 20)
-            .unwrap();
+        region.upsert_by_key("readme.md", "# Old", 20).unwrap();
         assert_eq!(region.current_tokens, 20);
 
         region
-            .upsert_by_key("readme.md", "# New and improved".to_string(), 35)
+            .upsert_by_key("readme.md", "# New and improved", 35)
             .unwrap();
         assert_eq!(region.entry_count(), 1);
         assert_eq!(region.current_tokens, 35);
 
         let entry = region.get_by_key("readme.md").unwrap();
-        assert_eq!(entry.content, "# New and improved");
+        assert_eq!(entry.content(), "# New and improved");
         assert_eq!(entry.tokens, 35);
     }
 
@@ -2797,23 +2796,23 @@ mod tests {
 
         // Insert entries that together fill the budget
         region
-            .upsert_by_key("first.rs", "first content".to_string(), 40)
+            .upsert_by_key("first.rs", "first content", 40)
             .unwrap();
         region.content[0].timestamp -= 200; // oldest
 
         region
-            .upsert_by_key("second.rs", "second content".to_string(), 40)
+            .upsert_by_key("second.rs", "second content", 40)
             .unwrap();
         region.content[1].timestamp -= 100; // middle age
 
         region
-            .upsert_by_key("third.rs", "third content".to_string(), 20)
+            .upsert_by_key("third.rs", "third content", 20)
             .unwrap();
         // total = 100, at budget
 
         // Inserting another entry that exceeds budget should evict oldest
         region
-            .upsert_by_key("fourth.rs", "fourth content".to_string(), 30)
+            .upsert_by_key("fourth.rs", "fourth content", 30)
             .unwrap();
 
         // first.rs (oldest timestamp) should have been evicted
@@ -2833,17 +2832,13 @@ mod tests {
             50000,
         );
 
-        region
-            .upsert_by_key("alpha", "aaa".to_string(), 10)
-            .unwrap();
+        region.upsert_by_key("alpha", "aaa", 10).unwrap();
         region.content[0].timestamp -= 200; // make oldest
 
-        region.upsert_by_key("beta", "bbb".to_string(), 10).unwrap();
+        region.upsert_by_key("beta", "bbb", 10).unwrap();
         region.content[1].timestamp -= 100;
 
-        region
-            .upsert_by_key("gamma", "ccc".to_string(), 10)
-            .unwrap();
+        region.upsert_by_key("gamma", "ccc", 10).unwrap();
 
         // Only 2 entries should remain, oldest evicted
         assert_eq!(region.entry_count(), 2);
@@ -2859,14 +2854,12 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             5000,
         );
-        region
-            .upsert_by_key("exists", "hello".to_string(), 5)
-            .unwrap();
+        region.upsert_by_key("exists", "hello", 5).unwrap();
 
         // Found
         let found = region.get_by_key("exists");
         assert!(found.is_some());
-        assert_eq!(found.unwrap().content, "hello");
+        assert_eq!(found.unwrap().content(), "hello");
 
         // Not found
         let missing = region.get_by_key("does_not_exist");
@@ -2880,9 +2873,7 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             5000,
         );
-        region
-            .upsert_by_key("target", "remove me".to_string(), 25)
-            .unwrap();
+        region.upsert_by_key("target", "remove me", 25).unwrap();
         assert_eq!(region.current_tokens, 25);
 
         let removed = region.remove_by_key("target");
@@ -2915,9 +2906,9 @@ mod tests {
         assert!(region.keys().is_empty());
 
         // Populated
-        region.upsert_by_key("one", "1".to_string(), 5).unwrap();
-        region.upsert_by_key("two", "2".to_string(), 5).unwrap();
-        region.upsert_by_key("three", "3".to_string(), 5).unwrap();
+        region.upsert_by_key("one", "1", 5).unwrap();
+        region.upsert_by_key("two", "2", 5).unwrap();
+        region.upsert_by_key("three", "3", 5).unwrap();
 
         let keys = region.keys();
         assert_eq!(keys.len(), 3);
@@ -2937,34 +2928,34 @@ mod tests {
     #[test]
     fn test_region_entry_serialization_with_key_field() {
         // Entry with key
-        let entry_with_key = RegionEntry {
-            content: "some data".to_string(),
-            tokens: 10,
-            timestamp: 1234567890,
-            metadata: None,
-            kind: EntryKind::default(),
-            key: Some("mykey".to_string()),
-        };
+        let entry_with_key = RegionEntry::from_parts(
+            "some data",
+            10,
+            1234567890,
+            None,
+            EntryKind::default(),
+            Some("mykey".to_string()),
+        );
         let json = serde_json::to_string(&entry_with_key).unwrap();
         let deserialized: RegionEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.key.as_deref(), Some("mykey"));
-        assert_eq!(deserialized.content, "some data");
+        assert_eq!(deserialized.content(), "some data");
         assert_eq!(deserialized.tokens, 10);
 
         // Entry without key
-        let entry_no_key = RegionEntry {
-            content: "no key data".to_string(),
-            tokens: 7,
-            timestamp: 1234567890,
-            metadata: None,
-            kind: EntryKind::default(),
-            key: None,
-        };
+        let entry_no_key = RegionEntry::from_parts(
+            "no key data",
+            7,
+            1234567890,
+            None,
+            EntryKind::default(),
+            None,
+        );
         let json = serde_json::to_string(&entry_no_key).unwrap();
         assert!(!json.contains("\"key\""));
         let deserialized: RegionEntry = serde_json::from_str(&json).unwrap();
         assert!(deserialized.key.is_none());
-        assert_eq!(deserialized.content, "no key data");
+        assert_eq!(deserialized.content(), "no key data");
     }
 
     #[test]
@@ -3014,12 +3005,8 @@ mod tests {
             10_000,
         )
         .with_taint_tracking();
-        region
-            .upsert_by_key("k1", "value one".to_string(), 10)
-            .unwrap();
-        region
-            .upsert_by_key("k2", "value two".to_string(), 10)
-            .unwrap();
+        region.upsert_by_key("k1", "value one", 10).unwrap();
+        region.upsert_by_key("k2", "value two", 10).unwrap();
 
         assert!(region.remove_by_key("k1"));
         assert!(!region.remove_by_key("missing"));
@@ -3040,12 +3027,8 @@ mod tests {
             10_000,
         )
         .with_taint_tracking();
-        region
-            .upsert_by_key("first", "aaa".to_string(), 10)
-            .unwrap();
-        region
-            .upsert_by_key("second", "bbb".to_string(), 10)
-            .unwrap();
+        region.upsert_by_key("first", "aaa", 10).unwrap();
+        region.upsert_by_key("second", "bbb", 10).unwrap();
 
         // Only the most-recently-inserted key survives after LRU eviction.
         assert_eq!(region.entry_count(), 1);
@@ -3069,5 +3052,38 @@ mod tests {
         region.evict_lru_entry();
         assert_eq!(region.entry_count(), 0);
         assert_eq!(region.current_tokens, 0);
+    }
+    #[test]
+    fn interned_entries_share_allocation_via_same_interner() {
+        let ix = ContentInterner::new();
+        let mut a = Region::new("pin".into(), RegionKind::Pinned, 10_000);
+        let mut b = Region::new("pin".into(), RegionKind::Pinned, 10_000);
+        let text = "architecture: shared across agents";
+        a.insert_entry(RegionEntry::interned(&ix, text, 20))
+            .unwrap();
+        b.insert_entry(RegionEntry::interned(&ix, text, 20))
+            .unwrap();
+        assert!(a.content[0].shares_content_with(&b.content[0]));
+        b.insert_entry(RegionEntry::interned(&ix, "private turn", 5))
+            .unwrap();
+        assert_eq!(a.content[0].content(), text);
+        assert!(!a.content[0].shares_content_with(&b.content[1]));
+    }
+
+    #[test]
+    fn domain_add_entry_allocates_uniquely() {
+        let mut a = Region::new("pin".into(), RegionKind::Pinned, 1000);
+        let mut b = Region::new("pin".into(), RegionKind::Pinned, 1000);
+        a.add_entry("same", 1).unwrap();
+        b.add_entry("same", 1).unwrap();
+        assert!(!a.content[0].shares_content_with(&b.content[0]));
+        assert_eq!(a.content[0].content(), b.content[0].content());
+    }
+
+    #[test]
+    fn domain_add_entry_does_not_require_interner() {
+        let mut region = Region::new("pin".into(), RegionKind::Pinned, 1000);
+        region.add_entry("hello", 5).unwrap();
+        assert_eq!(region.content[0].content(), "hello");
     }
 }

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -216,17 +216,33 @@ pub struct ContextWindow {
         String,
         std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
     >,
+
+    /// World-scoped interner handle (cloned from [`crate::ContentInternerRes`]
+    /// at spawn). Write paths intern through this handle; domain `Region`
+    /// methods never see it.
+    interner: leviath_core::ContentInterner,
 }
 
 impl ContextWindow {
     /// Create a new context window with the specified budget.
     pub fn new(max_tokens: usize) -> Self {
+        Self::with_interner(max_tokens, leviath_core::ContentInterner::new())
+    }
+
+    /// Build a window that shares `interner` with other agents in the same World.
+    pub fn with_interner(max_tokens: usize, interner: leviath_core::ContentInterner) -> Self {
         Self {
             regions: Vec::new(),
             current_tokens: 0,
             max_tokens,
             region_scripts: std::collections::HashMap::new(),
+            interner,
         }
+    }
+
+    /// The interner handle this window uses for entry text.
+    pub fn interner(&self) -> &leviath_core::ContentInterner {
+        &self.interner
     }
 
     /// The compiled script backing `region_name`, when it is a custom region
@@ -323,8 +339,13 @@ impl ContextWindow {
         else {
             return Ok(()); // the region's script dropped the entry
         };
+        let interner = self.interner.clone();
         self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_entry(content.clone(), tokens)
+            region.insert_entry(leviath_core::RegionEntry::interned(
+                &interner,
+                content.as_str(),
+                tokens,
+            ))
         })
     }
 
@@ -341,9 +362,14 @@ impl ContextWindow {
             // Dropped by the script: the region keeps its current content.
             return self.get_region(region_name).is_some();
         };
+        let interner = self.interner.clone();
         if let Some(region) = self.get_region_mut(region_name) {
             region.clear();
-            let _ = region.add_entry(content, tokens);
+            let _ = region.insert_entry(leviath_core::RegionEntry::interned(
+                &interner,
+                content.as_str(),
+                tokens,
+            ));
             self.current_tokens = self.calculate_tokens();
             true
         } else {
@@ -367,8 +393,12 @@ impl ContextWindow {
         else {
             return Ok(());
         };
+        let interner = self.interner.clone();
         self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_typed_entry(content.clone(), tokens, kind.clone())
+            let mut entry =
+                leviath_core::RegionEntry::interned(&interner, content.as_str(), tokens);
+            entry.kind = kind.clone();
+            region.insert_entry(entry)
         })
     }
 
@@ -646,7 +676,7 @@ impl ContextWindow {
                     let text = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
+                        .map(|e| e.content())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
@@ -658,7 +688,7 @@ impl ContextWindow {
                     let text = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
+                        .map(|e| e.content())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
@@ -692,7 +722,7 @@ impl ContextWindow {
                             EntryKind::UserMessage => {
                                 messages.push(leviath_providers::Message {
                                     role: "user".to_string(),
-                                    content: entry.content.clone().into(),
+                                    content: entry.content().into(),
                                     cache_breakpoint: false,
                                 });
                             }
@@ -700,14 +730,14 @@ impl ContextWindow {
                                 if tool_calls.is_empty() {
                                     messages.push(leviath_providers::Message {
                                         role: "assistant".to_string(),
-                                        content: entry.content.clone().into(),
+                                        content: entry.content().into(),
                                         cache_breakpoint: false,
                                     });
                                 } else {
                                     let mut blocks = Vec::new();
-                                    if !entry.content.is_empty() {
+                                    if !entry.content().is_empty() {
                                         blocks.push(leviath_providers::ContentBlock::Text {
-                                            text: entry.content.clone(),
+                                            text: entry.content_owned(),
                                         });
                                     }
                                     for tc in tool_calls {
@@ -734,13 +764,13 @@ impl ContextWindow {
                                 pending_tool_results.push(
                                     leviath_providers::ContentBlock::ToolResult {
                                         tool_use_id: tool_call_id.clone(),
-                                        content: entry.content.clone(),
+                                        content: entry.content_owned(),
                                         is_error: *is_error,
                                     },
                                 );
                             }
                             EntryKind::Text => {
-                                let trimmed = entry.content.trim();
+                                let trimmed = entry.content().trim();
                                 if let Some(rest) = trimmed.strip_prefix("Assistant: ") {
                                     messages.push(leviath_providers::Message {
                                         role: "assistant".to_string(),
@@ -756,7 +786,7 @@ impl ContextWindow {
                                 } else {
                                     messages.push(leviath_providers::Message {
                                         role: "user".to_string(),
-                                        content: entry.content.clone().into(),
+                                        content: entry.content().into(),
                                         cache_breakpoint: false,
                                     });
                                 }
@@ -781,7 +811,7 @@ impl ContextWindow {
                     let text = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
+                        .map(|e| e.content())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
@@ -793,7 +823,7 @@ impl ContextWindow {
                     let text = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
+                        .map(|e| e.content())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
@@ -805,7 +835,7 @@ impl ContextWindow {
                     let text = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
+                        .map(|e| e.content())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
@@ -838,9 +868,9 @@ impl ContextWindow {
                         .iter()
                         .map(|e| {
                             if let Some(key) = &e.key {
-                                format!("### [{}]\n{}", key, e.content)
+                                format!("### [{}]\n{}", key, e.content())
                             } else {
-                                e.content.clone()
+                                e.content_owned()
                             }
                         })
                         .collect::<Vec<_>>()
@@ -1000,8 +1030,12 @@ impl ContextWindow {
         else {
             return Ok(());
         };
+        let interner = self.interner.clone();
         self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_tainted_entry(content.clone(), tokens, taint_level)
+            region.insert_tainted_entry(
+                leviath_core::RegionEntry::interned(&interner, content.as_str(), tokens),
+                taint_level,
+            )
         })
     }
 
@@ -1023,8 +1057,12 @@ impl ContextWindow {
         else {
             return Ok(());
         };
+        let interner = self.interner.clone();
         self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_typed_tainted_entry(content.clone(), tokens, kind.clone(), taint_level)
+            let mut entry =
+                leviath_core::RegionEntry::interned(&interner, content.as_str(), tokens);
+            entry.kind = kind.clone();
+            region.insert_tainted_entry(entry, taint_level)
         })
     }
 
@@ -1170,14 +1208,14 @@ mod tests {
     fn replace_region_overwrites_existing_and_reports_missing() {
         let mut window = ContextWindow::new(10000);
         let mut region = Region::new("plan".to_string(), RegionKind::Pinned, 6000);
-        region.add_entry("old plan".to_string(), 3).unwrap();
+        region.add_entry("old plan", 3).unwrap();
         window.add_region(region);
 
         // Replacing an existing region overwrites its content wholesale.
         assert!(window.replace_region("plan", "new plan".to_string(), 3));
         let plan = window.get_region("plan").unwrap();
         assert_eq!(plan.content.len(), 1);
-        assert_eq!(plan.content[0].content, "new plan");
+        assert_eq!(plan.content[0].content(), "new plan");
 
         // A missing region is a no-op that reports false.
         assert!(!window.replace_region("nope", "x".to_string(), 1));
@@ -1187,12 +1225,8 @@ mod tests {
     fn test_clearable_eviction() {
         let mut window = ContextWindow::new(10000);
         let mut region = Region::new("scratch".to_string(), RegionKind::Clearable, 5000);
-        region
-            .add_entry("test content 1".to_string(), 1000)
-            .unwrap();
-        region
-            .add_entry("test content 2".to_string(), 1000)
-            .unwrap();
+        region.add_entry("test content 1", 1000).unwrap();
+        region.add_entry("test content 2", 1000).unwrap();
         window.add_region(region);
 
         assert_eq!(window.current_tokens, 2000);
@@ -1208,11 +1242,9 @@ mod tests {
     fn test_temporary_eviction_oldest_first() {
         let mut window = ContextWindow::new(10000);
         let mut region = Region::new("temp".to_string(), RegionKind::Temporary, 5000);
-        region.add_entry("old content".to_string(), 1000).unwrap();
-        region
-            .add_entry("middle content".to_string(), 1000)
-            .unwrap();
-        region.add_entry("new content".to_string(), 1000).unwrap();
+        region.add_entry("old content", 1000).unwrap();
+        region.add_entry("middle content", 1000).unwrap();
+        region.add_entry("new content", 1000).unwrap();
         window.add_region(region);
 
         assert_eq!(window.current_tokens, 3000);
@@ -1225,7 +1257,7 @@ mod tests {
         // Check that oldest was removed
         let region = window.get_region("temp").unwrap();
         assert_eq!(region.content.len(), 2);
-        assert_eq!(region.content[0].content, "middle content");
+        assert_eq!(region.content[0].content(), "middle content");
     }
 
     fn assert_sliding_window_unreduced(initial_count: usize, after_count: usize) {
@@ -1246,9 +1278,9 @@ mod tests {
             },
             5000,
         );
-        region.add_entry("msg 1".to_string(), 1000).unwrap();
-        region.add_entry("msg 2".to_string(), 1000).unwrap();
-        region.add_entry("msg 3".to_string(), 1000).unwrap();
+        region.add_entry("msg 1", 1000).unwrap();
+        region.add_entry("msg 2", 1000).unwrap();
+        region.add_entry("msg 3", 1000).unwrap();
         window.add_region(region);
 
         let initial_count = window.get_region("conversation").unwrap().content.len();
@@ -1277,9 +1309,7 @@ mod tests {
     fn test_pinned_never_touched() {
         let mut window = ContextWindow::new(10000);
         let mut region = Region::new("architecture".to_string(), RegionKind::Pinned, 3000);
-        region
-            .add_entry("architecture diagram".to_string(), 2000)
-            .unwrap();
+        region.add_entry("architecture diagram", 2000).unwrap();
         window.add_region(region);
 
         let initial_tokens = window.get_region("architecture").unwrap().current_tokens;
@@ -1303,19 +1333,13 @@ mod tests {
 
         // Add Clearable region
         let mut clearable = Region::new("scratch".to_string(), RegionKind::Clearable, 2000);
-        clearable
-            .add_entry("scratch data".to_string(), 1000)
-            .unwrap();
+        clearable.add_entry("scratch data", 1000).unwrap();
         window.add_region(clearable);
 
         // Add Temporary region
         let mut temporary = Region::new("temp".to_string(), RegionKind::Temporary, 3000);
-        temporary
-            .add_entry("temp data 1".to_string(), 1000)
-            .unwrap();
-        temporary
-            .add_entry("temp data 2".to_string(), 1000)
-            .unwrap();
+        temporary.add_entry("temp data 1", 1000).unwrap();
+        temporary.add_entry("temp data 2", 1000).unwrap();
         window.add_region(temporary);
 
         assert_eq!(window.current_tokens, 3000);
@@ -1389,9 +1413,7 @@ mod tests {
             },
             900,
         );
-        compacting
-            .add_entry("lots of content".to_string(), 600)
-            .unwrap();
+        compacting.add_entry("lots of content", 600).unwrap();
         window.add_region(compacting);
 
         assert_eq!(window.current_tokens, 600);
@@ -1414,8 +1436,8 @@ mod tests {
             },
             1100,
         );
-        compacting.add_entry("data 1".to_string(), 500).unwrap();
-        compacting.add_entry("data 2".to_string(), 500).unwrap();
+        compacting.add_entry("data 1", 500).unwrap();
+        compacting.add_entry("data 2", 500).unwrap();
         window.add_region(compacting);
 
         // 200 free tokens, request 500 → needs compaction
@@ -1431,9 +1453,7 @@ mod tests {
         // a configuration error instead of silently doing nothing useful.
         let mut window = ContextWindow::new(1000);
         let mut pinned = Region::new("architecture".to_string(), RegionKind::Pinned, 2000);
-        pinned
-            .add_entry("huge pinned doc".to_string(), 1500)
-            .unwrap();
+        pinned.add_entry("huge pinned doc", 1500).unwrap();
         window.add_region(pinned);
 
         let result = window.try_evict(100);
@@ -1451,11 +1471,11 @@ mod tests {
         let mut window = ContextWindow::new(2000);
 
         let mut region_a = Region::new("a".to_string(), RegionKind::Clearable, 1000);
-        region_a.add_entry("small".to_string(), 500).unwrap();
+        region_a.add_entry("small", 500).unwrap();
         window.add_region(region_a);
 
         let mut region_b = Region::new("b".to_string(), RegionKind::Clearable, 1000);
-        region_b.add_entry("large".to_string(), 1000).unwrap();
+        region_b.add_entry("large", 1000).unwrap();
         window.add_region(region_b);
 
         assert_eq!(window.current_tokens, 1500);
@@ -1534,7 +1554,7 @@ mod tests {
         window.add_region(region);
 
         let region = window.get_region_mut("test").unwrap();
-        region.add_entry("new content".to_string(), 50).unwrap();
+        region.add_entry("new content", 50).unwrap();
         assert_eq!(region.content.len(), 1);
 
         assert!(window.get_region_mut("nonexistent").is_none());
@@ -1562,9 +1582,9 @@ mod tests {
     fn test_context_window_calculate_tokens() {
         let mut window = ContextWindow::new(10000);
         let mut r1 = Region::new("a".to_string(), RegionKind::Pinned, 5000);
-        r1.add_entry("x".to_string(), 100).unwrap();
+        r1.add_entry("x", 100).unwrap();
         let mut r2 = Region::new("b".to_string(), RegionKind::Temporary, 5000);
-        r2.add_entry("y".to_string(), 200).unwrap();
+        r2.add_entry("y", 200).unwrap();
         window.add_region(r1);
         window.add_region(r2);
 
@@ -1661,9 +1681,7 @@ mod tests {
         // When the only region is Pinned (within budget), eviction frees nothing.
         let mut window = ContextWindow::new(10000);
         let mut pinned = Region::new("pinned".to_string(), RegionKind::Pinned, 5000);
-        pinned
-            .add_entry("important data".to_string(), 2000)
-            .unwrap();
+        pinned.add_entry("important data", 2000).unwrap();
         window.add_region(pinned);
 
         let result = with_tracing(|| window.try_evict(500)).unwrap();
@@ -1718,8 +1736,8 @@ mod tests {
     fn try_evict_continues_loop_when_each_entry_removal_is_insufficient() {
         let mut window = ContextWindow::new(1000);
         let mut temp = Region::new("cache".to_string(), RegionKind::Temporary, 800);
-        temp.add_entry("entry1".to_string(), 50).unwrap();
-        temp.add_entry("entry2".to_string(), 50).unwrap();
+        temp.add_entry("entry1", 50).unwrap();
+        temp.add_entry("entry2", 50).unwrap();
         window.add_region(temp);
         window.current_tokens = 950; // 95% full
 
@@ -2346,7 +2364,7 @@ mod tests {
             10_000,
         );
         region
-            .add_entry("summary of earlier conversation".to_string(), 50)
+            .add_entry("summary of earlier conversation", 50)
             .unwrap();
         window.add_region(region);
 
@@ -2373,9 +2391,7 @@ mod tests {
             },
             10_000,
         );
-        region
-            .add_entry("implementation details".to_string(), 50)
-            .unwrap();
+        region.add_entry("implementation details", 50).unwrap();
         window.add_region(region);
 
         let assembled = window.assemble();
@@ -2395,7 +2411,7 @@ mod tests {
     fn test_assemble_temporary_region_produces_system_block_never() {
         let mut window = ContextWindow::new(100_000);
         let mut region = Region::new("scratch".to_string(), RegionKind::Temporary, 10_000);
-        region.add_entry("temp data".to_string(), 20).unwrap();
+        region.add_entry("temp data", 20).unwrap();
         window.add_region(region);
 
         let assembled = window.assemble();
@@ -2412,7 +2428,7 @@ mod tests {
     fn test_assemble_clearable_region_produces_system_block_never() {
         let mut window = ContextWindow::new(100_000);
         let mut region = Region::new("cache".to_string(), RegionKind::Clearable, 10_000);
-        region.add_entry("clearable data".to_string(), 20).unwrap();
+        region.add_entry("clearable data", 20).unwrap();
         window.add_region(region);
 
         let assembled = window.assemble();
@@ -2439,8 +2455,8 @@ mod tests {
         // never silently dropped.
         let mut window = ContextWindow::new(100_000);
         let mut region = Region::new("brain".to_string(), custom_kind("b.rhai", false), 10_000);
-        region.add_entry("thought one".to_string(), 10).unwrap();
-        region.add_entry("thought two".to_string(), 10).unwrap();
+        region.add_entry("thought one", 10).unwrap();
+        region.add_entry("thought two", 10).unwrap();
         window.add_region(region);
 
         let assembled = window.assemble();
@@ -2460,8 +2476,8 @@ mod tests {
     fn try_evict_evicts_non_persistent_custom_regions_oldest_first() {
         let mut window = ContextWindow::new(100);
         let mut region = Region::new("brain".to_string(), custom_kind("b.rhai", false), 100);
-        region.add_entry("old".to_string(), 40).unwrap();
-        region.add_entry("new".to_string(), 40).unwrap();
+        region.add_entry("old", 40).unwrap();
+        region.add_entry("new", 40).unwrap();
         window.add_region(region);
         window.current_tokens = 80;
 
@@ -2469,7 +2485,7 @@ mod tests {
         assert!(result.tokens_freed >= 40);
         let brain = window.get_region("brain").unwrap();
         assert_eq!(brain.content.len(), 1);
-        assert_eq!(brain.content[0].content, "new");
+        assert_eq!(brain.content[0].content(), "new");
     }
 
     #[test]
@@ -2478,7 +2494,7 @@ mod tests {
         // exceeds the whole window budget the pinned over-budget guard fires.
         let mut window = ContextWindow::new(50);
         let mut vault = Region::new("vault".to_string(), custom_kind("v.rhai", true), 100);
-        vault.add_entry("precious".to_string(), 60).unwrap();
+        vault.add_entry("precious", 60).unwrap();
         window.add_region(vault);
         window.current_tokens = 60;
 
@@ -2549,7 +2565,7 @@ mod tests {
             .unwrap()
             .content
             .iter()
-            .map(|e| e.content.as_str())
+            .map(|e| e.content())
             .collect();
         assert_eq!(
             contents,
@@ -2562,7 +2578,7 @@ mod tests {
         assert!(window.replace_region("brain", "e".to_string(), 1));
         let region = window.get_region("brain").unwrap();
         assert_eq!(region.content.len(), 1);
-        assert_eq!(region.content[0].content, "text:e");
+        assert_eq!(region.content[0].content(), "text:e");
     }
 
     #[test]
@@ -2649,7 +2665,11 @@ mod tests {
         assert!(result.tokens_freed >= 40);
         let brain = window.get_region("brain").unwrap();
         assert_eq!(brain.content.len(), 1);
-        assert_eq!(brain.content[0].content, "new", "oldest-first fallback ran");
+        assert_eq!(
+            brain.content[0].content(),
+            "new",
+            "oldest-first fallback ran"
+        );
     }
 
     #[test]
@@ -2698,7 +2718,7 @@ mod tests {
             .add_to_region("plain", "untouched".to_string(), 2)
             .unwrap();
         assert_eq!(
-            window.get_region("plain").unwrap().content[0].content,
+            window.get_region("plain").unwrap().content[0].content(),
             "untouched"
         );
     }
@@ -2730,7 +2750,7 @@ mod tests {
 
         let region = window.get_region("brain").unwrap();
         assert_eq!(region.content.len(), 1);
-        assert_eq!(region.content[0].content, "next");
+        assert_eq!(region.content[0].content(), "next");
         assert_eq!(window.current_tokens, 20);
     }
 
@@ -2809,7 +2829,7 @@ mod tests {
             .unwrap()
             .content
             .iter()
-            .map(|e| e.content.as_str())
+            .map(|e| e.content())
             .collect();
         assert_eq!(
             contents,
@@ -3334,7 +3354,7 @@ mod tests {
         // Only a Pinned region, no SlidingWindow with user messages
         let mut pinned = Region::new("system".to_string(), RegionKind::Pinned, 10_000);
         pinned
-            .add_entry("You are a helpful assistant.".to_string(), 20)
+            .add_entry("You are a helpful assistant.", 20)
             .unwrap();
         window.add_region(pinned);
 
@@ -3566,15 +3586,11 @@ mod tests {
 
         // Add regions in "wrong" order: volatile first, stable last
         let mut clearable = Region::new("scratch".to_string(), RegionKind::Clearable, 10_000);
-        clearable
-            .add_entry("clearable data".to_string(), 20)
-            .unwrap();
+        clearable.add_entry("clearable data", 20).unwrap();
         window.add_region(clearable);
 
         let mut temporary = Region::new("temp".to_string(), RegionKind::Temporary, 10_000);
-        temporary
-            .add_entry("temporary data".to_string(), 20)
-            .unwrap();
+        temporary.add_entry("temporary data", 20).unwrap();
         window.add_region(temporary);
 
         let mut compacting = Region::new(
@@ -3584,15 +3600,11 @@ mod tests {
             },
             10_000,
         );
-        compacting
-            .add_entry("compacting data".to_string(), 20)
-            .unwrap();
+        compacting.add_entry("compacting data", 20).unwrap();
         window.add_region(compacting);
 
         let mut pinned = Region::new("system".to_string(), RegionKind::Pinned, 10_000);
-        pinned
-            .add_entry("pinned system prompt".to_string(), 20)
-            .unwrap();
+        pinned.add_entry("pinned system prompt", 20).unwrap();
         window.add_region(pinned);
 
         let assembled = window.assemble();
@@ -3750,7 +3762,7 @@ mod tests {
         let mut window = ContextWindow::new(100_000);
 
         let mut temp = Region::new("temp".to_string(), RegionKind::Temporary, 10_000);
-        temp.add_entry("temp data".to_string(), 10).unwrap();
+        temp.add_entry("temp data", 10).unwrap();
         window.add_region(temp);
 
         let mut history = Region::new(
@@ -3760,7 +3772,7 @@ mod tests {
             },
             10_000,
         );
-        history.add_entry("summary data".to_string(), 10).unwrap();
+        history.add_entry("summary data", 10).unwrap();
         window.add_region(history);
 
         let assembled = window.assemble();
@@ -3814,10 +3826,10 @@ mod tests {
             10_000,
         );
         region
-            .upsert_by_key("src/main.rs", "fn main() {}".to_string(), 10)
+            .upsert_by_key("src/main.rs", "fn main() {}", 10)
             .unwrap();
         region
-            .upsert_by_key("src/lib.rs", "pub mod foo;".to_string(), 8)
+            .upsert_by_key("src/lib.rs", "pub mod foo;", 8)
             .unwrap();
         window.add_region(region);
 
@@ -3839,9 +3851,7 @@ mod tests {
             RegionKind::HashMap { max_entries: None },
             10_000,
         );
-        region
-            .upsert_by_key("a.rs", "content".to_string(), 5)
-            .unwrap();
+        region.upsert_by_key("a.rs", "content", 5).unwrap();
         window.add_region(region);
 
         let assembled = window.assemble();
@@ -3863,7 +3873,7 @@ mod tests {
             10_000,
         );
         region
-            .upsert_by_key("config.toml", "key = \"value\"".to_string(), 10)
+            .upsert_by_key("config.toml", "key = \"value\"", 10)
             .unwrap();
         window.add_region(region);
 
@@ -3894,13 +3904,11 @@ mod tests {
             10_000,
         );
         region
-            .upsert_by_key("alpha.rs", "fn alpha() {}".to_string(), 10)
+            .upsert_by_key("alpha.rs", "fn alpha() {}", 10)
             .unwrap();
+        region.upsert_by_key("beta.rs", "fn beta() {}", 10).unwrap();
         region
-            .upsert_by_key("beta.rs", "fn beta() {}".to_string(), 10)
-            .unwrap();
-        region
-            .upsert_by_key("gamma.rs", "fn gamma() {}".to_string(), 10)
+            .upsert_by_key("gamma.rs", "fn gamma() {}", 10)
             .unwrap();
         window.add_region(region);
 
@@ -3945,7 +3953,7 @@ mod tests {
         // Pinned region
         let mut pinned = Region::new("system".to_string(), RegionKind::Pinned, 10_000);
         pinned
-            .add_entry("You are a helpful assistant.".to_string(), 20)
+            .add_entry("You are a helpful assistant.", 20)
             .unwrap();
         window.add_region(pinned);
 
@@ -3956,7 +3964,7 @@ mod tests {
             10_000,
         );
         hashmap
-            .upsert_by_key("main.rs", "fn main() {}".to_string(), 10)
+            .upsert_by_key("main.rs", "fn main() {}", 10)
             .unwrap();
         window.add_region(hashmap);
 
@@ -3970,11 +3978,7 @@ mod tests {
             50_000,
         );
         sliding
-            .add_typed_entry(
-                "Hello there".to_string(),
-                10,
-                leviath_core::EntryKind::UserMessage,
-            )
+            .add_typed_entry("Hello there", 10, leviath_core::EntryKind::UserMessage)
             .unwrap();
         window.add_region(sliding);
 
@@ -4079,6 +4083,22 @@ mod tests {
                 .iter()
                 .any(|b| b.text.contains("keyless content")),
             "keyless HashMap entry should appear verbatim in a system block"
+        );
+    }
+    #[test]
+    fn shared_interner_deduplicates_pinned_text_across_windows() {
+        let interner = leviath_core::ContentInterner::new();
+        let mut a = ContextWindow::with_interner(10_000, interner.clone());
+        let mut b = ContextWindow::with_interner(10_000, interner);
+        assert!(a.interner().ptr_eq(b.interner()));
+        a.add_region(Region::new("pin".into(), RegionKind::Pinned, 5_000));
+        b.add_region(Region::new("pin".into(), RegionKind::Pinned, 5_000));
+        let text = "shared architecture block";
+        a.add_to_region("pin", text.into(), 10).unwrap();
+        b.add_to_region("pin", text.into(), 10).unwrap();
+        assert!(
+            a.get_region("pin").unwrap().content[0]
+                .shares_content_with(&b.get_region("pin").unwrap().content[0])
         );
     }
 }

--- a/crates/leviath-runtime/src/content_interner.rs
+++ b/crates/leviath-runtime/src/content_interner.rs
@@ -1,0 +1,22 @@
+//! World-scoped content interner resource.
+//!
+//! One [`ContentInternerRes`] is inserted into the ECS World at pipeline
+//! construction. Every spawned [`crate::ContextWindow`] clones the handle so
+//! agents share interned entry text without any process-global table.
+
+use bevy_ecs::prelude::Resource;
+use leviath_core::ContentInterner;
+
+/// Bevy resource wrapping the shareable [`ContentInterner`] handle.
+#[derive(Resource, Clone, Default, Debug)]
+pub struct ContentInternerRes(pub ContentInterner);
+
+impl ContentInternerRes {
+    pub fn new() -> Self {
+        Self(ContentInterner::new())
+    }
+
+    pub fn handle(&self) -> ContentInterner {
+        self.0.clone()
+    }
+}

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -240,7 +240,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("build a parser"))
+                .any(|e| e.content().contains("build a parser"))
         );
         assert!(
             window
@@ -248,7 +248,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("focus on safety"))
+                .any(|e| e.content().contains("focus on safety"))
         );
         // An unknown seed key targets no region and is silently dropped.
         assert!(window.get_region("ghost").is_none());
@@ -327,7 +327,11 @@ mod tests {
             !region.content.is_empty(),
             "an oversized seed must be trimmed, not dropped"
         );
-        assert!(region.content[0].content.ends_with(SEED_TRUNCATION_MARKER));
+        assert!(
+            region.content[0]
+                .content()
+                .ends_with(SEED_TRUNCATION_MARKER)
+        );
     }
 
     #[test]
@@ -348,7 +352,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("fallback text"))
+                .any(|e| e.content().contains("fallback text"))
         );
     }
 
@@ -375,7 +379,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("do the thing"))
+                .any(|e| e.content().contains("do the thing"))
         );
         // Blueprint-declared tool_results / conversation are not duplicated.
         assert_eq!(
@@ -415,7 +419,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("seed task"))
+                .any(|e| e.content().contains("seed task"))
         );
     }
 
@@ -456,7 +460,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("fallback seed"))
+                .any(|e| e.content().contains("fallback seed"))
         );
     }
 
@@ -493,7 +497,7 @@ mod tests {
                 .unwrap()
                 .content
                 .iter()
-                .any(|e| e.content.contains("carried content"))
+                .any(|e| e.content().contains("carried content"))
         );
         assert!(window.get_region("scratch").unwrap().content.is_empty());
         // Token total recomputed from the surviving content.
@@ -632,7 +636,7 @@ mod tests {
         assert!(
             conv.content
                 .iter()
-                .any(|e| e.content.contains("hello from stage 0")),
+                .any(|e| e.content().contains("hello from stage 0")),
             "carried conversation must retain its history"
         );
     }

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -60,7 +60,7 @@ pub fn handle_context_tool(
                 let Some(k) = key else {
                     return "[error] HashMap regions require a 'key' argument".to_string();
                 };
-                match region.upsert_by_key(k, content.to_string(), tokens) {
+                match region.upsert_by_key(k, content, tokens) {
                     Ok(()) => format!("Stored in '{region_name}' section under key '{k}'."),
                     Err(e) => format!("[error] {e}"),
                 }
@@ -96,7 +96,7 @@ pub fn handle_context_tool(
                         .to_string();
                 };
                 if let Some(existing) = region.get_by_key(k) {
-                    let new_content = format!("{}\n{}", existing.content, content);
+                    let new_content = format!("{}\n{}", existing.content(), content);
                     let new_tokens = leviath_core::estimate_tokens(&new_content);
                     // Upserting an already-present key updates in place with no
                     // budget check, so this cannot fail.
@@ -105,7 +105,7 @@ pub fn handle_context_tool(
                         .expect("infallible: existing HashMap key updates in place");
                     format!("Appended to '{region_name}' section under key '{k}'.")
                 } else {
-                    match region.upsert_by_key(k, content.to_string(), tokens) {
+                    match region.upsert_by_key(k, content, tokens) {
                         Ok(()) => {
                             format!("Created entry in '{region_name}' section under key '{k}'.")
                         }
@@ -132,7 +132,7 @@ pub fn handle_context_tool(
             if matches!(region.kind, RegionKind::HashMap { .. }) {
                 if let Some(k) = key {
                     match region.get_by_key(k) {
-                        Some(entry) => entry.content.clone(),
+                        Some(entry) => entry.content_owned(),
                         None => {
                             format!("[not found] No entry with key '{k}' in region '{region_name}'")
                         }
@@ -154,7 +154,7 @@ pub fn handle_context_tool(
                 let text = region
                     .content
                     .iter()
-                    .map(|e| e.content.as_str())
+                    .map(|e| e.content())
                     .collect::<Vec<_>>()
                     .join("\n\n");
                 if text.is_empty() {
@@ -467,7 +467,7 @@ mod tests {
         // A stray keyless entry in a hashmap region is skipped by the listing.
         w.get_region_mut("files")
             .unwrap()
-            .add_entry("keyless".to_string(), 1)
+            .add_entry("keyless", 1)
             .unwrap();
         let listing = call(&mut w, "context_read", json!({"region": "files"}));
         assert!(listing.contains("a.rs") && !listing.contains("keyless"));

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -41,7 +41,7 @@ pub fn apply_context_transforms(world: &mut World, parent: Entity, child: Entity
                 let joined = region
                     .content
                     .iter()
-                    .map(|e| e.content.as_str())
+                    .map(|e| e.content())
                     .collect::<Vec<_>>()
                     .join("\n");
                 if !joined.is_empty() {
@@ -434,10 +434,10 @@ mod tests {
         let cw = w.get::<ContextWindow>(child).unwrap();
         let task = cw.get_region("task").unwrap();
         assert!(task.current_tokens > 0);
-        assert_eq!(task.content[0].content, "the plan");
+        assert_eq!(task.content[0].content(), "the plan");
         let inputs = cw.get_region("inputs").unwrap();
-        assert!(inputs.content[0].content.contains("\"keep\""));
-        assert!(!inputs.content[0].content.contains("\"drop\""));
+        assert!(inputs.content[0].content().contains("\"keep\""));
+        assert!(!inputs.content[0].content().contains("\"drop\""));
     }
 
     #[test]
@@ -668,7 +668,7 @@ mod tests {
                 .get_region("task")
                 .unwrap()
                 .content[0]
-                .content,
+                .content(),
             "the long plan"
         );
         // ...and the region is queued for deferred summarization.
@@ -801,7 +801,7 @@ mod tests {
                 .get_region("task")
                 .unwrap()
                 .content[0]
-                .content,
+                .content(),
             "SHORT"
         );
         assert!(world.get::<AwaitingContentSummary>(e).is_none());
@@ -830,7 +830,7 @@ mod tests {
                 .get_region("task")
                 .unwrap()
                 .content[0]
-                .content,
+                .content(),
             "keep me"
         );
         assert!(world.get::<AwaitingContentSummary>(e2).is_none());

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -42,7 +42,7 @@ pub(crate) enum OnWriteOutcome {
 /// hooks return instructions (drop indices, replacement text), never entries.
 fn entry_to_json(entry: &RegionEntry) -> serde_json::Value {
     let mut obj = serde_json::json!({
-        "content": entry.content,
+        "content": entry.content(),
         "tokens": entry.tokens,
         "timestamp": entry.timestamp,
         "key": entry.key,
@@ -92,7 +92,7 @@ fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
     let text = region
         .content
         .iter()
-        .map(|e| e.content.as_str())
+        .map(|e| e.content())
         .collect::<Vec<_>>()
         .join("\n\n");
     leviath_providers::SystemBlock {
@@ -534,9 +534,7 @@ mod tests {
             1000,
         );
         for (content, kind) in entries {
-            region
-                .add_typed_entry(content.to_string(), 10, kind.clone())
-                .unwrap();
+            region.add_typed_entry(*content, 10, kind.clone()).unwrap();
         }
         region
     }
@@ -943,7 +941,7 @@ mod tests {
         let freed = with_tracing(|| apply_overflow(&s, &mut region, 15));
         assert_eq!(freed, 20);
         assert_eq!(region.content.len(), 1);
-        assert_eq!(region.content[0].content, "b");
+        assert_eq!(region.content[0].content(), "b");
         assert_eq!(region.current_tokens, 10);
     }
 

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -1093,7 +1093,7 @@ mod tests {
             .get_region("plan")
             .unwrap();
         assert_eq!(plan.content.len(), 1);
-        assert_eq!(plan.content[0].content, "the plan");
+        assert_eq!(plan.content[0].content(), "the plan");
     }
 
     #[tokio::test]
@@ -1144,7 +1144,7 @@ mod tests {
             .unwrap()
             .get_region("plan")
             .unwrap();
-        assert_eq!(plan.content[0].content, "the plan");
+        assert_eq!(plan.content[0].content(), "the plan");
     }
 
     #[tokio::test]
@@ -1226,8 +1226,8 @@ mod tests {
             .get_region("plan")
             .unwrap();
         assert_eq!(plan.content.len(), 1);
-        assert!(plan.content[0].content.contains("[revised by user"));
-        assert!(plan.content[0].content.contains("the edited plan"));
+        assert!(plan.content[0].content().contains("[revised by user"));
+        assert!(plan.content[0].content().contains("the edited plan"));
         for _ in 0..8 {
             tokio::task::yield_now().await;
         }

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -9,6 +9,7 @@
 pub(crate) mod cancel;
 pub(crate) mod compaction_bridge;
 pub mod components;
+pub mod content_interner;
 pub mod context_setup;
 pub(crate) mod context_tools;
 pub(crate) mod context_transform;
@@ -43,6 +44,7 @@ pub mod world;
 mod test_support;
 
 pub use components::{AgentState, AgentStatus, ContextWindow, ParentRef, SubAgentChildren};
+pub use content_interner::ContentInternerRes;
 pub use fanout::{FanOutSpawner, FanOutSpawnerRes};
 pub use inference_bridge::RetryPolicy;
 pub use inference_pool::{InferencePoolConfig, InferencePools};

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -135,7 +135,7 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
                 .iter()
                 .enumerate()
                 .map(|(i, e)| RegionEntrySnapshot {
-                    content: e.content.clone(),
+                    content: e.content_owned(),
                     tokens: e.tokens,
                     kind: e.kind.clone(),
                     metadata: e.metadata.clone(),

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -71,7 +71,7 @@ pub fn dispatch_compaction(
             let content: String = region
                 .content
                 .iter()
-                .map(|e| e.content.as_str())
+                .map(|e| e.content())
                 .collect::<Vec<_>>()
                 .join("\n\n");
             if content.is_empty() {
@@ -345,7 +345,7 @@ pub(crate) fn build_edge_compact_requests(
             let content = region
                 .content
                 .iter()
-                .map(|e| e.content.as_str())
+                .map(|e| e.content())
                 .collect::<Vec<_>>()
                 .join("\n\n");
             (!content.is_empty())

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -2190,7 +2190,7 @@ fn conversation_text(world: &World, e: Entity) -> String {
         .unwrap()
         .content
         .iter()
-        .map(|entry| entry.content.clone())
+        .map(|entry| entry.content_owned())
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -2894,7 +2894,7 @@ fn routing_away_pointer_previews_and_truncates_long_results() {
         .unwrap()
         .content
         .iter()
-        .map(|e| e.content.clone())
+        .map(|e| e.content_owned())
         .collect();
     assert!(
         conv_txt.contains('…'),
@@ -2905,7 +2905,7 @@ fn routing_away_pointer_previews_and_truncates_long_results() {
             .unwrap()
             .content
             .iter()
-            .any(|e| e.content.contains(&long)),
+            .any(|e| e.content().contains(&long)),
         "full result stored in the region"
     );
 }
@@ -2955,7 +2955,7 @@ fn routing_away_keeps_pair_in_conversation_and_text_in_region() {
     assert!(
         cb.content
             .iter()
-            .any(|e| e.content.contains("FULL FILE BODY"))
+            .any(|e| e.content().contains("FULL FILE BODY"))
     );
     assert!(
         cb.content
@@ -3019,7 +3019,7 @@ fn routing_override_matches_bash_alias_to_shell() {
             .unwrap()
             .content
             .iter()
-            .any(|e| e.content.contains("All tests passed")),
+            .any(|e| e.content().contains("All tests passed")),
         "a `bash` override must route the canonical `shell` tool's result"
     );
 }
@@ -4369,10 +4369,10 @@ use leviath_core::blueprint::EdgeTransform;
 fn transform_window() -> ContextWindow {
     let mut w = ContextWindow::new(1000);
     let mut sys = Region::new("sys".to_string(), RegionKind::Pinned, 500);
-    let _ = sys.add_entry("identity".to_string(), 10);
+    let _ = sys.add_entry("identity", 10);
     w.add_region(sys);
     let mut scratch = Region::new("scratch".to_string(), RegionKind::Clearable, 500);
-    let _ = scratch.add_entry("work".to_string(), 10);
+    let _ = scratch.add_entry("work", 10);
     w.add_region(scratch);
     w.current_tokens = w.calculate_tokens();
     w
@@ -4408,7 +4408,7 @@ fn edge_transforms_respect_custom_region_persistence() {
         },
         500,
     );
-    let _ = scratch_custom.add_entry("wipe me".to_string(), 10);
+    let _ = scratch_custom.add_entry("wipe me", 10);
     w.add_region(scratch_custom);
     let mut vault = Region::new(
         "vault".to_string(),
@@ -4418,7 +4418,7 @@ fn edge_transforms_respect_custom_region_persistence() {
         },
         500,
     );
-    let _ = vault.add_entry("keep me".to_string(), 10);
+    let _ = vault.add_entry("keep me", 10);
     w.add_region(vault);
     w.current_tokens = w.calculate_tokens();
 
@@ -4442,10 +4442,10 @@ fn apply_edge_transform_compact_returns_stage_specific_with_content() {
 fn apply_edge_transform_custom_respects_carry_clear_and_compact() {
     let mut w = transform_window();
     let mut keep = Region::new("keep".to_string(), RegionKind::Clearable, 500);
-    let _ = keep.add_entry("keepme".to_string(), 10);
+    let _ = keep.add_entry("keepme", 10);
     w.add_region(keep);
     let mut drop = Region::new("drop".to_string(), RegionKind::Clearable, 500);
-    let _ = drop.add_entry("dropme".to_string(), 10);
+    let _ = drop.add_entry("dropme", 10);
     w.add_region(drop);
     w.current_tokens = w.calculate_tokens();
 
@@ -4475,7 +4475,7 @@ fn apply_edge_transform_custom_respects_carry_clear_and_compact() {
 fn scratch_window() -> ContextWindow {
     let mut w = ContextWindow::new(1000);
     let mut scratch = Region::new("scratch".to_string(), RegionKind::Clearable, 500);
-    let _ = scratch.add_entry("work to summarize".to_string(), 20);
+    let _ = scratch.add_entry("work to summarize", 20);
     w.add_region(scratch);
     w.current_tokens = w.calculate_tokens();
     w
@@ -4933,7 +4933,7 @@ fn note_stuck_prefers_the_stuck_report_region_then_conversation() {
     let mut fallback = ctx(&[("conversation", 10_000)]);
     note_stuck(&mut fallback, "implement", "you are looping");
     let conv = fallback.get_region("conversation").unwrap();
-    let text: String = conv.content.iter().map(|e| e.content.as_str()).collect();
+    let text: String = conv.content.iter().map(|e| e.content()).collect();
     assert!(
         text.contains("Stuck detected in stage 'implement'"),
         "{text}"
@@ -5022,7 +5022,9 @@ fn detect_stuck_stage_fires_once_and_routes_to_resolve_transition() {
     let window = world.get::<ContextWindow>(e).unwrap();
     let conv = window.get_region("conversation").unwrap();
     assert!(
-        conv.content.iter().any(|c| c.content.contains("where.py")),
+        conv.content
+            .iter()
+            .any(|c| c.content().contains("where.py")),
         "the diagnosis must reach the next stage's context"
     );
     assert!(world.get::<StageProgress>(e).unwrap().stuck_fired);
@@ -5495,7 +5497,7 @@ fn require_context_regions_injects_default_message() {
         .unwrap()
         .content
         .iter()
-        .map(|entry| entry.content.clone())
+        .map(|entry| entry.content_owned())
         .collect::<String>();
     assert!(conv.contains("Required context region 'plan' is still empty"));
 }
@@ -5750,7 +5752,7 @@ fn resolve_transition_holds_the_stage_when_a_gate_blocks() {
         .unwrap()
         .content
         .iter()
-        .map(|entry| entry.content.clone())
+        .map(|entry| entry.content_owned())
         .collect::<String>();
     assert!(conv.contains("[System] No file modifications"));
     // Not yet forced - the budget hasn't run out.
@@ -6396,7 +6398,7 @@ fn collect_tools_injects_repetition_nudge_when_looping() {
         .unwrap()
         .content
         .iter()
-        .map(|entry| entry.content.clone())
+        .map(|entry| entry.content_owned())
         .collect();
     assert!(
         joined.contains("[System]"),

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1334,7 +1334,12 @@ pub fn spawn_agent_seeded(
     // Seed the window from the blueprint layout + task, then apply stage 0's
     // context setup (layout swap + system-prompt injection) just as entering any
     // later stage would.
-    let mut window = ContextWindow::new(blueprint.context_layout.total_budget_tokens);
+    let interner = world
+        .get_resource::<crate::ContentInternerRes>()
+        .map(|r| r.handle())
+        .unwrap_or_default();
+    let mut window =
+        ContextWindow::with_interner(blueprint.context_layout.total_budget_tokens, interner);
     // Attach compiled custom-region scripts BEFORE seeding, so seed writes
     // pass through each region's on_write hook like any other entry.
     window.region_scripts = region_scripts;

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -98,6 +98,7 @@ pub fn restore_agent(
         let mut window = world
             .get_mut::<ContextWindow>(entity)
             .expect("a spawned agent has a context window");
+        let interner = window.interner().clone();
         for snap_region in &snapshot.regions {
             if let Some(region) = window
                 .regions
@@ -107,13 +108,16 @@ pub fn restore_agent(
                 region.content = snap_region
                     .entries
                     .iter()
-                    .map(|e| RegionEntry {
-                        content: e.content.clone(),
-                        tokens: e.tokens,
-                        timestamp: 0,
-                        metadata: e.metadata.clone(),
-                        kind: e.kind.clone(),
-                        key: e.key.clone(),
+                    .map(|e| {
+                        RegionEntry::from_parts_interned(
+                            &interner,
+                            &e.content,
+                            e.tokens,
+                            0,
+                            e.metadata.clone(),
+                            e.kind.clone(),
+                            e.key.clone(),
+                        )
                     })
                     .collect();
                 // Rebuild the taint alongside the content. Assigning `content`
@@ -348,7 +352,7 @@ mod tests {
         let window = world.get::<ContextWindow>(entity).unwrap();
         let region = window.get_region("conversation").unwrap();
         assert_eq!(region.content.len(), 2);
-        assert_eq!(region.content[0].content, "prior user turn");
+        assert_eq!(region.content[0].content(), "prior user turn");
         assert_eq!(region.content[0].kind, EntryKind::UserMessage);
         assert_eq!(region.current_tokens, 8);
 

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -153,6 +153,7 @@ impl PipelineWorld {
 
         let mut world = World::new();
         world.insert_resource(Providers(providers));
+        world.insert_resource(crate::ContentInternerRes::new());
         world.insert_resource(InferenceStage {
             pools: Arc::new(InferencePools::new(pool_config)),
             outcomes: inf_tx,
@@ -1759,7 +1760,7 @@ mod tests {
             .get::<crate::components::ContextWindow>(entity)
             .unwrap();
         assert_eq!(
-            win.get_region("conversation").unwrap().content[0].content,
+            win.get_region("conversation").unwrap().content[0].content(),
             "restored turn"
         );
     }

--- a/crates/leviath-runtime/tests/context_management.rs
+++ b/crates/leviath-runtime/tests/context_management.rs
@@ -65,15 +65,13 @@ fn test_eviction_cascade_temporary_then_compacting() {
 
     // Add a Clearable region
     let mut clearable = Region::new("scratch".to_string(), RegionKind::Clearable, 3000);
-    clearable
-        .add_entry("scratch data".to_string(), 1500)
-        .unwrap();
+    clearable.add_entry("scratch data", 1500).unwrap();
     window.add_region(clearable);
 
     // Add a Temporary region
     let mut temp = Region::new("temp".to_string(), RegionKind::Temporary, 4000);
-    temp.add_entry("temp old".to_string(), 1000).unwrap();
-    temp.add_entry("temp new".to_string(), 1000).unwrap();
+    temp.add_entry("temp old", 1000).unwrap();
+    temp.add_entry("temp new", 1000).unwrap();
     window.add_region(temp);
 
     // Add a SlidingWindow region (should never be touched)
@@ -85,8 +83,8 @@ fn test_eviction_cascade_temporary_then_compacting() {
         },
         4000,
     );
-    sliding.add_entry("msg 1".to_string(), 500).unwrap();
-    sliding.add_entry("msg 2".to_string(), 500).unwrap();
+    sliding.add_entry("msg 1", 500).unwrap();
+    sliding.add_entry("msg 2", 500).unwrap();
     window.add_region(sliding);
 
     assert_eq!(window.current_tokens, 4500);
@@ -138,15 +136,15 @@ fn test_token_budget_enforcement() {
     let mut region = Region::new("test".to_string(), RegionKind::Pinned, 1000);
 
     // Adding within budget should succeed
-    assert!(region.add_entry("small".to_string(), 100).is_ok());
+    assert!(region.add_entry("small", 100).is_ok());
     assert_eq!(region.current_tokens, 100);
 
     // Adding more within budget should succeed
-    assert!(region.add_entry("medium".to_string(), 500).is_ok());
+    assert!(region.add_entry("medium", 500).is_ok());
     assert_eq!(region.current_tokens, 600);
 
     // Exceeding budget should fail
-    let result = region.add_entry("too large".to_string(), 500);
+    let result = region.add_entry("too large", 500);
     assert!(result.is_err());
     assert_eq!(region.current_tokens, 600); // unchanged
 }
@@ -156,16 +154,16 @@ fn test_region_content_management() {
     let mut region = Region::new("test".to_string(), RegionKind::Temporary, 5000);
 
     // Add multiple entries
-    region.add_entry("entry 1".to_string(), 100).unwrap();
-    region.add_entry("entry 2".to_string(), 200).unwrap();
-    region.add_entry("entry 3".to_string(), 300).unwrap();
+    region.add_entry("entry 1", 100).unwrap();
+    region.add_entry("entry 2", 200).unwrap();
+    region.add_entry("entry 3", 300).unwrap();
 
     assert_eq!(region.entry_count(), 3);
     assert_eq!(region.current_tokens, 600);
 
     // Remove oldest
     let removed = region.remove_oldest().unwrap();
-    assert_eq!(removed.content, "entry 1");
+    assert_eq!(removed.content(), "entry 1");
     assert_eq!(removed.tokens, 100);
     assert_eq!(region.entry_count(), 2);
     assert_eq!(region.current_tokens, 500);
@@ -187,11 +185,11 @@ fn test_compacting_region_needs_compaction() {
     );
 
     // Below threshold
-    region.add_entry("data".to_string(), 300).unwrap();
+    region.add_entry("data", 300).unwrap();
     assert!(!region.needs_compaction());
 
     // Above threshold
-    region.add_entry("more data".to_string(), 300).unwrap();
+    region.add_entry("more data", 300).unwrap();
     assert!(region.needs_compaction());
 }
 
@@ -234,12 +232,8 @@ fn test_eviction_result_needs_compaction_when_compacting_full() {
         },
         1400,
     );
-    compacting
-        .add_entry("data block 1".to_string(), 600)
-        .unwrap();
-    compacting
-        .add_entry("data block 2".to_string(), 600)
-        .unwrap();
+    compacting.add_entry("data block 1", 600).unwrap();
+    compacting.add_entry("data block 2", 600).unwrap();
     window.add_region(compacting);
 
     assert_eq!(window.current_tokens, 1200);
@@ -257,9 +251,7 @@ fn test_eviction_clears_then_identifies_compaction() {
 
     // Add clearable region
     let mut clearable = Region::new("scratch".to_string(), RegionKind::Clearable, 1000);
-    clearable
-        .add_entry("scratch stuff".to_string(), 400)
-        .unwrap();
+    clearable.add_entry("scratch stuff", 400).unwrap();
     window.add_region(clearable);
 
     // Add compacting region over threshold
@@ -270,7 +262,7 @@ fn test_eviction_clears_then_identifies_compaction() {
         },
         1200,
     );
-    compacting.add_entry("impl data".to_string(), 900).unwrap();
+    compacting.add_entry("impl data", 900).unwrap();
     window.add_region(compacting);
 
     assert_eq!(window.current_tokens, 1300);
@@ -499,18 +491,10 @@ async fn test_file_tracking_sync_assembly_integration() {
             && let Some(region) = window.get_region_mut("files")
         {
             region
-                .upsert_by_key(
-                    "src/main.py",
-                    "def main():\n    print('hello')".to_string(),
-                    10,
-                )
+                .upsert_by_key("src/main.py", "def main():\n    print('hello')", 10)
                 .unwrap();
             region
-                .upsert_by_key(
-                    "src/utils.py",
-                    "def helper():\n    return 42".to_string(),
-                    8,
-                )
+                .upsert_by_key("src/utils.py", "def helper():\n    return 42", 8)
                 .unwrap();
         }
     }


### PR DESCRIPTION
Domain Region APIs stay pure (no ContentInterner parameter). A World-scoped ContentInternerRes is cloned onto each ContextWindow at spawn; write and restore paths intern, then insert_entry.

- RegionEntry stores private InternedString; callers see &str only
- add_entry / upsert allocate uniquely; insert_entry is the runtime edge
- No process-global table — distinct interners never share
- Snapshots remain plain strings; restore re-interns through the window

## What & why

<!-- What does this PR change, and what problem does it solve?
     Link the issue it addresses, if there is one: Fixes #NNN -->

## How it was tested

<!-- Beyond `cargo test`: if the change affects runtime behavior, describe the
     live run you did (`lev run ...`, `lev dash`, daemon restart, ...).
     CI-green alone is not evidence a behavior change works. -->

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [ ] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [ ] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
- [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
