### PR TITLE
Wake the tick loop when an inference slot is freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ requests since the previous version.
   answer blind.
 - A stage holding for its sub-agents could be walked back to `active` while
   those children were still running, if an unrelated prompt of its own resolved.
+- Fixed a slot leak that could park the daemon with capacity it could not see.
+  Releasing an inference-pool permit now wakes the tick loop, so the agents
+  queued on a full model pool are re-driven and can take the freed slot. A
+  cancelled inference used to hand its slot back in silence, and the loop is
+  event-driven, so the freed capacity stayed invisible until something
+  unrelated happened to wake it.
+- The daemon now re-drives itself on a timer (every 30s) instead of relying
+  solely on wakeups. Any missed wake anywhere is bounded to one interval rather
+  than parking the daemon indefinitely - previously an agent whose provider was
+  not registered, for example, sat at iteration 0 with the daemon completely
+  idle and silent.
+- Added a lane heartbeat so pool pressure is visible: per-model inference
+  occupancy, tool-lane busy/queued counts, and agents by status. It logs at
+  `info` only when a lane is at capacity with work queued behind it, and at
+  `debug` otherwise, so an idle daemon stays quiet.
 - Pause and resume are now user-facing: `lev pause <run-id>` and
   `lev resume <run-id>`, `POST /api/agents/{id}/pause` and `/resume` on the
   HTTP API, and `p`/`r` in the dashboard. A paused run shows as `paused` in

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -15,6 +15,7 @@
 //! resume, a delivered message) is applied immediately.
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use bevy_ecs::entity::Entity;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -454,7 +455,23 @@ pub struct WorldHost {
     /// clone so the receiver never closes (its `recv` never yields `None`).
     subagent_tx: UnboundedSender<SubAgentOp>,
     subagent_rx: UnboundedReceiver<SubAgentOp>,
+    /// How often [`Self::serve`] re-drives the world even though nothing woke
+    /// it. See [`Self::set_redrive_interval`].
+    redrive: Duration,
 }
+
+/// How often the serve loop re-drives the world on its own.
+///
+/// The loop is event-driven, so a missed wake anywhere parks it indefinitely -
+/// the daemon looks alive while nothing progresses, which is what issue #189
+/// reported as hours of frozen agents. This bounds any such wedge to one
+/// interval instead of "until something unrelated happens", and gives the lane
+/// heartbeat a place to run.
+///
+/// Deliberately not configurable: it is a correctness backstop, not a tuning
+/// knob. A no-op re-drive is one tick over a handful of systems plus an event
+/// diff, so at this cadence it costs nothing measurable.
+const DEFAULT_REDRIVE_INTERVAL: Duration = Duration::from_secs(30);
 
 impl WorldHost {
     /// Wrap a world with a fresh interaction hub.
@@ -486,7 +503,49 @@ impl WorldHost {
             emitted_interactions: HashSet::new(),
             subagent_tx,
             subagent_rx,
+            redrive: DEFAULT_REDRIVE_INTERVAL,
         }
+    }
+
+    /// Report what the lanes are holding, once per safety re-drive.
+    ///
+    /// The daemon otherwise logs nothing per tick, by design - observation goes
+    /// through the telemetry sink. But a wedged daemon emits no telemetry either,
+    /// precisely because nothing is happening, so "frozen for hours" left no
+    /// trace at all (issue #189). This is the one periodic line that can answer
+    /// "is anything running, and what is it queued behind?".
+    ///
+    /// Quiet by default: `info` only when a lane is at capacity with work behind
+    /// it, `debug` otherwise, so an idle daemon says nothing at `info`.
+    fn log_lane_pressure(&self) {
+        let snap = self.world.lane_snapshot();
+        if snap.is_under_pressure() {
+            tracing::info!(
+                agents = %snap.agents,
+                inference = %snap.inference_summary(),
+                tools_busy = snap.tools_busy,
+                tools_workers = snap.tools_workers,
+                tools_queued = snap.tools_queued,
+                "lane heartbeat: at capacity with work queued"
+            );
+        } else {
+            tracing::debug!(
+                agents = %snap.agents,
+                inference = %snap.inference_summary(),
+                tools_busy = snap.tools_busy,
+                tools_workers = snap.tools_workers,
+                tools_queued = snap.tools_queued,
+                "lane heartbeat"
+            );
+        }
+    }
+
+    /// Override how often [`Self::serve`] re-drives the world with no wake.
+    ///
+    /// Exists so tests don't have to wait out the 30-second default; the daemon
+    /// uses it as-is.
+    pub fn set_redrive_interval(&mut self, every: Duration) {
+        self.redrive = every;
     }
 
     /// A sender for [`SubAgentOp`]s. The daemon hands a clone to each agent's tool
@@ -1214,12 +1273,24 @@ impl WorldHost {
     pub async fn serve(&mut self, mut control_rx: UnboundedReceiver<ControlOp>) {
         let wake = self.world.wake_handle();
         let shutdown = self.world.shutdown_handle();
+        // `interval_at` rather than `interval`: the latter's first tick is
+        // immediately ready, which would spin one pointless pass at startup.
+        // `Delay` keeps a slow drive from queueing a burst of catch-up ticks.
+        let mut redrive =
+            tokio::time::interval_at(tokio::time::Instant::now() + self.redrive, self.redrive);
+        redrive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         'serve: loop {
             self.world.run_to_fixed_point();
             self.emit_events();
             tokio::select! {
                 _ = wake.notified() => {}
                 _ = shutdown.notified() => break 'serve,
+                // The backstop. Everything else here is edge-triggered, so a
+                // release or completion that forgets to wake us would otherwise
+                // park the daemon indefinitely with work left to do. Re-driving
+                // on a timer bounds that to one interval, and is where the lane
+                // heartbeat reports what the loop is actually waiting on.
+                _ = redrive.tick() => self.log_lane_pressure(),
                 op = control_rx.recv() => {
                     match op {
                         // Await the spawn preprocessor (e.g. lazy MCP connect) before
@@ -1462,6 +1533,291 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         host.handle(make(tx));
         rx.await.unwrap()
+    }
+
+    /// A provider whose call never returns while `hang` is set - the stalled
+    /// request that holds its pool permit until something cancels the job.
+    ///
+    /// The non-hanging arm is not decoration: a body that only ever diverges has
+    /// no reachable return, so the answering path is what keeps this honest (and
+    /// measurable) - the same shape `inference_bridge`'s `Scripted` uses.
+    struct Hangs {
+        hang: bool,
+    }
+    #[async_trait::async_trait]
+    impl Provider for Hangs {
+        async fn infer(
+            &self,
+            _req: InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            if self.hang {
+                std::future::pending().await
+            } else {
+                Err(ProviderError::Other("not hanging".to_string()))
+            }
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            100_000
+        }
+        fn name(&self) -> &str {
+            "hangs"
+        }
+        fn capabilities(&self, _m: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
+    }
+
+    /// The stalling provider's own surface. `infer` never returns by design, so
+    /// it is reached under a timeout; the rest are plain accessors the dispatch
+    /// path reads.
+    #[tokio::test]
+    async fn the_hanging_provider_answers_everything_except_a_hanging_infer() {
+        fn request() -> InferenceRequest {
+            InferenceRequest {
+                system: vec![],
+                messages: vec![],
+                model: "m".to_string(),
+                max_tokens: 1,
+                temperature: 0.0,
+                tools: vec![],
+                extra: serde_json::Value::Null,
+                request_timeout_secs: None,
+            }
+        }
+        let p = Hangs { hang: true };
+        assert_eq!(p.name(), "hangs");
+        assert_eq!(p.count_tokens("t", "m").await, 1);
+        assert_eq!(p.max_context_tokens("m"), 100_000);
+        let _ = p.capabilities("m");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), p.infer(request()))
+                .await
+                .is_err(),
+            "hanging: the whole point is that the call never lands"
+        );
+        // ...and the answering arm, so the call has a reachable way out.
+        assert!(Hangs { hang: false }.infer(request()).await.is_err());
+    }
+
+    /// A host whose only provider hangs, with model `m` capped at `limit`
+    /// concurrent inferences - so the second agent to want a slot is starved
+    /// until the first one gives its permit back.
+    fn host_with_full_pool(limit: usize) -> WorldHost {
+        let mut registry = crate::providers::ProviderRegistry::new();
+        registry.register("script".to_string(), Arc::new(Hangs { hang: true }));
+        let mut pools = InferencePoolConfig::new();
+        pools.set_limit("m", limit);
+        WorldHost::new(PipelineWorld::new(
+            registry,
+            Arc::new(NoTools),
+            pools,
+            1,
+            std::env::temp_dir(),
+            Handle::current(),
+        ))
+    }
+
+    /// How long [`serve_until_inferring`] waits at each park before calling the loop
+    /// wedged. A wake that is coming lands as soon as the freeing task is
+    /// polled, so this is only ever spent proving the *absence* of one.
+    const PARK: std::time::Duration = std::time::Duration::from_millis(250);
+
+    /// Drive `host` exactly the way [`WorldHost::serve`] does - run the world to
+    /// quiescence, then park until something wakes it - and report whether
+    /// `entity` got dispatched within `rounds` parks. `false` means the loop
+    /// parked with nothing left to wake it, which is the daemon wedging.
+    ///
+    /// Takes the entity rather than a predicate closure on purpose: a generic
+    /// parameter would give each call site its own instantiation, and no single
+    /// one of them exercises both the "it happened" and "we wedged" exits.
+    async fn serve_until_inferring(
+        host: &mut WorldHost,
+        rounds: usize,
+        park: std::time::Duration,
+        entity: Entity,
+    ) -> bool {
+        let wake = host.world_mut().wake_handle();
+        for _ in 0..rounds {
+            host.world_mut().run_to_fixed_point();
+            if is_inferring(host, entity) {
+                return true;
+            }
+            if tokio::time::timeout(park, wake.notified()).await.is_err() {
+                break; // parked with no wake pending - nothing will re-drive us
+            }
+        }
+        false
+    }
+
+    /// Whether `entity` has been handed a pool permit and dispatched.
+    fn is_inferring(host: &mut WorldHost, entity: Entity) -> bool {
+        host.world_mut()
+            .world()
+            .get::<crate::pipeline::AwaitingInference>(entity)
+            .is_some()
+    }
+
+    /// Regression for #189 ("slots=0 for hours, in_progress frozen").
+    ///
+    /// Releasing an inference permit has to wake the tick loop, because
+    /// `dispatch_inference` leaves a slot-starved agent `ReadyToInfer` to be
+    /// "retried on a later tick" - and the loop is event-driven, so a later tick
+    /// only happens when something wakes it. A cancelled job frees its permit
+    /// from a detached task, *after* the tick chain has already run to
+    /// quiescence over the cancel. If that release is silent, the freed slot is
+    /// invisible: capacity sits idle while every agent queued behind it stays
+    /// parked, for as long as it takes some unrelated event to wake the loop.
+    #[tokio::test]
+    async fn releasing_a_cancelled_runs_permit_wakes_the_starved_agent_behind_it() {
+        let mut host = host_with_full_pool(1);
+
+        // Dispatch the holder first and on its own, so which agent wins the
+        // single permit is decided here rather than by the parallel dispatch.
+        let holder = spawn(&mut host, "run-a", "agent-a");
+        host.world_mut().run_to_fixed_point();
+        assert!(is_inferring(&mut host, holder), "the holder takes the slot");
+
+        let starved = spawn(&mut host, "run-b", "agent-b");
+        host.world_mut().run_to_fixed_point();
+        assert!(
+            !is_inferring(&mut host, starved),
+            "the second agent is starved on the full pool"
+        );
+        // And it stays starved for as long as the slot is genuinely held - the
+        // cap is real, not an artifact of the wake. Several rounds, because the
+        // first park consumes the wake the spawn itself stored; the loop has to
+        // reach a park with nothing pending before "wedged" means anything.
+        assert!(
+            !serve_until_inferring(&mut host, 3, PARK, starved).await,
+            "no slot, no dispatch"
+        );
+
+        // Cancel the holder the way `lev cancel` does. The tick chain aborts its
+        // in-flight work; the permit itself comes back later, on the job's task.
+        assert!(
+            ask(&mut host, |reply| ControlOp::Cancel {
+                run_id: "run-a".to_string(),
+                reply,
+            })
+            .await
+        );
+
+        assert!(
+            serve_until_inferring(&mut host, 8, PARK, starved).await,
+            "the freed slot must wake the loop so the starved agent can take it; \
+             without that wake the daemon parks with capacity it cannot see"
+        );
+    }
+
+    /// The backstop, on its own terms: `serve` must make progress from a timer
+    /// alone, with nothing ever waking it. Whatever else goes silent - a release
+    /// that forgets to notify, a lane that reports nothing - the daemon still
+    /// re-examines the world instead of parking indefinitely.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn serve_redrives_the_world_on_its_own_timer_with_no_wake() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Counts ticks from inside the schedule, so the assertion is about the
+        // loop actually running - not about some state that a single startup
+        // pass could equally have produced.
+        static TICKS: AtomicUsize = AtomicUsize::new(0);
+        TICKS.store(0, Ordering::SeqCst);
+        fn count_ticks() {
+            TICKS.fetch_add(1, Ordering::SeqCst);
+        }
+
+        let mut host = host_with(vec![]);
+        host.world_mut().add_test_system(count_ticks);
+        host.set_redrive_interval(std::time::Duration::from_millis(20));
+        let shutdown = host.world_mut().shutdown_handle();
+
+        let (op_tx, op_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            host.serve(op_rx).await;
+        });
+
+        // Nothing is ever sent on `op_tx`, nothing is spawned, and no wake is
+        // signalled: an empty world quiesces immediately, so every tick past the
+        // first handful is one the timer produced.
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        let ticks = TICKS.load(Ordering::SeqCst);
+        shutdown.notify_one();
+        drop(op_tx);
+        handle.await.unwrap();
+
+        assert!(
+            ticks > 3,
+            "the timer must keep driving the world with nothing waking it; saw {ticks} ticks"
+        );
+    }
+
+    /// The heartbeat's two levels. Under pressure it is worth an `info` line;
+    /// idle it must not be, or a healthy daemon spams the log forever.
+    #[tokio::test]
+    async fn the_lane_heartbeat_distinguishes_pressure_from_idle() {
+        leviath_testkit::with_tracing(|| async {
+            // Idle: no agents, no pools touched, nothing queued.
+            let mut host = host_with_full_pool(1);
+            let idle = host.world_mut().lane_snapshot();
+            assert!(!idle.is_under_pressure(), "an empty world is not pressured");
+            assert_eq!(idle.inference_summary(), "none");
+            host.log_lane_pressure(); // the `debug` arm
+
+            // Two agents, one slot: one infers, one is queued behind a full pool.
+            spawn(&mut host, "run-a", "agent-a");
+            spawn(&mut host, "run-b", "agent-b");
+            host.world_mut().run_to_fixed_point();
+
+            let busy = host.world_mut().lane_snapshot();
+            assert_eq!(busy.agents.active, 2);
+            assert_eq!(busy.inference_summary(), "m=1/1");
+            assert!(
+                busy.is_under_pressure(),
+                "a full pool with active agents is exactly the state worth reporting"
+            );
+            host.log_lane_pressure(); // the `info` arm
+        })
+        .await;
+    }
+
+    /// Terminal agents are counted apart from live ones, so "nothing is running"
+    /// can't be read as "everything is running" just because finished runs are
+    /// still loaded.
+    #[tokio::test]
+    async fn the_lane_snapshot_counts_agents_by_status() {
+        let mut host = host_with(vec![]);
+        let active = spawn(&mut host, "run-active", "a");
+        let paused = spawn(&mut host, "run-paused", "b");
+        let waiting = spawn(&mut host, "run-waiting", "c");
+        let done = spawn(&mut host, "run-done", "d");
+        let idle = spawn(&mut host, "run-idle", "e");
+        host.world_mut().set_status(paused, AgentStatus::Paused);
+        host.world_mut().set_status(waiting, AgentStatus::Waiting);
+        host.world_mut().set_status(done, AgentStatus::Complete);
+        host.world_mut().set_status(idle, AgentStatus::Idle);
+
+        let counts = host.world_mut().lane_snapshot().agents;
+        assert_eq!(counts.active, 1);
+        assert_eq!(counts.paused, 1);
+        assert_eq!(counts.waiting, 1);
+        assert_eq!(counts.terminal, 1);
+        assert_eq!(counts.idle, 1);
+        assert_eq!(
+            counts.to_string(),
+            "active=1 waiting=1 paused=1 idle=1 terminal=1"
+        );
+        // The other two terminal statuses land in the same bucket.
+        host.world_mut().set_status(active, AgentStatus::Cancelled);
+        host.world_mut().set_status(
+            paused,
+            AgentStatus::Error {
+                message: "boom".to_string(),
+            },
+        );
+        assert_eq!(host.world_mut().lane_snapshot().agents.terminal, 3);
     }
 
     #[tokio::test]
@@ -2267,13 +2623,16 @@ mod tests {
     #[tokio::test]
     async fn serve_drives_agents_and_handles_ops_until_shutdown() {
         let mut host = host_with(vec![text("t1"), text("t2"), text("t3"), text("t4")]);
-        let e = spawn(&mut host, "run-a", "agent-a");
+        spawn(&mut host, "run-a", "agent-a");
         let shutdown = host.world_mut().shutdown_handle();
+        // Watch the event stream rather than the entity: a run that finishes is
+        // reaped out of the world once it has been seen terminal, so the
+        // broadcast is the durable record that it ran to completion.
+        let mut events = host.subscribe();
         let (op_tx, op_rx) = mpsc::unbounded_channel();
 
         let handle = tokio::spawn(async move {
             host.serve(op_rx).await;
-            host
         });
 
         // Query status via the live serve loop.
@@ -2286,10 +2645,20 @@ mod tests {
             .unwrap();
         let _ = rx.await.unwrap();
 
-        shutdown.notify_one();
-        let host = handle.await.unwrap();
         // The agent ran to completion under the serve loop.
-        assert_eq!(host.world.agent_status(e), Some(AgentStatus::Complete));
+        let completed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(WorldEvent::Completed { run_id, status, .. }) = events.recv().await {
+                    return (run_id, status);
+                }
+            }
+        })
+        .await
+        .expect("the serve loop must drive the agent to a terminal status");
+        assert_eq!(completed, ("run-a".to_string(), "complete".to_string()));
+
+        shutdown.notify_one();
+        handle.await.unwrap();
     }
 
     #[tokio::test]
@@ -2336,7 +2705,10 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let mut host = host_with(vec![]);
         host.set_spawner(child_spawner());
-        let _parent = spawn(&mut host, "parent", "parent");
+        // An inert parent: no `ReadyToInfer`, so it never infers, never errors on
+        // the empty response script, and stays live for the child to attach to.
+        let parent = host.world_mut().spawn_agent((agent_state("parent"),));
+        host.register("parent", parent);
         // Count preprocessor invocations: it must fire for the sub-agent Spawn,
         // and NOT for the non-Spawn Check op (the `_ => None` arm).
         let calls = Arc::new(AtomicUsize::new(0));

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -181,6 +181,11 @@ pub async fn run_inference_job(
     // and reports nothing: the agent is already terminal, so there is no outcome
     // to apply. Releasing the permit here is the point; a cancelled run used to
     // hold its model's pool slot for as long as the provider took to answer.
+    //
+    // Note this arm sends no outcome and so never reaches the `wake` below: the
+    // tick loop learns the slot is free from the permit's own `Drop` (see
+    // `InferencePools::with_wake`). Without that, this return frees a slot in
+    // silence and every agent queued on this model stays parked (issue #189).
     let result = tokio::select! {
         biased;
         _ = cancel.cancelled() => {

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
 
-use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{AcquireError, Notify, OwnedSemaphorePermit, Semaphore};
 
 /// How `tokio::sync::Semaphore` represents "effectively unbounded" - its own
 /// maximum permit count. A model with no configured limit gets this many
@@ -69,6 +69,9 @@ impl InferencePoolConfig {
 pub struct InferencePools {
     config: InferencePoolConfig,
     semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
+    /// The tick-loop wake handle, handed to every permit so that releasing one
+    /// re-drives dispatch. See [`InferencePools::with_wake`].
+    wake: Option<Arc<Notify>>,
 }
 
 impl InferencePools {
@@ -77,7 +80,27 @@ impl InferencePools {
         Self {
             config,
             semaphores: Mutex::new(HashMap::new()),
+            wake: None,
         }
+    }
+
+    /// Attach the tick-loop wake handle, so that **releasing** a permit wakes
+    /// the driver.
+    ///
+    /// This is load-bearing, not a nicety. `dispatch_inference` leaves a
+    /// slot-starved agent `ReadyToInfer` to be retried "on a later tick", and
+    /// the loop is event-driven: a later tick only happens when something wakes
+    /// it. So every path that frees a permit owes the loop a wake, or the freed
+    /// slot is invisible and everything queued behind it stays parked (issue
+    /// #189).
+    ///
+    /// Hanging the wake off the permit's `Drop` rather than off each release
+    /// site is the point: the obligation can't be forgotten by a new call site,
+    /// and it covers the paths that don't report an outcome at all - notably a
+    /// cancelled job, which frees its permit and returns with nothing to send.
+    pub fn with_wake(mut self, wake: Arc<Notify>) -> Self {
+        self.wake = Some(wake);
+        self
     }
 
     /// Acquire a permit for `model`, waiting for a free slot if the pool is
@@ -89,7 +112,7 @@ impl InferencePools {
         // `acquire_owned` only ever returns `Ok`; `expect_permit` documents and
         // enforces that invariant.
         let permit = expect_permit(semaphore.acquire_owned().await);
-        InferencePermit { _permit: permit }
+        self.issue(model, permit)
     }
 
     /// Try to take a permit for `model` **without waiting**. Returns `None` if
@@ -103,9 +126,51 @@ impl InferencePools {
         // `try_acquire_owned` errors only on "no permits" (pool full) or
         // "closed" (never, since we never close) - both mean "no slot now".
         match semaphore.try_acquire_owned() {
-            Ok(permit) => Some(InferencePermit { _permit: permit }),
+            Ok(permit) => Some(self.issue(model, permit)),
             Err(_) => None,
         }
+    }
+
+    /// Wrap a raw semaphore permit as an [`InferencePermit`] carrying this
+    /// pool's wake handle, and trace the acquisition. Acquire and release are
+    /// traced as a pair so a leaked or long-held slot can be read straight off
+    /// the log.
+    fn issue(&self, model: &str, permit: OwnedSemaphorePermit) -> InferencePermit {
+        tracing::trace!(model = %model, "inference slot acquired");
+        InferencePermit {
+            permit: Some(permit),
+            model: model.to_string(),
+            wake: self.wake.clone(),
+        }
+    }
+
+    /// How many slots are in use per model, against each model's cap. `None` as
+    /// the cap means the model is unbounded. Only models that have actually been
+    /// used appear - the semaphores are created lazily.
+    ///
+    /// This is what makes "the pool is full and has been for hours" observable
+    /// rather than inferred.
+    pub fn occupancy(&self) -> Vec<PoolOccupancy> {
+        let map = self
+            .semaphores
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let mut out: Vec<PoolOccupancy> = map
+            .iter()
+            .map(|(model, semaphore)| {
+                let cap = self.config.limit_for(model);
+                let free = semaphore.available_permits();
+                PoolOccupancy {
+                    model: model.clone(),
+                    // An unbounded pool starts at `UNBOUNDED_PERMITS`, so its
+                    // in-use count is the shortfall from that, not from a cap.
+                    in_use: cap.unwrap_or(UNBOUNDED_PERMITS).saturating_sub(free),
+                    cap,
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.model.cmp(&b.model)); // stable output for logs and tests
+        out
     }
 
     /// Fetch (or lazily create) the semaphore for `model`.
@@ -124,6 +189,34 @@ impl InferencePools {
     }
 }
 
+/// How busy one model's pool is. `cap: None` means the model is unbounded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolOccupancy {
+    /// The model key the pool is scoped to.
+    pub model: String,
+    /// Slots currently held.
+    pub in_use: usize,
+    /// The configured limit, or `None` when unbounded.
+    pub cap: Option<usize>,
+}
+
+impl PoolOccupancy {
+    /// Whether every slot in this pool is taken. An unbounded pool never is.
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        self.cap.is_some_and(|cap| self.in_use >= cap)
+    }
+}
+
+impl std::fmt::Display for PoolOccupancy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.cap {
+            Some(cap) => write!(f, "{}={}/{}", self.model, self.in_use, cap),
+            None => write!(f, "{}={}/unbounded", self.model, self.in_use),
+        }
+    }
+}
+
 /// Unwrap an `acquire_owned` result, panicking with a clear message if the
 /// semaphore was closed. Extracted as a free function (rather than an inline
 /// `.expect(...)`) so both arms - the ordinary `Ok` and the never-in-practice
@@ -133,10 +226,34 @@ fn expect_permit(result: Result<OwnedSemaphorePermit, AcquireError>) -> OwnedSem
 }
 
 /// An RAII permit occupying one slot of a model's inference pool. Dropping it
-/// frees the slot for the next waiting agent.
+/// frees the slot for the next waiting agent **and wakes the tick loop**, so the
+/// agents parked on a full pool are re-driven and can take it.
 #[derive(Debug)]
 pub struct InferencePermit {
-    _permit: OwnedSemaphorePermit,
+    /// `Option` purely so `Drop` can hand the slot back *before* it wakes the
+    /// loop; a field would otherwise be dropped after the `Drop` body, and the
+    /// woken tick could re-check the pool while this slot was still held.
+    permit: Option<OwnedSemaphorePermit>,
+    /// The model whose pool this slot belongs to; carried for the release trace.
+    model: String,
+    /// Present when the pools were built with [`InferencePools::with_wake`].
+    wake: Option<Arc<Notify>>,
+}
+
+impl Drop for InferencePermit {
+    fn drop(&mut self) {
+        // Release first, wake second. The other order is a race: the woken tick
+        // could run `dispatch_inference` before this slot was actually handed
+        // back, find the pool still full, and park again - with nothing left to
+        // wake it. That is the exact failure this whole mechanism exists to stop.
+        drop(self.permit.take());
+        tracing::trace!(model = %self.model, "inference slot released");
+        // `notify_one` stores a permit when nobody is parked yet, so a wake that
+        // lands mid-tick is remembered rather than lost.
+        if let Some(wake) = &self.wake {
+            wake.notify_one();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -231,5 +348,102 @@ mod tests {
         sem.close();
         // Acquiring on a closed semaphore yields the `Err` arm.
         let _ = expect_permit(sem.acquire_owned().await);
+    }
+
+    /// The issue #189 contract, at its narrowest: handing a slot back has to wake
+    /// the driver. `dispatch_inference` parks a slot-starved agent to be retried
+    /// "on a later tick", and the loop is event-driven - so a silent release
+    /// leaves the freed capacity invisible.
+    #[tokio::test]
+    async fn dropping_a_permit_frees_the_slot_and_wakes_the_driver() {
+        leviath_testkit::with_tracing(|| async {
+            let mut cfg = InferencePoolConfig::new();
+            cfg.set_limit("m", 1);
+            let wake = Arc::new(Notify::new());
+            let pools = InferencePools::new(cfg).with_wake(wake.clone());
+
+            let permit = pools.try_acquire("m").expect("the only slot");
+            assert!(pools.try_acquire("m").is_none(), "pool full");
+            // Nothing has released yet, so there is no wake to collect.
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
+                    .await
+                    .is_err(),
+                "holding a permit must not wake the driver"
+            );
+
+            drop(permit);
+            // The slot is back...
+            assert!(pools.try_acquire("m").is_some(), "slot freed");
+            // ...and the driver was told, so a parked loop re-drives dispatch.
+            tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
+                .await
+                .expect("releasing a permit must wake the driver");
+        })
+        .await;
+    }
+
+    /// Pools built without a wake (the embedding case, and every pre-existing
+    /// caller) still release cleanly - the handle is optional, not required.
+    #[tokio::test]
+    async fn a_permit_without_a_wake_handle_still_releases() {
+        let mut cfg = InferencePoolConfig::new();
+        cfg.set_limit("m", 1);
+        let pools = InferencePools::new(cfg); // no `with_wake`
+        let permit = pools.try_acquire("m").expect("the only slot");
+        assert!(pools.try_acquire("m").is_none());
+        drop(permit);
+        assert!(pools.try_acquire("m").is_some());
+    }
+
+    /// The async `acquire` path carries the wake too, not just `try_acquire`.
+    #[tokio::test]
+    async fn the_awaiting_acquire_path_also_wakes_on_release() {
+        let wake = Arc::new(Notify::new());
+        let pools = InferencePools::new(InferencePoolConfig::new()).with_wake(wake.clone());
+        drop(pools.acquire("m").await);
+        tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
+            .await
+            .expect("an awaited permit wakes on release as well");
+    }
+
+    #[tokio::test]
+    async fn occupancy_reports_in_use_against_each_models_cap() {
+        let mut cfg = InferencePoolConfig::new().with_default(None); // unlisted = unbounded
+        cfg.set_limit("capped", 2);
+        let pools = InferencePools::new(cfg);
+
+        // Untouched models don't appear: the semaphores are lazy.
+        assert!(pools.occupancy().is_empty());
+
+        let held = pools.try_acquire("capped").expect("free");
+        let _unbounded = pools.try_acquire("free").expect("unbounded is always free");
+        let occ = pools.occupancy();
+        assert_eq!(
+            occ,
+            vec![
+                PoolOccupancy {
+                    model: "capped".to_string(),
+                    in_use: 1,
+                    cap: Some(2)
+                },
+                PoolOccupancy {
+                    model: "free".to_string(),
+                    in_use: 1,
+                    cap: None
+                },
+            ],
+            "sorted by model, in-use counted against the cap where there is one"
+        );
+        assert!(!occ[0].is_full(), "1 of 2 is not full");
+        assert!(!occ[1].is_full(), "an unbounded pool is never full");
+        assert_eq!(occ[0].to_string(), "capped=1/2");
+        assert_eq!(occ[1].to_string(), "free=1/unbounded");
+
+        // Fill the capped pool and it reads as full.
+        let _second = pools.try_acquire("capped").expect("second of two");
+        assert!(pools.occupancy()[0].is_full(), "2 of 2 is full");
+        drop(held);
+        assert!(!pools.occupancy()[0].is_full(), "and not full once freed");
     }
 }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1159,7 +1159,7 @@ fn dispatch_persistence_persists_taint_audit_when_the_gate_has_events() {
     let (mut world, mut prx) = world_with_persistence();
     let (jtx, _jrx) = mpsc::unbounded_channel();
     world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.spawn((
         run_metadata(),
         agent_state(),
@@ -2230,7 +2230,7 @@ async fn dispatch_tools_enqueues_runnable_job_and_advances() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let e = world
         .spawn((
             agent_state(),
@@ -2305,7 +2305,7 @@ async fn dispatch_journals_the_batch_then_each_completion() {
     let (ptx, mut prx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(ReportingService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(PersistenceStage(ptx));
     // A batch mixing an inline-resolved call (a context tool) and a lane call.
     let e = world
@@ -2384,7 +2384,7 @@ async fn dispatch_all_inline_batch_is_not_journaled() {
     let (ptx, mut prx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(PersistenceStage(ptx));
     let e = world
         .spawn((
@@ -2412,7 +2412,7 @@ async fn dispatch_without_run_metadata_is_unjournaled() {
     let (ptx, mut prx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(ReportingService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(PersistenceStage(ptx));
     world.spawn((
         agent_state(),
@@ -2440,7 +2440,7 @@ async fn gate_held_batch_is_not_journaled_until_it_dispatches() {
     let (ptx, mut prx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(PersistenceStage(ptx));
     world.insert_resource(crate::interaction_hub::InteractionHub::new());
     world.insert_resource(crate::gate_prompt::GatePromptStage {
@@ -2505,7 +2505,7 @@ async fn dispatch_tools_skips_non_active_agent() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let mut st = agent_state();
     st.status = AgentStatus::Cancelled;
     let e = world
@@ -2581,7 +2581,7 @@ async fn dispatch_tools_applies_all_context_inline() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let e = world
         .spawn((
             agent_state(),
@@ -2638,7 +2638,7 @@ async fn dispatch_tools_refuses_a_tool_the_stage_never_offered() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let (_, result) = infer_with(vec![tc("c1", "write_file"), tc("c2", "read_file")]);
     let e = world
         .spawn((
@@ -2681,7 +2681,7 @@ async fn dispatch_tools_tells_a_toolless_stage_to_answer_directly() {
     let (jtx, _jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let (_, result) = infer_with(vec![tc("c1", "read_file")]);
     let e = world
         .spawn((
@@ -2713,7 +2713,7 @@ async fn dispatch_tools_matches_an_offered_tool_through_its_alias() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let canonical = leviath_tools::canonical_tool_name("bash");
     assert_ne!(
         canonical, "bash",
@@ -2749,7 +2749,7 @@ async fn dispatch_tools_honours_the_stage_tool_filter() {
     let (jtx, _jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let mut offers = offering(&["read_file", "write_file"]);
     offers.tool_filter = Some(vec!["read_file".to_string()]);
     let (_, result) = infer_with(vec![tc("c1", "write_file")]);
@@ -2772,7 +2772,7 @@ async fn dispatch_tools_treats_an_empty_tool_filter_as_no_narrowing() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let mut offers = offering(&["read_file"]);
     offers.tool_filter = Some(vec![]);
     let (_, result) = infer_with(vec![tc("c1", "read_file")]);
@@ -2799,7 +2799,7 @@ async fn dispatch_tools_refuses_an_unoffered_context_tool() {
     let (jtx, _jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let (_, result) = infer_with(vec![ctx_call("c1", "notes", "smuggled")]);
     let e = world
         .spawn((
@@ -2827,7 +2827,7 @@ async fn dispatch_tools_partitions_context_and_lane() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let e = world
         .spawn((
             agent_state(),
@@ -2887,7 +2887,7 @@ async fn dispatch_tools_refuses_arguments_that_fail_the_advertised_schema() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let result = crate::components::InferenceResult {
         response: "r".to_string(),
         tool_calls: vec![
@@ -2934,7 +2934,7 @@ async fn dispatch_tools_skips_validation_when_the_schema_does_not_compile() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let result = crate::components::InferenceResult {
         response: "r".to_string(),
         tool_calls: vec![fcall("c1", "typod", serde_json::json!({"whatever": true}))],
@@ -2969,7 +2969,7 @@ async fn dispatch_tools_validates_through_a_tool_alias() {
     let (jtx, _jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let canonical = leviath_tools::canonical_tool_name("bash");
     assert_ne!(
         canonical, "bash",
@@ -3012,7 +3012,7 @@ async fn dispatch_tools_validates_an_mcp_style_schema() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let schema = serde_json::json!({
         "type": "object",
         "properties": {
@@ -3115,7 +3115,7 @@ async fn dispatch_tools_gate_blocks_outbound_leak_but_allows_inbound() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     // `shell` is outbound (clearance Public) over Internal data ⇒ blocked;
     // `read_file` is inbound ⇒ always allowed ⇒ goes to the lane.
     let e = world
@@ -3149,7 +3149,7 @@ async fn dispatch_tools_holds_batch_for_an_interactive_gate_prompt() {
     let (gtx, _grx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(crate::interaction_hub::InteractionHub::new());
     world.insert_resource(crate::gate_prompt::GatePromptStage {
         outcomes: gtx,
@@ -3190,7 +3190,7 @@ async fn dispatch_tools_auto_approves_a_gate_block_under_yolo() {
     let (gtx, _grx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     world.insert_resource(crate::interaction_hub::InteractionHub::new());
     world.insert_resource(crate::gate_prompt::GatePromptStage {
         outcomes: gtx,
@@ -3243,7 +3243,7 @@ async fn dispatch_tools_executes_a_gate_approved_call_and_blocks_a_denied_one() 
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let mut resolved = crate::gate_prompt::GateResolved::default();
     resolved.approved.insert("c_ok".to_string());
     resolved
@@ -3288,7 +3288,7 @@ async fn dispatch_tools_falls_through_for_a_resolved_agents_unprompted_call() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     let e = world
         .spawn((
             agent_state(),
@@ -3314,7 +3314,7 @@ async fn dispatch_tools_gate_allows_outbound_via_allowlist() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     // An allowlist rule permits `shell` up to Internal sensitivity.
     world.insert_resource(PolicyGate(leviath_core::PolicyConfig {
         allowlist: vec![leviath_core::policy::AllowlistRule {
@@ -3349,7 +3349,7 @@ async fn dispatch_tools_gate_allows_outbound_via_scripted_rule() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let mut world = World::new();
     world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
-    world.insert_resource(ToolStage(jtx));
+    world.insert_resource(ToolStage::detached(jtx));
     // No static allowlist, but a scripted rule that permits `shell`.
     let checker: std::sync::Arc<crate::taint::ScriptRuleChecker> =
         std::sync::Arc::new(|tool: &str, _target: Option<&str>, _taint| {

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -77,9 +77,31 @@ pub trait ToolService: Send + Sync {
 #[derive(Resource, Clone)]
 pub struct ToolServiceRes(pub Arc<dyn ToolService>);
 
-/// The job sender feeding the tool lane, as a world resource.
+/// The job sender feeding the tool lane, as a world resource, paired with the
+/// lane's occupancy counters so dispatch can record what it queued.
 #[derive(Resource, Clone)]
-pub struct ToolStage(pub UnboundedSender<ToolJob>);
+pub struct ToolStage {
+    /// Where batches are handed to the lane.
+    pub jobs: UnboundedSender<ToolJob>,
+    /// Shared with the lane's workers; see [`crate::tool_bridge::ToolLaneStats`].
+    pub stats: Arc<crate::tool_bridge::ToolLaneStats>,
+}
+
+impl ToolStage {
+    /// A stage wired to a real lane's counters.
+    pub fn new(
+        jobs: UnboundedSender<ToolJob>,
+        stats: Arc<crate::tool_bridge::ToolLaneStats>,
+    ) -> Self {
+        Self { jobs, stats }
+    }
+
+    /// A stage with counters of its own, for callers that drive `dispatch_tools`
+    /// without a lane behind it (tests read the channel directly).
+    pub fn detached(jobs: UnboundedSender<ToolJob>) -> Self {
+        Self::new(jobs, Arc::new(crate::tool_bridge::ToolLaneStats::new(1)))
+    }
+}
 
 /// Context-tool results computed inline by [`dispatch_tools`] (the `context_*`
 /// tools mutate the ECS window, so they can't run on the async lane), held until
@@ -546,7 +568,8 @@ pub fn dispatch_tools(
         let cancel = crate::cancel::CancelToken::new();
         // The lane worker is alive for the world's lifetime; a failed send would
         // only happen during shutdown, where dropping the job is fine.
-        let _ = stage.0.send(ToolJob {
+        stage.stats.enqueued();
+        let _ = stage.jobs.send(ToolJob {
             entity,
             exec,
             cancel: cancel.clone(),

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -65,6 +65,83 @@ pub struct ToolOutcome {
 /// same channel by taking the lock only long enough to `recv()`.
 pub type SharedJobRx = Arc<Mutex<UnboundedReceiver<ToolJob>>>;
 
+/// Live occupancy of the tool lane.
+///
+/// The lane is a fixed number of workers reading one **unbounded** queue, so
+/// dispatch never blocks and a saturated lane is invisible from the outside: the
+/// batches just pile up. Several things a batch can await have no time bound at
+/// all (a tool-approval prompt, an `ask_user`, a `wait_for_agent` poll), so
+/// enough of them stall every other agent's tools. Counting what is queued and
+/// what is running is what makes that legible instead of guesswork.
+#[derive(Debug)]
+pub struct ToolLaneStats {
+    queued: std::sync::atomic::AtomicUsize,
+    busy: std::sync::atomic::AtomicUsize,
+    workers: usize,
+}
+
+impl ToolLaneStats {
+    /// Stats for a lane of `workers` workers.
+    pub fn new(workers: usize) -> Self {
+        Self {
+            queued: std::sync::atomic::AtomicUsize::new(0),
+            busy: std::sync::atomic::AtomicUsize::new(0),
+            workers: workers.max(1),
+        }
+    }
+
+    /// Record a batch handed to the lane.
+    pub fn enqueued(&self) {
+        self.queued
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Record a worker picking a batch up: it leaves the queue and occupies a
+    /// worker.
+    fn started(&self) {
+        self.queued
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        self.busy.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Record a worker finishing a batch, however it ended.
+    fn finished(&self) {
+        self.busy.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Batches waiting for a free worker.
+    pub fn queued(&self) -> usize {
+        self.queued.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Workers currently running a batch.
+    pub fn busy(&self) -> usize {
+        self.busy.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// The lane's worker count - its concurrency cap.
+    pub fn workers(&self) -> usize {
+        self.workers
+    }
+
+    /// Whether every worker is occupied and batches are waiting behind them.
+    #[must_use]
+    pub fn is_saturated(&self) -> bool {
+        self.busy() >= self.workers && self.queued() > 0
+    }
+}
+
+/// Marks a worker as busy for as long as it is held, so the count is restored on
+/// **every** exit - including the cancel path, which leaves the batch by way of
+/// `continue` rather than falling out the bottom.
+struct BusyGuard<'a>(&'a ToolLaneStats);
+
+impl Drop for BusyGuard<'_> {
+    fn drop(&mut self) {
+        self.0.finished();
+    }
+}
+
 /// One tool worker: pulls [`ToolJob`]s from the shared channel and runs them,
 /// reporting each outcome and waking the tick loop. Holds the receiver lock only
 /// across `recv()` (so sibling workers can run their `exec().await` in parallel),
@@ -74,6 +151,7 @@ pub async fn tool_worker(
     jobs: SharedJobRx,
     results: UnboundedSender<ToolOutcome>,
     wake: Arc<Notify>,
+    stats: Arc<ToolLaneStats>,
 ) {
     loop {
         // Serialize only the receive; drop the guard before executing.
@@ -89,6 +167,8 @@ pub async fn tool_worker(
         else {
             return; // channel closed → shut down
         };
+        stats.started();
+        let _busy = BusyGuard(&stats); // released on every path out, cancel included
         // A cancelled agent's batch is dropped rather than run to completion.
         // This is what returns the worker to the pool: several of the things a
         // batch can await are unbounded (a tool-approval prompt, an `ask_user`,
@@ -120,10 +200,18 @@ pub fn spawn_tool_pool(
     results: UnboundedSender<ToolOutcome>,
     wake: Arc<Notify>,
     workers: usize,
+    stats: Arc<ToolLaneStats>,
 ) -> Vec<JoinHandle<()>> {
     let shared: SharedJobRx = Arc::new(Mutex::new(jobs));
     (0..workers.max(1))
-        .map(|_| runtime.spawn(tool_worker(shared.clone(), results.clone(), wake.clone())))
+        .map(|_| {
+            runtime.spawn(tool_worker(
+                shared.clone(),
+                results.clone(),
+                wake.clone(),
+                stats.clone(),
+            ))
+        })
         .collect()
 }
 
@@ -200,7 +288,14 @@ mod tests {
         .unwrap();
         drop(jtx);
 
-        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
+        let handles = spawn_tool_pool(
+            &Handle::current(),
+            jrx,
+            rtx,
+            wake,
+            1,
+            Arc::new(ToolLaneStats::new(1)),
+        );
         tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
             .await
             .expect("the batch started");
@@ -230,7 +325,7 @@ mod tests {
         jtx.send(job(2, vec![("c2", "r2")])).unwrap();
         drop(jtx); // close the job channel so the worker loop ends
 
-        tool_worker(shared(jrx), rtx, wake).await;
+        tool_worker(shared(jrx), rtx, wake, Arc::new(ToolLaneStats::new(1))).await;
 
         let first = rrx.try_recv().unwrap();
         assert_eq!(
@@ -274,7 +369,14 @@ mod tests {
         jtx.send(job(2, vec![("c2", "r2")])).unwrap();
         drop(jtx);
 
-        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1);
+        let handles = spawn_tool_pool(
+            &Handle::current(),
+            jrx,
+            rtx,
+            wake,
+            1,
+            Arc::new(ToolLaneStats::new(1)),
+        );
         // Wait until the stuck batch is actually executing, then cancel it.
         tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
             .await
@@ -310,7 +412,7 @@ mod tests {
         jtx.send(job(9, vec![("c", "r")])).unwrap();
         drop(jtx);
         // Must drain the job and not panic despite the failed send.
-        tool_worker(shared(jrx), rtx, wake).await;
+        tool_worker(shared(jrx), rtx, wake, Arc::new(ToolLaneStats::new(1))).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
@@ -350,7 +452,14 @@ mod tests {
         }
         drop(jtx);
 
-        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 3);
+        let handles = spawn_tool_pool(
+            &Handle::current(),
+            jrx,
+            rtx,
+            wake,
+            3,
+            Arc::new(ToolLaneStats::new(3)),
+        );
         // All three outcomes must arrive; bounded so a serialization bug fails fast.
         for _ in 0..3 {
             tokio::time::timeout(Duration::from_secs(5), rrx.recv())
@@ -370,7 +479,14 @@ mod tests {
         let wake = Arc::new(Notify::new());
         jtx.send(job(7, vec![("c", "r")])).unwrap();
         drop(jtx);
-        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 0);
+        let handles = spawn_tool_pool(
+            &Handle::current(),
+            jrx,
+            rtx,
+            wake,
+            0,
+            Arc::new(ToolLaneStats::new(0)),
+        );
         assert_eq!(handles.len(), 1); // clamped up to one worker
         let out = rrx.recv().await.unwrap();
         assert_eq!(
@@ -380,5 +496,79 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+    }
+
+    /// A lane with no workers is still reported as having one, matching
+    /// `spawn_tool_pool`'s own clamp - otherwise the saturation check compares
+    /// against a lane width that never existed.
+    #[test]
+    fn lane_stats_clamp_the_worker_count_to_one() {
+        assert_eq!(ToolLaneStats::new(0).workers(), 1);
+    }
+
+    #[test]
+    fn lane_stats_track_queue_depth_and_saturation() {
+        let stats = ToolLaneStats::new(2);
+        assert_eq!((stats.queued(), stats.busy()), (0, 0));
+        assert!(!stats.is_saturated(), "an idle lane is not saturated");
+
+        stats.enqueued();
+        stats.enqueued();
+        stats.enqueued();
+        assert_eq!(stats.queued(), 3);
+        // Both workers pick a batch up: two leave the queue, two become busy.
+        stats.started();
+        stats.started();
+        assert_eq!((stats.queued(), stats.busy()), (1, 2));
+        assert!(
+            stats.is_saturated(),
+            "every worker busy with a batch still queued behind them"
+        );
+
+        stats.finished();
+        assert!(
+            !stats.is_saturated(),
+            "a free worker means the queue is draining"
+        );
+    }
+
+    /// The counters have to come back on **every** exit. The cancel path leaves
+    /// via `continue`, which is exactly the shape that skips a decrement written
+    /// at the bottom of the loop body - so a cancelled batch would permanently
+    /// consume one of the lane's fixed workers, as far as the numbers knew.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_batch_gives_its_worker_back_to_the_count() {
+        let (jtx, jrx) = mpsc::unbounded_channel();
+        let (rtx, mut rrx) = mpsc::unbounded_channel();
+        let wake = Arc::new(Notify::new());
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let cancel = crate::cancel::CancelToken::new();
+        let stats = Arc::new(ToolLaneStats::new(1));
+
+        stats.enqueued();
+        jtx.send(held_job(7, started.clone(), release, cancel.clone()))
+            .unwrap();
+        drop(jtx);
+
+        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1, stats.clone());
+        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
+            .await
+            .expect("the batch started");
+        assert_eq!(
+            (stats.queued(), stats.busy()),
+            (0, 1),
+            "running: off the queue, on a worker"
+        );
+
+        cancel.cancel();
+        for h in handles {
+            tokio::time::timeout(std::time::Duration::from_secs(5), h)
+                .await
+                .expect("the worker was freed by the cancel")
+                .unwrap();
+        }
+        assert_eq!(stats.busy(), 0, "the cancelled batch released its worker");
+        assert!(rrx.try_recv().is_err(), "and reported no results");
     }
 }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -87,6 +87,71 @@ pub enum TickOutcome {
     Unattributed,
 }
 
+/// How many agents are in each status. See [`PipelineWorld::lane_snapshot`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AgentCounts {
+    /// Doing work, or ready to.
+    pub active: usize,
+    /// Blocked on input, a child, or a prompt.
+    pub waiting: usize,
+    /// Parked by the user.
+    pub paused: usize,
+    /// Spawned but not yet started.
+    pub idle: usize,
+    /// Finished, still loaded pending reaping.
+    pub terminal: usize,
+}
+
+impl std::fmt::Display for AgentCounts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "active={} waiting={} paused={} idle={} terminal={}",
+            self.active, self.waiting, self.paused, self.idle, self.terminal
+        )
+    }
+}
+
+/// What the world is holding and what it is waiting on, at one instant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneSnapshot {
+    /// Loaded agents by status.
+    pub agents: AgentCounts,
+    /// Inference-pool occupancy, one entry per model actually used.
+    pub inference: Vec<crate::inference_pool::PoolOccupancy>,
+    /// Tool-lane workers currently running a batch.
+    pub tools_busy: usize,
+    /// Tool batches waiting for a free worker.
+    pub tools_queued: usize,
+    /// The tool lane's worker count.
+    pub tools_workers: usize,
+    /// Every worker busy with batches still queued behind them.
+    pub tools_saturated: bool,
+}
+
+impl LaneSnapshot {
+    /// Whether some lane is at capacity with work queued behind it - the shape
+    /// worth raising the log level for.
+    #[must_use]
+    pub fn is_under_pressure(&self) -> bool {
+        self.tools_saturated
+            || (self.agents.active > 0 && self.inference.iter().any(|p| p.is_full()))
+    }
+
+    /// The per-model inference occupancy, rendered for a log line.
+    #[must_use]
+    pub fn inference_summary(&self) -> String {
+        if self.inference.is_empty() {
+            return "none".to_string();
+        }
+        self.inference
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
 /// The shared ECS world that hosts and drives every agent.
 pub struct PipelineWorld {
     world: World,
@@ -137,12 +202,14 @@ impl PipelineWorld {
         let (cs_tx, cs_rx) = unbounded_channel();
         let (title_tx, title_rx) = unbounded_channel();
 
+        let tool_stats = Arc::new(crate::tool_bridge::ToolLaneStats::new(tool_concurrency));
         let tool_tasks = spawn_tool_pool(
             &runtime,
             tool_job_rx,
             tool_res_tx,
             wake.clone(),
             tool_concurrency,
+            tool_stats.clone(),
         );
         // Retained so `flush_and_stop` can drain it on shutdown. Left to its own
         // devices otherwise: it exits when the world (and thus its PersistenceStage
@@ -154,7 +221,10 @@ impl PipelineWorld {
         let mut world = World::new();
         world.insert_resource(Providers(providers));
         world.insert_resource(InferenceStage {
-            pools: Arc::new(InferencePools::new(pool_config)),
+            // The wake goes into the pools, not just the bridges: freeing a slot
+            // has to re-drive dispatch, or the agents parked on a full pool never
+            // learn that capacity came back (issue #189).
+            pools: Arc::new(InferencePools::new(pool_config).with_wake(wake.clone())),
             outcomes: inf_tx,
             transition_outcomes: trans_tx,
             compaction_outcomes: compact_tx,
@@ -182,7 +252,7 @@ impl PipelineWorld {
         world.insert_resource(TransitionResults(trans_rx));
         world.insert_resource(CompactionResults(compact_rx));
         world.insert_resource(ToolServiceRes(tool_service));
-        world.insert_resource(ToolStage(tool_job_tx));
+        world.insert_resource(ToolStage::new(tool_job_tx, tool_stats));
         world.insert_resource(ToolResults(tool_res_rx));
         world.insert_resource(PersistenceStage(persist_tx));
         world.insert_resource(MessageIntake(msg_rx));
@@ -415,6 +485,42 @@ impl PipelineWorld {
             .resource::<crate::telemetry::Telemetry>()
             .0
             .force_flush();
+    }
+
+    /// A point-in-time read of what the world is holding and what it is waiting
+    /// on: agents by status, per-model inference-pool occupancy, and tool-lane
+    /// occupancy.
+    ///
+    /// This is the answer to "the daemon has been quiet for hours - is anything
+    /// actually running?", which issue #189 had no way to ask.
+    pub fn lane_snapshot(&self) -> LaneSnapshot {
+        let mut agents = AgentCounts::default();
+        for state in self
+            .world
+            .iter_entities()
+            .filter_map(|e| e.get::<AgentState>())
+        {
+            match state.status {
+                AgentStatus::Active => agents.active += 1,
+                AgentStatus::Waiting => agents.waiting += 1,
+                AgentStatus::Paused => agents.paused += 1,
+                AgentStatus::Idle => agents.idle += 1,
+                // Terminal agents linger until the reaper unloads them; counting
+                // them apart keeps "nothing is running" honest.
+                AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled => {
+                    agents.terminal += 1
+                }
+            }
+        }
+        let tools = self.world.resource::<ToolStage>().stats.clone();
+        LaneSnapshot {
+            agents,
+            inference: self.world.resource::<InferenceStage>().pools.occupancy(),
+            tools_busy: tools.busy(),
+            tools_queued: tools.queued(),
+            tools_workers: tools.workers(),
+            tools_saturated: tools.is_saturated(),
+        }
     }
 
     /// The status of an agent, if it still exists.


### PR DESCRIPTION
## The defect

`WorldHost::serve` is purely event-driven: drive the world to quiescence, then park until
something wakes it. There was no timer anywhere in the daemon. `dispatch_inference` leans on
that — an agent that cannot get a pool permit stays `ReadyToInfer` to be "retried on a later
tick", and a later tick only ever happens on a wake.

So every path that frees a permit owes the loop a wake, and one did not:

```rust
// inference_bridge.rs
_ = cancel.cancelled() => {
    drop(permit);
    return;              // frees the slot, wakes nobody
}
```

A cancelled job drops its permit from a detached task that runs *after* the tick chain has
already gone quiet. The slot comes back, nobody is told, and everything queued on that model
stays parked until some unrelated event happens to wake the loop.

## Reproduced before fixing

**Deterministic** — a new test in `host.rs` drives a real `WorldHost` exactly the way `serve`
does (run to fixed point, park on the wake): pool of 1, holder hangs, second agent starved,
cancel the holder. On `main` it fails 5/5 at the intended assertion after a full park timeout;
with the fix it passes in 0.02s. Verified it genuinely depends on the change by stubbing the
re-drive arm out (1 tick vs >3).

**Live** — two runs on one model with `max_concurrent_inferences = 1` against a Rhai mock
provider whose first request never answers. Worth being precise: **the multi-threaded daemon
usually wins this race and recovered on its own**, so this path did not produce a multi-hour
live wedge. The cancel's own status-change wake buys one extra fixed-point pass that normally
covers it.

What did reproduce live, from the same root cause, is the reported shape: an agent whose
provider is not registered sat at `status: running, iteration: 0`, `updated_at` frozen at
spawn, with the daemon emitting **nothing at all for 90+ seconds**. That is issue #190's
`iter=0` shape, and on `main` it never clears.

## The change

1. **Wake-on-release, enforced by RAII.** `InferencePermit::Drop` hands the slot back and
   *then* notifies. The obligation moves into the type, so a new call site cannot forget it,
   and it covers the paths that report no outcome at all. Order is load-bearing: notifying
   first lets the woken tick re-check the pool while the slot is still held.

2. **A 30s safety re-drive** in `serve`, bounding any missed wake anywhere to one interval
   rather than parking the daemon indefinitely. Deliberately not a config key — a correctness
   backstop, not a tuning knob. Live, the wedged run above went from frozen-forever to
   re-driven with `updated_at` advancing while idle.

3. **A lane heartbeat** on that tick — per-model pool occupancy, tool-lane busy/queued, agents
   by status — at `info` only when a lane is at capacity with work behind it, `debug`
   otherwise, so an idle daemon stays quiet. Live output under real pressure:

   ```
   lane heartbeat: at capacity with work queued
     agents=active=2 waiting=0 paused=0 idle=0 terminal=0
     inference=m1=1/1 tools_busy=0 tools_workers=8 tools_queued=0
   ```

   That is "slots=0" with the reason attached — what the report had no way to see. "Frozen for
   hours" left no trace precisely because nothing was happening, so no telemetry fired either.

Two of the issue's suggestions already exist and are unchanged: `lev cancel --force` covers
"force-release a stuck slot", and the recovery sweep's `mark_crashed` covers "rebuild from live
agents on restart".

## Not in scope

- `dispatch_inference` warning "provider not registered" and returning with nothing to re-drive
  it is a separate wedge (#190). The re-drive now retries it instead of parking forever, but the
  missing provider itself still needs its own fix.
- The tool lane's fixed 8 workers can each be held for unbounded wall time by `wait_for_agent`
  or a blocked `ask`, with no gate and no timeout — a genuine second starvation surface. The
  heartbeat is what will prove or rule it out next time; the fix deserves its own issue.

## Verification

- `cargo xtask coverage --package leviath-runtime` — 100%
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — all green
- Live daemon runs as described above

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFmC3TLzfXbWy6wh7FN4tu
