### PR TITLE
Validate tool arguments against their advertised JSON Schemas at dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ requests since the previous version.
 - Note for downgraders: run metadata written while a run is paused uses the
   new `paused` status, which older `lev` binaries cannot read. Resume or
   cancel paused runs before downgrading.
+- Tool calls are now validated against the JSON Schema each tool advertises
+  before they run. A call with missing, mistyped, or out-of-range arguments is
+  refused back to the model with the concrete violations instead of executing
+  on garbage or surfacing as a permission prompt. A schema that cannot be
+  compiled (a typo'd Rhai `@param` type, an uninterpretable MCP fragment)
+  skips validation for that tool with a logged warning, and external `$ref`s
+  never resolve over the network.
+- Taint-gate `[blocked]` results no longer count as successful modifications,
+  so a stage whose writes were all blocked cannot satisfy a
+  `require_modifications` transition gate.
+- `send_to_agent`'s documented `target_region` argument now works: it was
+  silently dropped on the sub-agent path and every message landed in the
+  conversation region.
+- Removed the unused message priority field; inbox delivery was always
+  first-in, first-out in practice and now is by contract.
 
 ## 0.1.1 - 2026-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -670,6 +671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +698,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1257,6 +1270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1392,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1603,9 +1657,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2129,6 +2185,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2526,7 @@ name = "leviath-tools"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "jsonschema",
  "leviath-core",
  "leviath-providers",
  "leviath-sys",
@@ -2552,6 +2661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2783,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -2871,6 +2992,12 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "palette"
@@ -3447,6 +3574,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4666,6 +4830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4914,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,6 +4945,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,13 @@ regex = "1"
 # `reqwest::Url` IS this crate's `Url`, so the two interoperate directly.
 url = "2.5"
 tiktoken-rs = "0.12"
+# Compiles tool-parameter JSON Schemas and validates model-supplied arguments
+# before dispatch (issue #155). `default-features = false` is deliberate: the
+# default resolve-http/resolve-file features would let a server-supplied MCP
+# schema pull external `$ref`s over the network or filesystem at validation
+# time. Without them an external `$ref` simply fails to compile, and a schema
+# that fails to compile skips validation instead of refusing calls.
+jsonschema = { version = "0.49", default-features = false }
 async-trait = "0.1"
 futures = "0.3"
 sha2 = "0.11"

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -199,12 +199,18 @@ async fn send(h: &SubAgentHandle, args: &serde_json::Value) -> String {
     if agent_id.is_empty() || message.is_empty() {
         return "[error] send_to_agent requires 'agent_id' and 'message'".to_string();
     }
+    // Empty string means unset, same as absent: delivery defaults to the
+    // conversation region, which is what the tool's schema documents.
+    let target_region = Some(str_arg(args, "target_region"))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     let (tx, rx) = oneshot::channel();
     if h.sender
         .send(SubAgentOp::Send {
             run_id: agent_id.to_string(),
             caller_run_id: h.parent_run_id.clone(),
             content: message.to_string(),
+            target_region,
             reply: tx,
         })
         .is_err()
@@ -744,6 +750,64 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             .await
             .contains("shutting down")
         );
+    }
+
+    /// A host that answers only `Send`, recording each op's `target_region`.
+    #[allow(clippy::type_complexity)]
+    fn send_recording_host() -> (
+        SubAgentHandle,
+        std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let regions = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let regions_task = regions.clone();
+        let task = tokio::spawn(async move {
+            while let Some(op) = rx.recv().await {
+                match op {
+                    SubAgentOp::Send {
+                        reply,
+                        target_region,
+                        ..
+                    } => {
+                        regions_task.lock().unwrap().push(target_region);
+                        let _ = reply.send(true);
+                    }
+                    // Any other op: drop it unanswered; callers see a dropped
+                    // oneshot, which every handler already tolerates.
+                    other => drop(other),
+                }
+            }
+        });
+        (handle_with(tx), regions, task)
+    }
+
+    /// `target_region` was schema-advertised and documented but never read on
+    /// this path; the host op now carries it. Absent and empty both mean the
+    /// documented default (conversation), so they forward as `None`.
+    #[tokio::test]
+    async fn send_forwards_target_region() {
+        let (h, regions, task) = send_recording_host();
+        for args in [
+            json!({ "agent_id": "c", "message": "hi", "target_region": "notes" }),
+            json!({ "agent_id": "c", "message": "hi" }),
+            json!({ "agent_id": "c", "message": "hi", "target_region": "" }),
+        ] {
+            assert!(
+                handle(&h, &tc("send_to_agent", args))
+                    .await
+                    .contains("Delivered message")
+            );
+        }
+        assert_eq!(
+            *regions.lock().unwrap(),
+            vec![Some("notes".to_string()), None, None]
+        );
+        // A non-Send op goes through the recording host's drop arm.
+        handle(&h, &tc("check_agent", json!({ "agent_id": "c" }))).await;
+        // Closing the handle ends the host loop; the task exits cleanly.
+        drop(h);
+        task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -1102,8 +1102,6 @@ pub struct AgentMessage {
     pub content: String,
     /// Which region to add the message to (default: "conversation")
     pub target_region: Option<String>,
-    /// Priority (higher = processed sooner)
-    pub priority: i32,
 }
 
 /// Inbox component for receiving messages sent to a running agent.
@@ -1121,11 +1119,11 @@ impl MessageInbox {
         }
     }
 
-    /// Add a message to the inbox.
+    /// Add a message to the inbox. Messages deliver in the order they
+    /// arrived; there used to be a priority field here, but no path that
+    /// sends a message ever set it, so FIFO is what always happened.
     pub fn push(&mut self, msg: AgentMessage) {
         self.messages.push(msg);
-        // Sort by priority descending so highest priority is first
-        self.messages.sort_by_key(|m| std::cmp::Reverse(m.priority));
     }
 
     /// Drain all messages from the inbox.
@@ -1344,7 +1342,6 @@ mod tests {
             agent_id: "agent-1".to_string(),
             content: "hello".to_string(),
             target_region: None,
-            priority: 0,
         });
         assert_eq!(inbox.messages.len(), 1);
 
@@ -1354,32 +1351,20 @@ mod tests {
     }
 
     #[test]
-    fn test_message_inbox_priority_ordering() {
+    fn message_inbox_preserves_fifo_order() {
         let mut inbox = MessageInbox::new();
-
-        inbox.push(AgentMessage {
-            agent_id: "a".to_string(),
-            content: "low".to_string(),
-            target_region: None,
-            priority: 1,
-        });
-        inbox.push(AgentMessage {
-            agent_id: "a".to_string(),
-            content: "high".to_string(),
-            target_region: None,
-            priority: 10,
-        });
-        inbox.push(AgentMessage {
-            agent_id: "a".to_string(),
-            content: "medium".to_string(),
-            target_region: None,
-            priority: 5,
-        });
+        for content in ["first", "second", "third"] {
+            inbox.push(AgentMessage {
+                agent_id: "a".to_string(),
+                content: content.to_string(),
+                target_region: None,
+            });
+        }
 
         let msgs = inbox.drain_all();
-        assert_eq!(msgs[0].content, "high");
-        assert_eq!(msgs[1].content, "medium");
-        assert_eq!(msgs[2].content, "low");
+        assert_eq!(msgs[0].content, "first");
+        assert_eq!(msgs[1].content, "second");
+        assert_eq!(msgs[2].content, "third");
     }
 
     #[test]
@@ -1611,7 +1596,6 @@ mod tests {
             agent_id: "a".to_string(),
             content: "msg".to_string(),
             target_region: None,
-            priority: 0,
         });
         let _ = inbox.drain_all();
         assert!(inbox.messages.is_empty());
@@ -1626,13 +1610,11 @@ mod tests {
             agent_id: "agent-1".to_string(),
             content: "hello".to_string(),
             target_region: Some("conv".to_string()),
-            priority: 5,
         };
         let cloned = msg.clone();
         assert_eq!(cloned.agent_id, "agent-1");
         assert_eq!(cloned.content, "hello");
         assert_eq!(cloned.target_region, Some("conv".to_string()));
-        assert_eq!(cloned.priority, 5);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -169,6 +169,10 @@ pub enum SubAgentOp {
         caller_run_id: String,
         /// The message body.
         content: String,
+        /// Context region to deliver into (`None` = the "conversation"
+        /// default). The `send_to_agent` tool advertised this from the start
+        /// but the op had no field to carry it, so it was silently dropped.
+        target_region: Option<String>,
         /// Reply: whether the message was accepted.
         reply: oneshot::Sender<bool>,
     },
@@ -768,6 +772,7 @@ impl WorldHost {
                 run_id,
                 caller_run_id,
                 content,
+                target_region,
                 reply,
             } => {
                 if !self.is_within_tree(&run_id, &caller_run_id) {
@@ -781,7 +786,7 @@ impl WorldHost {
                     .send_message(AgentMessage {
                         agent_id: run_id,
                         content,
-                        target_region: None,
+                        target_region,
                     })
                     .is_ok();
                 let _ = reply.send(ok);
@@ -1673,6 +1678,7 @@ mod tests {
             run_id: "child".to_string(),
             caller_run_id: "parent".to_string(),
             content: "carry on".to_string(),
+            target_region: None,
             reply,
         })
         .await;
@@ -1689,6 +1695,7 @@ mod tests {
             run_id: "outsider".to_string(),
             caller_run_id: "run-a".to_string(),
             content: "take this".to_string(),
+            target_region: None,
             reply,
         })
         .await;
@@ -1708,6 +1715,7 @@ mod tests {
             run_id: "no-such-run".to_string(),
             caller_run_id: "run-a".to_string(),
             content: "hello?".to_string(),
+            target_region: None,
             reply,
         })
         .await;
@@ -1722,10 +1730,49 @@ mod tests {
             run_id: "run-a".to_string(),
             caller_run_id: "run-a".to_string(),
             content: "hello child".to_string(),
+            target_region: None,
             reply,
         })
         .await;
         assert!(ok);
+    }
+
+    /// The op's `target_region` reaches the named region, not just the
+    /// default conversation. The `send_to_agent` tool advertised this
+    /// parameter from the start, but the op had no field to carry it, so it
+    /// was silently dropped on this path.
+    #[tokio::test]
+    async fn subagent_send_delivers_into_the_target_region() {
+        let mut host = host_with(vec![]);
+        let e = spawn(&mut host, "run-a", "run-a");
+        host.world
+            .world_mut()
+            .get_mut::<crate::components::ContextWindow>(e)
+            .unwrap()
+            .add_region(Region::new(
+                "notes".to_string(),
+                RegionKind::Clearable,
+                5000,
+            ));
+
+        let ok = ask_sub(&mut host, |reply| SubAgentOp::Send {
+            run_id: "run-a".to_string(),
+            caller_run_id: "run-a".to_string(),
+            content: "filed under notes".to_string(),
+            target_region: Some("notes".to_string()),
+            reply,
+        })
+        .await;
+        assert!(ok);
+
+        host.world.tick(); // intake → inbox → window
+        let window = host
+            .world
+            .world()
+            .get::<crate::components::ContextWindow>(e)
+            .unwrap();
+        assert!(window.get_region("notes").unwrap().current_tokens > 0);
+        assert_eq!(window.get_region("conversation").unwrap().current_tokens, 0);
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -782,7 +782,6 @@ impl WorldHost {
                         agent_id: run_id,
                         content,
                         target_region: None,
-                        priority: 0,
                     })
                     .is_ok();
                 let _ = reply.send(ok);
@@ -1048,7 +1047,6 @@ impl WorldHost {
                         agent_id,
                         content,
                         target_region,
-                        priority: 0,
                     })
                     .is_ok();
                 let _ = reply.send(ok);

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -2850,6 +2850,244 @@ async fn dispatch_tools_partitions_context_and_lane() {
     assert_eq!(job.entity, e);
 }
 
+// ── argument validation (dispatch_tools) ──
+
+/// A stage advertising `tools`, each with a real parameter schema. The plain
+/// `offering()` fixture advertises `{}` (accepts anything); these tests are
+/// about what happens when a schema actually constrains.
+fn offering_with_schemas(tools: &[(&str, serde_json::Value)]) -> StageInference {
+    StageInference {
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
+        tools: tools
+            .iter()
+            .map(|(n, schema)| leviath_providers::Tool {
+                name: (*n).to_string(),
+                description: String::new(),
+                parameters: schema.clone(),
+            })
+            .collect(),
+        tool_filter: None,
+    }
+}
+
+fn path_required_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": { "path": { "type": "string" } },
+        "required": ["path"]
+    })
+}
+
+/// Layer 2: a call whose arguments do not satisfy the advertised schema is
+/// refused back to the model with the validator's message, and never reaches
+/// the lane - while a valid call in the same batch still runs.
+#[tokio::test]
+async fn dispatch_tools_refuses_arguments_that_fail_the_advertised_schema() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage(jtx));
+    let result = crate::components::InferenceResult {
+        response: "r".to_string(),
+        tool_calls: vec![
+            fcall("c1", "read_file", serde_json::json!({"path": 42})),
+            fcall("c2", "read_file", serde_json::json!({"path": "a.txt"})),
+        ],
+        tokens_used: 0,
+        timestamp: 0,
+    };
+    let e = world
+        .spawn((
+            agent_state(),
+            offering_with_schemas(&[("read_file", path_required_schema())]),
+            result,
+            conv_window(),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    let stashed = &world.get::<ContextToolResults>(e).unwrap().0;
+    assert_eq!(stashed.len(), 1, "only the invalid call was answered here");
+    assert_eq!(stashed[0].0, "c1");
+    let refusal = stashed[0].1.clone();
+    assert!(
+        refusal.starts_with("[error] invalid arguments for 'read_file'"),
+        "{refusal}"
+    );
+    // The message names the violation, so the next turn can self-correct.
+    assert!(refusal.contains("path"), "{refusal}");
+
+    let job = jrx.try_recv().expect("the valid call still runs");
+    assert_eq!(job.entity, e);
+}
+
+/// A schema that does not compile (a typo'd Rhai `@param` type produces
+/// `{"type": "strng"}`) must not turn its tool unusable: validation is
+/// skipped and the call dispatches as before.
+#[tokio::test]
+async fn dispatch_tools_skips_validation_when_the_schema_does_not_compile() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage(jtx));
+    let result = crate::components::InferenceResult {
+        response: "r".to_string(),
+        tool_calls: vec![fcall("c1", "typod", serde_json::json!({"whatever": true}))],
+        tokens_used: 0,
+        timestamp: 0,
+    };
+    let e = world
+        .spawn((
+            agent_state(),
+            offering_with_schemas(&[("typod", serde_json::json!({"type": "strng"}))]),
+            result,
+            conv_window(),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    assert!(
+        world.get::<ContextToolResults>(e).unwrap().0.is_empty(),
+        "nothing was refused"
+    );
+    assert!(jrx.try_recv().is_ok(), "the call dispatched anyway");
+}
+
+/// The schema lookup resolves aliases on both sides, like the Layer-1 check
+/// above it: a stage advertising `bash` constrains a call to `shell`.
+#[tokio::test]
+async fn dispatch_tools_validates_through_a_tool_alias() {
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage(jtx));
+    let canonical = leviath_tools::canonical_tool_name("bash");
+    assert_ne!(
+        canonical, "bash",
+        "this test needs a real alias to be a test"
+    );
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": { "command": { "type": "string" } },
+        "required": ["command"]
+    });
+    let result = crate::components::InferenceResult {
+        response: "r".to_string(),
+        tool_calls: vec![fcall("c1", canonical, serde_json::json!({}))],
+        tokens_used: 0,
+        timestamp: 0,
+    };
+    let e = world
+        .spawn((
+            agent_state(),
+            offering_with_schemas(&[("bash", schema)]),
+            result,
+            conv_window(),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    let text = conversation_text(&world, e);
+    assert!(text.contains("invalid arguments"), "{text}");
+    assert!(text.contains("command"), "{text}");
+}
+
+/// An MCP-style schema (server-supplied: enums, typed array items) constrains
+/// the same way - both directions, accept and refuse.
+#[tokio::test]
+async fn dispatch_tools_validates_an_mcp_style_schema() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage(jtx));
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "mode": { "enum": ["fast", "thorough"] },
+            "targets": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["mode"]
+    });
+    let result = crate::components::InferenceResult {
+        response: "r".to_string(),
+        tool_calls: vec![
+            fcall(
+                "c1",
+                "mcp_search",
+                serde_json::json!({"mode": "sideways", "targets": ["a", 7]}),
+            ),
+            fcall(
+                "c2",
+                "mcp_search",
+                serde_json::json!({"mode": "fast", "targets": ["a"]}),
+            ),
+        ],
+        tokens_used: 0,
+        timestamp: 0,
+    };
+    let e = world
+        .spawn((
+            agent_state(),
+            offering_with_schemas(&[("mcp_search", schema)]),
+            result,
+            conv_window(),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    let stashed = &world.get::<ContextToolResults>(e).unwrap().0;
+    assert_eq!(stashed.len(), 1);
+    assert_eq!(stashed[0].0, "c1");
+    assert!(stashed[0].1.contains("/mode"), "{}", stashed[0].1);
+    assert!(jrx.try_recv().is_ok(), "the conforming call ran");
+}
+
+/// The helper's own edges, directly: no def for the name means nothing to
+/// validate (after the unoffered check that cannot happen in dispatch), and
+/// the provider's `Null`-for-no-arguments convention satisfies an
+/// unconstraining schema.
+#[test]
+fn invalid_args_refusal_without_a_def_or_constraint_is_none() {
+    let stage = offering(&["read_file"]);
+    assert_eq!(
+        invalid_args_refusal(&stage, "never_advertised", &serde_json::json!({})),
+        None
+    );
+    assert_eq!(
+        invalid_args_refusal(&stage, "read_file", &serde_json::Value::Null),
+        None
+    );
+}
+
+/// Every refusal prefix dispatch can produce reads as "this never happened".
+/// `[blocked]` was missing until issue #155's pass, so a taint-blocked write
+/// counted as a modification.
+#[test]
+fn call_had_no_effect_covers_every_refusal_prefix() {
+    assert!(call_had_no_effect("[error] boom"));
+    assert!(call_had_no_effect("[denied] user said no"));
+    assert!(call_had_no_effect("[unavailable] not in this stage"));
+    assert!(call_had_no_effect("[blocked] taint gate"));
+    assert!(!call_had_no_effect("Successfully wrote 12 bytes"));
+}
+
 // ── taint gate (dispatch_tools) ──
 
 /// A taint-tracking window carrying `Internal`-level data.
@@ -6734,6 +6972,28 @@ fn collect_tools_ignores_a_write_the_stage_never_offered() {
     );
     assert_eq!(progress.modifying_tool_calls, 0);
     // Not "blocked" either - nobody declined it; the stage never had it.
+    assert_eq!(progress.blocked_modification_calls, 0);
+    assert_eq!(flags.modified_file_count, 0);
+    assert!(flags.modified_files.is_empty());
+}
+
+/// A taint-blocked write never ran either. `[blocked]` was missing from the
+/// no-effect prefixes, so it counted as a successful modification - a stage
+/// whose every write the gate stopped could still satisfy a
+/// `require_modifications` transition.
+#[test]
+fn collect_tools_ignores_a_write_the_taint_gate_blocked() {
+    let (progress, flags) = count_modifications(
+        &[(
+            "write_file",
+            serde_json::json!({"path": "exfil.txt"}),
+            "[blocked] 'write_file' would carry Internal-tainted data.",
+        )],
+        &[],
+    );
+    assert_eq!(progress.modifying_tool_calls, 0);
+    // Not "blocked_modification_calls" - that counter is the user declining;
+    // the gate refusing is not the agent having tried and been overruled.
     assert_eq!(progress.blocked_modification_calls, 0);
     assert_eq!(flags.modified_file_count, 0);
     assert!(flags.modified_files.is_empty());

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -3909,7 +3909,6 @@ fn msg(agent_id: &str, content: &str, region: Option<&str>) -> AgentMessage {
         agent_id: agent_id.to_string(),
         content: content.to_string(),
         target_region: region.map(String::from),
-        priority: 0,
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -121,17 +121,20 @@ pub(crate) fn merge_in_call_order(
 
 /// Whether a tool result describes a call whose side effect never happened.
 ///
-/// `[error]` (it ran and failed), `[denied]` (policy refused it) and
-/// `[unavailable]` (the stage never offered it) all mean the same thing to
-/// anything reasoning about what the agent *did*: file tracking must not record
-/// a write that was not written, and the modification counters behind a
-/// transition gate must not count it as work. Three separate prefix lists is
-/// exactly how a fourth prefix gets missed - `[unavailable]` was, when dispatch
-/// began refusing unoffered tools and both call sites still listed only two.
+/// `[error]` (it ran and failed), `[denied]` (policy refused it),
+/// `[unavailable]` (the stage never offered it) and `[blocked]` (the taint
+/// gate stopped it) all mean the same thing to anything reasoning about what
+/// the agent *did*: file tracking must not record a write that was not
+/// written, and the modification counters behind a transition gate must not
+/// count it as work. Separate prefix lists are exactly how a new prefix gets
+/// missed - `[unavailable]` was, when dispatch began refusing unoffered tools
+/// and both call sites still listed only two, and `[blocked]` was again, so a
+/// taint-blocked write counted as a modification until issue #155's pass.
 pub(crate) fn call_had_no_effect(result: &str) -> bool {
     result.starts_with("[error]")
         || result.starts_with("[denied]")
         || result.starts_with("[unavailable]")
+        || result.starts_with("[blocked]")
 }
 
 /// The effective tool names this stage advertised, canonicalised.
@@ -196,6 +199,47 @@ pub(crate) fn barrier_then(
             exec().await
         })
     })
+}
+
+/// `Some(refusal)` when `name`'s arguments do not satisfy the schema the
+/// stage advertised for it.
+///
+/// The def is found by canonicalising both the called name and each advertised
+/// name, the same resolution `offered_tool_names` applies, so a tool offered
+/// as `bash` validates a call to `shell` and vice versa. A name with no def
+/// here validates as fine - after the unoffered-tool check that cannot happen,
+/// and the schema's absence is not the model's mistake to be refused over.
+///
+/// A schema that does not compile (a typo'd Rhai `@param` type, an MCP
+/// fragment this crate cannot interpret) is logged and skipped rather than
+/// refused: validation must never turn a working tool into an unusable one.
+///
+/// Schemas are compiled per call, deliberately. They are small, calls arrive
+/// at model latency, and a compiled-validator cache would need invalidating on
+/// every dynamic-tools re-advertisement and scoping per agent - real
+/// complexity for unmeasurable savings.
+pub(crate) fn invalid_args_refusal(
+    stage: &StageInference,
+    name: &str,
+    args: &serde_json::Value,
+) -> Option<String> {
+    let canonical = leviath_tools::canonical_tool_name(name);
+    let tool = stage
+        .tools
+        .iter()
+        .find(|t| leviath_tools::canonical_tool_name(&t.name) == canonical)?;
+    match leviath_tools::validate_tool_args(name, &tool.parameters, args) {
+        leviath_tools::ArgValidation::Valid => None,
+        leviath_tools::ArgValidation::SchemaUnusable(e) => {
+            tracing::warn!(
+                tool = %name,
+                error = %e,
+                "tool schema did not compile; skipping argument validation"
+            );
+            None
+        }
+        leviath_tools::ArgValidation::Invalid(msg) => Some(msg),
+    }
 }
 
 /// Tool-dispatch system: for each `ReadyForTools` agent, apply its `context_*`
@@ -306,6 +350,16 @@ pub fn dispatch_tools(
             // and rewritten by the dynamic-tools refresh - so enforcement cannot
             // drift from advertising the way a second copy of the rule would.
             if let Some(refusal) = unoffered_tool_refusal(stage_inf, &c.name) {
+                context_results.push((c.tool_id.clone(), refusal));
+                continue;
+            }
+            // Layer 2: the call must satisfy the schema the model was shown.
+            // A mismatched call is refused back to the model with the
+            // validator's message, so the next turn can self-correct, rather
+            // than executed on garbage or surfaced to the user as a permission
+            // prompt for arguments that were never valid. Deterministic, so a
+            // gate-prompt re-run of the same batch refuses identically.
+            if let Some(refusal) = invalid_args_refusal(stage_inf, &c.name, &c.arguments) {
                 context_results.push((c.tool_id.clone(), refusal));
                 continue;
             }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1255,7 +1255,6 @@ mod tests {
                 agent_id: "a".to_string(),
                 content: "hello".to_string(),
                 target_region: Some("conversation".to_string()),
-                priority: 0,
             })
             .unwrap();
         world.tick(); // deliver_messages runs
@@ -1314,7 +1313,6 @@ mod tests {
             agent_id: "a".to_string(),
             content: "x".to_string(),
             target_region: None,
-            priority: 0,
         });
         assert!(err.is_err());
     }

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -17,6 +17,7 @@ leviath-core = { workspace = true }
 leviath-providers = { workspace = true }
 leviath-sys = { workspace = true }
 serde_json = { workspace = true }
+jsonschema = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -17,9 +17,11 @@ mod context;
 mod defs;
 mod exec;
 mod platform;
+mod validate;
 pub use context::*;
 pub use defs::{SUBAGENT_TOOLS, is_subagent_tool};
 pub use platform::*;
+pub use validate::*;
 
 /// Built-in tools: read_file, write_file, edit_file, list_dir, shell.
 ///

--- a/crates/leviath-tools/src/validate/mod.rs
+++ b/crates/leviath-tools/src/validate/mod.rs
@@ -1,0 +1,106 @@
+//! Structural validation of tool-call arguments against declared schemas.
+//!
+//! Every tool advertises a JSON Schema for its parameters (built-ins in
+//! `defs.rs`, Rhai script tools via their compiled `@param` annotations, MCP
+//! tools via the server's `inputSchema`). Until issue #155 nothing checked a
+//! model's arguments against that schema: handlers did ad-hoc presence checks
+//! that could not tell `{"path": 42}` from a missing `path`, and extra or
+//! misspelled properties passed through silently. This module is the one
+//! validator dispatch consults before a call is executed.
+//!
+//! Two properties are load-bearing:
+//!
+//! - **A schema that does not compile skips validation instead of refusing
+//!   calls.** Garbage schemas are reachable in normal operation - a typo'd
+//!   Rhai `@param n strng required` compiles to `{"type": "strng"}`, and MCP
+//!   servers may send fragments this crate cannot interpret. Refusing those
+//!   calls would break working tools; [`ArgValidation::SchemaUnusable`] lets
+//!   the caller log and dispatch anyway.
+//! - **External `$ref`s never resolve.** The `jsonschema` dependency is built
+//!   with `default-features = false`, so a server-supplied schema referencing
+//!   an external URI fails to compile (and is skipped, per the point above)
+//!   rather than fetching over the network or filesystem at validation time.
+
+use serde_json::Value;
+
+/// How many individual schema violations a refusal message reports before
+/// summarising the rest. The message goes back to the model as a tool result;
+/// three concrete violations are enough to self-correct on, and a pathological
+/// call (say, a giant object where a string was expected) should not turn into
+/// a pathological refusal.
+const MAX_REPORTED_ERRORS: usize = 3;
+
+/// Byte cap on each rendered violation. Validator messages embed the offending
+/// instance value, which the model already has; a huge argument does not need
+/// to be echoed back in full.
+const MAX_ERROR_LEN: usize = 256;
+
+/// The outcome of checking one tool call's arguments against its schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArgValidation {
+    /// The arguments satisfy the schema; dispatch the call.
+    Valid,
+    /// The arguments violate the schema. Carries the complete refusal text
+    /// (`[error] invalid arguments for '<tool>': ...`), ready to return as the
+    /// tool result. The `[error]` prefix is deliberate: it is already in the
+    /// dispatch layer's no-effect prefix list, so a refused call is not
+    /// counted as work the agent did.
+    Invalid(String),
+    /// The schema itself would not compile, so nothing was checked. Carries
+    /// the compile error for the caller to log; the call must still dispatch.
+    SchemaUnusable(String),
+}
+
+/// Validate `args` against `schema`, the exact parameter schema advertised to
+/// the model for `tool_name`.
+///
+/// `Value::Null` arguments are treated as `{}`: providers substitute an empty
+/// object when a model omits tool input entirely, and a null reaching here
+/// means the same "no arguments" - not a JSON null argument object.
+pub fn validate_tool_args(tool_name: &str, schema: &Value, args: &Value) -> ArgValidation {
+    let validator = match jsonschema::validator_for(schema) {
+        Ok(v) => v,
+        Err(e) => return ArgValidation::SchemaUnusable(e.to_string()),
+    };
+    let empty_object;
+    let instance = match args.is_null() {
+        true => {
+            empty_object = Value::Object(serde_json::Map::new());
+            &empty_object
+        }
+        false => args,
+    };
+    let violations: Vec<String> = validator.iter_errors(instance).map(render_error).collect();
+    if violations.is_empty() {
+        return ArgValidation::Valid;
+    }
+    let reported = violations
+        .iter()
+        .take(MAX_REPORTED_ERRORS)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("; ");
+    let suffix = match violations.len() > MAX_REPORTED_ERRORS {
+        true => format!("; (and {} more)", violations.len() - MAX_REPORTED_ERRORS),
+        false => String::new(),
+    };
+    ArgValidation::Invalid(format!(
+        "[error] invalid arguments for '{tool_name}': {reported}{suffix}"
+    ))
+}
+
+/// One violation as the model will read it: the validator's own message,
+/// length-capped, prefixed with the offending argument's path when the
+/// violation is not at the root.
+fn render_error(error: jsonschema::ValidationError<'_>) -> String {
+    let message = error.to_string();
+    let message = leviath_core::truncate_at_boundary(&message, MAX_ERROR_LEN);
+    let path = error.instance_path().to_string();
+    match path.is_empty() {
+        true => message.to_string(),
+        false => format!("at {path}: {message}"),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-tools/src/validate/tests.rs
+++ b/crates/leviath-tools/src/validate/tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use serde_json::json;
+
+fn invalid_message(v: ArgValidation) -> String {
+    match v {
+        ArgValidation::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    }
+}
+
+fn unusable_reason(v: ArgValidation) -> String {
+    match v {
+        ArgValidation::SchemaUnusable(m) => m,
+        other => panic!("expected SchemaUnusable, got {other:?}"),
+    }
+}
+
+/// A builtin-style schema: one required string property.
+fn read_file_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": { "path": { "type": "string" } },
+        "required": ["path"]
+    })
+}
+
+#[test]
+fn valid_arguments_pass() {
+    let v = validate_tool_args("read_file", &read_file_schema(), &json!({"path": "a.txt"}));
+    assert_eq!(v, ArgValidation::Valid);
+}
+
+#[test]
+fn missing_required_property_is_refused_with_tool_name_and_property() {
+    let msg = invalid_message(validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &json!({}),
+    ));
+    assert!(
+        msg.starts_with("[error] invalid arguments for 'read_file': "),
+        "{msg}"
+    );
+    assert!(msg.contains("path"), "{msg}");
+}
+
+#[test]
+fn wrong_type_is_refused_with_the_argument_path() {
+    let msg = invalid_message(validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &json!({"path": 42}),
+    ));
+    assert!(msg.contains("at /path:"), "{msg}");
+    assert!(msg.contains("42"), "{msg}");
+}
+
+#[test]
+fn non_object_arguments_are_refused_at_the_root() {
+    // A root-level violation renders without an `at <path>:` clause.
+    let msg = invalid_message(validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &json!("just a string"),
+    ));
+    assert!(!msg.contains("at /"), "{msg}");
+    assert!(msg.contains("object"), "{msg}");
+}
+
+#[test]
+fn violations_beyond_the_cap_are_summarised() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "a": {"type": "string"}, "b": {"type": "string"}, "c": {"type": "string"},
+            "d": {"type": "string"}, "e": {"type": "string"}
+        },
+        "required": ["a", "b", "c", "d", "e"]
+    });
+    let msg = invalid_message(validate_tool_args("many", &schema, &json!({})));
+    assert!(msg.ends_with("; (and 2 more)"), "{msg}");
+}
+
+#[test]
+fn violations_within_the_cap_have_no_summary_suffix() {
+    let msg = invalid_message(validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &json!({}),
+    ));
+    assert!(!msg.contains("more)"), "{msg}");
+}
+
+#[test]
+fn oversized_violation_messages_are_length_capped() {
+    // The validator's message embeds the offending value; a huge argument must
+    // not be echoed back in full. 4 KiB of string against an integer schema
+    // renders as a message capped well below the input size.
+    let schema = json!({
+        "type": "object",
+        "properties": { "n": { "type": "integer" } }
+    });
+    let huge = "x".repeat(4096);
+    let msg = invalid_message(validate_tool_args("sized", &schema, &json!({ "n": huge })));
+    assert!(
+        msg.len() < 1024,
+        "expected a capped message, got {} bytes",
+        msg.len()
+    );
+}
+
+#[test]
+fn a_schema_that_does_not_compile_is_reported_unusable() {
+    // A typo'd Rhai `@param n strng required` compiles to exactly this shape.
+    let reason = unusable_reason(validate_tool_args(
+        "typo",
+        &json!({"type": "strng"}),
+        &json!({"anything": true}),
+    ));
+    assert!(!reason.is_empty());
+}
+
+#[test]
+fn an_external_ref_does_not_resolve_and_is_reported_unusable() {
+    // With `default-features = false` an external `$ref` must fail to compile
+    // instead of fetching over the network at validation time.
+    let reason = unusable_reason(validate_tool_args(
+        "remote",
+        &json!({"$ref": "http://example.com/schema.json"}),
+        &json!({}),
+    ));
+    assert!(!reason.is_empty());
+}
+
+#[test]
+fn an_empty_schema_accepts_anything() {
+    // Test fixtures and tools without declared parameters advertise `{}`,
+    // which constrains nothing.
+    let v = validate_tool_args("anything", &json!({}), &json!({"whatever": [1, 2, 3]}));
+    assert_eq!(v, ArgValidation::Valid);
+}
+
+#[test]
+fn null_arguments_normalise_to_an_empty_object() {
+    let v = validate_tool_args("anything", &json!({}), &serde_json::Value::Null);
+    assert_eq!(v, ArgValidation::Valid);
+}
+
+#[test]
+fn null_arguments_still_fail_a_schema_with_required_properties() {
+    let msg = invalid_message(validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &serde_json::Value::Null,
+    ));
+    assert!(msg.contains("path"), "{msg}");
+}
+
+#[test]
+fn nested_mcp_style_schemas_validate_both_ways() {
+    // The kind of schema an MCP server can send: enums, arrays with typed
+    // items, a nested object.
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "mode": { "enum": ["fast", "thorough"] },
+            "targets": { "type": "array", "items": { "type": "string" } },
+            "options": {
+                "type": "object",
+                "properties": { "depth": { "type": "integer" } }
+            }
+        },
+        "required": ["mode"]
+    });
+    let ok = validate_tool_args(
+        "mcp_tool",
+        &schema,
+        &json!({"mode": "fast", "targets": ["a", "b"], "options": {"depth": 2}}),
+    );
+    assert_eq!(ok, ArgValidation::Valid);
+    let msg = invalid_message(validate_tool_args(
+        "mcp_tool",
+        &schema,
+        &json!({"mode": "sideways", "targets": ["a", 7]}),
+    ));
+    assert!(msg.contains("at /mode:"), "{msg}");
+    assert!(msg.contains("at /targets/1:"), "{msg}");
+}
+
+#[test]
+fn extra_properties_are_allowed_unless_the_schema_forbids_them() {
+    // Plain properties/required schemas (every builtin def) tolerate extras;
+    // that leniency is standard JSON Schema and deliberate here.
+    let v = validate_tool_args(
+        "read_file",
+        &read_file_schema(),
+        &json!({"path": "a.txt", "surprise": true}),
+    );
+    assert_eq!(v, ArgValidation::Valid);
+}

--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,9 @@ allow = [
     # Public-domain dedication. Reached via bevy_ecs → bevy_utils → ahash →
     # const-random → tiny-keccak.
     "CC0-1.0",
+    # MIT with the attribution requirement removed; OSI approved. Reached via
+    # jsonschema → referencing → fluent-uri → borrow-or-share.
+    "MIT-0",
 ]
 confidence-threshold = 0.9
 

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -428,7 +428,9 @@ object. The recognized directives:
 - `// @tool <name>` is required and names the tool (must match a stage's `available_tools` entry).
 - `// @description <text>` is an optional one-liner shown to the model.
 - `// @param <name> <type> <required|optional> "<description>"` is repeatable. `<type>` is a JSON
-  schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`.
+  schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`. A typo here produces a
+  schema that does not compile, which switches off [argument validation](/docs/tools#argument-validation)
+  for the tool (the daemon logs a warning); calls still run, just unchecked.
 - `// @requires <cap> [<cap>...]` lists platform capabilities the tool needs (`network`, `shell`,
   `filesystem`), comma or space separated and repeatable. Leviath drops the tool where the platform
   cannot provide one.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -112,3 +112,19 @@ edit_file = "allow"    # apply edits without prompting
 > `available_tools` and `tool_permissions` are separate gates: a tool must be listed in
 > `available_tools` to be offered at all, and its `tool_permissions` value then decides whether a
 > call is allowed, prompted, or refused.
+
+## Argument validation
+
+Before a call is dispatched, its arguments are checked against the exact JSON Schema the tool
+advertised to the model. This applies uniformly: built-in tools, Rhai script tools, MCP tools, and
+the sub-agent tools all declare schemas, and a call that does not satisfy its schema (a missing
+required argument, a number where a string belongs, a value outside a declared enum) is refused
+back to the model as an `[error]` result naming the violations. The call never executes and never
+reaches a permission prompt, and the refusal does not count as work the agent did; the model reads
+the message and corrects itself on the next turn.
+
+A schema that cannot be compiled (a typo'd type in a Rhai `@param` line, an MCP schema fragment the
+engine cannot interpret) turns validation off for that tool rather than refusing its calls. The
+daemon logs a warning when that happens so the broken schema gets noticed. Schemas with external
+`$ref` references fall in the same bucket by design: the validator never fetches anything over the
+network or filesystem, so such a schema fails to compile and is skipped.


### PR DESCRIPTION
Fixes #155.

Tools have always declared JSON Schemas for their parameters, but nothing checked a model's arguments against them: handlers did ad-hoc presence checks that cannot tell `{"path": 42}` from a missing `path`, and extra or misspelled properties passed through silently.

## What changed

- **New `leviath_tools::validate_tool_args`** on the `jsonschema` crate (added with `default-features = false`, deliberately: the default resolve features would let a server-supplied MCP schema pull external `$ref`s over the network or filesystem at validation time; without them such a schema fails to compile and is skipped instead).
- **Layer 2 of dispatch triage**: right after the unoffered-tool check in `dispatch_tools`, every call is validated against the exact schema the stage advertised, so builtin, Rhai, MCP, sub-agent and context tools are all covered at one choke point. A mismatched call is refused back to the model as `[error] invalid arguments for '<tool>': ...` naming the violations, never executed and never surfaced as a permission prompt. The lookup resolves aliases on both sides, mirroring Layer 1.
- **Never false-rejects**: a schema that does not compile (a typo'd Rhai `@param` type, an uninterpretable MCP fragment) logs a warning and skips validation for that call rather than refusing it.
- **`call_had_no_effect` gains the missing `[blocked]` prefix**: a taint-blocked write counted as a successful modification, so a stage whose every write the gate stopped could still satisfy a `require_modifications` transition. The function's own doc comment predicted exactly this miss.
- **Dropped the dead `AgentMessage.priority` field** (the issue's minor find): nothing outside tests ever set it to non-zero, it is on no wire or persistence format, and the sort was stable, so removal is behavior-identical FIFO.
- **Fixed `send_to_agent`'s half-wired `target_region`**: the tool advertised it and the docs describe it, but `SubAgentOp::Send` had no field to carry it, so it was silently dropped on the sub-agent path and every message landed in the conversation region.

## Verification

- All three touched crates pass the 100% line/function/region coverage gate; full workspace suite green (5341 tests); clippy, fmt, cargo deny (one allowlist addition: MIT-0, reached via jsonschema -> referencing -> fluent-uri -> borrow-or-share), ast-grep all clean.
- **Live-verified against the real daemon** with a Rhai mock provider:
  - a wrong-keyed `read_file` call was refused with `[error] invalid arguments for 'read_file': "path" is a required property` and the corrected call then executed;
  - a script tool with a typo'd `@param` type logged `tool schema did not compile; skipping argument validation` and still ran;
  - a parent agent's `send_to_agent` with `target_region: "notes"` landed the payload in the child's `notes` region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAzUB1dmQvNc6ATPJwZdW5