### PR TITLE
Write abnormal stage endings into context so recovery stages can see them

### DIFF
--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -331,7 +331,7 @@ transform = "custom"
 # stage-specific region including `test_results`, which is the raw evidence
 # reassess most needs. Compact only the conversation and leave the rest intact.
 [stages.implement.transitions.reassess.transform_config]
-carry = ["discovery", "workflow", "architecture", "conventions", "task", "plan", "codebase", "implementation", "prototypes", "errors", "test_results", "stuck_report"]
+carry = ["discovery", "workflow", "architecture", "conventions", "task", "plan", "codebase", "implementation", "prototypes", "errors", "test_results", "stuck_report", "error_report"]
 compact = ["conversation"]
 clear = ["scratch"]
 compact_prompt = "Summarize what was attempted in this stage: which files were edited and how often, which tests were run and their outcome, and the last point at which anything demonstrably worked."
@@ -380,6 +380,10 @@ which is where changes are made and re-reviewed.
    baseline captured, verification never run), say so.
 5. Check: correctness vs. the task, edge cases, error handling, security, and
    code quality/conventions.
+
+If `error_report` says the implement stage hit its iteration cap, it was cut off
+before declaring the work done - assume the implementation is incomplete and
+verify every DONE WHEN criterion rather than sampling.
 
 End with one of:
   APPROVED - no significant issues
@@ -471,7 +475,7 @@ bash      = "test_results"
 hint = "Corrected plan in hand - retry implementation"
 transform = "custom"
 [stages.reassess.transitions.implement.transform_config]
-carry = ["discovery", "workflow", "architecture", "conventions", "task", "plan", "codebase", "implementation", "prototypes", "errors", "stuck_report"]
+carry = ["discovery", "workflow", "architecture", "conventions", "task", "plan", "codebase", "implementation", "prototypes", "errors", "stuck_report", "error_report"]
 compact = ["conversation"]
 clear = ["scratch", "test_results"]
 compact_prompt = "Summarize the reassessment as three things: the wrong assumption, the corrected approach, and what must be reverted first."
@@ -490,11 +494,12 @@ available_tools = ["read_file", "bash", "context_append"]
 max_iterations = 10
 max_revisits = 2
 system_prompt = """
-An error occurred. Read the error details from context, diagnose the root cause,
-and note a fix or workaround. Append a one-line summary of the failure to the
-`errors` region (context_append) so repeated failures become visible as a pattern,
-then transition back to implement to retry. If you see the SAME error recurring in
-`errors`, change approach rather than repeating the fix.
+An error occurred. The `error_report` region holds the error text the runtime
+captured - read it first, diagnose the root cause, and note a fix or workaround.
+Append a one-line summary of the failure to the `errors` region (context_append)
+so repeated failures become visible as a pattern, then transition back to
+implement to retry. If you see the SAME error recurring in `errors`, change
+approach rather than repeating the fix.
 """
 
 # Route tool chatter to scratch (clearable), not `errors`: `errors` is a
@@ -541,6 +546,10 @@ prototypes   = { kind = "pinned", budget = "4%", max_tokens = 6000 }
 # Written by the RUNTIME when a `stuck` edge fires (issue #106): which threshold
 # tripped and why. Pinned so it survives the edge transform into `reassess`.
 stuck_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into `error_recovery` or `review`.
+error_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
 
 # ── Discovery (issue #108): written by the discover stage, read by every later
 # stage. Pinned, so no edge transform can clear or compact them. `required` puts

--- a/crates/leviath-cli/agents/daily-briefer/agent.leviath
+++ b/crates/leviath-cli/agents/daily-briefer/agent.leviath
@@ -72,6 +72,9 @@ using these tiers:
 
 Drop noise, duplicates, and irrelevant items entirely (don't write them). If a
 critical configured source came back empty, consider one more collect pass.
+
+If `error_report` says the collect stage hit its iteration cap, it was cut off
+before checking every source - flag the unchecked ones as gaps for the briefing.
 """
 
 [stages.prioritize.transitions.brief]
@@ -124,9 +127,10 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-A source fetch or parse failed. Read the error from context, note which source is
-unavailable, and record that gap so the briefing can flag it. Then return to
-prioritize with whatever was successfully collected.
+A source fetch or parse failed. The `error_report` region holds the error text
+the runtime captured - read it first, note which source is unavailable, and
+record that gap so the briefing can flag it. Then return to prioritize with
+whatever was successfully collected.
 """
 
 [stages.error_recovery.transitions.prioritize]
@@ -147,3 +151,8 @@ priorities  = { kind = "sliding_window", max_items = 25, budget = "10%", max_tok
 brief       = { kind = "clearable",      budget = "5%", max_tokens = 6000 }
 
 conversation = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -84,6 +84,10 @@ Analyze the `sources` against `sources_index`. Be rigorous:
 
 Prefer following a key citation (follow_citations) over re-searching when a claim
 hinges on a source you haven't read directly.
+
+If `error_report` says a previous stage hit its iteration cap, that stage was cut
+off before finishing - treat its output as incomplete and verify coverage before
+concluding.
 """
 
 [stages.analyze.transitions.gather]
@@ -171,9 +175,9 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-A source fetch or parse failed. Read the error from context, record which source
-is unavailable and why (as a gap), and hand back to analyze to continue with the
-material you do have.
+A call failed mid-research. The `error_report` region holds the error text the
+runtime captured - read it first. Record which source is unavailable and why (as
+a gap), and hand back to analyze to continue with the material you do have.
 """
 
 [stages.error_recovery.transitions.analyze]
@@ -199,3 +203,8 @@ analysis         = { kind = "compacting",      budget = "30%", compact_at = "80%
 analysis_history = { kind = "compact_history", source_region = "analysis", budget = "3%", max_tokens = 15000 }
 
 conversation   = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report   = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -69,6 +69,9 @@ Quantify everything (timestamps, counts, rates). For each finding, append to
 with SEVERITY in {critical, warning, info}. Keep a running tally in `severity_index`
 (context_write), e.g. "critical: 2, warning: 5, info: 3". Use the `script` stage
 when you need precise parsing/aggregation you can't eyeball.
+
+If `error_report` says a previous stage hit its iteration cap, that stage was cut
+off before finishing - treat its output as incomplete and re-check what it missed.
 """
 
 [stages.analyze.tool_routing]
@@ -167,9 +170,10 @@ available_tools = ["read_file", "bash"]
 max_iterations = 10
 max_revisits = 1
 system_prompt = """
-A read or script execution failed. Read the error from context, diagnose it
-(a malformed log line, a script bug, a missing file), note a workaround, then
-return to analyze to continue with the data available.
+A read or script execution failed. The `error_report` region holds the error
+text the runtime captured - read it first, diagnose it (a malformed log line, a
+script bug, a missing file), note a workaround, then return to analyze to
+continue with the data available.
 """
 
 [stages.error_recovery.transitions.analyze]
@@ -192,3 +196,8 @@ scripts_history = { kind = "compact_history", source_region = "scripts", budget 
 
 conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
 scratch         = { kind = "clearable", budget = "6%", max_tokens = 6000 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report    = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -79,6 +79,10 @@ Analyze the `raw_findings` against the `sources_index`. Do three things:
 
 Use web_fetch for a targeted follow-up only when a specific gap blocks a claim.
 Flag open questions you couldn't resolve.
+
+If `error_report` says a previous stage hit its iteration cap, that stage was cut
+off before finishing - treat its output as incomplete and verify coverage before
+concluding.
 """
 
 [stages.analyze.tool_routing]
@@ -129,9 +133,10 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-Something failed during research (a source fetch, a parse, etc.). Read the
-error from context, work out what went wrong, and note a workaround. Then hand
-back to analyze to continue with whatever material is available.
+Something failed during research (a source fetch, a parse, etc.). The
+`error_report` region holds the error text the runtime captured - read it first,
+work out what went wrong, and note a workaround. Then hand back to analyze to
+continue with whatever material is available.
 """
 
 [stages.error_recovery.transitions.analyze]
@@ -169,3 +174,8 @@ synthesis_history = { kind = "compact_history", source_region = "synthesis", bud
 # the per-stage layout is rebuilt from this table on each transition, so an
 # auto-added one would be dropped after the first stage.
 conversation      = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report      = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -157,6 +157,10 @@ Order findings most-severe first and group by severity level:
 For each: file and line, one-sentence defect summary, the failure scenario, and the
 fix. End with a short overall assessment (ship / ship-with-fixes / needs-work) that
 matches the severity_index totals.
+
+If `error_report` says an earlier stage hit its iteration cap, the review was cut
+off before covering everything - say so in the overall assessment and list what
+went unreviewed.
 """
 
 # Explicit empty transitions = terminal.
@@ -171,9 +175,9 @@ available_tools = ["read_file", "bash"]
 max_iterations = 10
 max_revisits = 1
 system_prompt = """
-An error occurred during review. Diagnose it from context, note a workaround
-(e.g. skip an unreadable file and record why), then return to deep_review to
-continue with the rest.
+An error occurred during review. The `error_report` region holds the error text
+the runtime captured - read it first, note a workaround (e.g. skip an unreadable
+file and record why), then return to deep_review to continue with the rest.
 """
 
 [stages.error_handler.transitions.deep_review]
@@ -218,3 +222,8 @@ report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
 # `conversation` region - the layout that replaces it on each stage transition is
 # rebuilt from this table, so an auto-added one would be dropped after stage 1.
 conversation    = { kind = "sliding_window", max_items = 30, budget = "15%", max_tokens = 18000, strategy = "bulk", overflow = 10 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report    = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/software-engineer/agent.leviath
+++ b/crates/leviath-cli/agents/software-engineer/agent.leviath
@@ -407,7 +407,7 @@ transform = "custom"
 # stage-specific region including `test_results`, the raw evidence reassess most
 # needs. Compact only the conversation and leave the rest intact.
 [stages.implement.transitions.reassess.transform_config]
-carry = ["discovery", "workflow", "task", "constraints", "architecture", "plan", "codebase", "implementation", "prototypes", "changelog", "decisions", "errors", "test_results", "stuck_report"]
+carry = ["discovery", "workflow", "task", "constraints", "architecture", "plan", "codebase", "implementation", "prototypes", "changelog", "decisions", "errors", "test_results", "stuck_report", "error_report"]
 compact = ["conversation"]
 clear = ["scratch"]
 compact_prompt = "Summarize what was attempted in this stage: which files were edited and how often, which tests were run and their outcome, and the last point at which anything demonstrably worked."
@@ -461,6 +461,10 @@ anything that passed there and fails now is a regression, and is grounds for
 NEEDS CHANGES on its own. Hold the work to `workflow`'s DONE WHEN line, and say
 so if the implement stage skipped its own stated workflow (no baseline captured,
 verification never run).
+
+If `error_report` says the implement stage hit its iteration cap, it was cut off
+before declaring the work done - assume the implementation is incomplete and
+verify every DONE WHEN criterion rather than sampling.
 
 End with one of:
   APPROVED - no significant issues
@@ -552,7 +556,7 @@ bash      = "test_results"
 hint = "Corrected plan in hand - retry implementation"
 transform = "custom"
 [stages.reassess.transitions.implement.transform_config]
-carry = ["discovery", "workflow", "task", "constraints", "architecture", "plan", "codebase", "implementation", "prototypes", "changelog", "decisions", "errors", "stuck_report"]
+carry = ["discovery", "workflow", "task", "constraints", "architecture", "plan", "codebase", "implementation", "prototypes", "changelog", "decisions", "errors", "stuck_report", "error_report"]
 compact = ["conversation"]
 clear = ["scratch", "test_results"]
 compact_prompt = "Summarize the reassessment as three things: the wrong assumption, the corrected approach, and what must be reverted first."
@@ -573,7 +577,7 @@ max_iterations = 10
 max_revisits = 2
 system_prompt = """
 An error occurred during implementation. Your job:
-1. Read the error details from the conversation context.
+1. Read the error text the runtime captured in the `error_report` region.
 2. Diagnose the root cause.
 3. Suggest a fix or workaround.
 
@@ -613,6 +617,10 @@ prototypes   = { kind = "pinned", budget = "4%", max_tokens = 6000 }
 # Written by the RUNTIME when a `stuck` edge fires (issue #106): which threshold
 # tripped and why. Pinned so it survives the edge transform into `reassess`.
 stuck_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into `error_recovery` or `review`.
+error_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
 # Deterministic repo scan, run once at spawn - the discover stage starts from
 # facts instead of burning iterations on `ls`. `git ls-files` behaves identically
 # on POSIX and Windows shells; outside a git repo it fails and this is simply

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -74,6 +74,9 @@ Compare across the `landscape`, organizing by THEME not by source:
 Record the key comparative judgments in `comparisons` (context_write) and any
 source disagreements you notice. Flag threads that deserve a deep_dive before you
 can rank them fairly. Help the reader see the shape of the field.
+
+If `error_report` says a previous stage hit its iteration cap, that stage was cut
+off before finishing - treat its coverage as incomplete when judging the field.
 """
 
 [stages.compare.transitions.survey]
@@ -156,8 +159,9 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-A source fetch failed during the survey. Read the error from context, note the
-gap, and return to compare to continue with the coverage you have.
+A call failed during the survey. The `error_report` region holds the error text
+the runtime captured - read it first, note the gap it leaves, and return to
+compare to continue with the coverage you have.
 """
 
 [stages.error_recovery.transitions.compare]
@@ -181,3 +185,8 @@ comparisons        = { kind = "compacting",      budget = "25%", compact_at = "8
 comparison_history = { kind = "compact_history", source_region = "comparisons", budget = "3%", max_tokens = 10000 }
 
 conversation       = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report       = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/agents/writing-assistant/agent.leviath
+++ b/crates/leviath-cli/agents/writing-assistant/agent.leviath
@@ -168,6 +168,9 @@ Edit the draft for structure and substance (not line-level polish yet):
 
 Make the edits directly (write the improved version). Note any substantive changes
 in `revisions` (context_append). Hand to proofread only once the structure is sound.
+
+If `error_report` says a previous stage hit its iteration cap, that stage was cut
+off before finishing - check the draft for missing sections before polishing it.
 """
 
 # Custom transform: keep task/outline/research/sources pinned, compact the draft
@@ -233,8 +236,9 @@ available_tools = ["read_file", "bash"]
 max_iterations = 8
 max_revisits = 1
 system_prompt = """
-Something failed (a research fetch or a file write). Read the error from context,
-note a workaround, then return to draft to continue with the material available.
+Something failed (a research fetch or a file write). The `error_report` region
+holds the error text the runtime captured - read it first, note a workaround,
+then return to draft to continue with the material available.
 """
 
 [stages.error_recovery.transitions.draft]
@@ -259,3 +263,8 @@ revisions     = { kind = "sliding_window", max_items = 15, budget = "4%", max_to
 
 conversation  = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
 scratch       = { kind = "clearable", budget = "5%", max_tokens = 6000 }
+
+# Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
+# inference call's error text, or a note that a stage hit its iteration cap.
+# Pinned so it survives the edge transform into the stage that acts on it.
+error_report  = { kind = "pinned", budget = "1%", max_tokens = 2000 }

--- a/crates/leviath-cli/tests/manifest_integration.rs
+++ b/crates/leviath-cli/tests/manifest_integration.rs
@@ -332,6 +332,75 @@ fn all_builtin_stuck_edges_are_armed_and_bounded() {
     }
 }
 
+/// Every built-in agent with an `error`-conditioned edge must give the runtime's
+/// abnormal-ending notes (issue #154: inference errors, iteration caps) a home:
+///   1. a pinned `error_report` region, so the note survives every edge
+///      transform into the stage that acts on it (the runtime falls back to
+///      `conversation`, but a bundled agent should use the durable region);
+///   2. that region must NOT be the agent's first pinned region -
+///      `apply_stage_context` injects stage instructions into the first pinned
+///      region, and a 2k-token report region would swallow them;
+///   3. every error-edge target's system prompt must tell the model to read
+///      `error_report` - the region is useless if no prompt points at it.
+#[test]
+fn builtin_error_edges_have_a_pinned_error_report_region() {
+    use leviath_core::{RegionKind, TransitionCondition};
+
+    for (name, path) in &discover_agent_manifests() {
+        let content = std::fs::read_to_string(path).unwrap();
+        let bp = leviath_core::manifest::parse_manifest(&content).unwrap();
+
+        let error_targets: std::collections::BTreeSet<&str> = bp
+            .stages
+            .iter()
+            .filter_map(|s| s.transitions.as_ref())
+            .flatten()
+            .filter(|(_, e)| e.condition == TransitionCondition::Error)
+            .map(|(target, _)| target.as_str())
+            .collect();
+        if error_targets.is_empty() {
+            continue; // e.g. parallel-fixer, which declares no error edge
+        }
+
+        let pinned: Vec<&str> = bp
+            .context_layout
+            .regions
+            .iter()
+            .filter(|r| matches!(r.kind, RegionKind::Pinned))
+            .map(|r| r.name.as_str())
+            .collect();
+        assert!(
+            pinned.contains(&"error_report"),
+            "agent '{name}' has error edges but no pinned `error_report` region - \
+             the runtime's error/iteration-cap notes would land in the evictable \
+             `conversation` window instead"
+        );
+        assert_ne!(
+            pinned.first(),
+            Some(&"error_report"),
+            "agent '{name}': `error_report` is the FIRST pinned region, so stage \
+             instructions would be injected into it (apply_stage_context targets \
+             the first pinned region) - declare it after the other pinned regions"
+        );
+
+        for target in error_targets {
+            let stage = bp
+                .find_stage(target)
+                .unwrap_or_else(|| panic!("agent '{name}': error edge → unknown stage '{target}'"));
+            assert!(
+                stage
+                    .config
+                    .get("system_prompt")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|p| p.contains("error_report")),
+                "agent '{name}' stage '{target}' is an error-edge target but its \
+                 system prompt never mentions `error_report` - the model won't \
+                 know where the runtime put the error text"
+            );
+        }
+    }
+}
+
 /// A stage with two or more *choosable* outgoing edges is routed by an LLM
 /// (`resolve_transition_sync` returns `Choose`, and `build_transition_prompt`
 /// asks the model to name a stage). Without a `transition_prompt` the model gets

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4941,6 +4941,65 @@ fn note_stuck_prefers_the_stuck_report_region_then_conversation() {
     assert!(text.contains("you are looping"), "{text}");
 }
 
+#[test]
+fn note_error_prefers_the_error_report_region_then_conversation() {
+    let mut with_report = ctx(&[("conversation", 10_000), ("error_report", 10_000)]);
+    note_error(&mut with_report, "gather", "provider timed out");
+    assert!(
+        with_report
+            .get_region("error_report")
+            .unwrap()
+            .current_tokens
+            > 0
+    );
+    assert_eq!(
+        with_report
+            .get_region("conversation")
+            .unwrap()
+            .current_tokens,
+        0
+    );
+
+    // Blueprints that declare no error_report still get the error text -
+    // every blueprint is required to declare `conversation`.
+    let mut fallback = ctx(&[("conversation", 10_000)]);
+    note_error(&mut fallback, "gather", "provider timed out");
+    let conv = fallback.get_region("conversation").unwrap();
+    let text: String = conv.content.iter().map(|e| e.content.as_str()).collect();
+    assert!(text.contains("Inference error in stage 'gather'"), "{text}");
+    assert!(text.contains("provider timed out"), "{text}");
+}
+
+#[test]
+fn note_max_iterations_prefers_the_error_report_region_then_conversation() {
+    let mut with_report = ctx(&[("conversation", 10_000), ("error_report", 10_000)]);
+    note_max_iterations(&mut with_report, "implement", 12);
+    assert!(
+        with_report
+            .get_region("error_report")
+            .unwrap()
+            .current_tokens
+            > 0
+    );
+    assert_eq!(
+        with_report
+            .get_region("conversation")
+            .unwrap()
+            .current_tokens,
+        0
+    );
+
+    let mut fallback = ctx(&[("conversation", 10_000)]);
+    note_max_iterations(&mut fallback, "implement", 12);
+    let conv = fallback.get_region("conversation").unwrap();
+    let text: String = conv.content.iter().map(|e| e.content.as_str()).collect();
+    assert!(
+        text.contains("Stage 'implement' hit its iteration cap (12)"),
+        "{text}"
+    );
+    assert!(text.contains("possibly incomplete"), "{text}");
+}
+
 /// Build a world holding one `ReadyToInfer` agent whose stage `a` carries a
 /// `stuck` edge to `b` armed on `cfg`.
 fn spawn_stuck_agent(
@@ -5221,6 +5280,12 @@ fn resolve_transition_routes_error_to_error_edge() {
         AgentStatus::Active
     );
     assert!(world.get::<StageOutcome>(e).is_none());
+    // The error text was written into context for the recovery stage to read.
+    let text = conversation_text(&world, e);
+    assert!(
+        text.contains("[Inference error in stage 'a'] boom"),
+        "{text}"
+    );
 }
 
 #[test]
@@ -5253,13 +5318,17 @@ fn resolve_transition_errors_terminally_without_an_error_edge() {
     );
     assert!(world.get::<StageOutcome>(e).is_none());
     assert!(world.get::<ResolveTransition>(e).is_none());
+    // A terminal error writes no note - the run is over and the status
+    // already carries the message.
+    assert_eq!(conversation_text(&world, e), "");
 }
 
 #[test]
 fn resolve_transition_routes_max_iterations_edge_else_falls_through() {
     // With a max_iterations edge → follow it.
     let mi = conditioned_edge("recovery", TransitionCondition::MaxIterations);
-    let a = stage_named("a", Some(vec![("m".to_string(), mi)]), false, None);
+    let mut a = stage_named("a", Some(vec![("m".to_string(), mi)]), false, None);
+    a.max_iterations = Some(7);
     let recovery = stage_named("recovery", None, false, None);
     let bp = blueprint(vec![a, recovery]);
     let mut world = World::new();
@@ -5271,9 +5340,17 @@ fn resolve_transition_routes_max_iterations_edge_else_falls_through() {
     );
     run_transition(&mut world);
     assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    // The cap note reached context so the recovery stage knows why it runs.
+    let text = conversation_text(&world, e);
+    assert!(
+        text.contains("Stage 'a' hit its iteration cap (7)"),
+        "{text}"
+    );
 
-    // Without one → fall through to a normal (linear) transition.
-    let a2 = stage_named("a", None, false, None);
+    // Without one → fall through to a normal (linear) transition, still
+    // telling the next stage the work was cut off.
+    let mut a2 = stage_named("a", None, false, None);
+    a2.max_iterations = Some(3);
     let b2 = stage_named("b", None, false, None);
     let bp2 = blueprint(vec![a2, b2]);
     let mut world2 = World::new();
@@ -5286,6 +5363,11 @@ fn resolve_transition_routes_max_iterations_edge_else_falls_through() {
     run_transition(&mut world2);
     assert_eq!(world2.get::<StageCursor>(e2).unwrap().index, 1); // linear fall-through
     assert!(world2.get::<StageOutcome>(e2).is_none());
+    let text2 = conversation_text(&world2, e2);
+    assert!(
+        text2.contains("Stage 'a' hit its iteration cap (3)"),
+        "{text2}"
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -216,6 +216,12 @@ pub fn enforce_max_iterations(
 /// stage that has to act on it.
 pub(crate) const STUCK_REPORT_REGION: &str = "stuck_report";
 
+/// The context region an abnormal-ending note (inference error, iteration cap)
+/// is written to when the blueprint declares one. Pinned by convention, like
+/// [`STUCK_REPORT_REGION`], so the note survives the edge transform into the
+/// stage that has to act on it.
+pub(crate) const ERROR_REPORT_REGION: &str = "error_report";
+
 /// The per-stage numbers a [`StuckConfig`](leviath_core::blueprint::StuckConfig)
 /// is evaluated against.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -303,6 +309,46 @@ pub(crate) fn note_stuck(window: &mut ContextWindow, stage: &str, reason: &str) 
     );
     let tokens = leviath_core::estimate_tokens(&content);
     let _ = window.add_to_region(region, content, tokens);
+}
+
+/// Write an abnormal-ending note where the next stage will read it: the
+/// blueprint's `error_report` region when it declares one, else `conversation`.
+/// Best-effort, like [`note_stuck`] - an overflowing region silently drops it.
+fn note_abnormal_ending(window: &mut ContextWindow, content: String) {
+    let region = if window.get_region(ERROR_REPORT_REGION).is_some() {
+        ERROR_REPORT_REGION
+    } else {
+        "conversation"
+    };
+    let tokens = leviath_core::estimate_tokens(&content);
+    let _ = window.add_to_region(region, content, tokens);
+}
+
+/// Write the inference error that ended a stage into context, so the recovery
+/// stage an `error` edge routes to starts out knowing what failed instead of
+/// being told to diagnose an error it cannot see.
+pub(crate) fn note_error(window: &mut ContextWindow, stage: &str, message: &str) {
+    note_abnormal_ending(
+        window,
+        format!(
+            "[Inference error in stage '{stage}'] {message}. Diagnose this failure from \
+             the error text above before retrying or working around it."
+        ),
+    );
+}
+
+/// Write an iteration-cap note into context when a stage runs out of
+/// iterations, so whatever stage runs next - a `max_iterations` edge target or
+/// the normal successor - knows the work was cut off rather than finished.
+pub(crate) fn note_max_iterations(window: &mut ContextWindow, stage: &str, cap: usize) {
+    note_abnormal_ending(
+        window,
+        format!(
+            "[Stage '{stage}' hit its iteration cap ({cap})] The stage was cut off before \
+             it declared completion - treat its output as possibly incomplete and verify \
+             it before building on it."
+        ),
+    );
 }
 
 /// Stuck-detection guard: for each `ReadyToInfer` agent whose current stage
@@ -830,12 +876,23 @@ pub fn resolve_transition(
             // An error/max-iterations edge is never gated: the stage already
             // failed, and holding it back to demand file changes would strand a
             // run that can't make any.
-            Some(StageOutcome::Errored(_)) => {
-                find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error)
-                    .map(|(i, t)| StageResolution::Next(i, t, None))
-                    .unwrap_or(StageResolution::TerminalError)
+            Some(StageOutcome::Errored(message)) => {
+                match find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error) {
+                    Some((i, t)) => {
+                        // Put the error where the recovery stage will read it;
+                        // without an error edge the run terminates and the
+                        // status already carries the message.
+                        note_error(&mut window, &stage.name, message);
+                        StageResolution::Next(i, t, None)
+                    }
+                    None => StageResolution::TerminalError,
+                }
             }
             Some(StageOutcome::MaxIterations) => {
+                // Whatever runs next - a max_iterations edge target, the normal
+                // successor, or the transition-choice model - should know the
+                // stage was cut off, not finished.
+                note_max_iterations(&mut window, &stage.name, stage.max_iterations.unwrap_or(0));
                 find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::MaxIterations)
                     .map(|(i, t)| StageResolution::Next(i, t, None))
                     .unwrap_or_else(|| {

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -62,6 +62,10 @@ stuck_after_minutes         = 30
 Any subset applies; the first threshold to trip fires the edge.
 
 > [!TIP]
-> When a `stuck` (or `error`) edge fires, the runtime writes *why* into the target stage's
+> When a `stuck` or `error` edge fires, the runtime writes *why* into the target stage's
 > [context](/docs/context), so the recovery stage starts out knowing what went wrong instead of
-> rediscovering it.
+> rediscovering it. The same happens when a stage hits its iteration cap: whatever stage runs
+> next is told the work was cut off, not finished. Stuck reasons go to a `stuck_report` region
+> when the blueprint declares one; error and iteration-cap notes prefer an `error_report` region.
+> Declare them `pinned` (a small budget like 2000 tokens is plenty) so the note survives edge
+> transforms; without them, notes land in `conversation`.


### PR DESCRIPTION
Closes #154.

## What

When an inference call failed, the error text went to the stage's logs and was dropped at the transition, so every bundled `error_recovery` stage was prompted to read an error that never reached context. Iteration caps were worse: the next stage was never told the previous one was cut off mid-work.

`resolve_transition` now writes a note into context before following the edge, mirroring the existing stuck-note pattern (`note_stuck`):

- **Inference errors** (`StageOutcome::Errored`): the error message is written when an error edge is taken. A terminal error writes nothing since the run stops and the status already carries the message.
- **Iteration caps** (`StageOutcome::MaxIterations`): a cap note is written on every resolution, including the fall-through, so the normal successor or the transition-choice model knows the stage was cut off rather than finished.

Notes prefer a pinned `error_report` region when the blueprint declares one, else `conversation` (which every blueprint must declare). Same best-effort semantics as the stuck note.

## Bundled agents

All 9 agents with an error edge now declare a pinned `error_report` region (declared last, so stage-instruction injection keeps targeting the agent's first pinned region), and their `error_recovery`/`error_handler` prompts point at it. The stages that inherit cut-off work (coder/software-engineer `review`, the researchers' `analyze`/`compare`, log-analyzer `analyze`, daily-briefer `prioritize`, writing-assistant `edit`, reviewer `report`) are told what an iteration-cap note means. coder and software-engineer carry `error_report` across their custom transforms, matching `stuck_report`. A new manifest invariant (`builtin_error_edges_have_a_pinned_error_report_region`) holds all discovered agents to this.

The stages-doc tip that already claimed the error half of this behavior is now true, and covers iteration caps.

## Verification

- `cargo xtask coverage`: all 11 packages at 100%.
- Live-verified against a real daemon with a deterministic Rhai mock provider driving the bundled researcher agent: a thrown gather inference produced `[Inference error in stage 'gather'] SYNTH-PROVIDER-FAILURE...` in the pinned `error_report` region of the recovery stage, and a stalled `error_recovery` stage hit its cap and delivered `[Stage 'error_recovery' hit its iteration cap (8)]` to the next stage's context. Both notes survived edge transforms through to the final stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXQyh181pARyoEa9FnBKE3