### PR TITLE
Expose pause/resume to users: CLI, REST, and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ in [the release docs](https://leviath.dev/docs/releases); each versioned
 GitHub release also carries auto-generated notes listing the merged pull
 requests since the previous version.
 
+## Unreleased
+
+- Pause and resume are now user-facing: `lev pause <run-id>` and
+  `lev resume <run-id>`, `POST /api/agents/{id}/pause` and `/resume` on the
+  HTTP API, and `p`/`r` in the dashboard. A paused run shows as `paused` in
+  `lev ps`, the dashboard, and the API, and comes back still paused after a
+  daemon restart.
+- Pausing a run that is waiting on input (or already finished) is now refused
+  instead of silently accepted; the old behavior could wedge a fan-out parent
+  by overwriting the status its merge poll depends on.
+- Note for downgraders: run metadata written while a run is paused uses the
+  new `paused` status, which older `lev` binaries cannot read. Resume or
+  cancel paused runs before downgrading.
+
 ## 0.1.1 - 2026-07-31
 
 Post-launch cleanup.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ And here is Leviath scored against [12-Factor Agents](https://github.com/humanla
 | 3 | Own your context window | ✓ | Region kinds, per-stage layouts, per-tool routing, percentage budgets |
 | 4 | Tools are structured outputs | partial | Tools declare JSON Schemas; arguments are checked per-handler, not schema-validated at dispatch |
 | 5 | Unify execution and business state | ✓ | One append-only run journal, replayable with `lev context` |
-| 6 | Launch / pause / resume | partial | Launch via CLI, REST, or ACP; pause and resume exist in the runtime but have no user-facing command yet |
+| 6 | Launch / pause / resume | ✓ | Launch via CLI, REST, or ACP; `lev pause` / `lev resume`, `POST /api/agents/{id}/pause` and `/resume`, dashboard `p` / `r`; a paused run shows as paused everywhere and survives a daemon restart |
 | 7 | Contact humans with tool calls | ✓ | `ask_user_*` tools plus blueprint `interaction_points`, answered from CLI, REST, or ACP |
 | 8 | Own your control flow | ✓ | Graph transitions with error, max-iterations, stuck, and LLM-choice conditions |
 | 9 | Compact errors into context | partial | Tool errors land in context; inference errors currently go to logs, not context |

--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -144,7 +144,9 @@ pub fn stop_reason_for(status: &RunStatus) -> Option<StopReason> {
         RunStatus::Complete | RunStatus::CompleteInteractive => Some(StopReason::EndTurn),
         RunStatus::Error => Some(StopReason::Refusal),
         RunStatus::Cancelled => Some(StopReason::Cancelled),
-        RunStatus::Starting | RunStatus::Running | RunStatus::WaitingInput => None,
+        RunStatus::Starting | RunStatus::Running | RunStatus::WaitingInput | RunStatus::Paused => {
+            None
+        }
     }
 }
 
@@ -420,6 +422,7 @@ this trailing text is ignored";
             (RunStatus::Starting, None),
             (RunStatus::Running, None),
             (RunStatus::WaitingInput, None),
+            (RunStatus::Paused, None),
             (RunStatus::Complete, Some(StopReason::EndTurn)),
             (RunStatus::CompleteInteractive, Some(StopReason::EndTurn)),
             (RunStatus::Error, Some(StopReason::Refusal)),

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -1,7 +1,7 @@
-//! `lev msg` / `lev cancel` - control operations on a running agent in the
-//! shared-world daemon.
+//! `lev msg` / `lev cancel` / `lev pause` / `lev resume` - control operations
+//! on a running agent in the shared-world daemon.
 //!
-//! Both send a control request over the daemon socket and report the boolean
+//! Each sends a control request over the daemon socket and reports the boolean
 //! outcome. The request/response cores are tested here; the socket-path
 //! resolution + connect live in the binary behind [`crate::dispatch::RiskyExecutors`].
 
@@ -32,6 +32,20 @@ pub struct CancelArgs {
     /// driving it, restart the daemon so it picks up the new state.
     #[arg(long)]
     pub force: bool,
+}
+
+/// Arguments for `lev pause`.
+#[derive(clap::Args, Debug, Clone)]
+pub struct PauseArgs {
+    /// The run id to pause.
+    pub run_id: String,
+}
+
+/// Arguments for `lev resume`.
+#[derive(clap::Args, Debug, Clone)]
+pub struct ResumeArgs {
+    /// The run id to resume.
+    pub run_id: String,
 }
 
 /// Arguments for `lev respond` - answer a pending `ask_user` interaction the
@@ -87,6 +101,33 @@ pub async fn send_message(client: &ControlClient, args: &MsgArgs) -> anyhow::Res
         },
         "message delivered",
         "no agent accepted the message",
+    )
+    .await
+}
+
+/// `lev pause`: park a run. The daemon refuses (`ok: false`) when the run does
+/// not exist or is not in a pausable state (waiting on input, or finished).
+pub async fn pause_run(client: &ControlClient, args: &PauseArgs) -> anyhow::Result<()> {
+    send_bool(
+        client,
+        ControlRequest::Pause {
+            run_id: args.run_id.clone(),
+        },
+        "paused",
+        "no such run, or it is not pausable in its current state",
+    )
+    .await
+}
+
+/// `lev resume`: un-pause a run.
+pub async fn resume_run(client: &ControlClient, args: &ResumeArgs) -> anyhow::Result<()> {
+    send_bool(
+        client,
+        ControlRequest::Resume {
+            run_id: args.run_id.clone(),
+        },
+        "resumed",
+        "no such run, or it is not paused",
     )
     .await
 }
@@ -313,6 +354,66 @@ mod tests {
         })
         .await;
         assert!(r.unwrap_err().to_string().contains("no agent accepted"));
+    }
+
+    #[tokio::test]
+    async fn pause_applied() {
+        let r = with_daemon(r#"{"result":"ok","ok":true}"#, |c| async move {
+            pause_run(
+                &c,
+                &PauseArgs {
+                    run_id: "r".to_string(),
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn pause_refused() {
+        let r = with_daemon(r#"{"result":"ok","ok":false}"#, |c| async move {
+            pause_run(
+                &c,
+                &PauseArgs {
+                    run_id: "r".to_string(),
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.unwrap_err().to_string().contains("not pausable"));
+    }
+
+    #[tokio::test]
+    async fn resume_applied() {
+        let r = with_daemon(r#"{"result":"ok","ok":true}"#, |c| async move {
+            resume_run(
+                &c,
+                &ResumeArgs {
+                    run_id: "r".to_string(),
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resume_refused() {
+        let r = with_daemon(r#"{"result":"ok","ok":false}"#, |c| async move {
+            resume_run(
+                &c,
+                &ResumeArgs {
+                    run_id: "r".to_string(),
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.unwrap_err().to_string().contains("not paused"));
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -394,6 +394,12 @@ impl Dashboard {
             KeyCode::Char('k') => {
                 self.handle_kill_from_detail();
             }
+            KeyCode::Char('p') => {
+                self.handle_pause();
+            }
+            KeyCode::Char('r') => {
+                self.handle_resume();
+            }
             _ => {}
         }
     }
@@ -473,6 +479,60 @@ impl Dashboard {
         }
     }
 
+    /// Pause the selected agent (main list and detail view share this: unlike
+    /// kill, there is no input state to reset). Gated on the states the daemon
+    /// will actually pause, so an ineligible row sends nothing instead of
+    /// producing a guaranteed refusal toast.
+    fn handle_pause(&mut self) {
+        if let Some(agent) = self.selected_agent()
+            && matches!(
+                agent.status,
+                AgentDisplayStatus::Active | AgentDisplayStatus::Idle | AgentDisplayStatus::Stale
+            )
+        {
+            let agent_id = agent.id.clone();
+            let _ = self.cmd_tx.send(DaemonCommand::Pause {
+                run_id: agent_id.clone(),
+            });
+            // See the comment in `handle_kill_from_detail` - the index is still
+            // valid because the `cmd_tx.send` above does not touch
+            // `display_indices`/`agents`/`selected`.
+            let idx = self
+                .selected_agent_raw_idx()
+                .expect("selected_agent() returned Some above");
+            let a = self
+                .agents
+                .get_mut(idx)
+                .expect("index snapshotted from the still-unchanged display_indices/agents above");
+            a.status = AgentDisplayStatus::Paused;
+            self.add_log(format!("{}: pause requested", agent_id));
+        }
+    }
+
+    /// Resume the selected agent if it is paused.
+    fn handle_resume(&mut self) {
+        if let Some(agent) = self.selected_agent()
+            && agent.status == AgentDisplayStatus::Paused
+        {
+            let agent_id = agent.id.clone();
+            let _ = self.cmd_tx.send(DaemonCommand::Resume {
+                run_id: agent_id.clone(),
+            });
+            // See the comment in `handle_kill_from_detail` - the index is still
+            // valid because the `cmd_tx.send` above does not touch
+            // `display_indices`/`agents`/`selected`.
+            let idx = self
+                .selected_agent_raw_idx()
+                .expect("selected_agent() returned Some above");
+            let a = self
+                .agents
+                .get_mut(idx)
+                .expect("index snapshotted from the still-unchanged display_indices/agents above");
+            a.status = AgentDisplayStatus::Active;
+            self.add_log(format!("{}: resume requested", agent_id));
+        }
+    }
+
     fn handle_main_list_key(&mut self, key_code: KeyCode) {
         match key_code {
             KeyCode::Esc => {
@@ -527,6 +587,12 @@ impl Dashboard {
             }
             KeyCode::Char('k') => {
                 self.handle_kill_from_list();
+            }
+            KeyCode::Char('p') => {
+                self.handle_pause();
+            }
+            KeyCode::Char('r') => {
+                self.handle_resume();
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
@@ -1545,6 +1611,125 @@ mod tests {
         dash.handle_key(key(KeyCode::Esc));
         assert!(!dash.input_mode);
         assert_eq!(dash.choice_selected, 0);
+    }
+
+    // ─── handle_pause / handle_resume ─────────────────────────────────────
+
+    /// Every state the daemon will pause is pausable from the list, sends the
+    /// command, and flips the row optimistically.
+    #[test]
+    fn pause_sends_command_for_each_pausable_state() {
+        for status in [
+            AgentDisplayStatus::Active,
+            AgentDisplayStatus::Idle,
+            AgentDisplayStatus::Stale,
+        ] {
+            let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+            let mut dash = Dashboard::new(cmd_tx);
+            dash.agents.push(make_test_agent("run-1", status.clone()));
+            dash.update_display_indices();
+            dash.handle_key(key(KeyCode::Char('p')));
+            assert_eq!(
+                cmd_rx.try_recv().ok(),
+                Some(DaemonCommand::Pause {
+                    run_id: "run-1".to_string()
+                }),
+                "pause from {status:?} sends the command"
+            );
+            assert_eq!(dash.agents[0].status, AgentDisplayStatus::Paused);
+        }
+    }
+
+    /// Waiting and finished runs are not pausable: nothing is sent, so the user
+    /// never sees a guaranteed refusal toast.
+    #[test]
+    fn pause_is_a_no_op_for_unpausable_states() {
+        for status in [
+            AgentDisplayStatus::Waiting,
+            AgentDisplayStatus::Paused,
+            AgentDisplayStatus::Complete,
+            AgentDisplayStatus::Cancelled,
+        ] {
+            let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+            let mut dash = Dashboard::new(cmd_tx);
+            dash.agents.push(make_test_agent("run-1", status.clone()));
+            dash.update_display_indices();
+            dash.handle_key(key(KeyCode::Char('p')));
+            assert!(
+                cmd_rx.try_recv().is_err(),
+                "pause from {status:?} sends nothing"
+            );
+            assert_eq!(dash.agents[0].status, status);
+        }
+    }
+
+    #[test]
+    fn resume_sends_command_for_a_paused_run_only() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Paused));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            cmd_rx.try_recv().ok(),
+            Some(DaemonCommand::Resume {
+                run_id: "run-1".to_string()
+            })
+        );
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+    }
+
+    #[test]
+    fn resume_is_a_no_op_for_a_run_that_is_not_paused() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert!(cmd_rx.try_recv().is_err());
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+    }
+
+    /// With no agents at all, both keys fall through the `selected_agent()`
+    /// guard without panicking or sending.
+    #[test]
+    fn pause_and_resume_with_no_agents_do_nothing() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.handle_key(key(KeyCode::Char('p')));
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    /// The detail view shares the same handlers via its own `p`/`r` bindings.
+    #[test]
+    fn pause_and_resume_work_from_the_detail_view() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.detail_view = true;
+
+        dash.handle_key(key(KeyCode::Char('p')));
+        assert_eq!(
+            cmd_rx.try_recv().ok(),
+            Some(DaemonCommand::Pause {
+                run_id: "run-1".to_string()
+            })
+        );
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Paused);
+
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            cmd_rx.try_recv().ok(),
+            Some(DaemonCommand::Resume {
+                run_id: "run-1".to_string()
+            })
+        );
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
     }
 
     // ─── handle_cancel_from_list ──────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -48,6 +48,12 @@ async fn daemon_background_loop(
             DaemonCommand::Cancel { run_id } => {
                 (run_id.clone(), ControlRequest::Cancel { run_id }, "cancel")
             }
+            DaemonCommand::Pause { run_id } => {
+                (run_id.clone(), ControlRequest::Pause { run_id }, "pause")
+            }
+            DaemonCommand::Resume { run_id } => {
+                (run_id.clone(), ControlRequest::Resume { run_id }, "resume")
+            }
             DaemonCommand::Answer { response } => (
                 response.request_id.clone(),
                 ControlRequest::AnswerInteraction { response },
@@ -408,6 +414,69 @@ mod tests {
             "got: {}",
             broken.message
         );
+    }
+
+    /// Drive one arbitrary command through the loop and return the outcome.
+    async fn command_outcome(
+        cmd: DaemonCommand,
+        reply: Option<&'static str>,
+    ) -> types::DaemonOutcome {
+        let dir = tempfile::tempdir().unwrap();
+        let (control, server) = replying_daemon(dir.path(), reply);
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<DaemonCommand>();
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(daemon_background_loop(control, cmd_rx, out_tx));
+        cmd_tx.send(cmd).unwrap();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), out_rx.recv())
+            .await
+            .expect("an outcome was reported")
+            .expect("the loop is alive");
+        let _ = server.await;
+        outcome
+    }
+
+    /// Pause and resume ride the same forwarding path as cancel; the daemon's
+    /// refusal is labelled with the verb the user actually pressed.
+    #[tokio::test]
+    async fn daemon_background_loop_forwards_pause_and_resume() {
+        let ok = command_outcome(
+            DaemonCommand::Pause {
+                run_id: "run-1".to_string(),
+            },
+            Some(r#"{"result":"ok","ok":true}"#),
+        )
+        .await;
+        assert!(ok.ok);
+        assert_eq!(ok.run_id, "run-1");
+
+        let refused = command_outcome(
+            DaemonCommand::Pause {
+                run_id: "run-1".to_string(),
+            },
+            Some(r#"{"result":"ok","ok":false}"#),
+        )
+        .await;
+        assert!(!refused.ok);
+        assert!(refused.message.contains("no such run to pause"));
+
+        let ok = command_outcome(
+            DaemonCommand::Resume {
+                run_id: "run-1".to_string(),
+            },
+            Some(r#"{"result":"ok","ok":true}"#),
+        )
+        .await;
+        assert!(ok.ok);
+
+        let refused = command_outcome(
+            DaemonCommand::Resume {
+                run_id: "run-1".to_string(),
+            },
+            Some(r#"{"result":"ok","ok":false}"#),
+        )
+        .await;
+        assert!(!refused.ok);
+        assert!(refused.message.contains("no such run to resume"));
     }
 
     /// The loop stops when the dashboard has gone away, rather than spinning on

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -143,6 +143,13 @@ impl Dashboard {
             ]),
             Line::from(vec![
                 Span::styled(
+                    "  p / r    ",
+                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("Pause / Resume agent"),
+            ]),
+            Line::from(vec![
+                Span::styled(
                     "  m        ",
                     Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
                 ),
@@ -248,6 +255,13 @@ impl Dashboard {
                     Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("Kill agent"),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "  p / r    ",
+                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("Pause / Resume agent"),
             ]),
             Line::from(vec![
                 Span::styled(
@@ -508,6 +522,7 @@ mod tests {
 
         let rendered = rendered_buffer(&terminal);
         assert!(rendered.contains("Main list"));
+        assert!(rendered.contains("Pause / Resume agent"));
         assert!(!rendered.contains("Detail view"));
         assert!(!rendered.contains("Switch stage tab"));
     }
@@ -527,6 +542,7 @@ mod tests {
         let rendered = rendered_buffer(&terminal);
         assert!(rendered.contains("Detail view"));
         assert!(rendered.contains("Switch stage tab"));
+        assert!(rendered.contains("Pause / Resume agent"));
         assert!(!rendered.contains("Main list"));
         assert!(!rendered.contains("Select agent"));
     }

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -365,6 +365,7 @@ impl Dashboard {
             ));
             spans.push(Span::raw(" kill  "));
         }
+        self.push_pause_resume_spans(&mut spans);
         spans.push(Span::styled(
             "[?]",
             Style::default().fg(C_DIM).add_modifier(Modifier::BOLD),
@@ -376,6 +377,30 @@ impl Dashboard {
         ));
         spans.push(Span::raw(" back"));
         Line::from(spans)
+    }
+
+    /// Append a `[p] pause` or `[r] resume` hint matching what the selected
+    /// agent's state actually allows (the same gates as the key handlers).
+    fn push_pause_resume_spans(&self, spans: &mut Vec<Span<'static>>) {
+        let Some(status) = self.selected_agent().map(|a| a.status.clone()) else {
+            return;
+        };
+        if matches!(
+            status,
+            AgentDisplayStatus::Active | AgentDisplayStatus::Idle | AgentDisplayStatus::Stale
+        ) {
+            spans.push(Span::styled(
+                "[p]",
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(" pause  "));
+        } else if status == AgentDisplayStatus::Paused {
+            spans.push(Span::styled(
+                "[r]",
+                Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(" resume  "));
+        }
     }
 
     fn build_main_list_help_bar(&self) -> Line<'static> {
@@ -419,6 +444,7 @@ impl Dashboard {
             ));
             spans.push(Span::raw(" kill  "));
         }
+        self.push_pause_resume_spans(&mut spans);
         spans.push(Span::styled(
             "[?]",
             Style::default().fg(C_DIM).add_modifier(Modifier::BOLD),
@@ -666,6 +692,57 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
+    }
+
+    fn rendered_buffer(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    /// The pause/resume hint tracks what the selected agent's state allows, in
+    /// both the main list and the detail view: `[p]` for a pausable run, `[r]`
+    /// for a paused one, neither for a finished one (or an empty list).
+    #[test]
+    fn help_bars_show_pause_or_resume_to_match_the_selected_agent() {
+        for detail_view in [false, true] {
+            for (status, expect_pause, expect_resume) in [
+                (Some(AgentDisplayStatus::Active), true, false),
+                (Some(AgentDisplayStatus::Paused), false, true),
+                (Some(AgentDisplayStatus::Complete), false, false),
+                (None, false, false),
+            ] {
+                let backend = TestBackend::new(200, 2);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let mut dash = make_test_dashboard();
+                if let Some(status) = &status {
+                    dash.agents.push(make_test_agent("run-1", status.clone()));
+                    dash.update_display_indices();
+                }
+                dash.detail_view = detail_view;
+                terminal
+                    .draw(|f| {
+                        let area = Rect::new(0, 0, 200, 1);
+                        dash.draw_help_bar(f, area);
+                    })
+                    .unwrap();
+                let rendered = rendered_buffer(&terminal);
+                assert_eq!(
+                    rendered.contains("[p] pause"),
+                    expect_pause,
+                    "{status:?} detail={detail_view}"
+                );
+                assert_eq!(
+                    rendered.contains("[r] resume"),
+                    expect_resume,
+                    "{status:?} detail={detail_view}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -327,6 +327,9 @@ impl Dashboard {
                 // Above the finished states: a stale run is unfinished business
                 // the user probably wants to clear.
                 AgentDisplayStatus::Stale => 2,
+                // Same altitude as Stale: deliberately parked, but still the
+                // user's unfinished business.
+                AgentDisplayStatus::Paused => 2,
             }
         };
         let mut indices: Vec<usize> = (0..self.agents.len())
@@ -561,6 +564,7 @@ impl Dashboard {
                     }
                 }
                 RunStatus::WaitingInput => AgentDisplayStatus::Waiting,
+                RunStatus::Paused => AgentDisplayStatus::Paused,
                 RunStatus::Complete => AgentDisplayStatus::Complete,
                 RunStatus::CompleteInteractive => AgentDisplayStatus::CompleteInteractive,
                 RunStatus::Error => {

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -636,9 +636,13 @@ impl Dashboard {
                 agent.tokens_out = run.completion_tokens;
                 agent.cached_tokens = run.cached_tokens;
                 agent.title = run.title.clone();
+                // Paused freezes the elapsed timer the same way a wait does:
+                // nothing is running, so the clock should not tick against it.
                 let now_is_waiting = matches!(
                     status,
-                    AgentDisplayStatus::Waiting | AgentDisplayStatus::CompleteInteractive
+                    AgentDisplayStatus::Waiting
+                        | AgentDisplayStatus::CompleteInteractive
+                        | AgentDisplayStatus::Paused
                 );
                 let is_terminal = matches!(
                     status,
@@ -763,6 +767,7 @@ impl Dashboard {
                         run.status,
                         RunStatus::WaitingInput
                             | RunStatus::CompleteInteractive
+                            | RunStatus::Paused
                             | RunStatus::Complete
                             | RunStatus::Cancelled
                             | RunStatus::Error
@@ -1044,6 +1049,24 @@ mod tests {
         assert_eq!(dash.agents[dash.display_indices[0]].id, "run-2"); // Active
         assert_eq!(dash.agents[dash.display_indices[1]].id, "run-3"); // Waiting
         assert_eq!(dash.agents[dash.display_indices[2]].id, "run-1"); // Complete
+    }
+
+    /// Paused sorts with Stale: above the finished states (it is the user's
+    /// deliberately parked unfinished business), below Active/Waiting.
+    #[test]
+    fn update_display_indices_ranks_paused_above_finished_runs() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-done", AgentDisplayStatus::Complete));
+        dash.agents
+            .push(make_test_agent("run-paused", AgentDisplayStatus::Paused));
+        dash.agents
+            .push(make_test_agent("run-live", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+
+        assert_eq!(dash.agents[dash.display_indices[0]].id, "run-live");
+        assert_eq!(dash.agents[dash.display_indices[1]].id, "run-paused");
+        assert_eq!(dash.agents[dash.display_indices[2]].id, "run-done");
     }
 
     /// Write a `run.lvr` for `run_id` with `points` context checkpoints.
@@ -2264,6 +2287,43 @@ mod tests {
                 cleanup_run(run_id);
             },
         );
+    }
+
+    /// A paused run shows PAUSED with its elapsed timer frozen, both when first
+    /// observed and when an already-tracked ACTIVE row flips to paused on a
+    /// later sync (the disk is authoritative - this is what makes the `p`
+    /// key's optimistic flip stick instead of reverting to ACTIVE).
+    #[test]
+    fn sync_from_run_state_paused_run_shows_paused_with_frozen_timer() {
+        crate::runstate::with_isolated_runs_dir("sync-paused-run", |_d| {
+            let run_id = "test-sync-paused";
+            cleanup_run(run_id);
+            let mut meta = make_run_meta(run_id, RunStatus::Running);
+            runstate::create_run(&meta).unwrap();
+
+            let mut dash = make_test_dashboard();
+            dash.sync_from_run_state();
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Active);
+            assert!(agent.active_until.is_none());
+
+            // The daemon pauses the run and persists the new status.
+            meta.status = RunStatus::Paused;
+            runstate::write_meta(&meta).unwrap();
+            dash.sync_from_run_state();
+            let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Paused);
+            assert!(agent.active_until.is_some(), "timer frozen while paused");
+
+            // A dashboard opened while the run is already paused agrees.
+            let mut fresh = make_test_dashboard();
+            fresh.sync_from_run_state();
+            let agent = fresh.agents.iter().find(|a| a.id == run_id).unwrap();
+            assert_eq!(agent.status, AgentDisplayStatus::Paused);
+            assert!(agent.active_until.is_some());
+
+            cleanup_run(run_id);
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -32,6 +32,10 @@ pub enum AgentDisplayStatus {
     CompleteInteractive,
     Error(String),
     Idle,
+    /// Paused by the user; resumable with `r` (or `lev resume`). Distinct from
+    /// `Idle` because a paused run is deliberate unfinished business, not a run
+    /// that merely has not ticked yet.
+    Paused,
     Cancelled,
     /// On disk the run claims to be live, but the daemon has no such run and its
     /// metadata has not been touched in a long time - so nothing is driving it.
@@ -51,6 +55,7 @@ impl std::fmt::Display for AgentDisplayStatus {
             Self::CompleteInteractive => write!(f, "{}COMPLETE", GLYPH_COMPLETE),
             Self::Error(msg) => write!(f, "{}ERROR: {}", GLYPH_ERROR, msg),
             Self::Idle => write!(f, "{}IDLE", GLYPH_PENDING),
+            Self::Paused => write!(f, "{}PAUSED", GLYPH_PENDING),
             Self::Cancelled => write!(f, "⊘CANCEL"),
             Self::Stale => write!(f, "{}STALE", GLYPH_ERROR),
         }
@@ -80,6 +85,7 @@ impl AgentDisplayStatus {
             Self::Complete | Self::CompleteInteractive => C_SUCCESS,
             Self::Error(_) => C_ERROR,
             Self::Idle => C_DIM,
+            Self::Paused => C_WARN,
             Self::Cancelled => C_DIM,
             Self::Stale => C_WARN,
         }

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -160,6 +160,10 @@ pub(super) struct LogEntry {
 pub(super) enum DaemonCommand {
     /// Cancel a run.
     Cancel { run_id: String },
+    /// Pause a run.
+    Pause { run_id: String },
+    /// Resume a paused run.
+    Resume { run_id: String },
     /// Answer a pending `ask_user` interaction.
     Answer {
         response: interaction::InteractionResponse,
@@ -260,6 +264,7 @@ mod tests {
                 .contains("boom")
         );
         assert!(AgentDisplayStatus::Idle.to_string().contains("IDLE"));
+        assert!(AgentDisplayStatus::Paused.to_string().contains("PAUSED"));
         assert!(AgentDisplayStatus::Cancelled.to_string().contains("CANCEL"));
         assert!(AgentDisplayStatus::Stale.to_string().contains("STALE"));
     }
@@ -279,6 +284,10 @@ mod tests {
         assert_eq!(AgentDisplayStatus::Cancelled.color(), C_DIM);
         // Stale is a warning, not a finished state: it wants attention.
         assert_eq!(AgentDisplayStatus::Stale.color(), C_WARN);
+        // Paused is deliberate unfinished business, not a dim afterthought.
+        assert_eq!(AgentDisplayStatus::Paused.color(), C_WARN);
+        assert!(!AgentDisplayStatus::Paused.is_terminal());
+        assert!(AgentDisplayStatus::Paused.is_killable());
         assert_eq!(AgentDisplayStatus::Waiting.color(), C_WARN);
         assert_eq!(AgentDisplayStatus::CompleteInteractive.color(), C_SUCCESS);
     }

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -17,6 +17,7 @@ fn status_label(status: &AgentStatus) -> &'static str {
     match status {
         AgentStatus::Idle => "idle",
         AgentStatus::Active => "active",
+        AgentStatus::Paused => "paused",
         AgentStatus::Waiting => "waiting",
         AgentStatus::Complete => "complete",
         AgentStatus::Error { .. } => "error",
@@ -60,6 +61,7 @@ mod tests {
     fn status_labels_cover_every_variant() {
         assert_eq!(status_label(&AgentStatus::Idle), "idle");
         assert_eq!(status_label(&AgentStatus::Active), "active");
+        assert_eq!(status_label(&AgentStatus::Paused), "paused");
         assert_eq!(status_label(&AgentStatus::Waiting), "waiting");
         assert_eq!(status_label(&AgentStatus::Complete), "complete");
         assert_eq!(

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -1378,7 +1378,12 @@ prompt = "Plan the work"
     #[tokio::test]
     async fn pause_agent_sends_pause_to_the_daemon() {
         let (control, _dir, _srv) = fake_daemon(|req| {
-            assert!(matches!(req, ControlRequest::Pause { .. }));
+            assert_eq!(
+                std::mem::discriminant(&req),
+                std::mem::discriminant(&ControlRequest::Pause {
+                    run_id: String::new()
+                })
+            );
             ControlResponse::Ok { ok: true }
         });
         assert_eq!(
@@ -1418,7 +1423,12 @@ prompt = "Plan the work"
     #[tokio::test]
     async fn resume_agent_sends_resume_to_the_daemon() {
         let (control, _dir, _srv) = fake_daemon(|req| {
-            assert!(matches!(req, ControlRequest::Resume { .. }));
+            assert_eq!(
+                std::mem::discriminant(&req),
+                std::mem::discriminant(&ControlRequest::Resume {
+                    run_id: String::new()
+                })
+            );
             ControlResponse::Ok { ok: true }
         });
         assert_eq!(

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -261,6 +261,60 @@ pub(super) async fn kill_agent(
     }
 }
 
+/// `POST /api/agents/{id}/pause`: park a run. The daemon refuses when the run
+/// does not exist or is not pausable (waiting on input, or finished), which
+/// both surface as 404 - the daemon's reply does not distinguish them.
+pub(super) async fn pause_agent(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    match state
+        .control
+        .request(&ControlRequest::Pause { run_id: id.clone() })
+        .await
+    {
+        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::NO_CONTENT),
+        Ok(ControlResponse::Ok { ok: false }) => Err(err(
+            StatusCode::NOT_FOUND,
+            format!("Agent run '{id}' not found or not pausable"),
+        )),
+        Ok(other) => Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Unexpected daemon response: {other:?}"),
+        )),
+        Err(e) => Err(err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("Daemon not reachable: {e}"),
+        )),
+    }
+}
+
+/// `POST /api/agents/{id}/resume`: un-pause a run.
+pub(super) async fn resume_agent(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    match state
+        .control
+        .request(&ControlRequest::Resume { run_id: id.clone() })
+        .await
+    {
+        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::NO_CONTENT),
+        Ok(ControlResponse::Ok { ok: false }) => Err(err(
+            StatusCode::NOT_FOUND,
+            format!("Agent run '{id}' not found or not paused"),
+        )),
+        Ok(other) => Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Unexpected daemon response: {other:?}"),
+        )),
+        Err(e) => Err(err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("Daemon not reachable: {e}"),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1291,6 +1345,112 @@ prompt = "Plan the work"
     async fn kill_agent_daemon_absent_is_503() {
         assert_eq!(
             delete_agent(no_daemon(), "a").await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    // ─── pause_agent / resume_agent ──────────────────────────────────────────
+
+    /// POST `/api/agents/{id}/pause` (or `/resume`) against a router holding
+    /// `control`, returning the response status.
+    async fn post_agent_action(control: ControlClient, id: &str, action: &str) -> StatusCode {
+        use axum::routing::post;
+        let (tx, _) = broadcast::channel(16);
+        let state = AppState {
+            config: Arc::new(Config::default()),
+            event_tx: tx,
+            control,
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        };
+        let app = Router::new()
+            .route("/api/agents/{id}/pause", post(pause_agent))
+            .route("/api/agents/{id}/resume", post(resume_agent))
+            .with_state(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/api/agents/{id}/{action}"))
+            .body(Body::empty())
+            .unwrap();
+        app.oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn pause_agent_sends_pause_to_the_daemon() {
+        let (control, _dir, _srv) = fake_daemon(|req| {
+            assert!(matches!(req, ControlRequest::Pause { .. }));
+            ControlResponse::Ok { ok: true }
+        });
+        assert_eq!(
+            post_agent_action(control, "run-a", "pause").await,
+            StatusCode::NO_CONTENT
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_agent_refused_is_404() {
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Ok { ok: false });
+        assert_eq!(
+            post_agent_action(control, "ghost", "pause").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_agent_unexpected_response_is_500() {
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Spawned {
+            run_id: "x".to_string(),
+        });
+        assert_eq!(
+            post_agent_action(control, "a", "pause").await,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_agent_daemon_absent_is_503() {
+        assert_eq!(
+            post_agent_action(no_daemon(), "a", "pause").await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_agent_sends_resume_to_the_daemon() {
+        let (control, _dir, _srv) = fake_daemon(|req| {
+            assert!(matches!(req, ControlRequest::Resume { .. }));
+            ControlResponse::Ok { ok: true }
+        });
+        assert_eq!(
+            post_agent_action(control, "run-a", "resume").await,
+            StatusCode::NO_CONTENT
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_agent_refused_is_404() {
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Ok { ok: false });
+        assert_eq!(
+            post_agent_action(control, "ghost", "resume").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_agent_unexpected_response_is_500() {
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Spawned {
+            run_id: "x".to_string(),
+        });
+        assert_eq!(
+            post_agent_action(control, "a", "resume").await,
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_agent_daemon_absent_is_503() {
+        assert_eq!(
+            post_agent_action(no_daemon(), "a", "resume").await,
             StatusCode::SERVICE_UNAVAILABLE
         );
     }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -90,6 +90,8 @@ fn api_router() -> Router<AppState> {
         .route("/api/agents/{id}/logs", get(agents::agent_logs))
         .route("/api/agents/{id}/result", get(agents::agent_result))
         .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
+        .route("/api/agents/{id}/pause", post(agents::pause_agent))
+        .route("/api/agents/{id}/resume", post(agents::resume_agent))
         // Messages
         .route("/api/agents/{id}/message", post(interactions::send_message))
         // Interactions
@@ -429,6 +431,23 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_pause_and_resume_routes_are_mounted() {
+        // With no daemon behind the test state the handlers answer 503 - the
+        // point here is only that the routes exist in the shared table (an
+        // unmounted route would 404 at the router).
+        for action in ["pause", "resume"] {
+            let app = test_app();
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!("/api/agents/some-run/{action}"))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        }
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -421,6 +421,12 @@ fn reload_one(
         );
     }
 
+    // A run the user paused stays paused across the restart: the default
+    // restore presents it `Active`, which would silently resume it.
+    if meta.status == RunStatus::Paused {
+        world.pause(entity);
+    }
+
     Ok(entity)
 }
 
@@ -625,6 +631,42 @@ mod tests {
         )
         .unwrap();
         std::fs::write(dir.join("run.lvr"), &buf).unwrap();
+    }
+
+    /// A run the user paused before the restart comes back paused, not the
+    /// default `Active` restore - a daemon restart must not silently resume it.
+    #[tokio::test]
+    async fn reload_keeps_a_paused_run_paused() {
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let runs = tempfile::tempdir().unwrap();
+        write_run(
+            runs.path(),
+            "run-paused",
+            manifest.to_str().unwrap(),
+            RunStatus::Paused,
+            None,
+        );
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            runs.path(),
+            999,
+            &sub_tx(),
+        );
+
+        assert_eq!(restored.len(), 1);
+        let (run_id, entity) = &restored[0];
+        assert_eq!(run_id, "run-paused");
+        assert_eq!(world.agent_status(*entity), Some(AgentStatus::Paused));
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -276,6 +276,7 @@ fn label(status: &AgentStatus) -> String {
     match status {
         AgentStatus::Idle => "idle".to_string(),
         AgentStatus::Active => "active".to_string(),
+        AgentStatus::Paused => "paused".to_string(),
         AgentStatus::Waiting => "waiting".to_string(),
         AgentStatus::Complete => "complete".to_string(),
         AgentStatus::Cancelled => "cancelled".to_string(),
@@ -501,6 +502,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     fn label_and_terminal_cover_all_statuses() {
         assert_eq!(label(&AgentStatus::Idle), "idle");
         assert_eq!(label(&AgentStatus::Active), "active");
+        assert_eq!(label(&AgentStatus::Paused), "paused");
         assert_eq!(label(&AgentStatus::Waiting), "waiting");
         assert_eq!(label(&AgentStatus::Complete), "complete");
         assert_eq!(label(&AgentStatus::Cancelled), "cancelled");

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -42,6 +42,12 @@ pub enum Commands {
     #[command(alias = "kill")]
     Cancel(commands::ctl::CancelArgs),
 
+    /// Pause a running agent (it finishes its in-flight step, then holds)
+    Pause(commands::ctl::PauseArgs),
+
+    /// Resume a paused agent
+    Resume(commands::ctl::ResumeArgs),
+
     /// Answer a pending interaction (or list open ones with no request id)
     Respond(commands::ctl::RespondArgs),
 
@@ -114,6 +120,10 @@ pub trait RiskyExecutors {
     async fn msg(&self, args: commands::ctl::MsgArgs) -> anyhow::Result<()>;
     /// `lev cancel` - resolves the control-socket path and cancels a run.
     async fn cancel(&self, args: commands::ctl::CancelArgs) -> anyhow::Result<()>;
+    /// `lev pause` - resolves the control-socket path and pauses a run.
+    async fn pause(&self, args: commands::ctl::PauseArgs) -> anyhow::Result<()>;
+    /// `lev resume` - resolves the control-socket path and resumes a run.
+    async fn resume(&self, args: commands::ctl::ResumeArgs) -> anyhow::Result<()>;
     /// `lev respond` - resolves the control-socket path and answers/lists interactions.
     async fn respond(&self, args: commands::ctl::RespondArgs) -> anyhow::Result<()>;
     /// `lev setup` - interactive (blocking stdin) or `--non-interactive`.
@@ -160,6 +170,8 @@ pub async fn dispatch(command: Commands, ex: &impl RiskyExecutors) -> anyhow::Re
         Commands::Ps(args) => ex.ps(args).await,
         Commands::Msg(args) => ex.msg(args).await,
         Commands::Cancel(args) => ex.cancel(args).await,
+        Commands::Pause(args) => ex.pause(args).await,
+        Commands::Resume(args) => ex.resume(args).await,
         Commands::Respond(args) => ex.respond(args).await,
         Commands::List(args) => commands::list::execute(args).await,
         Commands::Add(args) => commands::add::execute(args).await,
@@ -203,6 +215,12 @@ mod tests {
             Ok(())
         }
         async fn cancel(&self, _args: commands::ctl::CancelArgs) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn pause(&self, _args: commands::ctl::PauseArgs) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn resume(&self, _args: commands::ctl::ResumeArgs) -> anyhow::Result<()> {
             Ok(())
         }
         async fn setup(&self, _args: commands::setup::SetupArgs) -> anyhow::Result<()> {
@@ -320,6 +338,22 @@ mod tests {
             force: false,
         };
         assert!(dispatch(Commands::Cancel(args), &MockRisky).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_pause_variant_is_routed_through_the_executor() {
+        let args = commands::ctl::PauseArgs {
+            run_id: "r".to_string(),
+        };
+        assert!(dispatch(Commands::Pause(args), &MockRisky).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_resume_variant_is_routed_through_the_executor() {
+        let args = commands::ctl::ResumeArgs {
+            run_id: "r".to_string(),
+        };
+        assert!(dispatch(Commands::Resume(args), &MockRisky).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -82,6 +82,14 @@ impl RiskyExecutors for RealExecutors {
         commands::ctl::cancel_run(&control_client()?, &args).await
     }
 
+    async fn pause(&self, args: commands::ctl::PauseArgs) -> anyhow::Result<()> {
+        commands::ctl::pause_run(&control_client()?, &args).await
+    }
+
+    async fn resume(&self, args: commands::ctl::ResumeArgs) -> anyhow::Result<()> {
+        commands::ctl::resume_run(&control_client()?, &args).await
+    }
+
     async fn respond(&self, args: commands::ctl::RespondArgs) -> anyhow::Result<()> {
         commands::ctl::respond(&control_client()?, &args).await
     }

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -665,6 +665,7 @@ mod tests {
             RunStatus::WaitingInput,
             RunStatus::Complete,
             RunStatus::CompleteInteractive,
+            RunStatus::Paused,
             RunStatus::Error,
             RunStatus::Cancelled,
         ] {
@@ -684,6 +685,7 @@ mod tests {
             RunStatus::CompleteInteractive.to_string(),
             "CompleteInteractive"
         );
+        assert_eq!(RunStatus::Paused.to_string(), "Paused");
         assert_eq!(RunStatus::Error.to_string(), "Error");
         assert_eq!(RunStatus::Cancelled.to_string(), "Cancelled");
     }

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -21,6 +21,9 @@ pub enum RunStatus {
     /// All required stages done; agent still accepts optional follow-up input.
     /// Shown as "Complete" in the dashboard - no kill option, input still enabled.
     CompleteInteractive,
+    /// Paused by the user; resumes on request and is restored paused after a
+    /// daemon restart.
+    Paused,
     Error,
     Cancelled,
 }
@@ -33,6 +36,7 @@ impl std::fmt::Display for RunStatus {
             RunStatus::WaitingInput => write!(f, "WaitingInput"),
             RunStatus::Complete => write!(f, "Complete"),
             RunStatus::CompleteInteractive => write!(f, "CompleteInteractive"),
+            RunStatus::Paused => write!(f, "Paused"),
             RunStatus::Error => write!(f, "Error"),
             RunStatus::Cancelled => write!(f, "Cancelled"),
         }
@@ -462,6 +466,7 @@ mod tests {
             RunStatus::CompleteInteractive.to_string(),
             "CompleteInteractive"
         );
+        assert_eq!(RunStatus::Paused.to_string(), "Paused");
         assert_eq!(RunStatus::Error.to_string(), "Error");
         assert_eq!(RunStatus::Cancelled.to_string(), "Cancelled");
     }
@@ -474,6 +479,7 @@ mod tests {
             RunStatus::WaitingInput,
             RunStatus::Complete,
             RunStatus::CompleteInteractive,
+            RunStatus::Paused,
             RunStatus::Error,
             RunStatus::Cancelled,
         ] {
@@ -484,6 +490,10 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&RunStatus::WaitingInput).unwrap(),
             "\"waiting_input\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RunStatus::Paused).unwrap(),
+            "\"paused\""
         );
     }
 

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -109,6 +109,11 @@ pub enum AgentStatus {
     /// Agent is waiting for input or external event
     Waiting,
 
+    /// Agent was paused by the user. The async-starting systems skip it exactly
+    /// like `Idle`; the variant is distinct so the pause persists visibly
+    /// (`meta.json`, `lev ps`, dashboard) and so resume can be gated on it.
+    Paused,
+
     /// Agent has completed its task
     Complete,
 

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -370,6 +370,7 @@ fn status_str(status: &AgentStatus) -> &'static str {
     match status {
         AgentStatus::Idle => "idle",
         AgentStatus::Active => "active",
+        AgentStatus::Paused => "paused",
         AgentStatus::Waiting => "waiting",
         AgentStatus::Complete => "complete",
         AgentStatus::Error { .. } => "error",
@@ -1369,7 +1370,16 @@ mod tests {
         );
         assert_eq!(
             host.world.agent_status(host.by_run_id["run-a"]),
-            Some(AgentStatus::Idle)
+            Some(AgentStatus::Paused)
+        );
+
+        // Pausing an already-paused run refuses rather than reporting success.
+        assert!(
+            !ask(&mut host, |reply| ControlOp::Pause {
+                run_id: "run-a".to_string(),
+                reply
+            })
+            .await
         );
 
         assert!(
@@ -1378,6 +1388,10 @@ mod tests {
                 reply
             })
             .await
+        );
+        assert_eq!(
+            host.world.agent_status(host.by_run_id["run-a"]),
+            Some(AgentStatus::Active)
         );
         assert!(
             ask(&mut host, |reply| ControlOp::Cancel {
@@ -2274,6 +2288,7 @@ mod tests {
     fn status_str_covers_all_variants() {
         assert_eq!(status_str(&AgentStatus::Idle), "idle");
         assert_eq!(status_str(&AgentStatus::Active), "active");
+        assert_eq!(status_str(&AgentStatus::Paused), "paused");
         assert_eq!(status_str(&AgentStatus::Waiting), "waiting");
         assert_eq!(status_str(&AgentStatus::Complete), "complete");
         assert_eq!(

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -86,6 +86,7 @@ impl TokenTotals {
 pub fn run_status_from(status: &AgentStatus) -> RunStatus {
     match status {
         AgentStatus::Idle | AgentStatus::Active => RunStatus::Running,
+        AgentStatus::Paused => RunStatus::Paused,
         AgentStatus::Waiting => RunStatus::WaitingInput,
         AgentStatus::Complete => RunStatus::Complete,
         AgentStatus::Error { .. } => RunStatus::Error,
@@ -98,7 +99,8 @@ pub fn run_status_from(status: &AgentStatus) -> RunStatus {
 /// surfaces as `Error` (the stage stopped without completing).
 pub fn stage_status_from(status: &AgentStatus) -> StageRunStatus {
     match status {
-        AgentStatus::Idle | AgentStatus::Active => StageRunStatus::Active,
+        // A paused agent's current stage is still mid-flight, not a new stage state.
+        AgentStatus::Idle | AgentStatus::Active | AgentStatus::Paused => StageRunStatus::Active,
         AgentStatus::Waiting => StageRunStatus::WaitingInput,
         AgentStatus::Complete => StageRunStatus::Complete,
         AgentStatus::Error { .. } | AgentStatus::Cancelled => StageRunStatus::Error,
@@ -259,6 +261,7 @@ mod tests {
     fn status_mapping_covers_all_variants() {
         assert_eq!(run_status_from(&AgentStatus::Idle), RunStatus::Running);
         assert_eq!(run_status_from(&AgentStatus::Active), RunStatus::Running);
+        assert_eq!(run_status_from(&AgentStatus::Paused), RunStatus::Paused);
         assert_eq!(
             run_status_from(&AgentStatus::Waiting),
             RunStatus::WaitingInput
@@ -285,6 +288,10 @@ mod tests {
         );
         assert_eq!(
             stage_status_from(&AgentStatus::Active),
+            StageRunStatus::Active
+        );
+        assert_eq!(
+            stage_status_from(&AgentStatus::Paused),
             StageRunStatus::Active
         );
         assert_eq!(

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -3489,6 +3489,40 @@ fn transition_linear_advances_to_next_stage() {
 }
 
 #[test]
+fn transition_holds_while_paused_and_resolves_after_resume() {
+    // A pause that lands while a ResolveTransition is pending must not be
+    // undone by the transition system (entering a stage sets Active).
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1")],
+        VisitCounts::default(),
+    );
+    world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Paused;
+
+    run_transition(&mut world);
+
+    // Held: still paused, marker intact, cursor unmoved.
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    assert!(world.get::<ResolveTransition>(e).is_some());
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 0);
+
+    // After resume the parked transition resolves normally.
+    world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Active;
+    run_transition(&mut world);
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    assert!(world.get::<ResolveTransition>(e).is_none());
+}
+
+#[test]
 fn transition_terminal_marks_complete() {
     let bp = blueprint(vec![stage_named("only", None, false, None)]);
     let mut world = World::new();

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -869,6 +869,12 @@ pub fn resolve_transition(
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
+        // A pause that lands while a transition is pending must hold: entering
+        // the next stage flips the agent back to Active. The marker stays put,
+        // so the transition resolves on the first tick after resume.
+        if state.status == AgentStatus::Paused {
+            continue;
+        }
         let stage = &bp.0.stages[cursor.index];
         // How the stage ended governs the transition: an error/max-iterations
         // outcome follows its conditioned edge (e.g. → error_recovery) if present.

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -43,7 +43,9 @@ pub fn classify_restore(status: &RunStatus, parked_on_fanout: bool) -> Option<Re
         RunStatus::Complete | RunStatus::Error | RunStatus::Cancelled => None,
         _ if parked_on_fanout => Some(RestorePriority::Blocked),
         RunStatus::Starting | RunStatus::Running => Some(RestorePriority::Active),
-        RunStatus::WaitingInput | RunStatus::CompleteInteractive => Some(RestorePriority::Blocked),
+        RunStatus::WaitingInput | RunStatus::CompleteInteractive | RunStatus::Paused => {
+            Some(RestorePriority::Blocked)
+        }
     }
 }
 
@@ -401,6 +403,10 @@ mod tests {
         // No immediate progress → Blocked.
         assert_eq!(
             classify_restore(&RunStatus::WaitingInput, false),
+            Some(RestorePriority::Blocked)
+        );
+        assert_eq!(
+            classify_restore(&RunStatus::Paused, false),
             Some(RestorePriority::Blocked)
         );
         assert_eq!(

--- a/crates/leviath-runtime/src/telemetry.rs
+++ b/crates/leviath-runtime/src/telemetry.rs
@@ -74,7 +74,9 @@ fn terminal_label(status: &AgentStatus) -> Option<&'static str> {
         AgentStatus::Complete => Some("complete"),
         AgentStatus::Error { .. } => Some("error"),
         AgentStatus::Cancelled => Some("cancelled"),
-        AgentStatus::Idle | AgentStatus::Active | AgentStatus::Waiting => None,
+        AgentStatus::Idle | AgentStatus::Active | AgentStatus::Waiting | AgentStatus::Paused => {
+            None
+        }
     }
 }
 

--- a/crates/leviath-runtime/src/telemetry/tests.rs
+++ b/crates/leviath-runtime/src/telemetry/tests.rs
@@ -358,6 +358,7 @@ fn terminal_label_maps_every_status() {
     assert_eq!(terminal_label(&AgentStatus::Idle), None);
     assert_eq!(terminal_label(&AgentStatus::Active), None);
     assert_eq!(terminal_label(&AgentStatus::Waiting), None);
+    assert_eq!(terminal_label(&AgentStatus::Paused), None);
 }
 
 #[test]

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -438,14 +438,29 @@ impl PipelineWorld {
     }
 
     /// Pause an agent (it finishes any in-flight step, then stops before starting
-    /// new work). Returns `false` if the agent no longer exists.
+    /// new work). Only `Active` and `Idle` agents can be paused: a `Waiting`
+    /// agent's status is the marker the fan-out merge poll and interaction
+    /// resolution depend on, so overwriting it would wedge the run, and pausing
+    /// a terminal agent is meaningless. Returns `false` if the agent no longer
+    /// exists or is not in a pausable state.
     pub fn pause(&mut self, entity: Entity) -> bool {
-        self.set_status(entity, AgentStatus::Idle)
+        match self.agent_status(entity) {
+            Some(AgentStatus::Active | AgentStatus::Idle) => {
+                self.set_status(entity, AgentStatus::Paused)
+            }
+            _ => false,
+        }
     }
 
-    /// Resume a paused agent.
+    /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
+    /// agent that has not ticked yet); anything else returns `false`.
     pub fn resume(&mut self, entity: Entity) -> bool {
-        self.set_status(entity, AgentStatus::Active)
+        match self.agent_status(entity) {
+            Some(AgentStatus::Paused | AgentStatus::Idle) => {
+                self.set_status(entity, AgentStatus::Active)
+            }
+            _ => false,
+        }
     }
 
     /// Cancel an agent (it stops starting new work; in-flight results still land).
@@ -1303,12 +1318,55 @@ mod tests {
         assert!(world.pause(e));
 
         world.run_until_idle(30).await;
-        // Paused ⇒ parked as Idle, never inferred.
-        assert_eq!(world.agent_status(e), Some(AgentStatus::Idle));
+        // Paused ⇒ parked, never inferred.
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Paused));
 
         assert!(world.resume(e));
         world.run_until_idle(30).await;
         assert_eq!(world.agent_status(e), Some(AgentStatus::Complete));
+    }
+
+    #[tokio::test]
+    async fn pause_refuses_waiting_and_terminal_agents() {
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+
+        // A Waiting agent's status is the marker fan-out merges and interaction
+        // resolution key off - pause must not clobber it.
+        world.set_status(e, AgentStatus::Waiting);
+        assert!(!world.pause(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Waiting));
+
+        world.set_status(e, AgentStatus::Cancelled);
+        assert!(!world.pause(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn resume_refuses_agents_that_are_not_paused_or_idle() {
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+
+        // Already running: nothing to resume.
+        world.set_status(e, AgentStatus::Active);
+        assert!(!world.resume(e));
+
+        world.set_status(e, AgentStatus::Waiting);
+        assert!(!world.resume(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Waiting));
+
+        world.set_status(e, AgentStatus::Complete);
+        assert!(!world.resume(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Complete));
+    }
+
+    #[tokio::test]
+    async fn resume_nudges_an_idle_agent_active() {
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+        world.set_status(e, AgentStatus::Idle);
+        assert!(world.resume(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Active));
     }
 
     #[tokio::test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -61,6 +61,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
 | `GET /api/agents/{id}/result` · `/logs` · `/context` · `/context/history` | Run output, logs, context |
 | `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
+| `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
 | `POST /api/agents/{id}/message` | Steer a running agent |
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation |

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -39,6 +39,8 @@ run `lev <command> --help` for the full, authoritative flag list.
 | `lev ps` | List running agents and their status |
 | `lev msg <id> "…"` | Send a message to a running agent |
 | `lev respond` | Answer a pending `ask_user` question |
+| `lev pause <run-id>` | Pause a run (it finishes its in-flight step, then holds) |
+| `lev resume <run-id>` | Resume a paused run |
 | `lev cancel <run-id>` | Cancel a run |
 | `lev context <run-id>` | Show a run's context-window history |
 

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -93,6 +93,8 @@ talk to it:
 | `lev ps` | List running agents and their status |
 | `lev msg <id> <text>` | Send a message to a running agent |
 | `lev respond` | Answer a pending `ask_user` question |
+| `lev pause <run-id>` | Pause a run |
+| `lev resume <run-id>` | Resume a paused run |
 | `lev cancel <run-id>` | Cancel a run |
 | `lev context <run-id>` | Show a run's context-window history |
 

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -46,6 +46,7 @@ flowchart LR
 | `i` | Respond to or message the agent |
 | `/` | Search |
 | `k` | Kill the run |
+| `p` / `r` | Pause / resume the run |
 | `?` | Help |
 
 > [!TIP]


### PR DESCRIPTION
Closes #153.

The runtime has supported pause/resume end to end since the control socket landed, but nothing user-facing could trigger it. This wires it up everywhere the issue asked for, and makes the paused state visible instead of masquerading as a running one.

## What's new

- **CLI**: `lev pause <run-id>` / `lev resume <run-id>`, mirroring `lev cancel` over the control socket.
- **REST**: `POST /api/agents/{id}/pause` and `/resume` (204 / 404 / 500 / 503, same shape as the kill handler; auth applies, not admin-gated since they only toggle an existing run's status).
- **Dashboard**: `p` pauses, `r` resumes, in both the main list and the detail view, with the same optimistic-flip-plus-outcome-toast shape as cancel. Paused rows show `PAUSED`, freeze their elapsed timer, and sort with Stale above the finished states. Help bar and overlay list the keys.
- **Visible status**: new `AgentStatus::Paused` and `RunStatus::Paused`. Previously pause set the agent to `Idle`, which persists as `running`, so a paused run looked ACTIVE forever in `lev ps`, the API, and the dashboard, and the pause was silently lost on daemon restart. Now `paused` shows everywhere `meta.json` is read, and restart recovery re-applies the pause.
- **README**: 12-Factor factor 6 (Launch / pause / resume) moves from partial to met.

## Behavior changes worth calling out

- **Pause is now guarded** (this also fixes a latent bug): pause succeeds only from Active/Idle, resume only from Paused/Idle; anything else refuses with the existing `ok: false` reply. The old unconditional pause would overwrite a `Waiting` fan-out parent's status, destroying the marker its merge poll depends on and wedging the run.
- The transition system holds a pending stage transition while paused (entering a stage sets Active, which would have silently un-paused the run), and resolves it on the first tick after resume.
- **Downgrade note**: `meta.json` written while a run is paused uses the new `paused` status, which older `lev` binaries cannot parse. Resume or cancel paused runs before downgrading. (Changelog has the note.)

## Testing

- `cargo xtask coverage`: all 11 packages at 100%.
- Live-verified against a real daemon with a Rhai mock provider: pause/resume/refusals via CLI, `lev ps` showing `paused`, `meta.json` flipping to `paused` within one persist beat, REST 204/404/401 paths, pause surviving a daemon restart and resuming cleanly afterwards, and the dashboard driven through a pty (`p` flips the row to PAUSED, it survives the disk sync, `r` returns it to ACTIVE, help surfaces list the keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gzaMnBvgsFJ2T1VuQURr4