### PR TITLE
Stop reading a marker-neutral tick as quiescence (#197)

### DIFF
--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -98,7 +98,10 @@ pub struct GateAutoApprove;
 pub struct InteractionAutoApprove;
 
 /// Status of an agent.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+///
+/// `Hash` so the driver's quiescence check can fold an agent's status into its
+/// per-tick digest (see `PipelineWorld::agent_digest`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
 pub enum AgentStatus {
     /// Agent is idle, ready for tasks
     Idle,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -2036,6 +2036,116 @@ mod tests {
         );
     }
 
+    /// A two-stage linear blueprint (`one` -> `two`), for the stage-boundary
+    /// tests. No transitions declared: `resolve_transition_sync` falls through to
+    /// the next stage in order, which is the ordinary case.
+    fn two_stage_blueprint() -> leviath_core::Blueprint {
+        let layout = leviath_core::layout::ContextLayout::new(
+            vec![leviath_core::layout::RegionDefinition::new(
+                "conversation".to_string(),
+                RegionKind::Clearable,
+                10_000,
+            )],
+            12_000,
+        );
+        let model =
+            leviath_core::blueprint::ModelConfig::new("script".to_string(), "m".to_string());
+        // Both stages end by running out of iterations, which is how a stage that
+        // keeps calling tools finishes. That boundary is the one the driver used
+        // to miss: `enforce_max_iterations` and `resolve_transition` both run in
+        // the same tick, so the agent leaves `ReadyToInfer` and comes back to it
+        // with every marker count exactly as it was.
+        let mut one = leviath_core::Stage::new("one".to_string(), model.clone());
+        one.max_iterations = Some(1);
+        let mut two = leviath_core::Stage::new("two".to_string(), model);
+        two.max_iterations = Some(1);
+        let stages = vec![one, two];
+        leviath_core::Blueprint::new("t".to_string(), "d".to_string(), stages, layout)
+    }
+
+    /// Spawn an agent that starts at stage `one` of [`two_stage_blueprint`].
+    fn spawn_two_stage(host: &mut WorldHost, run_id: &str, agent_id: &str) -> Entity {
+        let mut state = agent_state(agent_id);
+        state.current_stage = "one".to_string();
+        let e = host.world_mut().spawn_agent((
+            AgentBlueprint(two_stage_blueprint()),
+            StageCursor { index: 0 },
+            state,
+            crate::components::MessageInbox::default(),
+            StageProgress::default(),
+            StageInferences(vec![si(), si()]),
+            StageSetups(vec![setup(), setup()]),
+            VisitCounts::default(),
+            window(),
+            si(),
+            setup().inference_config,
+            ReadyToInfer,
+        ));
+        host.register(run_id, e);
+        e
+    }
+
+    /// A response that asks for one tool call - what a working stage returns
+    /// right up to the iteration that ends it.
+    fn tool_call(id: &str) -> InferenceResponse {
+        InferenceResponse {
+            tool_calls: vec![leviath_providers::ToolCall {
+                id: id.to_string(),
+                name: "noop".to_string(),
+                arguments: serde_json::Value::Null,
+                thought_signature: None,
+            }],
+            ..text("working")
+        }
+    }
+
+    /// Regression for #197 ("entering the next stage waits for the re-drive
+    /// tick").
+    ///
+    /// `serve` is event-driven; its 30s re-drive is a correctness backstop for a
+    /// wake that never came, not the mechanism ordinary work runs on. A stage
+    /// boundary that only makes progress on the timer puts up to 30s of dead time
+    /// on every transition - a five-stage run loses minutes to nothing.
+    ///
+    /// The re-drive is set out of reach here, so the run can only finish through
+    /// the wake path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_stage_boundary_is_crossed_without_waiting_for_the_redrive() {
+        let mut host = host_with(vec![tool_call("c1"), tool_call("c2")]);
+        host.set_redrive_interval(std::time::Duration::from_secs(3600));
+        spawn_two_stage(&mut host, "run-a", "agent-a");
+
+        let mut events = host.subscribe();
+        let shutdown = host.world_mut().shutdown_handle();
+        let (op_tx, op_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move { host.serve(op_rx).await });
+
+        // Watch the event stream rather than the world: `serve` owns the host for
+        // as long as it runs. Everything before `Completed` (spawn, status,
+        // tokens) streams past on the way.
+        let completed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let event = events
+                    .recv()
+                    .await
+                    .expect("the event stream must outlive the run");
+                if let WorldEvent::Completed { status, .. } = event {
+                    break status;
+                }
+            }
+        })
+        .await;
+
+        shutdown.notify_one();
+        drop(op_tx);
+        handle.await.unwrap();
+
+        assert_eq!(
+            completed.expect("the run must reach stage two and finish on wakes alone"),
+            "complete"
+        );
+    }
+
     /// The heartbeat's two levels. Under pressure it is worth an `info` line;
     /// idle it must not be, or a healthy daemon spams the log forever.
     #[tokio::test]

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -50,9 +50,25 @@ use crate::pipeline::{
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::ToolLane;
 
-/// Counts of agents in each phase-marker - the world's per-tick "fingerprint".
-/// Two consecutive equal fingerprints mean a tick changed nothing (quiescence).
-type Fingerprint = [usize; 12];
+/// What a tick can change, as one comparable value. Two consecutive equal
+/// fingerprints mean a tick changed nothing (quiescence).
+///
+/// Marker counts alone are not enough, because a tick can move an agent out of a
+/// marker and back into it. A stage that ends on `max_iterations` does exactly
+/// that: `enforce_max_iterations` swaps `ReadyToInfer` for `ResolveTransition` in
+/// the first chained group, and `resolve_transition` enters the next stage and
+/// re-arms `ReadyToInfer` in the second - one tick, a whole stage transition, and
+/// every count identical either side of it. The driver read that as quiescence
+/// and parked on an agent that no dispatch system had yet seen in its new stage,
+/// leaving the 30s re-drive to start the next stage (issue #197).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Fingerprint {
+    /// How many agents hold each phase marker.
+    markers: [usize; 12],
+    /// Per-agent run progress that no marker reflects (see
+    /// [`PipelineWorld::agent_digest`]).
+    agents: u64,
+}
 
 /// How many attributed system panics one [`PipelineWorld::run_to_fixed_point`]
 /// round will absorb before it stops driving. Each one fails a different agent,
@@ -693,9 +709,52 @@ impl PipelineWorld {
         q.iter(&self.world).count()
     }
 
-    /// Snapshot the per-phase marker counts.
+    /// Digest the run progress a phase marker cannot show: each agent's status,
+    /// which stage it is in, and its per-stage counters.
+    ///
+    /// Only values that step on a real event go in. Anything that moves on its
+    /// own (a clock, a stall timestamp) would keep the fixed-point loop from ever
+    /// converging, which is a spinning daemon rather than a parked one.
+    ///
+    /// The per-agent digests are XOR-folded, so archetype iteration order doesn't
+    /// matter; each one includes the entity id so two agents swapping states
+    /// can't cancel out.
+    fn agent_digest(&mut self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut query = self.world.query::<(
+            Entity,
+            &AgentState,
+            Option<&crate::pipeline::StageCursor>,
+            Option<&crate::pipeline::StageProgress>,
+        )>();
+        query
+            .iter(&self.world)
+            .map(|(entity, state, cursor, progress)| {
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                entity.to_bits().hash(&mut hasher);
+                state.status.hash(&mut hasher);
+                state.current_stage.hash(&mut hasher);
+                state.iteration.hash(&mut hasher);
+                cursor.map(|c| c.index).hash(&mut hasher);
+                progress
+                    .map(|p| {
+                        (
+                            p.iterations,
+                            p.total_tool_calls,
+                            p.modifying_tool_calls,
+                            p.gate_reentries,
+                            p.stuck_fired,
+                        )
+                    })
+                    .hash(&mut hasher);
+                hasher.finish()
+            })
+            .fold(0, |acc, digest| acc ^ digest)
+    }
+
+    /// Snapshot the per-phase marker counts and the per-agent progress digest.
     fn fingerprint(&mut self) -> Fingerprint {
-        [
+        let markers = [
             self.count::<With<ReadyToInfer>>(),
             self.count::<With<AwaitingInference>>(),
             self.count::<With<ProcessResponse>>(),
@@ -708,7 +767,11 @@ impl PipelineWorld {
             self.count::<With<AwaitingCompaction>>(),
             self.count::<With<crate::title::PendingTitle>>(),
             self.count::<With<crate::title::AwaitingTitle>>(),
-        ]
+        ];
+        Fingerprint {
+            markers,
+            agents: self.agent_digest(),
+        }
     }
 
     /// Any agent waiting on an in-flight async job (inference, tools, a


### PR DESCRIPTION
Fixes #197.

## The defect

Entering a new stage did not dispatch until the daemon's 30s safety re-drive fired, so a two-stage run that should finish instantly took 12-22 seconds, all of it parked at the boundary.

The driver decides it has reached quiescence by comparing counts of who holds each of the 12 phase markers either side of a tick. A stage that ends on `max_iterations` is invisible to that comparison:

- `enforce_max_iterations` swaps `ReadyToInfer` for `ResolveTransition` in the **first** chained system group,
- `resolve_transition` enters the next stage and re-arms `ReadyToInfer` in the **second**.

One tick, a whole stage transition, every count identical either side. The drive stopped there and parked — on an `Active` agent that was ready to infer, that no dispatch system had yet seen in its new stage, with nothing in flight and no wake coming. Only the timer got it moving.

Note this only bites *some* boundaries. A stage ending on a plain text response passes through `ReadyForTransition`, so the counts differ and the drive continues. The reproducing shape is `max_iterations`, which is how any tool-calling stage ends.

## Ruled out before touching anything

The issue's own leading hypothesis (a `Notify` + `select!` lost wakeup) was explicitly filed as unproven. It is wrong, along with two neighbours:

- **Not a tokio lost wakeup.** `Notified::drop` in tokio 1.53 (`drop_notified`) re-runs `notify_locked`, so a future dropped after being notified stores the permit back. A `select!` branch cannot swallow a `notify_one`.
- **Not a rival waiter.** `wake_handle()` has exactly two consumers workspace-wide: `WorldHost::serve` and `PipelineWorld::run_until_idle`/`run`.
- **Not a lane that forgets to notify.** Every lane sender pairs its `send` with `wake.notify_one()`; `run_inference_job` drops the permit *before* the send and notifies twice.

## The fix

`Fingerprint` becomes a struct: the 12 marker counts plus `agent_digest()`, an XOR-fold of a per-agent hash of status, current stage, iteration, stage cursor and the per-stage counters. Each digest includes the entity id, so two agents swapping states can't cancel out.

Only values that step on a real event go in. A clock or a stall timestamp in there would keep the loop from ever converging, which is a spinning daemon rather than a parked one.

The 30s re-drive keeps its meaning: a backstop for a wake that never came, not the mechanism ordinary work runs on.

## Verification

- New `serve`-level regression test with the re-drive set an hour out, so only the wake path can make progress: times out at 5s without the fix, passes in 0.02s with it.
- Full workspace suite green, `cargo xtask coverage` at 100% on all 11 packages, clippy and `cargo doc -D warnings` clean.
- Live, against an offline three-stage mock daemon run, same repro either side of the change: **21.71s before, 0.11s after**, every stage's `started_at` and `ended_at` in the same second, and the daemon idle at 0% CPU afterwards (the fixed point still converges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz4rJde5nHbtgrfeNFQDtD