### PR TITLE
Stop a tool lane full of waiters from starving the runs they wait on

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -807,7 +807,7 @@ impl Dashboard {
     /// every run look dead.
     pub(super) async fn sync_daemon_runs(&mut self, control: &ControlClient) {
         self.daemon_run_ids = match control.request(&ControlRequest::List).await {
-            Ok(ControlResponse::List { runs }) => {
+            Ok(ControlResponse::List { runs, .. }) => {
                 Some(runs.into_iter().map(|entry| entry.run_id).collect())
             }
             _ => None,

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -7,7 +7,7 @@
 use anyhow::bail;
 use leviath_runtime::components::AgentStatus;
 use leviath_runtime::control_socket::{ControlClient, ControlResponse};
-use leviath_runtime::host::RunListEntry;
+use leviath_runtime::host::{DaemonHealth, RunListEntry};
 
 /// `lev ps --help`. Every status an operator can see, and what to do about it.
 pub const PS_LONG_ABOUT: &str = "\
@@ -41,7 +41,16 @@ These do not - the run is parked on other work and resumes by itself:
 
 So `waiting: children(3)` alongside busy children is a healthy factory, while
 `waiting: tool approval` is stopped until someone answers. Run with `--yolo` to
-approve automatically, including for sub-agents and fan-out workers.";
+approve automatically, including for sub-agents and fan-out workers.
+
+A `lanes:` line under the table means the daemon itself is worth a look. It
+shows the tool lane's occupancy - batches running, parked on a wait, and queued
+behind them - and, if the daemon has stopped getting anywhere, how many re-drive
+cycles it has gone without a single run moving. A run parked on a wait costs the
+lane nothing, so `parked` is not a problem on its own; `queued` with no progress
+is.
+
+--json prints {\"runs\": [...], \"health\": {...}} with the same two halves.";
 
 /// Arguments for `lev ps`.
 #[derive(clap::Args, Debug, Clone, Default)]
@@ -93,11 +102,45 @@ fn stage_cell(entry: &RunListEntry) -> String {
     }
 }
 
-/// Render a run listing as an aligned table (or a friendly note when empty).
+/// The daemon-wide footer: what the tool lane is holding, and whether the daemon
+/// as a whole has stopped getting anywhere.
+///
+/// Absent while everything is healthy, so an ordinary listing stays a table and
+/// nothing else. A lane at capacity is worth mentioning; a dead-cycle streak is
+/// worth mentioning loudly, because every row above it can look busy while the
+/// factory as a whole has not moved in hours (issue #191).
+fn health_footer(health: &DaemonHealth) -> Option<String> {
+    let saturated = health.tools_busy >= health.tools_workers && health.tools_queued > 0;
+    if !saturated && health.dead_cycles == 0 {
+        return None;
+    }
+    let mut line = format!(
+        "lanes: tools {}/{} busy",
+        health.tools_busy, health.tools_workers
+    );
+    if health.tools_parked > 0 {
+        line.push_str(&format!(", {} parked", health.tools_parked));
+    }
+    if health.tools_queued > 0 {
+        line.push_str(&format!(", {} queued", health.tools_queued));
+    }
+    if health.dead_cycles > 0 {
+        let seconds = health.dead_cycles as i64 * health.redrive_secs as i64;
+        line.push_str(&format!(
+            "  ·  no progress for {} cycles ({})",
+            health.dead_cycles,
+            humanize_age(seconds)
+        ));
+    }
+    Some(line)
+}
+
+/// Render a run listing as an aligned table (or a friendly note when empty),
+/// with the daemon's own health underneath when it has something to say.
 ///
 /// `now` is unix seconds, passed in rather than read here so the output is
 /// deterministic under test.
-pub fn format_runs(runs: &[RunListEntry], now: i64) -> String {
+pub fn format_runs(runs: &[RunListEntry], health: &DaemonHealth, now: i64) -> String {
     if runs.is_empty() {
         return "no agents running".to_string();
     }
@@ -153,25 +196,36 @@ pub fn format_runs(runs: &[RunListEntry], now: i64) -> String {
         .iter()
         .filter(|e| e.wait_reason.as_ref().is_some_and(|r| r.needs_a_person()))
         .count();
-    match blocked {
+    let mut out = match blocked {
         0 => table,
         1 => format!("{table}\n\n1 run needs an answer: lev respond"),
         n => format!("{table}\n\n{n} runs need an answer: lev respond"),
+    };
+    if let Some(footer) = health_footer(health) {
+        out.push_str(&format!("\n\n{footer}"));
     }
+    out
 }
 
 /// Query the daemon for its runs and print the listing.
 pub async fn send_list(client: &ControlClient, args: &PsArgs) -> anyhow::Result<()> {
     match client.list().await {
-        Ok(ControlResponse::List { runs }) => {
+        Ok(ControlResponse::List { runs, health }) => {
             match args.json {
-                // `RunListEntry` is plain data with no map keys to reject, so
-                // serializing it cannot fail.
+                // Plain data with no map keys to reject, so serializing cannot
+                // fail.
                 true => println!(
                     "{}",
-                    serde_json::to_string_pretty(&runs).expect("a run listing serializes")
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "runs": runs,
+                        "health": health,
+                    }))
+                    .expect("a run listing serializes")
                 ),
-                false => println!("{}", format_runs(&runs, chrono::Utc::now().timestamp())),
+                false => println!(
+                    "{}",
+                    format_runs(&runs, &health, chrono::Utc::now().timestamp())
+                ),
             }
             Ok(())
         }

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -4,6 +4,15 @@ use leviath_runtime::control_socket::{ControlId, bind_control_listener, control_
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 
+/// A daemon with room to spare and nothing to report about itself.
+fn healthy_daemon() -> DaemonHealth {
+    DaemonHealth {
+        tools_workers: 8,
+        redrive_secs: 30,
+        ..Default::default()
+    }
+}
+
 fn entry(run_id: &str, status: AgentStatus) -> RunListEntry {
     RunListEntry {
         run_id: run_id.to_string(),
@@ -107,7 +116,7 @@ fn stage_cell_shows_position_only_for_multi_stage_blueprints() {
 
 #[test]
 fn format_runs_handles_empty() {
-    assert_eq!(format_runs(&[], 0), "no agents running");
+    assert_eq!(format_runs(&[], &healthy_daemon(), 0), "no agents running");
 }
 
 /// The whole point of the change: two runs both `Waiting`, telling the operator
@@ -127,7 +136,7 @@ fn format_runs_distinguishes_two_kinds_of_waiting() {
     parked.tool_calls = 1;
     parked.last_progress_at = Some(1_190);
 
-    let out = format_runs(&[blocked, parked], 1_200);
+    let out = format_runs(&[blocked, parked], &healthy_daemon(), 1_200);
     let lines: Vec<&str> = out.lines().collect();
     assert!(lines[0].starts_with("RUN"), "header row: {out}");
     assert!(lines[0].contains("AGE"), "header row: {out}");
@@ -149,10 +158,14 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
         e
     };
     assert!(
-        !format_runs(std::slice::from_ref(&healthy), 0).contains("needs an answer"),
+        !format_runs(std::slice::from_ref(&healthy), &healthy_daemon(), 0)
+            .contains("needs an answer"),
         "a fan-out parent is not blocked on anyone"
     );
-    assert!(!format_runs(&[entry("run-b", AgentStatus::Active)], 0).contains("needs an answer"));
+    assert!(
+        !format_runs(&[entry("run-b", AgentStatus::Active)], &healthy_daemon(), 0)
+            .contains("needs an answer")
+    );
 
     let prompt = |id: &str, reason: WaitReason| {
         let mut e = entry(id, AgentStatus::Waiting);
@@ -161,6 +174,7 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
     };
     let one = format_runs(
         &[prompt("run-c", WaitReason::TaintGate), healthy.clone()],
+        &healthy_daemon(),
         0,
     );
     assert!(one.ends_with("1 run needs an answer: lev respond"), "{one}");
@@ -171,6 +185,7 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
             prompt("run-d", WaitReason::InteractionPoint),
             healthy,
         ],
+        &healthy_daemon(),
         0,
     );
     assert!(two.ends_with("2 runs need an answer: lev respond"), "{two}");
@@ -189,7 +204,7 @@ fn format_runs_aligns_columns() {
     let short = entry("a", AgentStatus::Active);
     let mut long = entry("a-much-longer-run-id", AgentStatus::Waiting);
     long.wait_reason = Some(WaitReason::UserPrompt);
-    let out = format_runs(&[short, long], 0);
+    let out = format_runs(&[short, long], &healthy_daemon(), 0);
     let lines: Vec<&str> = out.lines().collect();
 
     let status_col = lines[0]
@@ -208,6 +223,85 @@ fn format_runs_aligns_columns() {
     for line in &lines {
         assert_eq!(line.trim_end(), *line, "no trailing blanks: {out:?}");
     }
+}
+
+/// A healthy daemon says nothing about itself. Every row can look busy while the
+/// factory as a whole is fine, and a footer on every listing would train
+/// operators to skip the one that matters.
+#[test]
+fn a_healthy_daemon_adds_no_footer() {
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &healthy_daemon(), 0);
+    assert!(!out.contains("lanes:"), "{out}");
+    // Parked batches on their own are not a problem: they hold no capacity.
+    let parked = DaemonHealth {
+        tools_parked: 3,
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &parked, 0);
+    assert!(!out.contains("lanes:"), "{out}");
+}
+
+/// A full lane with work behind it is worth mentioning, even while runs are
+/// still moving - it is the first sign of the shape that wedges.
+#[test]
+fn a_saturated_lane_is_reported_under_the_table() {
+    let health = DaemonHealth {
+        tools_busy: 8,
+        tools_workers: 8,
+        tools_queued: 12,
+        tools_parked: 3,
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    assert!(
+        out.ends_with("lanes: tools 8/8 busy, 3 parked, 12 queued"),
+        "{out}"
+    );
+}
+
+/// The dead-cycle streak, in cycles and in the wall-clock time an operator
+/// actually cares about.
+#[test]
+fn a_dead_cycle_streak_is_reported_in_cycles_and_minutes() {
+    let health = DaemonHealth {
+        tools_busy: 8,
+        tools_workers: 8,
+        tools_queued: 12,
+        dead_cycles: 4,
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    assert!(
+        out.ends_with("lanes: tools 8/8 busy, 12 queued  ·  no progress for 4 cycles (2m)"),
+        "{out}"
+    );
+
+    // A streak counts even when the lane has since drained - the daemon still
+    // has not moved, and that is the part worth saying.
+    let drained = DaemonHealth {
+        dead_cycles: 1,
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &drained, 0);
+    assert!(
+        out.ends_with("lanes: tools 0/8 busy  ·  no progress for 1 cycles (30s)"),
+        "{out}"
+    );
+}
+
+/// The footer sits below the "needs an answer" call-out rather than replacing
+/// it: they answer different questions and an operator may need both.
+#[test]
+fn the_footer_and_the_answer_call_out_coexist() {
+    let mut blocked = entry("run-a", AgentStatus::Waiting);
+    blocked.wait_reason = Some(WaitReason::ToolApproval);
+    let health = DaemonHealth {
+        dead_cycles: 2,
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[blocked], &health, 0);
+    assert!(out.contains("1 run needs an answer: lev respond"), "{out}");
+    assert!(out.contains("no progress for 2 cycles"), "{out}");
 }
 
 /// Bind a control listener at a fresh id under `dir` and serve one canned

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -328,7 +328,10 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_unexpected_is_500() {
-        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::List { runs: vec![] });
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::List {
+            runs: vec![],
+            health: Default::default(),
+        });
         assert_eq!(
             status_of(
                 app_with(control),

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -139,6 +139,12 @@ pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
         Some(&before.limits.stall_timeout_secs),
         Some(&after.limits.stall_timeout_secs),
     );
+    push_if_changed(
+        &mut out,
+        "dead cycles before relief",
+        Some(&before.limits.dead_cycles_before_relief),
+        Some(&after.limits.dead_cycles_before_relief),
+    );
 
     let added = after
         .mcp_servers

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -897,6 +897,11 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             help: "Fail a run that can never dispatch (unconfigured provider). 0 waits forever.",
             value: FieldValue::Number(Some(config.limits.stall_timeout_secs)),
         },
+        Field {
+            label: "Dead cycles before relief",
+            help: "Widen the tool lane after this many 30s cycles with work queued and nothing moving. 0 never does.",
+            value: FieldValue::Number(Some(config.limits.dead_cycles_before_relief as u64)),
+        },
     ]
 }
 
@@ -925,6 +930,12 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             (5, FieldValue::Number(n)) => {
                 config.limits.stall_timeout_secs =
                     n.unwrap_or(Config::default().limits.stall_timeout_secs)
+            }
+            // Same rule: unset keeps the default, 0 is an explicit "never".
+            (6, FieldValue::Number(n)) => {
+                config.limits.dead_cycles_before_relief = n
+                    .map(|n| n as u32)
+                    .unwrap_or(Config::default().limits.dead_cycles_before_relief)
             }
             _ => {}
         }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -423,6 +423,10 @@ fn default_stall_timeout_secs() -> u64 {
     leviath_runtime::pipeline::DEFAULT_STALL_TIMEOUT_SECS
 }
 
+fn default_dead_cycles_before_relief() -> u32 {
+    leviath_runtime::host::DEFAULT_DEAD_CYCLES_BEFORE_RELIEF
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -477,6 +481,21 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_stall_timeout_secs")]
     pub stall_timeout_secs: u64,
+
+    /// How many consecutive safety re-drives may find the tool lane full and no
+    /// run moving before the daemon widens the lane to break the jam.
+    ///
+    /// The daemon re-drives itself every 30 seconds, so the default of `10` is
+    /// five minutes of a full lane going nowhere. Relief only ever *adds*
+    /// capacity, never cancels anything, and is capped at one extra lane's worth
+    /// over the daemon's life, so it cannot run away.
+    ///
+    /// `0` turns relief off. Detection and reporting stay on either way, so
+    /// `lev ps` and the metrics still show the streak.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_dead_cycles_before_relief")]
+    pub dead_cycles_before_relief: u32,
 }
 
 impl Default for LimitsConfig {
@@ -488,6 +507,7 @@ impl Default for LimitsConfig {
             exact_token_counting: false,
             script_shell_timeout_secs: default_script_shell_timeout_secs(),
             stall_timeout_secs: default_stall_timeout_secs(),
+            dead_cycles_before_relief: default_dead_cycles_before_relief(),
         }
     }
 }
@@ -1579,6 +1599,9 @@ mod tests {
         assert_eq!(limits.default_max_iterations, Some(50));
         // Exact token counting is opt-in, off by default.
         assert!(!limits.exact_token_counting);
+        // Relief is on by default: ten 30-second cycles of a full lane going
+        // nowhere before the daemon widens it.
+        assert_eq!(limits.dead_cycles_before_relief, 10);
         // And the top-level Config carries the same defaults.
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
     }
@@ -1616,6 +1639,7 @@ mod tests {
         let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
         assert_eq!(config.limits.max_concurrent_inferences, Some(8));
         assert_eq!(config.limits.default_max_iterations, Some(50));
+        assert_eq!(config.limits.dead_cycles_before_relief, 10);
     }
 
     #[test]
@@ -2788,6 +2812,7 @@ enabled = false
                 exact_token_counting: false,
                 script_shell_timeout_secs: 45,
                 stall_timeout_secs: 90,
+                dead_cycles_before_relief: 6,
             },
             batch_tool_hint: true,
             nudge: leviath_core::NudgeConfig {
@@ -2844,6 +2869,7 @@ enabled = false
         assert_eq!(deserialized.limits.max_concurrent_inferences, Some(4));
         assert_eq!(deserialized.limits.max_concurrent_tools, 3);
         assert_eq!(deserialized.limits.script_shell_timeout_secs, 45);
+        assert_eq!(deserialized.limits.dead_cycles_before_relief, 6);
         assert_eq!(
             deserialized.tool_script_permissions.http_get,
             ScriptPermission::Allow

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -170,6 +170,9 @@ pub fn build_host(
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());
     let mut host = WorldHost::with_interactions(world, hub.clone());
+    // How long the daemon may sit with a full tool lane and no run moving before
+    // it widens the lane to break the jam (issue #191).
+    host.set_dead_cycles_before_relief(config.limits.dead_cycles_before_relief);
     // Handed to each agent's tool state so its sub-agent tools reach the world
     // through the host.
     let subagent_tx = host.subagent_sender();

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -169,6 +169,16 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
     if agent_id.is_empty() {
         return "[error] wait_for_agent requires 'agent_id'".to_string();
     }
+    // The whole wait happens off the tool lane. The child's own tool batches
+    // queue on that lane, so a parent that kept lane capacity while waiting was
+    // holding the very thing the child needed to finish - a parent and child
+    // deadlocked on each other, which is what froze whole factories for hours
+    // (issue #191).
+    leviath_runtime::tool_bridge::off_lane(poll_until_finished(h, agent_id)).await
+}
+
+/// Poll `agent_id` until it reaches a terminal state, or until the caller does.
+async fn poll_until_finished(h: &SubAgentHandle, agent_id: &str) -> String {
     loop {
         match status_of(h, agent_id).await {
             None => return format!("[error] no such sub-agent '{agent_id}'"),
@@ -180,8 +190,8 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
             }
             // The caller itself was cancelled (or failed) while waiting. Give up
             // rather than keep polling for a child that is being torn down with
-            // it - this loop has no other exit, so it would hold its tool-lane
-            // worker for as long as the daemon lived.
+            // it - this loop has no other exit, so it would otherwise run for as
+            // long as the daemon lived.
             Some(_) if caller_is_terminal(h).await => {
                 return format!("[error] cancelled while waiting for '{agent_id}'");
             }
@@ -603,8 +613,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     }
 
     /// `wait_for_agent` gives up when the *calling* agent is cancelled. The loop
-    /// has no other exit, and it runs on a tool-lane worker - of which there are
-    /// a fixed number - so a cancelled caller would otherwise poll for a child
+    /// has no other exit, so a cancelled caller would otherwise poll for a child
     /// that is being torn down with it until the daemon exits.
     #[tokio::test]
     async fn wait_gives_up_when_the_calling_agent_is_cancelled() {
@@ -624,6 +633,80 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         assert!(
             out.contains("cancelled while waiting"),
             "reports why it stopped, got: {out}"
+        );
+    }
+
+    /// `wait_for_agent` waits off the tool lane.
+    ///
+    /// The child's own tool batches queue on that lane. A parent that kept lane
+    /// capacity for the length of the wait was holding exactly what the child
+    /// needed in order to finish, so a factory of parents waiting on children
+    /// wedged itself and stayed wedged (issue #191).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_does_not_hold_the_tool_lane() {
+        use leviath_runtime::tool_bridge::{ToolJob, ToolLane, ToolLaneStats};
+
+        // A child that never finishes, so the wait is still running throughout.
+        let (h, _seen, _t) = fake_host(
+            Ok("child-1".to_string()),
+            vec![Some(AgentStatus::Active); 64],
+            false,
+        );
+
+        let (job_tx, job_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (result_tx, mut results) = tokio::sync::mpsc::unbounded_channel();
+        let stats = std::sync::Arc::new(ToolLaneStats::new(1));
+        let lane = ToolLane::new(
+            tokio::runtime::Handle::current(),
+            result_tx,
+            std::sync::Arc::new(tokio::sync::Notify::new()),
+            1,
+            stats.clone(),
+        );
+        let _serving = lane.serve(job_rx);
+        let submit = |entity: u32, exec: leviath_runtime::tool_bridge::BoxedToolExec| {
+            stats.enqueued();
+            job_tx
+                .send(ToolJob {
+                    entity: bevy_ecs::entity::Entity::from_raw_u32(entity)
+                        .expect("a small index is a valid id"),
+                    exec,
+                    cancel: leviath_runtime::cancel::CancelToken::new(),
+                })
+                .expect("the lane is serving");
+        };
+
+        submit(
+            1,
+            Box::new(move || {
+                Box::pin(async move {
+                    let out =
+                        handle(&h, &tc("wait_for_agent", json!({"agent_id": "child-1"}))).await;
+                    vec![("wait".to_string(), out)]
+                })
+            }),
+        );
+        // The waiter gives the lane back rather than sitting on it.
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while stats.parked() == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the wait stepped off the lane");
+
+        // Which is what lets anything else run - a child's tool batch, here.
+        submit(
+            2,
+            Box::new(|| Box::pin(async { vec![("child".to_string(), "ran".to_string())] })),
+        );
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), results.recv())
+            .await
+            .expect("the batch behind the waiter ran")
+            .expect("an outcome arrived");
+        assert_eq!(
+            outcome.results,
+            vec![("child".to_string(), "ran".to_string())]
         );
     }
 

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -646,12 +646,12 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     async fn wait_does_not_hold_the_tool_lane() {
         use leviath_runtime::tool_bridge::{ToolJob, ToolLane, ToolLaneStats};
 
-        // A child that never finishes, so the wait is still running throughout.
-        let (h, _seen, _t) = fake_host(
-            Ok("child-1".to_string()),
-            vec![Some(AgentStatus::Active); 64],
-            false,
-        );
+        // The child stays busy for several polls - long enough that the parent is
+        // demonstrably parked - and then finishes, so the wait is exercised to its
+        // end rather than abandoned mid-await.
+        let mut statuses = vec![Some(AgentStatus::Active); 6];
+        statuses.push(Some(AgentStatus::Complete));
+        let (h, _seen, _t) = fake_host(Ok("child-1".to_string()), statuses, false);
 
         let (job_tx, job_rx) = tokio::sync::mpsc::unbounded_channel();
         let (result_tx, mut results) = tokio::sync::mpsc::unbounded_channel();
@@ -707,6 +707,20 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         assert_eq!(
             outcome.results,
             vec![("child".to_string(), "ran".to_string())]
+        );
+
+        // And the waiter takes a permit again and reports, once its child is done.
+        let waited = tokio::time::timeout(std::time::Duration::from_secs(30), results.recv())
+            .await
+            .expect("the wait finished")
+            .expect("an outcome arrived");
+        assert_eq!(waited.results.len(), 1);
+        // Bound first: an expression that only a *failing* assertion evaluates
+        // is a region no passing run ever reaches.
+        let reported = waited.results[0].1.clone();
+        assert!(
+            reported.contains("finished with status: complete"),
+            "got: {reported}"
         );
     }
 

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -310,7 +310,7 @@ async fn real_daemon_status() -> anyhow::Result<()> {
     let running = is_daemon_running(&id);
     let count = if running {
         match control_client()?.list().await {
-            Ok(ControlResponse::List { runs }) => runs.len(),
+            Ok(ControlResponse::List { runs, .. }) => runs.len(),
             _ => 0,
         }
     } else {

--- a/crates/leviath-core/src/telemetry.rs
+++ b/crates/leviath-core/src/telemetry.rs
@@ -144,6 +144,33 @@ impl TelemetryEvent {
     }
 }
 
+/// How the daemon as a whole is doing, sampled once per safety re-drive.
+///
+/// Deliberately not a [`TelemetryEvent`]: every variant of that enum belongs to
+/// one run, and this belongs to none of them. The distinction is the point. A
+/// daemon whose lanes are full and whose runs have all stopped moving emits no
+/// per-run telemetry at all, precisely because nothing is happening, so the
+/// silence that issue #191 reported was indistinguishable from an idle night.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LaneHealth {
+    /// Agents doing work, or ready to.
+    pub agents_active: usize,
+    /// Agents blocked on input, a child, or a prompt.
+    pub agents_waiting: usize,
+    /// Tool batches holding lane capacity and running.
+    pub tools_busy: usize,
+    /// Tool batches waiting for lane capacity.
+    pub tools_queued: usize,
+    /// Tool batches parked on an unbounded wait, holding no capacity.
+    pub tools_parked: usize,
+    /// The tool lane's concurrency cap, including any relief granted.
+    pub tools_workers: usize,
+    /// Consecutive re-drives that found a lane at capacity and no run moving.
+    pub dead_cycles: u32,
+    /// Extra tool-lane capacity handed out on this sample, if any.
+    pub relief_granted: usize,
+}
+
 /// Where telemetry events go.
 ///
 /// Implementations must tolerate being called from the engine's tick loop:
@@ -151,6 +178,10 @@ impl TelemetryEvent {
 pub trait TelemetrySink: Send + Sync {
     /// Record one event.
     fn emit(&self, event: TelemetryEvent);
+
+    /// Record one daemon-wide health sample. Default: ignore it, so a sink that
+    /// only cares about runs needs no changes.
+    fn observe_lanes(&self, _health: LaneHealth) {}
 
     /// Flush any buffered export before shutdown. Default: nothing buffered.
     fn force_flush(&self) {}
@@ -167,6 +198,7 @@ impl TelemetrySink for NoopSink {
 #[derive(Default)]
 pub struct MemorySink {
     events: std::sync::Mutex<Vec<TelemetryEvent>>,
+    lanes: std::sync::Mutex<Vec<LaneHealth>>,
     flushes: std::sync::atomic::AtomicUsize,
 }
 
@@ -174,6 +206,11 @@ impl MemorySink {
     /// A snapshot of everything emitted so far, in order.
     pub fn events(&self) -> Vec<TelemetryEvent> {
         self.events.lock().expect("telemetry event lock").clone()
+    }
+
+    /// Every lane-health sample recorded so far, in order.
+    pub fn lane_samples(&self) -> Vec<LaneHealth> {
+        self.lanes.lock().expect("telemetry lane lock").clone()
     }
 
     /// How many times `force_flush` was called.
@@ -188,6 +225,10 @@ impl TelemetrySink for MemorySink {
             .lock()
             .expect("telemetry event lock")
             .push(event);
+    }
+
+    fn observe_lanes(&self, health: LaneHealth) {
+        self.lanes.lock().expect("telemetry lane lock").push(health);
     }
 
     fn force_flush(&self) {
@@ -225,6 +266,21 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].kind(), "run_started");
         assert_eq!(events[1].kind(), "stage_entered");
+    }
+
+    #[test]
+    fn memory_sink_records_lane_samples_and_the_noop_ignores_them() {
+        let sink = MemorySink::default();
+        assert!(sink.lane_samples().is_empty());
+        sink.observe_lanes(LaneHealth {
+            dead_cycles: 3,
+            ..Default::default()
+        });
+        assert_eq!(sink.lane_samples().len(), 1);
+        assert_eq!(sink.lane_samples()[0].dead_cycles, 3);
+
+        // The default trait body: a sink that only cares about runs drops it.
+        NoopSink.observe_lanes(LaneHealth::default());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/cancel.rs
+++ b/crates/leviath-runtime/src/cancel.rs
@@ -3,14 +3,13 @@
 //! Cancelling an agent sets its status, which stops the dispatch systems from
 //! starting *new* work - but an inference request or tool batch handed to the
 //! async lanes before that keeps running to completion. For a stalled provider
-//! call that is up to the job timeout; for a tool batch there was no bound at
-//! all, and the batch holds one of the tool lane's fixed number of workers the
-//! whole time.
+//! call that is up to the job timeout; for a tool batch there is no bound at
+//! all, and the batch holds tool-lane capacity the whole time.
 //!
 //! A [`CancelToken`] is handed to each async job when it is dispatched and kept
 //! on the agent, so cancelling the agent drops the in-flight future at its next
-//! await point: the HTTP request is aborted, the pool permit and lane worker are
-//! released, and the result is never applied.
+//! await point: the HTTP request is aborted, the pool permit and lane capacity
+//! are released, and the result is never applied.
 //!
 //! This is deliberately a few lines rather than a dependency: the whole contract
 //! is "set a flag once, wake anyone waiting".

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{broadcast, oneshot};
 
 use crate::components::AgentStatus;
-use crate::host::{ControlOp, RunListEntry, SpawnArgs, WorldEvent};
+use crate::host::{ControlOp, DaemonHealth, RunListEntry, SpawnArgs, WorldEvent};
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 
 #[cfg(unix)]
@@ -247,10 +247,15 @@ pub enum ControlResponse {
         /// Whether the operation applied.
         ok: bool,
     },
-    /// A listing of runs, their statuses, and the context needed to read them.
+    /// A listing of runs, their statuses, and the context needed to read them,
+    /// with the daemon's own health alongside.
     List {
         /// One entry per live run.
         runs: Vec<RunListEntry>,
+        /// How the daemon itself is doing. Defaulted when absent so a listing
+        /// from an older daemon still parses.
+        #[serde(default)]
+        health: DaemonHealth,
     },
     /// A listing of open interactions.
     Interactions {
@@ -314,9 +319,8 @@ async fn dispatch(req: ControlRequest, op_tx: &UnboundedSender<ControlOp>) -> Co
         ControlRequest::List => {
             let (reply, rx) = oneshot::channel();
             let _ = op_tx.send(ControlOp::List { reply });
-            ControlResponse::List {
-                runs: rx.await.unwrap_or_default(),
-            }
+            let (runs, health) = rx.await.unwrap_or_default();
+            ControlResponse::List { runs, health }
         }
         ControlRequest::Message {
             agent_id,
@@ -916,7 +920,7 @@ mod tests {
                         let _ = reply.send(true);
                     }
                     ControlOp::List { reply } => {
-                        let _ = reply.send(vec![listing_entry()]);
+                        let _ = reply.send((vec![listing_entry()], DaemonHealth::default()));
                     }
                     ControlOp::ListInteractions { reply } => {
                         let _ = reply.send(vec![]);
@@ -1066,7 +1070,8 @@ mod tests {
         assert_eq!(
             resp,
             ControlResponse::List {
-                runs: vec![listing_entry()]
+                runs: vec![listing_entry()],
+                health: DaemonHealth::default(),
             }
         );
     }
@@ -1427,7 +1432,10 @@ mod tests {
         let ok: ControlResponse = serde_json::from_str(&ok_line).unwrap();
         assert_eq!(
             std::mem::discriminant(&ok),
-            std::mem::discriminant(&ControlResponse::List { runs: vec![] })
+            std::mem::discriminant(&ControlResponse::List {
+                runs: vec![],
+                health: DaemonHealth::default(),
+            })
         );
 
         // Close the client so the handler sees EOF and returns cleanly.
@@ -1499,7 +1507,10 @@ mod tests {
         let list = client.list().await.unwrap();
         assert_eq!(
             std::mem::discriminant(&list),
-            std::mem::discriminant(&ControlResponse::List { runs: vec![] })
+            std::mem::discriminant(&ControlResponse::List {
+                runs: vec![],
+                health: DaemonHealth::default(),
+            })
         );
         assert_eq!(
             client.shutdown().await.unwrap(),
@@ -1709,7 +1720,10 @@ mod tests {
         );
         assert_eq!(
             dispatch(ControlRequest::List, &op_tx).await,
-            ControlResponse::List { runs: vec![] }
+            ControlResponse::List {
+                runs: vec![],
+                health: DaemonHealth::default(),
+            }
         );
         assert_eq!(
             dispatch(ControlRequest::ListInteractions, &op_tx).await,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -642,6 +642,31 @@ impl WorldHost {
             false => 0,
         };
         self.log_lane_pressure(&snapshot);
+        self.observe_lanes(&snapshot, 0);
+    }
+
+    /// Hand one daemon-wide health sample to the telemetry sink.
+    ///
+    /// `relief` is the capacity granted on this sample, which is a per-sample
+    /// figure rather than a running total: the sink accumulates it.
+    fn observe_lanes(&self, snapshot: &LaneSnapshot, relief: usize) {
+        // Every `PipelineWorld::new` installs the sink resource (a no-op one
+        // unless a host replaced it), so this is a hard invariant rather than a
+        // branch - the same reasoning as `set_exact_token_counting`.
+        self.world
+            .world()
+            .resource::<crate::telemetry::Telemetry>()
+            .0
+            .observe_lanes(leviath_core::telemetry::LaneHealth {
+                agents_active: snapshot.agents.active,
+                agents_waiting: snapshot.agents.waiting,
+                tools_busy: snapshot.tools_busy,
+                tools_queued: snapshot.tools_queued,
+                tools_parked: snapshot.tools_parked,
+                tools_workers: snapshot.tools_workers,
+                dead_cycles: self.dead_cycles,
+                relief_granted: relief,
+            });
     }
 
     /// The daemon's own health: lane occupancy plus the dead-cycle count.
@@ -2026,6 +2051,32 @@ mod tests {
 
         host.observe_redrive();
         assert_eq!(host.dead_cycles, 0, "something moved");
+    }
+
+    /// Every re-drive hands the sink a daemon-wide sample, including the quiet
+    /// ones. A wedged daemon produces no per-run telemetry at all, which is
+    /// exactly why the health sample cannot be conditional on something having
+    /// happened.
+    #[tokio::test]
+    async fn each_re_drive_reports_lane_health_to_the_telemetry_sink() {
+        let sink = Arc::new(leviath_core::telemetry::MemorySink::default());
+        let mut host = host_with_full_pool(1);
+        host.world_mut()
+            .world_mut()
+            .insert_resource(crate::telemetry::Telemetry(sink.clone()));
+        spawn(&mut host, "run-a", "agent-a");
+        spawn(&mut host, "run-b", "agent-b");
+        host.world_mut().run_to_fixed_point();
+        host.emit_events();
+
+        host.observe_redrive();
+        host.observe_redrive();
+
+        let samples = sink.lane_samples();
+        assert_eq!(samples.len(), 2, "one per re-drive");
+        assert_eq!(samples[0].dead_cycles, 0);
+        assert_eq!(samples[1].dead_cycles, 1, "the streak is carried through");
+        assert_eq!(samples[1].agents_active, 2);
     }
 
     /// Stillness on its own is not a dead cycle. An idle daemon has nothing

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -571,6 +571,9 @@ pub struct WorldHost {
     /// Extra tool-lane permits the relief valve has handed out over this
     /// daemon's life.
     relief_granted: usize,
+    /// Dead cycles the daemon tolerates before widening the tool lane. `0`
+    /// disables relief. See [`Self::set_dead_cycles_before_relief`].
+    dead_cycles_before_relief: u32,
 }
 
 /// How often the serve loop re-drives the world on its own.
@@ -585,6 +588,14 @@ pub struct WorldHost {
 /// knob. A no-op re-drive is one tick over a handful of systems plus an event
 /// diff, so at this cadence it costs nothing measurable.
 const DEFAULT_REDRIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How many consecutive dead cycles trigger the tool-lane relief valve.
+///
+/// At the 30-second re-drive that is five minutes of a full lane going nowhere -
+/// long enough that ordinary backpressure never reaches it, short enough that a
+/// genuinely wedged daemon is not left overnight. Served from
+/// `[limits] dead_cycles_before_relief`; `0` disables relief.
+pub const DEFAULT_DEAD_CYCLES_BEFORE_RELIEF: u32 = 10;
 
 impl WorldHost {
     /// Wrap a world with a fresh interaction hub.
@@ -620,6 +631,7 @@ impl WorldHost {
             dead_cycles: 0,
             last_progress: None,
             relief_granted: 0,
+            dead_cycles_before_relief: DEFAULT_DEAD_CYCLES_BEFORE_RELIEF,
         }
     }
 
@@ -642,7 +654,59 @@ impl WorldHost {
             false => 0,
         };
         self.log_lane_pressure(&snapshot);
-        self.observe_lanes(&snapshot, 0);
+        let relief = self.relieve_if_wedged(&snapshot);
+        self.observe_lanes(&snapshot, relief);
+    }
+
+    /// Widen the tool lane if the daemon has been going nowhere long enough, and
+    /// report how much capacity was added.
+    ///
+    /// Deliberately additive. The tempting reading of "force-reclaim stuck
+    /// slots" is to kill whatever is holding them, and that is the wrong move
+    /// here: a run parked on an `ask_user` is doing exactly what it should, and
+    /// an operator who mistook `waiting` for `stuck` and started killing healthy
+    /// runs is the story behind issue #184. Handing out more capacity unwedges a
+    /// jammed lane without having to be right about which run deserves to die.
+    ///
+    /// Only the tool lane is widened. A full inference pool is a deliberate cap
+    /// on requests in flight to a provider, and forcing extra ones past it would
+    /// trade a wedge for a rate limit.
+    ///
+    /// Capped at one extra lane's worth over the daemon's life. If that is not
+    /// enough, the problem is not capacity and more of it will not help.
+    fn relieve_if_wedged(&mut self, snapshot: &LaneSnapshot) -> usize {
+        let threshold = self.dead_cycles_before_relief;
+        if threshold == 0 || self.dead_cycles < threshold || !snapshot.tools_saturated {
+            return 0;
+        }
+        // The snapshot's width already includes everything granted so far, so
+        // back it out to get the lane's configured width - the budget.
+        let configured = snapshot.tools_workers.saturating_sub(self.relief_granted);
+        let remaining = configured.saturating_sub(self.relief_granted);
+        let granted = self
+            .world
+            .relieve_tool_lane(remaining.min(snapshot.tools_queued));
+        self.relief_granted += granted;
+        tracing::error!(
+            dead_cycles = self.dead_cycles,
+            granted,
+            relief_granted = self.relief_granted,
+            tools_queued = snapshot.tools_queued,
+            tools_parked = snapshot.tools_parked,
+            "the tool lane has not drained in {} cycles; widening it by {granted}",
+            self.dead_cycles
+        );
+        // Give the widened lane a fresh interval to show whether it helped,
+        // rather than granting again on the very next re-drive.
+        self.dead_cycles = 0;
+        granted
+    }
+
+    /// How many dead cycles the daemon tolerates before widening the tool lane.
+    /// `0` disables relief; detection and reporting are unaffected. Served from
+    /// `[limits] dead_cycles_before_relief`.
+    pub fn set_dead_cycles_before_relief(&mut self, cycles: u32) {
+        self.dead_cycles_before_relief = cycles;
     }
 
     /// Hand one daemon-wide health sample to the telemetry sink.
@@ -2051,6 +2115,174 @@ mod tests {
 
         host.observe_redrive();
         assert_eq!(host.dead_cycles, 0, "something moved");
+    }
+
+    /// Fill the world's tool lane and queue one batch behind it, returning a
+    /// handle that releases the blocking batch.
+    ///
+    /// Uses the world's real lane rather than poking the counters, because the
+    /// point of relief is that the queued batch actually runs afterwards.
+    async fn wedge_the_tool_lane(host: &mut WorldHost) -> Arc<tokio::sync::Notify> {
+        let snapshot = host.world_mut().lane_snapshot();
+        let stage = host
+            .world_mut()
+            .world()
+            .resource::<crate::pipeline::ToolStage>()
+            .clone();
+        let release = Arc::new(tokio::sync::Notify::new());
+        let submit = |exec: crate::tool_bridge::BoxedToolExec| {
+            stage.stats.enqueued();
+            stage
+                .jobs
+                .send(crate::tool_bridge::ToolJob {
+                    // The lane never looks at the entity; these batches belong to
+                    // no agent.
+                    entity: Entity::from_raw_u32(9_001).expect("a small index is a valid id"),
+                    exec,
+                    cancel: crate::cancel::CancelToken::new(),
+                })
+                .expect("the lane is serving");
+        };
+        // Every batch here blocks until `release` fires, and nothing in these
+        // tests ever fires it. That is deliberate: a batch that can finish on its
+        // own makes the lane's occupancy a moving target, and the counts these
+        // tests assert on stop being deterministic.
+        let mut blocker = || {
+            let held = release.clone();
+            submit(Box::new(move || {
+                Box::pin(async move {
+                    held.notified().await;
+                    Vec::new()
+                })
+            }));
+        };
+        // Take whatever capacity is still free, so the lane is genuinely full
+        // rather than merely busy.
+        for _ in 0..snapshot.tools_workers.saturating_sub(snapshot.tools_busy) {
+            blocker();
+        }
+        // Wait for them to actually be holding it before queueing anything
+        // behind them: batches race each other for a permit, so one submitted
+        // alongside could get in first.
+        await_full_lane(host).await;
+        blocker(); // and one behind them, which can only run once there is room
+        await_saturation(host).await;
+        release
+    }
+
+    /// Block until every unit of the world's tool-lane capacity is held.
+    async fn await_full_lane(host: &mut WorldHost) {
+        await_lane(host, "the lane filled up", |snapshot| {
+            snapshot.tools_busy >= snapshot.tools_workers
+        })
+        .await;
+    }
+
+    /// Block until the world's tool lane reports itself saturated.
+    async fn await_saturation(host: &mut WorldHost) {
+        await_lane(host, "the lane saturated", |snapshot| {
+            snapshot.tools_saturated
+        })
+        .await;
+    }
+
+    /// Block until the world's tool lane drains its queue.
+    async fn await_drained_queue(host: &mut WorldHost) {
+        await_lane(host, "the queued batch got in", |snapshot| {
+            snapshot.tools_queued == 0
+        })
+        .await;
+    }
+
+    /// Poll the lane until `done`, or fail with `context`. Bounded so a wedge in
+    /// the code under test fails the run instead of hanging it.
+    async fn await_lane(
+        host: &mut WorldHost,
+        context: &str,
+        done: fn(&crate::world::LaneSnapshot) -> bool,
+    ) {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while !done(&host.world_mut().lane_snapshot()) {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{context}"));
+    }
+
+    /// The relief valve: a tool lane that has not drained in long enough gets
+    /// wider, so whatever is queued behind the jam can run.
+    ///
+    /// Additive on purpose. Killing whatever holds the lane is the tempting
+    /// reading of "reclaim stuck slots", and it is wrong: a run parked on an
+    /// `ask_user` is behaving correctly, and an operator killing healthy
+    /// `waiting` runs is the story behind issue #184.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_lane_that_never_drains_is_widened_rather_than_emptied() {
+        leviath_testkit::with_tracing(|| async {
+            let mut host = host_with_full_pool(1);
+            host.set_dead_cycles_before_relief(2);
+            let _release = wedge_the_tool_lane(&mut host).await;
+
+            host.observe_redrive(); // baseline
+            host.observe_redrive(); // 1
+            assert_eq!(host.relief_granted, 0, "still inside the grace period");
+            host.observe_redrive(); // 2 → relief
+            assert_eq!(host.relief_granted, 1, "the lane got wider");
+            assert_eq!(
+                host.dead_cycles, 0,
+                "the streak restarts so relief is not granted again immediately"
+            );
+            assert_eq!(host.health().tools_workers, 2);
+
+            // Which is the whole point: the batch that was queued behind the
+            // jam gets a permit, while the batch already holding one keeps it.
+            await_drained_queue(&mut host).await;
+            assert_eq!(host.world_mut().lane_snapshot().tools_busy, 2);
+        })
+        .await;
+    }
+
+    /// Relief is capped at one extra lane's worth over the daemon's life. If
+    /// that much did not help, the problem is not capacity.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relief_stops_after_one_extra_lane_s_worth() {
+        leviath_testkit::with_tracing(|| async {
+            let mut host = host_with_full_pool(1);
+            host.set_dead_cycles_before_relief(1);
+            let _release = wedge_the_tool_lane(&mut host).await;
+
+            host.observe_redrive();
+            host.observe_redrive();
+            assert_eq!(host.relief_granted, 1);
+
+            // Wedge it again at the wider width and keep pushing: the budget is
+            // spent, so nothing more is handed out.
+            let _release_two = wedge_the_tool_lane(&mut host).await;
+            for _ in 0..4 {
+                host.observe_redrive();
+            }
+            assert_eq!(host.relief_granted, 1, "the budget was already spent");
+        })
+        .await;
+    }
+
+    /// Relief is off when the operator says so, and detection carries on
+    /// regardless - the streak is still counted and still reported.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relief_can_be_turned_off_without_turning_off_detection() {
+        leviath_testkit::with_tracing(|| async {
+            let mut host = host_with_full_pool(1);
+            host.set_dead_cycles_before_relief(0);
+            let _release = wedge_the_tool_lane(&mut host).await;
+
+            for _ in 0..4 {
+                host.observe_redrive();
+            }
+            assert_eq!(host.relief_granted, 0, "relief is disabled");
+            assert_eq!(host.dead_cycles, 3, "but the streak is still counted");
+        })
+        .await;
     }
 
     /// Every re-drive hands the sink a daemon-wide sample, including the quiet

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -132,6 +132,36 @@ pub struct RunListEntry {
     pub unattended: bool,
 }
 
+/// The daemon's own health, alongside the run listing.
+///
+/// A per-run view answers "what is this run doing"; this answers "is the daemon
+/// getting anywhere at all". They are different questions, and issue #191 was
+/// only visible in the second: every individual run looked fine, and the factory
+/// as a whole had not moved in hours.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DaemonHealth {
+    /// Loaded agents by status.
+    pub agents: crate::world::AgentCounts,
+    /// Inference-pool occupancy, one entry per model actually used.
+    pub inference: Vec<crate::inference_pool::PoolOccupancy>,
+    /// Tool batches holding lane capacity and running.
+    pub tools_busy: usize,
+    /// Tool batches waiting for lane capacity.
+    pub tools_queued: usize,
+    /// Tool batches parked on an unbounded wait, holding no capacity.
+    pub tools_parked: usize,
+    /// The tool lane's concurrency cap, including any relief granted.
+    pub tools_workers: usize,
+    /// Consecutive safety re-drives that found a lane at capacity and no run
+    /// moving. Zero on a healthy daemon, and reset by any sign of progress.
+    pub dead_cycles: u32,
+    /// How many extra tool-lane permits the relief valve has handed out.
+    pub relief_granted: usize,
+    /// How often the daemon re-drives itself, so a client can turn
+    /// `dead_cycles` into wall-clock time.
+    pub redrive_secs: u64,
+}
+
 /// The daemon-installed function that turns [`SpawnArgs`] into a live agent:
 /// loads the blueprint, resolves stages/tools, spawns into the world, and
 /// returns the new entity (the host records the run-id mapping). Returns `Err`
@@ -273,10 +303,10 @@ pub enum ControlOp {
         /// Reply channel.
         reply: oneshot::Sender<bool>,
     },
-    /// List every known live run and its status.
+    /// List every known live run and its status, with the daemon's own health.
     List {
         /// Reply channel.
-        reply: oneshot::Sender<Vec<RunListEntry>>,
+        reply: oneshot::Sender<(Vec<RunListEntry>, DaemonHealth)>,
     },
     /// Deliver a message to a running agent (by agent id). Reply is `false` if the
     /// world's message channel is closed.
@@ -538,6 +568,9 @@ pub struct WorldHost {
     /// The progress fingerprint as of the previous re-drive, or `None` before
     /// the first one.
     last_progress: Option<u64>,
+    /// Extra tool-lane permits the relief valve has handed out over this
+    /// daemon's life.
+    relief_granted: usize,
 }
 
 /// How often the serve loop re-drives the world on its own.
@@ -586,6 +619,7 @@ impl WorldHost {
             redrive: DEFAULT_REDRIVE_INTERVAL,
             dead_cycles: 0,
             last_progress: None,
+            relief_granted: 0,
         }
     }
 
@@ -608,6 +642,26 @@ impl WorldHost {
             false => 0,
         };
         self.log_lane_pressure(&snapshot);
+    }
+
+    /// The daemon's own health: lane occupancy plus the dead-cycle count.
+    ///
+    /// Served alongside every run listing, because "is this run stuck" and "is
+    /// the daemon stuck" are answered by different numbers and an operator
+    /// looking at one wants the other in the same breath.
+    pub fn health(&self) -> DaemonHealth {
+        let snapshot = self.world.lane_snapshot();
+        DaemonHealth {
+            agents: snapshot.agents,
+            inference: snapshot.inference,
+            tools_busy: snapshot.tools_busy,
+            tools_queued: snapshot.tools_queued,
+            tools_parked: snapshot.tools_parked,
+            tools_workers: snapshot.tools_workers,
+            dead_cycles: self.dead_cycles,
+            relief_granted: self.relief_granted,
+            redrive_secs: self.redrive.as_secs(),
+        }
     }
 
     /// A number that changes exactly when some run observably moves.
@@ -1358,7 +1412,7 @@ impl WorldHost {
                 let _ = reply.send(ok);
             }
             ControlOp::List { reply } => {
-                let _ = reply.send(self.list());
+                let _ = reply.send((self.list(), self.health()));
             }
             ControlOp::Message {
                 agent_id,
@@ -2036,7 +2090,7 @@ mod tests {
         .await;
         assert_eq!(status, Some(AgentStatus::Active));
 
-        let list = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].run_id, "run-a");
         assert_eq!(list[0].status, AgentStatus::Active);
@@ -3456,7 +3510,7 @@ mod tests {
         // Despawn the entity behind the world's back; the run-id map is now stale.
         host.world_mut().world_mut().despawn(e);
 
-        let list = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
         assert!(list.is_empty()); // stale mapping filtered out
         let status = ask(&mut host, |reply| ControlOp::Status {
             run_id: "run-a".to_string(),
@@ -3744,7 +3798,7 @@ mod tests {
                 watermark
             },
         ));
-        let list = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
         assert_eq!(list[0].num_stages, Some(3));
         assert_eq!(list[0].tool_calls, 9);
         assert!(list[0].unattended);
@@ -3759,7 +3813,7 @@ mod tests {
         waiting_because(&mut host, e, |entity| {
             entity.insert(crate::pipeline::WaitingForChildren);
         });
-        let list = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
         assert_eq!(list.len(), 1);
         assert_eq!(
             list[0].wait_reason,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -2441,9 +2441,9 @@ mod tests {
         );
     }
 
-    /// Cancelling a run closes its open prompts. The blocked `ask` occupies a
-    /// tool-lane worker, and the lane has a fixed worker count - leaving it
-    /// parked forever is what starves every other agent's tool batches.
+    /// Cancelling a run closes its open prompts. The blocked `ask` waits off the
+    /// lane, so it no longer starves anyone, but a prompt left open for a run
+    /// that no longer exists is still surfaced to whoever is meant to answer it.
     #[tokio::test]
     async fn cancel_closes_the_runs_open_interactions() {
         let mut host = host_with(vec![]);

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -27,7 +27,7 @@ use crate::components::{
 };
 use crate::interaction_hub::InteractionHub;
 use crate::persistence::{RunMetadata, TokenTotals};
-use crate::world::PipelineWorld;
+use crate::world::{LaneSnapshot, PipelineWorld};
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 use serde::{Deserialize, Serialize};
 
@@ -497,7 +497,7 @@ fn status_str(status: &AgentStatus) -> &'static str {
 }
 
 /// The last-emitted snapshot of an agent, for change detection.
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 struct Emitted {
     status: &'static str,
     stage: String,
@@ -532,6 +532,12 @@ pub struct WorldHost {
     /// How often [`Self::serve`] re-drives the world even though nothing woke
     /// it. See [`Self::set_redrive_interval`].
     redrive: Duration,
+    /// Consecutive re-drives that found the lanes full and nothing moved. See
+    /// [`Self::observe_redrive`].
+    dead_cycles: u32,
+    /// The progress fingerprint as of the previous re-drive, or `None` before
+    /// the first one.
+    last_progress: Option<u64>,
 }
 
 /// How often the serve loop re-drives the world on its own.
@@ -578,10 +584,54 @@ impl WorldHost {
             subagent_tx,
             subagent_rx,
             redrive: DEFAULT_REDRIVE_INTERVAL,
+            dead_cycles: 0,
+            last_progress: None,
         }
     }
 
-    /// Report what the lanes are holding, once per safety re-drive.
+    /// Take stock once per safety re-drive: has anything moved, and are the lanes
+    /// full? Updates the dead-cycle count and reports.
+    ///
+    /// A *dead cycle* is a whole re-drive interval in which some lane was at
+    /// capacity with work queued behind it and no run observably moved. Both
+    /// halves matter. Pressure on its own is just a busy daemon. Stillness on its
+    /// own is an idle one, or one agent in a long inference with nobody waiting.
+    /// Together they are the shape issue #191 reported: work to do, no capacity to
+    /// do it with, and no sign of that ever changing.
+    fn observe_redrive(&mut self) {
+        let snapshot = self.world.lane_snapshot();
+        let progress = self.progress_fingerprint();
+        let went_nowhere = snapshot.is_under_pressure() && self.last_progress == Some(progress);
+        self.last_progress = Some(progress);
+        self.dead_cycles = match went_nowhere {
+            true => self.dead_cycles.saturating_add(1),
+            false => 0,
+        };
+        self.log_lane_pressure(&snapshot);
+    }
+
+    /// A number that changes exactly when some run observably moves.
+    ///
+    /// Derived from the per-run snapshots `emit_events` already keeps to decide
+    /// what to broadcast, so an unchanged fingerprint means "nothing happened
+    /// that anyone watching would have been told about" - not merely "no event
+    /// was sent", which would also be true of a daemon nobody is subscribed to.
+    ///
+    /// Summed rather than fed through one hasher because a `HashMap` has no
+    /// iteration order to depend on. Every field it covers is either monotonic or
+    /// hashed, so two different worlds colliding takes a deliberate effort.
+    fn progress_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut total = self.emitted.len() as u64;
+        for entry in &self.emitted {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            entry.hash(&mut hasher);
+            total = total.wrapping_add(hasher.finish());
+        }
+        total
+    }
+
+    /// Report what the lanes are holding.
     ///
     /// The daemon otherwise logs nothing per tick, by design - observation goes
     /// through the telemetry sink. But a wedged daemon emits no telemetry either,
@@ -589,26 +639,41 @@ impl WorldHost {
     /// trace at all (issue #189). This is the one periodic line that can answer
     /// "is anything running, and what is it queued behind?".
     ///
-    /// Quiet by default: `info` only when a lane is at capacity with work behind
-    /// it, `debug` otherwise, so an idle daemon says nothing at `info`.
-    fn log_lane_pressure(&self) {
-        let snap = self.world.lane_snapshot();
-        if snap.is_under_pressure() {
+    /// Quiet by default: `warn` once the daemon has been going nowhere, `info`
+    /// while a lane is merely at capacity, `debug` otherwise, so an idle daemon
+    /// says nothing above `debug`.
+    fn log_lane_pressure(&self, snapshot: &LaneSnapshot) {
+        let agents = snapshot.agents.to_string();
+        let inference = snapshot.inference_summary();
+        if self.dead_cycles > 0 {
+            tracing::warn!(
+                dead_cycles = self.dead_cycles,
+                agents = %agents,
+                inference = %inference,
+                tools_busy = snapshot.tools_busy,
+                tools_workers = snapshot.tools_workers,
+                tools_queued = snapshot.tools_queued,
+                tools_parked = snapshot.tools_parked,
+                "no progress while the lanes are full"
+            );
+        } else if snapshot.is_under_pressure() {
             tracing::info!(
-                agents = %snap.agents,
-                inference = %snap.inference_summary(),
-                tools_busy = snap.tools_busy,
-                tools_workers = snap.tools_workers,
-                tools_queued = snap.tools_queued,
+                agents = %agents,
+                inference = %inference,
+                tools_busy = snapshot.tools_busy,
+                tools_workers = snapshot.tools_workers,
+                tools_queued = snapshot.tools_queued,
+                tools_parked = snapshot.tools_parked,
                 "lane heartbeat: at capacity with work queued"
             );
         } else {
             tracing::debug!(
-                agents = %snap.agents,
-                inference = %snap.inference_summary(),
-                tools_busy = snap.tools_busy,
-                tools_workers = snap.tools_workers,
-                tools_queued = snap.tools_queued,
+                agents = %agents,
+                inference = %inference,
+                tools_busy = snapshot.tools_busy,
+                tools_workers = snapshot.tools_workers,
+                tools_queued = snapshot.tools_queued,
+                tools_parked = snapshot.tools_parked,
                 "lane heartbeat"
             );
         }
@@ -1364,7 +1429,7 @@ impl WorldHost {
                 // park the daemon indefinitely with work left to do. Re-driving
                 // on a timer bounds that to one interval, and is where the lane
                 // heartbeat reports what the loop is actually waiting on.
-                _ = redrive.tick() => self.log_lane_pressure(),
+                _ = redrive.tick() => self.observe_redrive(),
                 op = control_rx.recv() => {
                     match op {
                         // Await the spawn preprocessor (e.g. lazy MCP connect) before
@@ -1838,7 +1903,7 @@ mod tests {
             let idle = host.world_mut().lane_snapshot();
             assert!(!idle.is_under_pressure(), "an empty world is not pressured");
             assert_eq!(idle.inference_summary(), "none");
-            host.log_lane_pressure(); // the `debug` arm
+            host.log_lane_pressure(&idle); // the `debug` arm
 
             // Two agents, one slot: one infers, one is queued behind a full pool.
             spawn(&mut host, "run-a", "agent-a");
@@ -1852,9 +1917,74 @@ mod tests {
                 busy.is_under_pressure(),
                 "a full pool with active agents is exactly the state worth reporting"
             );
-            host.log_lane_pressure(); // the `info` arm
+            host.log_lane_pressure(&busy); // the `info` arm
         })
         .await;
+    }
+
+    /// A daemon with work queued and nothing moving is what issue #191 reported,
+    /// and until now it looked identical to a busy one. Each re-drive that finds
+    /// the lanes full and the world unchanged is one dead cycle.
+    #[tokio::test]
+    async fn re_drives_that_go_nowhere_under_pressure_count_as_dead_cycles() {
+        leviath_testkit::with_tracing(|| async {
+            // Two agents, one inference slot, and a provider that never answers:
+            // one is stuck mid-call, the other is queued behind a full pool.
+            let mut host = host_with_full_pool(1);
+            spawn(&mut host, "run-a", "agent-a");
+            spawn(&mut host, "run-b", "agent-b");
+            host.world_mut().run_to_fixed_point();
+            host.emit_events();
+
+            // The first re-drive has nothing to compare against.
+            host.observe_redrive();
+            assert_eq!(host.dead_cycles, 0, "the first cycle sets the baseline");
+
+            host.observe_redrive();
+            assert_eq!(host.dead_cycles, 1, "a whole interval, nothing moved");
+            host.observe_redrive();
+            assert_eq!(host.dead_cycles, 2, "and another - this is the `warn` arm");
+        })
+        .await;
+    }
+
+    /// Any sign of life clears the count. A daemon that moves once every few
+    /// minutes is slow, not wedged, and must not accumulate towards relief.
+    #[tokio::test]
+    async fn a_run_that_moves_clears_the_dead_cycle_count() {
+        let mut host = host_with_full_pool(1);
+        let entity = spawn(&mut host, "run-a", "agent-a");
+        spawn(&mut host, "run-b", "agent-b");
+        host.world_mut().run_to_fixed_point();
+        host.emit_events();
+        host.observe_redrive();
+        host.observe_redrive();
+        assert_eq!(host.dead_cycles, 1, "wedged to begin with");
+
+        // One run advances an iteration, which is exactly what the fingerprint
+        // is built to notice.
+        host.world_mut()
+            .world_mut()
+            .get_mut::<AgentState>(entity)
+            .expect("the agent is loaded")
+            .iteration += 1;
+        host.emit_events();
+
+        host.observe_redrive();
+        assert_eq!(host.dead_cycles, 0, "something moved");
+    }
+
+    /// Stillness on its own is not a dead cycle. An idle daemon has nothing
+    /// queued and nothing to do, and counting it would fire relief at every quiet
+    /// spell.
+    #[tokio::test]
+    async fn an_idle_daemon_never_counts_a_dead_cycle() {
+        let mut host = host_with_full_pool(1);
+        host.emit_events();
+        for _ in 0..3 {
+            host.observe_redrive();
+        }
+        assert_eq!(host.dead_cycles, 0, "no pressure, no dead cycles");
     }
 
     /// Terminal agents are counted apart from live ones, so "nothing is running"

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -2122,14 +2122,17 @@ mod tests {
     ///
     /// Uses the world's real lane rather than poking the counters, because the
     /// point of relief is that the queued batch actually runs afterwards.
-    async fn wedge_the_tool_lane(host: &mut WorldHost) -> Arc<tokio::sync::Notify> {
+    async fn wedge_the_tool_lane(host: &mut WorldHost) -> crate::cancel::CancelToken {
         let snapshot = host.world_mut().lane_snapshot();
         let stage = host
             .world_mut()
             .world()
             .resource::<crate::pipeline::ToolStage>()
             .clone();
-        let release = Arc::new(tokio::sync::Notify::new());
+        // A cancel token rather than a `Notify`: it latches, so a batch that has
+        // not started yet still sees the release rather than waiting for a
+        // wake-up that already happened.
+        let release = crate::cancel::CancelToken::new();
         let submit = |exec: crate::tool_bridge::BoxedToolExec| {
             stage.stats.enqueued();
             stage
@@ -2143,15 +2146,15 @@ mod tests {
                 })
                 .expect("the lane is serving");
         };
-        // Every batch here blocks until `release` fires, and nothing in these
-        // tests ever fires it. That is deliberate: a batch that can finish on its
-        // own makes the lane's occupancy a moving target, and the counts these
-        // tests assert on stop being deterministic.
+        // Every batch here blocks until `release` fires. That is deliberate: a
+        // batch that can finish on its own makes the lane's occupancy a moving
+        // target, and the counts these tests assert on stop being deterministic.
+        // `release_the_lane` lets them all go at the end.
         let mut blocker = || {
             let held = release.clone();
             submit(Box::new(move || {
                 Box::pin(async move {
-                    held.notified().await;
+                    held.cancelled().await;
                     Vec::new()
                 })
             }));
@@ -2207,7 +2210,23 @@ mod tests {
             }
         })
         .await
-        .unwrap_or_else(|_| panic!("{context}"));
+        .expect(context);
+    }
+
+    /// Let every wedged batch finish and wait for the lane to empty, so the
+    /// batches are exercised end to end rather than abandoned mid-await.
+    ///
+    /// Takes a slice rather than one token so a test that wedged the lane twice
+    /// releases both before waiting; releasing one and waiting would wait for
+    /// batches still held by the other.
+    async fn release_the_lane(host: &mut WorldHost, releases: &[crate::cancel::CancelToken]) {
+        for release in releases {
+            release.cancel();
+        }
+        await_lane(host, "the lane emptied", |snapshot| {
+            snapshot.tools_busy == 0 && snapshot.tools_queued == 0
+        })
+        .await;
     }
 
     /// The relief valve: a tool lane that has not drained in long enough gets
@@ -2222,7 +2241,7 @@ mod tests {
         leviath_testkit::with_tracing(|| async {
             let mut host = host_with_full_pool(1);
             host.set_dead_cycles_before_relief(2);
-            let _release = wedge_the_tool_lane(&mut host).await;
+            let release = wedge_the_tool_lane(&mut host).await;
 
             host.observe_redrive(); // baseline
             host.observe_redrive(); // 1
@@ -2239,6 +2258,7 @@ mod tests {
             // jam gets a permit, while the batch already holding one keeps it.
             await_drained_queue(&mut host).await;
             assert_eq!(host.world_mut().lane_snapshot().tools_busy, 2);
+            release_the_lane(&mut host, &[release]).await;
         })
         .await;
     }
@@ -2250,7 +2270,7 @@ mod tests {
         leviath_testkit::with_tracing(|| async {
             let mut host = host_with_full_pool(1);
             host.set_dead_cycles_before_relief(1);
-            let _release = wedge_the_tool_lane(&mut host).await;
+            let release = wedge_the_tool_lane(&mut host).await;
 
             host.observe_redrive();
             host.observe_redrive();
@@ -2258,11 +2278,12 @@ mod tests {
 
             // Wedge it again at the wider width and keep pushing: the budget is
             // spent, so nothing more is handed out.
-            let _release_two = wedge_the_tool_lane(&mut host).await;
+            let release_two = wedge_the_tool_lane(&mut host).await;
             for _ in 0..4 {
                 host.observe_redrive();
             }
             assert_eq!(host.relief_granted, 1, "the budget was already spent");
+            release_the_lane(&mut host, &[release, release_two]).await;
         })
         .await;
     }
@@ -2274,13 +2295,14 @@ mod tests {
         leviath_testkit::with_tracing(|| async {
             let mut host = host_with_full_pool(1);
             host.set_dead_cycles_before_relief(0);
-            let _release = wedge_the_tool_lane(&mut host).await;
+            let release = wedge_the_tool_lane(&mut host).await;
 
             for _ in 0..4 {
                 host.observe_redrive();
             }
             assert_eq!(host.relief_granted, 0, "relief is disabled");
             assert_eq!(host.dead_cycles, 3, "but the streak is still counted");
+            release_the_lane(&mut host, &[release]).await;
         })
         .await;
     }

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -2150,7 +2150,7 @@ mod tests {
         // batch that can finish on its own makes the lane's occupancy a moving
         // target, and the counts these tests assert on stop being deterministic.
         // `release_the_lane` lets them all go at the end.
-        let mut blocker = || {
+        let blocker = || {
             let held = release.clone();
             submit(Box::new(move || {
                 Box::pin(async move {

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -190,7 +190,7 @@ impl InferencePools {
 }
 
 /// How busy one model's pool is. `cap: None` means the model is unbounded.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PoolOccupancy {
     /// The model key the pool is scoped to.
     pub model: String,

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -221,8 +221,12 @@ impl std::fmt::Display for PoolOccupancy {
 /// semaphore was closed. Extracted as a free function (rather than an inline
 /// `.expect(...)`) so both arms - the ordinary `Ok` and the never-in-practice
 /// `Err` - are exercised directly by unit tests, keeping the region covered.
-fn expect_permit(result: Result<OwnedSemaphorePermit, AcquireError>) -> OwnedSemaphorePermit {
-    result.expect("inference pool semaphore is never closed")
+///
+/// Shared with the tool lane, whose semaphore is never closed either.
+pub(crate) fn expect_permit(
+    result: Result<OwnedSemaphorePermit, AcquireError>,
+) -> OwnedSemaphorePermit {
+    result.expect("a lane semaphore is never closed")
 }
 
 /// An RAII permit occupying one slot of a model's inference pool. Dropping it

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -8,9 +8,10 @@
 //! open requests over the control channel via [`InteractionHub::pending`] and
 //! delivers answers with [`InteractionHub::answer`] - no filesystem, no polling.
 //!
-//! `ask` blocks the calling tool worker until the request is answered or
-//! cancelled; with the tool lane sequential today that serializes interactive
-//! agents, which is acceptable (the lane becomes a pool later).
+//! `ask` blocks its caller until the request is answered or cancelled, which for
+//! a person at a keyboard can be a very long time. When the caller is a tool
+//! batch it waits [`off_lane`](crate::tool_bridge::off_lane), so a prompt nobody
+//! has answered yet costs the tool lane no capacity.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
@@ -84,7 +85,14 @@ impl InteractionHub {
         // agent's status (Active → Waiting) for the dashboard to surface.
         self.nudge();
         // The lock is released before awaiting; answer()/cancel() can run.
-        rx.await
+        //
+        // Off the tool lane, because there is no bound on how long a person
+        // takes: a batch that held lane capacity through a prompt was capacity
+        // no other agent's tools could use (issue #191). Callers that are not
+        // tool batches - the gate-prompt and interaction-point lanes - have no
+        // ticket, and for them this is a plain await.
+        crate::tool_bridge::off_lane(rx)
+            .await
             .unwrap_or_else(|_| InteractionResponse::text(id, ""))
     }
 
@@ -142,11 +150,9 @@ impl InteractionHub {
     ///
     /// This is the per-agent counterpart of [`Self::cancel`], which is keyed by
     /// request id - an id a canceller of a *run* doesn't have. Without it,
-    /// cancelling a run left its `ask` future blocked forever: the future holds a
-    /// tool-lane worker (the lane has a fixed worker count, so enough of them
-    /// stall every other agent's tool batches), and the orphaned request keeps
-    /// being surfaced by `lev respond` and the dashboard for a run that no longer
-    /// exists.
+    /// cancelling a run left its `ask` future blocked forever, and the orphaned
+    /// request kept being surfaced by `lev respond` and the dashboard for a run
+    /// that no longer exists.
     pub fn cancel_for_agent(&self, agent_id: &str) -> usize {
         // Dropping each entry drops its responder, waking `submit` with an error.
         let mut pending = self.pending.lock().unwrap_or_else(PoisonError::into_inner);
@@ -240,6 +246,104 @@ mod tests {
         assert_eq!(response.value.as_deref(), Some("hello"));
         // No longer pending.
         assert!(hub.pending().is_empty());
+    }
+
+    /// An unanswered prompt must not hold tool-lane capacity.
+    ///
+    /// The answer can arrive from another agent's tool call, and on a lane with
+    /// no room left that call is queued behind the batch that is waiting for it.
+    /// That is the shape that froze whole factories in issue #191: everything
+    /// looked `waiting`, nothing was failed, and nothing ever moved again.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_batch_waiting_on_a_prompt_does_not_hold_the_tool_lane() {
+        use crate::tool_bridge::{ToolJob, ToolLane, ToolLaneStats};
+        use bevy_ecs::entity::Entity;
+
+        let hub = InteractionHub::new();
+        let (job_tx, job_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (result_tx, mut results) = tokio::sync::mpsc::unbounded_channel();
+        let stats = Arc::new(ToolLaneStats::new(1));
+        let lane = ToolLane::new(
+            tokio::runtime::Handle::current(),
+            result_tx,
+            Arc::new(Notify::new()),
+            1,
+            stats.clone(),
+        );
+        let serving = lane.serve(job_rx);
+        let submit = |entity: u32, exec: crate::tool_bridge::BoxedToolExec| {
+            stats.enqueued();
+            job_tx
+                .send(ToolJob {
+                    entity: Entity::from_raw_u32(entity).expect("a small index is a valid id"),
+                    exec,
+                    cancel: crate::cancel::CancelToken::new(),
+                })
+                .expect("the lane is serving");
+        };
+
+        // The whole lane, spent on waiting for an answer.
+        let asking = hub.backend_for("agent-a");
+        submit(
+            1,
+            Box::new(move || {
+                Box::pin(async move {
+                    let response = asking.ask(req("q1")).await;
+                    vec![("q1".to_string(), response.value.unwrap_or_default())]
+                })
+            }),
+        );
+        wait_for_prompt(&hub).await;
+        assert_eq!(stats.parked(), 1, "the asker stepped off the lane");
+
+        // The answer, as another batch - only reachable if the lane is free.
+        let answering = hub.clone();
+        submit(
+            2,
+            Box::new(move || {
+                Box::pin(async move {
+                    answering.answer(InteractionResponse::text("q1", "hello"));
+                    vec![("answered".to_string(), "ok".to_string())]
+                })
+            }),
+        );
+
+        let mut answers = Vec::new();
+        for _ in 0..2 {
+            let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), results.recv())
+                .await
+                .expect("both batches finished")
+                .expect("an outcome arrived");
+            answers.extend(outcome.results);
+        }
+        answers.sort();
+        assert_eq!(
+            answers,
+            vec![
+                ("answered".to_string(), "ok".to_string()),
+                ("q1".to_string(), "hello".to_string()),
+            ],
+            "the asker got its answer from the batch behind it"
+        );
+
+        drop(job_tx);
+        tokio::time::timeout(std::time::Duration::from_secs(30), serving)
+            .await
+            .expect("the lane drained")
+            .expect("the lane task ended");
+    }
+
+    /// Block until a prompt is registered. `submit` inserts synchronously before
+    /// awaiting, but on a multi-threaded runtime the batch task may not have been
+    /// polled yet, so yielding a fixed number of times is not enough.
+    async fn wait_for_prompt(hub: &InteractionHub) {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while hub.pending().is_empty() {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the prompt was raised");
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -60,7 +60,9 @@
 //!   escape hatch: it tracks this crate's `bevy_ecs` version (re-exported as
 //!   [`ecs`]) and carries no compatibility promise.
 
-pub(crate) mod cancel;
+// Public because [`tool_bridge::ToolJob`] carries a `CancelToken`, so anything
+// handing work to the tool lane needs to name the type.
+pub mod cancel;
 pub(crate) mod compaction_bridge;
 pub mod components;
 pub mod context_setup;

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -113,7 +113,7 @@ pub(crate) fn retry_policy_for(
 ///
 /// Without it, cancelling only stopped *new* work from being dispatched: a
 /// request already handed to the async lanes ran to completion, holding its
-/// inference-pool permit or tool-lane worker the whole time.
+/// inference-pool permit or tool-lane capacity the whole time.
 #[derive(Component, Default, Debug)]
 pub struct InFlightWork(pub Vec<crate::cancel::CancelToken>);
 

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -580,7 +580,7 @@ pub fn dispatch_tools(
             None => exec,
         };
         let cancel = crate::cancel::CancelToken::new();
-        // The lane worker is alive for the world's lifetime; a failed send would
+        // The lane is alive for the world's lifetime; a failed send would
         // only happen during shutdown, where dropping the job is fine.
         stage.stats.enqueued();
         let _ = stage.jobs.send(ToolJob {

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -237,11 +237,6 @@ impl ToolLane {
         self.stats.widen(extra);
         extra
     }
-
-    /// The lane's occupancy counters.
-    pub fn stats(&self) -> &Arc<ToolLaneStats> {
-        &self.stats
-    }
 }
 
 /// Read jobs off the channel, spawning one task per batch, then wait for the

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -25,6 +25,12 @@
 //! is what [`off_lane`] does, and it is what makes the deadlock impossible:
 //! waiting costs the lane nothing, and the batch takes a permit again when it has
 //! something to do.
+//!
+//! **Order**: which of two batches submitted together gets in first is not
+//! fixed - they race for the permit as separate tasks. Nothing depends on it,
+//! since an agent only ever has one batch in flight, and once both are actually
+//! waiting the semaphore hands out permits first-come-first-served, so nothing
+//! is starved either.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -4,28 +4,41 @@
 //! When the pipeline decides an agent's response has tool calls to run, the
 //! tool-dispatch system builds a [`ToolJob`] (the agent plus a boxed async
 //! closure that executes that agent's batch of calls against its own tool
-//! registry / workdir / policy) and sends it to the tool lane. Each
-//! [`tool_worker`] pulls jobs and reports each [`ToolOutcome`] back on the
-//! results channel, waking the tick loop; the tool-collect system applies the
-//! results on a later tick.
+//! registry / workdir / policy) and sends it to the tool lane. The lane runs the
+//! batch and reports its [`ToolOutcome`] back on the results channel, waking the
+//! tick loop; the tool-collect system applies the results on a later tick.
 //!
-//! **Concurrency**: the lane is a *pool* - [`spawn_tool_pool`] runs N workers off
-//! one shared job channel (`Arc<Mutex<Receiver>>`). A worker holds the receiver
-//! lock only across `recv()`, then releases it and runs `exec().await`, so up to
-//! N agents' tool batches execute concurrently (the receive is serialized; the
-//! execution is not). This is the tool-lane counterpart of the inference pool's
-//! per-model concurrency cap. The dispatch/collect systems are unchanged.
+//! **Concurrency**: the lane is a *semaphore*, not a pool of workers.
+//! [`ToolLane::serve`] reads jobs off the channel and spawns one task per batch;
+//! each task holds a permit for as long as it is executing, so
+//! `max_concurrent_tools` batches run at a time.
+//!
+//! It used to be a fixed pool of worker tasks, and that deadlocked. Several
+//! things a batch can await have no time bound at all: a tool-approval prompt, an
+//! `ask_user`, a `wait_for_agent` poll that only ends when some other run
+//! finishes. A worker sitting in one of those was a unit of capacity spent on
+//! waiting rather than working, and a parent waiting on a child it had spawned
+//! was holding capacity that child needed to finish. Eight of those and no
+//! agent's tools ran again, for as long as the daemon lived (issue #191).
+//!
+//! A permit, unlike a worker, can be handed back in the middle of a batch. That
+//! is what [`off_lane`] does, and it is what makes the deadlock impossible:
+//! waiting costs the lane nothing, and the batch takes a permit again when it has
+//! something to do.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use bevy_ecs::entity::Entity;
 use tokio::runtime::Handle;
-use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::task::JoinHandle;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+
+use crate::inference_pool::expect_permit;
 
 /// The future produced by a boxed tool-execution closure: resolves to
 /// `(tool_call_id, result)` pairs - the same shape the engine's tool executors
@@ -34,7 +47,7 @@ pub type ToolExecFuture = Pin<Box<dyn Future<Output = Vec<(String, String)>> + S
 
 /// A boxed, per-agent tool-execution closure. Built by the dispatch system so it
 /// captures that agent's own tool registry, workdir, and policy; run once by the
-/// tool worker.
+/// tool lane.
 pub type BoxedToolExec = Box<dyn FnOnce() -> ToolExecFuture + Send>;
 
 /// A batch of tool calls to execute for one agent.
@@ -43,8 +56,8 @@ pub struct ToolJob {
     pub entity: Entity,
     /// Runs the agent's batch of tool calls.
     pub exec: BoxedToolExec,
-    /// Fires when the agent is cancelled, so the worker drops the batch instead
-    /// of running it to completion. The agent holds the other half.
+    /// Fires when the agent is cancelled, so the lane drops the batch instead of
+    /// running it to completion. The agent holds the other half.
     pub cancel: crate::cancel::CancelToken,
 }
 
@@ -61,176 +74,445 @@ pub struct ToolOutcome {
     pub elapsed: std::time::Duration,
 }
 
-/// A shared, multi-consumer job receiver: several [`tool_worker`]s pull from the
-/// same channel by taking the lock only long enough to `recv()`.
-pub type SharedJobRx = Arc<Mutex<UnboundedReceiver<ToolJob>>>;
-
 /// Live occupancy of the tool lane.
 ///
-/// The lane is a fixed number of workers reading one **unbounded** queue, so
-/// dispatch never blocks and a saturated lane is invisible from the outside: the
-/// batches just pile up. Several things a batch can await have no time bound at
-/// all (a tool-approval prompt, an `ask_user`, a `wait_for_agent` poll), so
-/// enough of them stall every other agent's tools. Counting what is queued and
-/// what is running is what makes that legible instead of guesswork.
+/// The lane reads an **unbounded** queue, so dispatch never blocks and a
+/// saturated lane is invisible from the outside: the batches just pile up.
+/// Counting what is queued, what is running, and what is parked on a wait is what
+/// makes that legible instead of guesswork.
 #[derive(Debug)]
 pub struct ToolLaneStats {
-    queued: std::sync::atomic::AtomicUsize,
-    busy: std::sync::atomic::AtomicUsize,
-    workers: usize,
+    queued: AtomicUsize,
+    busy: AtomicUsize,
+    parked: AtomicUsize,
+    /// The concurrency cap. Atomic because the relief valve can raise it (see
+    /// [`ToolLane::relieve`]).
+    workers: AtomicUsize,
 }
 
 impl ToolLaneStats {
-    /// Stats for a lane of `workers` workers.
+    /// Stats for a lane that runs `workers` batches at a time.
     pub fn new(workers: usize) -> Self {
         Self {
-            queued: std::sync::atomic::AtomicUsize::new(0),
-            busy: std::sync::atomic::AtomicUsize::new(0),
-            workers: workers.max(1),
+            queued: AtomicUsize::new(0),
+            busy: AtomicUsize::new(0),
+            parked: AtomicUsize::new(0),
+            workers: AtomicUsize::new(workers.max(1)),
         }
     }
 
     /// Record a batch handed to the lane.
     pub fn enqueued(&self) {
-        self.queued
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.queued.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a worker picking a batch up: it leaves the queue and occupies a
-    /// worker.
+    /// Record a batch leaving the queue without ever running - cancelled while it
+    /// waited for capacity.
+    fn abandoned(&self) {
+        self.queued.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Record a batch taking a permit: it leaves the queue and occupies the lane.
     fn started(&self) {
-        self.queued
-            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-        self.busy.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.queued.fetch_sub(1, Ordering::Relaxed);
+        self.busy.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a worker finishing a batch, however it ended.
+    /// Record a batch releasing its permit, however it ended.
     fn finished(&self) {
-        self.busy.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        self.busy.fetch_sub(1, Ordering::Relaxed);
     }
 
-    /// Batches waiting for a free worker.
+    /// Record a running batch stepping off the lane to wait for something
+    /// unbounded: it stops occupying the lane and starts being parked.
+    fn began_park(&self) {
+        self.busy.fetch_sub(1, Ordering::Relaxed);
+        self.parked.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a parked batch that took a permit again and is running.
+    fn resumed(&self) {
+        self.parked.fetch_sub(1, Ordering::Relaxed);
+        self.busy.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a parked batch that was dropped where it stood, without ever
+    /// taking a permit again.
+    fn ended_park(&self) {
+        self.parked.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Batches waiting for lane capacity.
     pub fn queued(&self) -> usize {
-        self.queued.load(std::sync::atomic::Ordering::Relaxed)
+        self.queued.load(Ordering::Relaxed)
     }
 
-    /// Workers currently running a batch.
+    /// Batches holding a permit and running.
     pub fn busy(&self) -> usize {
-        self.busy.load(std::sync::atomic::Ordering::Relaxed)
+        self.busy.load(Ordering::Relaxed)
     }
 
-    /// The lane's worker count - its concurrency cap.
+    /// Batches parked on an unbounded wait, holding no capacity.
+    pub fn parked(&self) -> usize {
+        self.parked.load(Ordering::Relaxed)
+    }
+
+    /// The lane's concurrency cap.
     pub fn workers(&self) -> usize {
-        self.workers
+        self.workers.load(Ordering::Relaxed)
     }
 
-    /// Whether every worker is occupied and batches are waiting behind them.
+    /// Raise the cap by `extra`, to match permits added to the semaphore.
+    fn widen(&self, extra: usize) {
+        self.workers.fetch_add(extra, Ordering::Relaxed);
+    }
+
+    /// Whether every unit of capacity is taken and batches are waiting behind
+    /// them.
     #[must_use]
     pub fn is_saturated(&self) -> bool {
-        self.busy() >= self.workers && self.queued() > 0
+        self.busy() >= self.workers() && self.queued() > 0
     }
 }
 
-/// Marks a worker as busy for as long as it is held, so the count is restored on
-/// **every** exit - including the cancel path, which leaves the batch by way of
-/// `continue` rather than falling out the bottom.
-struct BusyGuard<'a>(&'a ToolLaneStats);
-
-impl Drop for BusyGuard<'_> {
-    fn drop(&mut self) {
-        self.0.finished();
-    }
-}
-
-/// One tool worker: pulls [`ToolJob`]s from the shared channel and runs them,
-/// reporting each outcome and waking the tick loop. Holds the receiver lock only
-/// across `recv()` (so sibling workers can run their `exec().await` in parallel),
-/// then releases it before executing. Returns when the job channel is closed (all
-/// senders dropped - i.e. the world is shutting down).
-pub async fn tool_worker(
-    jobs: SharedJobRx,
-    results: UnboundedSender<ToolOutcome>,
-    wake: Arc<Notify>,
+/// The tool lane: the capacity that bounds how many batches execute at once, and
+/// the plumbing a batch needs to report its outcome.
+pub struct ToolLane {
+    /// One permit per concurrent batch.
+    permits: Arc<Semaphore>,
+    /// Shared with the world so `lane_snapshot` can read it.
     stats: Arc<ToolLaneStats>,
-) {
-    loop {
-        // Serialize only the receive; drop the guard before executing.
-        let next = {
-            let mut rx = jobs.lock().await;
-            rx.recv().await
-        };
-        let Some(ToolJob {
-            entity,
-            exec,
-            cancel,
-        }) = next
-        else {
-            return; // channel closed → shut down
-        };
-        stats.started();
-        let _busy = BusyGuard(&stats); // released on every path out, cancel included
-        // A cancelled agent's batch is dropped rather than run to completion.
-        // This is what returns the worker to the pool: several of the things a
-        // batch can await are unbounded (a tool-approval prompt, an `ask_user`,
-        // a `wait_for_agent` poll), so without this a cancelled agent kept one
-        // of the lane's fixed number of workers forever - and once they were all
-        // taken, no other agent's tools ran either.
-        let started = std::time::Instant::now();
-        let out = tokio::select! {
-            biased;
-            _ = cancel.cancelled() => continue,
-            out = exec() => out,
-        };
-        // Harmless no-op if the collect side has gone away.
-        let _ = results.send(ToolOutcome {
-            entity,
-            results: out,
-            elapsed: started.elapsed(),
-        });
-        wake.notify_one();
-    }
+    /// Where finished batches report.
+    results: UnboundedSender<ToolOutcome>,
+    /// Notified whenever a batch finishes or frees capacity, so the tick loop
+    /// re-drives.
+    wake: Arc<Notify>,
+    /// Where batch tasks are spawned.
+    runtime: Handle,
 }
 
-/// Spawn a pool of `workers` [`tool_worker`] tasks off one shared job channel and
-/// return their handles. `workers` is clamped to at least 1. This is the tool-lane
-/// concurrency cap - the number of agents whose tool batches may run at once.
-pub fn spawn_tool_pool(
-    runtime: &Handle,
-    jobs: UnboundedReceiver<ToolJob>,
-    results: UnboundedSender<ToolOutcome>,
-    wake: Arc<Notify>,
-    workers: usize,
-    stats: Arc<ToolLaneStats>,
-) -> Vec<JoinHandle<()>> {
-    let shared: SharedJobRx = Arc::new(Mutex::new(jobs));
-    (0..workers.max(1))
-        .map(|_| {
-            runtime.spawn(tool_worker(
-                shared.clone(),
-                results.clone(),
-                wake.clone(),
-                stats.clone(),
-            ))
+impl ToolLane {
+    /// Build a lane that runs `concurrency` batches at a time (clamped to at
+    /// least one, matching [`ToolLaneStats::new`]).
+    pub fn new(
+        runtime: Handle,
+        results: UnboundedSender<ToolOutcome>,
+        wake: Arc<Notify>,
+        concurrency: usize,
+        stats: Arc<ToolLaneStats>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            permits: Arc::new(Semaphore::new(concurrency.max(1))),
+            stats,
+            results,
+            wake,
+            runtime,
         })
-        .collect()
+    }
+
+    /// Start serving `jobs`. The returned handle completes once the job channel
+    /// closes (the world is shutting down) **and** every batch it started has
+    /// finished, so awaiting it drains the lane.
+    pub fn serve(self: &Arc<Self>, jobs: UnboundedReceiver<ToolJob>) -> JoinHandle<()> {
+        let lane = self.clone();
+        self.runtime.clone().spawn(serve_lane(lane, jobs))
+    }
+
+    /// Add `extra` permits, widening the lane for good.
+    ///
+    /// The relief valve under a lane that has stopped draining: handing out more
+    /// capacity lets the queued batches run without cancelling anything. Returns
+    /// how many were added.
+    pub fn relieve(&self, extra: usize) -> usize {
+        if extra == 0 {
+            return 0;
+        }
+        self.permits.add_permits(extra);
+        self.stats.widen(extra);
+        extra
+    }
+
+    /// The lane's occupancy counters.
+    pub fn stats(&self) -> &Arc<ToolLaneStats> {
+        &self.stats
+    }
+}
+
+/// Read jobs off the channel, spawning one task per batch, then wait for the
+/// batches still running once the channel closes.
+async fn serve_lane(lane: Arc<ToolLane>, mut jobs: UnboundedReceiver<ToolJob>) {
+    let mut batches = JoinSet::new();
+    loop {
+        tokio::select! {
+            job = jobs.recv() => match job {
+                Some(job) => {
+                    batches.spawn_on(run_batch(lane.clone(), job), &lane.runtime);
+                }
+                None => break, // channel closed → shutting down
+            },
+            // Reap finished batches as we go so the set can't grow without
+            // bound over a long-lived daemon. Disabled while empty, since
+            // `join_next` on an empty set is instantly ready and would spin.
+            Some(_) = batches.join_next(), if !batches.is_empty() => {}
+        }
+    }
+    while batches.join_next().await.is_some() {}
+}
+
+/// Run one batch: wait for capacity, execute it under a [`LaneTicket`], and
+/// report the outcome.
+async fn run_batch(lane: Arc<ToolLane>, job: ToolJob) {
+    let ToolJob {
+        entity,
+        exec,
+        cancel,
+    } = job;
+    // A cancel while the batch is still queued drops it without ever running -
+    // the same bargain the executing case makes below, one step earlier.
+    let permit = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            lane.stats.abandoned();
+            return;
+        }
+        permit = lane.permits.clone().acquire_owned() => expect_permit(permit),
+    };
+    lane.stats.started();
+    let ticket = Arc::new(LaneTicket::new(lane.clone(), permit));
+    let started = std::time::Instant::now();
+    // A cancelled agent's batch is dropped rather than run to completion. This
+    // is what hands the capacity back: several of the things a batch can await
+    // are unbounded, so without this a cancelled agent would keep occupying the
+    // lane until whatever it was waiting for answered.
+    let out = LANE_TICKET
+        .scope(ticket, async move {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => None,
+                out = exec() => Some(out),
+            }
+        })
+        .await;
+    // The ticket is dropped with the scope above, so the permit is already back
+    // and the loop already woken by the time the outcome goes out.
+    let Some(out) = out else { return };
+    // Harmless no-op if the collect side has gone away.
+    let _ = lane.results.send(ToolOutcome {
+        entity,
+        results: out,
+        elapsed: started.elapsed(),
+    });
+    lane.wake.notify_one();
+}
+
+tokio::task_local! {
+    /// The running batch's claim on the lane, readable from anywhere inside it.
+    ///
+    /// A task-local rather than an argument threaded through [`BoxedToolExec`]:
+    /// the waits that need it are several layers down inside the tool service,
+    /// and passing a ticket to every executor - including the many that never
+    /// wait on anything - would put a concurrency detail in the signature of
+    /// every `ToolService` implementation.
+    static LANE_TICKET: Arc<LaneTicket>;
+}
+
+/// A batch's claim on the tool lane.
+///
+/// Holds a permit while the batch is executing and gives it up around an
+/// unbounded wait, so a batch parked on a person or on another run costs the lane
+/// nothing. Dropping it releases whatever it is holding.
+struct LaneTicket {
+    lane: Arc<ToolLane>,
+    /// The permit, absent exactly while the batch is parked.
+    permit: std::sync::Mutex<Option<OwnedSemaphorePermit>>,
+    /// Whether this ticket is currently counted as parked rather than busy.
+    parked: AtomicBool,
+}
+
+impl LaneTicket {
+    fn new(lane: Arc<ToolLane>, permit: OwnedSemaphorePermit) -> Self {
+        Self {
+            lane,
+            permit: std::sync::Mutex::new(Some(permit)),
+            parked: AtomicBool::new(false),
+        }
+    }
+
+    /// Give the permit up and start counting as parked.
+    fn release(&self) {
+        let held = self.take_permit();
+        // Release first, wake second, for the reason `InferencePermit::drop`
+        // spells out: the other order lets the woken tick re-check the lane
+        // while this permit is still held.
+        drop(held);
+        self.parked.store(true, Ordering::Relaxed);
+        self.lane.stats.began_park();
+        self.lane.wake.notify_one();
+    }
+
+    /// Take a permit again, waiting for one if the lane is full. Ordinary
+    /// backpressure: nothing is held while we wait, so the batches ahead can
+    /// always finish.
+    async fn reacquire(&self) {
+        let permit = expect_permit(self.lane.permits.clone().acquire_owned().await);
+        // Stop counting as parked only once the permit is actually in hand, so
+        // a ticket dropped mid-wait is accounted for as the parked batch it is.
+        self.lane.stats.resumed();
+        self.parked.store(false, Ordering::Relaxed);
+        *self
+            .permit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(permit);
+    }
+
+    fn take_permit(&self) -> Option<OwnedSemaphorePermit> {
+        self.permit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+}
+
+impl Drop for LaneTicket {
+    fn drop(&mut self) {
+        // Release first, wake second - see `release`.
+        drop(self.take_permit());
+        match self.parked.load(Ordering::Relaxed) {
+            true => self.lane.stats.ended_park(),
+            false => self.lane.stats.finished(),
+        }
+        self.lane.wake.notify_one();
+    }
+}
+
+/// Await something with no time bound without holding the tool lane.
+///
+/// The lane permit is handed back before `fut` is polled and taken again before
+/// this returns, so a batch waiting on a person (a tool-approval prompt, an
+/// `ask_user`) or on another run (`wait_for_agent`) occupies no capacity while it
+/// waits. That is what stops a lane full of waiters from starving the very runs
+/// they are waiting for (issue #191).
+///
+/// Outside a lane task - the embedded runtime, tests driving an executor
+/// directly - there is no ticket and this is just `fut.await`.
+pub async fn off_lane<T>(fut: impl Future<Output = T>) -> T {
+    let Ok(ticket) = LANE_TICKET.try_with(Arc::clone) else {
+        return fut.await;
+    };
+    ticket.release();
+    let out = fut.await;
+    ticket.reacquire().await;
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use tokio::sync::mpsc;
 
-    fn job(entity: u32, pairs: Vec<(&'static str, &'static str)>) -> ToolJob {
-        job_with(entity, pairs, crate::cancel::CancelToken::new())
+    /// Everything a test lane needs: the lane itself, the job sender, and the
+    /// outcome receiver.
+    struct Harness {
+        lane: Arc<ToolLane>,
+        /// Taken by `drain`, which closes the lane by dropping it.
+        jobs: Option<UnboundedSender<ToolJob>>,
+        outcomes: mpsc::UnboundedReceiver<ToolOutcome>,
+        serving: Option<JoinHandle<()>>,
+        stats: Arc<ToolLaneStats>,
+    }
+
+    impl Harness {
+        fn new(concurrency: usize) -> Self {
+            let (jobs, job_rx) = mpsc::unbounded_channel();
+            let (result_tx, outcomes) = mpsc::unbounded_channel();
+            let stats = Arc::new(ToolLaneStats::new(concurrency));
+            let lane = ToolLane::new(
+                Handle::current(),
+                result_tx,
+                Arc::new(Notify::new()),
+                concurrency,
+                stats.clone(),
+            );
+            let serving = lane.serve(job_rx);
+            Self {
+                lane,
+                jobs: Some(jobs),
+                outcomes,
+                serving: Some(serving),
+                stats,
+            }
+        }
+
+        /// Hand a batch to the lane, counting it the way `dispatch_tools` does.
+        fn submit(&self, job: ToolJob) {
+            self.stats.enqueued();
+            self.sender().send(job).expect("the lane is serving");
+        }
+
+        fn sender(&self) -> &UnboundedSender<ToolJob> {
+            self.jobs.as_ref().expect("the lane is still open")
+        }
+
+        /// Close the lane and wait for every batch it started to finish.
+        async fn drain(&mut self) {
+            drop(self.jobs.take());
+            let serving = self.serving.take().expect("the lane was serving");
+            timeout(serving).await.expect("the lane task ended");
+        }
+
+        async fn next_outcome(&mut self) -> ToolOutcome {
+            timeout(self.outcomes.recv())
+                .await
+                .expect("an outcome arrived")
+        }
+
+        /// The next `n` outcomes' entity indices, sorted.
+        ///
+        /// Batches race for a permit as separate tasks, so which of two ready
+        /// batches gets in first is not fixed. Nothing depends on that order: a
+        /// given agent only ever has one batch in flight.
+        async fn next_indices(&mut self, n: usize) -> Vec<u64> {
+            let mut seen = Vec::new();
+            for _ in 0..n {
+                seen.push(self.next_outcome().await.entity.to_bits());
+            }
+            seen.sort_unstable();
+            seen
+        }
+    }
+
+    /// Bounded so a wedge fails the test instead of hanging it. Generous, since
+    /// a passing run never waits.
+    async fn timeout<T>(fut: impl Future<Output = T>) -> T {
+        tokio::time::timeout(Duration::from_secs(30), fut)
+            .await
+            .expect("the lane made progress")
+    }
+
+    /// Entity ids sorted the same way [`Harness::next_indices`] sorts them, so
+    /// an expectation does not depend on how bevy packs an id into its bits.
+    fn sorted_bits(entities: &[Entity]) -> Vec<u64> {
+        let mut bits: Vec<u64> = entities.iter().map(|e| e.to_bits()).collect();
+        bits.sort_unstable();
+        bits
+    }
+
+    fn entity(index: u32) -> Entity {
+        Entity::from_raw_u32(index).expect("a small literal index is a valid entity id")
+    }
+
+    fn job(index: u32, pairs: Vec<(&'static str, &'static str)>) -> ToolJob {
+        job_with(index, pairs, crate::cancel::CancelToken::new())
     }
 
     fn job_with(
-        entity: u32,
+        index: u32,
         pairs: Vec<(&'static str, &'static str)>,
         cancel: crate::cancel::CancelToken,
     ) -> ToolJob {
         ToolJob {
-            entity: Entity::from_raw_u32(entity).expect("index came from a live entity id"),
+            entity: entity(index),
             exec: Box::new(move || {
                 Box::pin(async move {
                     pairs
@@ -244,22 +526,21 @@ mod tests {
     }
 
     /// A job whose batch blocks until `release` fires, signalling `started` once
-    /// it is running. Used both for the cancel case (where it is dropped
-    /// mid-flight) and for the released case, so the batch body is exercised.
+    /// it is running.
+    ///
+    /// `notify_one` (not `notify_waiters`) on both signals: it stores a permit
+    /// when nobody is waiting yet, so neither side can lose the other's wakeup by
+    /// being slow to arm - a real flake on a loaded runner.
     fn held_job(
-        entity: u32,
+        index: u32,
         started: Arc<Notify>,
         release: Arc<Notify>,
         cancel: crate::cancel::CancelToken,
     ) -> ToolJob {
         ToolJob {
-            entity: Entity::from_raw_u32(entity).expect("index came from a live entity id"),
+            entity: entity(index),
             exec: Box::new(move || {
                 Box::pin(async move {
-                    // `notify_one` (not `notify_waiters`) on both signals: it
-                    // stores a permit when nobody is waiting yet, so neither the
-                    // test nor the batch can lose the other's wakeup by being
-                    // slow to arm - a real flake on a loaded runner.
                     started.notify_one();
                     release.notified().await;
                     vec![("held".to_string(), "done".to_string())]
@@ -269,303 +550,346 @@ mod tests {
         }
     }
 
-    /// The released counterpart of [`held_job`]: with no cancel, the batch runs
-    /// to completion and reports its results.
+    /// The same, except the wait happens [`off_lane`] - the shape of a
+    /// `wait_for_agent` or a tool-approval prompt.
+    ///
+    /// `started` fires from *inside* the parked future, which `off_lane` only
+    /// polls once the permit is already back. Signalling before the call would
+    /// race the test against the release.
+    fn parking_job(
+        index: u32,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+        cancel: crate::cancel::CancelToken,
+    ) -> ToolJob {
+        ToolJob {
+            entity: entity(index),
+            exec: Box::new(move || {
+                Box::pin(async move {
+                    off_lane(async move {
+                        started.notify_one();
+                        release.notified().await;
+                    })
+                    .await;
+                    vec![("parked".to_string(), "done".to_string())]
+                })
+            }),
+            cancel,
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_released_batch_completes_normally() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
+    async fn the_lane_runs_batches_and_reports_them() {
+        let mut h = Harness::new(1);
+        h.submit(job(1, vec![("c", "r")]));
+        h.submit(job(2, vec![("c", "r")]));
+
+        let first = h.next_outcome().await;
+        assert_eq!(
+            first.results,
+            vec![("c".to_string(), "r".to_string())],
+            "the batch reported its call"
+        );
+        let mut seen = vec![first.entity.to_bits()];
+        seen.extend(h.next_indices(1).await);
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            sorted_bits(&[entity(1), entity(2)]),
+            "both batches were reported"
+        );
+
+        h.drain().await;
+        assert!(h.outcomes.try_recv().is_err(), "no more outcomes");
+    }
+
+    /// The issue #191 regression, at its narrowest.
+    ///
+    /// A one-wide lane, a batch parked on something only a *later* batch can
+    /// deliver. With a fixed worker pool this is a deadlock: the waiter owns the
+    /// only worker, so the batch that would release it never runs. Handing the
+    /// permit back while parked is what makes both finish.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_parked_batch_lets_the_batch_it_waits_on_run() {
+        let mut h = Harness::new(1);
         let started = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
 
-        jtx.send(held_job(
-            7,
+        h.submit(parking_job(
+            1,
             started.clone(),
             release.clone(),
             crate::cancel::CancelToken::new(),
-        ))
-        .unwrap();
-        drop(jtx);
-
-        let handles = spawn_tool_pool(
-            &Handle::current(),
-            jrx,
-            rtx,
-            wake,
-            1,
-            Arc::new(ToolLaneStats::new(1)),
-        );
-        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
-            .await
-            .expect("the batch started");
-        release.notify_one();
-
-        let out = tokio::time::timeout(std::time::Duration::from_secs(5), rrx.recv())
-            .await
-            .expect("the batch finished")
-            .expect("an outcome arrived");
-        assert_eq!(out.results, vec![("held".to_string(), "done".to_string())]);
-        for h in handles {
-            let _ = h.await;
-        }
-    }
-
-    fn shared(rx: UnboundedReceiver<ToolJob>) -> SharedJobRx {
-        Arc::new(Mutex::new(rx))
-    }
-
-    #[tokio::test]
-    async fn worker_processes_jobs_in_order_then_exits_on_close() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
-
-        jtx.send(job(1, vec![("c1", "r1")])).unwrap();
-        jtx.send(job(2, vec![("c2", "r2")])).unwrap();
-        drop(jtx); // close the job channel so the worker loop ends
-
-        tool_worker(shared(jrx), rtx, wake, Arc::new(ToolLaneStats::new(1))).await;
-
-        let first = rrx.try_recv().unwrap();
+        ));
+        timeout(started.notified()).await;
         assert_eq!(
-            first.entity,
-            Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id")
+            (h.stats.busy(), h.stats.parked()),
+            (0, 1),
+            "the waiter gave the lane back"
         );
-        assert_eq!(first.results, vec![("c1".to_string(), "r1".to_string())]);
-        let second = rrx.try_recv().unwrap();
+
+        // Only reachable if the lane is genuinely free. It is what unblocks the
+        // waiter, exactly as a child run unblocks its parent.
+        let releaser = release.clone();
+        h.submit(ToolJob {
+            entity: entity(2),
+            exec: Box::new(move || {
+                Box::pin(async move {
+                    releaser.notify_one();
+                    vec![("c2".to_string(), "r2".to_string())]
+                })
+            }),
+            cancel: crate::cancel::CancelToken::new(),
+        });
+
         assert_eq!(
-            second.entity,
-            Entity::from_raw_u32(2).expect("a small literal index is always a valid entity id")
+            h.next_indices(2).await,
+            sorted_bits(&[entity(1), entity(2)]),
+            "both batches finished"
         );
-        assert!(rrx.try_recv().is_err()); // no more outcomes
+
+        h.drain().await;
     }
 
-    /// A cancelled batch is dropped, not run to completion, and the worker goes
-    /// back to serving the lane.
-    ///
-    /// This is what unwedges the daemon: several things a batch can await are
-    /// unbounded (a tool-approval prompt, `ask_user`, a `wait_for_agent` poll),
-    /// and the lane has a fixed number of workers - so a cancelled agent used to
-    /// hold one forever, and once all of them were held no agent's tools ran.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_cancelled_batch_is_abandoned_and_frees_the_worker() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
-        let cancel = crate::cancel::CancelToken::new();
-
-        // A batch that only finishes when released - the unbounded-prompt case.
+    /// The parked batch takes a permit again before it carries on, so the lane's
+    /// cap still means something after a wait.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn a_resumed_batch_takes_a_permit_again() {
+        let mut h = Harness::new(1);
         let started = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
-        jtx.send(held_job(
+        h.submit(parking_job(
             1,
             started.clone(),
             release.clone(),
-            cancel.clone(),
-        ))
-        .unwrap();
-        // Queued behind it: only reachable once the worker is released.
-        jtx.send(job(2, vec![("c2", "r2")])).unwrap();
-        drop(jtx);
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(started.notified()).await;
 
-        let handles = spawn_tool_pool(
-            &Handle::current(),
-            jrx,
-            rtx,
-            wake,
-            1,
-            Arc::new(ToolLaneStats::new(1)),
+        // Fill the lane with a batch that will not finish on its own.
+        let held_started = Arc::new(Notify::new());
+        let held_release = Arc::new(Notify::new());
+        h.submit(held_job(
+            2,
+            held_started.clone(),
+            held_release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(held_started.notified()).await;
+        assert_eq!(h.stats.busy(), 1, "the lane is full again");
+
+        // Waking the parked batch is not enough: it has to queue for capacity,
+        // and the holder has the only permit. Asserting the absence is what
+        // proves the permit was really taken again rather than assumed.
+        release.notify_one();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), h.outcomes.recv())
+                .await
+                .is_err(),
+            "the resumed batch waited for a permit instead of running"
         );
-        // Wait until the stuck batch is actually executing, then cancel it.
-        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
-            .await
-            .expect("the batch started");
+
+        held_release.notify_one();
+        let first = h.next_outcome().await;
+        assert_eq!(first.entity, entity(2), "the holder finished first");
+        let second = h.next_outcome().await;
+        assert_eq!(second.entity, entity(1), "then the resumed batch");
+
+        h.drain().await;
+        assert_eq!((h.stats.busy(), h.stats.parked()), (0, 0));
+    }
+
+    /// Outside a lane task there is no ticket, so `off_lane` is a plain await.
+    #[tokio::test]
+    async fn off_lane_outside_the_lane_just_awaits() {
+        assert_eq!(off_lane(async { 7 }).await, 7);
+    }
+
+    /// A cancelled batch is dropped rather than run to completion, and gives its
+    /// capacity straight back.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_batch_is_abandoned_and_frees_the_lane() {
+        let mut h = Harness::new(1);
+        let cancel = crate::cancel::CancelToken::new();
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(held_job(1, started.clone(), release, cancel.clone()));
+        timeout(started.notified()).await;
+        assert_eq!((h.stats.queued(), h.stats.busy()), (0, 1));
+
+        // Queued behind it, so it can only run once the cancel frees the lane.
+        h.submit(job(2, vec![("c2", "r2")]));
         cancel.cancel();
 
-        // The single worker moves on to the next job rather than staying parked.
-        let next = tokio::time::timeout(std::time::Duration::from_secs(5), rrx.recv())
-            .await
-            .expect("the worker was freed by the cancel")
-            .expect("an outcome arrived");
-        assert_eq!(
-            next.entity,
-            Entity::from_raw_u32(2).expect("a small literal index is always a valid entity id"),
-            "the queued batch ran"
-        );
+        let next = h.next_outcome().await;
+        assert_eq!(next.entity, entity(2), "the queued batch ran");
+        h.drain().await;
         assert!(
-            rrx.try_recv().is_err(),
-            "and the cancelled batch reported no results"
+            h.outcomes.try_recv().is_err(),
+            "the cancelled batch reported nothing"
         );
-        for h in handles {
-            let _ = h.await;
-        }
+        assert_eq!(h.stats.busy(), 0, "and gave its permit back");
     }
 
-    #[tokio::test]
-    async fn worker_survives_dropped_results_receiver() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, rrx) = mpsc::unbounded_channel();
-        drop(rrx); // nobody to receive outcomes
-        let wake = Arc::new(Notify::new());
+    /// Cancelling a batch that is parked on a wait leaves the counters straight:
+    /// it was never holding a permit, so nothing is handed back twice.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_parked_batch_leaves_the_counters_straight() {
+        let mut h = Harness::new(1);
+        let cancel = crate::cancel::CancelToken::new();
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(parking_job(1, started.clone(), release, cancel.clone()));
+        timeout(started.notified()).await;
+        assert_eq!((h.stats.busy(), h.stats.parked()), (0, 1));
 
-        jtx.send(job(9, vec![("c", "r")])).unwrap();
-        drop(jtx);
-        // Must drain the job and not panic despite the failed send.
-        tool_worker(shared(jrx), rtx, wake, Arc::new(ToolLaneStats::new(1))).await;
+        cancel.cancel();
+        h.submit(job(2, vec![("c2", "r2")]));
+        let next = h.next_outcome().await;
+        assert_eq!(next.entity, entity(2));
+
+        h.drain().await;
+        assert_eq!((h.stats.busy(), h.stats.parked()), (0, 0));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-    async fn pool_runs_batches_concurrently_and_all_exit_on_close() {
-        use std::time::Duration;
+    /// A cancel that lands while the batch is still waiting for capacity drops it
+    /// without it ever running, and takes it off the queue count.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_batch_cancelled_while_queued_never_runs() {
+        let mut h = Harness::new(1);
+        let blocker = crate::cancel::CancelToken::new();
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(held_job(1, started.clone(), release.clone(), blocker));
+        timeout(started.notified()).await;
 
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
+        let cancel = crate::cancel::CancelToken::new();
+        h.submit(job_with(2, vec![("c2", "r2")], cancel.clone()));
+        cancel.cancel();
+        release.notify_one();
 
-        // Three jobs that each block on a rendezvous: they can only all finish
-        // if they run concurrently (a single-worker lane would deadlock the
-        // test's timeout). `tokio::sync::Barrier` rather than a hand-rolled
+        let first = h.next_outcome().await;
+        assert_eq!(first.entity, entity(1));
+        h.drain().await;
+        assert!(
+            h.outcomes.try_recv().is_err(),
+            "the cancelled batch never produced results"
+        );
+        assert_eq!(h.stats.queued(), 0, "and left the queue count clean");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_lane_runs_batches_concurrently_up_to_its_cap() {
+        let h = Harness::new(3);
+        // Three jobs that each block on a rendezvous: they can only all finish if
+        // they run concurrently. `tokio::sync::Barrier` rather than a hand-rolled
         // counter + Notify: `notify_waiters` only wakes ALREADY-registered
-        // waiters, so the old counter check had a lost-wakeup window between
-        // loading the count and registering on `notified()` - a real deadlock
-        // that slow CI runners hit.
+        // waiters, so a counter check has a lost-wakeup window between loading
+        // the count and registering on `notified()`.
         let barrier = Arc::new(tokio::sync::Barrier::new(3));
         for i in 1..=3u32 {
             let barrier = barrier.clone();
-            jtx.send(ToolJob {
-                entity: Entity::from_raw_u32(i).expect("index came from a live entity id"),
+            h.submit(ToolJob {
+                entity: entity(i),
                 exec: Box::new(move || {
                     Box::pin(async move {
-                        // Blocks until all three have arrived (proving concurrency).
                         barrier.wait().await;
                         vec![("c".to_string(), "r".to_string())]
                     })
                 }),
                 cancel: crate::cancel::CancelToken::new(),
-            })
-            .unwrap();
+            });
         }
-        drop(jtx);
-
-        let handles = spawn_tool_pool(
-            &Handle::current(),
-            jrx,
-            rtx,
-            wake,
-            3,
-            Arc::new(ToolLaneStats::new(3)),
-        );
-        // All three outcomes must arrive; bounded so a serialization bug fails
-        // fast (generous for oversubscribed CI runners, instant when passing).
+        let mut h = h;
+        h.drain().await;
         for _ in 0..3 {
-            tokio::time::timeout(Duration::from_secs(60), rrx.recv())
-                .await
-                .expect("all batches complete concurrently")
-                .expect("outcome present");
-        }
-        for h in handles {
-            h.await.unwrap(); // every worker exits once the channel closes
+            timeout(h.outcomes.recv()).await.expect("outcome present");
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn spawn_tool_pool_clamps_zero_to_one_worker() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
-        jtx.send(job(7, vec![("c", "r")])).unwrap();
-        drop(jtx);
-        let handles = spawn_tool_pool(
-            &Handle::current(),
-            jrx,
-            rtx,
-            wake,
-            0,
-            Arc::new(ToolLaneStats::new(0)),
-        );
-        assert_eq!(handles.len(), 1); // clamped up to one worker
-        let out = rrx.recv().await.unwrap();
-        assert_eq!(
-            out.entity,
-            Entity::from_raw_u32(7).expect("a small literal index is always a valid entity id")
-        );
-        for h in handles {
-            h.await.unwrap();
-        }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_lane_survives_a_dropped_outcome_receiver() {
+        let mut h = Harness::new(1);
+        h.submit(job(9, vec![("c", "r")]));
+        // Nobody to receive the outcome: the lane must still drain the job and
+        // not panic on the failed send.
+        h.outcomes.close();
+        h.drain().await;
     }
 
-    /// A lane with no workers is still reported as having one, matching
-    /// `spawn_tool_pool`'s own clamp - otherwise the saturation check compares
-    /// against a lane width that never existed.
-    #[test]
-    fn lane_stats_clamp_the_worker_count_to_one() {
+    /// Relief widens the lane so batches queued behind a wedge can run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn relief_widens_the_lane() {
+        let mut h = Harness::new(1);
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(held_job(
+            1,
+            started.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(started.notified()).await;
+        h.submit(job(2, vec![("c2", "r2")]));
+        assert!(h.stats.is_saturated(), "full, with a batch behind it");
+
+        assert_eq!(h.lane.relieve(0), 0, "relieving nothing changes nothing");
+        assert_eq!(h.lane.relieve(1), 1);
+        assert_eq!(h.stats.workers(), 2, "the cap moved with the permits");
+
+        let freed = h.next_outcome().await;
+        assert_eq!(freed.entity, entity(2), "the queued batch got in");
+
+        release.notify_one();
+        let held = h.next_outcome().await;
+        assert_eq!(held.entity, entity(1));
+        h.drain().await;
+    }
+
+    /// A lane with no capacity is still reported as one wide, matching
+    /// [`ToolLane::new`]'s own clamp - otherwise the saturation check compares
+    /// against a width that never existed.
+    #[tokio::test]
+    async fn a_zero_width_lane_is_clamped_to_one() {
         assert_eq!(ToolLaneStats::new(0).workers(), 1);
+        let mut h = Harness::new(0);
+        h.submit(job(7, vec![("c", "r")]));
+        assert_eq!(h.next_outcome().await.entity, entity(7));
+        h.drain().await;
     }
 
     #[test]
     fn lane_stats_track_queue_depth_and_saturation() {
         let stats = ToolLaneStats::new(2);
-        assert_eq!((stats.queued(), stats.busy()), (0, 0));
+        assert_eq!((stats.queued(), stats.busy(), stats.parked()), (0, 0, 0));
         assert!(!stats.is_saturated(), "an idle lane is not saturated");
 
         stats.enqueued();
         stats.enqueued();
         stats.enqueued();
         assert_eq!(stats.queued(), 3);
-        // Both workers pick a batch up: two leave the queue, two become busy.
+        // Two batches take permits: two leave the queue, two occupy the lane.
         stats.started();
         stats.started();
         assert_eq!((stats.queued(), stats.busy()), (1, 2));
         assert!(
             stats.is_saturated(),
-            "every worker busy with a batch still queued behind them"
+            "the lane is full with a batch still queued"
         );
+
+        // One steps off to wait: it stops occupying the lane.
+        stats.began_park();
+        assert_eq!((stats.busy(), stats.parked()), (1, 1));
+        assert!(!stats.is_saturated(), "parked capacity is capacity");
+        stats.resumed();
+        assert_eq!((stats.busy(), stats.parked()), (2, 0));
+
+        stats.began_park();
+        stats.ended_park();
+        assert_eq!((stats.busy(), stats.parked()), (1, 0));
 
         stats.finished();
-        assert!(
-            !stats.is_saturated(),
-            "a free worker means the queue is draining"
-        );
-    }
-
-    /// The counters have to come back on **every** exit. The cancel path leaves
-    /// via `continue`, which is exactly the shape that skips a decrement written
-    /// at the bottom of the loop body - so a cancelled batch would permanently
-    /// consume one of the lane's fixed workers, as far as the numbers knew.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_cancelled_batch_gives_its_worker_back_to_the_count() {
-        let (jtx, jrx) = mpsc::unbounded_channel();
-        let (rtx, mut rrx) = mpsc::unbounded_channel();
-        let wake = Arc::new(Notify::new());
-        let started = Arc::new(Notify::new());
-        let release = Arc::new(Notify::new());
-        let cancel = crate::cancel::CancelToken::new();
-        let stats = Arc::new(ToolLaneStats::new(1));
-
-        stats.enqueued();
-        jtx.send(held_job(7, started.clone(), release, cancel.clone()))
-            .unwrap();
-        drop(jtx);
-
-        let handles = spawn_tool_pool(&Handle::current(), jrx, rtx, wake, 1, stats.clone());
-        tokio::time::timeout(std::time::Duration::from_secs(5), started.notified())
-            .await
-            .expect("the batch started");
-        assert_eq!(
-            (stats.queued(), stats.busy()),
-            (0, 1),
-            "running: off the queue, on a worker"
-        );
-
-        cancel.cancel();
-        for h in handles {
-            tokio::time::timeout(std::time::Duration::from_secs(5), h)
-                .await
-                .expect("the worker was freed by the cancel")
-                .unwrap();
-        }
-        assert_eq!(stats.busy(), 0, "the cancelled batch released its worker");
-        assert!(rrx.try_recv().is_err(), "and reported no results");
+        stats.abandoned();
+        assert_eq!((stats.queued(), stats.busy()), (0, 0));
     }
 }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -89,7 +89,7 @@ pub enum TickOutcome {
 }
 
 /// How many agents are in each status. See [`PipelineWorld::lane_snapshot`].
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AgentCounts {
     /// Doing work, or ready to.
     pub active: usize,

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -48,7 +48,7 @@ use crate::pipeline::{
     resolve_transition, sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
-use crate::tool_bridge::spawn_tool_pool;
+use crate::tool_bridge::ToolLane;
 
 /// Counts of agents in each phase-marker - the world's per-tick "fingerprint".
 /// Two consecutive equal fingerprints mean a tick changed nothing (quiescence).
@@ -120,13 +120,15 @@ pub struct LaneSnapshot {
     pub agents: AgentCounts,
     /// Inference-pool occupancy, one entry per model actually used.
     pub inference: Vec<crate::inference_pool::PoolOccupancy>,
-    /// Tool-lane workers currently running a batch.
+    /// Tool batches holding lane capacity and running.
     pub tools_busy: usize,
-    /// Tool batches waiting for a free worker.
+    /// Tool batches waiting for lane capacity.
     pub tools_queued: usize,
-    /// The tool lane's worker count.
+    /// Tool batches parked on an unbounded wait, holding no capacity.
+    pub tools_parked: usize,
+    /// The tool lane's concurrency cap.
     pub tools_workers: usize,
-    /// Every worker busy with batches still queued behind them.
+    /// The lane full with batches still queued behind it.
     pub tools_saturated: bool,
 }
 
@@ -160,10 +162,12 @@ pub struct PipelineWorld {
     wake: Arc<Notify>,
     shutdown: Arc<Notify>,
     msg_tx: UnboundedSender<AgentMessage>,
-    /// The tool worker pool tasks; kept so they live as long as the world. Each
-    /// exits on its own when the world (and thus the [`ToolStage`] sender) is
-    /// dropped. The pool size is the tool-lane concurrency cap.
-    _tool_tasks: Vec<JoinHandle<()>>,
+    /// The tool lane, kept so the world can widen it under relief.
+    tool_lane: Arc<ToolLane>,
+    /// The task serving the tool lane; kept so it lives as long as the world. It
+    /// exits on its own once the world (and thus the [`ToolStage`] sender) is
+    /// dropped and the batches it started have finished.
+    _tool_task: JoinHandle<()>,
     /// The persistence worker task. Retained (rather than detached) so
     /// [`Self::flush_and_stop`] can close its channel and `await` it, guaranteeing
     /// every queued snapshot reaches disk before shutdown. `None` once flushed.
@@ -209,14 +213,14 @@ impl PipelineWorld {
         let (title_tx, title_rx) = unbounded_channel();
 
         let tool_stats = Arc::new(crate::tool_bridge::ToolLaneStats::new(tool_concurrency));
-        let tool_tasks = spawn_tool_pool(
-            &runtime,
-            tool_job_rx,
+        let tool_lane = ToolLane::new(
+            runtime.clone(),
             tool_res_tx,
             wake.clone(),
             tool_concurrency,
             tool_stats.clone(),
         );
+        let tool_task = tool_lane.serve(tool_job_rx);
         // Retained so `flush_and_stop` can drain it on shutdown. Left to its own
         // devices otherwise: it exits when the world (and thus its PersistenceStage
         // sender) is dropped.
@@ -368,7 +372,8 @@ impl PipelineWorld {
             wake,
             shutdown,
             msg_tx,
-            _tool_tasks: tool_tasks,
+            tool_lane,
+            _tool_task: tool_task,
             persist_task: Some(persist_task),
         }
     }
@@ -535,9 +540,19 @@ impl PipelineWorld {
             inference: self.world.resource::<InferenceStage>().pools.occupancy(),
             tools_busy: tools.busy(),
             tools_queued: tools.queued(),
+            tools_parked: tools.parked(),
             tools_workers: tools.workers(),
             tools_saturated: tools.is_saturated(),
         }
+    }
+
+    /// Widen the tool lane by `extra` batches, permanently.
+    ///
+    /// The relief valve: when the lane has stopped draining, handing out more
+    /// capacity lets the queued batches through without cancelling anything.
+    /// Returns how many were added.
+    pub fn relieve_tool_lane(&self, extra: usize) -> usize {
+        self.tool_lane.relieve(extra)
     }
 
     /// The status of an agent, if it still exists.

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -279,7 +279,7 @@ impl PipelineWorld {
             (
                 // First: stop whatever a now-terminal agent still has running in
                 // the async lanes. Ahead of everything else so a cancel frees its
-                // inference permit and tool-lane worker on the very next tick,
+                // inference permit and tool-lane capacity on the very next tick,
                 // rather than whenever the provider or tool happens to answer.
                 abort_terminal_work,
                 deliver_messages,

--- a/crates/leviath-telemetry/src/log_sink.rs
+++ b/crates/leviath-telemetry/src/log_sink.rs
@@ -7,7 +7,7 @@
 //! the same reason this is hand-rolled rather than `opentelemetry-stdout`,
 //! which writes to stdout unconditionally.)
 
-use leviath_core::telemetry::{LogKind, TelemetryEvent, TelemetrySink};
+use leviath_core::telemetry::{LaneHealth, LogKind, TelemetryEvent, TelemetrySink};
 
 /// One readable line for an event.
 pub(crate) fn format_event(event: &TelemetryEvent) -> String {
@@ -94,12 +94,32 @@ pub(crate) fn format_event(event: &TelemetryEvent) -> String {
     }
 }
 
+/// One readable line for a daemon-wide health sample.
+pub(crate) fn format_lane_health(health: &LaneHealth) -> String {
+    format!(
+        "lanes: agents active={} waiting={}, tools {}/{} busy, {} parked, {} queued, \
+         dead cycles {}, relief {}",
+        health.agents_active,
+        health.agents_waiting,
+        health.tools_busy,
+        health.tools_workers,
+        health.tools_parked,
+        health.tools_queued,
+        health.dead_cycles,
+        health.relief_granted,
+    )
+}
+
 /// [`TelemetrySink`] that narrates events as `tracing` lines (→ stderr).
 pub struct LogSink;
 
 impl TelemetrySink for LogSink {
     fn emit(&self, event: TelemetryEvent) {
         tracing::info!(target: "leviath::telemetry", "{}", format_event(&event));
+    }
+
+    fn observe_lanes(&self, health: LaneHealth) {
+        tracing::info!(target: "leviath::telemetry", "{}", format_lane_health(&health));
     }
 }
 
@@ -262,5 +282,33 @@ mod tests {
             tool_calls: 0,
             at_ms: 0,
         });
+    }
+
+    /// The daemon-wide line reads as one sentence, with the numbers an operator
+    /// asks for in the order they ask for them.
+    #[test]
+    fn lane_health_formats_to_one_line() {
+        let line = format_lane_health(&LaneHealth {
+            agents_active: 6,
+            agents_waiting: 2,
+            tools_busy: 8,
+            tools_queued: 12,
+            tools_parked: 3,
+            tools_workers: 8,
+            dead_cycles: 4,
+            relief_granted: 2,
+        });
+        assert_eq!(
+            line,
+            "lanes: agents active=6 waiting=2, tools 8/8 busy, 3 parked, 12 queued, \
+             dead cycles 4, relief 2"
+        );
+        assert!(!line.contains('\n'), "one line: {line}");
+    }
+
+    #[test]
+    fn observe_lanes_routes_through_tracing_without_panicking() {
+        let _guard = leviath_testkit::tracing_guard();
+        LogSink.observe_lanes(LaneHealth::default());
     }
 }

--- a/crates/leviath-telemetry/src/otel.rs
+++ b/crates/leviath-telemetry/src/otel.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use leviath_core::config::ObservabilityConfig;
-use leviath_core::telemetry::{LogKind, TelemetryEvent, TelemetrySink};
+use leviath_core::telemetry::{LaneHealth, LogKind, TelemetryEvent, TelemetrySink};
 use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter};
 use opentelemetry::trace::{
@@ -112,6 +112,82 @@ struct Instruments {
     tool_calls: Counter<u64>,
     stage_duration: Histogram<f64>,
     inference_latency: Histogram<f64>,
+    /// Tool-lane occupancy, re-stated on every health sample. Up-down counters
+    /// rather than plain counters because these go both ways, and the sink adds
+    /// the delta from the previous sample so a scrape reads the current value.
+    lane: LaneInstruments,
+}
+
+/// The daemon-wide instruments, kept together because they share the
+/// last-sample bookkeeping that turns a level into a delta.
+struct LaneInstruments {
+    tools_busy: UpDownCounter<i64>,
+    tools_queued: UpDownCounter<i64>,
+    tools_parked: UpDownCounter<i64>,
+    dead_cycles: Counter<u64>,
+    relief: Counter<u64>,
+    /// The previous sample's levels, so each one can be reported as a delta.
+    last: Mutex<LaneLevels>,
+}
+
+/// The gauge-shaped parts of [`LaneHealth`], as last reported.
+#[derive(Default, Clone, Copy)]
+struct LaneLevels {
+    tools_busy: i64,
+    tools_queued: i64,
+    tools_parked: i64,
+    dead_cycles: u32,
+}
+
+impl LaneInstruments {
+    fn new(meter: &Meter) -> Self {
+        Self {
+            tools_busy: meter
+                .i64_up_down_counter("leviath.tool_lane.busy")
+                .with_description("Tool batches currently holding lane capacity")
+                .build(),
+            tools_queued: meter
+                .i64_up_down_counter("leviath.tool_lane.queued")
+                .with_description("Tool batches waiting for lane capacity")
+                .build(),
+            tools_parked: meter
+                .i64_up_down_counter("leviath.tool_lane.parked")
+                .with_description("Tool batches parked on an unbounded wait, holding no capacity")
+                .build(),
+            dead_cycles: meter
+                .u64_counter("leviath.scheduler.dead_cycles.total")
+                .with_description("Re-drives that found the lanes full and no run moving")
+                .build(),
+            relief: meter
+                .u64_counter("leviath.tool_lane.relief.total")
+                .with_description("Extra tool-lane capacity handed out to break a wedge")
+                .build(),
+            last: Mutex::new(LaneLevels::default()),
+        }
+    }
+
+    /// Report one sample, converting the levels into the deltas an up-down
+    /// counter wants.
+    fn record(&self, health: &LaneHealth) {
+        let now = LaneLevels {
+            tools_busy: health.tools_busy as i64,
+            tools_queued: health.tools_queued as i64,
+            tools_parked: health.tools_parked as i64,
+            dead_cycles: health.dead_cycles,
+        };
+        let mut last = self.last.lock().expect("telemetry lane level lock");
+        self.tools_busy.add(now.tools_busy - last.tools_busy, &[]);
+        self.tools_queued
+            .add(now.tools_queued - last.tools_queued, &[]);
+        self.tools_parked
+            .add(now.tools_parked - last.tools_parked, &[]);
+        // A streak that grew is that many more dead cycles; one that reset is
+        // not negative progress, it is simply nothing to add.
+        self.dead_cycles
+            .add(now.dead_cycles.saturating_sub(last.dead_cycles) as u64, &[]);
+        self.relief.add(health.relief_granted as u64, &[]);
+        *last = now;
+    }
 }
 
 impl Instruments {
@@ -139,6 +215,7 @@ impl Instruments {
                 .with_description("Per-call inference latency by provider")
                 .with_unit("s")
                 .build(),
+            lane: LaneInstruments::new(meter),
         }
     }
 }
@@ -544,6 +621,10 @@ impl TelemetrySink for OtelSink {
         }
     }
 
+    fn observe_lanes(&self, health: LaneHealth) {
+        self.instruments.lane.record(&health);
+    }
+
     fn force_flush(&self) {
         let _ = self.tracer_provider.force_flush();
         let _ = self.meter_provider.force_flush();
@@ -883,6 +964,84 @@ mod tests {
         ] {
             assert!(names.contains(&expected.to_string()), "{names:?}");
         }
+    }
+
+    /// The daemon-wide instruments. Lane occupancy goes up and down, so the sink
+    /// turns each sample's level into a delta; a dead-cycle streak only ever
+    /// grows, and resetting to zero adds nothing rather than going backwards.
+    #[test]
+    fn lane_health_samples_export_as_deltas() {
+        let h = harness();
+        h.sink.observe_lanes(LaneHealth {
+            tools_busy: 3,
+            tools_queued: 5,
+            tools_parked: 1,
+            tools_workers: 8,
+            dead_cycles: 2,
+            ..Default::default()
+        });
+        // Busier, one more dead cycle, and some relief handed out.
+        h.sink.observe_lanes(LaneHealth {
+            agents_active: 6,
+            agents_waiting: 2,
+            tools_busy: 8,
+            tools_queued: 2,
+            tools_parked: 4,
+            tools_workers: 8,
+            dead_cycles: 3,
+            relief_granted: 2,
+        });
+        // The wedge cleared: the streak resets, which must not subtract.
+        h.sink.observe_lanes(LaneHealth {
+            tools_workers: 8,
+            ..Default::default()
+        });
+        h.sink.force_flush();
+
+        let exported = h.metrics.get_finished_metrics().unwrap();
+        let names: Vec<String> = exported
+            .iter()
+            .flat_map(|rm| rm.scope_metrics())
+            .flat_map(|sm| sm.metrics())
+            .map(|m| m.name().to_string())
+            .collect();
+        for expected in [
+            "leviath.tool_lane.busy",
+            "leviath.tool_lane.queued",
+            "leviath.tool_lane.parked",
+            "leviath.scheduler.dead_cycles.total",
+            "leviath.tool_lane.relief.total",
+        ] {
+            assert!(names.contains(&expected.to_string()), "{names:?}");
+        }
+    }
+
+    /// The delta arithmetic on its own, where the numbers are readable.
+    #[test]
+    fn lane_levels_become_deltas_and_streaks_only_climb() {
+        let meter = SdkMeterProvider::builder().build().meter("test");
+        let lane = LaneInstruments::new(&meter);
+        let levels = |lane: &LaneInstruments| *lane.last.lock().unwrap();
+
+        lane.record(&LaneHealth {
+            tools_busy: 4,
+            tools_queued: 2,
+            tools_parked: 1,
+            dead_cycles: 5,
+            ..Default::default()
+        });
+        let after = levels(&lane);
+        assert_eq!((after.tools_busy, after.tools_queued), (4, 2));
+        assert_eq!(after.dead_cycles, 5);
+
+        // A quiet sample takes the levels back down and the streak to zero.
+        lane.record(&LaneHealth::default());
+        let after = levels(&lane);
+        assert_eq!(
+            (after.tools_busy, after.tools_queued, after.tools_parked),
+            (0, 0, 0)
+        );
+        assert_eq!(after.dead_cycles, 0, "the streak reset");
     }
 
     #[test]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -69,6 +69,8 @@ max_concurrent_tools      = 8    # agents whose tool batches may run at once, da
 default_max_iterations    = 50   # fallback cap for a stage that sets none
 exact_token_counting      = false
 script_shell_timeout_secs = 60
+stall_timeout_secs        = 60   # fail a run that can never dispatch
+dead_cycles_before_relief = 10   # widen the tool lane after this long going nowhere
 ```
 
 | Key | Default | Notes |
@@ -78,6 +80,8 @@ script_shell_timeout_secs = 60
 | `default_max_iterations` | `50` | A stage's explicit `max_iterations` always wins |
 | `exact_token_counting` | `false` | Counts each assembled request exactly before sending and rejects one that would overflow the window. Costs a network round trip per inference on providers with a remote count endpoint |
 | `script_shell_timeout_secs` | `60` | Cap on a Rhai script tool's `shell()` host call |
+| `stall_timeout_secs` | `60` | How long a run may sit ready to work but unable to dispatch before it is failed instead of left running. Only fires for something the runtime cannot resolve on its own, today a stage whose provider is not configured. Waiting for a busy model's pool is ordinary backpressure and is never failed. `0` waits forever |
+| `dead_cycles_before_relief` | `10` | How many consecutive 30-second cycles the daemon may spend with a full tool lane and no run moving before it widens the lane. See [the tool lane](/docs/engine#the-tool-lane). `0` never widens it; the count is still reported either way |
 
 <a id="security"></a>
 

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -94,8 +94,9 @@ process-wide state once at startup rather than per run:
 - provider keys and `[model_providers]` (the provider registry)
 - `[[mcp_servers]]` (live MCP connections), `[observability]` (the telemetry pipeline), and
   `[security] allow_local_network` (the outbound-network policy)
-- `[limits] stall_timeout_secs`, along with the other limits the world is built with
-  (`max_concurrent_inferences`, `max_concurrent_tools`, `exact_token_counting`)
+- `[limits] stall_timeout_secs` and `dead_cycles_before_relief`, along with the other limits the
+  world is built with (`max_concurrent_inferences`, `max_concurrent_tools`,
+  `exact_token_counting`)
 
 ## Control surface
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -223,6 +223,32 @@ how many *sub-agents* a stage spawns ([Sub-agents](/docs/sub-agents)), and
 `[rate_limits.<provider>]` shapes *request rate* to a provider. The pool bounds concurrency; the
 rate limiter bounds throughput; both apply.
 
+<a id="the-tool-lane"></a>
+
+## The tool lane
+
+Tools have a pool of their own. `[limits] max_concurrent_tools` (8 by default) caps how many
+agents' tool batches execute at once across the whole daemon, and a batch holds one unit of that
+capacity for as long as it is running.
+
+The interesting part is what happens when a batch is not running but waiting. Several things a
+batch can wait for have no time bound at all: a tool-approval prompt, an `ask_user`, a
+`wait_for_agent` that only ends when some other run finishes. A batch parked on one of those gives
+its capacity back and takes a fresh unit when it has something to do again, so waiting costs the
+lane nothing.
+
+That is not a nicety. A parent waiting for a child it spawned would otherwise be holding the very
+capacity the child needed in order to finish, and enough parents doing that froze whole factories
+for hours with every run reading as healthy. `lev ps` shows parked batches separately from running
+ones for the same reason: parked is fine, queued with nothing draining is not.
+
+As a backstop for jams nobody has diagnosed yet, the daemon counts the 30-second cycles it spends
+with a full tool lane and no run moving anywhere. Past `[limits] dead_cycles_before_relief` (10 by
+default, so five minutes) it widens the lane so the queued batches get through. It only ever adds
+capacity, never cancels anything, and it stops after granting one extra lane's worth: if that much
+did not help, the problem is not capacity. Set the key to `0` to turn relief off; the count is
+reported either way, in `lev ps` and as `leviath.scheduler.dead_cycles.total`.
+
 ## Stages are not entities
 
 A stage is not a separate entity or object. It is `StageCursor.index`, an index into the blueprint

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -39,9 +39,19 @@ them anywhere, which is the quickest way to see what would be exported.
 transitions, retries, and terminal status all land as span attributes, so a
 stuck or looping run is visible as a shape, not just a log line.
 
-**Metrics.** Token counters (prompt and completion), stage-duration
-histograms, and inference-latency histograms, labeled by agent, stage, and
+**Metrics.** Per run: `leviath.agents.active`, `leviath.tokens.total` and
+`leviath.tool_calls.total` counters, and `leviath.stage_duration` and
+`leviath.inference_latency` histograms, labeled by agent, stage, provider, and
 model.
+
+Per daemon, sampled every 30 seconds: `leviath.tool_lane.busy`,
+`leviath.tool_lane.queued`, and `leviath.tool_lane.parked` for what the tool
+lane is holding, plus `leviath.scheduler.dead_cycles.total` and
+`leviath.tool_lane.relief.total`. A dead cycle is a whole 30-second interval in
+which a lane was at capacity, work was queued behind it, and no run moved. It is
+the one number that separates a busy daemon from a wedged one, and it is worth
+alerting on: a healthy factory sits at zero, and anything sustained above it
+means work is arriving that nothing is getting to.
 
 **Logs.** Log records carry the run's trace ID, so a collector that joins the
 three signals can jump from a log line to the exact span that produced it.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -58,6 +58,31 @@ Waiting for a busy model is *not* this. An agent queued behind other in-flight r
 model is working as intended and is never failed, however long the queue takes — raise
 `[limits] max_concurrent_inferences` if you want more of them running at once.
 
+## Every run looks busy but nothing finishes
+
+Run `lev ps` and read the line under the table. If there isn't one, the daemon thinks it is
+getting somewhere and the problem is in a particular run rather than the daemon as a whole.
+
+A `lanes:` line means the tool lane is full with batches queued behind it. On its own that is just
+a busy factory. What matters is the second half:
+
+```
+lanes: tools 8/8 busy, 3 parked, 12 queued  ·  no progress for 14 cycles (7m)
+```
+
+A cycle is 30 seconds, so that reads as seven minutes in which work was waiting for the tool lane
+and not one run moved. `parked` is not part of the problem: a batch waiting on a person or on
+another run holds no capacity. `busy` with a `queued` figure that never falls is.
+
+The usual cause is too little tool capacity for the shape of the workload. Raise
+`[limits] max_concurrent_tools` and restart the daemon. Left alone, the daemon widens the lane
+itself after `[limits] dead_cycles_before_relief` cycles (10 by default) and says so in the log at
+`error` level; it never cancels anything, and it stops after one extra lane's worth.
+
+The same numbers are exported as `leviath.tool_lane.*` and
+`leviath.scheduler.dead_cycles.total` if you have [observability](/docs/observability) on. A
+healthy daemon sits at zero dead cycles.
+
 ## An agent seems stuck in a loop
 
 That's what [stuck detection](/docs/stages#graph) is for. Add a `condition = "stuck"` transition


### PR DESCRIPTION
Fixes #191.

## What was happening

The reporter's router sweeps once a minute, sees `in_progress=20 slots=0`, and spawns nothing, for
hours. Its slots are leviath runs, so `slots=0` forever means leviath runs stopped finishing.

The tool lane was a fixed pool of `max_concurrent_tools` worker tasks, and a batch owned a worker
for its whole life. Several things a batch can await have no time bound at all: a tool-approval
prompt, an `ask_user`, a `wait_for_agent` poll that only ends when another run finishes. That last
one is a deadlock, not just pressure: a parent waiting for a child it spawned was holding the very
capacity the child needed in order to finish. Enough parents doing that and no agent's tools ran
again. `tool_bridge.rs` already said as much in a comment; nothing acted on it.

Reproduced on `main` with `max_concurrent_tools = 1`, a parent that spawns one child and waits, and
offline mock providers. Three minutes in:

```
RUN                             STATUS  STAGE     ITER  TOOLS  AGE
parent-1785611206-cfc31df30281  active  delegate  1     1      3m
child-1785611206-393d7877ef0c   active  work      1     1      3m
```

Both `active`, nothing failed, `tools_busy=1 tools_workers=1 tools_queued=1` forever. The same
scenario on this branch finishes in seconds.

## What changed

**The lane is a semaphore, not a pool of workers.** Capacity is a permit, and a permit can be
handed back mid-batch. `off_lane` does exactly that: it drops the permit before an unbounded wait
and takes a fresh one afterwards, so waiting costs the lane nothing and whatever is being waited
for can always get in. Two seams use it, and each has a test that hangs the lane if the wrapper is
removed:

- `InteractionHub::submit`, covering every `ask_user_*` and tool-approval prompt
- `subagent::wait`, covering `wait_for_agent` and `spawn_agent(wait = true)`

Callers that are not tool batches (the gate-prompt and interaction-point lanes) have no ticket, and
for them `off_lane` is a plain await.

**Dead cycles.** A daemon at capacity looked the same whether it was chewing through work or
wedged. The 30-second safety re-drive now compares a fingerprint of every run's observable state
against the previous interval's; full lanes plus an unchanged fingerprint is a dead cycle, and
anything else resets the count. Both halves matter: pressure alone is a busy daemon, stillness
alone is an idle one.

**Reporting.** `lev ps` grows a footer when there is something to say, and `--json` gains a
`{"runs": …, "health": …}` envelope. The heartbeat escalates to `warn` on a streak. OTEL gets
`leviath.tool_lane.busy` / `.queued` / `.parked`, `leviath.scheduler.dead_cycles.total`, and
`leviath.tool_lane.relief.total`, via a default-bodied `TelemetrySink::observe_lanes` (every
`TelemetryEvent` belongs to a run; this belongs to none of them).

```
RUN                             STATUS  STAGE  ITER  TOOLS  AGE
queued-1785611494-feee36afd7bf  active  work   1     1      1m
hog-1785611494-83cf2e557a02     active  hold   1     1      1m

lanes: tools 1/1 busy, 1 queued  ·  no progress for 1 cycles (30s)
```

**The circuit breaker**, with one deliberate difference from what the issue asked for: it adds
capacity rather than taking runs away. Killing whatever holds the lane is the tempting reading of
"reclaim stuck slots" and it is the wrong one, because a run parked on an `ask_user` is behaving
correctly, and an operator killing healthy `waiting` runs is the story behind #184. Past
`[limits] dead_cycles_before_relief` (10 by default, so five minutes) the daemon widens the tool
lane so the queued batches get through. Capped at one extra lane's worth over the daemon's life: if
that did not help, the problem is not capacity. `0` turns relief off and leaves detection alone.

Only the tool lane is widened. A full inference pool is a deliberate cap on requests in flight to a
provider, and forcing extra ones past it would trade a wedge for a rate limit.

## Verification

100% coverage across all 11 packages, and live-verified against an isolated daemon with offline
Rhai mock providers:

- the `main` deadlock above, gone on this branch
- `parked=1` sustained while a parent waits on a child, with both permits held by other work, and
  the parent resuming and completing afterwards
- the dead-cycle streak counting up, the `warn` line, the `lanes:` footer, and relief firing:
  `the tool lane has not drained in 2 cycles; widening it by 1`, after which the queued run
  completed
- `lev ps --json` carrying the health block

One thing checked and cleared: a daemon takes as long as its longest running tool to exit after
`lev daemon stop`. That is identical on `main` (55.6s vs 55.7s for the same 60-second tool), so it
is not from this change.

## Out of scope

#197 (stage entry waiting for the re-drive tick) and #192 (`empty_output` on completed router runs)
are open and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLxhuZbKzMTtwXFsYkxx4V