### PR TITLE
Tell agents which shell they get, and document model identifiers

### DIFF
--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.0.1"
+version = "0.0.2"
 description = "Analyzes log files - identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
@@ -24,9 +24,11 @@ Ingest the log files named in `task`. Determine:
 3. Available fields/columns
 4. Obvious structural issues (corrupted lines, encoding problems)
 
-Use bash (head/wc/file) to sample rather than reading whole huge files. Write a
-short format/structure summary to `findings` (context_write) so the analyze stage
-starts oriented. Raw sampled content lands in `logs`.
+Use bash to sample rather than reading whole huge files - the first N lines, a
+line count, a file type probe. Reach for whatever your shell actually provides
+(`head`/`wc`/`file` on Unix, `Get-Content -TotalCount` and `Measure-Object` on
+Windows). Write a short format/structure summary to `findings` (context_write) so
+the analyze stage starts oriented. Raw sampled content lands in `logs`.
 """
 
 [stages.ingest.tool_routing]
@@ -106,7 +108,8 @@ Your script has produced results. Decide what happens next:
 - If the results answer the analysis questions, respond with: analyze
 """
 system_prompt = """
-Write scripts (awk/grep/python via bash) to process the logs:
+Write scripts to process the logs, in whatever your shell can run (awk/grep/sed
+or python via bash on Unix, PowerShell or python on Windows):
 - Parse structured fields, filter by time/severity/pattern
 - Aggregate counts, rates, percentiles
 - Detect anomalies via statistical thresholds

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -135,6 +135,12 @@ pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
     );
     push_if_changed(
         &mut out,
+        "platform shell hint",
+        Some(&before.shell_hint),
+        Some(&after.shell_hint),
+    );
+    push_if_changed(
+        &mut out,
         "stall timeout (seconds)",
         Some(&before.limits.stall_timeout_secs),
         Some(&after.limits.stall_timeout_secs),
@@ -352,6 +358,7 @@ mod tests {
         after.limits.default_max_iterations = None;
         after.limits.exact_token_counting = true;
         after.batch_tool_hint = false;
+        after.shell_hint = false;
 
         let lines = changes(&before, &plan_of(after));
 
@@ -362,6 +369,7 @@ mod tests {
         assert!(lines.contains(&"default max iterations: 50 → (unset)".to_string()));
         assert!(lines.contains(&"exact token counting: false → true".to_string()));
         assert!(lines.contains(&"batch tool hint: true → false".to_string()));
+        assert!(lines.contains(&"platform shell hint: true → false".to_string()));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -2259,14 +2259,15 @@ pub(super) mod tests {
         let seeded = limits_fields(&before);
         assert_eq!(seeded.len(), count, "the form is built from the config");
 
-        // Flip every boolean and bump every number, then read the form back
-        // out of the config it produced: a field that no arm writes comes back
-        // with its original value.
-        for field in &mut wizard.limits {
+        // Flip every toggle and give every number a distinct non-default
+        // value, then read the form back out of the config it produced: a
+        // field that no arm writes comes back with its original value. The
+        // limits form is toggles and numbers only, so the second arm is the
+        // number case rather than an unexercised catch-all.
+        for (i, field) in wizard.limits.iter_mut().enumerate() {
             field.value = match &field.value {
                 FieldValue::Bool(b) => FieldValue::Bool(!b),
-                FieldValue::Number(n) => FieldValue::Number(Some(n.unwrap_or(0) + 7)),
-                other => other.clone(),
+                _ => FieldValue::Number(Some(i as u64 + 11)),
             };
         }
         let expected: Vec<FieldValue> = wizard.limits.iter().map(|f| f.value.clone()).collect();

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -954,7 +954,7 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
                     .unwrap_or(Config::default().limits.dead_cycles_before_relief)
             }
             // And again: unset keeps the default, 0 means keep nothing.
-            (7, FieldValue::Number(n)) => {
+            (8, FieldValue::Number(n)) => {
                 config.limits.finished_retention_secs =
                     n.unwrap_or(Config::default().limits.finished_retention_secs)
             }
@@ -2222,6 +2222,9 @@ pub(super) mod tests {
         wizard.limits[3].value = FieldValue::Bool(true);
         wizard.limits[4].value = FieldValue::Bool(false);
         wizard.limits[5].value = FieldValue::Bool(false);
+        wizard.limits[6].value = FieldValue::Number(Some(11));
+        wizard.limits[7].value = FieldValue::Number(Some(22));
+        wizard.limits[8].value = FieldValue::Number(Some(33));
 
         let config = wizard.build_config();
 
@@ -2234,6 +2237,48 @@ pub(super) mod tests {
         assert!(config.limits.exact_token_counting);
         assert!(!config.batch_tool_hint);
         assert!(!config.shell_hint);
+        // Every remaining field gets a distinct value, so a form that grows a
+        // row without renumbering `apply_limits_fields` fails here rather than
+        // silently dropping whichever field the duplicated index shadowed.
+        assert_eq!(config.limits.stall_timeout_secs, 11);
+        assert_eq!(config.limits.dead_cycles_before_relief, 22);
+        assert_eq!(config.limits.finished_retention_secs, 33);
+    }
+
+    #[test]
+    fn every_limits_field_is_written_back() {
+        // The index in `apply_limits_fields` is positional and hand-written, so
+        // an inserted row shifts every arm below it. Round-tripping the form
+        // through itself catches a gap or a duplicate without naming indices.
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        wizard.enter(Step::Limits);
+        let count = wizard.limits.len();
+
+        let before = wizard.build_config();
+        let seeded = limits_fields(&before);
+        assert_eq!(seeded.len(), count, "the form is built from the config");
+
+        // Flip every boolean and bump every number, then read the form back
+        // out of the config it produced: a field that no arm writes comes back
+        // with its original value.
+        for field in &mut wizard.limits {
+            field.value = match &field.value {
+                FieldValue::Bool(b) => FieldValue::Bool(!b),
+                FieldValue::Number(n) => FieldValue::Number(Some(n.unwrap_or(0) + 7)),
+                other => other.clone(),
+            };
+        }
+        let expected: Vec<FieldValue> = wizard.limits.iter().map(|f| f.value.clone()).collect();
+        let after = limits_fields(&wizard.build_config());
+
+        for (i, (got, want)) in after.iter().zip(&expected).enumerate() {
+            assert_eq!(
+                &got.value, want,
+                "field {i} ({}) did not survive the round trip",
+                got.label
+            );
+        }
     }
 
     /// The four timing limits share one rule: an explicit number is stored,

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -893,6 +893,11 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             value: FieldValue::Bool(config.batch_tool_hint),
         },
         Field {
+            label: "Platform shell hint",
+            help: "Tell models what shell they get. Only says anything on Windows (cmd.exe).",
+            value: FieldValue::Bool(config.shell_hint),
+        },
+        Field {
             label: "Stall timeout (seconds)",
             help: "Fail a run that can never dispatch (unconfigured provider). 0 waits forever.",
             value: FieldValue::Number(Some(config.limits.stall_timeout_secs)),
@@ -935,14 +940,15 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             }
             (3, FieldValue::Bool(b)) => config.limits.exact_token_counting = *b,
             (4, FieldValue::Bool(b)) => config.batch_tool_hint = *b,
+            (5, FieldValue::Bool(b)) => config.shell_hint = *b,
             // Unset means "leave the watchdog at its default", not "disable it";
             // disabling is an explicit 0.
-            (5, FieldValue::Number(n)) => {
+            (6, FieldValue::Number(n)) => {
                 config.limits.stall_timeout_secs =
                     n.unwrap_or(Config::default().limits.stall_timeout_secs)
             }
             // Same rule: unset keeps the default, 0 is an explicit "never".
-            (6, FieldValue::Number(n)) => {
+            (7, FieldValue::Number(n)) => {
                 config.limits.dead_cycles_before_relief = n
                     .map(|n| n as u32)
                     .unwrap_or(Config::default().limits.dead_cycles_before_relief)
@@ -2215,6 +2221,7 @@ pub(super) mod tests {
         wizard.limits[2].value = FieldValue::Number(None);
         wizard.limits[3].value = FieldValue::Bool(true);
         wizard.limits[4].value = FieldValue::Bool(false);
+        wizard.limits[5].value = FieldValue::Bool(false);
 
         let config = wizard.build_config();
 
@@ -2226,6 +2233,7 @@ pub(super) mod tests {
         assert!(config.limits.default_max_iterations.is_none());
         assert!(config.limits.exact_token_counting);
         assert!(!config.batch_tool_hint);
+        assert!(!config.shell_hint);
     }
 
     /// The four timing limits share one rule: an explicit number is stored,

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -959,7 +959,7 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
                     n.unwrap_or(Config::default().limits.finished_retention_secs)
             }
             // Same rule once more, and here the default is itself 0 (off).
-            (8, FieldValue::Number(n)) => {
+            (9, FieldValue::Number(n)) => {
                 config.limits.wedge_timeout_secs =
                     n.unwrap_or(Config::default().limits.wedge_timeout_secs)
             }
@@ -2225,6 +2225,7 @@ pub(super) mod tests {
         wizard.limits[6].value = FieldValue::Number(Some(11));
         wizard.limits[7].value = FieldValue::Number(Some(22));
         wizard.limits[8].value = FieldValue::Number(Some(33));
+        wizard.limits[9].value = FieldValue::Number(Some(44));
 
         let config = wizard.build_config();
 
@@ -2243,6 +2244,7 @@ pub(super) mod tests {
         assert_eq!(config.limits.stall_timeout_secs, 11);
         assert_eq!(config.limits.dead_cycles_before_relief, 22);
         assert_eq!(config.limits.finished_retention_secs, 33);
+        assert_eq!(config.limits.wedge_timeout_secs, 44);
     }
 
     #[test]
@@ -2290,10 +2292,10 @@ pub(super) mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Limits);
-        wizard.limits[5].value = FieldValue::Number(Some(0));
         wizard.limits[6].value = FieldValue::Number(Some(0));
         wizard.limits[7].value = FieldValue::Number(Some(0));
-        wizard.limits[8].value = FieldValue::Number(Some(300));
+        wizard.limits[8].value = FieldValue::Number(Some(0));
+        wizard.limits[9].value = FieldValue::Number(Some(300));
 
         let config = wizard.build_config();
 
@@ -2304,10 +2306,10 @@ pub(super) mod tests {
 
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Limits);
-        wizard.limits[5].value = FieldValue::Number(None);
         wizard.limits[6].value = FieldValue::Number(None);
         wizard.limits[7].value = FieldValue::Number(None);
         wizard.limits[8].value = FieldValue::Number(None);
+        wizard.limits[9].value = FieldValue::Number(None);
 
         let config = wizard.build_config();
 

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -202,6 +202,19 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub batch_tool_hint: bool,
 
+    /// Global master switch for the platform shell hint.
+    ///
+    /// **On by default (opt-out).** When `true`, a stage that advertises the
+    /// `shell` tool carries a short system block describing the shell it will
+    /// actually get, so the model doesn't spend iterations discovering it. The
+    /// hint is emitted only where the platform warrants one (today: Windows,
+    /// where commands run through `cmd.exe /C` rather than a POSIX shell), so
+    /// on Linux and macOS this toggle costs nothing either way. Individual
+    /// agents or stages override it with `shell_hint` in their `[agent]` /
+    /// `[stages.<name>]` blocks.
+    #[serde(default = "default_true")]
+    pub shell_hint: bool,
+
     /// Machine-wide defaults for the empty-response nudge (`[nudge]`): the
     /// `[System]` message injected when a stage's model replies with text
     /// before making any tool call. All three keys (`enabled`, `max`, `text`)
@@ -791,6 +804,7 @@ impl Default for Config {
             taint_tracking: false,
             limits: LimitsConfig::default(),
             batch_tool_hint: true,
+            shell_hint: true,
             nudge: leviath_core::NudgeConfig::default(),
             webhook: WebhookConfig::default(),
             observability: ObservabilityConfig::default(),
@@ -2957,6 +2971,7 @@ enabled = false
                 provider_circuit_cooldown_secs: 120,
             },
             batch_tool_hint: true,
+            shell_hint: false,
             nudge: leviath_core::NudgeConfig {
                 enabled: Some(true),
                 max: Some(2),
@@ -3025,6 +3040,10 @@ enabled = false
             deserialized.tool_script_permissions.write_file,
             ScriptPermission::Deny
         );
+        // `shell_hint` defaults to true, so a `false` surviving the round trip
+        // is what proves the field is actually written and read back.
+        assert!(deserialized.batch_tool_hint);
+        assert!(!deserialized.shell_hint);
         assert!(!deserialized.security.allow_seed_commands);
         assert!(deserialized.security.allow_blueprint_read_paths);
         assert_eq!(deserialized.security.read_paths, vec!["~/.leviath/runs"]);

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -745,6 +745,11 @@ impl ScriptIo for RealScriptIo {
 }
 
 /// The system shell + command flag for the current platform.
+///
+/// Deliberately `/bin/sh` on Unix rather than the user's `$SHELL`, unlike the
+/// `shell` tool's `BuiltinTools::detect_shell`: a Rhai tool script is authored
+/// once and run on every machine, so it gets the POSIX shell it can count on
+/// instead of whatever interactive shell the operator happens to prefer.
 pub(crate) fn default_shell() -> (&'static str, &'static str) {
     #[cfg(windows)]
     {

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -899,7 +899,10 @@ fn build_agent_inner(
         blueprint,
         &seeds,
         stages,
-        config.batch_tool_hint,
+        leviath_core::config::PromptHints {
+            batch_tool: config.batch_tool_hint,
+            shell: config.shell_hint,
+        },
         config.nudge.clone(),
         region_scripts,
     )?;

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -58,6 +58,12 @@ pub struct Blueprint {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub batch_tool_hint: Option<bool>,
 
+    /// Agent-level override for the platform shell hint. `None` inherits the
+    /// global config toggle; a per-stage `shell_hint` overrides this. See
+    /// [`crate::taint::resolve_shell_hint`] for the cascade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_hint: Option<bool>,
+
     /// Agent-level default for the empty-response nudge. `None` inherits the
     /// global config's `[nudge]` section; a per-stage `[stages.<name>.nudge]`
     /// overrides this. See [`resolve_nudge`] for the cascade.
@@ -134,6 +140,7 @@ impl Blueprint {
             metadata: HashMap::new(),
             security: None,
             batch_tool_hint: None,
+            shell_hint: None,
             nudge: None,
             repetition_detection: None,
             file_tracking: None,
@@ -753,6 +760,13 @@ pub struct Stage {
     #[serde(default)]
     pub batch_tool_hint: Option<bool>,
 
+    /// Per-stage override for the platform shell hint. `None` inherits the
+    /// agent-level `Blueprint.shell_hint` (which in turn inherits the global
+    /// config toggle). A stage that grants no shell tool never emits the hint
+    /// regardless, so this is for opting a shell-granting stage out.
+    #[serde(default)]
+    pub shell_hint: Option<bool>,
+
     /// Per-stage empty-response nudge settings. Each field independently
     /// inherits the agent-level `Blueprint.nudge` (which in turn inherits the
     /// global config's `[nudge]` section). A stage whose deliverable is text -
@@ -802,6 +816,7 @@ impl Stage {
             allow_as_worker: false,
             security: None,
             batch_tool_hint: None,
+            shell_hint: None,
             nudge: None,
             sandbox: None,
             tool_result_routing: None,

--- a/crates/leviath-core/src/config.rs
+++ b/crates/leviath-core/src/config.rs
@@ -102,9 +102,83 @@ impl TelemetryExporterKind {
     }
 }
 
+/// The machine-wide toggles for the framework-authored system-prompt hints,
+/// carried from the CLI's config into a spawn.
+///
+/// Each field is the *global* end of a stage → agent → global cascade
+/// ([`crate::taint::resolve_batch_tool_hint`],
+/// [`crate::taint::resolve_shell_hint`]): a blueprint's `[agent]` or
+/// `[stages.<name>]` block overrides it per agent or per stage. They travel
+/// together as one value so adding a hint doesn't grow the arity of every spawn
+/// entry point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptHints {
+    /// Global default for the batch-tool-calls hint.
+    pub batch_tool: bool,
+    /// Global default for the platform shell hint.
+    pub shell: bool,
+}
+
+impl Default for PromptHints {
+    /// Both hints on, matching the CLI config's `default_true` for each.
+    fn default() -> Self {
+        Self {
+            batch_tool: true,
+            shell: true,
+        }
+    }
+}
+
+/// One narrower scope's overrides of [`PromptHints`], as a blueprint's `[agent]`
+/// or `[stages.<name>]` block writes them. `None` inherits the broader scope.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PromptHintOverrides {
+    /// Override for the batch-tool-calls hint.
+    pub batch_tool: Option<bool>,
+    /// Override for the platform shell hint.
+    pub shell: Option<bool>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prompt_hints_default_on_and_overrides_default_inherit() {
+        // The default has to match the CLI config's `default_true` for each
+        // field, or an embedder and the daemon would disagree about the same
+        // unset config.
+        let hints = PromptHints::default();
+        assert!(hints.batch_tool);
+        assert!(hints.shell);
+        assert_eq!(
+            hints,
+            PromptHints {
+                batch_tool: true,
+                shell: true
+            }
+        );
+        assert_ne!(
+            hints,
+            PromptHints {
+                batch_tool: true,
+                shell: false
+            }
+        );
+
+        // An override that names nothing inherits everything.
+        let overrides = PromptHintOverrides::default();
+        assert_eq!(overrides.batch_tool, None);
+        assert_eq!(overrides.shell, None);
+        assert_eq!(
+            overrides,
+            PromptHintOverrides {
+                batch_tool: None,
+                shell: None
+            }
+        );
+        assert!(format!("{hints:?} {overrides:?}").contains("batch_tool"));
+    }
 
     #[test]
     fn test_title_config_default() {

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -401,6 +401,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 stage.batch_tool_hint = Some(bth);
             }
 
+            // Parse per-stage shell_hint override: opt an individual stage
+            // in/out of the platform shell hint. Absent ⇒ inherit agent/global.
+            if let Some(sh) = stage_value.get("shell_hint").and_then(|v| v.as_bool()) {
+                stage.shell_hint = Some(sh);
+            }
+
             // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
             // each field inherits agent/global.
             if let Some(nudge_table) = stage_value.get("nudge").and_then(|v| v.as_table()) {
@@ -684,6 +690,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // Absent ⇒ inherit the global config toggle; a per-stage value overrides it.
     if let Some(bth) = agent.get("batch_tool_hint").and_then(|v| v.as_bool()) {
         blueprint.batch_tool_hint = Some(bth);
+    }
+
+    // Parse agent-level shell_hint override: `[agent] shell_hint`. Absent ⇒
+    // inherit the global config toggle; a per-stage value overrides it.
+    if let Some(sh) = agent.get("shell_hint").and_then(|v| v.as_bool()) {
+        blueprint.shell_hint = Some(sh);
     }
 
     // Parse agent-level nudge defaults: [agent.nudge]. Absent ⇒ each field
@@ -2834,6 +2846,60 @@ mode = "autonomous"
         let bp = parse_manifest(toml).unwrap();
         assert_eq!(bp.batch_tool_hint, None);
         assert_eq!(bp.find_stage("main").unwrap().batch_tool_hint, None);
+    }
+
+    #[test]
+    fn parse_manifest_agent_and_stage_shell_hint() {
+        let toml = r#"
+[agent]
+name = "shell-test"
+shell_hint = false
+
+[stages.plan]
+mode = "autonomous"
+shell_hint = true
+
+[stages.build]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        // Agent-level `[agent] shell_hint` parsed, and independent of the
+        // batch hint sharing the cascade shape.
+        assert_eq!(bp.shell_hint, Some(false));
+        assert_eq!(bp.batch_tool_hint, None);
+        // Stage-level override opts this one stage back in.
+        assert_eq!(bp.find_stage("plan").unwrap().shell_hint, Some(true));
+        // A stage with no override inherits (None).
+        assert_eq!(bp.find_stage("build").unwrap().shell_hint, None);
+        // End-to-end cascade: plan resolves on despite the agent and global
+        // both being off, build follows the agent's off despite the global on.
+        assert!(crate::taint::resolve_shell_hint(
+            false,
+            bp.shell_hint,
+            bp.find_stage("plan").unwrap().shell_hint,
+        ));
+        assert!(!crate::taint::resolve_shell_hint(
+            true,
+            bp.shell_hint,
+            bp.find_stage("build").unwrap().shell_hint,
+        ));
+    }
+
+    #[test]
+    fn parse_manifest_no_shell_hint_is_none() {
+        // No `shell_hint` anywhere ⇒ both levels None ⇒ inherit global.
+        let toml = r#"
+[agent]
+name = "no-shell-hint"
+
+[stages.main]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert_eq!(bp.shell_hint, None);
+        assert_eq!(bp.find_stage("main").unwrap().shell_hint, None);
+        assert!(crate::taint::resolve_shell_hint(true, None, None));
+        assert!(!crate::taint::resolve_shell_hint(false, None, None));
     }
 
     #[test]

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -333,13 +333,30 @@ pub fn resolve_security(
     resolved
 }
 
-/// Resolve whether the batch-tool-calls system-prompt hint is enabled for a
-/// stage, cascading stage → agent → global. A `Some(_)` at a narrower level
-/// overrides broader levels; when neither the stage nor the agent sets it, the
-/// global toggle (on by default) applies. (Same shape as
-/// [`resolve_taint_enabled`], but the global default is on rather than off.)
-pub fn resolve_batch_tool_hint(global: bool, agent: Option<bool>, stage: Option<bool>) -> bool {
+/// The shared stage → agent → global cascade behind the system-prompt hint
+/// toggles. A `Some(_)` at a narrower level overrides broader levels; when
+/// neither the stage nor the agent sets it, the global toggle applies. (Same
+/// shape as [`resolve_taint_enabled`], but the global default is on rather than
+/// off, and a manifest may turn a hint off - these are UX knobs, not security.)
+fn resolve_hint(global: bool, agent: Option<bool>, stage: Option<bool>) -> bool {
     stage.or(agent).unwrap_or(global)
+}
+
+/// Resolve whether the batch-tool-calls system-prompt hint is enabled for a
+/// stage, cascading stage → agent → global: a `Some(_)` at a narrower level
+/// wins, and an unset pair falls through to the global toggle.
+pub fn resolve_batch_tool_hint(global: bool, agent: Option<bool>, stage: Option<bool>) -> bool {
+    resolve_hint(global, agent, stage)
+}
+
+/// Resolve whether the platform shell hint is enabled for a stage, cascading
+/// stage → agent → global on the same terms as [`resolve_batch_tool_hint`].
+///
+/// Enabled only decides whether the hint is *eligible*. It is emitted only when
+/// the host platform has something worth saying about its shell and the stage
+/// actually advertises the shell tool, both checked at request-build time.
+pub fn resolve_shell_hint(global: bool, agent: Option<bool>, stage: Option<bool>) -> bool {
+    resolve_hint(global, agent, stage)
 }
 
 /// Result of a gate check - whether a tool invocation is allowed.

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -254,6 +254,12 @@ pub struct InferenceConfig {
     /// (see [`leviath_core::taint::resolve_batch_tool_hint`]); `false` by default
     /// so an unset config is a no-op.
     pub batch_tool_hint: bool,
+    /// Whether this stage is eligible for the platform shell hint. Resolved from
+    /// the global config → agent → stage cascade at spawn (see
+    /// [`leviath_core::taint::resolve_shell_hint`]); `false` by default so an
+    /// unset config is a no-op. Eligibility is not emission: the hint also needs
+    /// a platform worth describing and a stage that advertises the shell tool.
+    pub shell_hint: bool,
     /// Per-stage cap on the wall-clock time (in seconds) one inference for this
     /// stage may run (the whole call including retries). Sourced from
     /// `[stages.<name>.model] request_timeout_secs`. When `Some`, it overrides the

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -29,6 +29,9 @@ pub(crate) struct EmbedSpawner {
     /// (which then sees agents through `exec_for` on its own terms).
     pub basic_tools: Option<Arc<BasicToolService>>,
     pub defaults: ModelDefaults,
+    /// Global end of the system-prompt hint cascade, from
+    /// [`AgentWorldBuilder::prompt_hints`](crate::embed::AgentWorldBuilder::prompt_hints).
+    pub hints: leviath_core::config::PromptHints,
     pub staged: StagedBlueprints,
 }
 
@@ -110,7 +113,7 @@ impl EmbedSpawner {
             blueprint,
             &seeds,
             stages,
-            false,
+            self.hints,
             // The default nudge policy; blueprints override per stage/agent.
             leviath_core::NudgeConfig::default(),
             HashMap::new(),
@@ -498,6 +501,7 @@ mod tests {
         EmbedSpawner {
             basic_tools: None,
             defaults: ModelDefaults::default(),
+            hints: leviath_core::config::PromptHints::default(),
             staged: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -99,6 +99,7 @@ pub struct AgentWorldBuilder {
     tool_concurrency: usize,
     state_dir: Option<PathBuf>,
     defaults: ModelDefaults,
+    hints: leviath_core::config::PromptHints,
     runtime: Option<Handle>,
 }
 
@@ -112,6 +113,12 @@ impl AgentWorldBuilder {
             tool_concurrency: 4,
             state_dir: None,
             defaults: ModelDefaults::default(),
+            // Off unless asked for: an embedder owns its prompts, and the
+            // daemon's `config.toml` defaults do not reach this path.
+            hints: leviath_core::config::PromptHints {
+                batch_tool: false,
+                shell: false,
+            },
             runtime: None,
         }
     }
@@ -187,6 +194,16 @@ impl AgentWorldBuilder {
         self
     }
 
+    /// Opt in to the framework-authored system-prompt hints, off by default on
+    /// this path. `shell` is worth turning on for a blueprint that grants the
+    /// shell tool and may run on Windows: it tells the model that commands go
+    /// through `cmd.exe` rather than a POSIX shell. A blueprint's `[agent]` or
+    /// `[stages.<name>]` `batch_tool_hint` / `shell_hint` still overrides this.
+    pub fn prompt_hints(mut self, hints: leviath_core::config::PromptHints) -> Self {
+        self.hints = hints;
+        self
+    }
+
     /// Run the world on `handle` instead of the ambient Tokio runtime.
     pub fn runtime(mut self, handle: Handle) -> Self {
         self.runtime = Some(handle);
@@ -233,6 +250,7 @@ impl AgentWorldBuilder {
         let spawner = EmbedSpawner {
             basic_tools: basic_tools.clone(),
             defaults: self.defaults,
+            hints: self.hints,
             staged: staged.clone(),
         };
         host.set_spawner(Box::new(move |world, args| spawner.spawn(world, args)));
@@ -497,6 +515,35 @@ mod tests {
             thought_signature: None,
         });
         r
+    }
+
+    /// A provider that records the system blocks of every request it is handed,
+    /// then answers "done". For asserting what the framework prepends.
+    struct Recorder {
+        seen: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Recorder {
+        async fn infer(&self, r: InferenceRequest) -> Result<InferenceResponse, ProviderError> {
+            self.seen
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(r.system.iter().map(|b| b.text.clone()).collect());
+            Ok(text("done"))
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            100_000
+        }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn capabilities(&self, _m: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
     }
 
     fn mock_world(responses: Vec<InferenceResponse>) -> AgentWorld {
@@ -987,6 +1034,98 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         let run_dir = state.path().join("runs").join(run_id.as_ref());
         assert!(run_dir.join("meta.json").exists());
         assert!(state.path().join("machine-id").exists());
+    }
+
+    /// The single-stage blueprint the hint tests drive, with a shell tool so the
+    /// shell hint's tool guard is satisfied.
+    const SHELL_STAGE: &str = r#"[agent]
+name = "shelly"
+version = "0.0.0"
+description = "One stage that can run commands."
+entry_stage = "work"
+
+[stages.work]
+mode = "autonomous"
+model = { provider = "mock", model = "m" }
+description = "Do the work"
+available_tools = ["shell"]
+allow_complete = true
+system_prompt = "Work."
+
+[context.regions]
+instructions = { kind = "pinned", max_tokens = 2000 }
+conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
+"#;
+
+    /// Run `SHELL_STAGE` once against a [`Recorder`] and hand back the system
+    /// blocks of the first request, with `hints` as the world's global toggles.
+    async fn system_blocks_with(hints: leviath_core::config::PromptHints) -> Vec<String> {
+        let dir = tempfile::tempdir().unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let world = AgentWorld::builder()
+            .register_provider(
+                "mock",
+                Arc::new(Recorder {
+                    seen: Arc::clone(&seen),
+                }),
+            )
+            .prompt_hints(hints)
+            .build()
+            .expect("world builds inside the test runtime");
+        let mut events = world.events();
+        world
+            .spawn(SpawnSpec::new(
+                BlueprintSource::Toml(SHELL_STAGE.to_string()),
+                "go",
+                dir.path(),
+            ))
+            .await
+            .expect("spawns");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            events_until(&mut events, |e| matches!(e, WorldEvent::Completed { .. })),
+        )
+        .await
+        .expect("completes");
+        world.shutdown().await;
+        let seen = seen.lock().unwrap_or_else(PoisonError::into_inner);
+        seen.first().cloned().expect("one inference happened")
+    }
+
+    #[tokio::test]
+    async fn prompt_hints_reach_the_request_and_are_off_by_default() {
+        // Off unless asked for: an embedder that never calls `prompt_hints`
+        // gets exactly the blueprint's own prompt.
+        let default_blocks = system_blocks_with(leviath_core::config::PromptHints {
+            batch_tool: false,
+            shell: false,
+        })
+        .await;
+        assert!(
+            default_blocks
+                .iter()
+                .all(|b| b != crate::pipeline::BATCH_TOOL_HINT),
+        );
+        assert!(default_blocks.iter().any(|b| b.contains("Work.")));
+
+        // Turned on, the hint leads the prefix. The shell hint rides the same
+        // path but only says anything on Windows, so this asserts on the batch
+        // hint, which is the platform-independent half of the plumbing.
+        let hinted = system_blocks_with(leviath_core::config::PromptHints {
+            batch_tool: true,
+            shell: true,
+        })
+        .await;
+        assert_eq!(
+            hinted.first().map(String::as_str),
+            Some(crate::pipeline::BATCH_TOOL_HINT)
+        );
+        // Whatever the host OS says about its shell is what the run carries.
+        let shell_hint = crate::pipeline::shell_guidance_for(std::env::consts::OS);
+        assert_eq!(
+            hinted.iter().any(|b| Some(b.as_str()) == shell_hint),
+            shell_hint.is_some(),
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -1313,6 +1313,16 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         assert_eq!(mock.max_context_tokens("m"), 100_000);
         assert_eq!(mock.name(), "mock");
         let _ = mock.capabilities("m");
+
+        // Same for the recording fixture, which answers identically and is
+        // registered under the same name.
+        let recorder = Recorder {
+            seen: Arc::new(Mutex::new(Vec::new())),
+        };
+        assert_eq!(recorder.count_tokens("x", "m").await, 1);
+        assert_eq!(recorder.max_context_tokens("m"), 100_000);
+        assert_eq!(recorder.name(), "mock");
+        let _ = recorder.capabilities("m");
         assert!(
             mock.infer(
                 serde_json::from_value(serde_json::json!({

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -586,6 +586,7 @@ mod tests {
                 max_output_tokens: None,
                 extra_params: Default::default(),
                 batch_tool_hint: false,
+                shell_hint: false,
                 request_timeout_secs: None,
             },
             routing: None,

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1959,6 +1959,7 @@ mod tests {
                 max_output_tokens: None,
                 extra_params: Default::default(),
                 batch_tool_hint: false,
+                shell_hint: false,
                 request_timeout_secs: None,
             },
             routing: None,

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -14,6 +14,65 @@ writing a file then running a command that doesn't need its output), batch them 
 one response to cut round trips. Do NOT batch when a call depends on a previous \
 call's result, or when you must see a command's output before deciding the next step.";
 
+/// What the `shell` tool actually runs on Windows, and the PowerShell commands
+/// that stand in for the POSIX ones a model reaches for by reflex. Prepended to
+/// a shell-granting stage's system blocks when [`shell_guidance_for`] returns
+/// it; see [`InferenceConfig::shell_hint`](crate::components::InferenceConfig).
+pub(crate) const WINDOWS_SHELL_HINT: &str = "The shell tool runs on Windows through `cmd.exe /C`, \
+not a POSIX shell. GNU coreutils are not available: use `type` or PowerShell's `Get-Content` \
+instead of `cat`, `findstr` or `Select-String` instead of `grep`, `dir` or `Get-ChildItem` \
+instead of `ls`, and `Measure-Object -Line` instead of `wc -l`. Run a PowerShell command as \
+`powershell -Command \"...\"`. Paths use backslashes and drive letters, and `%VAR%` (cmd) or \
+`$env:VAR` (PowerShell) expands environment variables.";
+
+/// The shell guidance for `os`, or `None` when the platform's shell needs no
+/// explanation (a POSIX shell is what the model already assumes).
+///
+/// Pure over the OS string rather than `#[cfg]`-switched, following
+/// `leviath_sys::browser::open_command_for`, so every branch is reachable under
+/// test on a single platform. Callers pass [`std::env::consts::OS`].
+pub(crate) fn shell_guidance_for(os: &str) -> Option<&'static str> {
+    match os {
+        "windows" => Some(WINDOWS_SHELL_HINT),
+        _ => None,
+    }
+}
+
+/// The framework-authored system blocks a stage carries ahead of its own
+/// context, in the order they are prepended.
+///
+/// Both hints read the same on every agent, stage, and run of a given host, so
+/// they lead the `Always`-tier prefix (which `assemble` already sorts first) and
+/// leave prefix caching intact. `os` is the host OS string
+/// ([`std::env::consts::OS`] in production) and `tools` the stage's advertised
+/// tools: telling a stage that cannot run commands which shell it would have
+/// gotten is pure overhead, so the shell hint is gated on the tool being there.
+///
+/// Note this is a `build_request` concern, so the request paths that assemble
+/// their own [`InferenceRequest`] - `lev test`, title generation, compaction -
+/// carry no hints. That was already true of the batch hint.
+pub(crate) fn hint_blocks(
+    config: Option<&InferenceConfig>,
+    tools: &[Tool],
+    os: &str,
+) -> Vec<leviath_providers::SystemBlock> {
+    let always = |text: &str| leviath_providers::SystemBlock {
+        text: text.to_string(),
+        cache_hint: leviath_core::CacheHint::Always,
+    };
+    let mut blocks = Vec::new();
+    if config.map(|c| c.batch_tool_hint).unwrap_or(false) {
+        blocks.push(always(BATCH_TOOL_HINT));
+    }
+    if config.map(|c| c.shell_hint).unwrap_or(false)
+        && tools.iter().any(|t| t.name == "shell")
+        && let Some(text) = shell_guidance_for(os)
+    {
+        blocks.push(always(text));
+    }
+    blocks
+}
+
 /// Build the [`InferenceRequest`] for an agent from its context window + stage
 /// data. Pure; no `.await` - a custom region's render hook is a bounded,
 /// synchronous Rhai eval. (Ported from `AgentEngine::build_inference_request`,
@@ -64,20 +123,8 @@ pub(crate) fn build_request(
         _ => serde_json::Value::Null,
     };
 
-    // Prepend the batch-tool-calls hint as a stable, always-cacheable system
-    // block when this stage opts in. Prepending keeps it at the front of the
-    // `Always`-tier prefix (which `assemble` already sorts first), maximizing
-    // prefix-cache hits since the text never varies across agents/stages/runs.
-    let mut system = assembled.system_blocks;
-    if config.map(|c| c.batch_tool_hint).unwrap_or(false) {
-        system.insert(
-            0,
-            leviath_providers::SystemBlock {
-                text: BATCH_TOOL_HINT.to_string(),
-                cache_hint: leviath_core::CacheHint::Always,
-            },
-        );
-    }
+    let mut system = hint_blocks(config, &filtered_tools, std::env::consts::OS);
+    system.extend(assembled.system_blocks);
 
     InferenceRequest {
         system,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use crate::inference_pool::{InferencePoolConfig, InferencePools};
+use crate::test_support::hints;
 use leviath_core::{Region, RegionKind};
 use tokio::sync::mpsc;
 
@@ -122,6 +123,7 @@ fn build_request_filters_tools_and_uses_config_overrides() {
         max_output_tokens: Some(42),
         extra_params: Default::default(),
         batch_tool_hint: false,
+        shell_hint: false,
         request_timeout_secs: None,
     };
     let si = stage(
@@ -177,6 +179,7 @@ fn build_request_passes_through_extra_params() {
         max_output_tokens: None,
         extra_params,
         batch_tool_hint: false,
+        shell_hint: false,
         request_timeout_secs: None,
     };
     let si = stage("m", vec![], None);
@@ -208,6 +211,7 @@ fn build_request_prepends_batch_hint_when_enabled() {
         max_output_tokens: None,
         extra_params: Default::default(),
         batch_tool_hint: true,
+        shell_hint: false,
         request_timeout_secs: None,
     };
     let si = stage("m", vec![], None);
@@ -242,6 +246,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         max_output_tokens: None,
         extra_params: Default::default(),
         batch_tool_hint: false,
+        shell_hint: false,
         request_timeout_secs: None,
     };
     let req = build_request(
@@ -265,6 +270,102 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
     );
     assert!(!req_none.system.is_empty());
     assert!(req_none.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
+}
+
+/// An [`InferenceConfig`] with just the two hint toggles set, everything else
+/// at its inert default.
+fn hint_config(batch_tool_hint: bool, shell_hint: bool) -> InferenceConfig {
+    InferenceConfig {
+        temperature: None,
+        max_output_tokens: None,
+        extra_params: Default::default(),
+        batch_tool_hint,
+        shell_hint,
+        request_timeout_secs: None,
+    }
+}
+
+#[test]
+fn shell_guidance_is_windows_only() {
+    // The one platform whose shell isn't what a model assumes.
+    assert_eq!(shell_guidance_for("windows"), Some(WINDOWS_SHELL_HINT));
+    assert!(WINDOWS_SHELL_HINT.contains("cmd.exe"));
+    // Everywhere else a POSIX shell is the default assumption, so nothing to
+    // say - including for an OS string this build has never heard of.
+    assert_eq!(shell_guidance_for("linux"), None);
+    assert_eq!(shell_guidance_for("macos"), None);
+    assert_eq!(shell_guidance_for("freebsd"), None);
+    assert_eq!(shell_guidance_for("haiku"), None);
+}
+
+#[test]
+fn the_shell_hint_needs_the_toggle_the_platform_and_the_tool() {
+    let shell = vec![tool("shell")];
+    let cases = [
+        // (shell_hint, os, tools, expected)
+        (true, "windows", &shell, true),
+        // Opted out at some level of the cascade.
+        (false, "windows", &shell, false),
+        // A platform whose shell needs no explanation.
+        (true, "linux", &shell, false),
+        // A stage that cannot run commands doesn't pay for the hint.
+        (true, "windows", &vec![tool("read_file")], false),
+        (true, "windows", &vec![], false),
+    ];
+    for (shell_hint, os, tools, expected) in cases {
+        let cfg = hint_config(false, shell_hint);
+        let blocks = hint_blocks(Some(&cfg), tools, os);
+        assert_eq!(
+            blocks.iter().any(|b| b.text == WINDOWS_SHELL_HINT),
+            expected,
+            "shell_hint={shell_hint} os={os} tools={:?}",
+            tools.iter().map(|t| &t.name).collect::<Vec<_>>()
+        );
+    }
+    // No config at all is the same as both toggles off.
+    assert!(hint_blocks(None, &shell, "windows").is_empty());
+}
+
+#[test]
+fn both_hints_lead_the_prefix_with_the_batch_hint_first() {
+    // Order matters: these are the stable head of the `Always` cache prefix, so
+    // it has to be the same head on every request the host makes.
+    let cfg = hint_config(true, true);
+    let blocks = hint_blocks(Some(&cfg), &[tool("shell")], "windows");
+    let texts: Vec<&str> = blocks.iter().map(|b| b.text.as_str()).collect();
+    assert_eq!(texts, vec![BATCH_TOOL_HINT, WINDOWS_SHELL_HINT]);
+    assert!(
+        blocks
+            .iter()
+            .all(|b| b.cache_hint == leviath_core::CacheHint::Always)
+    );
+}
+
+#[test]
+fn build_request_puts_the_hints_ahead_of_the_stage_context() {
+    // `build_request` reads the *host* OS, so the shell hint's presence is not
+    // assertable portably here; what is assertable is that whatever hints apply
+    // come first and the stage's own blocks survive behind them.
+    let cfg = hint_config(true, true);
+    let si = stage("m", vec![tool("shell")], None);
+    let req = build_request(
+        &window_with_sys(),
+        Some(&cfg),
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+    );
+    let hints = hint_blocks(Some(&cfg), &si.tools, std::env::consts::OS);
+    for (i, hint) in hints.iter().enumerate() {
+        assert_eq!(req.system[i].text, hint.text);
+    }
+    assert!(
+        req.system[hints.len()..]
+            .iter()
+            .any(|b| b.text.contains("base system")),
+        "the stage's own system block is preserved after the hints"
+    );
 }
 
 #[test]
@@ -1630,7 +1731,7 @@ fn spawn_agent_seeds_the_stage_ledger_with_names() {
         bp,
         "task",
         vec![resolved("m"), resolved("m")],
-        true,
+        hints(true),
     )
     .expect("spawn");
     let led = world.get::<StageLedger>(e).expect("ledger seeded");
@@ -1684,7 +1785,7 @@ fn spawn_agent_seeded_resolves_percent_region_against_provider_window() {
         percent_region_blueprint(0.35),
         "task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .expect("spawn");
     let w = world.get::<ContextWindow>(e).expect("window");
@@ -1704,7 +1805,7 @@ fn spawn_agent_seeded_falls_back_when_provider_missing() {
             percent_region_blueprint(0.35),
             "task",
             vec![resolved("m")],
-            true,
+            hints(true),
         )
         .expect("spawn");
         let w = world.get::<ContextWindow>(e).expect("window");
@@ -1729,7 +1830,7 @@ fn spawn_agent_seeded_absolute_blueprint_is_unchanged() {
         bp,
         "task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .expect("spawn");
     let w = world.get::<ContextWindow>(e).expect("window");
@@ -1774,7 +1875,7 @@ fn spawn_agent_seeded_resolves_per_stage_layout() {
         bp,
         "task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .expect("spawn");
     let w = world.get::<ContextWindow>(e).expect("window");
@@ -1794,7 +1895,7 @@ fn spawn_agent_seeded_errors_when_resolved_global_layout_is_invalid() {
         percent_region_blueprint(0.95),
         "task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .expect_err("resolved layout should fail validation");
     assert!(err.contains("working tokens"), "{err}");
@@ -1835,7 +1936,7 @@ fn spawn_agent_seeded_errors_when_resolved_per_stage_layout_is_invalid() {
         bp,
         "task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .expect_err("per-stage layout should fail validation");
     assert!(err.contains("working tokens"), "{err}");
@@ -4497,6 +4598,7 @@ fn setup() -> StageSetup {
             max_output_tokens: None,
             extra_params: Default::default(),
             batch_tool_hint: false,
+            shell_hint: false,
             request_timeout_secs: None,
         },
         routing: None,
@@ -4837,6 +4939,7 @@ fn enter_stage_injects_system_prompt_and_config() {
         max_output_tokens: Some(99),
         extra_params: Default::default(),
         batch_tool_hint: false,
+        shell_hint: false,
         request_timeout_secs: None,
     };
     s.accepts_messages = false;
@@ -5027,7 +5130,7 @@ fn spawn_agent_builds_stage0_ready_with_config_and_routing() {
         bp,
         "the task",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .unwrap();
 
@@ -5074,7 +5177,7 @@ fn spawn_agent_defaults_config_and_no_routing() {
         bp,
         "t",
         vec![resolved("m")],
-        true,
+        hints(true),
     )
     .unwrap();
 
@@ -5110,21 +5213,62 @@ fn stage_setup_from_folds_fanout_split_prompt() {
         "system_prompt".to_string(),
         serde_json::Value::String("base instructions".to_string()),
     );
-    let sp = stage_setup_from(&s, true, None).system_prompt.unwrap();
+    let sp = stage_setup_from(&s, hints(true), Default::default())
+        .system_prompt
+        .unwrap();
     assert!(sp.contains("base instructions") && sp.contains("SPLIT NOW"));
 
     // Fan-out stage with no base prompt: the split prompt alone.
     let mut s2 = stage_named("fan", None, false, None);
     s2.mode = fanout("ONLY SPLIT");
     assert_eq!(
-        stage_setup_from(&s2, true, None).system_prompt,
+        stage_setup_from(&s2, hints(true), Default::default()).system_prompt,
         Some("ONLY SPLIT".to_string())
     );
 
     // Fan-out stage with an empty split prompt: base prompt is left as-is.
     let mut s3 = stage_named("fan", None, false, None);
     s3.mode = fanout("   ");
-    assert_eq!(stage_setup_from(&s3, true, None).system_prompt, None);
+    assert_eq!(
+        stage_setup_from(&s3, hints(true), Default::default()).system_prompt,
+        None
+    );
+}
+
+#[test]
+fn stage_setup_from_cascades_each_hint_independently() {
+    use leviath_core::config::{PromptHintOverrides, PromptHints};
+
+    // Globals on, agent silent, stage silent → both inherit on.
+    let s = stage_named("plan", None, false, None);
+    let cfg = stage_setup_from(&s, hints(true), PromptHintOverrides::default()).inference_config;
+    assert!(cfg.batch_tool_hint);
+    assert!(cfg.shell_hint);
+
+    // The agent level opts out of one hint without touching the other.
+    let agent_off_shell = PromptHintOverrides {
+        batch_tool: None,
+        shell: Some(false),
+    };
+    let cfg = stage_setup_from(&s, hints(true), agent_off_shell).inference_config;
+    assert!(cfg.batch_tool_hint);
+    assert!(!cfg.shell_hint);
+
+    // The stage level wins over the agent, in both directions at once.
+    let mut s2 = stage_named("plan", None, false, None);
+    s2.shell_hint = Some(true);
+    s2.batch_tool_hint = Some(false);
+    let cfg = stage_setup_from(
+        &s2,
+        PromptHints {
+            batch_tool: true,
+            shell: false,
+        },
+        agent_off_shell,
+    )
+    .inference_config;
+    assert!(!cfg.batch_tool_hint);
+    assert!(cfg.shell_hint);
 }
 
 #[test]
@@ -5145,7 +5289,7 @@ fn stage_setup_from_collects_extra_model_parameters() {
         .parameters
         .insert("seed".to_string(), serde_json::json!(11));
 
-    let setup = stage_setup_from(&s, true, None);
+    let setup = stage_setup_from(&s, hints(true), Default::default());
     assert_eq!(setup.inference_config.temperature, Some(0.3));
     assert_eq!(setup.inference_config.max_output_tokens, Some(256));
     let extra = &setup.inference_config.extra_params;
@@ -5160,7 +5304,7 @@ fn stage_setup_from_threads_request_timeout() {
     // Unset on the stage → None on the inference config.
     let s = stage_named("plan", None, false, None);
     assert_eq!(
-        stage_setup_from(&s, true, None)
+        stage_setup_from(&s, hints(true), Default::default())
             .inference_config
             .request_timeout_secs,
         None
@@ -5170,7 +5314,7 @@ fn stage_setup_from_threads_request_timeout() {
     let mut s2 = stage_named("plan", None, false, None);
     s2.model.request_timeout_secs = Some(300);
     assert_eq!(
-        stage_setup_from(&s2, true, None)
+        stage_setup_from(&s2, hints(true), Default::default())
             .inference_config
             .request_timeout_secs,
         Some(300)
@@ -5233,7 +5377,7 @@ fn spawn_agent_errors_on_oversized_system_prompt() {
         bp,
         "t",
         vec![resolved("m")],
-        true,
+        hints(true),
     );
     assert!(err.is_err());
 }

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1268,10 +1268,14 @@ pub(crate) fn context_window_tokens(world: &World, provider_name: &str, model: &
 /// Build a stage's [`StageSetup`] from its blueprint definition: inference config
 /// (from the model parameters), tool-result routing, accepts-messages, layout,
 /// and system prompt.
+///
+/// `global_hints` is the caller's config-level toggle for each system-prompt
+/// hint; `agent_hints` the blueprint's agent-level override of the same. Each
+/// one cascades stage → agent → global here.
 pub(crate) fn stage_setup_from(
     stage: &leviath_core::Stage,
-    global_batch_tool_hint: bool,
-    agent_batch_tool_hint: Option<bool>,
+    global_hints: leviath_core::config::PromptHints,
+    agent_hints: leviath_core::config::PromptHintOverrides,
 ) -> StageSetup {
     let temperature = stage
         .model
@@ -1314,11 +1318,16 @@ pub(crate) fn stage_setup_from(
         }
         _ => base_prompt,
     };
-    // Cascade the batch-tool-hint toggle: stage > agent > global (default on).
+    // Cascade each hint toggle: stage > agent > global (both default on).
     let batch_tool_hint = leviath_core::taint::resolve_batch_tool_hint(
-        global_batch_tool_hint,
-        agent_batch_tool_hint,
+        global_hints.batch_tool,
+        agent_hints.batch_tool,
         stage.batch_tool_hint,
+    );
+    let shell_hint = leviath_core::taint::resolve_shell_hint(
+        global_hints.shell,
+        agent_hints.shell,
+        stage.shell_hint,
     );
     StageSetup {
         inference_config: InferenceConfig {
@@ -1326,6 +1335,7 @@ pub(crate) fn stage_setup_from(
             max_output_tokens,
             extra_params,
             batch_tool_hint,
+            shell_hint,
             request_timeout_secs: stage.model.request_timeout_secs,
         },
         routing: stage.tool_result_routing.clone(),
@@ -1345,16 +1355,16 @@ pub(crate) fn stage_setup_from(
 ///
 /// `stages` must be aligned with `blueprint.stages` (one [`ResolvedStage`] each).
 ///
-/// `global_batch_tool_hint` is the caller's global config toggle for the
-/// batch-tool-calls system-prompt hint; it is resolved per stage against the
-/// blueprint's agent-level and each stage's `batch_tool_hint`.
+/// `global_hints` is the caller's global config toggle for each system-prompt
+/// hint; each is resolved per stage against the blueprint's agent-level and
+/// per-stage override of the same name.
 pub fn spawn_agent(
     world: &mut World,
     agent_id: String,
     blueprint: leviath_core::Blueprint,
     task: &str,
     stages: Vec<ResolvedStage>,
-    global_batch_tool_hint: bool,
+    global_hints: leviath_core::config::PromptHints,
 ) -> Result<Entity, String> {
     let seeds = std::collections::HashMap::from([("task".to_string(), task.to_string())]);
     // No compiled custom-region scripts on this path: script-backed regions
@@ -1369,7 +1379,7 @@ pub fn spawn_agent(
         blueprint,
         &seeds,
         stages,
-        global_batch_tool_hint,
+        global_hints,
         leviath_core::NudgeConfig::default(),
         std::collections::HashMap::new(),
     )
@@ -1391,7 +1401,7 @@ pub fn spawn_agent_seeded(
     mut blueprint: leviath_core::Blueprint,
     seeds: &std::collections::HashMap<String, String>,
     stages: Vec<ResolvedStage>,
-    global_batch_tool_hint: bool,
+    global_hints: leviath_core::config::PromptHints,
     global_nudge: leviath_core::NudgeConfig,
     region_scripts: std::collections::HashMap<
         String,
@@ -1435,11 +1445,14 @@ pub fn spawn_agent_seeded(
             fallbacks: rs.fallbacks,
         })
         .collect();
-    let agent_batch_tool_hint = blueprint.batch_tool_hint;
+    let agent_hints = leviath_core::config::PromptHintOverrides {
+        batch_tool: blueprint.batch_tool_hint,
+        shell: blueprint.shell_hint,
+    };
     let setups: Vec<StageSetup> = blueprint
         .stages
         .iter()
-        .map(|s| stage_setup_from(s, global_batch_tool_hint, agent_batch_tool_hint))
+        .map(|s| stage_setup_from(s, global_hints, agent_hints))
         .collect();
 
     // Seed the window from the blueprint layout + task, then apply stage 0's

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -298,6 +298,7 @@ mod tests {
                 max_output_tokens: None,
                 extra_params: Default::default(),
                 batch_tool_hint: false,
+                shell_hint: false,
                 request_timeout_secs: None,
             },
             routing: None,

--- a/crates/leviath-runtime/src/test_support.rs
+++ b/crates/leviath-runtime/src/test_support.rs
@@ -50,3 +50,14 @@ impl Drop for SilentPanics {
         std::panic::set_hook(previous);
     }
 }
+
+/// The global end of the system-prompt hint cascade for a spawn under test,
+/// where only the batch-tool hint is ever varied. The shell hint follows it so
+/// the two never disagree in a test that only cares about one of them; a test
+/// that does care builds the struct itself.
+pub(crate) fn hints(on: bool) -> leviath_core::config::PromptHints {
+    leviath_core::config::PromptHints {
+        batch_tool: on,
+        shell: on,
+    }
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -461,7 +461,7 @@ impl PipelineWorld {
         blueprint: leviath_core::Blueprint,
         task: &str,
         stages: Vec<crate::pipeline::ResolvedStage>,
-        global_batch_tool_hint: bool,
+        global_hints: leviath_core::config::PromptHints,
     ) -> Result<Entity, String> {
         let e = crate::pipeline::spawn_agent(
             &mut self.world,
@@ -469,7 +469,7 @@ impl PipelineWorld {
             blueprint,
             task,
             stages,
-            global_batch_tool_hint,
+            global_hints,
         )?;
         self.wake.notify_one();
         Ok(e)
@@ -947,7 +947,7 @@ mod tests {
 
     /// Serializes every test in this binary that swaps the **process-global**
     /// panic hook - see the definition for why they can't run concurrently.
-    use crate::test_support::PANIC_HOOK_LOCK;
+    use crate::test_support::{PANIC_HOOK_LOCK, hints};
 
     /// Run `f` with the process panic hook silenced (the panic is expected), and
     /// serialized against the other hook-swapping tests.
@@ -1157,6 +1157,7 @@ mod tests {
                 max_output_tokens: None,
                 extra_params: Default::default(),
                 batch_tool_hint: false,
+                shell_hint: false,
                 request_timeout_secs: None,
             },
             routing: None,
@@ -1829,7 +1830,7 @@ mod tests {
                     tools: vec![],
                     fallbacks: Vec::new(),
                 }],
-                true,
+                hints(true),
             )
             .unwrap();
 
@@ -2336,7 +2337,7 @@ mod tests {
                 tools: vec![],
                 fallbacks: Vec::new(),
             }],
-            true,
+            hints(true),
         );
         assert!(err.is_err());
     }

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -19,6 +19,28 @@ pub fn is_subagent_tool(name: &str) -> bool {
     SUBAGENT_TOOLS.contains(&name)
 }
 
+/// The `shell` tool's description, naming the shell this host actually resolved
+/// instead of listing every platform's and leaving the model to guess which one
+/// it got. Pure over the shell so both wordings are testable on any platform.
+pub(crate) fn shell_tool_description(shell: &str) -> String {
+    format!(
+        "Execute a shell command in the working directory. On this machine commands run \
+         through `{shell}`, so write them in its syntax. Use this for build commands, \
+         running tests, installing dependencies, or other shell operations. Has a \
+         60-second timeout."
+    )
+}
+
+/// [`shell_tool_description`] for the resolved shell, computed once.
+///
+/// `detect_shell` reads `$SHELL` and probes the filesystem on Unix, and
+/// `tool_defs` runs on every request, so the answer is cached. The shell cannot
+/// change under a running process in any way this would need to notice.
+fn resolved_shell_description() -> &'static str {
+    static DESCRIPTION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    DESCRIPTION.get_or_init(|| shell_tool_description(BuiltinTools::detect_shell().0))
+}
+
 impl BuiltinTools {
     /// All tool definitions to advertise to the LLM, minus any whose required
     /// platform capabilities aren't provided by the current platform.
@@ -109,7 +131,7 @@ impl BuiltinTools {
             },
             Tool {
                 name: "shell".to_string(),
-                description: "Execute a shell command in the working directory. Uses the system shell (bash/zsh on Unix, cmd on Windows). Use this for build commands, running tests, installing dependencies, or other shell operations. Has a 60-second timeout.".to_string(),
+                description: resolved_shell_description().to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -90,6 +90,29 @@ mod tests {
     }
 
     #[test]
+    fn the_shell_tool_advertises_the_shell_this_host_resolved() {
+        // Whichever shell the host has, the description has to name *it*: a
+        // model that reads "cmd" and gets zsh (or the reverse) writes the wrong
+        // commands, which is exactly the failure this replaced.
+        let dir = tempfile::tempdir().unwrap();
+        let defs = make_tools(dir.path()).tool_defs();
+        let shell = defs
+            .iter()
+            .find(|t| t.name == "shell")
+            .expect("shell is advertised on a desktop capability set");
+        let (resolved, _) = BuiltinTools::detect_shell();
+        assert!(
+            shell.description.contains(resolved),
+            "description {:?} does not name the resolved shell {resolved:?}",
+            shell.description
+        );
+
+        // Both platforms' wordings, without needing to run on both.
+        assert!(crate::defs::shell_tool_description("cmd.exe").contains("`cmd.exe`"));
+        assert!(crate::defs::shell_tool_description("/bin/zsh").contains("`/bin/zsh`"));
+    }
+
+    #[test]
     fn subagent_predicate_covers_the_five_names_and_nothing_else() {
         for name in SUBAGENT_TOOLS {
             assert!(is_subagent_tool(name));

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -421,3 +421,16 @@ Manage [taint tracking](/docs/security#taint-tracking-experimental) policy rules
 `LEVIATH_HOME` redirects the whole data root, and `LEVIATH_CONFIG_PATH` points at an exact config
 file. Those two plus the rest are in the
 [configuration reference](/docs/configuration#environment-variables).
+
+Examples on this page use Unix shell syntax. On Windows, set variables the way your shell does:
+
+```powershell
+$env:LEVIATH_HOME = "D:\leviath"          # PowerShell
+```
+
+```bat
+set LEVIATH_HOME=D:\leviath
+```
+
+The per-command Unix prefix form (`LEVIATH_HOME=/tmp/lev lev ps`) has no direct equivalent; set the
+variable first, then run the command.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -29,6 +29,7 @@ ollama_base_url      = "http://localhost:11434"   # env fallback: OLLAMA_HOST
 request_timeout_secs = 900           # per-request HTTP timeout to a provider
 taint_tracking       = false         # global master switch, see below
 batch_tool_hint      = true          # global master switch, see below
+shell_hint           = true          # global master switch, see below
 ```
 
 | Key | Type | Default | Notes |
@@ -41,6 +42,31 @@ batch_tool_hint      = true          # global master switch, see below
 | `request_timeout_secs` | integer | unset | Unset means the 15 minute ceiling. A stage's `[stages.<name>.model] request_timeout_secs` wins for that stage |
 | `taint_tracking` | bool | `false` | Turns on [taint tracking](/docs/security) for every agent. Off, an agent still opts in through its own `[security]` block |
 | `batch_tool_hint` | bool | `true` | Adds a short system hint telling the model it may batch independent tool calls. An agent or stage can set it either way at the narrower scope |
+| `shell_hint` | bool | `true` | Adds a short system hint describing the shell a stage will actually get. Only says anything where the platform warrants it (today: Windows). An agent or stage can set it either way at the narrower scope |
+
+### System-prompt hints
+
+`batch_tool_hint` and `shell_hint` are the two hints Leviath writes into a stage's system prompt on
+its own. Both are on by default, both cascade stage over agent over this file, and both sit at the
+front of the cacheable prefix so they cost nothing after the first call:
+
+```toml
+# config.toml: off for this machine
+shell_hint = false
+```
+
+```toml
+# a blueprint: back on for this one agent, off for one stage of it
+[agent]
+shell_hint = true
+
+[stages.plan]
+shell_hint = false
+```
+
+`shell_hint` only reaches a stage that advertises the `shell` tool, and only on a platform whose
+shell needs explaining. On Linux and macOS it is inert whatever you set it to. See
+[Built-in tools](/docs/tools#which-shell-you-get) for what it says on Windows.
 
 ## `[providers]`
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -115,6 +115,34 @@ lev dash
 > Prefer a browser or a REST/WebSocket client? `lev serve` exposes the same daemon over HTTP.
 > See the [API](/docs/api) and the web console.
 
+## On Windows
+
+`lev` itself is the same on every platform, and the commands above work unchanged in PowerShell.
+Two things around it differ.
+
+Environment variables. The shell examples in these docs use the Unix `VAR=value command` prefix,
+which PowerShell and `cmd` do not have:
+
+```powershell
+$env:ANTHROPIC_API_KEY = "sk-ant-..."     # PowerShell
+lev run coder --task "Fix the failing test"
+```
+
+```bat
+set ANTHROPIC_API_KEY=sk-ant-...
+lev run coder --task "Fix the failing test"
+```
+
+Quoting. PowerShell strips the outer quotes before `lev` sees the argument, so a task containing a
+literal quote needs escaping, and single quotes are safest when the text contains `$`:
+
+```powershell
+lev run coder --task 'Handle the $HOME case'
+```
+
+The agent's own shell is a separate matter: it runs through `cmd.exe`, not a POSIX shell, and
+Leviath tells the model so. See [which shell you get](/docs/tools#which-shell-you-get).
+
 ## Create your own
 
 ```bash

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -19,6 +19,47 @@ the [API](/docs/api).
 | Ollama | none (local) | [ollama.com/download](https://ollama.com/download) |
 | Claude Code | none (subscription) | see below |
 
+## Model identifiers
+
+A model is always named by a `provider` and a `model` together. The `model` string is passed to that
+provider verbatim, so it has to be spelled the way the provider spells it:
+
+| Provider | Shape | Example |
+|---|---|---|
+| Anthropic | the bare model name | `claude-sonnet-5` |
+| OpenAI | the bare model name | `gpt-5.4-mini` |
+| Google | the bare model name | `gemini-2.5-pro` |
+| OpenRouter | `vendor/model` | `deepseek/deepseek-v4-flash` |
+| Ollama | `model:tag` | `qwen3.5:9b` |
+
+OpenRouter is the one that trips people up: its identifiers carry a vendor prefix, and the prefix is
+part of the name. `deepseek-v4-flash` is not a valid OpenRouter model; `deepseek/deepseek-v4-flash`
+is. Browse the full catalog at [openrouter.ai/models](https://openrouter.ai/models), or ask your
+install:
+
+```bash
+lev models list --provider openrouter        # what Leviath knows offline
+lev models list --provider openrouter --remote   # live from the provider's API
+lev models list --all                        # every provider, even unconfigured ones
+```
+
+> [!NOTE]
+> Without `--remote`, `lev models list` prints a built-in table of well-known models. It is a
+> convenience, not the catalog. A model absent from it is not necessarily invalid, and Leviath does
+> not check model strings against it: `lev validate` never looks at them, and an unrecognized string
+> gets a conservative 128K context / 8192 output assumption locally and is then sent to the provider
+> as written.
+
+### Dated and rotating identifiers
+
+Providers publish dated aliases (`deepseek/deepseek-v4-flash-0731`,
+`deepseek/deepseek-r1-0528`) alongside undated ones. A dated alias can be perfectly valid upstream
+while being absent from `lev models list`, and it can also stop resolving later when the provider
+retires it. Nothing local will warn you: the first sign is a model-not-found error from the API.
+
+If you pin a dated identifier, treat it as something to revisit. If you would rather not, pin the
+undated one and accept that the provider may move it under you.
+
 ## Per-stage model selection with fallback
 
 Each [stage](/docs/stages) names an ordered list of provider/model pairs. The runtime picks the
@@ -93,6 +134,60 @@ wait restarts. Topping up an account needs no restart.
 retried. `lev ps --json` carries the same under `health.providers_down`, and the
 `leviath.provider.circuit.open` metric reports it per provider. Set `provider_failures_before_open`
 to `0` to switch the whole thing off and keep only per-run failover.
+
+## Which entry a stage starts on
+
+Failover decides where a run *goes*; this decides where it *begins*. The starting choice is made
+once, at spawn, and keys on whether the **provider** is configured, never on whether the model
+exists. In order:
+
+1. `lev run --model <provider>/<model>`, which overrides everything and skips the check entirely. A
+   bare `--model <model>` replaces only the model name and keeps the provider resolved below.
+2. The first entry in `models` whose provider is configured.
+3. Your `default_provider` / `default_model` from `config.toml`, if `default_model` is set, its
+   provider is configured, and the stage did not set `allow_user_default = false`.
+4. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
+   spawn with `stage '<name>' has no usable provider`.
+
+> [!IMPORTANT]
+> Step 3 is only reached when **no** listed provider is configured. Ollama needs no key and is
+> therefore registered unconditionally, so any stage listing Ollama matches at step 2 whether or not
+> Ollama is actually installed, and your `default_model` is never consulted for that stage.
+
+### Running the bundled agents on another provider
+
+The [bundled agents](/docs/agent-catalog) list Anthropic, OpenAI, and Ollama, in that order. None of
+them lists OpenRouter, Google, or a custom Rhai provider, so a key for one of those does not make
+them use it. On an install whose only key is an OpenRouter one:
+
+- Almost every stage matches Ollama at step 2 and runs against `http://localhost:11434`. If Ollama
+  is not installed, the run spawns fine and then fails at its first call.
+- `parallel-fixer`'s `parallel_fix` and `fix_worker` stages list only Anthropic and OpenAI, so they
+  fail at spawn: `stage 'parallel_fix' has no usable provider (tried: anthropic)`.
+
+Setting `default_provider` and `default_model` does **not** fix this, for the reason in the note
+above. Three things do. A full override, per run:
+
+```bash
+lev run coder -t "fix the failing test" --model openrouter/deepseek/deepseek-v4-flash
+```
+
+A host-wide `fallback_order`, which catches a stage once its own entries are exhausted:
+
+```toml
+[providers]
+fallback_order = ["openrouter/deepseek/deepseek-v4-flash"]
+```
+
+Or, for something permanent, copying the blueprint and naming your provider on the stages you care
+about:
+
+```toml
+model = { models = [
+  { provider = "openrouter", model = "deepseek/deepseek-v4-flash" },
+  { provider = "anthropic",  model = "claude-sonnet-5" },
+] }
+```
 
 ## Where credentials live
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -34,10 +34,33 @@ Read and modify files relative to the agent's working directory.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `shell` | Run a shell command in the working directory using the system shell (bash/zsh on Unix, cmd on Windows). Has a 60-second timeout. | `command` |
+| `shell` | Run a shell command in the working directory using the system shell. Has a 60-second timeout. | `command` |
 
 `bash` is an accepted alias for `shell`: a stage's `available_tools` may name either, and both
 resolve to the same tool advertised to the model.
+
+### Which shell you get
+
+Leviath resolves the shell per platform, and tells the model which one it resolved instead of
+leaving it to guess:
+
+| Platform | Shell |
+| --- | --- |
+| Windows | `cmd.exe /C` |
+| Unix | `$SHELL` when it exists and is a `sh`/`bash`/`zsh`, else the first of `/bin/bash`, `/usr/bin/bash`, `/bin/zsh`, `/usr/bin/zsh`, `/bin/sh` |
+
+The resolved shell is named in the `shell` tool's own description, so a model on Windows reads
+`cmd.exe` rather than a list of every platform's shell. On top of that, a stage that advertises the
+shell tool carries a short system block when the platform warrants one. Today only Windows does:
+it says commands run through `cmd.exe` rather than a POSIX shell, and gives the PowerShell stand-ins
+for `cat`, `grep`, `ls`, and `wc -l`. On Linux and macOS nothing is added.
+
+Turn it off with `shell_hint = false`, globally in `config.toml` or per agent or stage in a
+blueprint. See [Configuration](/docs/configuration#system-prompt-hints).
+
+> [!NOTE]
+> [Rhai tool scripts](/docs/rhai-tools) are a separate path: their `shell()` host function always
+> uses `/bin/sh` on Unix, never `$SHELL`, because a script is authored once and runs everywhere.
 
 > [!WARNING]
 > `shell` requires the platform's process-spawn capability. On platforms that don't provide it, the

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -126,7 +126,6 @@ If you see it anyway, check that `shell_hint` has not been turned off in `config
 blueprint's `[agent]` / `[stages.<name>]` block. A blueprint that spells out POSIX commands in its
 own prompt will still ask for them; that text has to change in the blueprint. See
 [which shell you get](/docs/tools#which-shell-you-get).
->>>>>>> a9de5a9 (Document model identifiers and what Windows actually gets)
 
 ## A run says `running` but never does anything
 

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -83,6 +83,51 @@ If the runs are failing on the very first request and you are not sure the crede
 problem at all, `lev doctor` checks the provider wiring layer by layer and names the first one that
 breaks.
 
+## `has no usable provider`, but I do have a key
+
+The message names what it tried: `stage 'parallel_fix' has no usable provider (tried: anthropic)`.
+That stage's `models` list simply never mentions the provider you configured. A blueprint only starts
+on a provider it lists, and the [bundled agents](/docs/agent-catalog) list Anthropic, OpenAI, and
+Ollama only, so a Google or OpenRouter key does not qualify.
+
+Pass `--model <provider>/<model>` for the run, add a `[providers] fallback_order` entry, or copy the
+blueprint and name your provider on the stage. Setting `default_model` often will not help: it is
+only consulted when no listed provider is configured at all. See
+[which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on).
+
+## My run went to Ollama and I never asked for it
+
+Ollama needs no key, so it is registered unconditionally, and every bundled agent lists it as its
+last entry. On an install with no Anthropic or OpenAI key, that is the first entry that matches, and
+the run starts against `http://localhost:11434` whether or not Ollama is installed.
+
+`lev doctor` reports the provider a run would start on before you spawn one, and a run records the
+model it actually used in its `meta.json`. The fixes are the same as the entry above.
+
+## The provider says my model doesn't exist
+
+Model strings are passed to the provider verbatim and are never checked locally, so a typo, a
+missing OpenRouter `vendor/` prefix, or an identifier the provider has retired all surface as an
+API error at the first call rather than at `lev validate` time.
+
+Check the spelling against `lev models list --provider <name> --remote`, which asks the provider
+rather than Leviath's built-in table. Note that a valid dated identifier such as
+`deepseek/deepseek-v4-flash-0731` may be absent from the offline table while still working, so
+absence there is not proof of a bad name. See
+[model identifiers](/docs/providers#model-identifiers).
+
+## A Windows agent keeps trying `cat`, `ls`, and `grep`
+
+The `shell` tool runs through `cmd.exe` on Windows, where those do not exist. Leviath names the
+resolved shell in the tool's description and, on Windows, prepends a short system block giving the
+PowerShell stand-ins, so an up-to-date install should not do this.
+
+If you see it anyway, check that `shell_hint` has not been turned off in `config.toml` or in the
+blueprint's `[agent]` / `[stages.<name>]` block. A blueprint that spells out POSIX commands in its
+own prompt will still ask for them; that text has to change in the blueprint. See
+[which shell you get](/docs/tools#which-shell-you-get).
+>>>>>>> a9de5a9 (Document model identifiers and what Windows actually gets)
+
 ## A run says `running` but never does anything
 
 Check its provider first, with `lev doctor`. If a stage's model list names only providers you


### PR DESCRIPTION
Closes #206 (which absorbed #210 and #212).

## What was wrong

Two gaps, both reported from Windows + OpenRouter.

**The shell.** `exec.rs` has run commands through `cmd.exe /C` on Windows since forever, but nothing told the model that. Prompts and docs assume a POSIX shell, so Windows agents burned iterations on `cat`, `grep -r`, and `ls -la` before finding the PowerShell equivalents by hand.

**Model identifiers.** Nothing documented what a valid model string looks like. OpenRouter takes a vendor-prefixed slug, dated aliases like `deepseek/deepseek-v4-flash-0731` are accepted upstream while being absent from `lev models list`, and nothing local checks either way.

### Two premises in the issue don't hold in this repo

Worth stating, since the issue asks for changes to files that do not exist:

- There are no `worker`, `tl`, or `cto` blueprints. The bundled set is 10 agents (coder, software-engineer, reviewer, parallel-fixer, log-analyzer, daily-briefer, researcher, deep-researcher, wide-researcher, writing-assistant). The names in the issue are the reporter's own blueprints under `~/.leviath/agents/`.
- There is no `ls → Get-ChildItem` mapping anywhere. `Get-ChildItem` and `PowerShell` have zero hits repo-wide, so there was nothing to copy from `tl` to the others. The guidance is written here for the first time.

Likewise `deepseek/deepseek-v4-flash-0731` appears in no file in this repo, and no bundled blueprint lists an `openrouter` entry at all, which turns out to be its own trap (below).

## What changed

**A shell hint the runtime derives, rather than prose repeated in ten blueprints.** A stage that advertises the `shell` tool now carries a short system block naming the shell it will actually get. The text comes from `shell_guidance_for(os)`, a pure function over the OS string following the `leviath-sys` idiom, so the Windows branch is reachable under test on Linux CI. Today only Windows returns anything; Linux and macOS are unchanged. Three guards, all required: the resolved toggle, a platform with something to say, and a stage that can actually run commands.

**`shell_hint`, cascading stage over agent over global**, mirroring `batch_tool_hint` down to the config key, the manifest parsing at both levels, and the setup wizard field. The two globals now travel together as `leviath_core::config::PromptHints`, replacing the bare `global_batch_tool_hint: bool` parameter, so the next hint doesn't grow the arity of `spawn_agent` / `spawn_agent_seeded` / `spawn_from_blueprint` again. Embedders opt in through `AgentWorldBuilder::prompt_hints`, which replaces a hardcoded `false` in the embed spawner.

**The `shell` tool description names the resolved shell.** It used to list every platform's and leave the model to work out which one it had.

**Docs.** A "Model identifiers" section in `providers.md` covering slug shapes per provider, where to find OpenRouter's, dated aliases, and what `models = [...]` actually resolves: a provider-availability choice made once at spawn, not runtime failover. Plus the OpenRouter-only trap, where an install with only an OpenRouter key falls past every step and lands on `has no usable provider` with a key in hand, because no bundled agent lists OpenRouter and `lev setup` leaves `default_model` unset. Windows shell/quoting/env-var examples in `getting-started.md` and `cli.md`, `shell_hint` in `configuration.md`, the resolved-shell table in `tools.md`, and four `troubleshooting.md` entries.

**Two blueprint prompts** in log-analyzer named POSIX binaries outright (`head/wc/file`, `awk/grep/python`); they are now platform-neutral. Version bumped so existing installs actually pick the text up. The `sed -i` / `tee` mentions elsewhere are left alone: those are prohibitions, and being told not to use a command you don't have is harmless.

Deliberately out of scope: the `lev validate` catalog check from #210. Valid dated slugs are absent from the offline table, so it would false-positive without a network call.

## Verification

`cargo test --workspace --all-features` green, clippy clean, docs build clean.

Live, against an isolated daemon and a Rhai provider that echoes the request back:

- The `shell` tool description reports `/bin/zsh`, this machine's actual shell, not the old static list.
- On macOS no shell block is added, which is the `None` arm behaving.
- With the guidance temporarily made to fire on macOS (a local probe, reverted before commit), the block lands on the shell-granting stage and is absent from the shell-less one, proving `config.toml` → `PromptHints` → `stage_setup_from` → `InferenceConfig` → `build_request` end to end.
- `shell_hint = false` in `config.toml` removes it on the next run with no daemon restart, and a per-stage `shell_hint = true` overrides that global `false`.

Local coverage was not run: the disk is at 99% with several sibling worktrees mid-build, and an instrumented build would have starved them. CI's coverage job is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KjsZN6A88f5rKAgyr9ov9