### PR TITLE
Make stage nudging programmable instead of a hard-coded rule

### DIFF
--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -202,6 +202,15 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub batch_tool_hint: bool,
 
+    /// Machine-wide defaults for the empty-response nudge (`[nudge]`): the
+    /// `[System]` message injected when a stage's model replies with text
+    /// before making any tool call. All three keys (`enabled`, `max`, `text`)
+    /// are optional; an agent's `[agent.nudge]` or a stage's
+    /// `[stages.<name>.nudge]` overrides each field independently. See
+    /// [`leviath_core::resolve_nudge`].
+    #[serde(default)]
+    pub nudge: leviath_core::NudgeConfig,
+
     /// Completion-webhook delivery tuning (retry/backoff/timeout).
     #[serde(default)]
     pub webhook: WebhookConfig,
@@ -646,6 +655,7 @@ impl Default for Config {
             taint_tracking: false,
             limits: LimitsConfig::default(),
             batch_tool_hint: true,
+            nudge: leviath_core::NudgeConfig::default(),
             webhook: WebhookConfig::default(),
             observability: ObservabilityConfig::default(),
             sandbox: None,
@@ -2635,6 +2645,28 @@ anthropic_api_key = "sk-ant-test-key"
             config.providers.anthropic_api_key.as_deref(),
             Some("sk-ant-test-key")
         );
+        // No [nudge] section ⇒ every field unset ⇒ built-in defaults apply.
+        assert_eq!(config.nudge, leviath_core::NudgeConfig::default());
+    }
+
+    #[test]
+    fn config_parses_partial_nudge_section() {
+        // A [nudge] section only pins the keys it names.
+        let config: Config = toml::from_str(
+            r#"
+default_provider = "openai"
+agent_paths = []
+
+[providers]
+
+[nudge]
+enabled = false
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.nudge.enabled, Some(false));
+        assert_eq!(config.nudge.max, None);
+        assert_eq!(config.nudge.text, None);
     }
 
     #[test]
@@ -2739,6 +2771,11 @@ anthropic_api_key = "sk-ant-test-key"
                 script_shell_timeout_secs: 45,
             },
             batch_tool_hint: true,
+            nudge: leviath_core::NudgeConfig {
+                enabled: Some(true),
+                max: Some(2),
+                text: Some("Use your tools.".to_string()),
+            },
             webhook: WebhookConfig {
                 max_retries: 5,
                 base_delay_ms: 250,
@@ -2808,6 +2845,14 @@ anthropic_api_key = "sk-ant-test-key"
             Some(&ReadPathGrants {
                 allow: vec!["glob:~/design-docs/**".to_string()],
             })
+        );
+        assert_eq!(
+            deserialized.nudge,
+            leviath_core::NudgeConfig {
+                enabled: Some(true),
+                max: Some(2),
+                text: Some("Use your tools.".to_string()),
+            }
         );
         assert_eq!(deserialized.webhook.max_retries, 5);
         assert_eq!(deserialized.webhook.base_delay_ms, 250);

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -972,6 +972,7 @@ fn build_agent_inner(
         &seeds,
         stages,
         config.batch_tool_hint,
+        config.nudge.clone(),
         region_scripts,
     )?;
 

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -58,6 +58,12 @@ pub struct Blueprint {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub batch_tool_hint: Option<bool>,
 
+    /// Agent-level default for the empty-response nudge. `None` inherits the
+    /// global config's `[nudge]` section; a per-stage `[stages.<name>.nudge]`
+    /// overrides this. See [`resolve_nudge`] for the cascade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nudge: Option<NudgeConfig>,
+
     /// Repetition detection configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repetition_detection: Option<RepetitionDetectionConfig>,
@@ -128,6 +134,7 @@ impl Blueprint {
             metadata: HashMap::new(),
             security: None,
             batch_tool_hint: None,
+            nudge: None,
             repetition_detection: None,
             file_tracking: None,
             sandbox: None,
@@ -746,6 +753,14 @@ pub struct Stage {
     #[serde(default)]
     pub batch_tool_hint: Option<bool>,
 
+    /// Per-stage empty-response nudge settings. Each field independently
+    /// inherits the agent-level `Blueprint.nudge` (which in turn inherits the
+    /// global config's `[nudge]` section). A stage whose deliverable is text -
+    /// a planner, a briefing writer - sets `enabled = false` here so it is
+    /// never told to "use your tools". See [`resolve_nudge`].
+    #[serde(default)]
+    pub nudge: Option<NudgeConfig>,
+
     /// Per-stage sandbox override. `None` inherits the agent-level
     /// `Blueprint.sandbox` (which in turn inherits the global default = host).
     /// Set a tighter sandbox here to isolate a single stage - e.g. run analysis
@@ -787,6 +802,7 @@ impl Stage {
             allow_as_worker: false,
             security: None,
             batch_tool_hint: None,
+            nudge: None,
             sandbox: None,
             tool_result_routing: None,
         }
@@ -1075,6 +1091,86 @@ pub const DEFAULT_GATE_ATTEMPTS: usize = 3;
 /// [`TransitionGate::tools`].
 pub const MODIFYING_TOOLS: &[&str] = &["write_file", "edit_file"];
 
+/// Settings for the empty-response nudge: the `[System]` message injected when
+/// a stage's model replies with text before making any tool call.
+///
+/// Every field is optional. A field left unset cascades stage → agent → global
+/// config and finally to the built-in default, so a `[stages.<name>.nudge]`
+/// block only has to name what it wants to change. An empty block is inert.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NudgeConfig {
+    /// Whether the nudge fires at all. When unset at every level, the default
+    /// is on - except for a stage with interaction points, whose text response
+    /// is its work product and which is left alone. Setting this explicitly at
+    /// any level overrides that implicit rule in both directions.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+
+    /// How many text-only responses to nudge before accepting the text as
+    /// final. Defaults to [`DEFAULT_MAX_NUDGES`].
+    #[serde(default)]
+    pub max: Option<usize>,
+
+    /// The nudge text. Defaults to [`DEFAULT_NUDGE_TEXT`]. Supports `{stage}`
+    /// (the stage's name) and `{regions}` (comma-separated names of the
+    /// stage's required context regions) placeholders.
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+/// Default nudge injected when a model responds with text before making any
+/// tool call, used when no [`NudgeConfig`] level sets `text`.
+pub const DEFAULT_NUDGE_TEXT: &str = "You have tools available. Please use them to complete the task. Start by reading the relevant files in the working directory.";
+
+/// Default number of text-only responses to nudge before accepting the text as
+/// final, used when no [`NudgeConfig`] level sets `max`.
+pub const DEFAULT_MAX_NUDGES: usize = 3;
+
+/// A fully-resolved nudge policy for one stage: every [`NudgeConfig`] field
+/// cascaded and defaulted. Produced by [`resolve_nudge`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedNudge {
+    /// Whether the nudge fires for this stage.
+    pub enabled: bool,
+    /// Text-only responses tolerated before the text is accepted as final.
+    pub max: usize,
+    /// The nudge text, before placeholder interpolation.
+    pub text: String,
+}
+
+/// Resolve the nudge policy for a stage, cascading each field independently
+/// stage → agent → global. Narrowest level wins with no clamping - like
+/// [`crate::taint::resolve_batch_tool_hint`], this is a UX knob, not a
+/// permission, so a manifest may raise `max` above the global setting.
+///
+/// `stage_is_reviewed` feeds only the *default* for `enabled`: a stage with
+/// interaction points presents its text for the user to approve, so nudging it
+/// to "use your tools" is off unless some level explicitly turns it on.
+pub fn resolve_nudge(
+    global: Option<&NudgeConfig>,
+    agent: Option<&NudgeConfig>,
+    stage: Option<&NudgeConfig>,
+    stage_is_reviewed: bool,
+) -> ResolvedNudge {
+    fn field<T: Clone>(
+        global: Option<&NudgeConfig>,
+        agent: Option<&NudgeConfig>,
+        stage: Option<&NudgeConfig>,
+        get: impl Fn(&NudgeConfig) -> Option<T>,
+    ) -> Option<T> {
+        stage
+            .and_then(&get)
+            .or_else(|| agent.and_then(&get))
+            .or_else(|| global.and_then(&get))
+    }
+    ResolvedNudge {
+        enabled: field(global, agent, stage, |c| c.enabled).unwrap_or(!stage_is_reviewed),
+        max: field(global, agent, stage, |c| c.max).unwrap_or(DEFAULT_MAX_NUDGES),
+        text: field(global, agent, stage, |c| c.text.clone())
+            .unwrap_or_else(|| DEFAULT_NUDGE_TEXT.to_string()),
+    }
+}
+
 /// Condition that determines when a transition edge is available.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1167,6 +1263,76 @@ mod tests {
     use crate::layout::ContextLayout;
     use crate::layout::RegionDefinition;
     use crate::region::RegionKind;
+
+    #[test]
+    fn resolve_nudge_defaults_when_nothing_is_configured() {
+        // No config anywhere: on for a normal stage, off for a reviewed one,
+        // with the built-in cap and text.
+        let normal = resolve_nudge(None, None, None, false);
+        assert!(normal.enabled);
+        assert_eq!(normal.max, DEFAULT_MAX_NUDGES);
+        assert_eq!(normal.text, DEFAULT_NUDGE_TEXT);
+        let reviewed = resolve_nudge(None, None, None, true);
+        assert!(!reviewed.enabled);
+        // The other fields don't depend on review status.
+        assert_eq!(reviewed.max, DEFAULT_MAX_NUDGES);
+        assert_eq!(reviewed.text, DEFAULT_NUDGE_TEXT);
+    }
+
+    #[test]
+    fn resolve_nudge_cascades_each_field_independently() {
+        let global = NudgeConfig {
+            enabled: Some(true),
+            max: Some(10),
+            text: Some("global".to_string()),
+        };
+        let agent = NudgeConfig {
+            max: Some(2),
+            ..Default::default()
+        };
+        let stage = NudgeConfig {
+            text: Some("stage".to_string()),
+            ..Default::default()
+        };
+        let resolved = resolve_nudge(Some(&global), Some(&agent), Some(&stage), false);
+        // enabled from global, max from agent, text from stage.
+        assert!(resolved.enabled);
+        assert_eq!(resolved.max, 2);
+        assert_eq!(resolved.text, "stage");
+        // The stage level wins over both when it sets a field.
+        let stage_all = NudgeConfig {
+            enabled: Some(false),
+            max: Some(0),
+            text: Some("s".to_string()),
+        };
+        let resolved = resolve_nudge(Some(&global), Some(&agent), Some(&stage_all), false);
+        assert_eq!(
+            resolved,
+            ResolvedNudge {
+                enabled: false,
+                max: 0,
+                text: "s".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_nudge_explicit_enabled_overrides_review_suppression() {
+        // A reviewed stage is only *implicitly* exempt: any level that sets
+        // `enabled` speaks for itself, in either direction.
+        let on = NudgeConfig {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        assert!(resolve_nudge(None, None, Some(&on), true).enabled);
+        assert!(resolve_nudge(None, Some(&on), None, true).enabled);
+        assert!(resolve_nudge(Some(&on), None, None, true).enabled);
+        let off = NudgeConfig {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        assert!(!resolve_nudge(None, None, Some(&off), false).enabled);
+    }
 
     #[test]
     fn test_blueprint_creation() {

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -34,9 +34,9 @@ pub mod telemetry;
 pub mod text;
 
 pub use blueprint::{
-    Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, ReadPathsConfig,
-    RepetitionDetectionConfig, Stage, StuckConfig, ToolResultRouting, TransitionCondition,
-    TransitionEdge,
+    Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, NudgeConfig, ReadPathsConfig,
+    RepetitionDetectionConfig, ResolvedNudge, Stage, StuckConfig, ToolResultRouting,
+    TransitionCondition, TransitionEdge, resolve_nudge,
 };
 pub use cache::CacheHint;
 pub use credentials::{

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -401,6 +401,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 stage.batch_tool_hint = Some(bth);
             }
 
+            // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
+            // each field inherits agent/global.
+            if let Some(nudge_table) = stage_value.get("nudge").and_then(|v| v.as_table()) {
+                stage.nudge = Some(parse_nudge_config(nudge_table));
+            }
+
             // Parse per-stage sandbox override: [stages.<name>.sandbox]
             if let Some(sandbox_table) = stage_value.get("sandbox").and_then(|v| v.as_table()) {
                 stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
@@ -678,6 +684,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // Absent ⇒ inherit the global config toggle; a per-stage value overrides it.
     if let Some(bth) = agent.get("batch_tool_hint").and_then(|v| v.as_bool()) {
         blueprint.batch_tool_hint = Some(bth);
+    }
+
+    // Parse agent-level nudge defaults: [agent.nudge]. Absent ⇒ each field
+    // inherits the global config's [nudge] section; a per-stage block wins.
+    if let Some(nudge_table) = agent.get("nudge").and_then(|v| v.as_table()) {
+        blueprint.nudge = Some(parse_nudge_config(nudge_table));
     }
 
     // Parse agent-level sandbox config: [sandbox]
@@ -1154,6 +1166,29 @@ fn parse_transition_gate(table: &toml::value::Table) -> crate::blueprint::Transi
         gate.max_attempts = Some(max as usize);
     }
     gate
+}
+
+/// Parse an `[agent.nudge]` / `[stages.X.nudge]` table into a `NudgeConfig`.
+/// Every key is optional; an empty table is inert (each field still inherits
+/// the broader level).
+fn parse_nudge_config(table: &toml::value::Table) -> crate::blueprint::NudgeConfig {
+    let mut nudge = crate::blueprint::NudgeConfig::default();
+    if let Some(enabled) = table.get("enabled").and_then(|v| v.as_bool()) {
+        nudge.enabled = Some(enabled);
+    }
+    // A negative count is a typo, not "never accept the text" - fall back to
+    // inheriting rather than wrapping around.
+    if let Some(max) = table
+        .get("max")
+        .and_then(|v| v.as_integer())
+        .filter(|max| *max >= 0)
+    {
+        nudge.max = Some(max as usize);
+    }
+    if let Some(text) = table.get("text").and_then(|v| v.as_str()) {
+        nudge.text = Some(text.trim().to_string());
+    }
+    nudge
 }
 
 fn parse_security_config(security_table: &toml::value::Table) -> crate::SecurityConfig {
@@ -2799,6 +2834,96 @@ mode = "autonomous"
         let bp = parse_manifest(toml).unwrap();
         assert_eq!(bp.batch_tool_hint, None);
         assert_eq!(bp.find_stage("main").unwrap().batch_tool_hint, None);
+    }
+
+    #[test]
+    fn parse_manifest_agent_and_stage_nudge_blocks() {
+        let toml = r#"
+[agent]
+name = "nudge-test"
+
+[agent.nudge]
+max = 2
+
+[stages.plan]
+mode = "autonomous"
+
+[stages.plan.nudge]
+enabled = false
+
+[stages.implement]
+mode = "autonomous"
+
+[stages.implement.nudge]
+max = 5
+text = "  Edit the files named in {regions}.  "
+
+[stages.review]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        // Agent-level `[agent.nudge]` parsed; unset fields stay None.
+        let agent_nudge = bp.nudge.as_ref().unwrap();
+        assert_eq!(agent_nudge.enabled, None);
+        assert_eq!(agent_nudge.max, Some(2));
+        assert_eq!(agent_nudge.text, None);
+        // Stage-level blocks: each carries only what it names.
+        let plan = bp.find_stage("plan").unwrap().nudge.as_ref().unwrap();
+        assert_eq!(plan.enabled, Some(false));
+        assert_eq!(plan.max, None);
+        let implement = bp.find_stage("implement").unwrap().nudge.as_ref().unwrap();
+        assert_eq!(implement.max, Some(5));
+        // Text is trimmed, placeholders kept verbatim for the runtime.
+        assert_eq!(
+            implement.text.as_deref(),
+            Some("Edit the files named in {regions}.")
+        );
+        // A stage with no block inherits (None).
+        assert!(bp.find_stage("review").unwrap().nudge.is_none());
+    }
+
+    #[test]
+    fn parse_manifest_nudge_ignores_bad_types_and_negative_max() {
+        // An empty block is inert; wrong-typed values and a negative `max`
+        // fall back to inheriting rather than misconfiguring the stage.
+        let toml = r#"
+[agent]
+name = "nudge-bad"
+
+[agent.nudge]
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.nudge]
+enabled = "yes"
+max = -1
+text = 7
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert_eq!(
+            bp.nudge.as_ref().unwrap(),
+            &crate::blueprint::NudgeConfig::default()
+        );
+        assert_eq!(
+            bp.find_stage("main").unwrap().nudge.as_ref().unwrap(),
+            &crate::blueprint::NudgeConfig::default()
+        );
+    }
+
+    #[test]
+    fn parse_manifest_no_nudge_blocks_is_none() {
+        // No nudge block anywhere ⇒ both levels None ⇒ inherit global.
+        let toml = r#"
+[agent]
+name = "no-nudge"
+
+[stages.main]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert!(bp.nudge.is_none());
+        assert!(bp.find_stage("main").unwrap().nudge.is_none());
     }
 
     #[test]

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -58,6 +58,21 @@ pub fn estimate_tokens(s: &str) -> usize {
     s.len().div_ceil(4)
 }
 
+/// Substitute `{name}` placeholders in a template.
+///
+/// Plain sequential `str::replace`, the same scheme `CompactionConfig`'s
+/// `user_prompt` uses for `{content}` / `{region_name}` - not a template
+/// language. Placeholders absent from `vars` pass through untouched, so a
+/// nudge or required-region message can contain literal braces without
+/// escaping as long as they don't collide with a supported name.
+pub fn interpolate(template: &str, vars: &[(&str, &str)]) -> String {
+    let mut out = template.to_string();
+    for (name, value) in vars {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,6 +85,20 @@ mod tests {
         assert_eq!(estimate_tokens("abcde"), 2);
         // Bytes, not chars: one 3-byte character still costs one budget unit.
         assert_eq!(estimate_tokens("\u{65e5}"), 1);
+    }
+
+    #[test]
+    fn interpolate_replaces_known_placeholders_and_keeps_the_rest() {
+        // Present, repeated, and absent placeholders in one template.
+        assert_eq!(
+            interpolate(
+                "populate {region} - yes, {region} - in stage {stage} {unknown}",
+                &[("region", "plan"), ("stage", "design")]
+            ),
+            "populate plan - yes, plan - in stage design {unknown}"
+        );
+        // No vars: the template passes through unchanged.
+        assert_eq!(interpolate("no placeholders", &[]), "no placeholders");
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -285,11 +285,14 @@ pub(crate) fn edited_path(call: &crate::components::ToolCall) -> Option<&str> {
         .flatten()
 }
 
-/// The "use your tools" nudge injected when a model responds with text before
-/// making any tool call.
-pub(crate) const NUDGE_TEXT: &str = "You have tools available. Please use them to complete the task. Start by reading the relevant files in the working directory.";
-/// How many text-only responses to nudge before accepting the text as final.
-pub(crate) const MAX_TEXT_ONLY_NUDGES: usize = 3;
+/// The global config's `[nudge]` defaults, captured per agent at spawn time so
+/// a hot-reloaded config applies from the next run rather than mutating live
+/// ones (same snapshot semantics as the batch-tool-hint global). Absent on
+/// worlds that spawn agents without going through the seeded spawn (tests,
+/// embedders); [`leviath_core::resolve_nudge`] then falls through to the
+/// built-in defaults.
+#[derive(Component, Debug, Clone, Default)]
+pub struct GlobalNudge(pub leviath_core::NudgeConfig);
 
 /// Whether this stage's deliverable *is* its text response.
 ///
@@ -309,14 +312,19 @@ pub(crate) fn stage_output_is_reviewed(bp: &AgentBlueprint, cursor: &StageCursor
 }
 
 /// Empty-response system: for each `ReadyForTransition` agent decide whether the
-/// stage is done. If the agent has already made tool calls, or we've nudged the
-/// max number of times, the text response is accepted and the agent advances to
-/// `ResolveTransition`. Otherwise (text only, no work yet) the response + a
-/// "use your tools" nudge are added to context and the agent loops back to
-/// `ReadyToInfer`. Ported from `AgentEngine::loop_handle_empty_tool_calls`.
+/// stage is done. If the agent has already made tool calls, its nudge is
+/// disabled, or it has been nudged its budgeted number of times, the text
+/// response is accepted and the agent advances to `ResolveTransition`.
+/// Otherwise (text only, no work yet) the response + the stage's nudge are
+/// added to context and the agent loops back to `ReadyToInfer`. Ported from
+/// `AgentEngine::loop_handle_empty_tool_calls`.
 ///
-/// A stage whose output is reviewed is never nudged - see
-/// `stage_output_is_reviewed`.
+/// The nudge is programmable per stage (`[stages.<name>.nudge]`), per agent
+/// (`[agent.nudge]`), and globally (config `[nudge]`), each field cascading
+/// independently through [`leviath_core::resolve_nudge`]. With nothing
+/// configured, a stage whose output is reviewed is never nudged - see
+/// `stage_output_is_reviewed` - but an explicit `enabled` at any level speaks
+/// for itself. The text supports `{stage}` and `{regions}` placeholders.
 #[allow(clippy::type_complexity)]
 pub fn handle_empty_response(
     mut agents: Query<
@@ -327,17 +335,23 @@ pub fn handle_empty_response(
             &mut StageProgress,
             &AgentBlueprint,
             &StageCursor,
+            Option<&GlobalNudge>,
         ),
         With<ReadyForTransition>,
     >,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, mut window, infer, mut progress, bp, cursor) in agents.iter_mut() {
+    for (entity, mut window, infer, mut progress, bp, cursor, global) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
-        if progress.total_tool_calls > 0
-            || progress.text_only_nudges >= MAX_TEXT_ONLY_NUDGES
-            || stage_output_is_reviewed(bp, cursor)
+        let stage = bp.0.stages.get(cursor.index);
+        let nudge = leviath_core::resolve_nudge(
+            global.map(|g| &g.0),
+            bp.0.nudge.as_ref(),
+            stage.and_then(|s| s.nudge.as_ref()),
+            stage_output_is_reviewed(bp, cursor),
+        );
+        if progress.total_tool_calls > 0 || !nudge.enabled || progress.text_only_nudges >= nudge.max
         {
             commands
                 .entity(entity)
@@ -352,17 +366,36 @@ pub fn handle_empty_response(
                 infer.response.clone(),
                 response_tokens,
             );
-            let nudge_tokens = leviath_core::estimate_tokens(NUDGE_TEXT);
-            let _ = window.add_typed_entry(
-                "conversation",
-                leviath_core::EntryKind::UserMessage,
-                NUDGE_TEXT.to_string(),
-                nudge_tokens,
+            let stage_name = stage.map(|s| s.name.as_str()).unwrap_or("");
+            let regions = stage
+                .and_then(|s| s.context_layout.as_ref())
+                .unwrap_or(&bp.0.context_layout)
+                .regions
+                .iter()
+                .filter(|r| r.required)
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let text = leviath_core::text::interpolate(
+                &nudge.text,
+                &[("stage", stage_name), ("regions", &regions)],
             );
+            inject_system_nudge(&mut window, &text);
             commands
                 .entity(entity)
                 .remove::<ReadyForTransition>()
                 .insert(ReadyToInfer);
         }
     }
+}
+
+/// Append a `[System]` nudge to the conversation region: the one injection path
+/// shared by the empty-response nudge, the required-region nudges, and the
+/// transition-gate hold, so every nudge reaches the model with the same shape.
+/// (An unprefixed `Text` entry assembles as a user message, so the prefix is
+/// what distinguishes framework guidance from real user input.)
+pub(crate) fn inject_system_nudge(window: &mut ContextWindow, text: &str) {
+    let content = format!("[System] {text}");
+    let tokens = leviath_core::estimate_tokens(&content);
+    let _ = window.add_to_region("conversation", content, tokens);
 }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1670,7 +1670,7 @@ fn empty_response_finishes_after_max_nudges() {
     let mut world = World::new();
     let progress = StageProgress {
         total_tool_calls: 0,
-        text_only_nudges: MAX_TEXT_ONLY_NUDGES,
+        text_only_nudges: leviath_core::blueprint::DEFAULT_MAX_NUDGES,
         iterations: 0,
         ..Default::default()
     };
@@ -1757,15 +1757,166 @@ fn empty_response_nudges_and_loops_back_when_text_only() {
     assert!(world.get::<ReadyToInfer>(e).is_some());
     assert!(world.get::<ResolveTransition>(e).is_none());
     assert_eq!(world.get::<StageProgress>(e).unwrap().text_only_nudges, 1);
+    // The default text goes in through the shared `[System]` injection path.
+    let injected = conversation_text(&world, e);
+    assert!(injected.contains(&format!(
+        "[System] {}",
+        leviath_core::blueprint::DEFAULT_NUDGE_TEXT
+    )));
+}
+
+#[test]
+fn empty_response_respects_a_stage_that_disables_its_nudge() {
+    // The issue-#127 shape: the stage knows its deliverable is text and says so.
+    let mut bp = nudge_bp(false);
+    bp.0.stages[0].nudge = Some(leviath_core::NudgeConfig {
+        enabled: Some(false),
+        ..Default::default()
+    });
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            bp,
+            StageCursor { index: 0 },
+            ReadyForTransition,
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ResolveTransition>(e).is_some());
+    assert_eq!(world.get::<StageProgress>(e).unwrap().text_only_nudges, 0);
+    assert!(conversation_text(&world, e).is_empty());
+}
+
+#[test]
+fn empty_response_honors_an_agent_level_max() {
+    // `[agent.nudge] max = 0`: the very first text-only response is final.
+    let mut bp = nudge_bp(false);
+    bp.0.nudge = Some(leviath_core::NudgeConfig {
+        max: Some(0),
+        ..Default::default()
+    });
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            bp,
+            StageCursor { index: 0 },
+            ReadyForTransition,
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ResolveTransition>(e).is_some());
+    assert!(world.get::<ReadyToInfer>(e).is_none());
+}
+
+#[test]
+fn empty_response_interpolates_custom_text_placeholders() {
+    // A custom text names the stage and its required regions.
+    let mut bp = nudge_bp(false);
+    bp.0.stages[0].nudge = Some(leviath_core::NudgeConfig {
+        text: Some("Populate {regions} to finish stage {stage}.".to_string()),
+        ..Default::default()
+    });
+    bp.0.context_layout
+        .regions
+        .push(leviath_core::layout::RegionDefinition::new(
+            "plan".to_string(),
+            RegionKind::Pinned,
+            1_000,
+        ));
+    bp.0.context_layout.regions[1].required = true;
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            bp,
+            StageCursor { index: 0 },
+            ReadyForTransition,
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ReadyToInfer>(e).is_some());
     assert!(
-        world
-            .get::<ContextWindow>(e)
-            .unwrap()
-            .get_region("conversation")
-            .unwrap()
-            .current_tokens
-            > 0
+        conversation_text(&world, e).contains("[System] Populate plan to finish stage a."),
+        "placeholders resolve against the stage name and required region names"
     );
+}
+
+#[test]
+fn empty_response_explicit_enabled_overrides_review_suppression() {
+    // The inverse of `empty_response_never_nudges_a_stage_whose_output_is
+    // _reviewed`: the suppression is only the default, and a stage author who
+    // explicitly asks for nudging on a reviewed stage gets it.
+    let mut bp = nudge_bp(true);
+    bp.0.stages[0].nudge = Some(leviath_core::NudgeConfig {
+        enabled: Some(true),
+        ..Default::default()
+    });
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            bp,
+            StageCursor { index: 0 },
+            ReadyForTransition,
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    assert_eq!(world.get::<StageProgress>(e).unwrap().text_only_nudges, 1);
+}
+
+#[test]
+fn empty_response_reads_the_global_nudge_component() {
+    // A spawn-time `GlobalNudge` snapshot participates in the cascade when the
+    // blueprint sets nothing at either level.
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            nudge_bp(false),
+            StageCursor { index: 0 },
+            ReadyForTransition,
+            GlobalNudge(leviath_core::NudgeConfig {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ResolveTransition>(e).is_some());
+    assert!(conversation_text(&world, e).is_empty());
+}
+
+#[test]
+fn empty_response_with_an_out_of_range_cursor_uses_blueprint_defaults() {
+    // A cursor past the stage list (nothing configures the nudge, no stage to
+    // name): the default text still goes in and the agent loops back.
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_result(false),
+            StageProgress::default(),
+            nudge_bp(false),
+            StageCursor { index: 7 },
+            ReadyForTransition,
+        ))
+        .id();
+    run_empty(&mut world);
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    assert!(conversation_text(&world, e).contains(leviath_core::blueprint::DEFAULT_NUDGE_TEXT));
 }
 
 // ── tool-dispatch ──
@@ -5614,6 +5765,29 @@ fn require_context_regions_injects_default_message() {
         .map(|entry| entry.content.clone())
         .collect::<String>();
     assert!(conv.contains("Required context region 'plan' is still empty"));
+}
+
+#[test]
+fn require_context_regions_interpolates_a_custom_message() {
+    // A custom required_message may name its region via {region} - the same
+    // substitution the generated default goes through.
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            required_bp(
+                &["context_write"],
+                Some("Write {region} with context_write before finishing."),
+            ),
+            StageCursor { index: 0 },
+            window_with_plan(false),
+            ResolveTransition,
+        ))
+        .id();
+    run_require(&mut world);
+    assert!(
+        conversation_text(&world, e)
+            .contains("[System] Write plan with context_write before finishing.")
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -642,21 +642,22 @@ pub(crate) fn unmet_required_regions(
 }
 
 /// Inject a `[System]` nudge into the conversation region for each unmet required
-/// region, so the stage re-run tells the agent exactly what to populate.
+/// region, so the stage re-run tells the agent exactly what to populate. A custom
+/// `required_message` may name the region via a `{region}` placeholder; the
+/// generated default is built through the same substitution.
 pub(crate) fn inject_required_region_nudges(
     window: &mut ContextWindow,
     unmet: &[(String, Option<String>)],
 ) {
+    const DEFAULT_REQUIRED_MESSAGE: &str = "Required context region '{region}' is still empty. \
+         You must populate it (e.g. via context_write with region=\"{region}\") before this \
+         stage can complete.";
     for (name, msg) in unmet {
-        let text = msg.clone().unwrap_or_else(|| {
-            format!(
-                "Required context region '{name}' is still empty. You must populate it \
-                 (e.g. via context_write with region=\"{name}\") before this stage can complete."
-            )
-        });
-        let content = format!("[System] {text}");
-        let tokens = leviath_core::estimate_tokens(&content);
-        let _ = window.add_to_region("conversation", content, tokens);
+        let text = leviath_core::text::interpolate(
+            msg.as_deref().unwrap_or(DEFAULT_REQUIRED_MESSAGE),
+            &[("region", name)],
+        );
+        crate::pipeline::response::inject_system_nudge(window, &text);
     }
 }
 
@@ -815,9 +816,7 @@ pub(crate) fn hold_for_gate(
     window: &mut ContextWindow,
     commands: &mut Commands,
 ) {
-    let content = format!("[System] {nudge}");
-    let tokens = leviath_core::estimate_tokens(&content);
-    let _ = window.add_to_region("conversation", content, tokens);
+    crate::pipeline::response::inject_system_nudge(window, nudge);
     progress.gate_reentries += 1;
     commands
         .entity(entity)
@@ -1323,7 +1322,10 @@ pub fn spawn_agent(
     let seeds = std::collections::HashMap::from([("task".to_string(), task.to_string())]);
     // No compiled custom-region scripts on this path: script-backed regions
     // require the seeded spawn (the CLI resolves and compiles them). A custom
-    // region spawned through here renders its fallback shape.
+    // region spawned through here renders its fallback shape. Global nudge
+    // defaults are likewise a seeded-spawn concern (the CLI reads them from
+    // config.toml); agents spawned through here cascade straight from the
+    // blueprint to the built-in defaults.
     spawn_agent_seeded(
         world,
         agent_id,
@@ -1331,6 +1333,7 @@ pub fn spawn_agent(
         &seeds,
         stages,
         global_batch_tool_hint,
+        leviath_core::NudgeConfig::default(),
         std::collections::HashMap::new(),
     )
 }
@@ -1339,6 +1342,12 @@ pub fn spawn_agent(
 /// (caller-input regions filled by the CLI/ACP/API, plus blueprint-resolved
 /// seeds) rather than a single task string. `spawn_agent` is the thin wrapper
 /// that seeds only the `task` key.
+///
+/// `global_nudge` is the caller's config-level `[nudge]` defaults, captured on
+/// the agent as a [`crate::pipeline::response::GlobalNudge`] component; each
+/// field is resolved per stage against the blueprint's agent-level and
+/// per-stage nudge settings when an empty response is handled.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_agent_seeded(
     world: &mut World,
     agent_id: String,
@@ -1346,6 +1355,7 @@ pub fn spawn_agent_seeded(
     seeds: &std::collections::HashMap<String, String>,
     stages: Vec<ResolvedStage>,
     global_batch_tool_hint: bool,
+    global_nudge: leviath_core::NudgeConfig,
     region_scripts: std::collections::HashMap<
         String,
         std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
@@ -1459,9 +1469,11 @@ pub fn spawn_agent_seeded(
         ))
         .id();
     // Inserted after spawn: the bundle above is already at bevy's 15-tuple limit.
-    world
-        .entity_mut(entity)
-        .insert((ledger, StageIoBuffer::default()));
+    world.entity_mut(entity).insert((
+        ledger,
+        StageIoBuffer::default(),
+        crate::pipeline::response::GlobalNudge(global_nudge),
+    ));
     if let Some(detector) = repetition {
         world.entity_mut(entity).insert(detector);
     }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1136,6 +1136,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn agent_nudge_max_bounds_the_loop_end_to_end() {
+        // `[agent.nudge] max = 1` (issue #127): the second text-only response
+        // is final, so a two-response script finishes where the default cap
+        // would have demanded four. A third scripted response left unconsumed
+        // would keep the driver looping past run_until_idle's budget.
+        let mut world = build_world(registry_with(vec![text("thinking"), text("final")]));
+        let mut bp = blueprint();
+        bp.nudge = Some(leviath_core::NudgeConfig {
+            max: Some(1),
+            ..Default::default()
+        });
+        let e = world.spawn_agent((
+            AgentBlueprint(bp),
+            StageCursor { index: 0 },
+            agent_state(),
+            crate::components::MessageInbox::default(),
+            StageProgress::default(),
+            StageInferences(vec![stage("m")]),
+            StageSetups(vec![setup()]),
+            VisitCounts::default(),
+            window(),
+            stage("m"),
+            setup().inference_config,
+            ReadyToInfer,
+        ));
+
+        world.run_until_idle(30).await;
+
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Complete));
+    }
+
+    #[tokio::test]
     async fn agent_runs_tools_then_completes() {
         // First response calls a tool; after the tool result comes back the
         // second response is text-only, finishing the run.

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -69,3 +69,38 @@ Any subset applies; the first threshold to trip fires the edge.
 > when the blueprint declares one; error and iteration-cap notes prefer an `error_report` region.
 > Declare them `pinned` (a small budget like 2000 tokens is plenty) so the note survives edge
 > transforms; without them, notes land in `conversation`.
+
+## Nudging
+
+When a stage's model replies with plain text before it has made a single tool call, the runtime
+normally injects a `[System]` nudge ("You have tools available...") and re-runs the stage, up to
+three times. That is the right reflex for a coding stage that stalls, and the wrong one for a stage
+whose deliverable *is* text: a planner told to "use your tools" goes hunting for a write tool it
+does not have.
+
+Each stage can say what should happen instead:
+
+```toml
+[agent.nudge]                # agent-wide default for every stage
+max = 2
+
+[stages.plan.nudge]
+enabled = false              # this stage's deliverable is text; never nudge
+
+[stages.implement.nudge]
+max = 2
+text = "You have edit tools. Make the change described in {regions} rather than describing it again."
+```
+
+All three keys are optional and cascade independently: a stage block wins over `[agent.nudge]`,
+which wins over the `[nudge]` section of your `config.toml`, which falls back to the built-in
+defaults. This is a UX knob, not a permission, so a manifest may raise `max` above the global
+setting as freely as it lowers it.
+
+The `text` may name `{stage}` (the stage's name) and `{regions}` (the comma-separated names of the
+stage's required context regions). The same substitution applies to a required region's
+`required_message`, where `{region}` names the region being demanded.
+
+With nothing configured, one stage shape is already exempt: a stage with interaction points
+presents its text for review, so it is never nudged for producing exactly that text. Setting
+`enabled` explicitly at any level overrides this in either direction.


### PR DESCRIPTION
Closes #127.

The empty-response nudge (the "You have tools available..." message injected when a stage's model replies with text before any tool call) had all three of its knobs hard-coded: the text, the cap of three, and whether it fires at all. A `plan` stage whose deliverable *is* text got told to use tools it does not have, and the fix for that was another hard-coded rule.

## What this does

**Per-stage / per-agent / global config.** A `NudgeConfig` (`enabled`, `max`, `text`, all optional) parses from `[stages.<name>.nudge]`, `[agent.nudge]`, and the config.toml `[nudge]` section. `resolve_nudge` cascades each field independently, narrowest level wins with no clamping (same shape as `resolve_batch_tool_hint`; this is a UX knob, not a permission, so a manifest may raise `max`).

```toml
[stages.plan.nudge]
enabled = false          # this stage's deliverable is text; never nudge

[stages.implement.nudge]
max = 2
text = "You have edit tools. Make the change described in {regions} rather than describing it again."
```

**Explicit beats implicit.** The interaction-point suppression from the plan-stage misfire is now just the *default* for `enabled`: unset anywhere, a reviewed stage is still never nudged; set `enabled = true` at any level and the stage author's word wins.

**Hot-reload-correct plumbing.** The daemon captures config.toml's `[nudge]` on each agent at spawn (a `GlobalNudge` component rather than a world resource), so a hot-reloaded config (#180) applies from the next run without touching live ones.

**The two nudge mechanisms converge.** Empty-response nudges, required-region nudges, and the transition-gate hold all inject through one `inject_system_nudge` helper (`[System]` prefix, conversation region), and their texts share one `text::interpolate` substitution: `{stage}` / `{regions}` in nudge text, `{region}` in a region's `required_message` (which previously got no interpolation at all). Behavior note: an unprefixed `Text` entry already assembled as a user message, so the empty-response nudge changes only by gaining the `[System]` prefix the other paths already had.

## Verification

- `cargo xtask coverage`: all 11 packages at 100%.
- Live daemon runs (isolated `LEVIATH_HOME`, text-only Rhai mock provider):
  - no config: 3 default nudges, `[System]`-prefixed, run completes;
  - `[stages.work.nudge] max = 1, text = "...{stage}...{regions}..."`: exactly one interpolated nudge;
  - `[stages.work.nudge] enabled = false`: zero nudges, immediate completion;
  - `[nudge] max = 2, text = "GLOBAL..."` appended to config.toml with the daemon running: hot-reload picked it up and the next run got exactly two global-text nudges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW7tM6kxjSn9APnrWtP6fd