### PR TITLE
Make the runtime embeddable: AgentWorld, source-emitted events, opt-in persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,14 +350,25 @@ jobs:
           import pathlib, re, sys
 
           root = pathlib.Path("crates/leviath")
-          allowed_files = {"Cargo.toml", "README.md", "src/lib.rs"}
+          required_files = {"Cargo.toml", "README.md", "src/lib.rs"}
+          # Runnable examples are allowed (compiled by CI, exempt from the
+          # coverage gate like every examples/ dir); lib.rs stays locked to
+          # re-exports by the line check below.
+          example = re.compile(r"examples/\w[\w-]*\.rs")
           actual_files = {
               str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()
           }
-          if actual_files != allowed_files:
+          unexpected = sorted(
+              f
+              for f in actual_files
+              if f not in required_files and not example.fullmatch(f)
+          )
+          missing = sorted(required_files - actual_files)
+          if unexpected or missing:
               print(
                   "::error::crates/leviath must contain exactly "
-                  f"{sorted(allowed_files)}, found {sorted(actual_files)}. "
+                  f"{sorted(required_files)} plus optional examples/*.rs; "
+                  f"unexpected: {unexpected}, missing: {missing}. "
                   "The facade is coverage-exempt, so no other files (build.rs, "
                   "tests, extra modules) may live in it."
               )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "leviath-scripting",
  "leviath-telemetry",
  "leviath-tools",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_tasks",
  "chrono",
+ "futures-core",
  "leviath-core",
  "leviath-providers",
  "leviath-scripting",
@@ -2468,6 +2469,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -4570,6 +4572,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cargo install leviath-cli                # released version from crates.io
 cargo install --git https://github.com/GEMISIS/leviath.git --bin lev   # latest development build
 ```
 
-Leviath is also a library: add the [`leviath`](https://crates.io/crates/leviath) crate to embed the runtime in your own application.
+Leviath is also a library: add the [`leviath`](https://crates.io/crates/leviath) crate to embed the runtime in your own application. The [embedding guide](https://leviath.dev/docs/embedding) covers building a world, spawning agents, and streaming their events in-process.
 
 ### 2. Configure a provider
 

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -29,7 +29,7 @@ debug-http = ["leviath-providers/debug-http"]
 [dependencies]
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
-leviath-runtime = { workspace = true }
+leviath-runtime = { workspace = true, features = ["control-socket"] }
 leviath-telemetry = { workspace = true }
 leviath-providers = { workspace = true }
 leviath-mcp = { workspace = true }

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -415,7 +415,7 @@ impl Server {
                         self.flush_output(&session_id, &mut tail, &run_id).await;
                         return StopReason::EndTurn;
                     };
-                    if world_event_run_id(&event) != run_id {
+                    if event.run_id() != run_id {
                         continue; // another run in the shared world
                     }
                     self.flush_output(&session_id, &mut tail, &run_id).await;
@@ -736,19 +736,6 @@ fn read_run_status(runs_dir: &std::path::Path, run_id: &str) -> Option<RunStatus
 /// work and is only idling for optional follow-up, so control returns to the
 /// client. `WaitingInput` does **not** - the agent is blocked on an interaction,
 /// which is exactly the state that must not be reported as "done".
-/// The run id carried by any [`WorldEvent`] variant.
-fn world_event_run_id(event: &WorldEvent) -> &str {
-    match event {
-        WorldEvent::Spawned { run_id, .. }
-        | WorldEvent::Status { run_id, .. }
-        | WorldEvent::Tokens { run_id, .. }
-        | WorldEvent::Context { run_id, .. }
-        | WorldEvent::Interaction { run_id, .. }
-        | WorldEvent::Completed { run_id, .. }
-        | WorldEvent::Log { run_id, .. } => run_id,
-    }
-}
-
 /// Mint a session id from the agent name - reuses the run-id generator's
 /// collision-resistant `<name>-<timestamp>-<suffix>` scheme.
 fn new_session_id(agent_name: &str) -> String {

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -783,7 +783,7 @@ fn world_event_run_id_reads_the_run_id_from_a_log_event() {
         agent_id: "a".to_string(),
         line: "some output".to_string(),
     };
-    assert_eq!(world_event_run_id(&ev), "run-log");
+    assert_eq!(ev.run_id(), "run-log");
 }
 
 // ─── session/prompt: spawn / message failures ────────────────────────────────

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -806,16 +806,23 @@ prompt = "Run"
         let dir = agents_dir().join(&name);
         std::fs::create_dir_all(&dir).unwrap();
         let manifest_path = dir.join("agent.leviath");
-        std::fs::write(&manifest_path, test_manifest()).unwrap();
 
-        // Hold an exclusive (no-share) handle open for the duration of the
-        // delete attempt below, so `remove_dir_all` hits a sharing
-        // violation trying to unlink `manifest_path`.
-        let _locked = OpenOptions::new()
+        // Create the manifest THROUGH an exclusive (no-share) handle and hold
+        // it open for the duration of the delete attempt below, so
+        // `remove_dir_all` hits a sharing violation trying to unlink
+        // `manifest_path`. Writing the file first and reopening it exclusively
+        // was a CI flake: Windows Defender / the indexer briefly opens a
+        // just-written file, and then it is OUR exclusive open that gets the
+        // sharing violation. Creating it exclusively from the start leaves no
+        // closed-file window for a scanner to grab.
+        let mut locked = OpenOptions::new()
+            .create(true)
             .write(true)
             .share_mode(0)
             .open(&manifest_path)
             .unwrap();
+        std::io::Write::write_all(&mut locked, test_manifest().as_bytes()).unwrap();
+        let _locked = locked;
 
         let app = Router::new().route("/api/blueprints/{name}", delete(delete_blueprint));
         let req = Request::builder()

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -148,6 +148,12 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             run_id,
             line,
         },
+        // Everything else (stage transitions, tool call start/finish, and any
+        // variant the runtime grows later - the enum is non-exhaustive) is
+        // forwarded verbatim as its own serde-tagged JSON.
+        other => ServerEvent::World {
+            event: serde_json::to_value(&other).unwrap_or(serde_json::Value::Null),
+        },
     }
 }
 
@@ -426,6 +432,54 @@ mod tests {
             }),
             "log"
         );
+        // Source-emitted events (and any future variant) ride the generic
+        // passthrough, keeping their own serde tags inside `event`.
+        assert_eq!(
+            mapped_tag(WorldEvent::StageTransition {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                from: "plan".into(),
+                to: "implement".into(),
+                iteration: 1
+            }),
+            "world"
+        );
+        assert_eq!(
+            mapped_tag(WorldEvent::ToolCallStarted {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                call_id: "c1".into(),
+                tool: "read_file".into()
+            }),
+            "world"
+        );
+        assert_eq!(
+            mapped_tag(WorldEvent::ToolCallFinished {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                call_id: "c1".into(),
+                tool: "read_file".into(),
+                ok: true,
+                summary: "ok".into()
+            }),
+            "world"
+        );
+    }
+
+    #[test]
+    fn passthrough_keeps_the_inner_event_tag_and_run_id() {
+        let ev = to_server_event(WorldEvent::StageTransition {
+            run_id: "run-9".into(),
+            agent_id: "a".into(),
+            from: "plan".into(),
+            to: "implement".into(),
+            iteration: 2,
+        });
+        assert_eq!(ev.run_id(), "run-9");
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["event"]["event"], "stage_transition");
+        assert_eq!(json["event"]["from"], "plan");
+        assert_eq!(json["event"]["to"], "implement");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -123,6 +123,33 @@ pub enum ServerEvent {
         #[serde(default)]
         cache_write_tokens: usize,
     },
+    /// A world event with no dedicated WebSocket translation (stage
+    /// transitions, tool call start/finish, and whatever the runtime adds
+    /// next), forwarded verbatim. `event` is the runtime's own serde-tagged
+    /// [`WorldEvent`](leviath_runtime::host::WorldEvent) JSON, so clients get
+    /// new event kinds without a server release.
+    World { event: serde_json::Value },
+}
+
+impl ServerEvent {
+    /// The run id this event belongs to, for per-run subscription filtering.
+    /// `World` events read it from the wrapped JSON (every runtime event
+    /// carries one; an absent field filters as the empty string).
+    pub fn run_id(&self) -> &str {
+        match self {
+            ServerEvent::AgentStatus { run_id, .. }
+            | ServerEvent::ContextUpdate { run_id, .. }
+            | ServerEvent::Log { run_id, .. }
+            | ServerEvent::InteractionNeeded { run_id, .. }
+            | ServerEvent::AgentSpawned { run_id, .. }
+            | ServerEvent::AgentCompleted { run_id, .. }
+            | ServerEvent::Tokens { run_id, .. } => run_id,
+            ServerEvent::World { event } => event
+                .get("run_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -557,5 +584,94 @@ mod tests {
         };
         let json = serde_json::to_string(&err).unwrap();
         assert!(json.contains("\"error\":\"not found\""));
+    }
+
+    #[test]
+    fn server_event_run_id_covers_every_variant() {
+        let cases: Vec<(ServerEvent, &str)> = vec![
+            (
+                ServerEvent::AgentStatus {
+                    agent_id: "a".to_string(),
+                    run_id: "r1".to_string(),
+                    status: "active".to_string(),
+                    stage: "s".to_string(),
+                    iteration: 0,
+                    tool_calls: 0,
+                    accepts_messages: false,
+                },
+                "r1",
+            ),
+            (
+                ServerEvent::ContextUpdate {
+                    agent_id: "a".to_string(),
+                    run_id: "r2".to_string(),
+                    total_tokens: 1,
+                    max_tokens: 2,
+                },
+                "r2",
+            ),
+            (
+                ServerEvent::Log {
+                    agent_id: "a".to_string(),
+                    run_id: "r3".to_string(),
+                    line: "l".to_string(),
+                },
+                "r3",
+            ),
+            (
+                ServerEvent::InteractionNeeded {
+                    agent_id: "a".to_string(),
+                    run_id: "r4".to_string(),
+                    request: serde_json::Value::Null,
+                },
+                "r4",
+            ),
+            (
+                ServerEvent::AgentSpawned {
+                    agent_id: "a".to_string(),
+                    run_id: "r5".to_string(),
+                    parent_id: None,
+                    blueprint: "b".to_string(),
+                },
+                "r5",
+            ),
+            (
+                ServerEvent::AgentCompleted {
+                    agent_id: "a".to_string(),
+                    run_id: "r6".to_string(),
+                    status: "complete".to_string(),
+                    result: None,
+                },
+                "r6",
+            ),
+            (
+                ServerEvent::Tokens {
+                    agent_id: "a".to_string(),
+                    run_id: "r7".to_string(),
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                },
+                "r7",
+            ),
+            (
+                ServerEvent::World {
+                    event: serde_json::json!({"event": "stage_transition", "run_id": "r8"}),
+                },
+                "r8",
+            ),
+            // A wrapped event with no run_id filters as the empty string
+            // rather than panicking (real world events always carry one).
+            (
+                ServerEvent::World {
+                    event: serde_json::Value::Null,
+                },
+                "",
+            ),
+        ];
+        for (ev, want) in cases {
+            assert_eq!(ev.run_id(), want);
+        }
     }
 }

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -40,19 +40,10 @@ async fn handle_ws(
                 match event {
                     Ok(ev) => {
                         // If filtering by run_id, skip non-matching events
-                        if let Some(ref filter) = filter_run_id {
-                            let event_run_id = match &ev {
-                                ServerEvent::AgentStatus { run_id, .. } => run_id,
-                                ServerEvent::ContextUpdate { run_id, .. } => run_id,
-                                ServerEvent::Log { run_id, .. } => run_id,
-                                ServerEvent::InteractionNeeded { run_id, .. } => run_id,
-                                ServerEvent::AgentSpawned { run_id, .. } => run_id,
-                                ServerEvent::AgentCompleted { run_id, .. } => run_id,
-                                ServerEvent::Tokens { run_id, .. } => run_id,
-                            };
-                            if event_run_id != filter {
-                                continue;
-                            }
+                        if let Some(ref filter) = filter_run_id
+                            && ev.run_id() != filter
+                        {
+                            continue;
                         }
 
                         // ServerEvent always serializes; a failure is a bug.
@@ -798,26 +789,6 @@ mod tests {
         assert_some_byte_arrived(result);
     }
 
-    /// Single shared copy of the `run_id`-extraction match every test below
-    /// exercises, instead of each test carrying its own inline copy.
-    /// `llvm-cov` counts coverage per source line, not per logical match: with
-    /// the match duplicated inline across tests that each construct only 1-5 of
-    /// the 7 `ServerEvent` variants, most arms of most copies read as never hit -
-    /// even though every arm works, just not from that copy's test data. A
-    /// single shared function means every arm only needs to be hit once, from
-    /// any caller, to be covered.
-    fn get_run_id(ev: &ServerEvent) -> &str {
-        match ev {
-            ServerEvent::AgentStatus { run_id, .. } => run_id,
-            ServerEvent::ContextUpdate { run_id, .. } => run_id,
-            ServerEvent::Log { run_id, .. } => run_id,
-            ServerEvent::InteractionNeeded { run_id, .. } => run_id,
-            ServerEvent::AgentSpawned { run_id, .. } => run_id,
-            ServerEvent::AgentCompleted { run_id, .. } => run_id,
-            ServerEvent::Tokens { run_id, .. } => run_id,
-        }
-    }
-
     #[test]
     fn server_event_run_id_extraction_agent_status() {
         let ev = ServerEvent::AgentStatus {
@@ -829,7 +800,7 @@ mod tests {
             tool_calls: 0,
             accepts_messages: true,
         };
-        assert_eq!(get_run_id(&ev), "run-123");
+        assert_eq!(ev.run_id(), "run-123");
     }
 
     #[test]
@@ -840,7 +811,7 @@ mod tests {
             total_tokens: 100,
             max_tokens: 200000,
         };
-        assert_eq!(get_run_id(&ev), "run-ctx");
+        assert_eq!(ev.run_id(), "run-ctx");
     }
 
     #[test]
@@ -894,7 +865,7 @@ mod tests {
         ];
 
         for (ev, expected) in variants {
-            assert_eq!(get_run_id(&ev), expected);
+            assert_eq!(ev.run_id(), expected);
         }
     }
 
@@ -920,8 +891,8 @@ mod tests {
             accepts_messages: true,
         };
 
-        assert_eq!(get_run_id(&matching), filter);
-        assert_ne!(get_run_id(&non_matching), filter);
+        assert_eq!(matching.run_id(), filter);
+        assert_ne!(non_matching.run_id(), filter);
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -432,7 +432,7 @@ mod tests {
             cli.clone(),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         );
         let spawner = spawner_with(cli.clone());

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -518,7 +518,7 @@ mod tests {
             cli.clone(),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         );
         (world, cli)

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -154,7 +154,7 @@ pub fn build_host(
         tool_service.clone(),
         pool_config,
         config.limits.max_concurrent_tools,
-        runs_dir.clone(),
+        Some(runs_dir.clone()),
         runtime,
     );
     // Opt-in accurate pre-inference budget guard (off by default).
@@ -476,7 +476,7 @@ mod tests {
             tool_service.clone(),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         );
         let mut reaper = make_reaper(tool_service.clone());

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1461,7 +1461,7 @@ mod tests {
             cli.clone(),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         );
         (world, cli)

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -15,14 +15,14 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use bevy_ecs::entity::Entity;
 use bevy_ecs::world::World;
-use leviath_core::blueprint::{Blueprint, ModelConfig};
+use leviath_core::blueprint::Blueprint;
 use leviath_providers::Tool;
-use leviath_runtime::ProviderRegistry;
 use leviath_runtime::host::{SpawnArgs, SubAgentOp};
 use leviath_runtime::interaction_hub::InteractionHub;
 use leviath_runtime::persistence::{RunMetadata, TokenTotals};
 use leviath_runtime::pipeline::{
-    CompactionSettings, PersistWatermark, Providers, ResolvedStage, spawn_agent_seeded,
+    CompactionSettings, ModelDefaults, PersistWatermark, Providers, resolve_stages,
+    spawn_agent_seeded,
 };
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::UnboundedSender;
@@ -35,100 +35,13 @@ use crate::daemon::tool_service::{AgentToolState, CliToolService};
 /// Default max sub-agent tree depth when a blueprint doesn't set one.
 const DEFAULT_SUBAGENT_DEPTH: usize = 3;
 
-/// Resolve a stage's [`ModelConfig`] to a concrete `(provider, model)` against
-/// the registered providers. Honors a `--model` override (`provider/model` or a
-/// bare `model`), otherwise picks the first listed model whose provider is
-/// registered, then falls back to the user default (when `allow_user_default`),
-/// and finally to the config's first listed entry. (Ported from the executor's
-/// inline resolution.)
-pub fn resolve_stage_model(
-    model_cfg: &ModelConfig,
-    model_override: Option<&str>,
-    config: &Config,
-    registry: &ProviderRegistry,
-) -> (String, String) {
-    let (override_provider, override_model) = match model_override {
-        Some(ov) if ov.contains('/') => {
-            let (p, m) = ov.split_once('/').unwrap();
-            (Some(p.to_string()), Some(m.to_string()))
-        }
-        Some(ov) => (None, Some(ov.to_string())),
-        None => (None, None),
-    };
-
-    // Full provider/model override wins outright.
-    if let Some(provider) = override_provider {
-        return (provider, override_model.unwrap_or_default());
+/// The user's default provider/model from `config.toml`, in the plain form the
+/// runtime's stage resolver takes.
+pub(crate) fn model_defaults(config: &Config) -> ModelDefaults {
+    ModelDefaults {
+        provider: config.default_provider.clone(),
+        model: config.default_model.clone(),
     }
-
-    // First listed model whose provider is registered.
-    for entry in &model_cfg.models {
-        if registry.has(&entry.provider) {
-            let model = override_model
-                .clone()
-                .unwrap_or_else(|| entry.model.clone());
-            return (entry.provider.clone(), model);
-        }
-    }
-
-    // Fall back to the user's default model, or finally the first listed entry.
-    user_default_model(model_cfg, override_model.as_deref(), config, registry).unwrap_or_else(
-        || {
-            (
-                model_cfg.provider().to_string(),
-                model_cfg.model().to_string(),
-            )
-        },
-    )
-}
-
-/// The user-default fallback for [`resolve_stage_model`]: `None` when the stage
-/// forbids it or no usable default exists.
-fn user_default_model(
-    model_cfg: &ModelConfig,
-    override_model: Option<&str>,
-    config: &Config,
-    registry: &ProviderRegistry,
-) -> Option<(String, String)> {
-    if !model_cfg.allow_user_default {
-        return None;
-    }
-    if let Some(model) = override_model {
-        return Some((config.default_provider.clone(), model.to_string()));
-    }
-    if let Some(default_model) = &config.default_model
-        && registry.has(&config.default_provider)
-    {
-        return Some((config.default_provider.clone(), default_model.clone()));
-    }
-    None
-}
-
-/// Resolve every stage's provider/model + effective tool set from the blueprint.
-fn resolve_stages(
-    blueprint: &Blueprint,
-    model_override: Option<&str>,
-    config: &Config,
-    registry: &ProviderRegistry,
-    all_tool_defs: &[Tool],
-) -> Vec<ResolvedStage> {
-    blueprint
-        .stages
-        .iter()
-        .map(|stage| {
-            let (provider_name, model) =
-                resolve_stage_model(&stage.model, model_override, config, registry);
-            // Empty `available_tools` exposes no tools; otherwise filter the full
-            // set by name (alias-resolved). A name matching nothing (a typo, or an
-            // MCP tool whose server isn't installed) is simply omitted.
-            let tools = filter_tools_by_available(all_tool_defs, &stage.available_tools);
-            ResolvedStage {
-                provider_name,
-                model,
-                tools,
-            }
-        })
-        .collect()
 }
 
 /// The directories scanned for an agent's Rhai script tools, in precedence order
@@ -291,23 +204,6 @@ pub(crate) fn discover_script_tools_in(
         });
     }
     (set, names, defs)
-}
-
-/// Filter `all` tool defs down to those a stage's `available_tools` names
-/// (alias-resolved). Shared by spawn-time stage resolution and the mid-run
-/// tool-service refresh so both apply Layer-1 identically.
-pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool> {
-    if available.is_empty() {
-        return Vec::new();
-    }
-    all.iter()
-        .filter(|t| {
-            available
-                .iter()
-                .any(|n| leviath_tools::canonical_tool_name(n) == t.name)
-        })
-        .cloned()
-        .collect()
 }
 
 /// Discover the agent's Rhai script tools and build their `Tool`
@@ -869,7 +765,7 @@ fn build_agent_inner(
         resolve_stages(
             &blueprint,
             args.model.as_deref(),
-            config,
+            &model_defaults(config),
             registry,
             &all_tool_defs,
         )
@@ -1167,6 +1063,8 @@ fn build_agent_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leviath_core::blueprint::ModelConfig;
+    use leviath_runtime::ProviderRegistry;
     use leviath_runtime::world::PipelineWorld;
 
     /// A throwaway sub-agent op sender for tests that don't exercise the bridge.
@@ -1330,115 +1228,6 @@ mod tests {
         fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
             leviath_providers::ModelCapabilities::default()
         }
-    }
-
-    #[test]
-    fn resolve_full_override_wins() {
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("anthropic", "x")]),
-            Some("openai/gpt-5"),
-            &Config::default(),
-            &registry_with(&[]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("openai", "gpt-5"));
-    }
-
-    #[test]
-    fn resolve_first_available_model() {
-        // anthropic not registered, openai is → picks openai.
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("anthropic", "a"), ("openai", "o")]),
-            None,
-            &Config::default(),
-            &registry_with(&["openai"]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("openai", "o"));
-    }
-
-    #[test]
-    fn resolve_model_only_override_keeps_available_provider() {
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("openai", "o")]),
-            Some("gpt-override"),
-            &Config::default(),
-            &registry_with(&["openai"]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("openai", "gpt-override"));
-    }
-
-    #[test]
-    fn resolve_user_default_when_nothing_listed_available() {
-        // Listed provider "ghost" is unavailable; anthropic (the default) is.
-        let config = Config {
-            default_provider: "anthropic".to_string(),
-            default_model: Some("claude-default".to_string()),
-            ..Default::default()
-        };
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("ghost", "g")]),
-            None,
-            &config,
-            &registry_with(&["anthropic"]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("anthropic", "claude-default"));
-    }
-
-    #[test]
-    fn resolve_user_default_with_model_override() {
-        let config = Config {
-            default_provider: "anthropic".to_string(),
-            ..Default::default()
-        };
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("ghost", "g")]),
-            Some("just-a-model"),
-            &config,
-            &registry_with(&[]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("anthropic", "just-a-model"));
-    }
-
-    #[test]
-    fn resolve_user_default_provider_unavailable_falls_through() {
-        // allow_user_default, a default_model set, but the default provider isn't
-        // registered ⇒ neither user-default branch fires ⇒ last resort.
-        let config = Config {
-            default_provider: "ghost-default".to_string(),
-            default_model: Some("dm".to_string()),
-            ..Default::default()
-        };
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("ghost", "g")]),
-            None,
-            &config,
-            &registry_with(&[]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
-    }
-
-    #[test]
-    fn resolve_last_resort_first_listed() {
-        // No override, nothing available, no usable default → first listed entry.
-        let config = Config::default(); // default_model None
-        let (p, m) = resolve_stage_model(
-            &model_cfg(vec![("ghost", "g")]),
-            None,
-            &config,
-            &registry_with(&[]),
-        );
-        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
-    }
-
-    #[test]
-    fn resolve_no_user_default_uses_last_resort() {
-        let mut cfg = model_cfg(vec![("ghost", "g")]);
-        cfg.allow_user_default = false; // forbid the default fallback
-        let config = Config {
-            default_model: Some("would-be-default".to_string()),
-            ..Default::default()
-        };
-        let (p, m) = resolve_stage_model(&cfg, None, &config, &registry_with(&["anthropic"]));
-        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
     }
 
     // ── build_agent (full spawn from a manifest) ──
@@ -2624,63 +2413,6 @@ mod tests {
         let mut map = base();
         bump_read_sensitivities(&mut map, false);
         assert_eq!(map, base(), "no grant, no change");
-    }
-
-    #[test]
-    fn resolve_stages_empty_available_tools_gets_none() {
-        let mut stage =
-            leviath_core::Stage::new("s".to_string(), model_cfg(vec![("anthropic", "m")]));
-        stage.available_tools = vec![]; // empty ⇒ no tools
-        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
-        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
-        let tools = vec![Tool {
-            name: "read_file".to_string(),
-            description: String::new(),
-            parameters: serde_json::Value::Null,
-        }];
-        let resolved = resolve_stages(
-            &bp,
-            None,
-            &Config::default(),
-            &registry_with(&["anthropic"]),
-            &tools,
-        );
-        assert!(resolved[0].tools.is_empty());
-    }
-
-    #[test]
-    fn resolve_stages_matches_by_alias_and_skips_unknown_names() {
-        // A stage names `bash` (an alias) and a not-installed MCP tool. The
-        // filter must select the canonical `shell` definition for the alias and
-        // silently omit the unknown name (no error, no panic).
-        let mut stage =
-            leviath_core::Stage::new("s".to_string(), model_cfg(vec![("anthropic", "m")]));
-        stage.available_tools = vec!["bash".to_string(), "acme__uninstalled".to_string()];
-        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
-        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
-        let tools = vec![
-            Tool {
-                name: "shell".to_string(),
-                description: String::new(),
-                parameters: serde_json::Value::Null,
-            },
-            Tool {
-                name: "read_file".to_string(),
-                description: String::new(),
-                parameters: serde_json::Value::Null,
-            },
-        ];
-        let resolved = resolve_stages(
-            &bp,
-            None,
-            &Config::default(),
-            &registry_with(&["anthropic"]),
-            &tools,
-        );
-        let selected: Vec<&str> = resolved[0].tools.iter().map(|t| t.name.as_str()).collect();
-        // `bash` resolved to `shell`; the unknown MCP name and unlisted
-        // `read_file` were both excluded.
-        assert_eq!(selected, vec!["shell"]);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -504,7 +504,7 @@ impl ToolService for CliToolService {
         let available = ctx.stage_available.get(stage_index)?;
         let mut all = ctx.static_defs.clone();
         all.extend(script_defs);
-        Some(crate::daemon::spawn::filter_tools_by_available(
+        Some(leviath_runtime::pipeline::filter_tools_by_available(
             &all, available,
         ))
     }

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -27,6 +27,8 @@ leviath-tools = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_tasks = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"] }
+futures-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -12,17 +12,23 @@ keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
 
+[features]
+# The daemon's control transport (unix socket / named pipe, auth token, pid
+# file). Off by default so embedders compile a runtime with no daemon
+# machinery; the CLI turns it on.
+control-socket = ["dep:rand", "dep:leviath-sys"]
+
 [dependencies]
 leviath-core = { workspace = true }
 # Custom-region Rhai hooks (render/on_write/on_overflow). The boundary is
 # JSON-in/JSON-out, so this crate needs no direct rhai dependency.
 leviath-scripting = { workspace = true }
-# Control-channel token generation.
-rand = { workspace = true }
+# Control-channel token generation (control-socket only).
+rand = { workspace = true, optional = true }
 leviath-providers = { workspace = true }
 # For the control socket's file permissions and peer-uid check. `leviath-sys`
 # has no leviath dependencies of its own, so this adds no cycle.
-leviath-sys = { workspace = true }
+leviath-sys = { workspace = true, optional = true }
 leviath-tools = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_tasks = { workspace = true }

--- a/crates/leviath-runtime/src/embed/error.rs
+++ b/crates/leviath-runtime/src/embed/error.rs
@@ -1,0 +1,63 @@
+//! Errors from building or driving an embedded world.
+
+/// Why an [`AgentWorld`](super::AgentWorld) could not be built or a request to
+/// it could not be served.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EmbedError {
+    /// The builder was given no providers: no credentials and no custom
+    /// provider registrations. A world with nothing to infer against can only
+    /// error, so this fails at build time instead.
+    NoProviders,
+    /// No Tokio runtime was found. `build()` must run inside a Tokio runtime
+    /// (or be given a handle via
+    /// [`runtime`](super::AgentWorldBuilder::runtime)).
+    NoRuntime,
+    /// The blueprint could not be loaded, parsed, or validated.
+    Blueprint(String),
+    /// The spawn was rejected (bad workdir, unresolvable seeds, and so on).
+    Spawn(String),
+    /// The world's serve loop is gone (already shut down), so the request
+    /// could not be delivered or answered.
+    ChannelClosed,
+}
+
+impl std::fmt::Display for EmbedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EmbedError::NoProviders => {
+                write!(f, "no providers configured: add credentials or a provider")
+            }
+            EmbedError::NoRuntime => {
+                write!(f, "no tokio runtime: build inside one or pass a handle")
+            }
+            EmbedError::Blueprint(msg) => write!(f, "blueprint error: {msg}"),
+            EmbedError::Spawn(msg) => write!(f, "spawn error: {msg}"),
+            EmbedError::ChannelClosed => write!(f, "the world has shut down"),
+        }
+    }
+}
+
+impl std::error::Error for EmbedError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_covers_every_variant() {
+        let cases = [
+            (EmbedError::NoProviders, "no providers"),
+            (EmbedError::NoRuntime, "no tokio runtime"),
+            (
+                EmbedError::Blueprint("bad".to_string()),
+                "blueprint error: bad",
+            ),
+            (EmbedError::Spawn("nope".to_string()), "spawn error: nope"),
+            (EmbedError::ChannelClosed, "shut down"),
+        ];
+        for (err, needle) in cases {
+            assert!(err.to_string().contains(needle));
+        }
+    }
+}

--- a/crates/leviath-runtime/src/embed/mod.rs
+++ b/crates/leviath-runtime/src/embed/mod.rs
@@ -6,5 +6,13 @@
 //! same machinery ([`PipelineWorld`](crate::world::PipelineWorld) +
 //! [`WorldHost`](crate::host::WorldHost)) assembled from plain values.
 
+mod error;
+mod spawner;
+mod stream;
 mod tool_service;
+mod world;
+
+pub use error::EmbedError;
+pub use stream::EventStream;
 pub use tool_service::BasicToolService;
+pub use world::{AgentWorld, AgentWorldBuilder, BlueprintSource, RunId, SpawnSpec};

--- a/crates/leviath-runtime/src/embed/mod.rs
+++ b/crates/leviath-runtime/src/embed/mod.rs
@@ -1,0 +1,10 @@
+//! Embedding the runtime as a library: the batteries-included assembly a
+//! Rust application uses to run agents in-process, without the `lev` CLI,
+//! the daemon, or a config file.
+//!
+//! The daemon remains the primary interface for the CLI; this module is the
+//! same machinery ([`PipelineWorld`](crate::world::PipelineWorld) +
+//! [`WorldHost`](crate::host::WorldHost)) assembled from plain values.
+
+mod tool_service;
+pub use tool_service::BasicToolService;

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -108,6 +108,8 @@ impl EmbedSpawner {
             &seeds,
             stages,
             false,
+            // The default nudge policy; blueprints override per stage/agent.
+            leviath_core::NudgeConfig::default(),
             HashMap::new(),
         )?;
 

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -1,0 +1,537 @@
+//! The embed spawner: turns a [`SpawnArgs`] into a live agent, the way the
+//! daemon's spawner does, but from plain values instead of the CLI's config.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use bevy_ecs::entity::Entity;
+
+use super::BasicToolService;
+use crate::host::SpawnArgs;
+use crate::persistence::{RunMetadata, RunOutcomeFlags, TokenTotals};
+use crate::pipeline::{
+    ModelDefaults, PersistWatermark, Providers, resolve_stages, spawn_agent_seeded,
+};
+use crate::world::PipelineWorld;
+
+/// Blueprints handed to [`AgentWorld::spawn`](super::AgentWorld::spawn)
+/// inline (parsed TOML or a constructed value), parked here until the
+/// spawner picks them up by their `inline:<run_id>` pseudo-path. Keeps the
+/// wire-level [`SpawnArgs`] untouched.
+pub(crate) type StagedBlueprints = Arc<Mutex<HashMap<String, leviath_core::Blueprint>>>;
+
+/// Everything the embed spawner closure needs, captured once at build time.
+pub(crate) struct EmbedSpawner {
+    /// Registers per-agent tool state when the world runs the default
+    /// service; `None` when the embedder installed a custom [`ToolService`]
+    /// (which then sees agents through `exec_for` on its own terms).
+    pub basic_tools: Option<Arc<BasicToolService>>,
+    pub defaults: ModelDefaults,
+    pub staged: StagedBlueprints,
+}
+
+impl EmbedSpawner {
+    /// Spawn one agent into `world` from `args`. Mirrors the daemon's
+    /// `build_agent` minus its config-driven policy layers (sandboxes, MCP,
+    /// script tools, taint, seed commands).
+    pub(crate) fn spawn(
+        &self,
+        world: &mut PipelineWorld,
+        args: &SpawnArgs,
+    ) -> Result<Entity, String> {
+        // The working directory must exist before anything is built over it,
+        // or every tool call fails with a message naming the shell rather
+        // than the directory.
+        if !std::fs::metadata(&args.workdir).is_ok_and(|m| m.is_dir()) {
+            return Err(format!(
+                "workspace '{}' does not exist or is not a directory",
+                args.workdir
+            ));
+        }
+
+        // The blueprint: staged inline by `AgentWorld::spawn`, or a manifest
+        // path to load.
+        let blueprint = match args.blueprint_path.strip_prefix("inline:") {
+            Some(key) => self
+                .staged
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .remove(key)
+                .ok_or_else(|| format!("no staged blueprint under '{key}'"))?,
+            None => {
+                let content = std::fs::read_to_string(&args.blueprint_path)
+                    .map_err(|e| format!("read manifest '{}': {e}", args.blueprint_path))?;
+                let blueprint = leviath_core::manifest::parse_manifest(&content)
+                    .map_err(|e| format!("parse manifest: {e}"))?;
+                blueprint
+                    .validate()
+                    .map_err(|e| format!("invalid blueprint: {e}"))?;
+                blueprint
+            }
+        };
+
+        let seeds = resolve_embedded_seeds(&blueprint, args)?;
+
+        // Resolve stages against the world's providers, over the tool set the
+        // default service can execute. A custom service keeps the same
+        // advertised set in v1; richer advertisement is part of the service
+        // seam, not the spawner.
+        let workdir = PathBuf::from(&args.workdir);
+        let all_tool_defs = BasicToolService::tool_defs(&workdir);
+        let stages = {
+            let registry = &world
+                .world()
+                .get_resource::<Providers>()
+                .expect("Providers resource present in a PipelineWorld")
+                .0;
+            resolve_stages(
+                &blueprint,
+                args.model.as_deref(),
+                &self.defaults,
+                registry,
+                &all_tool_defs,
+            )
+        };
+
+        let agent_name = blueprint.name.clone();
+        let num_stages = blueprint.stages.len();
+        let model_label = stages
+            .first()
+            .map(|s| format!("{}/{}", s.provider_name, s.model));
+
+        let entity = spawn_agent_seeded(
+            world.world_mut(),
+            args.run_id.clone(),
+            blueprint,
+            &seeds,
+            stages,
+            false,
+            HashMap::new(),
+        )?;
+
+        // Metadata + counters, so events, persistence, and status all work.
+        let started_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        world.world_mut().entity_mut(entity).insert((
+            RunMetadata {
+                run_id: args.run_id.clone(),
+                agent_name,
+                agent_path: args.blueprint_path.clone(),
+                task: args.task.clone(),
+                model: model_label,
+                workdir: args.workdir.clone(),
+                num_stages,
+                started_at,
+                parent_run_id: args.parent_run_id.clone(),
+                metadata: args.metadata.clone(),
+                callback_url: None,
+                callback_secret: None,
+                title: None,
+            },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            RunOutcomeFlags::default(),
+        ));
+
+        if let Some(tools) = &self.basic_tools {
+            tools.register(entity, &args.run_id, workdir);
+        }
+        Ok(entity)
+    }
+}
+
+/// Resolve the blueprint's region seeds from the spawn request. Embedded
+/// worlds resolve `caller_input` and `literal` seeds; the file, glob, Rhai,
+/// and command kinds are daemon policy (workdir scans and spawn-time
+/// execution) and are skipped here - a hard error only when the region is
+/// `required`, so an unused discovery nicety never sinks a run.
+fn resolve_embedded_seeds(
+    blueprint: &leviath_core::Blueprint,
+    args: &SpawnArgs,
+) -> Result<HashMap<String, String>, String> {
+    use leviath_core::layout::RegionSeed;
+
+    let mut caller: HashMap<&str, &str> = HashMap::new();
+    caller.insert("task", &args.task);
+    for (k, v) in &args.regions {
+        caller.insert(k, v);
+    }
+
+    let mut seeds = HashMap::new();
+    for region in &blueprint.context_layout.regions {
+        let Some(seed) = &region.seed else { continue };
+        match seed {
+            RegionSeed::CallerInput { name } => {
+                let value = caller.get(name.as_str()).copied().unwrap_or("");
+                if value.trim().is_empty() {
+                    if region.required {
+                        return Err(region.required_message.clone().unwrap_or_else(|| {
+                            format!(
+                                "required region '{}' was not provided; supply it in \
+                                 SpawnSpec::regions under the key '{name}'",
+                                region.name
+                            )
+                        }));
+                    }
+                    continue;
+                }
+                seeds.insert(region.name.clone(), value.to_string());
+            }
+            RegionSeed::Literal { text } => {
+                seeds.insert(region.name.clone(), text.clone());
+            }
+            other => {
+                if region.required {
+                    return Err(format!(
+                        "required region '{}' uses a seed kind ({}) embedded worlds \
+                         do not resolve; provide the content via SpawnSpec::regions",
+                        region.name,
+                        seed_kind_name(other)
+                    ));
+                }
+            }
+        }
+    }
+    Ok(seeds)
+}
+
+/// A short label for the unsupported seed kinds, for error messages.
+fn seed_kind_name(seed: &leviath_core::layout::RegionSeed) -> &'static str {
+    use leviath_core::layout::RegionSeed;
+    match seed {
+        RegionSeed::CallerInput { .. } => "caller_input",
+        RegionSeed::Literal { .. } => "literal",
+        RegionSeed::Glob { .. } => "glob",
+        RegionSeed::Files { .. } => "files",
+        RegionSeed::Rhai { .. } => "rhai",
+        RegionSeed::Command { .. } => "command",
+    }
+}
+
+/// Mint a run id: `<stem>-<unix-secs>-<counter>`. The per-process counter
+/// keeps ids unique even when several spawns land in the same second.
+pub(crate) fn mint_run_id(stem: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem: String = stem
+        .chars()
+        .map(|c| match c.is_ascii_alphanumeric() {
+            true => c.to_ascii_lowercase(),
+            false => '-',
+        })
+        .collect();
+    let stem = match stem.is_empty() {
+        true => "agent".to_string(),
+        false => stem,
+    };
+    format!("{stem}-{secs}-{n:04x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::layout::{ContextLayout, RegionDefinition, RegionSeed};
+    use leviath_core::region::RegionKind;
+
+    fn region(name: &str, seed: Option<RegionSeed>, required: bool) -> RegionDefinition {
+        let mut r = RegionDefinition::new(name.to_string(), RegionKind::Pinned, 1000);
+        r.seed = seed;
+        r.required = required;
+        r
+    }
+
+    fn bp(regions: Vec<RegionDefinition>) -> leviath_core::Blueprint {
+        let s = leviath_core::Stage::new(
+            "s".to_string(),
+            leviath_core::blueprint::ModelConfig::new("mock".to_string(), "m".to_string()),
+        );
+        leviath_core::Blueprint::new(
+            "t".to_string(),
+            "d".to_string(),
+            vec![s],
+            ContextLayout::new(regions, 10_000),
+        )
+    }
+
+    fn args(task: &str, regions: &[(&str, &str)]) -> SpawnArgs {
+        SpawnArgs {
+            task: task.to_string(),
+            regions: regions
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn seeds_fill_task_literal_and_named_regions() {
+        let bp = bp(vec![
+            region(
+                "task",
+                Some(RegionSeed::CallerInput {
+                    name: "task".to_string(),
+                }),
+                true,
+            ),
+            region(
+                "criteria",
+                Some(RegionSeed::CallerInput {
+                    name: "criteria".to_string(),
+                }),
+                false,
+            ),
+            region(
+                "guide",
+                Some(RegionSeed::Literal {
+                    text: "be kind".to_string(),
+                }),
+                false,
+            ),
+            region("plain", None, false),
+        ]);
+        let seeds =
+            resolve_embedded_seeds(&bp, &args("do the thing", &[("criteria", "fast")])).unwrap();
+        assert_eq!(seeds["task"], "do the thing");
+        assert_eq!(seeds["criteria"], "fast");
+        assert_eq!(seeds["guide"], "be kind");
+        assert!(!seeds.contains_key("plain"));
+    }
+
+    #[test]
+    fn missing_optional_caller_input_is_left_empty() {
+        let bp = bp(vec![region(
+            "notes",
+            Some(RegionSeed::CallerInput {
+                name: "notes".to_string(),
+            }),
+            false,
+        )]);
+        let seeds = resolve_embedded_seeds(&bp, &args("t", &[])).unwrap();
+        assert!(seeds.is_empty());
+    }
+
+    #[test]
+    fn missing_required_caller_input_fails_before_any_inference() {
+        let bp = bp(vec![region(
+            "spec",
+            Some(RegionSeed::CallerInput {
+                name: "spec".to_string(),
+            }),
+            true,
+        )]);
+        let err = resolve_embedded_seeds(&bp, &args("t", &[])).unwrap_err();
+        assert!(err.contains("required region 'spec'"));
+        assert!(err.contains("'spec'"));
+    }
+
+    #[test]
+    fn required_message_overrides_the_default_error() {
+        let mut r = region(
+            "spec",
+            Some(RegionSeed::CallerInput {
+                name: "spec".to_string(),
+            }),
+            true,
+        );
+        r.required_message = Some("bring a spec".to_string());
+        let err = resolve_embedded_seeds(&bp(vec![r]), &args("t", &[])).unwrap_err();
+        assert_eq!(err, "bring a spec");
+    }
+
+    #[test]
+    fn unsupported_seed_kinds_skip_unless_required() {
+        let optional = bp(vec![region(
+            "ctx",
+            Some(RegionSeed::Glob {
+                pattern: "*.md".to_string(),
+            }),
+            false,
+        )]);
+        assert!(
+            resolve_embedded_seeds(&optional, &args("t", &[]))
+                .unwrap()
+                .is_empty()
+        );
+
+        let required = bp(vec![region(
+            "ctx",
+            Some(RegionSeed::Files {
+                paths: vec!["a.md".to_string()],
+            }),
+            true,
+        )]);
+        let err = resolve_embedded_seeds(&required, &args("t", &[])).unwrap_err();
+        assert!(err.contains("seed kind (files)"));
+    }
+
+    #[test]
+    fn seed_kind_names_cover_every_variant() {
+        use leviath_core::layout::RegionSeed;
+        let cases = [
+            (
+                RegionSeed::CallerInput {
+                    name: "n".to_string(),
+                },
+                "caller_input",
+            ),
+            (
+                RegionSeed::Literal {
+                    text: "t".to_string(),
+                },
+                "literal",
+            ),
+            (
+                RegionSeed::Glob {
+                    pattern: "p".to_string(),
+                },
+                "glob",
+            ),
+            (RegionSeed::Files { paths: vec![] }, "files"),
+            (
+                RegionSeed::Rhai {
+                    script: "s".to_string(),
+                },
+                "rhai",
+            ),
+        ];
+        for (seed, want) in cases {
+            assert_eq!(seed_kind_name(&seed), want);
+        }
+    }
+
+    #[test]
+    fn seed_kind_names_include_command() {
+        assert_eq!(
+            seed_kind_name(&RegionSeed::Command {
+                command: "ls".to_string(),
+            }),
+            "command"
+        );
+    }
+
+    fn pipeline_world() -> crate::world::PipelineWorld {
+        crate::world::PipelineWorld::new(
+            crate::providers::ProviderRegistry::new(),
+            Arc::new(super::super::BasicToolService::new(
+                crate::interaction_hub::InteractionHub::new(),
+            )),
+            crate::inference_pool::InferencePoolConfig::new(),
+            1,
+            None,
+            tokio::runtime::Handle::current(),
+        )
+    }
+
+    fn spawner() -> EmbedSpawner {
+        EmbedSpawner {
+            basic_tools: None,
+            defaults: ModelDefaults::default(),
+            staged: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_missing_staged_blueprint_is_a_spawn_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut world = pipeline_world();
+        let err = spawner()
+            .spawn(
+                &mut world,
+                &SpawnArgs {
+                    run_id: "r".to_string(),
+                    blueprint_path: "inline:ghost".to_string(),
+                    workdir: dir.path().to_string_lossy().into_owned(),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("no staged blueprint"));
+    }
+
+    #[tokio::test]
+    async fn a_manifest_that_parses_but_fails_validation_is_a_spawn_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Valid TOML whose entry_stage names no stage: parses, fails validate.
+        let manifest = r#"[agent]
+name = "x"
+version = "0.0.0"
+description = "d"
+entry_stage = "ghost"
+
+[stages.only]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Only stage"
+
+[context.regions]
+conversation = { kind = "sliding_window", max_items = 10, max_tokens = 2000 }
+"#;
+        let path = dir.path().join("invalid.leviath");
+        std::fs::write(&path, manifest).unwrap();
+        let mut world = pipeline_world();
+        let err = spawner()
+            .spawn(
+                &mut world,
+                &SpawnArgs {
+                    run_id: "r".to_string(),
+                    blueprint_path: path.to_string_lossy().into_owned(),
+                    workdir: dir.path().to_string_lossy().into_owned(),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("invalid blueprint"));
+    }
+
+    #[tokio::test]
+    async fn an_unspawnable_blueprint_surfaces_the_seeded_spawn_error() {
+        // A pinned region far too small for the stage's system prompt: the
+        // world-level spawn (spawn_agent_seeded) rejects it.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = r#"[agent]
+name = "tiny"
+version = "0.0.0"
+description = "Tiny region."
+
+[stages.only]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Only stage"
+system_prompt = "This stage instruction text is far larger than the one-token region it must be pinned into, so applying the stage context fails."
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1 }
+"#;
+        let path = dir.path().join("tiny.leviath");
+        std::fs::write(&path, manifest).unwrap();
+        let mut world = pipeline_world();
+        let result = spawner().spawn(
+            &mut world,
+            &SpawnArgs {
+                run_id: "r".to_string(),
+                blueprint_path: path.to_string_lossy().into_owned(),
+                workdir: dir.path().to_string_lossy().into_owned(),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn minted_run_ids_are_sanitized_and_unique() {
+        let a = mint_run_id("My Coder!");
+        let b = mint_run_id("My Coder!");
+        assert!(a.starts_with("my-coder-"));
+        assert_ne!(a, b);
+        assert!(mint_run_id("").starts_with("agent-"));
+    }
+}

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -133,6 +133,7 @@ impl EmbedSpawner {
                 callback_url: None,
                 callback_secret: None,
                 title: None,
+                unattended: args.yolo,
             },
             TokenTotals::default(),
             PersistWatermark::default(),

--- a/crates/leviath-runtime/src/embed/stream.rs
+++ b/crates/leviath-runtime/src/embed/stream.rs
@@ -1,0 +1,97 @@
+//! The in-process event stream an embedder consumes.
+
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+
+use crate::host::WorldEvent;
+
+/// An async stream of [`WorldEvent`]s from an embedded world.
+///
+/// Wraps the host's broadcast channel: a slow consumer that falls more than
+/// the channel capacity behind skips the missed events (with a warning)
+/// rather than erroring, and the stream ends (`None`) when the world shuts
+/// down. Implements [`futures_core::Stream`], and offers an inherent
+/// [`next`](Self::next) so the common loop needs no extra imports:
+///
+/// ```ignore
+/// while let Some(event) = events.next().await {
+///     // ...
+/// }
+/// ```
+pub struct EventStream {
+    inner: BroadcastStream<WorldEvent>,
+}
+
+impl EventStream {
+    pub(crate) fn new(rx: tokio::sync::broadcast::Receiver<WorldEvent>) -> Self {
+        Self {
+            inner: BroadcastStream::new(rx),
+        }
+    }
+
+    /// The next event, or `None` once the world has shut down.
+    pub async fn next(&mut self) -> Option<WorldEvent> {
+        use futures_core::Stream;
+        std::future::poll_fn(|cx| std::pin::Pin::new(&mut *self).poll_next(cx)).await
+    }
+}
+
+impl futures_core::Stream for EventStream {
+    type Item = WorldEvent;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        loop {
+            match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(Ok(event))) => return Poll::Ready(Some(event)),
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
+                    tracing::warn!("event stream lagged, skipped {n} events");
+                    continue; // resubscribed at the live edge; keep polling
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn log(line: &str) -> WorldEvent {
+        WorldEvent::Log {
+            run_id: "r".to_string(),
+            agent_id: "a".to_string(),
+            line: line.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn yields_events_then_ends_when_the_sender_drops() {
+        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let mut stream = EventStream::new(rx);
+        tx.send(log("one")).unwrap();
+        tx.send(log("two")).unwrap();
+        assert_eq!(stream.next().await, Some(log("one")));
+        assert_eq!(stream.next().await, Some(log("two")));
+        drop(tx);
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn skips_over_a_lag_instead_of_erroring() {
+        // Capacity 1: sending twice before reading overwrites the first event,
+        // which surfaces as a Lagged error the stream must swallow.
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
+        let mut stream = EventStream::new(rx);
+        tx.send(log("dropped")).unwrap();
+        tx.send(log("kept")).unwrap();
+        assert_eq!(stream.next().await, Some(log("kept")));
+        drop(tx);
+        assert_eq!(stream.next().await, None);
+    }
+}

--- a/crates/leviath-runtime/src/embed/tool_service.rs
+++ b/crates/leviath-runtime/src/embed/tool_service.rs
@@ -1,0 +1,286 @@
+//! The batteries-included [`ToolService`] for embedded worlds: the built-in
+//! file/shell tools over each agent's workdir, with the `ask_user_*` /
+//! `present_for_review` / `edit_document` interaction tools routed through an
+//! [`InteractionHub`] so the host application answers them (surfaced as
+//! [`Interaction`](crate::host::WorldEvent::Interaction) events).
+//!
+//! Deliberately smaller than the daemon's tool service: no MCP tools, no Rhai
+//! script tools, no sandboxes, no per-tool approval policy - the embedder is
+//! code, not an unattended model, and can install its own [`ToolService`] for
+//! anything richer.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use bevy_ecs::entity::Entity;
+use leviath_tools::{BuiltinTools, ToolContext};
+
+use crate::dynamic_interaction::dispatch_dynamic_interaction;
+use crate::interaction_hub::{HubInteractionBackend, InteractionHub};
+use crate::pipeline::ToolService;
+use crate::tool_bridge::BoxedToolExec;
+
+/// One registered agent's tool state: its confined built-in tools and its
+/// hub-backed interaction channel.
+struct AgentTools {
+    tools: BuiltinTools,
+    backend: HubInteractionBackend,
+    /// The agent's current stage name, stamped into interaction requests so
+    /// the host knows which stage is asking. Updated by `sync_stage`.
+    stage_name: Mutex<String>,
+}
+
+/// The default tool service for embedded worlds. See the module docs for what
+/// it does and does not provide.
+pub struct BasicToolService {
+    hub: InteractionHub,
+    agents: Mutex<HashMap<Entity, Arc<AgentTools>>>,
+}
+
+impl BasicToolService {
+    /// A service whose interaction tools ask through `hub`.
+    pub fn new(hub: InteractionHub) -> Self {
+        Self {
+            hub,
+            agents: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The tool definitions this service can execute for an agent working in
+    /// `workdir` - the set stage resolution filters `available_tools` against.
+    pub fn tool_defs(workdir: &Path) -> Vec<leviath_providers::Tool> {
+        BuiltinTools::new(ToolContext::new(workdir.to_path_buf())).tool_defs()
+    }
+
+    /// Register `entity`'s tool state: built-ins confined to `workdir`, and
+    /// interactions attributed to `agent_id`. The embed spawner calls this for
+    /// every agent it creates; a host spawning agents directly on the world
+    /// does the same.
+    pub fn register(&self, entity: Entity, agent_id: &str, workdir: PathBuf) {
+        let state = AgentTools {
+            tools: BuiltinTools::new(ToolContext::new(workdir)),
+            backend: self.hub.backend_for(agent_id),
+            stage_name: Mutex::new(String::new()),
+        };
+        self.agents
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(entity, Arc::new(state));
+    }
+
+    /// Drop `entity`'s tool state. Called by the reaper when a terminal agent
+    /// is unloaded, so the map stays bounded by the set of live agents.
+    pub fn unregister(&self, entity: Entity) {
+        self.agents
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&entity);
+    }
+}
+
+impl ToolService for BasicToolService {
+    fn exec_for(&self, entity: Entity, calls: Vec<leviath_providers::ToolCall>) -> BoxedToolExec {
+        let state = self
+            .agents
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+            .cloned();
+        Box::new(move || {
+            Box::pin(async move {
+                let mut results = Vec::with_capacity(calls.len());
+                let Some(state) = state else {
+                    // Never registered (an agent spawned around the embed
+                    // spawner): answer every call rather than dropping the
+                    // batch, which would strand the agent.
+                    for call in calls {
+                        results.push((
+                            call.id,
+                            "[error] no tool state registered for this agent".to_string(),
+                        ));
+                    }
+                    return results;
+                };
+                let stage_name = state
+                    .stage_name
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .clone();
+                for call in calls {
+                    // Interaction tools block on the hub (the host answers);
+                    // everything else runs on the built-ins.
+                    let result = match dispatch_dynamic_interaction(
+                        &state.backend,
+                        &call.name,
+                        &call.id,
+                        &call.arguments,
+                        &stage_name,
+                    )
+                    .await
+                    {
+                        Some(result) => result,
+                        None => state.tools.execute(&call.name, call.arguments).await,
+                    };
+                    results.push((call.id, result));
+                }
+                results
+            })
+        })
+    }
+
+    fn sync_stage(&self, entity: Entity, _stage_index: usize, stage_name: &str) {
+        if let Some(state) = self
+            .agents
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+        {
+            *state
+                .stage_name
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = stage_name.to_string();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::interaction::InteractionResponse;
+
+    fn call(id: &str, name: &str, args: serde_json::Value) -> leviath_providers::ToolCall {
+        leviath_providers::ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: args,
+            thought_signature: None,
+        }
+    }
+
+    fn entity(index: u32) -> Entity {
+        Entity::from_raw_u32(index).expect("a small literal index is always a valid entity id")
+    }
+
+    #[tokio::test]
+    async fn executes_builtin_tools_in_the_registered_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "hi there").unwrap();
+        let svc = BasicToolService::new(InteractionHub::new());
+        let e = entity(1);
+        svc.register(e, "agent-a", dir.path().to_path_buf());
+
+        let exec = svc.exec_for(
+            e,
+            vec![
+                call("c1", "read_file", serde_json::json!({"path": "hello.txt"})),
+                call(
+                    "c2",
+                    "write_file",
+                    serde_json::json!({"path": "out.txt", "content": "made"}),
+                ),
+            ],
+        );
+        let results = exec().await;
+        assert_eq!(results[0].0, "c1");
+        assert!(results[0].1.contains("hi there"));
+        assert_eq!(results[1].0, "c2");
+        assert!(!results[1].1.starts_with("[error]"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+            "made"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_reports_an_error_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = BasicToolService::new(InteractionHub::new());
+        let e = entity(1);
+        svc.register(e, "agent-a", dir.path().to_path_buf());
+
+        let results =
+            svc.exec_for(e, vec![call("c1", "no_such_tool", serde_json::Value::Null)])().await;
+        assert!(results[0].1.starts_with("[error]"));
+    }
+
+    #[tokio::test]
+    async fn unregistered_entity_answers_instead_of_stranding_the_batch() {
+        let svc = BasicToolService::new(InteractionHub::new());
+        let results = svc.exec_for(
+            entity(9),
+            vec![call("c1", "read_file", serde_json::json!({"path": "x"}))],
+        )()
+        .await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("no tool state"));
+    }
+
+    #[tokio::test]
+    async fn ask_user_text_routes_through_the_hub_and_resumes_on_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let hub = InteractionHub::new();
+        let svc = BasicToolService::new(hub.clone());
+        let e = entity(1);
+        svc.register(e, "agent-a", dir.path().to_path_buf());
+        svc.sync_stage(e, 0, "plan");
+
+        let exec = svc.exec_for(
+            e,
+            vec![call(
+                "c1",
+                "ask_user_text",
+                serde_json::json!({"prompt": "Which database?"}),
+            )],
+        );
+        let worker = tokio::spawn(async move { exec().await });
+
+        // The request lands on the hub, attributed to the agent + stage.
+        let (agent_id, request) = loop {
+            let pending = hub.pending();
+            if let Some(p) = pending.into_iter().next() {
+                break p;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        };
+        assert_eq!(agent_id, "agent-a");
+        assert_eq!(request.stage_name, "plan");
+        assert!(request.prompt.contains("Which database?"));
+
+        // Answering unblocks the tool call, which carries the answer back.
+        assert!(hub.answer(InteractionResponse::text(request.id.clone(), "postgres")));
+        let results = worker.await.unwrap();
+        assert!(results[0].1.contains("postgres"));
+    }
+
+    #[tokio::test]
+    async fn sync_stage_for_an_unknown_entity_is_a_no_op() {
+        let svc = BasicToolService::new(InteractionHub::new());
+        svc.sync_stage(entity(3), 0, "plan"); // nothing to update, no panic
+    }
+
+    #[tokio::test]
+    async fn unregister_drops_the_agent_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = BasicToolService::new(InteractionHub::new());
+        let e = entity(1);
+        svc.register(e, "agent-a", dir.path().to_path_buf());
+        svc.unregister(e);
+        let results = svc.exec_for(
+            e,
+            vec![call("c1", "read_file", serde_json::json!({"path": "x"}))],
+        )()
+        .await;
+        assert!(results[0].1.contains("no tool state"));
+    }
+
+    #[test]
+    fn tool_defs_cover_the_builtin_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let defs = BasicToolService::tool_defs(dir.path());
+        let names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"read_file"));
+        assert!(names.contains(&"shell"));
+        assert!(names.contains(&"ask_user_text"));
+    }
+}

--- a/crates/leviath-runtime/src/embed/tool_service.rs
+++ b/crates/leviath-runtime/src/embed/tool_service.rs
@@ -18,7 +18,7 @@ use leviath_tools::{BuiltinTools, ToolContext};
 
 use crate::dynamic_interaction::dispatch_dynamic_interaction;
 use crate::interaction_hub::{HubInteractionBackend, InteractionHub};
-use crate::pipeline::ToolService;
+use crate::pipeline::{ToolProgress, ToolService};
 use crate::tool_bridge::BoxedToolExec;
 
 /// One registered agent's tool state: its confined built-in tools and its
@@ -80,7 +80,12 @@ impl BasicToolService {
 }
 
 impl ToolService for BasicToolService {
-    fn exec_for(&self, entity: Entity, calls: Vec<leviath_providers::ToolCall>) -> BoxedToolExec {
+    fn exec_for(
+        &self,
+        entity: Entity,
+        calls: Vec<leviath_providers::ToolCall>,
+        progress: ToolProgress,
+    ) -> BoxedToolExec {
         let state = self
             .agents
             .lock()
@@ -95,10 +100,9 @@ impl ToolService for BasicToolService {
                     // spawner): answer every call rather than dropping the
                     // batch, which would strand the agent.
                     for call in calls {
-                        results.push((
-                            call.id,
-                            "[error] no tool state registered for this agent".to_string(),
-                        ));
+                        let answer = "[error] no tool state registered for this agent";
+                        progress(&call.id, answer);
+                        results.push((call.id, answer.to_string()));
                     }
                     return results;
                 };
@@ -122,6 +126,7 @@ impl ToolService for BasicToolService {
                         Some(result) => result,
                         None => state.tools.execute(&call.name, call.arguments).await,
                     };
+                    progress(&call.id, &result);
                     results.push((call.id, result));
                 }
                 results
@@ -147,6 +152,7 @@ impl ToolService for BasicToolService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::noop_progress;
     use leviath_core::interaction::InteractionResponse;
 
     fn call(id: &str, name: &str, args: serde_json::Value) -> leviath_providers::ToolCall {
@@ -180,6 +186,7 @@ mod tests {
                     serde_json::json!({"path": "out.txt", "content": "made"}),
                 ),
             ],
+            noop_progress(),
         );
         let results = exec().await;
         assert_eq!(results[0].0, "c1");
@@ -199,8 +206,12 @@ mod tests {
         let e = entity(1);
         svc.register(e, "agent-a", dir.path().to_path_buf());
 
-        let results =
-            svc.exec_for(e, vec![call("c1", "no_such_tool", serde_json::Value::Null)])().await;
+        let results = svc.exec_for(
+            e,
+            vec![call("c1", "no_such_tool", serde_json::Value::Null)],
+            noop_progress(),
+        )()
+        .await;
         assert!(results[0].1.starts_with("[error]"));
     }
 
@@ -210,6 +221,7 @@ mod tests {
         let results = svc.exec_for(
             entity(9),
             vec![call("c1", "read_file", serde_json::json!({"path": "x"}))],
+            noop_progress(),
         )()
         .await;
         assert_eq!(results.len(), 1);
@@ -232,6 +244,7 @@ mod tests {
                 "ask_user_text",
                 serde_json::json!({"prompt": "Which database?"}),
             )],
+            noop_progress(),
         );
         let worker = tokio::spawn(async move { exec().await });
 
@@ -269,6 +282,7 @@ mod tests {
         let results = svc.exec_for(
             e,
             vec![call("c1", "read_file", serde_json::json!({"path": "x"}))],
+            noop_progress(),
         )()
         .await;
         assert!(results[0].1.contains("no tool state"));

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -409,13 +409,16 @@ impl AgentWorld {
         self.hub.answer(response)
     }
 
-    /// Shut the world down: stop the serve loop, then drain any queued
-    /// persistence writes before returning.
+    /// Shut the world down and wait for it to finish. The serve loop drains
+    /// every queued persistence write before it returns (its own
+    /// flush-and-stop), so once this resolves nothing is left in flight.
     pub async fn shutdown(self) {
         let _ = self.ask(|reply| ControlOp::Shutdown { reply }).await;
-        if let Ok(mut host) = self.serve_task.await {
-            host.world_mut().flush_and_stop().await;
-        }
+        // Joining is enough: `WorldHost::serve` flushes on its way out, and a
+        // second flush would tick a world whose persistence resource is
+        // already gone. `Err` here means the task was aborted; there is
+        // nothing left to wait for either way.
+        drop(self.serve_task.await);
     }
 }
 

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -1,0 +1,1157 @@
+//! [`AgentWorld`]: the embedder-facing runtime. Build one with plain values,
+//! spawn agents, watch the event stream, answer their questions, shut down.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{broadcast, oneshot};
+
+use super::spawner::{EmbedSpawner, StagedBlueprints, mint_run_id};
+use super::{BasicToolService, EmbedError, EventStream};
+use crate::components::AgentStatus;
+use crate::host::{ControlOp, SpawnArgs, WorldEvent, WorldHost};
+use crate::inference_pool::InferencePoolConfig;
+use crate::interaction_hub::InteractionHub;
+use crate::pipeline::{ModelDefaults, ToolService};
+use crate::provider_creds::{ProviderCreds, build_provider_registry};
+use crate::providers::ProviderRegistry;
+use crate::world::PipelineWorld;
+
+/// An opaque run identifier, minted by [`AgentWorld::spawn`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RunId(String);
+
+impl std::fmt::Display for RunId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for RunId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Where a spawn's blueprint comes from.
+pub enum BlueprintSource {
+    /// A `.leviath` manifest file on disk.
+    Path(PathBuf),
+    /// Manifest TOML held in memory (parsed and validated at spawn).
+    Toml(String),
+    /// An already-constructed blueprint value (boxed: a Blueprint is a
+    /// large value, and boxing keeps the enum small).
+    Inline(Box<leviath_core::Blueprint>),
+}
+
+/// One spawn request. Build with [`SpawnSpec::new`], then set the optional
+/// fields directly; the struct is non-exhaustive so new options stay
+/// additive.
+#[non_exhaustive]
+pub struct SpawnSpec {
+    /// The agent's blueprint.
+    pub blueprint: BlueprintSource,
+    /// The task prompt, seeded into the blueprint's `task` region.
+    pub task: String,
+    /// Working directory tools are confined to. Must exist.
+    pub workdir: PathBuf,
+    /// Optional model override (`provider/model` or a bare model name).
+    pub model: Option<String>,
+    /// Seed content for named caller-input regions.
+    pub regions: HashMap<String, String>,
+    /// Custom key/value metadata carried in the run's metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+impl SpawnSpec {
+    /// A spec with the required fields; optional fields start empty.
+    pub fn new(
+        blueprint: BlueprintSource,
+        task: impl Into<String>,
+        workdir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            blueprint,
+            task: task.into(),
+            workdir: workdir.into(),
+            model: None,
+            regions: HashMap::new(),
+            metadata: HashMap::new(),
+        }
+    }
+}
+
+/// Builds an [`AgentWorld`] from plain values - no config file, no daemon.
+///
+/// ```ignore
+/// let world = AgentWorld::builder()
+///     .provider(ProviderCreds::anthropic(api_key))
+///     .build()?;
+/// ```
+pub struct AgentWorldBuilder {
+    creds: Vec<ProviderCreds>,
+    custom_providers: Vec<(String, Arc<dyn leviath_providers::Provider>)>,
+    tool_service: Option<Arc<dyn ToolService>>,
+    pool_config: InferencePoolConfig,
+    tool_concurrency: usize,
+    state_dir: Option<PathBuf>,
+    defaults: ModelDefaults,
+    runtime: Option<Handle>,
+}
+
+impl AgentWorldBuilder {
+    fn new() -> Self {
+        Self {
+            creds: Vec::new(),
+            custom_providers: Vec::new(),
+            tool_service: None,
+            pool_config: InferencePoolConfig::new(),
+            tool_concurrency: 4,
+            state_dir: None,
+            defaults: ModelDefaults::default(),
+            runtime: None,
+        }
+    }
+
+    /// Add a provider from credentials (repeatable). See [`ProviderCreds`]
+    /// for the supported providers.
+    pub fn provider(mut self, creds: ProviderCreds) -> Self {
+        self.creds.push(creds);
+        self
+    }
+
+    /// Register a custom [`Provider`](leviath_providers::Provider)
+    /// implementation under `name` (repeatable). Wins over a credentials
+    /// entry with the same name.
+    pub fn register_provider(
+        mut self,
+        name: impl Into<String>,
+        provider: Arc<dyn leviath_providers::Provider>,
+    ) -> Self {
+        self.custom_providers.push((name.into(), provider));
+        self
+    }
+
+    /// The user-default provider/model, the fallback when none of a stage's
+    /// listed models has a registered provider.
+    pub fn default_model(mut self, provider: impl Into<String>, model: impl Into<String>) -> Self {
+        self.defaults = ModelDefaults {
+            provider: provider.into(),
+            model: Some(model.into()),
+        };
+        self
+    }
+
+    /// Replace the default [`BasicToolService`] with a custom tool service.
+    /// The embed spawner then skips per-agent tool registration; the custom
+    /// service sees agents through its own `exec_for`.
+    pub fn tool_service(mut self, service: Arc<dyn ToolService>) -> Self {
+        self.tool_service = Some(service);
+        self
+    }
+
+    /// Persist run state on disk under `dir`, in the daemon's layout
+    /// (`<dir>/runs/<run_id>/`, machine id at `<dir>/machine-id`). Without
+    /// this the world runs entirely in memory and never touches disk.
+    pub fn state_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.state_dir = Some(dir.into());
+        self
+    }
+
+    /// Per-model inference concurrency limits.
+    pub fn inference_pool(mut self, config: InferencePoolConfig) -> Self {
+        self.pool_config = config;
+        self
+    }
+
+    /// How many tool batches may execute concurrently (default 4).
+    pub fn tool_concurrency(mut self, n: usize) -> Self {
+        self.tool_concurrency = n;
+        self
+    }
+
+    /// Run the world on `handle` instead of the ambient Tokio runtime.
+    pub fn runtime(mut self, handle: Handle) -> Self {
+        self.runtime = Some(handle);
+        self
+    }
+
+    /// Assemble the world and start its serve loop on the Tokio runtime.
+    pub fn build(self) -> Result<AgentWorld, EmbedError> {
+        if self.creds.is_empty() && self.custom_providers.is_empty() {
+            return Err(EmbedError::NoProviders);
+        }
+        let handle = match self.runtime {
+            Some(handle) => handle,
+            None => Handle::try_current().map_err(|_| EmbedError::NoRuntime)?,
+        };
+
+        let mut registry: ProviderRegistry = build_provider_registry(&self.creds);
+        for (name, provider) in self.custom_providers {
+            registry.register(name, provider);
+        }
+
+        let hub = InteractionHub::new();
+        let (service, basic_tools): (Arc<dyn ToolService>, Option<Arc<BasicToolService>>) =
+            match self.tool_service {
+                Some(service) => (service, None),
+                None => {
+                    let basic = Arc::new(BasicToolService::new(hub.clone()));
+                    (basic.clone(), Some(basic))
+                }
+            };
+
+        let mut world = PipelineWorld::new(
+            registry,
+            service,
+            self.pool_config,
+            self.tool_concurrency,
+            self.state_dir.map(|d| d.join("runs")),
+            handle.clone(),
+        );
+        world.insert_interaction_hub(hub.clone());
+        let mut host = WorldHost::with_interactions(world, hub.clone());
+
+        let staged: StagedBlueprints = Arc::new(Mutex::new(HashMap::new()));
+        let spawner = EmbedSpawner {
+            basic_tools: basic_tools.clone(),
+            defaults: self.defaults,
+            staged: staged.clone(),
+        };
+        host.set_spawner(Box::new(move |world, args| spawner.spawn(world, args)));
+        if let Some(tools) = basic_tools {
+            host.set_reaper(Box::new(move |_world, entity| tools.unregister(entity)));
+        }
+
+        let events = host.event_sender();
+        let (control, control_rx) = tokio::sync::mpsc::unbounded_channel();
+        let serve_task = handle.spawn(async move {
+            host.serve(control_rx).await;
+            host
+        });
+
+        Ok(AgentWorld {
+            control,
+            events,
+            hub,
+            staged,
+            serve_task,
+        })
+    }
+}
+
+/// A running embedded world: agents spawn into it, events stream out of it.
+///
+/// Internally this is the same [`WorldHost`] the daemon serves - addressed
+/// in-process over a channel instead of over the control socket.
+pub struct AgentWorld {
+    control: UnboundedSender<ControlOp>,
+    events: broadcast::Sender<WorldEvent>,
+    hub: InteractionHub,
+    staged: StagedBlueprints,
+    serve_task: tokio::task::JoinHandle<WorldHost>,
+}
+
+impl AgentWorld {
+    /// Start building a world.
+    pub fn builder() -> AgentWorldBuilder {
+        AgentWorldBuilder::new()
+    }
+
+    /// Send one control op and await its reply.
+    async fn ask<T>(
+        &self,
+        build: impl FnOnce(oneshot::Sender<T>) -> ControlOp,
+    ) -> Result<T, EmbedError> {
+        let (reply, rx) = oneshot::channel();
+        self.control
+            .send(build(reply))
+            .map_err(|_| EmbedError::ChannelClosed)?;
+        rx.await.map_err(|_| EmbedError::ChannelClosed)
+    }
+
+    /// Spawn an agent. Returns its [`RunId`] once the agent is live in the
+    /// world (blueprint loaded, stages resolved, seeds applied).
+    pub async fn spawn(&self, spec: SpawnSpec) -> Result<RunId, EmbedError> {
+        // Resolve the blueprint source: a path passes through to the spawner;
+        // in-memory blueprints validate here and park in the staged map under
+        // the freshly minted run id.
+        enum Resolved {
+            Path(PathBuf),
+            Inline(Box<leviath_core::Blueprint>),
+        }
+        let resolved = match spec.blueprint {
+            BlueprintSource::Path(path) => Resolved::Path(path),
+            BlueprintSource::Toml(toml) => Resolved::Inline(Box::new(
+                leviath_core::manifest::parse_manifest(&toml)
+                    .map_err(|e| EmbedError::Blueprint(format!("parse manifest: {e}")))?,
+            )),
+            BlueprintSource::Inline(blueprint) => Resolved::Inline(blueprint),
+        };
+        if let Resolved::Inline(blueprint) = &resolved {
+            blueprint
+                .validate()
+                .map_err(|e| EmbedError::Blueprint(format!("invalid blueprint: {e}")))?;
+        }
+        let stem = match &resolved {
+            Resolved::Path(path) => path
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            Resolved::Inline(blueprint) => blueprint.name.clone(),
+        };
+        let run_id = mint_run_id(&stem);
+        let blueprint_path = match resolved {
+            Resolved::Path(path) => path.to_string_lossy().into_owned(),
+            Resolved::Inline(blueprint) => {
+                self.staged
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .insert(run_id.clone(), *blueprint);
+                format!("inline:{run_id}")
+            }
+        };
+        let args = SpawnArgs {
+            run_id,
+            blueprint_path,
+            task: spec.task,
+            regions: spec.regions,
+            model: spec.model,
+            workdir: spec.workdir.to_string_lossy().into_owned(),
+            metadata: spec.metadata,
+            ..Default::default()
+        };
+        let run_id = self
+            .ask(|reply| ControlOp::Spawn {
+                args: Box::new(args),
+                reply,
+            })
+            .await?
+            .map_err(EmbedError::Spawn)?;
+        Ok(RunId(run_id))
+    }
+
+    /// Subscribe to the world's events, from this moment on.
+    pub fn events(&self) -> EventStream {
+        EventStream::new(self.events.subscribe())
+    }
+
+    /// A run's current status, or `None` if the world doesn't know it.
+    pub async fn status(&self, id: &RunId) -> Option<AgentStatus> {
+        self.ask(|reply| ControlOp::Status {
+            run_id: id.0.clone(),
+            reply,
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    /// Deliver a message into a running agent's inbox. `false` when the
+    /// world can no longer accept messages (shut down or shutting down).
+    pub async fn send_message(&self, id: &RunId, content: &str) -> bool {
+        self.ask(|reply| ControlOp::Message {
+            agent_id: id.0.clone(),
+            content: content.to_string(),
+            target_region: None,
+            reply,
+        })
+        .await
+        .unwrap_or(false)
+    }
+
+    /// Pause a run. `false` if there is no such live run.
+    pub async fn pause(&self, id: &RunId) -> bool {
+        self.ask(|reply| ControlOp::Pause {
+            run_id: id.0.clone(),
+            reply,
+        })
+        .await
+        .unwrap_or(false)
+    }
+
+    /// Resume a paused run. `false` if there is no such live run.
+    pub async fn resume(&self, id: &RunId) -> bool {
+        self.ask(|reply| ControlOp::Resume {
+            run_id: id.0.clone(),
+            reply,
+        })
+        .await
+        .unwrap_or(false)
+    }
+
+    /// Cancel a run. `false` if there is no such live run.
+    pub async fn cancel(&self, id: &RunId) -> bool {
+        self.ask(|reply| ControlOp::Cancel {
+            run_id: id.0.clone(),
+            reply,
+        })
+        .await
+        .unwrap_or(false)
+    }
+
+    /// Every open question agents are waiting on, as `(run, request)`. Each
+    /// also arrived as an [`Interaction`](WorldEvent::Interaction) event.
+    pub fn pending_inputs(&self) -> Vec<(RunId, leviath_core::interaction::InteractionRequest)> {
+        self.hub
+            .pending()
+            .into_iter()
+            .map(|(agent_id, request)| (RunId(agent_id), request))
+            .collect()
+    }
+
+    /// Answer an open question (matched by the response's `request_id`).
+    /// `false` if no such request is open.
+    pub fn answer(&self, response: leviath_core::interaction::InteractionResponse) -> bool {
+        self.hub.answer(response)
+    }
+
+    /// Shut the world down: stop the serve loop, then drain any queued
+    /// persistence writes before returning.
+    pub async fn shutdown(self) {
+        let _ = self.ask(|reply| ControlOp::Shutdown { reply }).await;
+        if let Ok(mut host) = self.serve_task.await {
+            host.world_mut().flush_and_stop().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_providers::{
+        FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, Provider,
+        ProviderError, TokenUsage, ToolCall,
+    };
+    use std::collections::VecDeque;
+
+    /// A scripted provider: pops one canned response per inference call.
+    struct Mock {
+        responses: Mutex<VecDeque<InferenceResponse>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Mock {
+        async fn infer(&self, _r: InferenceRequest) -> Result<InferenceResponse, ProviderError> {
+            self.responses
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .pop_front()
+                .ok_or_else(|| ProviderError::Other("script exhausted".to_string()))
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            100_000
+        }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn capabilities(&self, _m: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
+    }
+
+    fn text(content: &str) -> InferenceResponse {
+        InferenceResponse {
+            content: content.to_string(),
+            tool_calls: vec![],
+            tokens_used: TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+            },
+            finish_reason: FinishReason::Complete,
+        }
+    }
+
+    fn with_tool(id: &str, name: &str, args: serde_json::Value) -> InferenceResponse {
+        let mut r = text("");
+        r.tool_calls.push(ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: args,
+            thought_signature: None,
+        });
+        r
+    }
+
+    fn mock_world(responses: Vec<InferenceResponse>) -> AgentWorld {
+        AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(responses.into_iter().collect()),
+                }),
+            )
+            .build()
+            .expect("world builds inside the test runtime")
+    }
+
+    const TWO_STAGE: &str = r#"[agent]
+name = "embedded"
+version = "0.0.0"
+description = "Two stage embedded test agent."
+entry_stage = "work"
+
+[stages.work]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Do the work"
+available_tools = ["read_file"]
+system_prompt = "Work."
+[stages.work.transitions.wrap]
+transform = "direct"
+
+[stages.wrap]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Wrap up"
+allow_complete = true
+system_prompt = "Wrap."
+
+[context.regions]
+conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
+"#;
+
+    const ASKER: &str = r#"[agent]
+name = "asker"
+version = "0.0.0"
+description = "Asks one question then finishes."
+entry_stage = "chat"
+
+[stages.chat]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Chat"
+available_tools = ["ask_user_text"]
+allow_complete = true
+system_prompt = "Ask."
+
+[context.regions]
+conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
+"#;
+
+    /// Drain events until `pred` matches (or the stream ends), collecting
+    /// everything seen. Bounded by the caller's `tokio::time::timeout`.
+    async fn events_until(
+        stream: &mut EventStream,
+        pred: impl Fn(&WorldEvent) -> bool,
+    ) -> Vec<WorldEvent> {
+        let mut seen = Vec::new();
+        while let Some(event) = stream.next().await {
+            let done = pred(&event);
+            seen.push(event);
+            if done {
+                break;
+            }
+        }
+        seen
+    }
+
+    #[tokio::test]
+    async fn build_without_providers_is_refused() {
+        let err = AgentWorld::builder().build().map(|_| ()).unwrap_err();
+        assert_eq!(err, EmbedError::NoProviders);
+    }
+
+    #[test]
+    fn build_outside_a_tokio_runtime_is_refused() {
+        let err = AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(VecDeque::new()),
+                }),
+            )
+            .build()
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(err, EmbedError::NoRuntime);
+    }
+
+    #[test]
+    fn build_accepts_an_explicit_runtime_handle() {
+        // A plain test (no ambient runtime): the handle passed via
+        // `.runtime()` is what makes build succeed.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let world = AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(VecDeque::new()),
+                }),
+            )
+            .runtime(rt.handle().clone())
+            .build()
+            .expect("explicit handle suffices");
+        rt.block_on(world.shutdown());
+    }
+
+    #[tokio::test]
+    async fn agent_runs_to_completion_with_stage_and_tool_events() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "the notes").unwrap();
+        // The wrap stage makes no tool calls, so its text-only responses get
+        // the "use your tools" nudge up to the cap before the last is
+        // accepted; script enough of them.
+        let world = mock_world(vec![
+            with_tool("c1", "read_file", serde_json::json!({"path": "notes.txt"})),
+            text("moving on"),
+            text("done"),
+            text("done"),
+            text("done"),
+            text("done"),
+        ]);
+        let mut events = world.events();
+
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(TWO_STAGE.to_string()),
+                "summarize the notes",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+        assert!(run_id.as_ref().starts_with("embedded-"));
+
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completed before timeout");
+
+        let spawned = seen
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Spawned { run_id: r, .. } if r == run_id.as_ref()));
+        assert!(spawned, "saw Spawned: {seen:?}");
+        let transitioned = seen.iter().any(|e| {
+            matches!(e, WorldEvent::StageTransition { from, to, .. }
+                if from == "work" && to == "wrap")
+        });
+        assert!(transitioned, "saw StageTransition: {seen:?}");
+        let started = seen
+            .iter()
+            .any(|e| matches!(e, WorldEvent::ToolCallStarted { tool, .. } if tool == "read_file"));
+        assert!(started, "saw ToolCallStarted: {seen:?}");
+        let finished = seen.iter().any(|e| {
+            matches!(e, WorldEvent::ToolCallFinished { tool, ok, summary, .. }
+                if tool == "read_file" && *ok && summary.contains("the notes"))
+        });
+        assert!(finished, "saw ToolCallFinished: {seen:?}");
+        let completed = seen
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Completed { status, .. } if status == "complete"));
+        assert!(completed, "saw Completed: {seen:?}");
+
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ask_user_surfaces_as_interaction_and_resumes_on_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = mock_world(vec![
+            with_tool(
+                "c1",
+                "ask_user_text",
+                serde_json::json!({"prompt": "Which database?"}),
+            ),
+            text("done"),
+        ]);
+        let mut events = world.events();
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(ASKER.to_string()),
+                "pick a database",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+
+        // The question arrives on the event stream and in pending_inputs.
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Interaction { .. })),
+        )
+        .await
+        .expect("interaction before timeout");
+        let request = seen
+            .iter()
+            .find_map(|e| match e {
+                WorldEvent::Interaction {
+                    run_id: r, request, ..
+                } if r == run_id.as_ref() => Some(request.clone()),
+                _ => None,
+            })
+            .expect("interaction event carries the request");
+        assert!(request.prompt.contains("Which database?"));
+        let pending = world.pending_inputs();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, run_id);
+
+        // A live, parked agent is controllable: pause/resume round-trips, and
+        // a message is accepted.
+        assert!(world.pause(&run_id).await);
+        assert!(world.resume(&run_id).await);
+        assert!(world.send_message(&run_id, "prefer something boring").await);
+
+        // Answering resumes the run to completion.
+        assert!(
+            world.answer(leviath_core::interaction::InteractionResponse::text(
+                request.id.clone(),
+                "postgres"
+            ))
+        );
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completed before timeout");
+        assert!(
+            seen.iter()
+                .any(|e| matches!(e, WorldEvent::Completed { .. }))
+        );
+
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn spawn_reports_blueprint_and_workdir_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = mock_world(vec![]);
+
+        // Unparseable TOML.
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml("not = [valid".to_string()),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().starts_with("blueprint error"));
+
+        // A manifest path that does not exist fails in the spawner.
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Path(dir.path().join("missing.leviath")),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().starts_with("spawn error"));
+
+        // A workdir that does not exist is refused before anything spawns.
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(TWO_STAGE.to_string()),
+                "t",
+                dir.path().join("nope"),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().starts_with("spawn error"));
+
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn spawn_from_a_manifest_file_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("embedded.leviath");
+        std::fs::write(&manifest, TWO_STAGE).unwrap();
+        // Both stages are text-only here, so each needs its nudge budget.
+        let world = mock_world(vec![
+            text("moving on"),
+            text("moving on"),
+            text("moving on"),
+            text("moving on"),
+            text("done"),
+            text("done"),
+            text("done"),
+            text("done"),
+        ]);
+        let mut events = world.events();
+
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Path(manifest),
+                "just finish",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns from the file");
+        assert!(run_id.as_ref().starts_with("embedded-"));
+
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completed before timeout");
+        assert!(
+            seen.iter()
+                .any(|e| matches!(e, WorldEvent::Completed { .. }))
+        );
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_runs_answer_negatively() {
+        let world = mock_world(vec![]);
+        let ghost = RunId("no-such-run".to_string());
+        assert_eq!(world.status(&ghost).await, None);
+        assert!(!world.pause(&ghost).await);
+        assert!(!world.resume(&ghost).await);
+        assert!(!world.cancel(&ghost).await);
+        assert!(world.pending_inputs().is_empty());
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_ends_the_event_stream_and_further_requests_fail() {
+        let world = mock_world(vec![]);
+        let mut events = world.events();
+        let control = world.control.clone();
+        world.shutdown().await;
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), events.next())
+                .await
+                .expect("stream ends"),
+            None
+        );
+        // The serve loop is gone (shutdown consumed the world after joining
+        // it), so its receiver is dropped and a late op cannot be delivered.
+        assert!(control.is_closed());
+        let (reply, _rx) = oneshot::channel();
+        assert!(control.send(ControlOp::List { reply }).is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_a_parked_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = mock_world(vec![with_tool(
+            "c1",
+            "ask_user_text",
+            serde_json::json!({"prompt": "?"}),
+        )]);
+        let mut events = world.events();
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(ASKER.to_string()),
+                "ask",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Interaction { .. })),
+        )
+        .await
+        .expect("parked on the question");
+
+        assert!(world.cancel(&run_id).await);
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("terminal event after cancel");
+        assert!(seen.iter().any(|e| {
+            matches!(e, WorldEvent::Completed { status, .. } if status == "cancelled")
+        }));
+        world.shutdown().await;
+    }
+
+    /// A tool service that answers every call with a canned string; used to
+    /// exercise the custom-service seam (no per-agent registration).
+    struct CannedService;
+    impl crate::pipeline::ToolService for CannedService {
+        fn exec_for(
+            &self,
+            _entity: bevy_ecs::entity::Entity,
+            calls: Vec<leviath_providers::ToolCall>,
+        ) -> crate::tool_bridge::BoxedToolExec {
+            Box::new(move || {
+                Box::pin(async move {
+                    calls
+                        .into_iter()
+                        .map(|c| (c.id, "canned".to_string()))
+                        .collect()
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn every_builder_option_composes_and_state_dir_persists_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let world = AgentWorld::builder()
+            .provider(ProviderCreds::simple("ollama"))
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(
+                        vec![
+                            with_tool("c1", "read_file", serde_json::json!({"path": "x"})),
+                            text("done"),
+                            text("done"),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                }),
+            )
+            .default_model("mock", "m")
+            .state_dir(state.path())
+            .inference_pool(InferencePoolConfig::new())
+            .tool_concurrency(2)
+            .build()
+            .expect("all options compose");
+        let mut events = world.events();
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(TWO_STAGE.to_string()),
+                "persist me",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completes");
+        world.shutdown().await;
+
+        // The daemon's on-disk layout appeared under the state dir.
+        let run_dir = state.path().join("runs").join(run_id.as_ref());
+        assert!(run_dir.join("meta.json").exists());
+        assert!(state.path().join("machine-id").exists());
+    }
+
+    #[tokio::test]
+    async fn a_custom_tool_service_replaces_the_builtin_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(
+                        vec![
+                            with_tool("c1", "read_file", serde_json::json!({"path": "x"})),
+                            text("done"),
+                            text("done"),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                }),
+            )
+            .tool_service(Arc::new(CannedService))
+            .build()
+            .expect("builds with a custom service");
+        let mut events = world.events();
+        world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(TWO_STAGE.to_string()),
+                "use the canned tools",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completes");
+        // The canned result (not a real file read) came back through the lane.
+        assert!(seen.iter().any(|e| {
+            matches!(e, WorldEvent::ToolCallFinished { summary, .. } if summary == "canned")
+        }));
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn manifest_files_that_do_not_parse_or_validate_fail_the_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = mock_world(vec![]);
+
+        let garbled = dir.path().join("garbled.leviath");
+        std::fs::write(&garbled, "not = [valid").unwrap();
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Path(garbled),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("parse manifest"));
+
+        // A path with no file stem still spawns an attempt (and fails to read).
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Path(PathBuf::from("")),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().starts_with("spawn error"));
+
+        // A required caller-input region that was not provided fails before
+        // any inference.
+        let demanding = format!(
+            "{TWO_STAGE}\nspec = {{ kind = \"pinned\", max_tokens = 2000, seed = \"input\", required = true }}\n"
+        );
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(demanding),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("required region"));
+
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn requests_after_the_world_closes_fail_closed() {
+        let world = mock_world(vec![]);
+        // Stop the serve loop out from under the handle (without consuming
+        // the AgentWorld, as shutdown() would).
+        let (reply, _rx) = oneshot::channel();
+        world
+            .control
+            .send(ControlOp::Shutdown { reply })
+            .expect("world is up");
+        // Wait until the serve loop is really gone (its rx dropped).
+        while !world.control.is_closed() {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let ghost = RunId("ghost".to_string());
+        assert_eq!(world.status(&ghost).await, None);
+        assert!(!world.pause(&ghost).await);
+        assert!(!world.send_message(&ghost, "hello").await);
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(TWO_STAGE.to_string()),
+                "t",
+                std::env::temp_dir(),
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(err, EmbedError::ChannelClosed);
+    }
+
+    #[tokio::test]
+    async fn inline_blueprints_spawn_and_invalid_ones_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let world = mock_world(vec![text("done"), text("done"), text("done"), text("done")]);
+        let mut events = world.events();
+
+        // An invalid inline blueprint (entry stage names nothing) is refused
+        // before it reaches the world.
+        let mut invalid = leviath_core::manifest::parse_manifest(TWO_STAGE).unwrap();
+        invalid.entry_stage = Some("ghost".to_string());
+        let err = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Inline(Box::new(invalid)),
+                "t",
+                dir.path(),
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid blueprint"));
+
+        // A valid one runs. Trim it to a single text-only stage.
+        let mut valid = leviath_core::manifest::parse_manifest(TWO_STAGE).unwrap();
+        valid.stages.truncate(1);
+        valid.stages[0].transitions = None;
+        valid.entry_stage = Some(valid.stages[0].name.clone());
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Inline(Box::new(valid)),
+                "just answer",
+                dir.path(),
+            ))
+            .await
+            .expect("inline blueprint spawns");
+        assert!(run_id.as_ref().starts_with("embedded-"));
+        let seen = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completes");
+        assert!(
+            seen.iter()
+                .any(|e| matches!(e, WorldEvent::Completed { .. }))
+        );
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_survives_an_aborted_serve_loop() {
+        let world = mock_world(vec![]);
+        // Kill the serve task out from under the world: shutdown must not
+        // hang or panic when the join fails.
+        world.serve_task.abort();
+        world.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn the_mock_provider_is_a_minimal_stub() {
+        // Pins the fixture's inert answers so its impl stays measured (the
+        // pipeline only calls infer when exact token counting is off).
+        let mock = Mock {
+            responses: Mutex::new(VecDeque::new()),
+        };
+        assert_eq!(mock.count_tokens("x", "m").await, 1);
+        assert_eq!(mock.max_context_tokens("m"), 100_000);
+        assert_eq!(mock.name(), "mock");
+        let _ = mock.capabilities("m");
+        assert!(
+            mock.infer(
+                serde_json::from_value(serde_json::json!({
+                    "messages": [],
+                    "model": "m",
+                    "max_tokens": 1,
+                    "temperature": 0.0,
+                    "tools": [],
+                    "extra": null,
+                }))
+                .unwrap()
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn run_id_displays_as_its_string() {
+        let id = RunId("coder-1-2".to_string());
+        assert_eq!(id.to_string(), "coder-1-2");
+        assert_eq!(id.as_ref(), "coder-1-2");
+    }
+}

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -888,6 +888,7 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
             &self,
             _entity: bevy_ecs::entity::Entity,
             calls: Vec<leviath_providers::ToolCall>,
+            _progress: crate::pipeline::ToolProgress,
         ) -> crate::tool_bridge::BoxedToolExec {
             Box::new(move || {
                 Box::pin(async move {

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -703,10 +703,10 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].0, run_id);
 
-        // A live, parked agent is controllable: pause/resume round-trips, and
-        // a message is accepted.
-        assert!(world.pause(&run_id).await);
-        assert!(world.resume(&run_id).await);
+        // A live, parked agent still accepts messages. (Pause is refused
+        // while the agent waits on input - see the capacity test below for
+        // the pause/resume round-trip.)
+        assert!(!world.pause(&run_id).await);
         assert!(world.send_message(&run_id, "prefer something boring").await);
 
         // Answering resumes the run to completion.
@@ -1149,6 +1149,40 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
             .await
             .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_round_trip_on_an_active_run() {
+        // Zero inference permits for the model: the agent stays Active,
+        // parked on the pool, which is exactly when pause applies.
+        let dir = tempfile::tempdir().unwrap();
+        let mut pool = InferencePoolConfig::new();
+        pool.set_limit("m", 0);
+        let world = AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Mock {
+                    responses: Mutex::new(VecDeque::new()),
+                }),
+            )
+            .inference_pool(pool)
+            .build()
+            .expect("builds");
+        let run_id = world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(ASKER.to_string()),
+                "wait around",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+
+        // Agents spawn Active, and with no permits nothing can change that.
+        assert_eq!(world.status(&run_id).await, Some(AgentStatus::Active));
+        assert!(world.pause(&run_id).await);
+        assert!(world.resume(&run_id).await);
+        assert!(world.cancel(&run_id).await);
+        world.shutdown().await;
     }
 
     #[test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1424,7 +1424,7 @@ mod tests {
             Arc::new(NoTools),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         );
         WorldHost::new(world)

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -318,9 +318,17 @@ pub enum ControlOp {
     },
 }
 
-/// A change in the world, broadcast to subscribers (the HTTP/WS gateway) so they
-/// get pushed updates instead of polling. Emitted by the host as it drives the
-/// world; streamed over the control transport via `ControlRequest::Subscribe`.
+/// A change in the world, broadcast to subscribers (the HTTP/WS gateway and
+/// in-process embedders) so they get pushed updates instead of polling. The
+/// coarse per-run variants (`Spawned`/`Status`/`Tokens`/`Context`/`Completed`)
+/// are emitted by the host's change-detection pass as it drives the world;
+/// `StageTransition`/`ToolCallStarted`/`ToolCallFinished`/`Log` are pushed at
+/// the source by pipeline systems through [`WorldEventSink`]. Streamed over the
+/// control transport via `ControlRequest::Subscribe`.
+///
+/// Marked non-exhaustive: new variants are additive, so consumers outside this
+/// crate must keep a catch-all arm.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum WorldEvent {
@@ -394,6 +402,52 @@ pub enum WorldEvent {
         /// The terminal status label.
         status: String,
     },
+    /// A run moved from one stage to another. Emitted by the transition systems
+    /// at the moment the new stage is entered (the initial stage at spawn is
+    /// covered by [`WorldEvent::Spawned`], not by this).
+    StageTransition {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The stage being left.
+        from: String,
+        /// The stage being entered.
+        to: String,
+        /// How many times the destination stage has been entered, this entry
+        /// included.
+        iteration: usize,
+    },
+    /// A tool call was handed to the async tool lane for execution. Inline
+    /// calls (context tools, refusals, gate blocks) resolve without touching
+    /// the lane and don't produce this event.
+    ToolCallStarted {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The provider-assigned tool call id.
+        call_id: String,
+        /// The tool name.
+        tool: String,
+    },
+    /// A lane-executed tool call returned. Paired with
+    /// [`WorldEvent::ToolCallStarted`] by `call_id`.
+    ToolCallFinished {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The provider-assigned tool call id.
+        call_id: String,
+        /// The tool name.
+        tool: String,
+        /// Whether the call took effect (`false` for `[error]`/`[blocked]`/
+        /// `[unavailable]` results).
+        ok: bool,
+        /// The result, flattened to one line and truncated.
+        summary: String,
+    },
     /// A run produced a per-agent log/output line (readable assistant output or
     /// an operational `[Tokens: …]` / `[tool] …` / `[error] …` line).
     Log {
@@ -404,6 +458,26 @@ pub enum WorldEvent {
         /// The log line text.
         line: String,
     },
+}
+
+impl WorldEvent {
+    /// The run id this event belongs to. Every variant carries one; this saves
+    /// consumers an exhaustive match (which, with the enum non-exhaustive,
+    /// they could not write anyway).
+    pub fn run_id(&self) -> &str {
+        match self {
+            WorldEvent::Spawned { run_id, .. }
+            | WorldEvent::Status { run_id, .. }
+            | WorldEvent::Tokens { run_id, .. }
+            | WorldEvent::Context { run_id, .. }
+            | WorldEvent::Interaction { run_id, .. }
+            | WorldEvent::Completed { run_id, .. }
+            | WorldEvent::StageTransition { run_id, .. }
+            | WorldEvent::ToolCallStarted { run_id, .. }
+            | WorldEvent::ToolCallFinished { run_id, .. }
+            | WorldEvent::Log { run_id, .. } => run_id,
+        }
+    }
 }
 
 /// A world resource holding a clone of the host's [`WorldEvent`] broadcast
@@ -3566,5 +3640,80 @@ mod tests {
         // blueprint's shape or how it was launched.
         assert_eq!(list[0].num_stages, None);
         assert!(!list[0].unattended);
+    }
+
+    #[test]
+    fn every_world_event_variant_carries_its_run_id() {
+        let rid = "run-x".to_string();
+        let aid = "agent-x".to_string();
+        let events = vec![
+            WorldEvent::Spawned {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                blueprint: "b".to_string(),
+            },
+            WorldEvent::Status {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                status: "active".to_string(),
+                stage: "s".to_string(),
+                iteration: 1,
+                tool_calls: 0,
+                accepts_messages: false,
+            },
+            WorldEvent::Tokens {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                prompt_tokens: 1,
+                completion_tokens: 2,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+            },
+            WorldEvent::Context {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                total_tokens: 3,
+                max_tokens: 4,
+            },
+            WorldEvent::Interaction {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                request: InteractionRequest::free_text("i", "p", "s", true),
+            },
+            WorldEvent::Completed {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                status: "complete".to_string(),
+            },
+            WorldEvent::StageTransition {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                from: "a".to_string(),
+                to: "b".to_string(),
+                iteration: 1,
+            },
+            WorldEvent::ToolCallStarted {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                call_id: "c".to_string(),
+                tool: "t".to_string(),
+            },
+            WorldEvent::ToolCallFinished {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                call_id: "c".to_string(),
+                tool: "t".to_string(),
+                ok: true,
+                summary: "s".to_string(),
+            },
+            WorldEvent::Log {
+                run_id: rid.clone(),
+                agent_id: aid.clone(),
+                line: "l".to_string(),
+            },
+        ];
+        for ev in events {
+            assert_eq!(ev.run_id(), "run-x");
+        }
     }
 }

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1689,7 +1689,7 @@ mod tests {
             Arc::new(NoTools),
             pools,
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         ))
     }

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -5,6 +5,60 @@
 //! The runtime manages agent lifecycle, context window management, task scheduling,
 //! and inference execution through a game-loop-inspired architecture where agents
 //! are entities and their behaviors are systems.
+//!
+//! ## Embedding
+//!
+//! [`AgentWorld`] is the front door for running agents inside your own
+//! application - no `lev` CLI, daemon, or config file. Build a world from
+//! plain values, spawn an agent, and drive the event stream:
+//!
+//! ```no_run
+//! use leviath_runtime::{AgentWorld, BlueprintSource, ProviderCreds, SpawnSpec, WorldEvent};
+//!
+//! # async fn embed() -> Result<(), Box<dyn std::error::Error>> {
+//! let world = AgentWorld::builder()
+//!     .provider(ProviderCreds {
+//!         name: "anthropic".to_string(),
+//!         api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+//!         ..ProviderCreds::simple("anthropic")
+//!     })
+//!     .build()?;
+//!
+//! let mut events = world.events();
+//! let run = world
+//!     .spawn(SpawnSpec::new(
+//!         BlueprintSource::Path("coder.leviath".into()),
+//!         "Build a CSV parser",
+//!         std::env::current_dir()?,
+//!     ))
+//!     .await?;
+//!
+//! while let Some(event) = events.next().await {
+//!     match event {
+//!         WorldEvent::StageTransition { from, to, .. } => println!("{from} -> {to}"),
+//!         WorldEvent::ToolCallStarted { tool, .. } => println!("running {tool}"),
+//!         WorldEvent::Interaction { request, .. } => {
+//!             // The agent asked a question: answer via world.answer(...).
+//!         }
+//!         WorldEvent::Completed { run_id, status, .. } if run_id == run.as_ref() => break,
+//!         _ => {}
+//!     }
+//! }
+//! world.shutdown().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Stability layers
+//!
+//! - [`AgentWorld`] and the other [`embed`] types are the stable embedding
+//!   surface.
+//! - [`WorldHost`] and [`PipelineWorld`] are the semi-stable machinery both
+//!   the daemon and `AgentWorld` are built on; use them when you need your
+//!   own assembly (custom spawners, hooks, tick control).
+//! - The raw ECS underneath ([`PipelineWorld::world_mut`]) is the unstable
+//!   escape hatch: it tracks this crate's `bevy_ecs` version (re-exported as
+//!   [`ecs`]) and carries no compatibility promise.
 
 pub(crate) mod cancel;
 pub(crate) mod compaction_bridge;
@@ -45,10 +99,28 @@ pub mod world;
 mod test_support;
 
 pub use components::{AgentState, AgentStatus, ContextWindow, ParentRef, SubAgentChildren};
+pub use embed::{
+    AgentWorld, AgentWorldBuilder, BasicToolService, BlueprintSource, EmbedError, EventStream,
+    RunId, SpawnSpec,
+};
 pub use fanout::{FanOutSpawner, FanOutSpawnerRes};
+pub use host::{ControlOp, SpawnArgs, WorldEvent, WorldHost};
 pub use inference_bridge::RetryPolicy;
 pub use inference_pool::{InferencePoolConfig, InferencePools};
+pub use interaction_hub::InteractionHub;
+pub use pipeline::{ModelDefaults, ResolvedStage, ToolService};
 pub use provider_creds::{ProviderCreds, build_provider_registry};
 pub use providers::ProviderRegistry;
 pub use taint::TaintGate;
 pub use tool_bridge::BoxedToolExec;
+pub use world::{PipelineWorld, TickOutcome};
+
+/// The name issue-facing docs use for the world's event enum; the same type
+/// as [`WorldEvent`].
+pub type AgentEvent = WorldEvent;
+
+/// The `bevy_ecs` version this runtime is built against, for code that
+/// reaches through [`PipelineWorld::world_mut`] into the raw ECS. Depending
+/// on this re-export (instead of your own `bevy_ecs`) keeps the versions
+/// aligned.
+pub use bevy_ecs as ecs;

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod components;
 pub mod context_setup;
 pub(crate) mod context_tools;
 pub(crate) mod context_transform;
+#[cfg(feature = "control-socket")]
 pub mod control_socket;
 pub mod custom_region;
 pub mod dynamic_interaction;

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod context_transform;
 pub mod control_socket;
 pub mod custom_region;
 pub mod dynamic_interaction;
+pub mod embed;
 pub mod fanout;
 pub(crate) mod gate_prompt;
 pub mod host;

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -624,7 +624,8 @@ mod tests {
         // stays empty (no run dirs, no machine-id next to it).
         let dir = tempfile::tempdir().unwrap();
         let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(PersistMsg::Snapshot(Box::new(job("run-a")))).unwrap();
+        tx.send(PersistMsg::Snapshot(Box::new(job("run-a"))))
+            .unwrap();
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         tx.send(PersistMsg::Append {
             run_id: "run-a".to_string(),
@@ -713,7 +714,7 @@ mod tests {
         })
         .unwrap();
         drop(tx);
-        persistence_worker(dir.path().to_path_buf(), rx).await;
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
 
         ack_rx.await.expect("append acked");
         let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
@@ -738,7 +739,7 @@ mod tests {
         })
         .unwrap();
         drop(tx);
-        persistence_worker(dir.path().to_path_buf(), rx).await;
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
 
         ack_rx.await.expect("acked despite the skip");
         assert!(!dir.path().join("run-none").join("run.lvr").exists());

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -75,7 +75,25 @@ pub enum PersistMsg {
 /// (`<runs_dir>/../machine-id`, created once) and a per-process `world_id` - which
 /// it stamps into every run's portable archive so a run copied to another machine
 /// is unambiguously attributable (see [`leviath_core::run_archive`]).
-pub async fn persistence_worker(runs_dir: PathBuf, mut jobs: UnboundedReceiver<PersistMsg>) {
+///
+/// `runs_dir: None` means the world runs in memory only: the worker drains and
+/// drops every message without touching the filesystem (no run dirs, no
+/// machine-id), while keeping the channel-close shutdown contract so
+/// [`flush_and_stop`](crate::world::PipelineWorld::flush_and_stop) still joins
+/// it - and still acking appends, so a dispatch-side barrier never waits on a
+/// dead channel.
+pub async fn persistence_worker(
+    runs_dir: Option<PathBuf>,
+    mut jobs: UnboundedReceiver<PersistMsg>,
+) {
+    let Some(runs_dir) = runs_dir else {
+        while let Some(msg) = jobs.recv().await {
+            if let PersistMsg::Append { ack: Some(ack), .. } = msg {
+                let _ = ack.send(());
+            }
+        }
+        return;
+    };
     let machine_id = load_or_create_machine_id(&runs_dir);
     let world_id = generate_id();
     // The last context window archived per run, so the next write can be stored
@@ -427,7 +445,7 @@ mod tests {
         .unwrap();
         drop(tx); // close so the worker loop ends
 
-        persistence_worker(dir.path().to_path_buf(), rx).await;
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
 
         let run_dir = dir.path().join("run-1");
         let meta_json = std::fs::read_to_string(run_dir.join("meta.json")).unwrap();
@@ -593,8 +611,37 @@ mod tests {
         terminal.meta.status = leviath_core::run_meta::RunStatus::Complete;
         tx.send(PersistMsg::Snapshot(Box::new(terminal))).unwrap();
         drop(tx);
-        persistence_worker(dir.path().to_path_buf(), rx).await;
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
         assert!(dir.path().join("run-term").join("meta.json").exists());
+    }
+
+    #[tokio::test]
+    async fn worker_without_a_runs_dir_drains_messages_and_writes_nothing() {
+        // `runs_dir: None` is the in-memory mode: snapshots are received and
+        // dropped, appends are still acked (a dispatch-side barrier must not
+        // wait on a dead channel), the worker still ends when the channel
+        // closes, and the directory a persistent world would have written to
+        // stays empty (no run dirs, no machine-id next to it).
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(PersistMsg::Snapshot(Box::new(job("run-a")))).unwrap();
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        tx.send(PersistMsg::Append {
+            run_id: "run-a".to_string(),
+            record: Box::new(batch_record(0, "c1")),
+            ack: Some(ack_tx),
+        })
+        .unwrap();
+        tx.send(PersistMsg::Append {
+            run_id: "run-a".to_string(),
+            record: Box::new(batch_record(0, "c2")),
+            ack: None, // the fire-and-forget shape drains too
+        })
+        .unwrap();
+        drop(tx);
+        persistence_worker(None, rx).await;
+        assert_eq!(ack_rx.await, Ok(()));
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -50,6 +50,8 @@ mod response;
 pub use response::*;
 mod inference;
 pub use inference::*;
+mod resolve;
+pub use resolve::*;
 
 // ─── Phase marker components (an agent is in exactly one) ────────────────────
 

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -1,0 +1,382 @@
+//! Stage model and tool resolution: turning a blueprint's per-stage
+//! [`ModelConfig`] and `available_tools` into concrete [`ResolvedStage`]s
+//! against whatever providers and tools the host actually has.
+//!
+//! Lives in the runtime (rather than the CLI daemon, where it started) so an
+//! embedding host resolves stages exactly the way `lev run` does. The one
+//! policy input the CLI used to read from its config file - the user's default
+//! provider/model - arrives as a plain [`ModelDefaults`] value instead.
+
+use leviath_core::Blueprint;
+use leviath_core::blueprint::ModelConfig;
+
+use super::ResolvedStage;
+use crate::providers::ProviderRegistry;
+use leviath_providers::Tool;
+
+/// The user's default provider/model, the fallback when none of a stage's
+/// listed models has a registered provider. The CLI fills this from
+/// `config.toml`; an embedder sets it on the world builder (or leaves it
+/// empty, keeping the blueprint's own entries as the last resort).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModelDefaults {
+    /// The default provider name (e.g. `anthropic`).
+    pub provider: String,
+    /// The default model, if the user configured one.
+    pub model: Option<String>,
+}
+
+/// Resolve a stage's [`ModelConfig`] to a concrete `(provider, model)` against
+/// the registered providers. Honors a `--model` override (`provider/model` or a
+/// bare `model`), otherwise picks the first listed model whose provider is
+/// registered, then falls back to the user default (when `allow_user_default`),
+/// and finally to the config's first listed entry. (Ported from the executor's
+/// inline resolution.)
+pub fn resolve_stage_model(
+    model_cfg: &ModelConfig,
+    model_override: Option<&str>,
+    defaults: &ModelDefaults,
+    registry: &ProviderRegistry,
+) -> (String, String) {
+    let (override_provider, override_model) = match model_override {
+        Some(ov) if ov.contains('/') => {
+            let (p, m) = ov.split_once('/').unwrap();
+            (Some(p.to_string()), Some(m.to_string()))
+        }
+        Some(ov) => (None, Some(ov.to_string())),
+        None => (None, None),
+    };
+
+    // Full provider/model override wins outright.
+    if let Some(provider) = override_provider {
+        return (provider, override_model.unwrap_or_default());
+    }
+
+    // First listed model whose provider is registered.
+    for entry in &model_cfg.models {
+        if registry.has(&entry.provider) {
+            let model = override_model
+                .clone()
+                .unwrap_or_else(|| entry.model.clone());
+            return (entry.provider.clone(), model);
+        }
+    }
+
+    // Fall back to the user's default model, or finally the first listed entry.
+    user_default_model(model_cfg, override_model.as_deref(), defaults, registry).unwrap_or_else(
+        || {
+            (
+                model_cfg.provider().to_string(),
+                model_cfg.model().to_string(),
+            )
+        },
+    )
+}
+
+/// The user-default fallback for [`resolve_stage_model`]: `None` when the stage
+/// forbids it or no usable default exists.
+fn user_default_model(
+    model_cfg: &ModelConfig,
+    override_model: Option<&str>,
+    defaults: &ModelDefaults,
+    registry: &ProviderRegistry,
+) -> Option<(String, String)> {
+    if !model_cfg.allow_user_default {
+        return None;
+    }
+    if let Some(model) = override_model {
+        return Some((defaults.provider.clone(), model.to_string()));
+    }
+    if let Some(default_model) = &defaults.model
+        && registry.has(&defaults.provider)
+    {
+        return Some((defaults.provider.clone(), default_model.clone()));
+    }
+    None
+}
+
+/// Filter `all` tool defs down to those a stage's `available_tools` names
+/// (alias-resolved). Shared by spawn-time stage resolution and the mid-run
+/// tool-service refresh so both apply Layer-1 identically.
+pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool> {
+    if available.is_empty() {
+        return Vec::new();
+    }
+    all.iter()
+        .filter(|t| {
+            available
+                .iter()
+                .any(|n| leviath_tools::canonical_tool_name(n) == t.name)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Resolve every stage's provider/model + effective tool set from the blueprint.
+pub fn resolve_stages(
+    blueprint: &Blueprint,
+    model_override: Option<&str>,
+    defaults: &ModelDefaults,
+    registry: &ProviderRegistry,
+    all_tool_defs: &[Tool],
+) -> Vec<ResolvedStage> {
+    blueprint
+        .stages
+        .iter()
+        .map(|stage| {
+            let (provider_name, model) =
+                resolve_stage_model(&stage.model, model_override, defaults, registry);
+            // Empty `available_tools` exposes no tools; otherwise filter the full
+            // set by name (alias-resolved). A name matching nothing (a typo, or an
+            // MCP tool whose server isn't installed) is simply omitted.
+            let tools = filter_tools_by_available(all_tool_defs, &stage.available_tools);
+            ResolvedStage {
+                provider_name,
+                model,
+                tools,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::blueprint::ModelEntry;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn model_cfg(models: Vec<(&str, &str)>) -> ModelConfig {
+        ModelConfig {
+            models: models
+                .into_iter()
+                .map(|(p, m)| ModelEntry {
+                    provider: p.to_string(),
+                    model: m.to_string(),
+                })
+                .collect(),
+            allow_user_default: true,
+            parameters: HashMap::new(),
+            request_timeout_secs: None,
+        }
+    }
+
+    fn registry_with(providers: &[&str]) -> ProviderRegistry {
+        let mut r = ProviderRegistry::new();
+        for p in providers {
+            r.register(p.to_string(), Arc::new(FakeProvider));
+        }
+        r
+    }
+
+    struct FakeProvider;
+    #[async_trait::async_trait]
+    impl leviath_providers::Provider for FakeProvider {
+        async fn infer(
+            &self,
+            _r: leviath_providers::InferenceRequest,
+        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+            Err(leviath_providers::ProviderError::Other(
+                "test provider".to_string(),
+            ))
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            1000
+        }
+        fn name(&self) -> &str {
+            "fake"
+        }
+        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn fake_provider_is_a_minimal_registry_stub() {
+        // The resolver only asks the registry `has()`, so the fixture provider
+        // is inert; this pins its stub answers so the impl stays measured.
+        use leviath_providers::Provider as _;
+        let p = FakeProvider;
+        let request: leviath_providers::InferenceRequest =
+            serde_json::from_value(serde_json::json!({
+                "messages": [],
+                "model": "m",
+                "max_tokens": 1,
+                "temperature": 0.0,
+                "tools": [],
+                "extra": null,
+            }))
+            .unwrap();
+        assert!(p.infer(request).await.is_err());
+        assert_eq!(p.count_tokens("x", "m").await, 1);
+        assert_eq!(p.max_context_tokens("m"), 1000);
+        assert_eq!(p.name(), "fake");
+        let _ = p.capabilities("m");
+    }
+
+    #[test]
+    fn resolve_full_override_wins() {
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("anthropic", "x")]),
+            Some("openai/gpt-5"),
+            &ModelDefaults::default(),
+            &registry_with(&[]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("openai", "gpt-5"));
+    }
+
+    #[test]
+    fn resolve_first_available_model() {
+        // anthropic not registered, openai is → picks openai.
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("anthropic", "a"), ("openai", "o")]),
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&["openai"]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("openai", "o"));
+    }
+
+    #[test]
+    fn resolve_model_only_override_keeps_available_provider() {
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("openai", "o")]),
+            Some("gpt-override"),
+            &ModelDefaults::default(),
+            &registry_with(&["openai"]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("openai", "gpt-override"));
+    }
+
+    #[test]
+    fn resolve_user_default_when_nothing_listed_available() {
+        // Listed provider "ghost" is unavailable; anthropic (the default) is.
+        let defaults = ModelDefaults {
+            provider: "anthropic".to_string(),
+            model: Some("claude-default".to_string()),
+        };
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("ghost", "g")]),
+            None,
+            &defaults,
+            &registry_with(&["anthropic"]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("anthropic", "claude-default"));
+    }
+
+    #[test]
+    fn resolve_user_default_with_model_override() {
+        let defaults = ModelDefaults {
+            provider: "anthropic".to_string(),
+            model: None,
+        };
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("ghost", "g")]),
+            Some("just-a-model"),
+            &defaults,
+            &registry_with(&[]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("anthropic", "just-a-model"));
+    }
+
+    #[test]
+    fn resolve_user_default_provider_unavailable_falls_through() {
+        // allow_user_default, a default model set, but the default provider isn't
+        // registered ⇒ neither user-default branch fires ⇒ last resort.
+        let defaults = ModelDefaults {
+            provider: "ghost-default".to_string(),
+            model: Some("dm".to_string()),
+        };
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("ghost", "g")]),
+            None,
+            &defaults,
+            &registry_with(&[]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
+    }
+
+    #[test]
+    fn resolve_last_resort_first_listed() {
+        // No override, nothing available, no usable default → first listed entry.
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("ghost", "g")]),
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&[]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
+    }
+
+    #[test]
+    fn resolve_no_user_default_uses_last_resort() {
+        let mut cfg = model_cfg(vec![("ghost", "g")]);
+        cfg.allow_user_default = false; // forbid the default fallback
+        let defaults = ModelDefaults {
+            provider: "anthropic".to_string(),
+            model: Some("would-be-default".to_string()),
+        };
+        let (p, m) = resolve_stage_model(&cfg, None, &defaults, &registry_with(&["anthropic"]));
+        assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
+    }
+
+    #[test]
+    fn resolve_stages_empty_available_tools_gets_none() {
+        let mut stage =
+            leviath_core::Stage::new("s".to_string(), model_cfg(vec![("anthropic", "m")]));
+        stage.available_tools = vec![]; // empty ⇒ no tools
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+        let tools = vec![Tool {
+            name: "read_file".to_string(),
+            description: String::new(),
+            parameters: serde_json::Value::Null,
+        }];
+        let resolved = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&["anthropic"]),
+            &tools,
+        );
+        assert!(resolved[0].tools.is_empty());
+    }
+
+    #[test]
+    fn resolve_stages_matches_by_alias_and_skips_unknown_names() {
+        // A stage names `bash` (an alias) and a not-installed MCP tool. The
+        // filter must select the canonical `shell` definition for the alias and
+        // silently omit the unknown name (no error, no panic).
+        let mut stage =
+            leviath_core::Stage::new("s".to_string(), model_cfg(vec![("anthropic", "m")]));
+        stage.available_tools = vec!["bash".to_string(), "acme__uninstalled".to_string()];
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+        let tools = vec![
+            Tool {
+                name: "shell".to_string(),
+                description: String::new(),
+                parameters: serde_json::Value::Null,
+            },
+            Tool {
+                name: "read_file".to_string(),
+                description: String::new(),
+                parameters: serde_json::Value::Null,
+            },
+        ];
+        let resolved = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&["anthropic"]),
+            &tools,
+        );
+        let selected: Vec<&str> = resolved[0].tools.iter().map(|t| t.name.as_str()).collect();
+        // `bash` resolved to `shell`; the unknown MCP name and unlisted
+        // `read_file` were both excluded.
+        assert_eq!(selected, vec!["shell"]);
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8552,3 +8552,211 @@ fn collect_compaction_records_success_and_failure() {
         vec![crate::telemetry::ActivityRecord::Compaction { success: false }]
     );
 }
+
+// ── source-emitted world events (stage transitions + tool calls) ──
+
+#[test]
+fn resolve_transition_emits_a_stage_transition_event() {
+    use crate::host::{WorldEvent, WorldEventSink};
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let mut world = World::new();
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let e = spawn_transition_agent(
+        &mut world,
+        bp,
+        vec![stage("m", vec![], None), stage("m", vec![], None)],
+        VisitCounts::default(),
+    );
+    world.entity_mut(e).insert(run_metadata());
+
+    run_transition(&mut world);
+
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    let ev = sink_rx.try_recv().expect("stage transition event");
+    assert_eq!(
+        ev,
+        WorldEvent::StageTransition {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            from: "s".to_string(), // the fixture agent's starting stage name
+            to: "b".to_string(),
+            iteration: 1,
+        }
+    );
+    assert!(sink_rx.try_recv().is_err(), "exactly one event");
+}
+
+#[test]
+fn stage_transition_event_needs_run_metadata() {
+    use crate::host::WorldEventSink;
+    // A sink is installed but the agent carries no RunMetadata (a bare test
+    // agent): the transition happens, the stream stays silent.
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let mut world = World::new();
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let e = spawn_transition_agent(
+        &mut world,
+        bp,
+        vec![stage("m", vec![], None), stage("m", vec![], None)],
+        VisitCounts::default(),
+    );
+
+    run_transition(&mut world);
+
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    assert!(sink_rx.try_recv().is_err(), "no event without metadata");
+}
+
+#[test]
+fn collect_choice_emits_a_stage_transition_event() {
+    use crate::host::{WorldEvent, WorldEventSink};
+    let (mut world, tx) = world_with_transition_results();
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let e = spawn_responding_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1")],
+        vec![plain_edge("b")],
+    );
+    world.entity_mut(e).insert(run_metadata());
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(resp("b")),
+    })
+    .unwrap();
+
+    run_collect_transition(&mut world);
+
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    let ev = sink_rx.try_recv().expect("stage transition event");
+    assert_eq!(
+        ev,
+        WorldEvent::StageTransition {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            from: "s".to_string(),
+            to: "b".to_string(),
+            iteration: 1,
+        }
+    );
+}
+
+#[tokio::test]
+async fn dispatch_tools_announces_lane_calls() {
+    use crate::host::{WorldEvent, WorldEventSink};
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage(jtx));
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_result(true),
+            conv_window(),
+            ReadyForTools,
+            run_metadata(),
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    assert!(world.get::<AwaitingTools>(e).is_some());
+    let _ = jrx.try_recv().expect("job enqueued");
+    let ev = sink_rx.try_recv().expect("tool call started event");
+    assert_eq!(
+        ev,
+        WorldEvent::ToolCallStarted {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            call_id: "t".to_string(),
+            tool: "n".to_string(),
+        }
+    );
+    assert!(sink_rx.try_recv().is_err(), "one event per lane call");
+}
+
+#[test]
+fn collect_tools_reports_finished_lane_calls() {
+    use crate::host::{WorldEvent, WorldEventSink};
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolResults(rx));
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let e = world
+        .spawn((
+            ctx(&[("conversation", 10_000)]),
+            infer_with(vec![tc("c1", "read"), tc("c2", "write")]),
+            agent_state(),
+            run_metadata(),
+            AwaitingTools,
+        ))
+        .id();
+    tx.send(ToolOutcome {
+        elapsed: std::time::Duration::ZERO,
+        entity: e,
+        // A success, a failure, and a result whose id matches no known call
+        // (the tool name falls back to empty rather than panicking).
+        results: vec![
+            ("c1".to_string(), "file body".to_string()),
+            ("c2".to_string(), "[error] denied".to_string()),
+            ("zz".to_string(), "stray".to_string()),
+        ],
+    })
+    .unwrap();
+
+    run_collect_tools(&mut world);
+
+    assert_eq!(
+        sink_rx.try_recv().expect("first finish"),
+        WorldEvent::ToolCallFinished {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            call_id: "c1".to_string(),
+            tool: "read".to_string(),
+            ok: true,
+            summary: "file body".to_string(),
+        }
+    );
+    assert_eq!(
+        sink_rx.try_recv().expect("second finish"),
+        WorldEvent::ToolCallFinished {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            call_id: "c2".to_string(),
+            tool: "write".to_string(),
+            ok: false,
+            summary: "[error] denied".to_string(),
+        }
+    );
+    assert_eq!(
+        sink_rx.try_recv().expect("stray finish"),
+        WorldEvent::ToolCallFinished {
+            run_id: "run-1".to_string(),
+            agent_id: "a".to_string(),
+            call_id: "zz".to_string(),
+            tool: String::new(),
+            ok: true,
+            summary: "stray".to_string(),
+        }
+    );
+    assert!(sink_rx.try_recv().is_err(), "no extra events");
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8661,7 +8661,7 @@ async fn dispatch_tools_announces_lane_calls() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
     world.insert_resource(WorldEventSink(sink_tx));
     let e = world

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -332,9 +332,14 @@ pub fn collect_tools(
             Option<&mut StageProgress>,
             Option<&mut crate::persistence::RunOutcomeFlags>,
             Option<&mut crate::telemetry::StageActivity>,
+            (
+                Option<&crate::persistence::RunMetadata>,
+                Option<&crate::components::AgentState>,
+            ),
         ),
         With<AwaitingTools>,
     >,
+    sink: Option<Res<crate::host::WorldEventSink>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -352,11 +357,33 @@ pub fn collect_tools(
             progress,
             flags,
             activity,
+            (metadata, agent_state),
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(outcome.entity);
+        // Report each lane call's completion before file tracking rewrites
+        // successful results. Pairs with `ToolCallStarted` by call id; inline
+        // context results (merged below) were never announced and are skipped.
+        if let (Some(sink), Some(md), Some(state)) = (sink.as_ref(), metadata, agent_state) {
+            for (id, result) in &outcome.results {
+                let tool = infer
+                    .tool_calls
+                    .iter()
+                    .find(|c| &c.tool_id == id)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_default();
+                let _ = sink.0.send(crate::host::WorldEvent::ToolCallFinished {
+                    run_id: md.run_id.clone(),
+                    agent_id: state.agent_id.clone(),
+                    call_id: id.clone(),
+                    tool,
+                    ok: !call_had_no_effect(result),
+                    summary: one_line(result, 200),
+                });
+            }
+        }
         // Merge the inline context-tool results (if any) with the lane results,
         // ordered by the original tool calls.
         let mut parts = outcome.results;

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -304,6 +304,7 @@ pub fn dispatch_tools(
     hub: Option<Res<InteractionHub>>,
     gate_stage: Option<Res<crate::gate_prompt::GatePromptStage>>,
     persist: Option<Res<PersistenceStage>>,
+    sink: Option<Res<crate::host::WorldEventSink>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -560,6 +561,19 @@ pub fn dispatch_tools(
             }
             _ => (noop_progress(), None),
         };
+        // Announce each lane-bound call before it starts executing. Inline
+        // results (context tools, refusals, blocks) never reach the lane and
+        // are deliberately not announced.
+        if let (Some(sink), Some(md)) = (sink.as_ref(), metadata) {
+            for call in &lane_calls {
+                let _ = sink.0.send(crate::host::WorldEvent::ToolCallStarted {
+                    run_id: md.run_id.clone(),
+                    agent_id: state.agent_id.clone(),
+                    call_id: call.id.clone(),
+                    tool: call.name.clone(),
+                });
+            }
+        }
         let exec = service.0.exec_for(entity, lane_calls, progress);
         let exec = match ack {
             Some(ack) => barrier_then(exec, ack, BATCH_JOURNAL_ACK_TIMEOUT),

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -846,9 +846,11 @@ pub fn resolve_transition(
             &mut ContextWindow,
             Option<&StageOutcome>,
             Option<&mut crate::persistence::RunOutcomeFlags>,
+            Option<&crate::persistence::RunMetadata>,
         ),
         With<ResolveTransition>,
     >,
+    sink: Option<Res<crate::host::WorldEventSink>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -865,6 +867,7 @@ pub fn resolve_transition(
         mut window,
         outcome,
         mut flags,
+        metadata,
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -952,6 +955,7 @@ pub fn resolve_transition(
                 // new stage's layout/prompt setup.
                 let to_compact = apply_edge_transform(&mut window, &transform);
                 let setup = &setups.0[idx];
+                let from = state.current_stage.clone();
                 match enter_stage(
                     idx,
                     &bp.0,
@@ -962,11 +966,12 @@ pub fn resolve_transition(
                     setup,
                     &mut window,
                 ) {
-                    Ok(()) => {
+                    Ok(visit) => {
                         // Entering a stage is active work; clears a prior error
                         // status when recovering down an `error` edge.
                         state.status = AgentStatus::Active;
                         let name = bp.0.stages[idx].name.clone();
+                        emit_stage_transition(&sink, metadata, &state.agent_id, from, &name, visit);
                         let mut ec = commands.entity(entity);
                         ec.remove::<ResolveTransition>().remove::<StageOutcome>();
                         attach_stage_components(ec, stage_infs.0[idx].clone(), setup, idx, name);
@@ -1014,6 +1019,9 @@ pub fn resolve_transition(
 ///
 /// Returns `Err` only when the system prompt doesn't fit its region - the same
 /// hard failure the imperative loop raises; the caller marks the agent `Error`.
+/// `Ok` carries the stage's updated visit count (this entry included), which the
+/// transition systems stamp into the [`StageTransition`](crate::host::WorldEvent)
+/// event.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn enter_stage(
     idx: usize,
@@ -1024,15 +1032,40 @@ pub(crate) fn enter_stage(
     visits: &mut VisitCounts,
     setup: &StageSetup,
     window: &mut ContextWindow,
-) -> Result<(), String> {
+) -> Result<usize, String> {
     cursor.index = idx;
     let name = blueprint.stages[idx].name.clone();
     state.current_stage = name.clone();
     state.accepts_messages = setup.accepts_messages;
     *progress = StageProgress::default();
-    *visits.0.entry(name).or_insert(0) += 1;
+    let visit = visits.0.entry(name).or_insert(0);
+    *visit += 1;
+    let visit = *visit;
 
-    apply_stage_context(setup, window)
+    apply_stage_context(setup, window).map(|()| visit)
+}
+
+/// Push a [`StageTransition`](crate::host::WorldEvent::StageTransition) event
+/// into the world's event stream. A no-op in worlds that don't stream (no
+/// [`WorldEventSink`](crate::host::WorldEventSink) resource) and for bare
+/// agents without run metadata.
+fn emit_stage_transition(
+    sink: &Option<Res<crate::host::WorldEventSink>>,
+    metadata: Option<&crate::persistence::RunMetadata>,
+    agent_id: &str,
+    from: String,
+    to: &str,
+    iteration: usize,
+) {
+    if let (Some(sink), Some(md)) = (sink.as_ref(), metadata) {
+        let _ = sink.0.send(crate::host::WorldEvent::StageTransition {
+            run_id: md.run_id.clone(),
+            agent_id: agent_id.to_string(),
+            from,
+            to: to.to_string(),
+            iteration,
+        });
+    }
 }
 
 /// Apply a stage's context setup to a window: swap to the stage's layout (if any)
@@ -1157,7 +1190,7 @@ pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
             &setup,
             &mut window,
         ) {
-            Ok(()) => Some((stage_inf, setup, name)),
+            Ok(_) => Some((stage_inf, setup, name)),
             Err(message) => {
                 state.status = AgentStatus::Error { message };
                 None
@@ -1709,7 +1742,9 @@ pub fn collect_transition_choice(
         &mut ContextWindow,
         &AwaitingTransitionResponse,
         Option<&mut crate::persistence::RunOutcomeFlags>,
+        Option<&crate::persistence::RunMetadata>,
     )>,
+    sink: Option<Res<crate::host::WorldEventSink>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -1725,6 +1760,7 @@ pub fn collect_transition_choice(
             mut window,
             resp,
             mut flags,
+            metadata,
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -1802,6 +1838,7 @@ pub fn collect_transition_choice(
                 }
                 let to_compact = apply_edge_transform(&mut window, &transform);
                 let setup = &setups.0[idx];
+                let from = state.current_stage.clone();
                 match enter_stage(
                     idx,
                     &bp.0,
@@ -1812,8 +1849,9 @@ pub fn collect_transition_choice(
                     setup,
                     &mut window,
                 ) {
-                    Ok(()) => {
+                    Ok(visit) => {
                         let name = bp.0.stages[idx].name.clone();
+                        emit_stage_transition(&sink, metadata, &state.agent_id, from, &name, visit);
                         let mut ec = commands.entity(outcome.entity);
                         ec.remove::<AwaitingTransitionResponse>();
                         attach_stage_components(ec, stage_infs.0[idx].clone(), setup, idx, name);

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -417,32 +417,28 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
     async fn pool_runs_batches_concurrently_and_all_exit_on_close() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::time::Duration;
 
         let (jtx, jrx) = mpsc::unbounded_channel();
         let (rtx, mut rrx) = mpsc::unbounded_channel();
         let wake = Arc::new(Notify::new());
 
-        // Three jobs that each block on a barrier: they can only all finish if
-        // they run concurrently (a single-worker lane would deadlock the test's
-        // timeout). A shared counter + Notify serves as the rendezvous.
-        let arrived = Arc::new(AtomicUsize::new(0));
-        let go = Arc::new(Notify::new());
+        // Three jobs that each block on a rendezvous: they can only all finish
+        // if they run concurrently (a single-worker lane would deadlock the
+        // test's timeout). `tokio::sync::Barrier` rather than a hand-rolled
+        // counter + Notify: `notify_waiters` only wakes ALREADY-registered
+        // waiters, so the old counter check had a lost-wakeup window between
+        // loading the count and registering on `notified()` - a real deadlock
+        // that slow CI runners hit.
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
         for i in 1..=3u32 {
-            let arrived = arrived.clone();
-            let go = go.clone();
+            let barrier = barrier.clone();
             jtx.send(ToolJob {
                 entity: Entity::from_raw_u32(i).expect("index came from a live entity id"),
                 exec: Box::new(move || {
                     Box::pin(async move {
-                        if arrived.fetch_add(1, Ordering::SeqCst) + 1 == 3 {
-                            go.notify_waiters();
-                        }
-                        // Wait until all three have arrived (proving concurrency).
-                        while arrived.load(Ordering::SeqCst) < 3 {
-                            go.notified().await;
-                        }
+                        // Blocks until all three have arrived (proving concurrency).
+                        barrier.wait().await;
                         vec![("c".to_string(), "r".to_string())]
                     })
                 }),
@@ -460,9 +456,10 @@ mod tests {
             3,
             Arc::new(ToolLaneStats::new(3)),
         );
-        // All three outcomes must arrive; bounded so a serialization bug fails fast.
+        // All three outcomes must arrive; bounded so a serialization bug fails
+        // fast (generous for oversubscribed CI runners, instant when passing).
         for _ in 0..3 {
-            tokio::time::timeout(Duration::from_secs(5), rrx.recv())
+            tokio::time::timeout(Duration::from_secs(60), rrx.recv())
                 .await
                 .expect("all batches complete concurrently")
                 .expect("outcome present");

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1942,6 +1942,7 @@ mod tests {
                 callback_url: None,
                 callback_secret: None,
                 title: None,
+                unattended: false,
             },
             crate::persistence::TokenTotals::default(),
             crate::pipeline::PersistWatermark::default(),

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -368,6 +368,11 @@ impl PipelineWorld {
 
     /// Mutable access to the underlying ECS world, for spawning agents (the CLI /
     /// daemon builds each agent's component bundle) and inspection.
+    ///
+    /// This is the unstable layer: it exposes raw `bevy_ecs` (re-exported as
+    /// [`crate::ecs`] so versions stay aligned) and carries no compatibility
+    /// promise across releases. Prefer [`crate::AgentWorld`] or
+    /// [`crate::host::WorldHost`] unless you are building your own assembly.
     pub fn world_mut(&mut self) -> &mut World {
         &mut self.world
     }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -173,12 +173,17 @@ impl PipelineWorld {
     /// Build a world: wire the pool/bridge resources, register the providers and
     /// tool service, spawn the tool worker onto `runtime`, and assemble the tick
     /// schedule. Agents are added later via [`Self::spawn_agent`].
+    ///
+    /// `runs_dir` is where agent snapshots persist (`<runs_dir>/<run_id>/`, the
+    /// daemon's on-disk layout). `None` keeps the world entirely in memory:
+    /// snapshots are still produced and drained (so log events and watermarks
+    /// behave identically) but nothing is ever written to disk.
     pub fn new(
         providers: ProviderRegistry,
         tool_service: Arc<dyn ToolService>,
         pool_config: InferencePoolConfig,
         tool_concurrency: usize,
-        runs_dir: std::path::PathBuf,
+        runs_dir: Option<std::path::PathBuf>,
         runtime: Handle,
     ) -> Self {
         // `Query::par_iter` fans out over the compute task pool; initialize it
@@ -1074,14 +1079,14 @@ mod tests {
     }
 
     fn build_world(providers: ProviderRegistry) -> PipelineWorld {
-        // These agents carry no RunMetadata, so persistence never fires and the
-        // runs dir is never written; any path is fine.
+        // These agents carry no RunMetadata, so persistence never fires; run the
+        // world fully in memory.
         PipelineWorld::new(
             providers,
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            std::env::temp_dir(),
+            None,
             Handle::current(),
         )
     }
@@ -1568,7 +1573,7 @@ mod tests {
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            dir.path().to_path_buf(),
+            Some(dir.path().to_path_buf()),
             Handle::current(),
         );
         world.spawn_agent((
@@ -1653,7 +1658,7 @@ mod tests {
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            dir.path().to_path_buf(),
+            Some(dir.path().to_path_buf()),
             Handle::current(),
         );
         world.spawn_agent((
@@ -1754,7 +1759,7 @@ mod tests {
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            dir.path().to_path_buf(),
+            Some(dir.path().to_path_buf()),
             Handle::current(),
         );
         world.insert_interaction_hub(crate::interaction_hub::InteractionHub::new());
@@ -1838,7 +1843,7 @@ mod tests {
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            dir.path().to_path_buf(),
+            Some(dir.path().to_path_buf()),
             Handle::current(),
         );
         world.spawn_agent((
@@ -1891,6 +1896,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn in_memory_world_runs_and_flushes_without_touching_disk() {
+        // `runs_dir: None` is the embedding mode: the agent runs to completion,
+        // snapshots are produced and drained exactly as in the persistent world
+        // (same watermark/log behavior), but nothing lands on disk. The tempdir
+        // doubles as the agent workdir and as the canary a persistent world
+        // would have written run dirs and a machine-id into.
+        let dir = tempfile::tempdir().unwrap();
+        let mut world = PipelineWorld::new(
+            registry_with(vec![with_tool("c1", "do"), text("done")]),
+            Arc::new(EchoTools),
+            InferencePoolConfig::new(),
+            1,
+            None,
+            Handle::current(),
+        );
+        let entity = world.spawn_agent((
+            AgentBlueprint(blueprint()),
+            StageCursor { index: 0 },
+            agent_state(),
+            crate::components::MessageInbox::default(),
+            StageProgress::default(),
+            StageInferences(vec![stage("m")]),
+            StageSetups(vec![setup()]),
+            VisitCounts::default(),
+            window(),
+            stage("m"),
+            setup().inference_config,
+            crate::persistence::RunMetadata {
+                run_id: "run-inmem".to_string(),
+                agent_name: "a".to_string(),
+                agent_path: "/p".to_string(),
+                task: "t".to_string(),
+                model: None,
+                workdir: dir.path().to_string_lossy().to_string(),
+                num_stages: 1,
+                started_at: 0,
+                parent_run_id: None,
+                metadata: std::collections::HashMap::new(),
+                callback_url: None,
+                callback_secret: None,
+                title: None,
+            },
+            crate::persistence::TokenTotals::default(),
+            crate::pipeline::PersistWatermark::default(),
+            ReadyToInfer,
+        ));
+
+        world.run_until_idle(20).await;
+        world.flush_and_stop().await;
+
+        assert_eq!(world.agent_status(entity), Some(AgentStatus::Complete));
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
     async fn world_init_and_restore_needs_no_daemon_infra() {
         // `PipelineWorld::new` + `restore::restore_agent` form a self-contained
         // spin-up→restore path: no control socket, HTTP server, PID files, or build
@@ -1905,7 +1965,7 @@ mod tests {
             Arc::new(EchoTools),
             InferencePoolConfig::new(),
             1,
-            dir.path().to_path_buf(),
+            Some(dir.path().to_path_buf()),
             Handle::current(),
         );
         let entity = world.spawn_agent((

--- a/crates/leviath/Cargo.toml
+++ b/crates/leviath/Cargo.toml
@@ -17,6 +17,12 @@ readme = "README.md"
 # to count), so any executable code added here would ship untested. The guard
 # fails the build on anything other than doc comments and `pub use` lines.
 
+[features]
+# The daemon's control transport, forwarded from leviath-runtime. Off by
+# default: embedders talk to the world in-process via leviath::runtime's
+# AgentWorld; only a client for a running lev daemon needs the socket.
+control-socket = ["leviath-runtime/control-socket"]
+
 [dependencies]
 leviath-core = { workspace = true }
 leviath-runtime = { workspace = true }

--- a/crates/leviath/Cargo.toml
+++ b/crates/leviath/Cargo.toml
@@ -34,5 +34,9 @@ leviath-telemetry = { workspace = true }
 leviath-package = { workspace = true }
 leviath-agent-client = { workspace = true }
 
+# For examples/ only (the library itself is re-exports and needs nothing).
+[dev-dependencies]
+tokio = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/leviath/README.md
+++ b/crates/leviath/README.md
@@ -12,29 +12,50 @@ one namespace so an application only needs a single dependency:
 leviath = "0.1"
 ```
 
+Running an agent in-process takes a provider, a blueprint, and an event
+loop. No daemon, no config file:
+
 ```rust
-use leviath::core::manifest::parse_manifest;
+use leviath::prelude::*;
 
-fn main() -> leviath::core::Result<()> {
-    let blueprint = parse_manifest(
-        r#"
-        [agent]
-        name = "hello"
-        version = "0.1.0"
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let world = AgentWorld::builder()
+        .provider(ProviderCreds {
+            api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+            ..ProviderCreds::simple("anthropic")
+        })
+        .build()?;
 
-        [model]
-        provider = "anthropic"
-        model = "claude-sonnet-4-6"
+    let mut events = world.events();
+    let run = world
+        .spawn(SpawnSpec::new(
+            BlueprintSource::Path("coder.leviath".into()),
+            "Build a CSV parser",
+            std::env::current_dir()?,
+        ))
+        .await?;
 
-        [[stages]]
-        name = "work"
-        prompt = "Do the task."
-        "#,
-    )?;
-    println!("{} has {} stage(s)", blueprint.name, blueprint.stages.len());
+    while let Some(event) = events.next().await {
+        match event {
+            AgentEvent::StageTransition { from, to, .. } => println!("{from} -> {to}"),
+            AgentEvent::Completed { run_id, status, .. } if run_id == run.as_ref() => {
+                println!("finished: {status}");
+                break;
+            }
+            _ => {}
+        }
+    }
+    world.shutdown().await;
     Ok(())
 }
 ```
+
+A full program that also answers the agent's questions lives in
+`examples/embedded_agent.rs` (`cargo run --example embedded_agent -p
+leviath`), and the embedding guide at
+[leviath.dev/docs/embedding](https://leviath.dev/docs/embedding) walks
+through the builder options, the event stream, and the tool-service seam.
 
 The most-used types are one import away with `use leviath::prelude::*;`.
 

--- a/crates/leviath/examples/embedded_agent.rs
+++ b/crates/leviath/examples/embedded_agent.rs
@@ -1,0 +1,102 @@
+//! A complete embedded agent: build a world, spawn one agent, stream its
+//! events, and answer its questions from the terminal.
+//!
+//! Run with an Anthropic API key:
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=sk-... cargo run --example embedded_agent -p leviath
+//! ```
+//!
+//! The agent works in the current directory with the read-only built-in
+//! tools, so it is safe to point at any checkout.
+
+use leviath::prelude::*;
+
+/// A self-contained blueprint: explore the workdir, ask one clarifying
+/// question if needed, and report. No manifest file required.
+const BLUEPRINT: &str = r#"[agent]
+name = "explorer"
+version = "0.1.0"
+description = "Looks around the working directory and reports what it finds."
+entry_stage = "explore"
+
+[stages.explore]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "Explore and summarize"
+available_tools = ["read_file", "list_dir", "ask_user_text"]
+allow_complete = true
+system_prompt = """
+Look at the files in the working directory and produce a short summary of
+what this project is. Use list_dir and read_file. If something important is
+ambiguous, ask the user one question with ask_user_text. Finish with a
+plain-text summary.
+"""
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 2000, seed = "task_input" }
+conversation = { kind = "sliding_window", max_items = 60, max_tokens = 60000 }
+"#;
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") else {
+        eprintln!("Set ANTHROPIC_API_KEY to run this example:");
+        eprintln!("  ANTHROPIC_API_KEY=sk-... cargo run --example embedded_agent -p leviath");
+        return Ok(());
+    };
+
+    // A world with one provider, fully in memory (add .state_dir(dir) to
+    // persist runs in the daemon's on-disk layout).
+    let world = AgentWorld::builder()
+        .provider(ProviderCreds {
+            api_key: Some(api_key),
+            ..ProviderCreds::simple("anthropic")
+        })
+        .build()?;
+
+    let mut events = world.events();
+    let run = world
+        .spawn(SpawnSpec::new(
+            BlueprintSource::Toml(BLUEPRINT.to_string()),
+            "Tell me what this project is.",
+            std::env::current_dir()?,
+        ))
+        .await?;
+    println!("spawned {run}");
+
+    while let Some(event) = events.next().await {
+        match event {
+            AgentEvent::StageTransition { from, to, .. } => {
+                println!("stage: {from} -> {to}");
+            }
+            AgentEvent::ToolCallStarted { tool, .. } => {
+                println!("tool: {tool}...");
+            }
+            AgentEvent::ToolCallFinished { tool, ok, .. } => {
+                println!("tool: {tool} {}", if ok { "ok" } else { "failed" });
+            }
+            AgentEvent::Interaction { request, .. } => {
+                // The agent asked something; answer from the terminal.
+                println!("agent asks: {}", request.prompt);
+                let mut answer = String::new();
+                std::io::stdin().read_line(&mut answer)?;
+                world.answer(InteractionResponse::text(
+                    request.id.clone(),
+                    answer.trim().to_string(),
+                ));
+            }
+            AgentEvent::Log { line, .. } => {
+                println!("  {line}");
+            }
+            AgentEvent::Completed { run_id, status, .. } if run_id == run.as_ref() => {
+                println!("finished: {status}");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    world.shutdown().await;
+    Ok(())
+}

--- a/crates/leviath/src/lib.rs
+++ b/crates/leviath/src/lib.rs
@@ -7,8 +7,42 @@
 //! crate) is the packaged product; this crate is for embedding the same
 //! machinery in your own application.
 //!
-//! ```
+//! Build a world, spawn an agent, watch the events:
+//!
+//! ```no_run
 //! use leviath::prelude::*;
+//!
+//! # async fn embed() -> std::result::Result<(), Box<dyn std::error::Error>> {
+//! let world = AgentWorld::builder()
+//!     .provider(ProviderCreds {
+//!         api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+//!         ..ProviderCreds::simple("anthropic")
+//!     })
+//!     .build()?;
+//!
+//! let mut events = world.events();
+//! let run = world
+//!     .spawn(SpawnSpec::new(
+//!         BlueprintSource::Path("coder.leviath".into()),
+//!         "Build a CSV parser",
+//!         std::env::current_dir()?,
+//!     ))
+//!     .await?;
+//!
+//! while let Some(event) = events.next().await {
+//!     match event {
+//!         AgentEvent::StageTransition { from, to, .. } => println!("{from} -> {to}"),
+//!         AgentEvent::ToolCallStarted { tool, .. } => println!("running {tool}"),
+//!         AgentEvent::Interaction { request, .. } => {
+//!             // The agent asked a question: answer it via world.answer(...).
+//!         }
+//!         AgentEvent::Completed { run_id, status, .. } if run_id == run.as_ref() => break,
+//!         _ => {}
+//!     }
+//! }
+//! world.shutdown().await;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! Each module below is a re-export of one of the underlying workspace
@@ -55,10 +89,13 @@ pub use leviath_agent_client as agent_client;
 
 /// The types most embeddings touch first, importable in one line.
 pub mod prelude {
+    pub use leviath_core::interaction::{InteractionRequest, InteractionResponse};
     pub use leviath_core::{
-        BudgetSpec, ContextLayout, Error, PolicyConfig, RegionDefinition, Result,
+        Blueprint, BudgetSpec, ContextLayout, Error, PolicyConfig, RegionDefinition, Result,
     };
     pub use leviath_runtime::{
-        AgentState, AgentStatus, ContextWindow, ProviderRegistry, build_provider_registry,
+        AgentEvent, AgentState, AgentStatus, AgentWorld, AgentWorldBuilder, BasicToolService,
+        BlueprintSource, ContextWindow, EmbedError, EventStream, ProviderCreds, ProviderRegistry,
+        RunId, SpawnSpec, ToolService, WorldEvent, build_provider_registry,
     };
 }

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -1,0 +1,157 @@
+---
+title: Embedding
+group: Reference
+group_order: 3
+order: 9
+---
+
+# Embedding Leviath in a Rust application
+
+Leviath is also a library. The same runtime the `lev` daemon serves can run
+inside your own process: add the `leviath` crate, build a world, spawn agents,
+and consume their events as an async stream. No CLI, no daemon, no config
+file, no socket.
+
+```toml
+[dependencies]
+leviath = "0.1"
+tokio = { version = "1", features = ["full"] }
+```
+
+## The shape of it
+
+```rust
+use leviath::prelude::*;
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let world = AgentWorld::builder()
+        .provider(ProviderCreds {
+            api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+            ..ProviderCreds::simple("anthropic")
+        })
+        .build()?;
+
+    let mut events = world.events();
+    let run = world
+        .spawn(SpawnSpec::new(
+            BlueprintSource::Path("coder.leviath".into()),
+            "Build a CSV parser",
+            std::env::current_dir()?,
+        ))
+        .await?;
+
+    while let Some(event) = events.next().await {
+        match event {
+            AgentEvent::StageTransition { from, to, .. } => println!("{from} -> {to}"),
+            AgentEvent::ToolCallFinished { tool, ok, .. } => println!("{tool}: ok={ok}"),
+            AgentEvent::Completed { run_id, status, .. } if run_id == run.as_ref() => {
+                println!("finished: {status}");
+                break;
+            }
+            _ => {}
+        }
+    }
+    world.shutdown().await;
+    Ok(())
+}
+```
+
+`AgentWorld::builder()` must run inside a Tokio runtime (or be handed one via
+`.runtime(handle)`). The serve loop runs as a background task on that runtime;
+`shutdown()` stops it and drains any pending persistence writes before
+returning.
+
+## Builder options
+
+| Method | What it does |
+| --- | --- |
+| `provider(creds)` | Register a provider from credentials. Repeatable. `ProviderCreds::simple(name)` covers key-free providers like `ollama`. |
+| `register_provider(name, arc)` | Register your own `Provider` implementation, including mocks for tests. Wins over a credentials entry with the same name. |
+| `default_model(provider, model)` | The fallback when none of a stage's listed models has a registered provider. |
+| `tool_service(arc)` | Replace the built-in tool service with your own (see below). |
+| `state_dir(dir)` | Persist runs on disk in the daemon's layout (`dir/runs/<run_id>/`). Without it the world is fully in memory and never touches disk. |
+| `inference_pool(config)` | Per-model inference concurrency limits. |
+| `tool_concurrency(n)` | How many tool batches may execute at once (default 4). |
+| `runtime(handle)` | Run on a specific Tokio runtime instead of the ambient one. |
+
+Blueprints come from three places: `BlueprintSource::Path` (a `.leviath`
+manifest file), `BlueprintSource::Toml` (manifest text in memory), or
+`BlueprintSource::Inline` (a constructed `Blueprint` value). Region seeds of
+kind `caller_input` fill from `SpawnSpec::regions` (and the task prompt fills
+the `task` key), `literal` seeds resolve as written; the file, glob, rhai, and
+command seed kinds are daemon behavior and only error when the region is
+`required`.
+
+## Events
+
+Everything the world does streams through `world.events()`, an async stream of
+`AgentEvent` (the same enum the daemon broadcasts to WebSocket clients).
+
+| Event | When |
+| --- | --- |
+| `Spawned` | A run appeared in the world. |
+| `Status` | Status, stage, iteration, or tool-call count changed. |
+| `Tokens` / `Context` | Token totals or context-window usage changed. |
+| `StageTransition` | The run moved from one stage to another. |
+| `ToolCallStarted` / `ToolCallFinished` | A tool call entered the async lane / returned, paired by `call_id`. |
+| `Interaction` | The agent asked something and is waiting on an answer. |
+| `Log` | A readable output or operational log line. |
+| `Completed` | The run reached a terminal status. |
+
+The enum is non-exhaustive; keep a catch-all arm. Every variant carries the
+run id (`event.run_id()`), so one stream serves any number of concurrent
+agents. A consumer that falls behind the channel skips ahead rather than
+erroring, and the stream ends after `shutdown()`.
+
+## Answering an agent's questions
+
+When a blueprint uses `ask_user_text`, `ask_user_choice`, `ask_user_confirm`,
+`present_for_review`, or `edit_document`, the call parks on the interaction
+hub and surfaces as an `Interaction` event carrying the request. Answer it and
+the agent resumes:
+
+```rust
+AgentEvent::Interaction { request, .. } => {
+    let reply = my_ui.ask(&request.prompt).await;
+    world.answer(InteractionResponse::text(request.id.clone(), reply));
+}
+```
+
+`world.pending_inputs()` lists everything currently waiting, if you would
+rather poll than watch the stream.
+
+## Controlling runs
+
+`status`, `pause`, `resume`, `cancel`, and `send_message` all address a run by
+its `RunId`. A completed run is unloaded from memory shortly after its
+`Completed` event; with `state_dir` set, its snapshots stay on disk in the
+same format `lev ps` and the dashboard read.
+
+## What the built-in tool service covers
+
+Embedded agents get the built-in tools (file reads and writes, directory
+listing, shell) confined to the spawn's workdir, plus the interaction tools
+routed through the hub. The daemon-only layers are deliberately absent: MCP
+servers, Rhai script tools, sandboxes, taint gates, and tool-approval
+prompts. The embedder is code, and code that wants richer behavior implements
+the `ToolService` trait and passes it to `tool_service()`; the trait is one
+method plus optional per-stage hooks.
+
+## Stability layers
+
+- `AgentWorld` and the other embed types are the stable surface.
+- `WorldHost` and `PipelineWorld` are the semi-stable machinery underneath,
+  for hosts that need their own assembly (custom spawners, hooks, manual tick
+  control).
+- The raw ECS behind `PipelineWorld::world_mut()` is the unstable escape
+  hatch. It tracks the runtime's `bevy_ecs` version, re-exported as
+  `leviath::runtime::ecs` so downstream code stays version-aligned.
+
+The daemon's control-socket transport is compiled out of library builds by
+default. If you are writing a client for a running `lev` daemon rather than
+hosting agents yourself, enable the `control-socket` feature on the `leviath`
+crate.
+
+A complete runnable program lives at `crates/leviath/examples/embedded_agent.rs`
+in the repository: `cargo run --example embedded_agent -p leviath`.

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -2,7 +2,7 @@
 title: Embedding
 group: Reference
 group_order: 3
-order: 9
+order: 13
 ---
 
 # Embedding Leviath in a Rust application


### PR DESCRIPTION
Closes #72.

Leviath now runs as a library, front-doored by the published `leviath` crate: build a world from plain values, spawn agents, and stream their events in-process. No CLI, daemon, config file, or socket. The daemon remains the primary interface and runs on the exact same machinery.

```rust
use leviath::prelude::*;

let world = AgentWorld::builder()
    .provider(ProviderCreds { api_key, ..ProviderCreds::simple("anthropic") })
    .build()?;
let mut events = world.events();
let run = world.spawn(SpawnSpec::new(blueprint, task, workdir)).await?;
while let Some(event) = events.next().await { /* StageTransition, ToolCall*, Interaction, Completed */ }
world.shutdown().await;
```

## What changed, commit by commit

- **Persistence is opt-in.** `PipelineWorld::new` takes `Option<PathBuf>`; `None` runs fully in memory (no run dirs, no machine-id) with identical log/watermark/flush semantics. The daemon passes `Some(runs_dir)` and is unchanged.
- **Source-emitted events.** `WorldEvent` gains `StageTransition`, `ToolCallStarted`, and `ToolCallFinished`, pushed from the transition and tool systems through the existing `WorldEventSink` (so daemon subscribers get them free). The enum is `#[non_exhaustive]` with a `run_id()` accessor; `lev serve` forwards new variants over WebSocket verbatim as `ServerEvent::World`.
- **Stage/model resolution moved into the runtime.** `resolve_stage_model` / `resolve_stages` / `filter_tools_by_available` now live in `leviath_runtime::pipeline::resolve` with a plain `ModelDefaults` input; the CLI consumes them. Tests moved verbatim.
- **`BasicToolService`.** Built-in file/shell tools confined to each agent's workdir, with `ask_user_*` / `present_for_review` / `edit_document` routed through the `InteractionHub` so the host application answers them. No MCP, script tools, sandboxes, or approval prompts; the `ToolService` trait stays the seam for richer setups.
- **`AgentWorld` + builder + `EventStream` + `EmbedError`.** The embed assembly: same `WorldHost::serve` as the daemon, addressed over an in-process channel. Blueprints spawn from a path, TOML text, or a constructed value; caller-input and literal seeds resolve like the daemon's (file/glob/rhai/command seeds error only when required, follow-up below). `EventStream` implements `futures_core::Stream`, skips lag, and ends on shutdown.
- **`control-socket` feature.** The daemon transport is compiled out of library builds by default (`rand`/`leviath-sys` become optional); the CLI enables it, the facade forwards it.
- **Exports + docs.** Runtime root re-exports (incl. `AgentEvent` alias and `bevy_ecs as ecs` for the escape hatch), facade prelude additions, compiled doctests on both crate roots, a `docs/content/embedding.md` guide, `crates/leviath/examples/embedded_agent.rs`, and a guard-facade allowlist amendment admitting `examples/*.rs` while keeping lib.rs re-export-only.

## Verification

- Every crate at the hard 100% coverage gate; clippy `-D warnings`; full workspace suite green after rebasing onto the nudge-config work.
- **Live-verified**: `cargo run --example embedded_agent` against real Anthropic ran list_dir/read_file, streamed `ToolCallStarted`/`ToolCallFinished`/`Completed`, produced a correct summary, and exited 0 with nothing written to disk (the live run also caught and fixed a double-flush panic on shutdown).
- **Daemon regression, live**: isolated `LEVIATH_HOME`, `lev daemon` + `lev run` through the changed spawn path completed and persisted the daemon's on-disk layout.

## Follow-up candidates (deliberate non-goals here)

- MCP tools, Rhai script tools, and sandboxes for embedded worlds (the `ToolService` seam exists).
- File/glob/rhai/command region seeds in the embed spawner.
- Sub-agent fan-out tools in `BasicToolService`.
- Physically moving `control_socket` out of leviath-runtime (now feature-gated instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb1EkzEy3dmW66DseMF2f1