### PR TITLE
Fail runs that can never dispatch instead of leaving them 'running' for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ requests since the previous version.
   occupancy, tool-lane busy/queued counts, and agents by status. It logs at
   `info` only when a lane is at capacity with work queued behind it, and at
   `debug` otherwise, so an idle daemon stays quiet.
+- Fixed runs that were spawned but never executed: they sat at iteration 0 with
+  no tokens, reported as `running` for ever. A `lev run` whose stages have no
+  configured provider is now refused outright, naming the stage and every
+  provider it tried, instead of starting a run that could never take a turn.
+- A spawn that fails now records the failure in the run directory it staked
+  out, rather than leaving a `starting` placeholder that claimed the run was
+  alive for ever.
+- A run that ends up unable to dispatch anyway - a provider removed from the
+  config after it started, say - is now failed once its stall outlives
+  `[limits] stall_timeout_secs` (default 60 seconds; `0` waits indefinitely, as
+  before). Waiting for a busy model's inference pool is never failed: that is
+  ordinary backpressure, however long it lasts.
+- An async lane task that dies without reporting (a provider adapter that
+  panics) no longer strands its agent waiting for a completion that can never
+  arrive; it surfaces as an ordinary inference, routing, or compaction error.
 - Pause and resume are now user-facing: `lev pause <run-id>` and
   `lev resume <run-id>`, `POST /api/agents/{id}/pause` and `/resume` on the
   HTTP API, and `p`/`r` in the dashboard. A paused run shows as `paused` in

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -183,7 +183,7 @@ fn report_forced(
         None => String::new(),
     };
     match outcome {
-        O::Cancelled => {
+        O::Terminated => {
             println!(
                 "cancelled '{run_id}' on disk{why}; if a daemon is still running, \
                  restart it so it picks up the change"

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -133,6 +133,12 @@ pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
         Some(&before.batch_tool_hint),
         Some(&after.batch_tool_hint),
     );
+    push_if_changed(
+        &mut out,
+        "stall timeout (seconds)",
+        Some(&before.limits.stall_timeout_secs),
+        Some(&after.limits.stall_timeout_secs),
+    );
 
     let added = after
         .mcp_servers

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -892,6 +892,11 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             help: "Nudge models to request several tools in one turn.",
             value: FieldValue::Bool(config.batch_tool_hint),
         },
+        Field {
+            label: "Stall timeout (seconds)",
+            help: "Fail a run that can never dispatch (unconfigured provider). 0 waits forever.",
+            value: FieldValue::Number(Some(config.limits.stall_timeout_secs)),
+        },
     ]
 }
 
@@ -915,6 +920,12 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             }
             (3, FieldValue::Bool(b)) => config.limits.exact_token_counting = *b,
             (4, FieldValue::Bool(b)) => config.batch_tool_hint = *b,
+            // Unset means "leave the watchdog at its default", not "disable it";
+            // disabling is an explicit 0.
+            (5, FieldValue::Number(n)) => {
+                config.limits.stall_timeout_secs =
+                    n.unwrap_or(Config::default().limits.stall_timeout_secs)
+            }
             _ => {}
         }
     }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -419,6 +419,10 @@ fn default_script_shell_timeout_secs() -> u64 {
     60
 }
 
+fn default_stall_timeout_secs() -> u64 {
+    leviath_runtime::pipeline::DEFAULT_STALL_TIMEOUT_SECS
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -460,6 +464,19 @@ pub struct LimitsConfig {
     /// hang an agent on a runaway command. Defaults to `60`.
     #[serde(default = "default_script_shell_timeout_secs")]
     pub script_shell_timeout_secs: u64,
+
+    /// How long (seconds) a run may sit ready to work but unable to dispatch
+    /// before it is failed instead of left running.
+    ///
+    /// This only ever fires for something the runtime cannot resolve on its own -
+    /// today, a stage whose provider is not configured. Waiting for a busy
+    /// model's inference pool is ordinary backpressure and is never failed, no
+    /// matter how long it takes. Defaults to `60`; `0` disables the watchdog and
+    /// restores the old behaviour of waiting indefinitely.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_stall_timeout_secs")]
+    pub stall_timeout_secs: u64,
 }
 
 impl Default for LimitsConfig {
@@ -470,6 +487,7 @@ impl Default for LimitsConfig {
             default_max_iterations: default_default_max_iterations(),
             exact_token_counting: false,
             script_shell_timeout_secs: default_script_shell_timeout_secs(),
+            stall_timeout_secs: default_stall_timeout_secs(),
         }
     }
 }
@@ -2769,6 +2787,7 @@ enabled = false
                 default_max_iterations: Some(99),
                 exact_token_counting: false,
                 script_shell_timeout_secs: 45,
+                stall_timeout_secs: 90,
             },
             batch_tool_hint: true,
             nudge: leviath_core::NudgeConfig {

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -340,7 +340,7 @@ pub fn build_host(
         // grant, a permission change) takes effect on the next `lev run`
         // without a daemon restart.
         let config = spawn_reloader.current();
-        build_agent(
+        let built = build_agent(
             world.world_mut(),
             tool_service.as_ref(),
             &config,
@@ -350,7 +350,19 @@ pub fn build_host(
             args,
             now_secs(),
             subagent_tx.clone(),
-        )
+        );
+        // The placeholder above is `Starting`, which is *not* terminal - so a
+        // failed spawn used to leave a run that claimed to be alive for ever,
+        // listed by `lev ps` and the dashboard with nothing behind it. Record
+        // the failure where the placeholder is (issue #190).
+        if let Err(message) = &built {
+            crate::runstate::force_error_in(
+                &spawn_runs_dir.join(&args.run_id),
+                message,
+                now_secs(),
+            );
+        }
+        built
     }));
     host
 }
@@ -473,6 +485,14 @@ mod tests {
     use leviath_runtime::host::{ControlOp, SpawnArgs};
     use tokio::sync::oneshot;
 
+    /// A config whose registry actually has `anthropic` in it, so a spawn of a
+    /// manifest naming that provider is not refused for having none.
+    fn config_with_anthropic_key() -> Config {
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("test-key".to_string());
+        config
+    }
+
     #[tokio::test]
     async fn make_reaper_delegates_to_tool_service_reap() {
         // Exercises the reaper closure body build_host installs. The daemon only
@@ -538,9 +558,11 @@ mod tests {
     async fn setup_daemon_host_builds_a_working_host() {
         // Config::default has no MCP servers → the shared MCP connect is a no-op.
         // An empty runs dir → restart recovery finds nothing to reload.
+        // A key for the manifest's provider, because a spawn whose stages have
+        // no usable provider is now refused outright (issue #190).
         let runs = tempfile::tempdir().unwrap();
         let mut host = setup_daemon_host(
-            Config::default(),
+            config_with_anthropic_key(),
             runs.path().to_path_buf(),
             Handle::current(),
         )
@@ -577,9 +599,10 @@ mod tests {
     /// A spawn can die before any state exists (3 of 13 empty runs in one live
     /// batch), leaving nothing on disk to diagnose. The spawner stakes out the
     /// run directory first, so a spawn that fails at *any* later step still
-    /// leaves a `meta.json`.
+    /// leaves a `meta.json` - and, since `Starting` is not terminal and would
+    /// otherwise claim the run was alive for ever, records the failure in it.
     #[tokio::test]
-    async fn spawner_pre_creates_the_run_dir_even_when_the_spawn_fails() {
+    async fn spawner_records_the_failure_in_the_run_dir_it_staked_out() {
         let runs = tempfile::tempdir().unwrap();
         let mut host = setup_daemon_host(
             Config::default(),
@@ -604,7 +627,13 @@ mod tests {
 
         let meta = crate::runstate::read_meta_from(&runs.path().join("my-agent-1234-ab12"))
             .expect("a failed spawn still leaves meta.json behind");
-        assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Starting);
+        // Terminal, not `Starting`: nothing is going to advance this run.
+        assert_eq!(meta.status, leviath_core::run_meta::RunStatus::Error);
+        assert!(
+            meta.error
+                .is_some_and(|e| e.contains("/no/such/agent.leviath")),
+            "and it says what went wrong"
+        );
         assert_eq!(meta.task, "t");
         // The agent name is recovered from the run id's prefix, dashes and all.
         assert_eq!(meta.agent_name, "my-agent");

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -159,6 +159,13 @@ pub fn build_host(
     );
     // Opt-in accurate pre-inference budget guard (off by default).
     world.set_exact_token_counting(config.limits.exact_token_counting);
+    // How long a run may sit unable to dispatch before the watchdog fails it
+    // rather than leaving it "running" for ever (issue #190).
+    world
+        .world_mut()
+        .insert_resource(leviath_runtime::pipeline::StallTimeout(
+            config.limits.stall_timeout_secs,
+        ));
     // Share the hub with the tick loop so a blocked agent's open prompt is
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -768,7 +768,7 @@ fn build_agent_inner(
             &model_defaults(config),
             registry,
             &all_tool_defs,
-        )
+        )?
     };
 
     // 4. Snapshot the blueprint bits we need after it's moved into the world.
@@ -2478,6 +2478,52 @@ system_prompt = "SYSTEM_PROMPT_PLACEHOLDER"
             sub_tx(),
         );
         assert!(result.is_err(), "expected spawn error, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn build_agent_refuses_a_manifest_with_no_usable_provider() {
+        // The end-to-end shape of issue #190: this used to build an agent
+        // pointed at a provider nothing answers to, which then sat at
+        // iteration 0 for the life of the daemon.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("ghostly.leviath");
+        std::fs::write(
+            &manifest,
+            r#"
+[agent]
+name = "ghostly"
+version = "0.1.0"
+description = "d"
+entry_stage = "main"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000 }
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "ghost", model = "m" }], allow_user_default = false }
+description = "d"
+available_tools = []
+"#,
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .unwrap_err();
+        assert!(err.contains("main"), "names the stage: {err}");
+        assert!(err.contains("ghost"), "names what it tried: {err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -304,8 +304,8 @@ pub fn is_terminal_status(status: &RunStatus) -> bool {
 /// The outcome of forcing a run to a terminal state on disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ForceCancelOutcome {
-    /// The run was live on disk and is now recorded `Cancelled`.
-    Cancelled,
+    /// The run was live on disk and is now recorded terminal.
+    Terminated,
     /// The run was already finished; nothing was written.
     AlreadyTerminal,
     /// No run directory with that id exists.
@@ -340,6 +340,30 @@ pub fn force_cancel(run_id: &str) -> ForceCancelOutcome {
 /// `Cancelled` record written: such a run is otherwise skipped by `list_runs`,
 /// which makes it invisible *and* permanent.
 pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
+    force_terminal_in(run_dir, RunStatus::Cancelled, None, now)
+}
+
+/// Force the run in `run_dir` to `Error` with `message`, stamping `updated_at`.
+///
+/// For the spawn that never became a run. The spawner stakes out the run
+/// directory and writes a `Starting` placeholder *before* building the agent, so
+/// a spawn that fails leaves something to diagnose - but `Starting` is not
+/// terminal, so that placeholder went on claiming the run was alive for ever,
+/// showing up in `lev ps` and the dashboard with nothing behind it (issue #190).
+/// Recording the failure where the placeholder is turns it into an answer.
+pub fn force_error_in(run_dir: &Path, message: &str, now: i64) -> ForceCancelOutcome {
+    force_terminal_in(run_dir, RunStatus::Error, Some(message.to_string()), now)
+}
+
+/// Rewrite the run in `run_dir` to a terminal `status`, attaching `error` when
+/// there is something to say. Shared by [`force_cancel_in`] and
+/// [`force_error_in`] so "terminated on disk" has one implementation.
+fn force_terminal_in(
+    run_dir: &Path,
+    status: RunStatus,
+    error: Option<String>,
+    now: i64,
+) -> ForceCancelOutcome {
     if !run_dir.is_dir() {
         return ForceCancelOutcome::NoSuchRun;
     }
@@ -347,19 +371,26 @@ pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let cancelled = match read_meta_from(run_dir) {
+    let terminated = match read_meta_from(run_dir) {
         Ok(meta) if is_terminal_status(&meta.status) => return ForceCancelOutcome::AlreadyTerminal,
         Ok(meta) => RunMeta {
-            status: RunStatus::Cancelled,
+            status,
             updated_at: now,
+            // Keep whatever the run had already recorded when there is nothing
+            // new to say (the cancel path).
+            error: error.clone().or(meta.error),
             ..meta
         },
         // Unreadable metadata: synthesize just enough to record the outcome. The
         // run id is the directory name, which is the one field always recoverable.
         Err(_) => RunMeta {
-            status: RunStatus::Cancelled,
+            status,
             updated_at: now,
-            error: Some("run metadata was unreadable; cancelled".to_string()),
+            error: Some(
+                error
+                    .clone()
+                    .unwrap_or_else(|| "run metadata was unreadable; cancelled".to_string()),
+            ),
             ..RunMeta::new(
                 run_id.clone(),
                 run_id,
@@ -371,8 +402,8 @@ pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
             )
         },
     };
-    match write_meta_to(run_dir, &cancelled) {
-        Ok(()) => ForceCancelOutcome::Cancelled,
+    match write_meta_to(run_dir, &terminated) {
+        Ok(()) => ForceCancelOutcome::Terminated,
         Err(e) => {
             // Formatted outside the macro: a method call inside a `%field` is
             // only evaluated when a subscriber visits the value, so it would go
@@ -381,7 +412,7 @@ pub fn force_cancel_in(run_dir: &Path, now: i64) -> ForceCancelOutcome {
             tracing::warn!(
                 run_dir = %path,
                 error = %e,
-                "could not force a run to cancelled on disk"
+                "could not force a run to a terminal state on disk"
             );
             ForceCancelOutcome::WriteFailed
         }
@@ -2075,7 +2106,7 @@ mod tests {
             RunStatus::WaitingInput,
         ] {
             let dir = run_dir_with(base.path(), &format!("live-{status}"), status.clone());
-            assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Cancelled);
+            assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Terminated);
             let meta = read_meta_from(&dir).unwrap();
             assert_eq!(meta.status, RunStatus::Cancelled, "{status} is killable");
             assert_eq!(meta.updated_at, 99, "the cancel is stamped");
@@ -2119,7 +2150,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("meta.json"), "{ not json").unwrap();
 
-        assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Cancelled);
+        assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Terminated);
         let meta = read_meta_from(&dir).expect("now parses");
         assert_eq!(meta.status, RunStatus::Cancelled);
         assert_eq!(meta.run_id, "corrupt-run", "recovered from the dir name");
@@ -2141,6 +2172,101 @@ mod tests {
             assert_eq!(outcome, ForceCancelOutcome::WriteFailed);
             assert!(outcome.found_run());
         });
+    }
+
+    /// The spawn that never became a run: the placeholder is `Starting`, which
+    /// is not terminal, so it has to be rewritten or it claims to be alive for
+    /// ever (issue #190).
+    #[test]
+    fn force_error_records_the_failure_over_a_starting_placeholder() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("stillborn-run");
+        let meta = RunMeta::new(
+            "stillborn-run".to_string(),
+            "agent".to_string(),
+            "/no/such/agent.leviath".to_string(),
+            "t".to_string(),
+            None,
+            "/tmp".to_string(),
+            0,
+        );
+        create_run_in(&dir, &meta).unwrap();
+        assert_eq!(read_meta_from(&dir).unwrap().status, RunStatus::Starting);
+
+        assert_eq!(
+            force_error_in(&dir, "blueprint not found", 99),
+            ForceCancelOutcome::Terminated
+        );
+
+        let written = read_meta_from(&dir).unwrap();
+        assert_eq!(written.status, RunStatus::Error);
+        assert_eq!(written.error.as_deref(), Some("blueprint not found"));
+        assert_eq!(written.updated_at, 99);
+        // The rest of the placeholder survives, so the run still explains itself.
+        assert_eq!(written.task, "t");
+    }
+
+    #[test]
+    fn force_error_leaves_a_run_that_already_finished_alone() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("done-run");
+        let mut meta = RunMeta::new(
+            "done-run".to_string(),
+            "agent".to_string(),
+            String::new(),
+            "t".to_string(),
+            None,
+            "/tmp".to_string(),
+            0,
+        );
+        meta.status = RunStatus::Complete;
+        create_run_in(&dir, &meta).unwrap();
+
+        assert_eq!(
+            force_error_in(&dir, "too late", 99),
+            ForceCancelOutcome::AlreadyTerminal
+        );
+        assert_eq!(read_meta_from(&dir).unwrap().status, RunStatus::Complete);
+    }
+
+    #[test]
+    fn force_cancel_keeps_an_error_the_run_had_already_recorded() {
+        // Cancelling passes no message of its own, so whatever the run managed
+        // to say about itself before it was killed must survive.
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("noisy-run");
+        let mut meta = RunMeta::new(
+            "noisy-run".to_string(),
+            "agent".to_string(),
+            String::new(),
+            "t".to_string(),
+            None,
+            "/tmp".to_string(),
+            0,
+        );
+        meta.error = Some("a provider hiccup".to_string());
+        create_run_in(&dir, &meta).unwrap();
+
+        assert_eq!(force_cancel_in(&dir, 99), ForceCancelOutcome::Terminated);
+        let written = read_meta_from(&dir).unwrap();
+        assert_eq!(written.status, RunStatus::Cancelled);
+        assert_eq!(written.error.as_deref(), Some("a provider hiccup"));
+    }
+
+    #[test]
+    fn force_error_writes_its_message_over_unreadable_metadata() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("corrupt-stillborn");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("meta.json"), "{ not json").unwrap();
+
+        assert_eq!(
+            force_error_in(&dir, "blueprint not found", 99),
+            ForceCancelOutcome::Terminated
+        );
+        let written = read_meta_from(&dir).expect("now parses");
+        assert_eq!(written.status, RunStatus::Error);
+        assert_eq!(written.error.as_deref(), Some("blueprint not found"));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -421,9 +421,66 @@ mod tests {
         );
     }
 
+    /// A provider that never answers - enough to be *registered*, which is all
+    /// stage resolution asks of it.
+    struct StubProvider;
+
+    #[async_trait::async_trait]
+    impl leviath_providers::Provider for StubProvider {
+        async fn infer(
+            &self,
+            _request: leviath_providers::InferenceRequest,
+        ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
+        {
+            Err(leviath_providers::ProviderError::ApiError(
+                "stub".to_string(),
+            ))
+        }
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+            text.len()
+        }
+        fn max_context_tokens(&self, _model: &str) -> usize {
+            8192
+        }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn capabilities(&self, _model: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn stub_provider_metadata_is_exercised() {
+        use leviath_providers::Provider as _;
+        let p = StubProvider;
+        assert_eq!(p.name(), "mock");
+        assert_eq!(p.count_tokens("abc", "m").await, 3);
+        assert_eq!(p.max_context_tokens("m"), 8192);
+        let _ = p.capabilities("m");
+        assert!(
+            p.infer(leviath_providers::InferenceRequest {
+                system: vec![],
+                messages: vec![],
+                model: "m".to_string(),
+                max_tokens: 1,
+                temperature: 0.0,
+                tools: vec![],
+                extra: serde_json::Value::Null,
+                request_timeout_secs: None,
+            })
+            .await
+            .is_err()
+        );
+    }
+
+    /// A world whose registry has the `mock` provider these manifests name, so
+    /// a spawn gets past stage resolution to whatever it is actually testing.
     fn pipeline_world() -> crate::world::PipelineWorld {
+        let mut registry = crate::providers::ProviderRegistry::new();
+        registry.register("mock".to_string(), Arc::new(StubProvider));
         crate::world::PipelineWorld::new(
-            crate::providers::ProviderRegistry::new(),
+            registry,
             Arc::new(super::super::BasicToolService::new(
                 crate::interaction_hub::InteractionHub::new(),
             )),
@@ -493,6 +550,42 @@ conversation = { kind = "sliding_window", max_items = 10, max_tokens = 2000 }
             )
             .unwrap_err();
         assert!(err.contains("invalid blueprint"));
+    }
+
+    #[tokio::test]
+    async fn a_stage_with_no_registered_provider_is_a_spawn_error() {
+        // Issue #190: an embedder that never registered the provider a stage
+        // names used to get a live agent that could not take a single turn.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = r#"[agent]
+name = "ghostly"
+version = "0.0.0"
+description = "d"
+
+[stages.only]
+mode = "autonomous"
+model = { provider = "ghost", model = "m" }
+description = "Only stage"
+
+[context.regions]
+conversation = { kind = "sliding_window", max_items = 10, max_tokens = 2000 }
+"#;
+        let path = dir.path().join("ghostly.leviath");
+        std::fs::write(&path, manifest).unwrap();
+        let mut world = pipeline_world();
+        let err = spawner()
+            .spawn(
+                &mut world,
+                &SpawnArgs {
+                    run_id: "r".to_string(),
+                    blueprint_path: path.to_string_lossy().into_owned(),
+                    workdir: dir.path().to_string_lossy().into_owned(),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("no usable provider"), "got: {err}");
+        assert!(err.contains("ghost"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -92,7 +92,7 @@ impl EmbedSpawner {
                 &self.defaults,
                 registry,
                 &all_tool_defs,
-            )
+            )?
         };
 
         let agent_name = blueprint.name.clone();

--- a/crates/leviath-runtime/src/lane_supervisor.rs
+++ b/crates/leviath-runtime/src/lane_supervisor.rs
@@ -72,6 +72,16 @@ mod tests {
 
     use crate::test_support::SilentPanics;
 
+    /// The `report_lost` callback both tests below hand to the supervisor:
+    /// forward whatever it reports. Shared (rather than an inline closure per
+    /// test) because the "left alone" test's callback must never run, and an
+    /// unexecuted closure body is an uncovered region.
+    fn forward_to(tx: mpsc::UnboundedSender<String>) -> impl FnOnce(String) + Send + 'static {
+        move |message| {
+            let _ = tx.send(message);
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_panicking_job_is_reported_instead_of_vanishing() {
         let _silent = SilentPanics::install();
@@ -82,9 +92,7 @@ mod tests {
             async {
                 panic!("the provider adapter blew up");
             },
-            move |message| {
-                let _ = tx.send(message);
-            },
+            forward_to(tx),
         );
 
         let message = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
@@ -100,14 +108,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_job_that_reports_for_itself_is_left_alone() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let seen = calls.clone();
-        spawn_supervised(&Handle::current(), "inference", async {}, move |_| {
-            seen.fetch_add(1, Ordering::SeqCst);
-        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        spawn_supervised(&Handle::current(), "inference", async {}, forward_to(tx));
         // Give the supervisor every chance to fire spuriously.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(
+            rx.try_recv().is_err(),
+            "a job that returned normally owes no synthesized outcome"
+        );
     }
 
     #[tokio::test]
@@ -123,9 +131,9 @@ mod tests {
         assert!(message.contains("boom"), "got: {message}");
 
         // An aborted task's does not - it never ran to a panic.
-        let handle = tokio::spawn(async {
-            std::future::pending::<()>().await;
-        });
+        let handle = tokio::spawn(std::future::pending::<()>());
+        // Let it be polled once, so the abort interrupts a task that started.
+        tokio::task::yield_now().await;
         handle.abort();
         let err = handle.await.expect_err("the task was aborted");
         let message = lost_lane_message("transition", err);

--- a/crates/leviath-runtime/src/lane_supervisor.rs
+++ b/crates/leviath-runtime/src/lane_supervisor.rs
@@ -1,0 +1,135 @@
+//! Supervision for the async lanes, so a task that dies still reports.
+//!
+//! Every lane between the ECS and the network follows the same contract: a
+//! dispatch system marks the agent `Awaiting…`, `tokio::spawn`s a job, and the
+//! matching collect system clears the marker when the job's outcome lands. The
+//! agent's whole forward progress therefore rests on the outcome arriving.
+//!
+//! A dropped [`JoinHandle`](tokio::task::JoinHandle) breaks that contract
+//! silently. If the job panics before its send, no outcome is ever produced -
+//! and the marker it is waiting on is one of the `has_async_inflight` states, so
+//! the driver treats the agent as busy rather than quiescent and it waits for a
+//! completion that can no longer happen (issue #190). The panic guard around the
+//! tick schedule (`world::run_isolated`) does not help here: these panics happen
+//! on a tokio worker, not in a system.
+//!
+//! [`spawn_supervised`] keeps the handle and turns a dead task back into an
+//! ordinary lane error, which every collect system already knows how to apply.
+
+use std::future::Future;
+
+use tokio::runtime::Handle;
+use tokio::task::JoinError;
+
+/// Spawn `job` on `runtime` and watch it: if it ends without reporting - it
+/// panicked, or was aborted - hand `report_lost` a message describing what
+/// happened so the caller can synthesize the outcome its lane owes the agent.
+///
+/// `report_lost` runs only on that failure path. A job that returns normally
+/// (including a cancelled inference, which deliberately reports nothing) is left
+/// entirely alone.
+pub(crate) fn spawn_supervised<F>(
+    runtime: &Handle,
+    lane: &'static str,
+    job: F,
+    report_lost: impl FnOnce(String) + Send + 'static,
+) where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let inner = runtime.clone();
+    runtime.spawn(async move {
+        let Err(e) = inner.spawn(job).await else {
+            return; // reported for itself
+        };
+        let message = lost_lane_message(lane, e);
+        tracing::error!(lane, %message, "an async lane task died without reporting");
+        report_lost(message);
+    });
+}
+
+/// Describe a lane task that ended without reporting, for the error outcome the
+/// supervisor synthesizes in its place.
+///
+/// Split out (rather than inlined above) so both endings a [`JoinError`] can
+/// carry are exercised directly, without having to drive a real lane into each.
+pub(crate) fn lost_lane_message(lane: &str, err: JoinError) -> String {
+    if !err.is_panic() {
+        return format!("the {lane} task was cancelled before it reported a result");
+    }
+    let payload = err.into_panic();
+    format!(
+        "the {lane} task panicked and reported nothing: {}",
+        leviath_core::panic_message(payload.as_ref())
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::mpsc;
+
+    use crate::test_support::SilentPanics;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_panicking_job_is_reported_instead_of_vanishing() {
+        let _silent = SilentPanics::install();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        spawn_supervised(
+            &Handle::current(),
+            "inference",
+            async {
+                panic!("the provider adapter blew up");
+            },
+            move |message| {
+                let _ = tx.send(message);
+            },
+        );
+
+        let message = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("the supervisor reports promptly")
+            .expect("a message");
+        assert!(message.contains("inference"), "got: {message}");
+        assert!(
+            message.contains("the provider adapter blew up"),
+            "the panic text must survive so the run says why it failed, got: {message}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_job_that_reports_for_itself_is_left_alone() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = calls.clone();
+        spawn_supervised(&Handle::current(), "inference", async {}, move |_| {
+            seen.fetch_add(1, Ordering::SeqCst);
+        });
+        // Give the supervisor every chance to fire spuriously.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn lost_lane_message_names_the_lane_and_the_ending() {
+        // A panicking task's JoinError carries the payload.
+        let silent = SilentPanics::install();
+        let err = tokio::spawn(async { panic!("boom") })
+            .await
+            .expect_err("the task panicked");
+        drop(silent);
+        let message = lost_lane_message("compaction", err);
+        assert!(message.contains("compaction"), "got: {message}");
+        assert!(message.contains("boom"), "got: {message}");
+
+        // An aborted task's does not - it never ran to a panic.
+        let handle = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        handle.abort();
+        let err = handle.await.expect_err("the task was aborted");
+        let message = lost_lane_message("transition", err);
+        assert!(message.contains("transition"), "got: {message}");
+        assert!(message.contains("cancelled"), "got: {message}");
+    }
+}

--- a/crates/leviath-runtime/src/lane_supervisor.rs
+++ b/crates/leviath-runtime/src/lane_supervisor.rs
@@ -66,8 +66,6 @@ pub(crate) fn lost_lane_message(lane: &str, err: JoinError) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::mpsc;
 
     use crate::test_support::SilentPanics;

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -78,6 +78,7 @@ pub(crate) mod inference_bridge;
 pub mod inference_pool;
 pub mod interaction_hub;
 pub mod interaction_points;
+pub(crate) mod lane_supervisor;
 pub mod persistence;
 pub(crate) mod persistence_bridge;
 pub mod pipeline;

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -24,6 +24,36 @@ pub struct CompactionResults(pub UnboundedReceiver<CompactionOutcome>);
 /// the same 0.9 the imperative `evict_and_compact` uses.
 pub(crate) const EVICTION_THRESHOLD: f32 = 0.9;
 
+/// Spawn a compaction job under the lane supervisor, so a job that dies without
+/// reporting still produces an outcome.
+///
+/// Compaction is best-effort, but *waiting* for it is not: the agent is held
+/// `AwaitingCompaction` until an outcome lands. A lost job would park it there
+/// for good. The synthesized error takes the collect system's failure path,
+/// which returns the agent to `ReadyToInfer` with its context untouched - the
+/// same place a genuine summarization failure leaves it.
+fn spawn_supervised_compaction(stage: &InferenceStage, entity: Entity, job: CompactionJob) {
+    let lost_outcomes = stage.compaction_outcomes.clone();
+    let lost_wake = stage.wake.clone();
+    crate::lane_supervisor::spawn_supervised(
+        &stage.runtime,
+        "compaction",
+        run_compaction_job(
+            job,
+            std::time::Duration::from_secs(leviath_providers::DEFAULT_INFERENCE_TIMEOUT_SECS),
+            stage.compaction_outcomes.clone(),
+            stage.wake.clone(),
+        ),
+        move |message| {
+            let _ = lost_outcomes.send(CompactionOutcome {
+                entity,
+                result: Err(leviath_providers::ProviderError::Other(message)),
+            });
+            lost_wake.notify_one();
+        },
+    );
+}
+
 /// Compaction-dispatch system: for each `ReadyToInfer` agent with
 /// [`CompactionSettings`] whose window is over the eviction threshold, do the
 /// synchronous eviction inline; if that surfaces regions needing LLM
@@ -93,17 +123,16 @@ pub fn dispatch_compaction(
             continue; // pool full - skip compaction this round
         };
 
-        stage.runtime.spawn(run_compaction_job(
+        spawn_supervised_compaction(
+            &stage,
+            entity,
             CompactionJob {
                 entity,
                 provider,
                 requests,
                 permit,
             },
-            std::time::Duration::from_secs(leviath_providers::DEFAULT_INFERENCE_TIMEOUT_SECS),
-            stage.compaction_outcomes.clone(),
-            stage.wake.clone(),
-        ));
+        );
         commands
             .entity(entity)
             .remove::<ReadyToInfer>()
@@ -306,19 +335,16 @@ pub fn dispatch_edge_compact(
                 let requests = build_edge_compact_requests(window, &pending.0, config)?;
                 let provider = providers.0.get(&config.provider)?;
                 let permit = stage.pools.try_acquire(&config.model)?;
-                stage.runtime.spawn(run_compaction_job(
+                spawn_supervised_compaction(
+                    &stage,
+                    entity,
                     CompactionJob {
                         entity,
                         provider,
                         requests,
                         permit,
                     },
-                    std::time::Duration::from_secs(
-                        leviath_providers::DEFAULT_INFERENCE_TIMEOUT_SECS,
-                    ),
-                    stage.compaction_outcomes.clone(),
-                    stage.wake.clone(),
-                ));
+                );
                 Some(())
             })
             .is_some();

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -168,6 +168,7 @@ pub fn dispatch_inference(
             &StageInference,
             Option<&InFlightWork>,
             Option<&StageProgress>,
+            Option<&DispatchStall>,
         ),
         With<ReadyToInfer>,
     >,
@@ -188,13 +189,22 @@ pub fn dispatch_inference(
     // machinery *itself* unattributed rather than blamed on whichever agent a
     // previous system left recorded.
     crate::tick_scope::clear();
-    agents
-        .par_iter()
-        .for_each(|(entity, state, window, config, si, in_flight, progress)| {
+    let now = chrono::Utc::now().timestamp();
+    agents.par_iter().for_each(
+        |(entity, state, window, config, si, in_flight, progress, stalled)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
                     return; // paused / waiting / cancelled - don't start new work
                 }
+                // Every decline below records why and since when, so the
+                // watchdog can tell a run that is waiting from one that is
+                // waiting for something that will never happen (issue #190).
+                let stall = |reason| {
+                    let noted = note_stall(stalled, reason, now);
+                    par_commands.command_scope(|mut commands| {
+                        commands.entity(entity).insert(noted);
+                    });
+                };
                 let Some(provider) = providers.0.get(&si.provider_name) else {
                     // Leave ready and retry later - but say so. A silently
                     // starved agent reads as a wedged run with no error.
@@ -202,6 +212,7 @@ pub fn dispatch_inference(
                         provider = %si.provider_name,
                         "inference waiting: provider not registered"
                     );
+                    stall(StallReason::ProviderMissing);
                     return;
                 };
                 let Some(permit) = stage.pools.try_acquire(&si.model) else {
@@ -212,6 +223,7 @@ pub fn dispatch_inference(
                         model = %si.model,
                         "inference waiting: per-model pool is full"
                     );
+                    stall(StallReason::PoolFull);
                     return;
                 };
                 let request = build_request(
@@ -261,8 +273,12 @@ pub fn dispatch_inference(
                     commands
                         .entity(entity)
                         .remove::<ReadyToInfer>()
+                        // Dispatched: whatever it was waiting for, it isn't
+                        // waiting any more.
+                        .remove::<DispatchStall>()
                         .insert(AwaitingInference);
                 });
             });
-        });
+        },
+    );
 }

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -230,13 +230,32 @@ pub fn dispatch_inference(
                     exact_token_counting: stage.exact_token_counting,
                 };
                 let cancel = crate::cancel::CancelToken::new();
-                stage.runtime.spawn(run_inference_job(
-                    job,
-                    stage.outcomes.clone(),
-                    stage.wake.clone(),
-                    retry_policy_for(config),
-                    cancel.clone(),
-                ));
+                // Supervised: this agent is about to become `AwaitingInference`,
+                // which the driver reads as "busy". A job that died without
+                // reporting would leave it waiting on a completion that can no
+                // longer come, so the supervisor reports one in its place.
+                let lost_outcomes = stage.outcomes.clone();
+                let lost_wake = stage.wake.clone();
+                crate::lane_supervisor::spawn_supervised(
+                    &stage.runtime,
+                    "inference",
+                    run_inference_job(
+                        job,
+                        stage.outcomes.clone(),
+                        stage.wake.clone(),
+                        retry_policy_for(config),
+                        cancel.clone(),
+                    ),
+                    move |message| {
+                        let _ = lost_outcomes.send(InferenceOutcome {
+                            entity,
+                            result: Err(leviath_providers::ProviderError::Other(message)),
+                            // The job never got to measure itself.
+                            latency: std::time::Duration::ZERO,
+                        });
+                        lost_wake.notify_one();
+                    },
+                );
                 par_commands.command_scope(|mut commands| {
                     track_in_flight(&mut commands, entity, in_flight, cancel);
                     commands

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -52,6 +52,8 @@ mod inference;
 pub use inference::*;
 mod resolve;
 pub use resolve::*;
+mod stall;
+pub use stall::*;
 
 // ─── Phase marker components (an agent is in exactly one) ────────────────────
 

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -112,29 +112,81 @@ pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool
         .collect()
 }
 
-/// Resolve every stage's provider/model + effective tool set from the blueprint.
+/// Every provider a stage could have used, in the order they were tried, for
+/// the error message when none of them is configured.
+///
+/// A `--model provider/model` override is the whole list on its own: it names
+/// exactly one provider and skips the blueprint's fallbacks entirely.
+fn providers_tried(
+    model_cfg: &ModelConfig,
+    model_override: Option<&str>,
+    defaults: &ModelDefaults,
+) -> String {
+    let mut names: Vec<String> = match model_override {
+        Some(ov) if ov.contains('/') => vec![
+            ov.split_once('/')
+                .map(|(p, _)| p.to_string())
+                .expect("the `contains('/')` guard guarantees a split"),
+        ],
+        _ => {
+            let mut listed: Vec<String> = model_cfg
+                .models
+                .iter()
+                .map(|e| e.provider.clone())
+                .collect();
+            if model_cfg.allow_user_default && !defaults.provider.is_empty() {
+                listed.push(defaults.provider.clone());
+            }
+            listed
+        }
+    };
+    names.dedup();
+    names.join(", ")
+}
+
+/// Resolve every stage's provider/model + effective tool set from the
+/// blueprint, or report the first stage that has no usable provider.
+///
+/// The last fallback in [`resolve_stage_model`] is unchecked - it hands back
+/// the blueprint's own first entry whether or not anything answers to that
+/// name, and a full `provider/model` override skips the registry outright. So
+/// a stage could resolve to a provider that does not exist, and the agent
+/// spawned anyway: `Active`, iteration 0, and unable to take a single turn for
+/// as long as the host lived (issue #190). Catching it here turns a silently
+/// wedged run into an error the caller sees.
 pub fn resolve_stages(
     blueprint: &Blueprint,
     model_override: Option<&str>,
     defaults: &ModelDefaults,
     registry: &ProviderRegistry,
     all_tool_defs: &[Tool],
-) -> Vec<ResolvedStage> {
+) -> Result<Vec<ResolvedStage>, String> {
     blueprint
         .stages
         .iter()
         .map(|stage| {
             let (provider_name, model) =
                 resolve_stage_model(&stage.model, model_override, defaults, registry);
+            // `registry.has` also consults the script layer, so a `.rhai`
+            // provider sitting on disk counts as usable and is never
+            // false-rejected here.
+            if !registry.has(&provider_name) {
+                return Err(format!(
+                    "stage '{}' has no usable provider (tried: {}). Configure one \
+                     with `lev setup`, or add it to config.toml and restart the daemon.",
+                    stage.name,
+                    providers_tried(&stage.model, model_override, defaults)
+                ));
+            }
             // Empty `available_tools` exposes no tools; otherwise filter the full
             // set by name (alias-resolved). A name matching nothing (a typo, or an
             // MCP tool whose server isn't installed) is simply omitted.
             let tools = filter_tools_by_available(all_tool_defs, &stage.available_tools);
-            ResolvedStage {
+            Ok(ResolvedStage {
                 provider_name,
                 model,
                 tools,
-            }
+            })
         })
         .collect()
 }
@@ -341,8 +393,84 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&["anthropic"]),
             &tools,
-        );
+        )
+        .expect("anthropic is registered");
         assert!(resolved[0].tools.is_empty());
+    }
+
+    #[test]
+    fn resolve_stages_refuses_a_stage_with_no_usable_provider() {
+        // Issue #190: the last fallback in `resolve_stage_model` is unchecked,
+        // so this used to resolve to "ghost" and produce an agent that could
+        // never take a turn. It has to be an error the caller sees.
+        let stage = leviath_core::Stage::new("plan".to_string(), model_cfg(vec![("ghost", "m")]));
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+
+        let err = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&[]),
+            &[],
+        )
+        .expect_err("no provider is configured");
+
+        assert!(err.contains("plan"), "names the stage: {err}");
+        assert!(err.contains("ghost"), "names what it tried: {err}");
+        assert!(err.contains("lev setup"), "says what to do: {err}");
+    }
+
+    #[test]
+    fn resolve_stages_refuses_an_override_naming_an_unregistered_provider() {
+        // `--model ghost/x` short-circuits every fallback, so the override is
+        // the only provider that was tried.
+        let stage =
+            leviath_core::Stage::new("plan".to_string(), model_cfg(vec![("anthropic", "m")]));
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+
+        let err = resolve_stages(
+            &bp,
+            Some("ghost/x"),
+            &ModelDefaults::default(),
+            &registry_with(&["anthropic"]),
+            &[],
+        )
+        .expect_err("the override names a provider that isn't registered");
+
+        assert!(err.contains("tried: ghost"), "got: {err}");
+        assert!(
+            !err.contains("anthropic"),
+            "the override skipped the blueprint's list entirely: {err}"
+        );
+    }
+
+    #[test]
+    fn providers_tried_lists_the_blueprint_entries_and_the_user_default() {
+        let defaults = ModelDefaults {
+            provider: "fallback".to_string(),
+            model: None,
+        };
+        let cfg = model_cfg(vec![("one", "m"), ("two", "m")]);
+        assert_eq!(providers_tried(&cfg, None, &defaults), "one, two, fallback");
+
+        // A stage that opts out of the user default doesn't claim to have tried it.
+        let mut no_default = cfg.clone();
+        no_default.allow_user_default = false;
+        assert_eq!(providers_tried(&no_default, None, &defaults), "one, two");
+
+        // Neither does an embedder that configured no default at all.
+        assert_eq!(
+            providers_tried(&cfg, None, &ModelDefaults::default()),
+            "one, two"
+        );
+
+        // A bare `--model m` override still uses the blueprint's providers.
+        assert_eq!(
+            providers_tried(&cfg, Some("m"), &defaults),
+            "one, two, fallback"
+        );
     }
 
     #[test]
@@ -373,7 +501,8 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&["anthropic"]),
             &tools,
-        );
+        )
+        .expect("anthropic is registered");
         let selected: Vec<&str> = resolved[0].tools.iter().map(|t| t.name.as_str()).collect();
         // `bash` resolved to `shell`; the unknown MCP name and unlisted
         // `read_file` were both excluded.

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -166,9 +166,8 @@ pub fn fail_stalled_dispatch(
             continue; // still inside the grace period
         }
         let message = format!(
-            "provider '{}' is not configured, so this run could never start its \
-             first inference; add it to config.toml (or run `lev setup`) and \
-             restart the daemon",
+            "provider '{}' is not configured, so this run has no way to go on; \
+             add it to config.toml (or run `lev setup`) and restart the daemon",
             si.provider_name
         );
         tracing::error!(
@@ -333,10 +332,11 @@ mod tests {
             world.get::<AgentState>(inside).unwrap().status,
             AgentStatus::Active
         );
-        assert!(matches!(
-            world.get::<AgentState>(past).unwrap().status,
-            AgentStatus::Error { .. }
-        ));
+        let status = &world.get::<AgentState>(past).unwrap().status;
+        assert!(
+            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
+            "got: {status:?}"
+        );
     }
 
     #[test]
@@ -370,10 +370,11 @@ mod tests {
 
         run(&mut world);
 
-        assert!(matches!(
-            world.get::<AgentState>(e).unwrap().status,
-            AgentStatus::Error { .. }
-        ));
+        let status = &world.get::<AgentState>(e).unwrap().status;
+        assert!(
+            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
+            "got: {status:?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -1,0 +1,442 @@
+//! The dispatch-stall watchdog: fail a run that is runnable but can never run.
+
+use super::*;
+
+/// Why a dispatch system declined to start work for an agent this tick.
+///
+/// The two cases look identical from the outside - the agent keeps its
+/// `ReadyToInfer` marker either way - but they are opposites in kind, which is
+/// what the watchdog acts on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StallReason {
+    /// The stage names a provider that is not in the registry. Nothing the
+    /// runtime does will change that: no work is in flight to finish, no permit
+    /// will free up. Only editing the config and restarting the daemon (or
+    /// dropping in the matching `.rhai` script) can.
+    ProviderMissing,
+    /// The model's inference pool is full. This is ordinary backpressure and
+    /// resolves itself: every permit is held by a job that the job timeout
+    /// bounds, and releasing one wakes the driver.
+    PoolFull,
+}
+
+impl StallReason {
+    /// A short label for logs.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            StallReason::ProviderMissing => "provider-missing",
+            StallReason::PoolFull => "pool-full",
+        }
+    }
+}
+
+/// An agent that was ready to work but whose dispatch declined, and since when.
+///
+/// Attached by the dispatch systems when they decline, refreshed while the same
+/// reason persists, and removed the moment work is dispatched - so its presence
+/// means "runnable right now, and has been going nowhere since `since`".
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DispatchStall {
+    /// Unix seconds when this stall started (not when it was last observed, so
+    /// the age is the whole stall).
+    pub since: i64,
+    /// Unix seconds of the most recent decline.
+    ///
+    /// This is what keeps the record honest. An agent can leave the ready state
+    /// for reasons that have nothing to do with dispatch - a stuck edge, an
+    /// iteration cap - and come back later; without a freshness stamp it would
+    /// return carrying an ancient `since` and be judged on a wait it was not
+    /// actually doing. A record that stops being refreshed simply expires.
+    pub last_seen: i64,
+    /// What is holding the agent up.
+    pub reason: StallReason,
+}
+
+/// How long a [`DispatchStall`] stays meaningful without being refreshed.
+///
+/// The dispatch systems re-stamp it on every tick they decline, and the host
+/// re-drives at least once per `DEFAULT_REDRIVE_INTERVAL` (30s), so a live
+/// stall is never more than one interval stale. This is comfortably above that
+/// so an ongoing stall is never mistaken for an abandoned record; anything
+/// older than this really does describe a wait that has since ended.
+pub(crate) const STALL_FRESHNESS_SECS: i64 = 120;
+
+/// How long a `ProviderMissing` stall may last before the run is failed.
+///
+/// A world resource rather than a constant because the daemon serves it from
+/// `[limits] stall_timeout_secs`. Zero disables the watchdog.
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StallTimeout(pub u64);
+
+impl Default for StallTimeout {
+    fn default() -> Self {
+        Self(DEFAULT_STALL_TIMEOUT_SECS)
+    }
+}
+
+/// Default grace period before an unresolvable stall fails its run.
+///
+/// Long enough that a provider arriving late - a `.rhai` script dropped into the
+/// providers directory resolves on the next dispatch - still rescues the run,
+/// short enough that an operator watching `lev ps` gets an answer rather than a
+/// run that claims to be working.
+pub const DEFAULT_STALL_TIMEOUT_SECS: u64 = 60;
+
+/// Record that an agent's dispatch declined for `reason`, preserving the start
+/// time of an ongoing stall of the same kind.
+///
+/// The clock restarts unless this continues a stall that is both the *same
+/// kind* and still fresh. A changed reason is a different problem and deserves
+/// its own grace period rather than inheriting the age of the old one; a stale
+/// record describes a wait that already ended (see
+/// [`STALL_FRESHNESS_SECS`]).
+pub(crate) fn note_stall(
+    existing: Option<&DispatchStall>,
+    reason: StallReason,
+    now: i64,
+) -> DispatchStall {
+    let since = match existing {
+        Some(prev)
+            if prev.reason == reason
+                && now.saturating_sub(prev.last_seen) <= STALL_FRESHNESS_SECS =>
+        {
+            prev.since
+        }
+        _ => now,
+    };
+    DispatchStall {
+        since,
+        last_seen: now,
+        reason,
+    }
+}
+
+/// Dispatch-stall watchdog: fail any agent whose dispatch has been declining for
+/// an unresolvable reason longer than [`StallTimeout`].
+///
+/// This is the backstop under issue #190. A stage pointing at a provider that
+/// isn't registered leaves the agent `Active` and `ReadyToInfer` with nothing in
+/// flight - so from the outside it reads as a healthy running run, for ever, at
+/// iteration 0. The daemon now re-ticks on a heartbeat, which makes the retry
+/// real, but retrying a provider that will never exist just means failing
+/// quietly for ever instead of loudly once.
+///
+/// Only [`StallReason::ProviderMissing`] is failed. A full pool is deliberately
+/// exempt: it is what backpressure is supposed to look like, and a run waiting
+/// its turn behind seven long inferences is working exactly as intended.
+///
+/// What makes this safe from false positives is *which* agents can carry a
+/// [`DispatchStall`] at all. Only a dispatch system that declined attaches one,
+/// and dispatching removes it - so an agent holding one has nothing
+/// outstanding. A fifteen-minute inference is `AwaitingInference` with no stall
+/// record, and is never a candidate here.
+#[allow(clippy::type_complexity)]
+pub fn fail_stalled_dispatch(
+    mut agents: Query<(
+        Entity,
+        &DispatchStall,
+        &StageInference,
+        &mut AgentState,
+        Option<&mut StageIoBuffer>,
+    )>,
+    timeout: Option<Res<StallTimeout>>,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    let limit = timeout.map(|t| t.0).unwrap_or(DEFAULT_STALL_TIMEOUT_SECS);
+    if limit == 0 {
+        return; // watchdog disabled
+    }
+    let now = chrono::Utc::now().timestamp();
+    for (entity, stall, si, mut state, buffer) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        if state.status != AgentStatus::Active || stall.reason != StallReason::ProviderMissing {
+            continue;
+        }
+        if now.saturating_sub(stall.last_seen) > STALL_FRESHNESS_SECS {
+            // The wait this describes has ended; nothing to act on.
+            tracing::debug!(
+                reason = stall.reason.label(),
+                "discarding a dispatch stall that stopped being refreshed"
+            );
+            commands.entity(entity).remove::<DispatchStall>();
+            continue;
+        }
+        if now.saturating_sub(stall.since) < limit as i64 {
+            continue; // still inside the grace period
+        }
+        let message = format!(
+            "provider '{}' is not configured, so this run could never start its \
+             first inference; add it to config.toml (or run `lev setup`) and \
+             restart the daemon",
+            si.provider_name
+        );
+        tracing::error!(
+            provider = %si.provider_name,
+            stalled_secs = now.saturating_sub(stall.since),
+            "failing a run whose provider will never resolve"
+        );
+        if let Some(mut buffer) = buffer {
+            buffer.logs.push((0, format!("[stalled] {message}")));
+        }
+        state.status = AgentStatus::Error { message };
+        commands
+            .entity(entity)
+            .remove::<ReadyToInfer>()
+            .remove::<DispatchStall>();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent_state() -> AgentState {
+        AgentState {
+            agent_id: "a".to_string(),
+            current_stage: "s".to_string(),
+            iteration: 0,
+            status: AgentStatus::Active,
+            spawned_children_ids: vec![],
+            pending_wait: None,
+            accepts_messages: true,
+        }
+    }
+
+    fn stage_inference() -> StageInference {
+        StageInference {
+            provider_name: "ghost".to_string(),
+            model: "m".to_string(),
+            tools: vec![],
+            tool_filter: None,
+        }
+    }
+
+    /// A stall that started `age` seconds ago and is still being refreshed.
+    fn stalled_for(reason: StallReason, age: i64) -> DispatchStall {
+        let now = chrono::Utc::now().timestamp();
+        DispatchStall {
+            since: now - age,
+            last_seen: now,
+            reason,
+        }
+    }
+
+    /// Spawn an agent that has been stalled for `age` seconds for `reason`.
+    fn spawn_stalled(world: &mut World, reason: StallReason, age: i64) -> Entity {
+        world
+            .spawn((
+                agent_state(),
+                stage_inference(),
+                stalled_for(reason, age),
+                StageIoBuffer::default(),
+                ReadyToInfer,
+            ))
+            .id()
+    }
+
+    fn run(world: &mut World) {
+        let mut schedule = Schedule::default();
+        schedule.add_systems(fail_stalled_dispatch);
+        schedule.run(world);
+    }
+
+    #[test]
+    fn a_provider_that_will_never_resolve_fails_the_run() {
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 61);
+
+        run(&mut world);
+
+        let status = &world.get::<AgentState>(e).unwrap().status;
+        assert!(
+            matches!(status, AgentStatus::Error { message }
+                if message.contains("ghost") && message.contains("not configured")),
+            "got: {status:?}"
+        );
+        // Taken out of dispatch, and the stall record is spent.
+        assert!(world.get::<ReadyToInfer>(e).is_none());
+        assert!(world.get::<DispatchStall>(e).is_none());
+        // The operator sees why in the stage log the dashboard renders.
+        let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+        assert!(
+            logs.iter().any(|(_, line)| line.starts_with("[stalled]")),
+            "expected a [stalled] log line, got: {logs:?}"
+        );
+    }
+
+    #[test]
+    fn a_stall_inside_the_grace_period_is_left_alone() {
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 59);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+    }
+
+    #[test]
+    fn a_full_pool_is_backpressure_and_is_never_failed() {
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        // Far past the grace period: waiting behind long inferences is fine.
+        let e = spawn_stalled(&mut world, StallReason::PoolFull, 10_000);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(world.get::<DispatchStall>(e).is_some());
+    }
+
+    #[test]
+    fn a_zero_timeout_disables_the_watchdog() {
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(0));
+        let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 10_000);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+    }
+
+    #[test]
+    fn a_world_without_the_resource_uses_the_default_timeout() {
+        // Test worlds and `lev run` don't insert `StallTimeout`.
+        let mut world = World::new();
+        let inside = spawn_stalled(
+            &mut world,
+            StallReason::ProviderMissing,
+            DEFAULT_STALL_TIMEOUT_SECS as i64 - 1,
+        );
+        let past = spawn_stalled(
+            &mut world,
+            StallReason::ProviderMissing,
+            DEFAULT_STALL_TIMEOUT_SECS as i64 + 1,
+        );
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(inside).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(matches!(
+            world.get::<AgentState>(past).unwrap().status,
+            AgentStatus::Error { .. }
+        ));
+    }
+
+    #[test]
+    fn a_non_active_agent_is_left_to_its_own_status() {
+        // A paused run is not stalled - it is stopped on purpose, and resuming
+        // it must not find it failed.
+        let mut world = World::new();
+        let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 10_000);
+        world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Paused;
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Paused
+        );
+    }
+
+    #[test]
+    fn an_agent_without_a_stage_log_still_fails() {
+        // `StageIoBuffer` is optional (test worlds, `lev run`).
+        let mut world = World::new();
+        let e = world
+            .spawn((
+                agent_state(),
+                stage_inference(),
+                stalled_for(StallReason::ProviderMissing, 10_000),
+                ReadyToInfer,
+            ))
+            .id();
+
+        run(&mut world);
+
+        assert!(matches!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Error { .. }
+        ));
+    }
+
+    #[test]
+    fn a_stall_that_stopped_being_refreshed_is_discarded() {
+        // The agent left the ready state for some unrelated reason (a stuck
+        // edge, an iteration cap) and came back. It must not be judged on a
+        // wait it was not actually doing.
+        let mut world = World::new();
+        let now = chrono::Utc::now().timestamp();
+        let e = world
+            .spawn((
+                agent_state(),
+                stage_inference(),
+                DispatchStall {
+                    since: now - 10_000,
+                    last_seen: now - STALL_FRESHNESS_SECS - 1,
+                    reason: StallReason::ProviderMissing,
+                },
+                ReadyToInfer,
+            ))
+            .id();
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+        assert!(
+            world.get::<DispatchStall>(e).is_none(),
+            "the spent record is cleared rather than left to mislead"
+        );
+    }
+
+    #[test]
+    fn note_stall_continues_a_live_stall_and_restarts_otherwise() {
+        // A continuing stall keeps its start time, so the age is the whole wait.
+        let first = note_stall(None, StallReason::PoolFull, 100);
+        assert_eq!((first.since, first.last_seen), (100, 100));
+        let still = note_stall(Some(&first), StallReason::PoolFull, 120);
+        assert_eq!(still.since, 100, "an ongoing stall keeps its clock");
+        assert_eq!(still.last_seen, 120, "but records that it is still live");
+        // A different reason is a different problem: it gets its own grace.
+        let changed = note_stall(Some(&first), StallReason::ProviderMissing, 120);
+        assert_eq!(changed.since, 120);
+        assert_eq!(changed.reason, StallReason::ProviderMissing);
+        // So does a stall that went unobserved long enough to have ended.
+        let resumed = note_stall(
+            Some(&first),
+            StallReason::PoolFull,
+            100 + STALL_FRESHNESS_SECS + 1,
+        );
+        assert_eq!(resumed.since, 100 + STALL_FRESHNESS_SECS + 1);
+    }
+
+    #[test]
+    fn stall_reasons_have_labels() {
+        assert_eq!(StallReason::ProviderMissing.label(), "provider-missing");
+        assert_eq!(StallReason::PoolFull.label(), "pool-full");
+    }
+
+    #[test]
+    fn the_default_timeout_is_the_documented_grace_period() {
+        assert_eq!(StallTimeout::default().0, DEFAULT_STALL_TIMEOUT_SECS);
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -412,6 +412,82 @@ impl StageInference {
     }
 }
 
+/// A provider whose `infer` panics, standing in for any bug that kills a lane
+/// task before it can report - the case that used to leave the agent waiting on
+/// an outcome that would never arrive (issue #190).
+struct Exploding;
+#[async_trait::async_trait]
+impl Provider for Exploding {
+    async fn infer(
+        &self,
+        _r: InferenceRequest,
+    ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+        panic!("provider adapter blew up")
+    }
+    async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        1
+    }
+    fn max_context_tokens(&self, _m: &str) -> usize {
+        100_000
+    }
+    fn name(&self) -> &str {
+        "exploding"
+    }
+    fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+        leviath_providers::ModelCapabilities::default()
+    }
+}
+
+/// Register [`Exploding`] under `"exploding"` in an already-built test world.
+fn register_exploding(world: &mut World) {
+    world
+        .resource_mut::<Providers>()
+        .0
+        .register("exploding".to_string(), Arc::new(Exploding));
+}
+
+#[tokio::test]
+async fn exploding_provider_metadata_is_exercised() {
+    // Keep the mock's non-`infer` trait methods measured.
+    let p = Exploding;
+    assert_eq!(p.name(), "exploding");
+    assert_eq!(p.count_tokens("t", "m").await, 1);
+    assert_eq!(p.max_context_tokens("m"), 100_000);
+    let _ = p.capabilities("m");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_panicking_inference_job_reports_an_error_instead_of_vanishing() {
+    let (mut world, mut rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    register_exploding(&mut world);
+    let e = world
+        .spawn((
+            agent_state(),
+            window(),
+            stage("m", vec![], None).clone_with_provider("exploding"),
+            ReadyToInfer,
+        ))
+        .id();
+
+    let _silent = crate::test_support::SilentPanics::install();
+    run(&mut world);
+
+    // The agent is parked on `AwaitingInference`, which the driver reads as
+    // "busy" - so an outcome has to arrive or it waits for ever.
+    assert!(world.get::<AwaitingInference>(e).is_some());
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("the supervisor reports promptly")
+        .expect("an outcome");
+    assert_eq!(outcome.entity, e);
+    let err = outcome
+        .result
+        .expect_err("a dead job is an error")
+        .to_string();
+    assert!(err.contains("panicked"), "got: {err}");
+    assert!(err.contains("provider adapter blew up"), "got: {err}");
+}
+
 // ── collect system ──
 
 fn agent_state() -> AgentState {
@@ -4886,6 +4962,39 @@ async fn compaction_dispatches_when_over_threshold() {
     assert!(world.get::<ReadyToInfer>(e).is_none());
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_panicking_compaction_job_reports_an_error_instead_of_vanishing() {
+    let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    register_exploding(&mut world);
+    let (ctx, mut crx) = mpsc::unbounded_channel();
+    world.resource_mut::<InferenceStage>().compaction_outcomes = ctx;
+    let e = world
+        .spawn((
+            compacting_window(),
+            compaction_settings("exploding", "m"),
+            agent_state(),
+            ReadyToInfer,
+        ))
+        .id();
+
+    let _silent = crate::test_support::SilentPanics::install();
+    run_dispatch_compaction(&mut world);
+
+    // Compaction is best-effort, but *waiting* for it is not: the agent is held
+    // `AwaitingCompaction` until an outcome lands.
+    assert!(world.get::<AwaitingCompaction>(e).is_some());
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), crx.recv())
+        .await
+        .expect("the supervisor reports promptly")
+        .expect("an outcome");
+    assert_eq!(outcome.entity, e);
+    let err = outcome
+        .result
+        .expect_err("a dead job is an error")
+        .to_string();
+    assert!(err.contains("compaction"), "got: {err}");
+}
+
 #[tokio::test]
 async fn compaction_skips_non_active_agent() {
     let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
@@ -8029,6 +8138,39 @@ async fn dispatch_choice_moves_to_awaiting_response_and_injects_prompt() {
     // The spawned routing job reports back on the transition lane.
     let outcome = trx.recv().await.expect("routing outcome");
     assert_eq!(outcome.entity, e);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_panicking_routing_job_reports_an_error_instead_of_vanishing() {
+    let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    register_exploding(&mut world);
+    let (ttx, mut trx) = mpsc::unbounded_channel();
+    world.resource_mut::<InferenceStage>().transition_outcomes = ttx;
+
+    let bp = blueprint(vec![stage_named("a", None, false, None)]);
+    let e = spawn_choosing_agent(&mut world, bp, vec![si("m0")], vec![plain_edge("a")]);
+    world
+        .entity_mut(e)
+        .insert(stage_infs_head().clone_with_provider("exploding"));
+
+    let _silent = crate::test_support::SilentPanics::install();
+    let mut schedule = Schedule::default();
+    schedule.add_systems(dispatch_transition_choice);
+    schedule.run(&mut world);
+
+    // Parked on `AwaitingTransitionResponse`: without an outcome the agent is
+    // stranded mid-route, having already left its stage behind.
+    assert!(world.get::<AwaitingTransitionResponse>(e).is_some());
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), trx.recv())
+        .await
+        .expect("the supervisor reports promptly")
+        .expect("an outcome");
+    assert_eq!(outcome.entity, e);
+    let err = outcome
+        .result
+        .expect_err("a dead job is an error")
+        .to_string();
+    assert!(err.contains("transition-choice"), "got: {err}");
 }
 
 #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1709,13 +1709,30 @@ pub fn dispatch_transition_choice(
             exact_token_counting: false,
         };
         let cancel = crate::cancel::CancelToken::new();
-        stage.runtime.spawn(run_inference_job(
-            job,
-            stage.transition_outcomes.clone(),
-            stage.wake.clone(),
-            crate::inference_bridge::RetryPolicy::default(),
-            cancel.clone(),
-        ));
+        // Supervised for the same reason as the inference lane: the agent is
+        // about to wait on `AwaitingTransitionResponse`, so a job that dies
+        // without reporting would strand it mid-route.
+        let lost_outcomes = stage.transition_outcomes.clone();
+        let lost_wake = stage.wake.clone();
+        crate::lane_supervisor::spawn_supervised(
+            &stage.runtime,
+            "transition-choice",
+            run_inference_job(
+                job,
+                stage.transition_outcomes.clone(),
+                stage.wake.clone(),
+                crate::inference_bridge::RetryPolicy::default(),
+                cancel.clone(),
+            ),
+            move |message| {
+                let _ = lost_outcomes.send(crate::inference_bridge::InferenceOutcome {
+                    entity,
+                    result: Err(leviath_providers::ProviderError::Other(message)),
+                    latency: std::time::Duration::ZERO,
+                });
+                lost_wake.notify_one();
+            },
+        );
         track_in_flight(&mut commands, entity, in_flight, cancel);
         commands
             .entity(entity)

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1652,6 +1652,7 @@ pub fn dispatch_transition_choice(
             &StageCursor,
             &AwaitingTransitionChoice,
             Option<&InFlightWork>,
+            Option<&DispatchStall>,
         ),
         With<AwaitingTransitionChoice>,
     >,
@@ -1660,15 +1661,26 @@ pub fn dispatch_transition_choice(
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, state, mut window, si, bp, cursor, choice, in_flight) in agents.iter_mut() {
+    let now = chrono::Utc::now().timestamp();
+    for (entity, state, mut window, si, bp, cursor, choice, in_flight, stalled) in agents.iter_mut()
+    {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled - don't start new work
         }
+        // Same bookkeeping as the inference lane: an agent parked here is
+        // runnable with nothing outstanding, so a decline that never resolves
+        // wedges the run just as thoroughly (issue #190).
         let Some(provider) = providers.0.get(&si.provider_name) else {
+            commands
+                .entity(entity)
+                .insert(note_stall(stalled, StallReason::ProviderMissing, now));
             continue; // provider not registered - retry later
         };
         let Some(permit) = stage.pools.try_acquire(&si.model) else {
+            commands
+                .entity(entity)
+                .insert(note_stall(stalled, StallReason::PoolFull, now));
             continue; // pool full - retry next tick
         };
 
@@ -1737,6 +1749,7 @@ pub fn dispatch_transition_choice(
         commands
             .entity(entity)
             .remove::<AwaitingTransitionChoice>()
+            .remove::<DispatchStall>()
             .insert(AwaitingTransitionResponse(choice.0.clone()));
     }
 }

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1226,6 +1226,7 @@ pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
 /// set - the per-stage input to [`spawn_agent`]. The caller (CLI / daemon) owns
 /// the model-selection policy (overrides, availability, user defaults) and tool
 /// filtering; the runtime just turns the result into agent data.
+#[derive(Debug)]
 pub struct ResolvedStage {
     /// The provider to call for this stage.
     pub provider_name: String,

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -16,8 +16,12 @@ pub(crate) struct SilentPanics {
     _lock: std::sync::MutexGuard<'static, ()>,
     /// The hook to put back. `Option` because `Drop` only has `&mut self` and
     /// `set_hook` needs the box by value.
-    previous: Option<Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>>,
+    previous: Option<PanicHook>,
 }
+
+/// What `std::panic::take_hook` hands back, named so the field above doesn't
+/// trip `clippy::type_complexity`.
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
 
 impl SilentPanics {
     pub(crate) fn install() -> Self {

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -14,14 +14,18 @@ pub(crate) struct SilentPanics {
     /// Held for the guard's lifetime: swapping the process-global hook has to be
     /// serialized against every other test that does it.
     _lock: std::sync::MutexGuard<'static, ()>,
-    /// The hook to put back. `Option` because `Drop` only has `&mut self` and
-    /// `set_hook` needs the box by value.
-    previous: Option<PanicHook>,
+    /// The hook to put back.
+    previous: PanicHook,
 }
 
 /// What `std::panic::take_hook` hands back, named so the field above doesn't
 /// trip `clippy::type_complexity`.
 type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// The hook installed while the guard lives: print nothing. A named function
+/// rather than two `|_| {}` closures so the silencer and the throwaway below are
+/// the same (exercised) code.
+fn swallow_panic(_: &std::panic::PanicHookInfo<'_>) {}
 
 impl SilentPanics {
     pub(crate) fn install() -> Self {
@@ -29,18 +33,20 @@ impl SilentPanics {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
+        std::panic::set_hook(Box::new(swallow_panic));
         Self {
             _lock: lock,
-            previous: Some(previous),
+            previous,
         }
     }
 }
 
 impl Drop for SilentPanics {
     fn drop(&mut self) {
-        if let Some(previous) = self.previous.take() {
-            std::panic::set_hook(previous);
-        }
+        // Swap a throwaway in so the real hook can be moved out of `&mut self`.
+        // (An `Option` + `take` would work too, but its `None` arm can never be
+        // reached, and the coverage gate counts that.)
+        let previous = std::mem::replace(&mut self.previous, Box::new(swallow_panic));
+        std::panic::set_hook(previous);
     }
 }

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -1,4 +1,42 @@
 #![cfg(test)]
-//! Crate-local names for the shared helpers in `leviath-testkit`.
+//! Crate-local names for the shared helpers in `leviath-testkit`, plus the ones
+//! that only this crate needs.
 
 pub(crate) use leviath_testkit::{PANIC_HOOK_LOCK, with_silenced_panics, with_tracing};
+
+/// Silence the process panic hook for as long as the guard lives.
+///
+/// `with_silenced_panics` takes a synchronous closure, which is enough when the
+/// panic happens inside it. The lane tests provoke a panic on a *tokio worker*,
+/// some time after the spawning call returns, so the hook has to stay swapped
+/// across an await - hence a guard rather than a closure.
+pub(crate) struct SilentPanics {
+    /// Held for the guard's lifetime: swapping the process-global hook has to be
+    /// serialized against every other test that does it.
+    _lock: std::sync::MutexGuard<'static, ()>,
+    /// The hook to put back. `Option` because `Drop` only has `&mut self` and
+    /// `set_hook` needs the box by value.
+    previous: Option<Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>>,
+}
+
+impl SilentPanics {
+    pub(crate) fn install() -> Self {
+        let lock = PANIC_HOOK_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        Self {
+            _lock: lock,
+            previous: Some(previous),
+        }
+    }
+}
+
+impl Drop for SilentPanics {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            std::panic::set_hook(previous);
+        }
+    }
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -42,9 +42,10 @@ use crate::pipeline::{
     abort_terminal_work, check_workspace_health, collect_compaction, collect_inference,
     collect_tools, collect_transition_choice, deliver_messages, detect_stuck_stage,
     dispatch_compaction, dispatch_edge_compact, dispatch_inference, dispatch_persistence,
-    dispatch_tools, dispatch_transition_choice, enforce_max_iterations, gate_requires_children,
-    handle_empty_response, poll_dynamic_tool_refresh, process_response, reflect_interaction_status,
-    refresh_advertised_tools, require_context_regions, resolve_transition, sync_tool_stages,
+    dispatch_tools, dispatch_transition_choice, enforce_max_iterations, fail_stalled_dispatch,
+    gate_requires_children, handle_empty_response, poll_dynamic_tool_refresh, process_response,
+    reflect_interaction_status, refresh_advertised_tools, require_context_regions,
+    resolve_transition, sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::spawn_tool_pool;
@@ -345,6 +346,12 @@ impl PipelineWorld {
                 // this same tick.
                 crate::title::collect_title,
                 crate::title::dispatch_title,
+                // Fail a run whose dispatch has been declining for something
+                // that will never arrive. Last of the guards, and after *both*
+                // dispatch systems, so it reads stall records both lanes have
+                // refreshed on this same tick - and before persistence, so the
+                // failure reaches disk immediately.
+                fail_stalled_dispatch,
                 // Mirror open interaction-hub requests into agent status
                 // (Active ↔ Waiting) so the dashboard surfaces blocked prompts;
                 // must run before persistence so the status change is written.
@@ -1235,6 +1242,54 @@ mod tests {
             }),
         );
         r
+    }
+
+    #[tokio::test]
+    async fn an_agent_whose_provider_is_missing_wedges_at_iteration_zero() {
+        // Issue #190. The registry has no `script` provider, so
+        // `dispatch_inference` declines and leaves the agent `ReadyToInfer`.
+        // Nothing about the world changed, so the fixed point is reached
+        // immediately and nothing is in flight to wake the driver - the agent
+        // used to sit `Active` at iteration 0 for ever, which on disk reads as
+        // a `running` run with no tokens and a frozen `updated_at`.
+        let mut world = build_world(ProviderRegistry::new());
+        let e = spawn(&mut world);
+
+        world.run_until_idle(30).await;
+
+        // Nothing has dispatched, and within the grace period that is still
+        // just a wait - but it is now a *recorded* one.
+        let state = world.world().get::<AgentState>(e).expect("the agent");
+        assert_eq!(state.iteration, 0, "not a single inference happened");
+        assert_eq!(state.status, AgentStatus::Active);
+        let stall = world
+            .world()
+            .get::<crate::pipeline::DispatchStall>(e)
+            .expect("the decline is recorded");
+        assert_eq!(stall.reason, crate::pipeline::StallReason::ProviderMissing);
+
+        // Backdate it past the grace period, as the host's redrive timer would
+        // find it on a later tick, and the run fails with an answer rather than
+        // hanging.
+        let past =
+            chrono::Utc::now().timestamp() - crate::pipeline::DEFAULT_STALL_TIMEOUT_SECS as i64 - 1;
+        world
+            .world_mut()
+            .get_mut::<crate::pipeline::DispatchStall>(e)
+            .expect("the stall record")
+            .since = past;
+        world.run_to_fixed_point();
+
+        let status = world.agent_status(e);
+        assert!(
+            matches!(status, Some(AgentStatus::Error { ref message })
+                if message.contains("script") && message.contains("not configured")),
+            "got: {status:?}"
+        );
+        assert!(
+            world.world().get::<ReadyToInfer>(e).is_none(),
+            "and it is out of the dispatch systems"
+        );
     }
 
     #[tokio::test]

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -94,6 +94,8 @@ process-wide state once at startup rather than per run:
 - provider keys and `[model_providers]` (the provider registry)
 - `[[mcp_servers]]` (live MCP connections), `[observability]` (the telemetry pipeline), and
   `[security] allow_local_network` (the outbound-network policy)
+- `[limits] stall_timeout_secs`, along with the other limits the world is built with
+  (`max_concurrent_inferences`, `max_concurrent_tools`, `exact_token_counting`)
 
 ## Control surface
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -213,6 +213,11 @@ waiting for a permit just stay in their ready-to-infer state, which costs nothin
 comes from `[limits] max_concurrent_inferences` in the [config](/docs/configuration), and per-model
 limits override it.
 
+Waiting for a permit is ordinary backpressure and is never treated as a failure, however long it
+lasts. Waiting for a provider that isn't configured is a different thing entirely: that agent has
+nothing to wait for, so it is failed once its stall outlives `[limits] stall_timeout_secs`
+(60 seconds by default; `0` waits indefinitely).
+
 This is a different knob from the two it is often confused with: fan-out's `max_workers` bounds
 how many *sub-agents* a stage spawns ([Sub-agents](/docs/sub-agents)), and
 `[rate_limits.<provider>]` shapes *request rate* to a provider. The pool bounds concurrency; the

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -44,6 +44,20 @@ isn't mounted, so it returns **405 Method Not Allowed** (the read routes still w
 An agent needs at least one [provider](/docs/providers). Run `lev setup`, or point Leviath at a
 local [Ollama](https://ollama.com) for a no-key start.
 
+## A run says `running` but never does anything
+
+Check its provider first. If a stage's model list names only providers you haven't configured,
+`lev run` refuses the spawn outright and tells you which ones it tried — configure one with
+`lev setup`, or add it to `config.toml` and restart the daemon.
+
+A run that gets past that and still can't dispatch (say you removed a provider key after it
+started) is failed after `[limits] stall_timeout_secs`, 60 seconds by default. Its `meta.json`
+records the reason. Set the limit to `0` to wait indefinitely instead.
+
+Waiting for a busy model is *not* this. An agent queued behind other in-flight requests to the same
+model is working as intended and is never failed, however long the queue takes — raise
+`[limits] max_concurrent_inferences` if you want more of them running at once.
+
 ## An agent seems stuck in a loop
 
 That's what [stuck detection](/docs/stages#graph) is for. Add a `condition = "stuck"` transition


### PR DESCRIPTION
Closes #190.

## What was wrong

Runs sat at `iteration=0` with no tokens, reported as `running` for ever. The issue's hypotheses assumed a per-run subprocess, but every run is a `bevy_ecs` entity inside the one daemon process (`RunMeta.pid` is hard-coded `0`) — there is no fork/exec to crash and no spawn race. A swallowed first-call error was also ruled out: `collect_inference` already routes provider errors to `AgentStatus::Error`.

The real cause is a dispatch that declines for something that will never resolve. `dispatch_inference` skips an agent whose stage names an unregistered provider, leaving it `Active` + `ReadyToInfer` to be "retried on a later tick". A run gets there because `resolve_stage_model` prefers entries whose provider is registered but **falls back to the blueprint's first entry unchecked**, and a `--model provider/model` override skipped the registry entirely.

## What this changes

- **Refuse the spawn.** A stage with no usable provider now fails `lev run` outright, naming the stage and every provider tried, instead of starting a run that can never take a turn. `registry.has` already consults the script layer, so a `.rhai` provider on disk still counts and cannot be false-rejected.
- **Terminate the placeholder.** The spawner stakes out the run directory and writes a `Starting` placeholder before building the agent. `Starting` is not terminal, so a failed spawn went on claiming the run was alive, listed by `lev ps` with nothing behind it. `force_error_in` records the failure there, sharing `force_cancel_in`'s implementation so "terminated on disk" keeps one definition.
- **Watchdog for what gets past that** — a provider removed from the config after a run started, say. A `DispatchStall` records why each dispatch declined and since when; an unresolvable stall outliving `[limits] stall_timeout_secs` (default 60s, `0` waits for ever) fails the run with a message naming the provider. A full inference pool is deliberately exempt: that is backpressure working as intended, however long it takes. The record carries a freshness stamp as well as a start time, so an agent that left the ready state for unrelated reasons (a stuck edge, an iteration cap) cannot come back carrying an ancient clock.
- **Supervise the async lanes.** Every lane spawned its job with the `JoinHandle` dropped, so a job that panicked before its send produced no outcome at all — and the marker it left behind is one of the `has_async_inflight` states, so the driver read the agent as busy and waited for a completion that could no longer happen. The tick schedule's panic guard does not reach these: they happen on a tokio worker, not in a system. A dead task now becomes an ordinary lane error, which every collect system already knows how to apply.

Two fixes I had written for this issue — the cancel path failing to wake on a freed permit, and a re-drive timer for the parked loop — landed on main first via #189, so this branch drops them and builds on that. `STALL_FRESHNESS_SECS` is calibrated against that 30s redrive interval.

## Verification

`cargo xtask coverage` green (all 11 packages at 100%) and the full suite passes. The behaviour was reproduced first, both as a failing unit test and against a real daemon, before anything was fixed.

Live, against an isolated daemon with offline Rhai mock providers:

| Scenario | Before | After |
|---|---|---|
| Agent whose only provider is unconfigured | `running`, iter 0, `updated_at` frozen 91s+, still in `lev ps` | `lev run` refused with the stage and providers tried; run dir recorded `error` |
| Provider deleted after the run started | same silent wedge | failed 34s in (15s timeout + redrive granularity), `error` names the provider, leaves `lev ps` |
| Ordinary two-stage run | — | unaffected: completes, 7 iterations, 3 tool calls, tokens accrued |

**Out of scope, worth its own issue:** entering a new stage does not dispatch until the next re-drive tick — a run that should finish instantly takes ~15s. Measured identically on `main` at e81d698 and on this branch, so it predates this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwTo8pGkkEzigsDM39masx
