### PR TITLE
Keep a finished run in the listing long enough to be seen (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ requests since the previous version.
 
 ## Unreleased
 
+- A run stays in `lev ps` for five minutes after it ends instead of vanishing
+  when the daemon unloads it. A run that died on its first inference used to
+  leave the listing a second or two later, which made it indistinguishable from
+  a run that had never been spawned: both read as `no agents running`. Anything
+  scheduling work by spawning agents then had to guess how long a healthy agent
+  takes to get going, and a guess that came in under a cold start would abandon
+  runs that were still starting. The row now carries the status the run ended
+  on, so an `HTTP 402` at iteration 0 says so. Tunable with
+  `[limits] finished_retention_secs`; `0` restores the old behaviour. The record
+  is in memory, so a restart clears it, and `meta.json` and `GET /api/agents`
+  remain the durable copy.
+- `lev ps --json` gained a `finished` key alongside `runs` and `health`.
+  Finished runs are kept apart rather than mixed in, so `lev daemon status` and
+  the dashboard still count only the agents the daemon is hosting.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -49,6 +49,12 @@ So `waiting: children(3)` alongside busy children is a healthy factory, while
 `waiting: tool approval` is stopped until someone answers. Run with `--yolo` to
 approve automatically, including for sub-agents and fan-out workers.
 
+A run stays listed for a few minutes after it finishes, so a script polling on
+an interval learns how a run ended rather than finding it gone. Set
+`[limits] finished_retention_secs` to change the window, or 0 to drop a run the
+moment it finishes. The record is held in memory, so a daemon restart clears it;
+`meta.json` and the REST API keep the durable copy.
+
 A `lanes:` line under the table means the daemon itself is worth a look. It
 shows the tool lane's occupancy - batches running, parked on a wait, and queued
 behind them - and, if the daemon has stopped getting anywhere, how many re-drive
@@ -56,7 +62,8 @@ cycles it has gone without a single run moving. A run parked on a wait costs the
 lane nothing, so `parked` is not a problem on its own; `queued` with no progress
 is.
 
---json prints {\"runs\": [...], \"health\": {...}} with the same two halves.";
+--json prints {\"runs\": [...], \"finished\": [...], \"health\": {...}}, keeping
+finished runs apart from the ones the daemon is still hosting.";
 
 /// Arguments for `lev ps`.
 #[derive(clap::Args, Debug, Clone, Default)]
@@ -150,15 +157,27 @@ fn health_footer(health: &DaemonHealth) -> Option<String> {
 /// Render a run listing as an aligned table (or a friendly note when empty),
 /// with the daemon's own health underneath when it has something to say.
 ///
+/// `finished` are runs the daemon has unloaded but still remembers. They are
+/// listed after the live ones rather than left out, because "the run I started
+/// died on its first inference" and "there is no such run" are the two answers
+/// issue #205's scheduler could not tell apart, and an empty table said the
+/// second when it meant the first.
+///
 /// `now` is unix seconds, passed in rather than read here so the output is
 /// deterministic under test.
-pub fn format_runs(runs: &[RunListEntry], health: &DaemonHealth, now: i64) -> String {
-    if runs.is_empty() {
+pub fn format_runs(
+    runs: &[RunListEntry],
+    finished: &[RunListEntry],
+    health: &DaemonHealth,
+    now: i64,
+) -> String {
+    if runs.is_empty() && finished.is_empty() {
         return "no agents running".to_string();
     }
     let headers = ["RUN", "STATUS", "STAGE", "ITER", "TOOLS", "AGE"];
     let rows: Vec<[String; 6]> = runs
         .iter()
+        .chain(finished)
         .map(|e| {
             [
                 e.run_id.clone(),
@@ -222,21 +241,28 @@ pub fn format_runs(runs: &[RunListEntry], health: &DaemonHealth, now: i64) -> St
 /// Query the daemon for its runs and print the listing.
 pub async fn send_list(client: &ControlClient, args: &PsArgs) -> anyhow::Result<()> {
     match client.list().await {
-        Ok(ControlResponse::List { runs, health }) => {
+        Ok(ControlResponse::List {
+            runs,
+            finished,
+            health,
+        }) => {
             match args.json {
                 // Plain data with no map keys to reject, so serializing cannot
-                // fail.
+                // fail. `finished` is its own key rather than folded into
+                // `runs` so a script can tell a run that is still going from one
+                // that has ended without guessing from the status.
                 true => println!(
                     "{}",
                     serde_json::to_string_pretty(&serde_json::json!({
                         "runs": runs,
+                        "finished": finished,
                         "health": health,
                     }))
                     .expect("a run listing serializes")
                 ),
                 false => println!(
                     "{}",
-                    format_runs(&runs, &health, chrono::Utc::now().timestamp())
+                    format_runs(&runs, &finished, &health, chrono::Utc::now().timestamp())
                 ),
             }
             Ok(())

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -133,7 +133,49 @@ fn stage_cell_shows_position_only_for_multi_stage_blueprints() {
 
 #[test]
 fn format_runs_handles_empty() {
-    assert_eq!(format_runs(&[], &healthy_daemon(), 0), "no agents running");
+    assert_eq!(
+        format_runs(&[], &[], &healthy_daemon(), 0),
+        "no agents running"
+    );
+}
+
+/// Issue #205: a scheduler spawns a run, the run dies on its first inference,
+/// and the daemon unloads it. Nothing is running, but "no agents running" is the
+/// answer that cost forty minutes of spawn-and-revert, because it reads exactly
+/// like a run that was never spawned. The row has to be there, with the reason.
+#[test]
+fn format_runs_shows_a_finished_run_when_nothing_is_running() {
+    let mut died = entry(
+        "worker-1785616492",
+        AgentStatus::Error {
+            message: "HTTP 402 Payment Required".to_string(),
+        },
+    );
+    died.last_progress_at = Some(1_140);
+
+    let out = format_runs(&[], &[died], &healthy_daemon(), 1_200);
+    assert_ne!(out, "no agents running");
+    let lines: Vec<&str> = out.lines().collect();
+    assert!(lines[0].starts_with("RUN"), "header row: {out}");
+    assert!(lines[1].contains("worker-1785616492"), "{out}");
+    assert!(lines[1].contains("HTTP 402"), "the reason it ended: {out}");
+    assert!(lines[1].contains("1m"), "and how long ago: {out}");
+}
+
+/// Finished runs are listed under the live ones, not mixed into them, and a
+/// finished run is never counted as needing an answer.
+#[test]
+fn format_runs_lists_finished_runs_after_the_live_ones() {
+    let out = format_runs(
+        &[entry("run-live", AgentStatus::Active)],
+        &[entry("run-ended", AgentStatus::Complete)],
+        &healthy_daemon(),
+        0,
+    );
+    let lines: Vec<&str> = out.lines().collect();
+    assert!(lines[1].contains("run-live"), "{out}");
+    assert!(lines[2].contains("run-ended"), "{out}");
+    assert!(!out.contains("needs an answer"), "{out}");
 }
 
 /// The whole point of the change: two runs both `Waiting`, telling the operator
@@ -153,7 +195,7 @@ fn format_runs_distinguishes_two_kinds_of_waiting() {
     parked.tool_calls = 1;
     parked.last_progress_at = Some(1_190);
 
-    let out = format_runs(&[blocked, parked], &healthy_daemon(), 1_200);
+    let out = format_runs(&[blocked, parked], &[], &healthy_daemon(), 1_200);
     let lines: Vec<&str> = out.lines().collect();
     assert!(lines[0].starts_with("RUN"), "header row: {out}");
     assert!(lines[0].contains("AGE"), "header row: {out}");
@@ -175,13 +217,18 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
         e
     };
     assert!(
-        !format_runs(std::slice::from_ref(&healthy), &healthy_daemon(), 0)
+        !format_runs(std::slice::from_ref(&healthy), &[], &healthy_daemon(), 0)
             .contains("needs an answer"),
         "a fan-out parent is not blocked on anyone"
     );
     assert!(
-        !format_runs(&[entry("run-b", AgentStatus::Active)], &healthy_daemon(), 0)
-            .contains("needs an answer")
+        !format_runs(
+            &[entry("run-b", AgentStatus::Active)],
+            &[],
+            &healthy_daemon(),
+            0
+        )
+        .contains("needs an answer")
     );
 
     let prompt = |id: &str, reason: WaitReason| {
@@ -191,6 +238,7 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
     };
     let one = format_runs(
         &[prompt("run-c", WaitReason::TaintGate), healthy.clone()],
+        &[],
         &healthy_daemon(),
         0,
     );
@@ -202,6 +250,7 @@ fn format_runs_calls_out_only_the_runs_needing_an_answer() {
             prompt("run-d", WaitReason::InteractionPoint),
             healthy,
         ],
+        &[],
         &healthy_daemon(),
         0,
     );
@@ -221,7 +270,7 @@ fn format_runs_aligns_columns() {
     let short = entry("a", AgentStatus::Active);
     let mut long = entry("a-much-longer-run-id", AgentStatus::Waiting);
     long.wait_reason = Some(WaitReason::UserPrompt);
-    let out = format_runs(&[short, long], &healthy_daemon(), 0);
+    let out = format_runs(&[short, long], &[], &healthy_daemon(), 0);
     let lines: Vec<&str> = out.lines().collect();
 
     let status_col = lines[0]
@@ -247,14 +296,19 @@ fn format_runs_aligns_columns() {
 /// operators to skip the one that matters.
 #[test]
 fn a_healthy_daemon_adds_no_footer() {
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &healthy_daemon(), 0);
+    let out = format_runs(
+        &[entry("run-a", AgentStatus::Active)],
+        &[],
+        &healthy_daemon(),
+        0,
+    );
     assert!(!out.contains("lanes:"), "{out}");
     // Parked batches on their own are not a problem: they hold no capacity.
     let parked = DaemonHealth {
         tools_parked: 3,
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &parked, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &parked, 0);
     assert!(!out.contains("lanes:"), "{out}");
 }
 
@@ -269,7 +323,7 @@ fn a_saturated_lane_is_reported_under_the_table() {
         tools_parked: 3,
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &health, 0);
     assert!(
         out.ends_with("lanes: tools 8/8 busy, 3 parked, 12 queued"),
         "{out}"
@@ -287,7 +341,7 @@ fn a_dead_cycle_streak_is_reported_in_cycles_and_minutes() {
         dead_cycles: 4,
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &health, 0);
     assert!(
         out.ends_with("lanes: tools 8/8 busy, 12 queued  ·  no progress for 4 cycles (2m)"),
         "{out}"
@@ -299,7 +353,7 @@ fn a_dead_cycle_streak_is_reported_in_cycles_and_minutes() {
         dead_cycles: 1,
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &drained, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &drained, 0);
     assert!(
         out.ends_with("lanes: tools 0/8 busy  ·  no progress for 1 cycles (30s)"),
         "{out}"
@@ -316,7 +370,7 @@ fn the_footer_and_the_answer_call_out_coexist() {
         dead_cycles: 2,
         ..healthy_daemon()
     };
-    let out = format_runs(&[blocked], &health, 0);
+    let out = format_runs(&[blocked], &[], &health, 0);
     assert!(out.contains("1 run needs an answer: lev respond"), "{out}");
     assert!(out.contains("no progress for 2 cycles"), "{out}");
 }
@@ -352,7 +406,9 @@ async fn list(response_line: &'static str, args: &PsArgs) -> anyhow::Result<()> 
     result
 }
 
-const LISTING: &str = r#"{"result":"list","runs":[{"run_id":"run-a","status":"Waiting","reason":"tool_approval","stage":"implement","iteration":3,"tool_calls":7,"unattended":true}]}"#;
+/// One run still going and one the daemon has finished with, so both halves of
+/// the reply are exercised by the table and the `--json` paths alike.
+const LISTING: &str = r#"{"result":"list","runs":[{"run_id":"run-a","status":"Waiting","reason":"tool_approval","stage":"implement","iteration":3,"tool_calls":7,"unattended":true}],"finished":[{"run_id":"run-b","status":{"Error":{"message":"HTTP 402 Payment Required"}},"stage":"implement","iteration":0,"tool_calls":0}]}"#;
 
 #[tokio::test]
 async fn send_list_prints_runs() {

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -330,6 +330,7 @@ mod tests {
     async fn send_message_unexpected_is_500() {
         let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::List {
             runs: vec![],
+            finished: vec![],
             health: Default::default(),
         });
         assert_eq!(

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -145,6 +145,12 @@ pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
         Some(&before.limits.dead_cycles_before_relief),
         Some(&after.limits.dead_cycles_before_relief),
     );
+    push_if_changed(
+        &mut out,
+        "finished run retention (seconds)",
+        Some(&before.limits.finished_retention_secs),
+        Some(&after.limits.finished_retention_secs),
+    );
 
     let added = after
         .mcp_servers

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -902,6 +902,11 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             help: "Widen the tool lane after this many 30s cycles with work queued and nothing moving. 0 never does.",
             value: FieldValue::Number(Some(config.limits.dead_cycles_before_relief as u64)),
         },
+        Field {
+            label: "Finished run retention (seconds)",
+            help: "Keep a run in `lev ps` this long after it ends, so a script polling on an interval sees how it ended. 0 drops it at once.",
+            value: FieldValue::Number(Some(config.limits.finished_retention_secs)),
+        },
     ]
 }
 
@@ -936,6 +941,11 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
                 config.limits.dead_cycles_before_relief = n
                     .map(|n| n as u32)
                     .unwrap_or(Config::default().limits.dead_cycles_before_relief)
+            }
+            // And again: unset keeps the default, 0 means keep nothing.
+            (7, FieldValue::Number(n)) => {
+                config.limits.finished_retention_secs =
+                    n.unwrap_or(Config::default().limits.finished_retention_secs)
             }
             _ => {}
         }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -427,6 +427,10 @@ fn default_dead_cycles_before_relief() -> u32 {
     leviath_runtime::host::DEFAULT_DEAD_CYCLES_BEFORE_RELIEF
 }
 
+fn default_finished_retention_secs() -> u64 {
+    leviath_runtime::host::DEFAULT_FINISHED_RETENTION_SECS
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -496,6 +500,23 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_dead_cycles_before_relief")]
     pub dead_cycles_before_relief: u32,
+
+    /// How long (seconds) a run keeps its place in `lev ps` after the daemon
+    /// unloads it from memory.
+    ///
+    /// A terminal run used to leave the listing the moment it was unloaded,
+    /// which made a run that died on its first inference look exactly like a run
+    /// that had never been spawned. A scheduler polling the listing could only
+    /// tell the two apart with a stopwatch, and issue #205 is what that cost:
+    /// forty minutes of spawning work, timing out, and spawning it again.
+    ///
+    /// Defaults to `300`. `0` drops a run as soon as it finishes, which is the
+    /// old behaviour. The record lives in memory, so a restart clears it
+    /// whatever this is set to.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_finished_retention_secs")]
+    pub finished_retention_secs: u64,
 }
 
 impl Default for LimitsConfig {
@@ -508,6 +529,7 @@ impl Default for LimitsConfig {
             script_shell_timeout_secs: default_script_shell_timeout_secs(),
             stall_timeout_secs: default_stall_timeout_secs(),
             dead_cycles_before_relief: default_dead_cycles_before_relief(),
+            finished_retention_secs: default_finished_retention_secs(),
         }
     }
 }
@@ -1602,6 +1624,9 @@ mod tests {
         // Relief is on by default: ten 30-second cycles of a full lane going
         // nowhere before the daemon widens it.
         assert_eq!(limits.dead_cycles_before_relief, 10);
+        // A finished run stays listed for five minutes, so a scheduler polling
+        // about once a minute still learns how it ended.
+        assert_eq!(limits.finished_retention_secs, 300);
         // And the top-level Config carries the same defaults.
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
     }
@@ -1640,6 +1665,7 @@ mod tests {
         assert_eq!(config.limits.max_concurrent_inferences, Some(8));
         assert_eq!(config.limits.default_max_iterations, Some(50));
         assert_eq!(config.limits.dead_cycles_before_relief, 10);
+        assert_eq!(config.limits.finished_retention_secs, 300);
     }
 
     #[test]
@@ -2813,6 +2839,7 @@ enabled = false
                 script_shell_timeout_secs: 45,
                 stall_timeout_secs: 90,
                 dead_cycles_before_relief: 6,
+                finished_retention_secs: 120,
             },
             batch_tool_hint: true,
             nudge: leviath_core::NudgeConfig {
@@ -2870,6 +2897,7 @@ enabled = false
         assert_eq!(deserialized.limits.max_concurrent_tools, 3);
         assert_eq!(deserialized.limits.script_shell_timeout_secs, 45);
         assert_eq!(deserialized.limits.dead_cycles_before_relief, 6);
+        assert_eq!(deserialized.limits.finished_retention_secs, 120);
         assert_eq!(
             deserialized.tool_script_permissions.http_get,
             ScriptPermission::Allow

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -173,6 +173,9 @@ pub fn build_host(
     // How long the daemon may sit with a full tool lane and no run moving before
     // it widens the lane to break the jam (issue #191).
     host.set_dead_cycles_before_relief(config.limits.dead_cycles_before_relief);
+    // How long a finished run keeps its place in the listing, so a scheduler
+    // polling on an interval can see how a run ended (issue #205).
+    host.set_finished_retention_secs(config.limits.finished_retention_secs);
     // Handed to each agent's tool state so its sub-agent tools reach the world
     // through the host.
     let subagent_tx = host.subagent_sender();

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -252,6 +252,12 @@ pub enum ControlResponse {
     List {
         /// One entry per live run.
         runs: Vec<RunListEntry>,
+        /// Runs the daemon unloaded recently enough to still report, oldest
+        /// first. Separate from `runs` so a caller counting hosted agents, or
+        /// asking which runs the daemon still holds, is not answered with runs
+        /// that have finished. Defaulted for the same reason as `health`.
+        #[serde(default)]
+        finished: Vec<RunListEntry>,
         /// How the daemon itself is doing. Defaulted when absent so a listing
         /// from an older daemon still parses.
         #[serde(default)]
@@ -319,8 +325,12 @@ async fn dispatch(req: ControlRequest, op_tx: &UnboundedSender<ControlOp>) -> Co
         ControlRequest::List => {
             let (reply, rx) = oneshot::channel();
             let _ = op_tx.send(ControlOp::List { reply });
-            let (runs, health) = rx.await.unwrap_or_default();
-            ControlResponse::List { runs, health }
+            let listing = rx.await.unwrap_or_default();
+            ControlResponse::List {
+                runs: listing.runs,
+                finished: listing.finished,
+                health: listing.health,
+            }
         }
         ControlRequest::Message {
             agent_id,
@@ -921,7 +931,13 @@ mod tests {
                         let _ = reply.send(true);
                     }
                     ControlOp::List { reply } => {
-                        let _ = reply.send((vec![listing_entry()], DaemonHealth::default()));
+                        let mut ended = listing_entry();
+                        ended.run_id = "run-ended".to_string();
+                        let _ = reply.send(crate::host::RunListing {
+                            runs: vec![listing_entry()],
+                            finished: vec![ended],
+                            ..Default::default()
+                        });
                     }
                     ControlOp::ListInteractions { reply } => {
                         let _ = reply.send(vec![]);
@@ -1068,10 +1084,29 @@ mod tests {
     #[tokio::test]
     async fn list_request_round_trips() {
         let resp = round_trip(&ControlRequest::List).await;
+        let mut ended = listing_entry();
+        ended.run_id = "run-ended".to_string();
         assert_eq!(
             resp,
             ControlResponse::List {
                 runs: vec![listing_entry()],
+                finished: vec![ended],
+                health: DaemonHealth::default(),
+            }
+        );
+    }
+
+    /// A client built against a newer daemon still has to read an older one's
+    /// reply, which carries neither the daemon's health nor the runs it has
+    /// finished. Both arrive as empty rather than failing the whole listing.
+    #[test]
+    fn a_listing_without_the_later_fields_still_parses() {
+        let older = r#"{"result":"list","runs":[]}"#;
+        assert_eq!(
+            serde_json::from_str::<ControlResponse>(older).expect("an older listing parses"),
+            ControlResponse::List {
+                runs: vec![],
+                finished: vec![],
                 health: DaemonHealth::default(),
             }
         );
@@ -1435,6 +1470,7 @@ mod tests {
             std::mem::discriminant(&ok),
             std::mem::discriminant(&ControlResponse::List {
                 runs: vec![],
+                finished: vec![],
                 health: DaemonHealth::default(),
             })
         );
@@ -1510,6 +1546,7 @@ mod tests {
             std::mem::discriminant(&list),
             std::mem::discriminant(&ControlResponse::List {
                 runs: vec![],
+                finished: vec![],
                 health: DaemonHealth::default(),
             })
         );
@@ -1723,6 +1760,7 @@ mod tests {
             dispatch(ControlRequest::List, &op_tx).await,
             ControlResponse::List {
                 runs: vec![],
+                finished: vec![],
                 health: DaemonHealth::default(),
             }
         );

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -14,7 +14,7 @@
 //! handling a control op and then re-driving to quiescence so its effect (a
 //! resume, a delivered message) is applied immediately.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
 use bevy_ecs::entity::Entity;
@@ -140,6 +140,24 @@ pub struct RunListEntry {
     /// daemon simply omits it.
     #[serde(default)]
     pub empty_output: bool,
+}
+
+/// Everything one [`ControlOp::List`] answers with: the live runs, the runs that
+/// finished recently enough to still be worth reporting, and the daemon's health.
+///
+/// A named struct rather than a tuple because the reply has now grown twice, and
+/// each time every caller had to be re-read positionally to find out which half
+/// was which.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RunListing {
+    /// One entry per run the daemon is hosting.
+    pub runs: Vec<RunListEntry>,
+    /// Runs the daemon has unloaded within its retention window, oldest first.
+    /// Kept apart from `runs` so a caller asking "what is running" still gets
+    /// only that.
+    pub finished: Vec<RunListEntry>,
+    /// How the daemon itself is doing.
+    pub health: DaemonHealth,
 }
 
 /// The daemon's own health, alongside the run listing.
@@ -316,7 +334,7 @@ pub enum ControlOp {
     /// List every known live run and its status, with the daemon's own health.
     List {
         /// Reply channel.
-        reply: oneshot::Sender<(Vec<RunListEntry>, DaemonHealth)>,
+        reply: oneshot::Sender<RunListing>,
     },
     /// Deliver a message to a running agent (by agent id). Reply is `false` if the
     /// world's message channel is closed.
@@ -584,6 +602,13 @@ pub struct WorldHost {
     /// Dead cycles the daemon tolerates before widening the tool lane. `0`
     /// disables relief. See [`Self::set_dead_cycles_before_relief`].
     dead_cycles_before_relief: u32,
+    /// Runs unloaded recently enough to still be worth reporting, oldest first,
+    /// each paired with the unix second it was unloaded. See
+    /// [`Self::record_finished`].
+    finished: VecDeque<(i64, RunListEntry)>,
+    /// How long an unloaded run stays in [`Self::finished`]. `0` keeps none.
+    /// See [`Self::set_finished_retention_secs`].
+    finished_retention_secs: u64,
 }
 
 /// How often the serve loop re-drives the world on its own.
@@ -606,6 +631,35 @@ const DEFAULT_REDRIVE_INTERVAL: Duration = Duration::from_secs(30);
 /// genuinely wedged daemon is not left overnight. Served from
 /// `[limits] dead_cycles_before_relief`; `0` disables relief.
 pub const DEFAULT_DEAD_CYCLES_BEFORE_RELIEF: u32 = 10;
+
+/// How long a run stays in the listing after the daemon unloads it.
+///
+/// A terminal agent is unloaded a pass or two after it finishes, and until now
+/// it vanished from the listing at that moment. A run that died on its first
+/// inference was therefore indistinguishable from one that had never been
+/// spawned, which is what left the scheduler in issue #205 with nothing to go on
+/// but a stopwatch: it could not tell a dead spawn from a slow one, so it
+/// reverted the work and spawned again, for forty minutes.
+///
+/// Five minutes covers several polls of any scheduler that checks in about once
+/// a minute, so a single missed or slow poll does not lose the evidence. It is
+/// also what the rest of the daemon already means by "long enough that a hiccup
+/// cannot cause it": the dashboard calls a run stale at 300 seconds, and
+/// [`DEFAULT_DEAD_CYCLES_BEFORE_RELIEF`] at the 30-second re-drive works out to
+/// the same five minutes.
+///
+/// Served from `[limits] finished_retention_secs`; `0` keeps nothing and
+/// restores the old behaviour.
+pub const DEFAULT_FINISHED_RETENTION_SECS: u64 = 300;
+
+/// How many unloaded runs [`WorldHost::finished`] holds before the oldest are
+/// dropped, whatever the retention window says.
+///
+/// Not configurable: it is a memory bound, not a tuning knob. A factory that
+/// finishes runs faster than this fills the window keeps the most recent ones,
+/// which are the ones anyone is still asking about. Set the window shorter to
+/// control how much the listing shows; this only stops it growing without end.
+const MAX_RETAINED_FINISHED: usize = 256;
 
 impl WorldHost {
     /// Wrap a world with a fresh interaction hub.
@@ -642,6 +696,8 @@ impl WorldHost {
             last_progress: None,
             relief_granted: 0,
             dead_cycles_before_relief: DEFAULT_DEAD_CYCLES_BEFORE_RELIEF,
+            finished: VecDeque::new(),
+            finished_retention_secs: DEFAULT_FINISHED_RETENTION_SECS,
         }
     }
 
@@ -710,6 +766,54 @@ impl WorldHost {
         // rather than granting again on the very next re-drive.
         self.dead_cycles = 0;
         granted
+    }
+
+    /// How long a run stays in the listing after the daemon unloads it. `0`
+    /// keeps none, which is how the listing behaved before issue #205. Served
+    /// from `[limits] finished_retention_secs`.
+    pub fn set_finished_retention_secs(&mut self, secs: u64) {
+        self.finished_retention_secs = secs;
+    }
+
+    /// Keep `entry` in the listing as a run that finished at `at`.
+    ///
+    /// One row per run: an id already held is replaced rather than duplicated,
+    /// so however often a run is unloaded it is reported once.
+    ///
+    /// `last_progress_at` is filled in from `at` when the run never persisted a
+    /// snapshot. That is not a guess. A run that died on its first inference has
+    /// no watermark to read, and the listing would show its age as `-` - which
+    /// is the one thing an operator or a scheduler most wants to know about a
+    /// run that failed instantly. For a run being unloaded, the unload is the
+    /// last thing that happened to it.
+    fn record_finished(&mut self, mut entry: RunListEntry, at: i64) {
+        if self.finished_retention_secs == 0 {
+            return;
+        }
+        entry.last_progress_at.get_or_insert(at);
+        self.finished
+            .retain(|(_, held)| held.run_id != entry.run_id);
+        self.finished.push_back((at, entry));
+        while self.finished.len() > MAX_RETAINED_FINISHED {
+            self.finished.pop_front();
+        }
+    }
+
+    /// Drop unloaded runs that have outlived the retention window.
+    ///
+    /// `now` is passed in rather than read here so a test can age the buffer
+    /// without sleeping through the window, the same reason `lev ps`'s
+    /// `format_runs` takes it. Called once per [`Self::emit_events`], which the
+    /// serve loop runs before it handles any control op, so a listing never has
+    /// to prune on the way out.
+    fn prune_finished(&mut self, now: i64) {
+        let window = self.finished_retention_secs as i64;
+        while let Some(&(at, _)) = self.finished.front() {
+            if now.saturating_sub(at) <= window {
+                break;
+            }
+            self.finished.pop_front();
+        }
     }
 
     /// How many dead cycles the daemon tolerates before widening the tool lane.
@@ -870,7 +974,12 @@ impl WorldHost {
             .collect();
         // Terminal agents to unload from memory this pass (their disk state is
         // preserved and still viewable). Collected during the loop, reaped after.
-        let mut to_reap: Vec<(String, Entity)> = Vec::new();
+        // The listing row travels with each one: it is built here, while the
+        // entity is untouched, rather than in the reap loop below, where the
+        // daemon's reap hook has already had the world and is free to have taken
+        // the components it reads.
+        let mut to_reap: Vec<(String, Entity, RunListEntry)> = Vec::new();
+        let now = chrono::Utc::now().timestamp();
         for (run_id, entity) in pairs {
             let Some(state) = self.world.world().get::<AgentState>(entity) else {
                 continue; // reaped between registration and now
@@ -991,7 +1100,8 @@ impl WorldHost {
             // prior pass already saw it terminal, so the event went out and the
             // persistence lane captured it) and no live parent still needs it.
             if cur.terminal && was_terminal && self.no_live_parent(entity) {
-                to_reap.push((run_id.clone(), entity));
+                let entry = self.entry_for(&run_id, entity, state);
+                to_reap.push((run_id.clone(), entity, entry));
             }
             // NOTE: non-terminal `Waiting` agents are intentionally NOT unloaded.
             // Every `Waiting` state carries a live, unpersisted continuation - a
@@ -1010,15 +1120,19 @@ impl WorldHost {
         // is safe. The reaper is moved out for the loop to avoid borrowing `self`
         // twice, then restored.
         let mut reaper = self.reaper.take();
-        for (run_id, entity) in to_reap {
+        for (run_id, entity, entry) in to_reap {
             if let Some(reaper) = reaper.as_mut() {
                 reaper(&mut self.world, entity);
             }
             self.world.world_mut().despawn(entity);
             self.by_run_id.remove(&run_id);
             self.emitted.remove(&run_id);
+            // The run leaves memory but not the listing: for a while yet it can
+            // still say how it ended, which is the whole of issue #205.
+            self.record_finished(entry, now);
         }
         self.reaper = reaper;
+        self.prune_finished(now);
 
         for (agent_id, request) in self.interactions.pending() {
             if self.emitted_interactions.insert(request.id.clone()) {
@@ -1408,6 +1522,37 @@ impl WorldHost {
         None
     }
 
+    /// One listing row for a run, read off the live world.
+    ///
+    /// Shared by [`Self::list`] and by the unload path in [`Self::emit_events`],
+    /// so a run's last row is built exactly the way every row before it was.
+    /// Takes the state rather than looking it up because the unload path already
+    /// holds one, and a `None` it could never return would be a branch nothing
+    /// can reach.
+    fn entry_for(&self, run_id: &str, entity: Entity, state: &AgentState) -> RunListEntry {
+        let world = self.world.world();
+        let metadata = world.get::<RunMetadata>(entity);
+        RunListEntry {
+            run_id: run_id.to_string(),
+            status: state.status.clone(),
+            wait_reason: self.wait_reason(entity),
+            stage: state.current_stage.clone(),
+            stage_index: world
+                .get::<crate::pipeline::StageCursor>(entity)
+                .map(|c| c.index),
+            num_stages: metadata.map(|m| m.num_stages),
+            iteration: state.iteration,
+            tool_calls: world.get::<TokenTotals>(entity).map_or(0, |t| t.tool_calls),
+            last_progress_at: world
+                .get::<crate::pipeline::PersistWatermark>(entity)
+                .and_then(|w| w.last_progress_at()),
+            unattended: metadata.is_some_and(|m| m.unattended),
+            empty_output: world
+                .get::<crate::persistence::RunOutcomeFlags>(entity)
+                .is_some_and(|f| crate::persistence::is_empty_output(&state.status, &f.0)),
+        }
+    }
+
     /// List every known live run with the context an operator needs to read its
     /// status: why it is waiting, where it is, and when it last moved.
     fn list(&self) -> Vec<RunListEntry> {
@@ -1416,27 +1561,22 @@ impl WorldHost {
             .iter()
             .filter_map(|(run_id, &entity)| {
                 let state = world.get::<AgentState>(entity)?;
-                let metadata = world.get::<RunMetadata>(entity);
-                Some(RunListEntry {
-                    run_id: run_id.clone(),
-                    status: state.status.clone(),
-                    wait_reason: self.wait_reason(entity),
-                    stage: state.current_stage.clone(),
-                    stage_index: world
-                        .get::<crate::pipeline::StageCursor>(entity)
-                        .map(|c| c.index),
-                    num_stages: metadata.map(|m| m.num_stages),
-                    iteration: state.iteration,
-                    tool_calls: world.get::<TokenTotals>(entity).map_or(0, |t| t.tool_calls),
-                    last_progress_at: world
-                        .get::<crate::pipeline::PersistWatermark>(entity)
-                        .and_then(|w| w.last_progress_at()),
-                    unattended: metadata.is_some_and(|m| m.unattended),
-                    empty_output: world
-                        .get::<crate::persistence::RunOutcomeFlags>(entity)
-                        .is_some_and(|f| crate::persistence::is_empty_output(&state.status, &f.0)),
-                })
+                Some(self.entry_for(run_id, entity, state))
             })
+            .collect()
+    }
+
+    /// The runs unloaded recently enough to still be reported, oldest first.
+    ///
+    /// Kept apart from [`Self::list`] rather than folded into it because
+    /// "running now" and "finished a moment ago" are different questions, and
+    /// two callers already depend on the first one: `lev daemon status` counts
+    /// the hosted agents, and the dashboard uses the listing to decide which
+    /// runs the daemon still holds.
+    fn finished(&self) -> Vec<RunListEntry> {
+        self.finished
+            .iter()
+            .map(|(_, entry)| entry.clone())
             .collect()
     }
 
@@ -1482,9 +1622,18 @@ impl WorldHost {
                 let _ = reply.send(result);
             }
             ControlOp::Status { run_id, reply } => {
+                // A run the daemon has unloaded still has an answer for a
+                // while, so a caller that asks a moment too late learns how the
+                // run ended instead of being told there is no such run.
                 let status = self
                     .live_entity(&run_id)
-                    .and_then(|e| self.world.agent_status(e));
+                    .and_then(|e| self.world.agent_status(e))
+                    .or_else(|| {
+                        self.finished
+                            .iter()
+                            .find(|(_, e)| e.run_id == run_id)
+                            .map(|(_, e)| e.status.clone())
+                    });
                 let _ = reply.send(status);
             }
             ControlOp::Pause { run_id, reply } => {
@@ -1514,7 +1663,11 @@ impl WorldHost {
                 let _ = reply.send(ok);
             }
             ControlOp::List { reply } => {
-                let _ = reply.send((self.list(), self.health()));
+                let _ = reply.send(RunListing {
+                    runs: self.list(),
+                    finished: self.finished(),
+                    health: self.health(),
+                });
             }
             ControlOp::Message {
                 agent_id,
@@ -2518,7 +2671,7 @@ mod tests {
         .await;
         assert_eq!(status, Some(AgentStatus::Active));
 
-        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].run_id, "run-a");
         assert_eq!(list[0].status, AgentStatus::Active);
@@ -3733,6 +3886,143 @@ mod tests {
         );
     }
 
+    // ─── Runs that finished but are still worth reporting (issue #205) ───────
+
+    /// Unload `run_id` the way the daemon does: an agent that has gone terminal
+    /// with `status`, then the two passes it takes to emit and reap it.
+    fn unload_with(host: &mut WorldHost, run_id: &str, status: AgentStatus) {
+        let mut s = agent_state(run_id);
+        s.status = status;
+        let e = host.world.world_mut().spawn(s).id();
+        host.register(run_id, e);
+        host.emit_events();
+        host.emit_events();
+    }
+
+    /// The failure behind issue #205: a run that died on its first inference was
+    /// unloaded a pass later and vanished, so a scheduler polling the listing
+    /// could not tell it from a run that had never been spawned. It now keeps
+    /// its place, and keeps the whole error rather than the status word - which
+    /// is the reason the row is built from the world and not from `Emitted`,
+    /// whose `status` is a `&'static str`.
+    #[tokio::test]
+    async fn an_unloaded_run_stays_in_the_listing_with_the_reason_it_ended() {
+        let mut host = host_with(vec![]);
+        let died = AgentStatus::Error {
+            message: "HTTP 402 Payment Required".to_string(),
+        };
+        unload_with(&mut host, "worker-1", died.clone());
+
+        assert!(host.live_entity("worker-1").is_none(), "unloaded");
+        let listing = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        assert!(listing.runs.is_empty(), "nothing is running");
+        assert_eq!(listing.finished.len(), 1);
+        assert_eq!(listing.finished[0].run_id, "worker-1");
+        assert_eq!(listing.finished[0].status, died);
+        // A run that never persisted a snapshot still has to show an age, or the
+        // listing answers "when did it die" with a dash.
+        assert!(listing.finished[0].last_progress_at.is_some());
+    }
+
+    /// The window is what keeps the listing from growing without end.
+    #[tokio::test]
+    async fn an_unloaded_run_leaves_the_listing_once_it_is_stale() {
+        let mut host = host_with(vec![]);
+        unload_with(&mut host, "worker-1", AgentStatus::Complete);
+        let window = DEFAULT_FINISHED_RETENTION_SECS as i64;
+        let at = host.finished.front().expect("just unloaded").0;
+
+        // Inside the window it stays...
+        host.prune_finished(at + window);
+        assert_eq!(host.finished().len(), 1);
+        // ...and one second past it, it goes.
+        host.prune_finished(at + window + 1);
+        assert!(host.finished().is_empty());
+    }
+
+    /// `0` is how an operator asks for the old behaviour back.
+    #[tokio::test]
+    async fn a_zero_window_keeps_nothing() {
+        let mut host = host_with(vec![]);
+        host.set_finished_retention_secs(0);
+        unload_with(&mut host, "worker-1", AgentStatus::Complete);
+
+        assert!(host.live_entity("worker-1").is_none(), "still unloaded");
+        assert!(host.finished().is_empty());
+    }
+
+    /// However often a run is recorded, it is one row - the newest.
+    #[tokio::test]
+    async fn a_run_is_listed_once_however_often_it_is_recorded() {
+        let mut host = host_with(vec![]);
+        let entry = |status| RunListEntry {
+            run_id: "worker-1".to_string(),
+            status,
+            wait_reason: None,
+            stage: "work".to_string(),
+            stage_index: None,
+            num_stages: None,
+            iteration: 0,
+            tool_calls: 0,
+            last_progress_at: None,
+            unattended: false,
+            empty_output: false,
+        };
+        host.record_finished(entry(AgentStatus::Cancelled), 100);
+        host.record_finished(entry(AgentStatus::Complete), 200);
+
+        let finished = host.finished();
+        assert_eq!(finished.len(), 1);
+        assert_eq!(finished[0].status, AgentStatus::Complete);
+    }
+
+    /// A factory that finishes runs faster than the window empties keeps the
+    /// most recent ones rather than growing for ever.
+    #[tokio::test]
+    async fn the_listing_of_finished_runs_is_capped() {
+        let mut host = host_with(vec![]);
+        for i in 0..=MAX_RETAINED_FINISHED {
+            host.record_finished(
+                RunListEntry {
+                    run_id: format!("worker-{i}"),
+                    status: AgentStatus::Complete,
+                    wait_reason: None,
+                    stage: "work".to_string(),
+                    stage_index: None,
+                    num_stages: None,
+                    iteration: 0,
+                    tool_calls: 0,
+                    last_progress_at: None,
+                    unattended: false,
+                    empty_output: false,
+                },
+                100,
+            );
+        }
+
+        let finished = host.finished();
+        assert_eq!(finished.len(), MAX_RETAINED_FINISHED);
+        assert_eq!(
+            finished[0].run_id, "worker-1",
+            "the oldest is the one dropped"
+        );
+    }
+
+    /// The status query agrees with the listing rather than reporting no such
+    /// run a moment after the listing still had one.
+    #[tokio::test]
+    async fn the_status_of_an_unloaded_run_is_still_answerable() {
+        let mut host = host_with(vec![]);
+        unload_with(&mut host, "worker-1", AgentStatus::Complete);
+
+        let status = ask(&mut host, |reply| ControlOp::Status {
+            run_id: "worker-1".to_string(),
+            reply,
+        })
+        .await;
+        assert_eq!(status, Some(AgentStatus::Complete));
+    }
+
     /// Spawn a `Waiting` agent (optionally with an extra marker component) and
     /// register it under `run_id`.
     fn register_waiting(host: &mut WorldHost, run_id: &str) -> Entity {
@@ -3938,7 +4228,7 @@ mod tests {
         // Despawn the entity behind the world's back; the run-id map is now stale.
         host.world_mut().world_mut().despawn(e);
 
-        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;
         assert!(list.is_empty()); // stale mapping filtered out
         let status = ask(&mut host, |reply| ControlOp::Status {
             run_id: "run-a".to_string(),
@@ -4226,7 +4516,7 @@ mod tests {
                 watermark
             },
         ));
-        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;
         assert_eq!(list[0].num_stages, Some(3));
         assert_eq!(list[0].tool_calls, 9);
         assert!(list[0].unattended);
@@ -4247,14 +4537,14 @@ mod tests {
             .entity_mut(e)
             .insert(crate::persistence::RunOutcomeFlags::default());
         // Still running: nothing to say yet.
-        assert!(!ask(&mut host, |reply| ControlOp::List { reply }).await.0[0].empty_output);
+        assert!(!ask(&mut host, |reply| ControlOp::List { reply }).await.runs[0].empty_output);
 
         host.world_mut()
             .world_mut()
             .get_mut::<AgentState>(e)
             .expect("spawned agent has state")
             .status = AgentStatus::Complete;
-        assert!(ask(&mut host, |reply| ControlOp::List { reply }).await.0[0].empty_output);
+        assert!(ask(&mut host, |reply| ControlOp::List { reply }).await.runs[0].empty_output);
 
         // ...unless it never had a way to write, which is not its failing.
         host.world_mut()
@@ -4263,7 +4553,7 @@ mod tests {
             .expect("just inserted")
             .0
             .no_output_tools = true;
-        assert!(!ask(&mut host, |reply| ControlOp::List { reply }).await.0[0].empty_output);
+        assert!(!ask(&mut host, |reply| ControlOp::List { reply }).await.runs[0].empty_output);
     }
 
     /// The listing carries the reason and the progress context, not just a word.
@@ -4274,7 +4564,7 @@ mod tests {
         waiting_because(&mut host, e, |entity| {
             entity.insert(crate::pipeline::WaitingForChildren);
         });
-        let (list, _health) = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;
         assert_eq!(list.len(), 1);
         assert_eq!(
             list[0].wait_reason,

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -190,8 +190,42 @@ Agents that never had a file-writing tool are never marked this way. A router th
 delegates, or a researcher whose answer is its report, has nothing to be measured against,
 so the run says nothing rather than reporting a failure it cannot have had.
 
-`lev ps --json` prints the same data unformatted, for scripts, including an `empty_output`
-field. The completion webhook carries the same key.
+### Runs that have finished
+
+A run keeps its place in the listing for five minutes after it ends, then drops out.
+
+Without that, a run left the listing the moment the daemon unloaded it, a second or two after
+it finished. A run that died on its first inference was then indistinguishable from a run that
+had never been spawned, and both read as `no agents running`. That is a hard thing to schedule
+against: the only way to tell a dead spawn from a slow one was to guess how long a healthy
+agent takes to get going, and anything that guessed too low would give up on runs that were
+still starting.
+
+So a run that failed is still there to say so:
+
+```
+RUN                             STATUS                              STAGE  ITER  TOOLS  AGE
+worker-1785616492-6f0d21ab4c11  error: HTTP 402 Payment Required    work   0     0      41s
+```
+
+`ITER 0` and `TOOLS 0` next to an error mean the run never got as far as its first turn. Set
+`[limits] finished_retention_secs` to widen or narrow the window, or `0` to drop a run as soon
+as it finishes. The record is held in memory, so restarting the daemon clears it early; the
+durable copy is the run's `meta.json`, which `GET /api/agents` reads.
+
+Two things this does not cover. A spawn that fails outright never becomes a run, so it is
+reported by `lev run` itself rather than here. And a run that finished longer ago than the
+window is gone from the listing for good.
+
+`lev ps --json` prints the same data unformatted, for scripts:
+
+```json
+{ "runs": [ ... ], "finished": [ ... ], "health": { ... } }
+```
+
+Finished runs are their own key rather than mixed into `runs`, so counting what is running
+stays a matter of reading one list. Both carry the `empty_output` field, and the completion
+webhook carries the same key.
 
 ## The daemon and API
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -71,6 +71,7 @@ exact_token_counting      = false
 script_shell_timeout_secs = 60
 stall_timeout_secs        = 60   # fail a run that can never dispatch
 dead_cycles_before_relief = 10   # widen the tool lane after this long going nowhere
+finished_retention_secs   = 300  # keep a finished run in `lev ps` this long
 ```
 
 | Key | Default | Notes |
@@ -82,6 +83,7 @@ dead_cycles_before_relief = 10   # widen the tool lane after this long going now
 | `script_shell_timeout_secs` | `60` | Cap on a Rhai script tool's `shell()` host call |
 | `stall_timeout_secs` | `60` | How long a run may sit ready to work but unable to dispatch before it is failed instead of left running. Only fires for something the runtime cannot resolve on its own, today a stage whose provider is not configured. Waiting for a busy model's pool is ordinary backpressure and is never failed. `0` waits forever |
 | `dead_cycles_before_relief` | `10` | How many consecutive 30-second cycles the daemon may spend with a full tool lane and no run moving before it widens the lane. See [the tool lane](/docs/engine#the-tool-lane). `0` never widens it; the count is still reported either way |
+| `finished_retention_secs` | `300` | How long a run stays in [`lev ps`](/docs/cli#runs-that-have-finished) after it ends, so a script polling on an interval can see how it ended instead of finding it gone. `0` drops it as soon as it finishes. Held in memory, so a daemon restart clears it whatever this is set to |
 
 <a id="security"></a>
 

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -58,6 +58,33 @@ Waiting for a busy model is *not* this. An agent queued behind other in-flight r
 model is working as intended and is never failed, however long the queue takes — raise
 `[limits] max_concurrent_inferences` if you want more of them running at once.
 
+## A run I spawned is not in `lev ps`
+
+There are three of these, and they need different answers.
+
+**It is still starting.** A spawn is not a start. Loading the blueprint, running any seed
+commands, and getting through the first inference all happen before an agent can call its first
+tool, and a cold model can take several seconds on its own. A run in this state is in `lev ps`
+already, at `iteration 0`. It is there; give it a moment.
+
+**It finished, and you looked within the retention window.** It is still listed, with the
+status it ended on. An `error` row at `ITER 0` and `TOOLS 0` is a run that never got a turn,
+and the message says why. `HTTP 402` there means the provider account is out of credit, not
+that Leviath lost the run.
+
+**It finished longer ago than the window.** Now it really is gone from the listing, and the
+answer is on disk: `~/.leviath/runs/<run-id>/meta.json`, or `GET /api/agents`, which reads the
+same records and does not expire them. Widen `[limits] finished_retention_secs` if you are
+polling less often than the default five minutes.
+
+If it is none of those, the spawn itself failed and no run was ever created. `lev run` reports
+that on the spot, and the daemon logs it at `error` level, so check there rather than in the
+listing.
+
+This matters most to anything that schedules work by spawning agents and watching for them.
+Poll the listing rather than timing how long a run "should" take: a wall-clock deadline that is
+shorter than a cold start will keep giving up on runs that were about to work.
+
 ## Every run looks busy but nothing finishes
 
 Run `lev ps` and read the line under the table. If there isn't one, the daemon thinks it is


### PR DESCRIPTION
Closes #205.

## What was reported, and what is actually ours

The issue reports a scheduler stuck in a spawn/revert loop: it spawns an agent, waits a 30-second TTL for the agent to claim its work item, sees nothing, reverts, and re-spawns. Three work items cycled like that for forty minutes and no work got done.

The TTL, the revert logic, the backoff and the route circuit breaker all live in `router-sweep.ps1` on the reporter's Windows box. There is no router, bead, claim, lease or revert machinery anywhere in this workspace, so none of those four asks can be implemented here.

What *is* ours is the reason a stopwatch was the scheduler's only option.

## The defect

A terminal agent is unloaded a pass or two after it finishes (`host.rs`, the `to_reap` path), and `WorldHost::list` iterates `by_run_id` only. So a finished run left `lev ps` and `lev ps --json` a second or two after it ended, and `ControlOp::Status` answered `None` for it.

A run that died on its first inference was therefore indistinguishable from a run that had never been spawned. Both read as `no agents running`. That is exactly sibling issue #201, where ten workers each died on their first inference with `HTTP 402 Payment Required` at `pid=0 tool_calls=0` and simply were not there to be found.

`GET /api/agents` reads `RunMeta` from disk and does show terminal runs, so the two surfaces already disagreed about whether a finished run exists.

## The change

The daemon keeps a bounded, time-windowed record of runs it recently unloaded, and reports them alongside the live listing.

```
$ lev ps
RUN                             STATUS                            STAGE  ITER  TOOLS  AGE
worker-1785616492-6f0d21ab4c11  error: HTTP 402 Payment Required  work   0     0      41s
```

Details worth reviewing:

- **The row is built at the unload site, not in the reap loop.** `Reaper` is a daemon-installed hook that takes `&mut PipelineWorld` and is free to strip components before the row could be read. Building it where `to_reap` is populated means the entity is still untouched. `entry_for` takes `&AgentState` and returns a `RunListEntry` rather than an `Option`, so there is no unreachable `None` arm at that site.
- **Finished runs travel in their own list.** `ControlResponse::List` gains `finished` next to `runs` and `health`, and `ControlOp::List` now replies with a named `RunListing` instead of a growing tuple. This keeps `lev daemon status`'s `runs.len()` counting only hosted agents and the dashboard's `daemon_run_ids` meaning only what it says. Both match with `..` and needed no change.
- **`last_progress_at` is filled from the unload stamp when the run never persisted a snapshot**, so a run that died instantly shows a real AGE instead of `-`. That is the one thing you most want to know about such a run.
- **Two knobs, kept separate.** `[limits] finished_retention_secs` (default 300, `0` restores the old behaviour) and a non-configurable `MAX_RETAINED_FINISHED = 256` memory bound. `0` never means unbounded.
- Wire compatibility follows the existing `health` precedent: `#[serde(default)]`, so a newer client still parses an older daemon's reply.

## What this does not cover

Both are documented rather than left to be discovered:

- A spawn that fails outright never becomes a run, so it never enters the buffer. It is already returned synchronously on the spawn reply and logged at `error`. The #201 shape (spawn succeeds, first inference 402s) is covered.
- The record is in memory, so a daemon restart clears it. `meta.json` and `GET /api/agents` remain the durable copy.

## Verification

`cargo xtask coverage`: all 11 packages at 100%, first pass.

Live, against an isolated daemon and a Rhai mock provider:

- a run that dies before its first turn is reaped from `runs` and still reported in `finished`, carrying its full error at `iter 0`, `tools 0`
- it expires past the window, and the listing returns to `no agents running`
- a successful run appears the same way, with its real status and age
- `lev daemon status` still reports `daemon running (0 agents)`, confirming the split
- `finished_retention_secs = 0` restores the old vanish-immediately behaviour exactly
- the new key serializes into a config generated by `lev setup`
- `lev dash` in a pty renders all four runs with their terminal status and marks nothing STALE

## Related

#201 and #202 share this root observability gap but are not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CJMeYhnh9PLXZKwzgHn7X