### PR TITLE
Say which layer of the provider wiring is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,30 @@ requests since the previous version.
   above this is what stops an external scheduler leaking slots to runs that
   have quietly stopped, and there is now a page on doing that reconciliation
   properly in the daemon docs.
+- New `lev doctor`, which checks that provider wiring works without you having
+  to build a throwaway agent to find out. Four checks run in order and each is
+  reported: the config file parses and a registry can be built, your defaults
+  resolve to a provider that is actually registered, one real inference reaches
+  the model, and a one-turn agent spawns over the control socket and finishes.
+  The check that fails is the diagnosis. That last one matters most: config,
+  resolve and inference passing while `daemon` fails is the difference between
+  "my keys are wrong" and "the daemon is wedged", which used to look identical
+  from the outside.
+- `lev doctor` prints the provider and model it actually resolved to, not just
+  "OK". A stage that names no model of its own falls back to `anthropic`, so a
+  machine holding only an OpenRouter key can resolve to a provider it has no
+  credential for, spawn, and sit at iteration 0 — which is how a batch of runs
+  once went nowhere at once. Now it says so, before anything is spawned.
+- A failing provider call is reported verbatim, status line and response body
+  included, so a 402 naming the exhausted credit or a 404 naming the model
+  reads as itself rather than as "inference failed". `--model provider/model`
+  tries a model string before you wire it into a blueprint, and is the only way
+  to reach a Rhai script provider, which is resolved by name and cannot be
+  listed. `--no-daemon` stops after the inference; `--json` prints the checks
+  for scripts; a failure exits non-zero, so it works as a CI gate.
+- The probe cleans up after itself: the throwaway agent is staged in a temp
+  directory and its run is deleted on every path out, including the failing
+  ones, so nothing is left in `lev ps` or on disk.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -1,0 +1,690 @@
+//! `lev doctor` - prove the provider wiring works, one layer at a time.
+//!
+//! Four checks run in order and each one is reported, so a failure names the
+//! layer that broke instead of leaving the caller to guess:
+//!
+//! 1. `config` - the config file parses and a provider registry can be built.
+//! 2. `resolve` - the user's defaults pick a provider that is actually
+//!    registered. This is the check that catches a stage resolving to
+//!    `anthropic/claude-sonnet-4-6` (the hard-coded last resort in
+//!    [`ModelConfig::provider`](leviath_core::blueprint::ModelConfig::provider))
+//!    on a machine with no Anthropic key - the root cause of a fleet of runs
+//!    that spawned, sat at iteration 0, and never took a turn.
+//! 3. `inference` - one real call to that provider, straight through
+//!    [`Provider::infer`]. No world, no run, nothing on disk.
+//! 4. `daemon` - a throwaway one-stage agent spawned over the control socket
+//!    and waited on, then deleted. This is the only check that exercises the
+//!    handoff, which is why it is worth the second billed call: checks 1-3
+//!    passing while this one fails is exactly the "credentials are fine, the
+//!    daemon is wedged" verdict that used to take a hand-built canary agent to
+//!    establish.
+//!
+//! The daemon-touching I/O lives behind [`crate::dispatch::RiskyExecutors`], so
+//! the cores here are driven by unit tests against injected registries and a
+//! scripted control socket. The registry builder is a `&dyn Fn` rather than a
+//! generic for the coverage reason documented on
+//! [`crate::commands::models`]'s equivalent seam.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::bail;
+use leviath_core::blueprint::ModelConfig;
+use leviath_providers::{InferenceRequest, Message, Provider};
+use leviath_runtime::ProviderRegistry;
+use leviath_runtime::control_socket::{ControlClient, ControlResponse};
+use leviath_runtime::pipeline::{providers_tried, resolve_stage_model};
+
+use crate::commands::run::session::build_provider_registry_from_config;
+use crate::config::Config;
+use crate::daemon::spawn::model_defaults;
+
+/// `lev doctor --help`. What each check proves, and what a failure at it means.
+pub const DOCTOR_LONG_ABOUT: &str = "\
+Check that provider wiring works, end to end.
+
+Four checks run in order, and the first failure stops the rest. The check that
+fails is the diagnosis:
+
+  config     the config file parses and a provider registry can be built.
+             Fails on a malformed config.toml.
+  resolve    your default provider/model picks a provider that is actually
+             registered. Fails when a key is missing or misspelled - and
+             catches the case where a blueprint with no model falls back to
+             anthropic on a machine that has no Anthropic key.
+  inference  one real call to that provider. Fails on a bad key, an unknown
+             model id, or a billing problem; the provider's own error is
+             printed verbatim, status line and response body included.
+  daemon     a one-stage agent spawned over the control socket, waited on,
+             then deleted. Fails when the handoff is broken even though the
+             credentials are fine.
+
+So config/resolve/inference OK with daemon FAIL means the daemon is the
+problem, not your keys - the distinction this command exists to make.
+
+`--model` takes the same forms `lev run --model` does: `provider/model` picks
+both (the way to reach a Rhai script provider, which cannot be listed), and a
+bare model id pairs with your default_provider. Use it to try a model string
+before wiring it into a blueprint.
+
+Two inferences are billed per run, capped at 64 output tokens each.
+`--no-daemon` stops after the third check and bills one.
+
+Exits non-zero on failure, so it works as a CI gate. --json prints the same
+checks as {\"checks\": [...], \"passed\": bool}.";
+
+/// Arguments for `lev doctor`.
+#[derive(clap::Args, Debug, Clone, Default)]
+pub struct DoctorArgs {
+    /// Model to test (`provider/model`, or a bare model id paired with the
+    /// configured default provider). Defaults to your configured default.
+    #[arg(short, long)]
+    pub model: Option<String>,
+
+    /// Stop after the direct inference check: never contact (or start) the
+    /// daemon, and create no run.
+    #[arg(long)]
+    pub no_daemon: bool,
+
+    /// Print the checks as JSON instead of a table.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// How long the daemon check waits for its throwaway run to reach a terminal
+/// status before calling the handoff wedged.
+const DAEMON_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// How often the daemon check re-asks for the run's status.
+const DAEMON_POLL: Duration = Duration::from_millis(250);
+
+/// Output cap for both probe inferences. The prompt is four tokens and the
+/// wanted answer is one word, so this only bounds a model that ignores both.
+const PROBE_MAX_TOKENS: usize = 64;
+
+/// What the probe asks for, in both the direct call and the daemon run.
+const PROBE_PROMPT: &str = "Reply with exactly: PONG";
+
+/// The word a cooperating model comes back with. Reported, never required:
+/// a model that answers something else has still proved the wiring, and
+/// failing on it would make this command flaky across providers.
+const PROBE_EXPECTED: &str = "PONG";
+
+// ─── Report types ─────────────────────────────────────────────────────────────
+
+/// Whether a check proved what it set out to prove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    /// The layer works.
+    Ok,
+    /// The layer is broken; nothing after it ran.
+    Fail,
+}
+
+impl CheckStatus {
+    /// The cell as it appears in the table.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::Fail => "FAIL",
+        }
+    }
+}
+
+/// One layer's verdict, with whatever detail makes it actionable.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Check {
+    /// The layer's short name (`config`, `resolve`, `inference`, `daemon`).
+    pub name: &'static str,
+    /// Whether it passed.
+    pub status: CheckStatus,
+    /// What was found: the resolved names, the token usage, or the raw error.
+    pub detail: String,
+    /// Wall-clock cost, for the checks that make a network call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+}
+
+impl Check {
+    /// A passing check with no timing (the two offline checks).
+    fn ok(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: CheckStatus::Ok,
+            detail: detail.into(),
+            elapsed_ms: None,
+        }
+    }
+
+    /// A failing check with no timing.
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+            elapsed_ms: None,
+        }
+    }
+
+    /// Attach how long the call took.
+    fn timed(mut self, elapsed: Duration) -> Self {
+        self.elapsed_ms = Some(elapsed.as_millis() as u64);
+        self
+    }
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+/// Render the checks as the table `lev doctor` prints.
+///
+/// Pure: everything that varies between runs (timings, resolved names) is
+/// already baked into the `Check`s, so the same input always renders the same
+/// output and the tests can assert on it exactly.
+pub fn format_report(checks: &[Check]) -> String {
+    let name_width = checks.iter().map(|c| c.name.len()).max().unwrap_or(0);
+    let status_width = checks
+        .iter()
+        .map(|c| c.status.label().len())
+        .max()
+        .unwrap_or(0);
+
+    let mut out = String::from("\n");
+    for check in checks {
+        out.push_str(&format!(
+            "  {:<name_width$}  {:<status_width$}  {}",
+            check.name,
+            check.status.label(),
+            check.detail,
+        ));
+        if let Some(ms) = check.elapsed_ms {
+            out.push_str(&format!("  ({:.1}s)", ms as f64 / 1000.0));
+        }
+        out.push('\n');
+    }
+    if checks.iter().all(|c| c.status == CheckStatus::Ok) {
+        out.push_str("\ndoctor passed\n");
+    }
+    out
+}
+
+// ─── Check 1: config ──────────────────────────────────────────────────────────
+
+/// Report what the config named and what the registry ended up holding.
+///
+/// Only native providers can be listed - a Rhai script provider is resolved by
+/// name on demand and never enumerated - so the line says so rather than
+/// implying the user's `.rhai` providers are missing.
+fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
+    let mut names = registry.provider_names();
+    names.sort_unstable();
+    let registered = match names.is_empty() {
+        true => "none".to_string(),
+        false => names.join(", "),
+    };
+    Check::ok(
+        "config",
+        format!(
+            "default_provider={}; registered: {} (script providers resolve by name)",
+            config.default_provider, registered
+        ),
+    )
+}
+
+// ─── Check 2: resolve ─────────────────────────────────────────────────────────
+
+/// What check 2 settled on, when it settled on something usable. The handle is
+/// carried rather than looked up again so the later checks cannot disagree with
+/// the one that reported.
+struct Resolved {
+    provider_name: String,
+    model: String,
+    provider: Arc<dyn Provider>,
+}
+
+/// Run the real stage-model fallback chain against an **empty** [`ModelConfig`],
+/// so what comes back is what the user's config alone would pick for a stage
+/// that states no preference of its own.
+///
+/// The guard afterwards is the one [`leviath_runtime::pipeline::resolve_stages`]
+/// applies at spawn: the last resort in the chain is unchecked and hands back
+/// `anthropic`/`claude-sonnet-4-6` whether or not anything answers to that name.
+/// Resolving through [`ProviderRegistry::get`] rather than `has` makes the same
+/// decision (native first, then the script layer) while keeping the handle, so
+/// the provider cannot go missing between deciding to use it and using it.
+fn resolve_check(
+    config: &Config,
+    model_override: Option<&str>,
+    registry: &ProviderRegistry,
+) -> (Check, Option<Resolved>) {
+    let empty = ModelConfig {
+        models: Vec::new(),
+        allow_user_default: true,
+        parameters: std::collections::HashMap::new(),
+        request_timeout_secs: None,
+    };
+    let defaults = model_defaults(config);
+    let (provider_name, model) = resolve_stage_model(&empty, model_override, &defaults, registry);
+
+    match registry.get(&provider_name) {
+        Some(provider) => (
+            Check::ok("resolve", format!("{provider_name} / {model}")),
+            Some(Resolved {
+                provider_name,
+                model,
+                provider,
+            }),
+        ),
+        None => (
+            Check::fail(
+                "resolve",
+                format!(
+                    "resolved to '{provider_name}', which is not configured (tried: {}). \
+                     Configure it with `lev setup`, or add it to config.toml.",
+                    providers_tried(&empty, model_override, &defaults)
+                ),
+            ),
+            None,
+        ),
+    }
+}
+
+// ─── Check 3: inference ───────────────────────────────────────────────────────
+
+/// One real call to the resolved provider. No context window, no blueprint, no
+/// world: the point is to isolate "can this credential reach this model" from
+/// everything the framework layers on top of it.
+async fn inference_check(provider: &dyn Provider, model: &str) -> Check {
+    let caps = provider.capabilities(model);
+    let request = InferenceRequest {
+        system: Vec::new(),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: PROBE_PROMPT.into(),
+            cache_breakpoint: false,
+        }],
+        model: model.to_string(),
+        max_tokens: PROBE_MAX_TOKENS.min(caps.max_output_tokens),
+        // Deterministic where it is allowed; providers that reject the
+        // parameter outright get the same value and ignore it.
+        temperature: 0.0,
+        tools: Vec::new(),
+        extra: serde_json::Value::Null,
+        request_timeout_secs: Some(60),
+    };
+
+    let started = Instant::now();
+    match provider.infer(request).await {
+        Ok(response) => {
+            let usage = response.tokens_used;
+            let echo = match response.content.contains(PROBE_EXPECTED) {
+                true => format!("replied {PROBE_EXPECTED}"),
+                // Not a failure. The call succeeded, which is the thing being
+                // checked; what the model chose to say is a note.
+                false => format!("no {PROBE_EXPECTED} in the reply"),
+            };
+            Check::ok(
+                "inference",
+                format!(
+                    "{} in / {} out / {} total, {echo}",
+                    usage.prompt_tokens, usage.completion_tokens, usage.total_tokens
+                ),
+            )
+            .timed(started.elapsed())
+        }
+        // Verbatim. Every provider formats a non-2xx as `HTTP <status>: <body>`,
+        // and that body is the whole diagnosis for the cases this command is
+        // for - a 402 naming the exhausted credit, a 404 naming the model.
+        // Summarising it here would throw away the answer.
+        Err(e) => Check::fail("inference", e.to_string()).timed(started.elapsed()),
+    }
+}
+
+// ─── Check 4: daemon ──────────────────────────────────────────────────────────
+
+/// The throwaway blueprint the daemon check spawns: one autonomous stage, one
+/// iteration, no tools, no transitions.
+///
+/// A single stage with no transitions is a valid "pure linear" blueprint and
+/// goes `Complete` after one text-only turn. Advertising no tools also keeps it
+/// out of the empty-output report - an agent with no way to modify a file is
+/// never judged for not having modified one.
+///
+/// `provider` and `model` are serialised as JSON strings, whose escaping is a
+/// subset of TOML's basic-string escaping, so a name containing a quote or a
+/// backslash cannot break out of the literal.
+fn canary_manifest(provider: &str, model: &str) -> String {
+    let provider = serde_json::to_string(provider).expect("a str always serializes to JSON");
+    let model = serde_json::to_string(model).expect("a str always serializes to JSON");
+    format!(
+        r#"[agent]
+name = "doctor"
+version = "0.0.1"
+description = "One-turn provider probe spawned by `lev doctor`, deleted when it finishes."
+entry_stage = "ping"
+
+[stages.ping]
+mode = "autonomous"
+model = {{ models = [{{ provider = {provider}, model = {model} }}] }}
+description = "Answer once, in text."
+available_tools = []
+max_iterations = 1
+system_prompt = "Reply with exactly: {PROBE_EXPECTED}. Call no tools."
+
+[context.regions]
+task = {{ kind = "pinned", max_tokens = 1000, seed = "task" }}
+conversation = {{ kind = "sliding_window", max_items = 4, max_tokens = 2000 }}
+"#
+    )
+}
+
+/// Delete everything the canary run left behind.
+///
+/// Ordered the way the dashboard's delete is: record the run terminal on disk
+/// *before* removing it, so that if an in-flight persist job loses the race and
+/// recreates the directory, it reappears as a finished run rather than a live
+/// one nobody will ever collect.
+fn cleanup_run(run_id: &str) {
+    let _ = crate::runstate::force_cancel(run_id);
+    let _ = std::fs::remove_dir_all(crate::runstate::run_dir(run_id));
+    let _ = leviath_core::paths::data_dir().map(|d| {
+        let _ = std::fs::remove_dir_all(d.join("state").join(run_id));
+    });
+}
+
+/// The daemon check's own outcome, before it is turned into a [`Check`], so the
+/// spawn/wait/cleanup steps each have one thing to say.
+enum DaemonOutcome {
+    /// The run finished successfully; carries the summary line.
+    Complete(String),
+    /// The run reached the daemon but did not end well.
+    Failed(String),
+}
+
+/// Write the canary manifest under `root`, returning its path.
+///
+/// The manifest's parent directory names the agent, and so prefixes the run id:
+/// the canary is identifiable as `doctor-...` for as long as it exists.
+fn stage_canary(
+    root: &std::path::Path,
+    provider: &str,
+    model: &str,
+) -> std::io::Result<std::path::PathBuf> {
+    let agent_dir = root.join("doctor");
+    std::fs::create_dir_all(&agent_dir)?;
+    let manifest = agent_dir.join("agent.leviath");
+    std::fs::write(&manifest, canary_manifest(provider, model))?;
+    Ok(manifest)
+}
+
+/// Spawn the canary, wait for it, and report. The run is deleted on every path
+/// out of here, including the failing ones.
+async fn daemon_check(
+    client: &ControlClient,
+    provider_name: &str,
+    model: &str,
+    timeout: Duration,
+    poll: Duration,
+    root: &std::path::Path,
+) -> Check {
+    let started = Instant::now();
+    let manifest = match stage_canary(root, provider_name, model) {
+        Ok(manifest) => manifest,
+        Err(e) => return Check::fail("daemon", format!("could not stage a probe agent: {e}")),
+    };
+
+    match spawn_and_wait(client, &manifest, root, timeout, poll).await {
+        DaemonOutcome::Complete(detail) => Check::ok("daemon", detail).timed(started.elapsed()),
+        DaemonOutcome::Failed(detail) => Check::fail("daemon", detail).timed(started.elapsed()),
+    }
+}
+
+/// Ask the daemon to run the staged canary and wait for a terminal status.
+async fn spawn_and_wait(
+    client: &ControlClient,
+    manifest: &std::path::Path,
+    workdir: &std::path::Path,
+    timeout: Duration,
+    poll: Duration,
+) -> DaemonOutcome {
+    // `--yolo`: a probe that stops to ask a person for a tool approval has
+    // stopped being a probe. It advertises no tools, so this waives nothing
+    // that could actually run.
+    let args = crate::daemon::client::resolve_spawn_args(
+        &manifest.to_string_lossy(),
+        Some(PROBE_PROMPT),
+        // The probe brings its own task, so the editor fallback is unreachable.
+        // Answering "not a terminal" anyway makes that structural rather than
+        // incidental: a doctor that opened an editor would be a bad joke.
+        &|| false,
+        None,
+        &workdir.to_string_lossy(),
+        true,
+        Vec::new(),
+        None,
+        std::collections::HashMap::new(),
+        false,
+    );
+    let args = match args {
+        Ok(args) => args,
+        Err(e) => return DaemonOutcome::Failed(format!("could not build the spawn request: {e}")),
+    };
+    let run_id = args.run_id.clone();
+
+    let spawned = match client.spawn(args).await {
+        Ok(ControlResponse::Spawned { run_id }) => Ok(run_id),
+        Ok(ControlResponse::Error { message }) => {
+            Err(format!("the daemon refused the spawn: {message}"))
+        }
+        Ok(other) => Err(format!("unexpected daemon response to spawn: {other:?}")),
+        Err(e) => Err(format!(
+            "the daemon is not reachable ({e}); start it with `lev daemon`"
+        )),
+    };
+    let run_id = match spawned {
+        Ok(id) => id,
+        Err(detail) => {
+            // The daemon may have staked out the run directory before failing.
+            cleanup_run(&run_id);
+            return DaemonOutcome::Failed(detail);
+        }
+    };
+
+    let outcome = wait_for_run(client, &run_id, timeout, poll).await;
+    cleanup_run(&run_id);
+    outcome
+}
+
+/// Poll the run until it reaches a terminal status, or the deadline passes.
+async fn wait_for_run(
+    client: &ControlClient,
+    run_id: &str,
+    timeout: Duration,
+    poll: Duration,
+) -> DaemonOutcome {
+    let started = Instant::now();
+    loop {
+        let still = match client.status(run_id).await {
+            Ok(ControlResponse::Status {
+                status: Some(status),
+            }) => {
+                if leviath_runtime::pipeline::is_terminal_status(&status) {
+                    return finished(run_id, &status);
+                }
+                status.label()
+            }
+            // The daemon reaps a finished run, so a run that was live a moment
+            // ago and is now unknown has ended - and its meta.json says how.
+            Ok(ControlResponse::Status { status: None }) => return reaped(run_id),
+            Ok(other) => {
+                return DaemonOutcome::Failed(format!("unexpected daemon response: {other:?}"));
+            }
+            Err(e) => {
+                return DaemonOutcome::Failed(format!("lost contact with the daemon: {e}"));
+            }
+        };
+        if started.elapsed() >= timeout {
+            return DaemonOutcome::Failed(format!(
+                "the run was still '{still}' after {}s - the daemon took the spawn but is not \
+                 getting anywhere. Check `lev ps` for the lane footer.",
+                timeout.as_secs()
+            ));
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+/// Turn a terminal [`AgentStatus`](leviath_runtime::components::AgentStatus)
+/// into the daemon check's verdict, reading the iteration count off disk.
+fn finished(run_id: &str, status: &leviath_runtime::components::AgentStatus) -> DaemonOutcome {
+    use leviath_runtime::components::AgentStatus;
+    let iterations = crate::runstate::read_meta(run_id)
+        .map(|m| m.iteration)
+        .unwrap_or(0);
+    match status {
+        AgentStatus::Complete => DaemonOutcome::Complete(format!(
+            "run {run_id} complete after {iterations} iteration(s)"
+        )),
+        AgentStatus::Error { message } => {
+            DaemonOutcome::Failed(format!("run {run_id} ended in error: {message}"))
+        }
+        other => DaemonOutcome::Failed(format!("run {run_id} ended {}", other.label())),
+    }
+}
+
+/// The run is no longer known to the daemon: fall back to what it wrote.
+fn reaped(run_id: &str) -> DaemonOutcome {
+    match crate::runstate::read_meta(run_id) {
+        Ok(meta) if crate::runstate::is_terminal_status(&meta.status) => match meta.error {
+            Some(err) => DaemonOutcome::Failed(format!("run {run_id} ended in error: {err}")),
+            None => DaemonOutcome::Complete(format!(
+                "run {run_id} {} after {} iteration(s)",
+                meta.status, meta.iteration
+            )),
+        },
+        // Never seen, or seen and still unfinished: either way the daemon took
+        // the spawn and then lost the run, which is a handoff failure.
+        _ => DaemonOutcome::Failed(format!(
+            "run {run_id} vanished before it finished; the daemon accepted the spawn but \
+             never completed it"
+        )),
+    }
+}
+
+// ─── Orchestration ────────────────────────────────────────────────────────────
+
+/// What the fourth check has to work with.
+///
+/// `Unavailable` exists so a daemon that will not start is still *reported* as
+/// a daemon failure rather than aborting the command: the caller auto-starts
+/// one before the checks begin, and if that abort propagated, `lev doctor`
+/// would refuse to tell you whether your credentials were fine - which is most
+/// of what it is for.
+pub enum DaemonTarget<'a> {
+    /// Do not run the fourth check at all (`--no-daemon`).
+    Skip,
+    /// Run it against this daemon.
+    Client(&'a ControlClient),
+    /// There is no daemon to hand off to, and this is why.
+    Unavailable(String),
+}
+
+/// Run the checks in order, stopping at the first failure.
+pub async fn run_checks(
+    args: &DoctorArgs,
+    build_registry: &dyn Fn(&Config) -> ProviderRegistry,
+    daemon: DaemonTarget<'_>,
+) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // A config that will not parse is itself a finding, and the most common
+    // one there is - reporting it as `config FAIL` beats the bare load error.
+    let config = match Config::load() {
+        Ok(config) => config,
+        Err(e) => {
+            checks.push(Check::fail("config", e.to_string()));
+            return checks;
+        }
+    };
+    for warning in config.validate_keys() {
+        eprintln!("Warning: {warning}");
+    }
+
+    let registry = build_registry(&config);
+    checks.push(config_check(&config, &registry));
+
+    let (check, resolved) = resolve_check(&config, args.model.as_deref(), &registry);
+    checks.push(check);
+    let Some(resolved) = resolved else {
+        return checks;
+    };
+
+    let check = inference_check(resolved.provider.as_ref(), &resolved.model).await;
+    let inference_failed = check.status == CheckStatus::Fail;
+    checks.push(check);
+    if inference_failed {
+        return checks;
+    }
+
+    match daemon {
+        DaemonTarget::Skip => {}
+        DaemonTarget::Unavailable(reason) => checks.push(Check::fail("daemon", reason)),
+        DaemonTarget::Client(client) => {
+            // `.expect`: a temp directory that cannot be created means the
+            // machine has no writable scratch space at all, which every other
+            // part of a run would hit first. Nothing here could report it more
+            // usefully.
+            let stage = tempfile::tempdir().expect("the system temp directory is writable");
+            checks.push(
+                daemon_check(
+                    client,
+                    &resolved.provider_name,
+                    &resolved.model,
+                    DAEMON_TIMEOUT,
+                    DAEMON_POLL,
+                    stage.path(),
+                )
+                .await,
+            );
+        }
+    }
+    checks
+}
+
+/// Print the checks and report the first failure as the command's error, so the
+/// process exits non-zero and `lev doctor` works as a CI gate.
+async fn execute_with_registry(
+    args: DoctorArgs,
+    build_registry: &dyn Fn(&Config) -> ProviderRegistry,
+    daemon: DaemonTarget<'_>,
+) -> anyhow::Result<()> {
+    let checks = run_checks(&args, build_registry, daemon).await;
+    let failed = checks.iter().find(|c| c.status == CheckStatus::Fail);
+
+    if args.json {
+        let report = serde_json::json!({
+            "checks": checks,
+            "passed": failed.is_none(),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).expect("a Check report always serializes")
+        );
+    } else {
+        print!("{}", format_report(&checks));
+    }
+
+    match failed {
+        Some(check) => bail!("doctor failed at: {}", check.name),
+        None => Ok(()),
+    }
+}
+
+/// `lev doctor`. The binary decides what the fourth check gets to talk to; see
+/// [`DaemonTarget`].
+pub async fn execute(args: DoctorArgs, daemon: DaemonTarget<'_>) -> anyhow::Result<()> {
+    execute_with_registry(args, &build_provider_registry_from_config, daemon).await
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -1,0 +1,888 @@
+//! Tests for `lev doctor`.
+//!
+//! Every test that reaches `Config::load()`, the runs directory, or the data
+//! root goes through [`with_env`], which redirects all three at once. No test
+//! can make a billed call: the provider registry is always injected, and the
+//! isolation clears every provider key from the environment anyway.
+
+use super::*;
+
+use leviath_providers::{
+    FinishReason, InferenceResponse, ModelCapabilities, ProviderError, TokenUsage,
+};
+use leviath_runtime::components::AgentStatus;
+use leviath_runtime::control_socket::{ControlId, bind_control_listener, control_id};
+use std::path::{Path, PathBuf};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::task::JoinHandle;
+
+// ─── Harness ──────────────────────────────────────────────────────────────────
+
+/// Run `f` with the config path, data root, and runs directory all redirected
+/// into one fresh temp root, and every provider key cleared.
+///
+/// One `temp_env` call, not two: it serializes process-wide and holds its lock
+/// across the future, so nesting `with_isolated_config_path_async` inside a
+/// second call would deadlock.
+async fn with_env<R, Fut>(f: impl FnOnce(PathBuf) -> Fut) -> R
+where
+    Fut: std::future::Future<Output = R>,
+{
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let root = dir.path().to_path_buf();
+    let mut vars = crate::config::config_isolation_vars(&root);
+    vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+    vars.push(("LEVIATH_RUNS_DIR", Some(root.join("runs").into_os_string())));
+    temp_env::async_with_vars(vars, f(root)).await
+}
+
+/// A provider whose single inference is decided up front.
+struct StubProvider {
+    reply: Result<String, ProviderError>,
+}
+
+impl StubProvider {
+    fn replying(content: &str) -> Arc<dyn Provider> {
+        Arc::new(Self {
+            reply: Ok(content.to_string()),
+        })
+    }
+
+    fn failing(message: &str) -> Arc<dyn Provider> {
+        Arc::new(Self {
+            reply: Err(ProviderError::ApiError(message.to_string())),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for StubProvider {
+    async fn infer(
+        &self,
+        _request: InferenceRequest,
+    ) -> leviath_providers::Result<InferenceResponse> {
+        match &self.reply {
+            Ok(content) => Ok(InferenceResponse {
+                content: content.clone(),
+                tool_calls: Vec::new(),
+                tokens_used: TokenUsage {
+                    prompt_tokens: 12,
+                    completion_tokens: 4,
+                    total_tokens: 16,
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                },
+                finish_reason: FinishReason::Complete,
+            }),
+            Err(e) => Err(ProviderError::ApiError(e.to_string())),
+        }
+    }
+
+    async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        text.len()
+    }
+
+    fn max_context_tokens(&self, _model: &str) -> usize {
+        8192
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+
+    fn capabilities(&self, _model: &str) -> ModelCapabilities {
+        ModelCapabilities::default()
+    }
+}
+
+/// A registry holding one stub under `name`.
+fn registry_with(name: &str, provider: Arc<dyn Provider>) -> ProviderRegistry {
+    let mut registry = ProviderRegistry::new();
+    registry.register(name.to_string(), provider);
+    registry
+}
+
+/// Bind a control listener under `dir` and serve `responses` one per incoming
+/// connection - the client opens a fresh one per request. Once they run out the
+/// listener drops, so a further request fails to connect, which is how the
+/// "lost contact" path is driven.
+fn scripted_daemon(dir: &Path, responses: Vec<String>) -> (ControlId, JoinHandle<()>) {
+    let id = control_id(dir);
+    let mut listener = bind_control_listener(&id).expect("bind a fresh control socket");
+    let handle = tokio::spawn(async move {
+        for line in responses {
+            let Ok(Some(stream)) = listener.accept().await else {
+                return;
+            };
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _request = lines.next_line().await;
+            let _ = write_half.write_all(line.as_bytes()).await;
+            let _ = write_half.write_all(b"\n").await;
+        }
+    });
+    (id, handle)
+}
+
+const SPAWNED: &str = r#"{"result":"spawned","run_id":"doctor-1-abc"}"#;
+const COMPLETE: &str = r#"{"result":"status","status":"Complete"}"#;
+const ACTIVE: &str = r#"{"result":"status","status":"Active"}"#;
+
+/// Stage a canary manifest under `root` and hand back its path, for the tests
+/// that drive `spawn_and_wait` directly.
+fn staged(root: &Path) -> PathBuf {
+    stage_canary(root, "stub", "m").expect("staging into a fresh temp dir succeeds")
+}
+
+/// Write a `meta.json` for `run_id` so the on-disk fallbacks have something to
+/// read - one iteration in, and whatever terminal state the test is after.
+fn write_meta(run_id: &str, status: leviath_core::run_meta::RunStatus, error: Option<&str>) {
+    let dir = crate::runstate::run_dir(run_id);
+    std::fs::create_dir_all(&dir).expect("create the run dir");
+    let mut meta = leviath_core::run_meta::RunMeta::new(
+        run_id.to_string(),
+        "doctor".to_string(),
+        String::new(),
+        PROBE_PROMPT.to_string(),
+        None,
+        String::new(),
+        1,
+    );
+    meta.status = status;
+    meta.error = error.map(str::to_string);
+    meta.iteration = 1;
+    std::fs::write(
+        dir.join("meta.json"),
+        serde_json::to_string(&meta).expect("RunMeta serializes"),
+    )
+    .expect("write meta.json");
+}
+
+// ─── format_report ────────────────────────────────────────────────────────────
+
+#[test]
+fn format_report_of_nothing_is_a_pass() {
+    // Degenerate, but the width computation has to survive it.
+    assert!(format_report(&[]).contains("doctor passed"));
+}
+
+#[test]
+fn format_report_renders_timings_and_the_pass_line() {
+    let checks = vec![
+        Check::ok("config", "default_provider=stub"),
+        Check::ok("inference", "12 in / 4 out / 16 total, replied PONG")
+            .timed(Duration::from_millis(1234)),
+    ];
+    let out = format_report(&checks);
+    assert!(out.contains("config     OK"), "columns pad: {out}");
+    assert!(out.contains("(1.2s)"), "timing rendered: {out}");
+    assert!(out.ends_with("doctor passed\n"), "{out}");
+}
+
+#[test]
+fn format_report_of_a_failure_has_no_pass_line() {
+    let checks = vec![
+        Check::ok("config", "fine"),
+        Check::fail("resolve", "resolved to 'nope'"),
+    ];
+    let out = format_report(&checks);
+    assert!(out.contains("FAIL"), "{out}");
+    assert!(!out.contains("doctor passed"), "{out}");
+}
+
+// ─── config_check ─────────────────────────────────────────────────────────────
+
+#[test]
+fn config_check_lists_registered_providers_sorted() {
+    let config = Config::default();
+    let mut registry = registry_with("openrouter", StubProvider::replying("hi"));
+    registry.register("anthropic".to_string(), StubProvider::replying("hi"));
+    let check = config_check(&config, &registry);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.detail.contains("registered: anthropic, openrouter"),
+        "got: {}",
+        check.detail
+    );
+}
+
+#[test]
+fn config_check_says_none_when_nothing_is_registered() {
+    let check = config_check(&Config::default(), &ProviderRegistry::new());
+    assert!(
+        check.detail.contains("registered: none"),
+        "{}",
+        check.detail
+    );
+}
+
+// ─── resolve_check ────────────────────────────────────────────────────────────
+
+#[test]
+fn resolve_check_uses_the_configured_default() {
+    let config = Config {
+        default_provider: "stub".to_string(),
+        default_model: Some("m-1".to_string()),
+        ..Config::default()
+    };
+    let registry = registry_with("stub", StubProvider::replying("hi"));
+    let (check, resolved) = resolve_check(&config, None, &registry);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert_eq!(check.detail, "stub / m-1");
+    let resolved = resolved.expect("a registered provider resolves");
+    assert_eq!(
+        (resolved.provider_name.as_str(), resolved.model.as_str()),
+        ("stub", "m-1")
+    );
+}
+
+#[test]
+fn resolve_check_honours_a_provider_slash_model_override() {
+    let config = Config {
+        default_provider: "anthropic".to_string(),
+        ..Config::default()
+    };
+    let registry = registry_with("stub", StubProvider::replying("hi"));
+    let (check, resolved) = resolve_check(&config, Some("stub/m-2"), &registry);
+    assert_eq!(check.detail, "stub / m-2");
+    assert!(resolved.is_some());
+}
+
+#[test]
+fn resolve_check_reports_an_unconfigured_provider_and_what_was_tried() {
+    // The exact shape of the incident this command exists for: nothing is
+    // registered, so the chain falls through to its hard-coded last resort.
+    let config = Config {
+        default_provider: "openrouter".to_string(),
+        ..Config::default()
+    };
+    let (check, resolved) = resolve_check(&config, None, &ProviderRegistry::new());
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(check.detail.contains("not configured"), "{}", check.detail);
+    assert!(check.detail.contains("openrouter"), "{}", check.detail);
+    assert!(resolved.is_none());
+}
+
+// ─── inference_check ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn inference_check_reports_usage_and_the_echo() {
+    let provider = StubProvider::replying("PONG");
+    let check = inference_check(provider.as_ref(), "m").await;
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check
+            .detail
+            .contains("12 in / 4 out / 16 total, replied PONG"),
+        "got: {}",
+        check.detail
+    );
+    assert!(check.elapsed_ms.is_some());
+}
+
+#[tokio::test]
+async fn inference_check_passes_even_without_the_expected_word() {
+    // The call is what is being checked. What the model chose to say is a note,
+    // not a verdict - otherwise this command would be flaky across providers.
+    let provider = StubProvider::replying("Sure! Hello there.");
+    let check = inference_check(provider.as_ref(), "m").await;
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.detail.contains("no PONG in the reply"),
+        "{}",
+        check.detail
+    );
+}
+
+#[tokio::test]
+async fn inference_check_reports_the_provider_error_verbatim() {
+    let raw = r#"HTTP 402 Payment Required: {"error":{"message":"credit balance too low"}}"#;
+    let provider = StubProvider::failing(raw);
+    let check = inference_check(provider.as_ref(), "m").await;
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.detail.contains("credit balance too low") && check.detail.contains("402"),
+        "the body is the diagnosis and must survive: {}",
+        check.detail
+    );
+}
+
+// ─── The canary blueprint ─────────────────────────────────────────────────────
+
+#[test]
+fn the_canary_manifest_is_a_valid_blueprint() {
+    let manifest = canary_manifest("openrouter", "anthropic/claude-sonnet-4.5");
+    let blueprint =
+        leviath_core::manifest::parse_manifest(&manifest).expect("the canary manifest parses");
+    blueprint.validate().expect("the canary manifest validates");
+    assert_eq!(blueprint.stages.len(), 1, "one stage, one turn");
+    let stage = &blueprint.stages[0];
+    assert_eq!(stage.max_iterations, Some(1));
+    assert!(
+        stage.available_tools.is_empty(),
+        "a probe with a file tool would be judged for not having used it"
+    );
+    assert!(stage.transitions.is_none(), "nothing to transition to");
+    assert_eq!(stage.model.provider(), "openrouter");
+    assert_eq!(stage.model.model(), "anthropic/claude-sonnet-4.5");
+}
+
+#[test]
+fn the_canary_manifest_escapes_hostile_names() {
+    // Provider names come from config, and a quote in one must not be able to
+    // close the TOML literal and inject the rest of the file.
+    let manifest = canary_manifest("ev\"il", "m\\1");
+    let blueprint =
+        leviath_core::manifest::parse_manifest(&manifest).expect("an escaped name still parses");
+    assert_eq!(blueprint.stages[0].model.provider(), "ev\"il");
+    assert_eq!(blueprint.stages[0].model.model(), "m\\1");
+}
+
+#[test]
+fn stage_canary_reports_a_root_it_cannot_write_into() {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let blocker = dir.path().join("not-a-dir");
+    std::fs::write(&blocker, b"i am a file").expect("write the blocker");
+    let err = stage_canary(&blocker, "stub", "m").expect_err("a file is not a directory");
+    assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn stage_canary_reports_a_manifest_it_cannot_write() {
+    // The directory is fine; the manifest path itself is occupied by a
+    // directory, so the write is what fails.
+    let dir = tempfile::tempdir().expect("a temp dir");
+    std::fs::create_dir_all(dir.path().join("doctor").join("agent.leviath"))
+        .expect("occupy the manifest path");
+    let err = stage_canary(dir.path(), "stub", "m").expect_err("cannot write over a directory");
+    assert!(!err.to_string().is_empty());
+}
+
+// ─── Terminal-status reporting ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn finished_reads_the_iteration_count_off_disk() {
+    with_env(|_root| async {
+        write_meta("r-ok", leviath_core::run_meta::RunStatus::Complete, None);
+        let DaemonOutcome::Complete(detail) = finished("r-ok", &AgentStatus::Complete) else {
+            panic!("a Complete run reports complete");
+        };
+        assert!(detail.contains("1 iteration(s)"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn finished_reports_an_errored_run() {
+    with_env(|_root| async {
+        let outcome = finished(
+            "r-err",
+            &AgentStatus::Error {
+                message: "no usable provider".to_string(),
+            },
+        );
+        let DaemonOutcome::Failed(detail) = outcome else {
+            panic!("an errored run fails the check");
+        };
+        assert!(detail.contains("no usable provider"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn finished_reports_any_other_terminal_status() {
+    with_env(|_root| async {
+        let DaemonOutcome::Failed(detail) = finished("r-x", &AgentStatus::Cancelled) else {
+            panic!("a cancelled probe is not a pass");
+        };
+        assert!(detail.contains("cancelled"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reaped_falls_back_to_a_finished_meta() {
+    with_env(|_root| async {
+        write_meta(
+            "r-reaped",
+            leviath_core::run_meta::RunStatus::Complete,
+            None,
+        );
+        let DaemonOutcome::Complete(detail) = reaped("r-reaped") else {
+            panic!("a completed run on disk is a pass");
+        };
+        assert!(detail.contains("Complete after 1 iteration(s)"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reaped_surfaces_a_recorded_error() {
+    with_env(|_root| async {
+        write_meta(
+            "r-bad",
+            leviath_core::run_meta::RunStatus::Error,
+            Some("provider refused"),
+        );
+        let DaemonOutcome::Failed(detail) = reaped("r-bad") else {
+            panic!("a recorded error fails the check");
+        };
+        assert!(detail.contains("provider refused"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reaped_treats_an_unfinished_run_as_a_lost_one() {
+    with_env(|_root| async {
+        write_meta("r-live", leviath_core::run_meta::RunStatus::Running, None);
+        let DaemonOutcome::Failed(detail) = reaped("r-live") else {
+            panic!("a run the daemon forgot mid-flight is a handoff failure");
+        };
+        assert!(detail.contains("vanished"), "{detail}");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reaped_treats_a_run_with_no_meta_as_a_lost_one() {
+    with_env(|_root| async {
+        let DaemonOutcome::Failed(detail) = reaped("r-never") else {
+            panic!("a run with nothing on disk is a handoff failure");
+        };
+        assert!(detail.contains("vanished"), "{detail}");
+    })
+    .await;
+}
+
+// ─── wait_for_run ─────────────────────────────────────────────────────────────
+
+/// Drive `wait_for_run` against a scripted daemon.
+async fn wait_against(responses: Vec<&str>, timeout: Duration) -> DaemonOutcome {
+    let responses: Vec<String> = responses.into_iter().map(str::to_string).collect();
+    with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, responses);
+        wait_for_run(
+            &ControlClient::new(id),
+            "r-wait",
+            timeout,
+            Duration::from_millis(1),
+        )
+        .await
+    })
+    .await
+}
+
+#[tokio::test]
+async fn wait_for_run_returns_as_soon_as_the_run_is_terminal() {
+    let DaemonOutcome::Complete(detail) =
+        wait_against(vec![COMPLETE], Duration::from_secs(5)).await
+    else {
+        panic!("a Complete status ends the wait");
+    };
+    assert!(detail.contains("r-wait"), "{detail}");
+}
+
+#[tokio::test]
+async fn wait_for_run_polls_until_the_run_finishes() {
+    let outcome = wait_against(vec![ACTIVE, ACTIVE, COMPLETE], Duration::from_secs(5)).await;
+    assert!(matches!(outcome, DaemonOutcome::Complete(_)));
+}
+
+#[tokio::test]
+async fn wait_for_run_gives_up_on_a_run_that_never_moves() {
+    // A zero deadline means the very first poll is also the last one.
+    let DaemonOutcome::Failed(detail) = wait_against(vec![ACTIVE], Duration::ZERO).await else {
+        panic!("a run that never leaves 'active' is a wedged handoff");
+    };
+    assert!(detail.contains("still 'active'"), "{detail}");
+}
+
+#[tokio::test]
+async fn wait_for_run_falls_back_to_disk_when_the_run_is_reaped() {
+    let outcome = wait_against(
+        vec![r#"{"result":"status","status":null}"#],
+        Duration::from_secs(5),
+    )
+    .await;
+    // Nothing was written for `r-wait`, so the fallback reports it lost.
+    let DaemonOutcome::Failed(detail) = outcome else {
+        panic!("an unknown run with no meta is a failure");
+    };
+    assert!(detail.contains("vanished"), "{detail}");
+}
+
+#[tokio::test]
+async fn wait_for_run_rejects_an_unexpected_response() {
+    let DaemonOutcome::Failed(detail) =
+        wait_against(vec![r#"{"result":"ok","ok":true}"#], Duration::from_secs(5)).await
+    else {
+        panic!("a nonsense reply is a failure");
+    };
+    assert!(detail.contains("unexpected daemon response"), "{detail}");
+}
+
+#[tokio::test]
+async fn wait_for_run_reports_a_lost_connection() {
+    // No scripted responses: the listener is already gone when we connect.
+    let DaemonOutcome::Failed(detail) = wait_against(vec![], Duration::from_secs(5)).await else {
+        panic!("an unreachable daemon is a failure");
+    };
+    assert!(detail.contains("lost contact"), "{detail}");
+}
+
+// ─── spawn_and_wait ───────────────────────────────────────────────────────────
+
+/// Drive `spawn_and_wait` against a scripted daemon, with the canary staged
+/// into the isolated root.
+async fn spawn_against(responses: Vec<&str>) -> DaemonOutcome {
+    let responses: Vec<String> = responses.into_iter().map(str::to_string).collect();
+    with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, responses);
+        let manifest = staged(&root);
+        spawn_and_wait(
+            &ControlClient::new(id),
+            &manifest,
+            &root,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .await
+    })
+    .await
+}
+
+#[tokio::test]
+async fn spawn_and_wait_completes_a_healthy_handoff() {
+    let outcome = spawn_against(vec![SPAWNED, COMPLETE]).await;
+    assert!(matches!(outcome, DaemonOutcome::Complete(_)), "healthy");
+}
+
+#[tokio::test]
+async fn spawn_and_wait_reports_a_refused_spawn() {
+    let DaemonOutcome::Failed(detail) = spawn_against(vec![
+        r#"{"result":"error","message":"stage 'ping' has no usable provider"}"#,
+    ])
+    .await
+    else {
+        panic!("a refused spawn fails the check");
+    };
+    assert!(detail.contains("no usable provider"), "{detail}");
+}
+
+#[tokio::test]
+async fn spawn_and_wait_rejects_an_unexpected_spawn_response() {
+    let DaemonOutcome::Failed(detail) = spawn_against(vec![r#"{"result":"ok","ok":true}"#]).await
+    else {
+        panic!("a nonsense spawn reply fails the check");
+    };
+    assert!(
+        detail.contains("unexpected daemon response to spawn"),
+        "{detail}"
+    );
+}
+
+#[tokio::test]
+async fn spawn_and_wait_reports_an_unreachable_daemon() {
+    let DaemonOutcome::Failed(detail) = spawn_against(vec![]).await else {
+        panic!("an unreachable daemon fails the check");
+    };
+    assert!(detail.contains("not reachable"), "{detail}");
+}
+
+#[tokio::test]
+async fn spawn_and_wait_reports_a_manifest_it_cannot_resolve() {
+    let outcome = with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, Vec::new());
+        spawn_and_wait(
+            &ControlClient::new(id),
+            &root.join("nowhere").join("agent.leviath"),
+            &root,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .await
+    })
+    .await;
+    let DaemonOutcome::Failed(detail) = outcome else {
+        panic!("a missing manifest fails before the daemon is contacted");
+    };
+    assert!(
+        detail.contains("could not build the spawn request"),
+        "{detail}"
+    );
+}
+
+#[tokio::test]
+async fn spawn_and_wait_leaves_nothing_behind() {
+    // The whole point of a canary is that it cleans up after itself.
+    let leftovers = with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, vec![SPAWNED.to_string(), COMPLETE.to_string()]);
+        let manifest = staged(&root);
+        let _ = spawn_and_wait(
+            &ControlClient::new(id),
+            &manifest,
+            &root,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .await;
+        crate::runstate::run_dir("doctor-1-abc").exists()
+    })
+    .await;
+    assert!(!leftovers, "the probe run must not survive the check");
+}
+
+// ─── daemon_check ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn daemon_check_passes_on_a_healthy_daemon() {
+    let check = with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, vec![SPAWNED.to_string(), COMPLETE.to_string()]);
+        daemon_check(
+            &ControlClient::new(id),
+            "stub",
+            "m",
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+            &root,
+        )
+        .await
+    })
+    .await;
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(check.elapsed_ms.is_some());
+}
+
+#[tokio::test]
+async fn daemon_check_fails_when_the_daemon_is_unreachable() {
+    let check = with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, Vec::new());
+        daemon_check(
+            &ControlClient::new(id),
+            "stub",
+            "m",
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+            &root,
+        )
+        .await
+    })
+    .await;
+    assert_eq!(check.status, CheckStatus::Fail);
+}
+
+#[tokio::test]
+async fn daemon_check_fails_when_the_probe_cannot_be_staged() {
+    let check = with_env(|root| async move {
+        let (id, _server) = scripted_daemon(&root, Vec::new());
+        let blocker = root.join("blocked");
+        std::fs::write(&blocker, b"i am a file").expect("write the blocker");
+        daemon_check(
+            &ControlClient::new(id),
+            "stub",
+            "m",
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+            &blocker,
+        )
+        .await
+    })
+    .await;
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.detail.contains("could not stage a probe agent"),
+        "{}",
+        check.detail
+    );
+}
+
+// ─── cleanup_run ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn cleanup_run_removes_the_run_and_its_saved_state() {
+    with_env(|root| async move {
+        write_meta("r-clean", leviath_core::run_meta::RunStatus::Complete, None);
+        let state = root.join(".leviath").join("state").join("r-clean");
+        std::fs::create_dir_all(&state).expect("create the saved state dir");
+        cleanup_run("r-clean");
+        assert!(!crate::runstate::run_dir("r-clean").exists());
+        assert!(!state.exists());
+    })
+    .await;
+}
+
+// ─── run_checks ───────────────────────────────────────────────────────────────
+
+/// A registry builder that ignores the config and always yields `registry`.
+fn always(registry: ProviderRegistry) -> impl Fn(&Config) -> ProviderRegistry {
+    move |_| registry.clone()
+}
+
+/// Write the smallest `config.toml` that parses, naming `provider`/`model` as
+/// the defaults and appending `providers_extra` under `[providers]`.
+fn write_config(root: &Path, provider: &str, model: Option<&str>, providers_extra: &str) {
+    let model_line = model
+        .map(|m| format!("default_model = \"{m}\"\n"))
+        .unwrap_or_default();
+    std::fs::write(
+        root.join("config.toml"),
+        format!(
+            "agent_paths = []\ndefault_provider = \"{provider}\"\n{model_line}\
+             \n[providers]\n{providers_extra}"
+        ),
+    )
+    .expect("write config.toml");
+}
+
+#[tokio::test]
+async fn run_checks_reports_a_config_that_will_not_parse() {
+    let checks = with_env(|root| async move {
+        std::fs::write(root.join("config.toml"), "this is not = = toml").expect("write");
+        let build = always(ProviderRegistry::new());
+        run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert_eq!(checks.len(), 1, "nothing runs after a broken config");
+    assert_eq!(checks[0].name, "config");
+    assert_eq!(checks[0].status, CheckStatus::Fail);
+}
+
+#[tokio::test]
+async fn run_checks_stops_at_an_unconfigured_provider() {
+    let checks = with_env(|root| async move {
+        write_config(&root, "openrouter", None, "");
+        let build = always(ProviderRegistry::new());
+        run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert_eq!(checks.len(), 2, "no inference is attempted: {checks:?}");
+    assert_eq!(checks[1].name, "resolve");
+    assert_eq!(checks[1].status, CheckStatus::Fail);
+}
+
+#[tokio::test]
+async fn run_checks_stops_at_a_failing_inference() {
+    let checks = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::failing("HTTP 402")));
+        run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert_eq!(checks.len(), 3, "the daemon is never contacted: {checks:?}");
+    assert_eq!(checks[2].status, CheckStatus::Fail);
+}
+
+#[tokio::test]
+async fn run_checks_skips_the_daemon_when_asked_to() {
+    let checks = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert_eq!(checks.len(), 3, "--no-daemon stops after the inference");
+    assert!(checks.iter().all(|c| c.status == CheckStatus::Ok));
+}
+
+#[tokio::test]
+async fn run_checks_reports_a_daemon_that_would_not_start() {
+    // The credentials are fine and the report says so; the daemon is the
+    // problem, and the report says that too. Answering neither - which is what
+    // aborting on the auto-start failure would do - is the thing to avoid.
+    let checks = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        let target = DaemonTarget::Unavailable("did not start within 5s".to_string());
+        run_checks(&DoctorArgs::default(), &build, target).await
+    })
+    .await;
+    assert_eq!(checks.len(), 4, "{checks:?}");
+    assert!(checks[..3].iter().all(|c| c.status == CheckStatus::Ok));
+    assert_eq!(checks[3].status, CheckStatus::Fail);
+    assert!(checks[3].detail.contains("did not start"), "{checks:?}");
+}
+
+#[tokio::test]
+async fn run_checks_runs_all_four_against_a_healthy_daemon() {
+    let checks = with_env(|root| async move {
+        // A key of the wrong shape, so the warning branch runs too.
+        write_config(
+            &root,
+            "stub",
+            Some("m"),
+            "anthropic_api_key = \"not-a-real-shape\"\n",
+        );
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        let (id, _server) = scripted_daemon(&root, vec![SPAWNED.to_string(), COMPLETE.to_string()]);
+        let client = ControlClient::new(id);
+        run_checks(
+            &DoctorArgs::default(),
+            &build,
+            DaemonTarget::Client(&client),
+        )
+        .await
+    })
+    .await;
+    assert_eq!(checks.len(), 4, "{checks:?}");
+    assert!(
+        checks.iter().all(|c| c.status == CheckStatus::Ok),
+        "{checks:?}"
+    );
+}
+
+// ─── execute ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn execute_prints_a_table_and_succeeds() {
+    let result = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        execute_with_registry(DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[tokio::test]
+async fn execute_prints_json_when_asked() {
+    let result = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        let args = DoctorArgs {
+            json: true,
+            ..DoctorArgs::default()
+        };
+        execute_with_registry(args, &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[tokio::test]
+async fn execute_names_the_check_that_failed() {
+    let err = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::failing("HTTP 402")));
+        execute_with_registry(DoctorArgs::default(), &build, DaemonTarget::Skip)
+            .await
+            .expect_err("a failing inference fails the command")
+    })
+    .await;
+    assert_eq!(err.to_string(), "doctor failed at: inference");
+}
+
+#[tokio::test]
+async fn execute_wires_the_real_registry_builder() {
+    // `execute` differs from `execute_with_registry` only in that builder, and
+    // with no credentials in the isolated env it resolves to nothing usable -
+    // which is the answer, and proves the production seam is connected.
+    let err = with_env(|root| async move {
+        write_config(&root, "nothing-here", None, "");
+        execute(DoctorArgs::default(), DaemonTarget::Skip)
+            .await
+            .expect_err("no configured provider fails the command")
+    })
+    .await;
+    assert_eq!(err.to_string(), "doctor failed at: resolve");
+}

--- a/crates/leviath-cli/src/commands/mod.rs
+++ b/crates/leviath-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod ctl;
 pub mod daemon;
 pub mod daemon_service;
 pub mod dashboard;
+pub mod doctor;
 pub mod list;
 pub mod mcp;
 pub mod models;

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -1251,8 +1251,14 @@ fn make_fake_config_dir(unique: &str) -> std::path::PathBuf {
 /// `LEVIATH_SKIP_DOTENV`, and clear every provider API key (so no real, billed
 /// inference call can be made). Consumed by [`with_isolated_config_path`] and
 /// its async twin, which hand it to `temp_env` for scoped set-and-restore.
+///
+/// `pub(crate)` because `temp_env` serializes process-wide and holds its lock
+/// across the closure, so a test needing *these* overrides plus others (the
+/// `lev doctor` tests also redirect `LEVIATH_HOME` and `LEVIATH_RUNS_DIR`)
+/// cannot nest a second `temp_env` call inside the wrapper - it has to build
+/// one combined list from this one.
 #[cfg(test)]
-fn config_isolation_vars(
+pub(crate) fn config_isolation_vars(
     fake_dir: &std::path::Path,
 ) -> Vec<(&'static str, Option<std::ffi::OsString>)> {
     let mut vars: Vec<(&'static str, Option<std::ffi::OsString>)> = vec![

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -52,6 +52,10 @@ pub enum Commands {
     /// Answer a pending interaction (or list open ones with no request id)
     Respond(commands::ctl::RespondArgs),
 
+    /// Check that provider wiring works, end to end
+    #[command(long_about = commands::doctor::DOCTOR_LONG_ABOUT)]
+    Doctor(commands::doctor::DoctorArgs),
+
     /// List available and installed blueprints
     List(commands::list::ListArgs),
 
@@ -127,6 +131,9 @@ pub trait RiskyExecutors {
     async fn resume(&self, args: commands::ctl::ResumeArgs) -> anyhow::Result<()>;
     /// `lev respond` - resolves the control-socket path and answers/lists interactions.
     async fn respond(&self, args: commands::ctl::RespondArgs) -> anyhow::Result<()>;
+    /// `lev doctor` - makes real billed inference calls, and (unless
+    /// `--no-daemon`) auto-starts the daemon and spawns a throwaway run.
+    async fn doctor(&self, args: commands::doctor::DoctorArgs) -> anyhow::Result<()>;
     /// `lev setup` - interactive (blocking stdin) or `--non-interactive`.
     async fn setup(&self, args: commands::setup::SetupArgs) -> anyhow::Result<()>;
     /// `lev dash` - takes over the real terminal and blocks on real keyboard input.
@@ -174,6 +181,7 @@ pub async fn dispatch(command: Commands, ex: &impl RiskyExecutors) -> anyhow::Re
         Commands::Pause(args) => ex.pause(args).await,
         Commands::Resume(args) => ex.resume(args).await,
         Commands::Respond(args) => ex.respond(args).await,
+        Commands::Doctor(args) => ex.doctor(args).await,
         Commands::List(args) => commands::list::execute(args).await,
         Commands::Add(args) => commands::add::execute(args).await,
         Commands::Remove(args) => commands::remove::execute(args).await,
@@ -213,6 +221,9 @@ mod tests {
             Ok(())
         }
         async fn respond(&self, _args: commands::ctl::RespondArgs) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn doctor(&self, _args: commands::doctor::DoctorArgs) -> anyhow::Result<()> {
             Ok(())
         }
         async fn cancel(&self, _args: commands::ctl::CancelArgs) -> anyhow::Result<()> {
@@ -330,6 +341,14 @@ mod tests {
             session: false,
         };
         assert!(dispatch(Commands::Respond(args), &MockRisky).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_doctor_variant_is_routed_through_the_executor() {
+        // Routed, not called directly: `lev doctor` bills two inferences and
+        // auto-starts a daemon, so a unit test must never reach the real one.
+        let args = commands::doctor::DoctorArgs::default();
+        assert!(dispatch(Commands::Doctor(args), &MockRisky).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -94,6 +94,10 @@ impl RiskyExecutors for RealExecutors {
         commands::ctl::respond(&control_client()?, &args).await
     }
 
+    async fn doctor(&self, args: commands::doctor::DoctorArgs) -> anyhow::Result<()> {
+        real_doctor(args).await
+    }
+
     async fn setup(&self, args: commands::setup::SetupArgs) -> anyhow::Result<()> {
         real_setup(args).await
     }
@@ -209,6 +213,30 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
     // to happen (a bad path, a typo'd region) from auto-starting a daemon.
     ensure_daemon_running().await?;
     leviath_cli::daemon::client::send_spawn(&control_client()?, spawn_args).await
+}
+
+/// `lev doctor`: run the wiring checks, starting the daemon first so the fourth
+/// one has something to hand off to.
+///
+/// A daemon that will not start is reported *as* the fourth check failing, not
+/// propagated: the whole point of the command is to say whether the credentials
+/// or the daemon is at fault, and aborting here would answer neither.
+/// `--no-daemon` skips both the auto-start and the check, so a caller who only
+/// wants to test credentials never causes a daemon to exist. The checks
+/// themselves are the tested `commands::doctor::run_checks`; the auto-start and
+/// socket connect are the un-unit-testable slivers kept here.
+async fn real_doctor(args: commands::doctor::DoctorArgs) -> anyhow::Result<()> {
+    use commands::doctor::DaemonTarget;
+    if args.no_daemon {
+        return commands::doctor::execute(args, DaemonTarget::Skip).await;
+    }
+    let started = ensure_daemon_running()
+        .await
+        .and_then(|()| control_client());
+    match started {
+        Ok(client) => commands::doctor::execute(args, DaemonTarget::Client(&client)).await,
+        Err(e) => commands::doctor::execute(args, DaemonTarget::Unavailable(e.to_string())).await,
+    }
 }
 
 /// Ensure a daemon is listening on the control port, auto-starting a detached

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -117,7 +117,12 @@ pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool
 ///
 /// A `--model provider/model` override is the whole list on its own: it names
 /// exactly one provider and skips the blueprint's fallbacks entirely.
-fn providers_tried(
+///
+/// Public because [`resolve_stages`] is not the only place that has to explain
+/// an unusable resolution: `lev doctor` runs the same chain against an empty
+/// [`ModelConfig`] to report what the user's config alone would pick, and it
+/// must name the same providers in the same order rather than reimplement this.
+pub fn providers_tried(
     model_cfg: &ModelConfig,
     model_override: Option<&str>,
     defaults: &ModelDefaults,

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -310,6 +310,45 @@ Start the [REST and WebSocket API](/docs/api).
 
 ## Configuration and tools
 
+### `lev doctor`
+
+Check that provider wiring works, end to end. Four checks run in order, the first failure stops the
+rest, and the one that fails is the diagnosis.
+
+| Check | What it proves | A failure means |
+|---|---|---|
+| `config` | `config.toml` parses and a provider registry can be built | The config file is malformed |
+| `resolve` | Your defaults pick a provider that is actually registered | A key is missing or misspelled |
+| `inference` | One real call reaches the model | A bad key, an unknown model id, or a billing problem |
+| `daemon` | A one-stage agent spawns over the control socket, runs, and finishes | The handoff is broken even though the credentials are fine |
+
+```bash
+$ lev doctor
+
+  config     OK  default_provider=openrouter; registered: ollama, openrouter (script providers resolve by name)
+  resolve    OK  openrouter / anthropic/claude-sonnet-4.5
+  inference  OK  12 in / 4 out / 16 total, replied PONG  (1.2s)
+  daemon     OK  run doctor-1785649252-bf7b3d07a265 Complete after 1 iteration(s)  (0.3s)
+
+doctor passed
+```
+
+The fourth check spawns a throwaway one-stage agent with no tools, waits for it, and then deletes
+the run. Nothing is left in `lev ps` or on disk.
+
+| Flag | Purpose |
+|---|---|
+| `-m`, `--model <MODEL>` | Test a specific model. Takes the same forms as `lev run --model`: `provider/model` picks both, a bare model id pairs with your `default_provider` |
+| `--no-daemon` | Stop after the third check. Contacts no daemon, starts none, and creates no run |
+| `--json` | Print the checks as `{"checks": [...], "passed": bool}` |
+
+`--model provider/model` is the way to reach a [Rhai script provider](/docs/rhai-providers), which
+is resolved by name and so cannot be listed. Use it to try a model string before wiring it into a
+blueprint.
+
+`lev doctor` exits non-zero when a check fails, so it works as a CI gate. It bills two inferences
+per run, each capped at 64 output tokens; `--no-daemon` bills one.
+
 ### `lev setup`
 
 The interactive [provider](/docs/providers) wizard. Every value it asks for has a flag, so the

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -9,6 +9,13 @@ order: 2
 
 Common snags and how to clear them.
 
+## Start with `lev doctor`
+
+Before reading further, run [`lev doctor`](/docs/cli#lev-doctor). It checks the config file, model
+resolution, one real inference, and the daemon handoff, in that order, and reports each one. The
+check that fails tells you which section below you need — in particular it separates "my keys are
+wrong" from "the daemon is wedged", which look identical from the outside.
+
 ## The console can't reach my server
 
 The browser [console](/app) talks straight to your `lev serve` endpoint, so three things must line
@@ -44,11 +51,16 @@ isn't mounted, so it returns **405 Method Not Allowed** (the read routes still w
 An agent needs at least one [provider](/docs/providers). Run `lev setup`, or point Leviath at a
 local [Ollama](https://ollama.com) for a no-key start.
 
+`lev doctor` says which provider your defaults actually resolve to, and which ones it tried to get
+there. That matters because a stage naming no model of its own falls back to `anthropic` — so a
+machine with only an OpenRouter key can resolve to a provider it has no credential for, spawn, and
+sit at iteration 0.
+
 ## A run says `running` but never does anything
 
-Check its provider first. If a stage's model list names only providers you haven't configured,
-`lev run` refuses the spawn outright and tells you which ones it tried — configure one with
-`lev setup`, or add it to `config.toml` and restart the daemon.
+Check its provider first, with `lev doctor`. If a stage's model list names only providers you
+haven't configured, `lev run` refuses the spawn outright and tells you which ones it tried —
+configure one with `lev setup`, or add it to `config.toml` and restart the daemon.
 
 A run that gets past that and still can't dispatch (say you removed a provider key after it
 started) is failed after `[limits] stall_timeout_secs`, 60 seconds by default. Its `meta.json`


### PR DESCRIPTION
Closes #211.

## The problem

There was no way to find out whether an install could actually reach a model
without building a throwaway agent by hand, running it, deleting the agent, and
archiving the run. Four manual steps, and the only thing anyone wanted out of
them was one bit of information.

Worse, a single pass/fail probe would not have been enough. A credential problem
and a daemon problem look identical from the outside, which is exactly why the
upgrade smoke test needed a real run to tell them apart.

## What this adds

`lev doctor` runs four checks in order, reports each one, and stops at the first
failure. The check that fails is the diagnosis.

| Check | Proves | A failure means |
|---|---|---|
| `config` | `config.toml` parses, a registry can be built | The config file is malformed |
| `resolve` | The defaults pick a provider that is really registered | A key is missing or misspelled |
| `inference` | One real call reaches the model | Bad key, unknown model id, or billing |
| `daemon` | A one-turn agent spawns over the control socket and finishes | The handoff is broken though the credentials are fine |

```
$ lev doctor

  config     OK  default_provider=openrouter; registered: ollama, openrouter (script providers resolve by name)
  resolve    OK  openrouter / anthropic/claude-sonnet-4.5
  inference  OK  12 in / 4 out / 16 total, replied PONG  (1.2s)
  daemon     OK  run doctor-1785649252-bf7b3d07a265 Complete after 1 iteration(s)  (0.3s)

doctor passed
```

Flags: `-m/--model` (same forms as `lev run --model`), `--no-daemon` (stop after
the inference, contact no daemon, create no run), `--json`. Exits non-zero on
failure, so it works as a CI gate. Two billed inferences per run, capped at 64
output tokens each; `--no-daemon` bills one.

## Notes on the design

**The resolve check is the one that would have caught the iter=0 fleet.** A stage
naming no model of its own falls through to a hard-coded `anthropic`, so a
machine holding only an OpenRouter key resolves to a provider it has no
credential for, spawns, and sits at iteration 0. It reuses the runtime's own
`resolve_stage_model` and its `providers_tried` (now `pub`) so it names the same
providers, in the same order, as the spawn-time guard in `resolve_stages`.

**Provider errors are printed verbatim**, status line and response body included.
A 402 naming the exhausted credit is the whole diagnosis; summarising it would
throw the answer away.

**Whether the model actually said PONG is reported but never fails the check.**
The call succeeding is what is being tested. Failing on the reply would make the
command flaky across providers.

**A daemon that will not start is reported as the fourth check failing**, not
propagated. Found while live-testing: `ensure_daemon_running()` aborting would
have made `lev doctor` refuse to say whether the credentials were fine, which is
most of what it is for. Hence `DaemonTarget::{Skip, Client, Unavailable}`.

**The probe cleans up after itself.** The throwaway agent is staged in a temp
directory; the run is force-cancelled then deleted on every path out, including
the failing ones, in the order the dashboard's delete documents (record terminal
first, so a lost race with an in-flight persist job reappears as finished rather
than live).

The daemon-touching I/O sits behind `RiskyExecutors`; the cores are driven by
unit tests against injected registries and a scripted control socket.

## Verification

- `cargo xtask coverage` at 100% for `leviath-cli` and `leviath-runtime`.
- Full workspace suite green; clippy clean; `cargo fmt` applied.
- Live-verified against a real daemon under an isolated `LEVIATH_HOME`, with a
  Rhai mock provider:
  1. All four checks pass; `runs/` is empty afterwards and `lev ps` shows nothing.
  2. `default_provider = "nope"` → `resolve FAIL  resolved to 'anthropic', which is not configured (tried: nope)`, checks 3-4 never run.
  3. `--model broke/whatever` → the provider's raw `HTTP 402 Payment Required: {"error":{"message":"credit balance is too low"}}`, verbatim.
  4. Daemon unable to bind its socket → checks 1-3 OK, `daemon FAIL  the leviath daemon did not start within 5s`.
  5. Recovery once the daemon can start again, still leaving nothing behind.
  6. `--no-daemon` stops after the inference and starts no daemon.
  7. `--json` shape, and exit code 1 on failure.
- A Rhai script provider resolves by name throughout (`registry.get` consults
  the script layer), which is how the reporter's `xai`/`spark1` providers are
  reachable at all.

## `main.rs`

Touches `main.rs` (the `RealExecutors::doctor` wiring and `real_doctor`), so this
needs the `allow-main-rs-change` label before CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dsg6tX9Pn5TNWGgHn5SeMY