### PR TITLE
Stop unattended runs parking for ever on a question nobody will answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,33 @@ requests since the previous version.
   name the model calls, so the entry was never consulted. And
   `software-engineer`'s review stage had no `max_iterations`.
 - `POST /api/blueprints/validate` returns a `warnings` list alongside `errors`.
+- An unattended run no longer gets the tools that wait on a person.
+  `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `present_for_review`,
+  and `edit_document` do one thing: open a prompt and block. Under `--yolo`
+  nobody answers, so a call to one used to park the agent in `WaitingInput`
+  until the daemon restarted; six production runs sat there for three to five
+  hours each, holding their slots. They are now dropped from the tool set the
+  model is offered, per stage, before the first inference. The model never sees
+  them and decides for itself instead of spending a round trip to be told nobody
+  is there.
+- A stage that genuinely needs a person opts out with `required_tools`, listing
+  the human tools it keeps even when the run is unattended. Entries must also
+  appear in `available_tools`, and a manifest where one does not is rejected
+  rather than quietly ignored.
+- Interaction points gained the same escape hatch. `unattended = "ask"` on a
+  point holds the run for a real answer under `--yolo` instead of approving
+  itself. The bundled `software-engineer` uses it for plan approval: everything
+  after that gate writes code, so waving it through unread is the one thing that
+  agent should not do on its own.
+- New `[limits] interaction_timeout_secs`, one hour by default, puts a deadline
+  on any prompt that waits on a person: `ask_user_*`, tool approvals, taint
+  gates, and interaction points alike. There had never been one. Expiry resolves
+  the prompt exactly as cancelling it does, so an approval and a taint gate both
+  deny, the model is told no answer came, and a checkpoint proceeds with no user
+  text. A timeout is never read as consent. Set it to `0` to wait indefinitely.
+- `lev validate` warns when an autonomous stage offers one of these tools
+  without opting out, naming the stage and the tools, since that combination is
+  the shape the whole problem took.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,9 +178,10 @@ requests since the previous version.
   the prompt exactly as cancelling it does, so an approval and a taint gate both
   deny, the model is told no answer came, and a checkpoint proceeds with no user
   text. A timeout is never read as consent. Set it to `0` to wait indefinitely.
-- `lev validate` warns when an autonomous stage offers one of these tools
-  without opting out, naming the stage and the tools, since that combination is
-  the shape the whole problem took.
+- `lev validate`'s `blocking-tool-in-autonomous-stage` warning now takes
+  `required_tools` as the answer it is asking for. Keeping a tool says the same
+  thing `allow_blocking_tools` says, one tool at a time, and says it about the
+  run as well as the manifest.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/crates/leviath-cli/agents/software-engineer/agent.leviath
+++ b/crates/leviath-cli/agents/software-engineer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "software-engineer"
-version = "0.0.1"
+version = "0.0.2"
 description = "Plan-then-implement agent - mirrors the Claude Code discover→plan→approve→code→review workflow"
 entry_stage = "discover"
 
@@ -103,6 +103,12 @@ mode = "interactive_points"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Explore the codebase and produce a step-by-step implementation plan"
 available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document"]
+# Planning is the one place this agent genuinely needs its user, so these three
+# survive an unattended run instead of being dropped with the rest of the
+# blocking tools. The plan_approval point below opts out of auto-approval on the
+# same grounds; the revise and add-detail branches are worth nothing without the
+# tools that carry them out.
+required_tools = ["ask_user_text", "ask_user_choice", "edit_document"]
 max_iterations = 20
 max_revisits = 6
 # "Abort" is handled deterministically by the engine (see abort_options on the
@@ -205,6 +211,12 @@ transform = "direct"
 name     = "plan_approval"
 prompt   = "Review the plan above. What would you like to do?"
 required = true
+# Hold this checkpoint for a person even under `--yolo`. Approving a plan
+# unread is the one thing this agent must not do on its own: everything after
+# it writes code. An operator who wants the run to sail through sets
+# `[limits] interaction_timeout_secs`, which releases the gate on its own
+# terms rather than pretending someone approved it.
+unattended = "ask"
 style    = "multiple_choice"
 options  = ["Approve - proceed to implementation", "Revise - I'll describe changes", "Add detail - expand a section", "Abort - cancel this run"]
 

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -917,6 +917,11 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             help: "Fail a run nothing in the engine can reach any more. 0 is off; 300 is a sensible value.",
             value: FieldValue::Number(Some(config.limits.wedge_timeout_secs)),
         },
+        Field {
+            label: "Interaction timeout (seconds)",
+            help: "Resolve a prompt nobody answered after this long, so the run carries on. 0 waits for ever.",
+            value: FieldValue::Number(Some(config.limits.interaction_timeout_secs)),
+        },
     ]
 }
 
@@ -962,6 +967,12 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             (9, FieldValue::Number(n)) => {
                 config.limits.wedge_timeout_secs =
                     n.unwrap_or(Config::default().limits.wedge_timeout_secs)
+            }
+            // Same rule again: unset keeps the default hour, 0 is an explicit
+            // "wait for a person however long it takes".
+            (9, FieldValue::Number(n)) => {
+                config.limits.interaction_timeout_secs =
+                    n.unwrap_or(Config::default().limits.interaction_timeout_secs)
             }
             _ => {}
         }

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -970,7 +970,7 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             }
             // Same rule again: unset keeps the default hour, 0 is an explicit
             // "wait for a person however long it takes".
-            (9, FieldValue::Number(n)) => {
+            (10, FieldValue::Number(n)) => {
                 config.limits.interaction_timeout_secs =
                     n.unwrap_or(Config::default().limits.interaction_timeout_secs)
             }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -456,6 +456,10 @@ fn default_provider_circuit_cooldown_secs() -> u64 {
     leviath_runtime::pipeline::DEFAULT_CIRCUIT_COOLDOWN_SECS
 }
 
+fn default_interaction_timeout_secs() -> u64 {
+    leviath_runtime::interaction_hub::DEFAULT_INTERACTION_TIMEOUT_SECS
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -587,6 +591,25 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_provider_circuit_cooldown_secs")]
     pub provider_circuit_cooldown_secs: u64,
+    /// How long (seconds) a prompt may go unanswered before the daemon resolves
+    /// it itself and lets the run carry on.
+    ///
+    /// Covers every prompt that waits on a person: an agent's `ask_user_*` /
+    /// `present_for_review` call, a tool-approval prompt, a taint gate, and a
+    /// blueprint interaction point. Before this existed, a run whose operator
+    /// had walked away sat in `WaitingInput` holding its slot until the daemon
+    /// restarted - hours, in the report that prompted it (issue #204).
+    ///
+    /// Expiry resolves the prompt exactly as cancelling it would: a tool
+    /// approval and a taint gate **deny**, an `ask_user_*` call is told nobody
+    /// answered, and an interaction point proceeds with no user text. Nothing is
+    /// approved on the strength of a timeout.
+    ///
+    /// Defaults to `3600` (one hour); `0` waits indefinitely.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_interaction_timeout_secs")]
+    pub interaction_timeout_secs: u64,
 }
 
 impl Default for LimitsConfig {
@@ -603,6 +626,7 @@ impl Default for LimitsConfig {
             wedge_timeout_secs: default_wedge_timeout_secs(),
             provider_failures_before_open: default_provider_failures_before_open(),
             provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
+            interaction_timeout_secs: default_interaction_timeout_secs(),
         }
     }
 }
@@ -1723,8 +1747,35 @@ mod tests {
         // A finished run stays listed for five minutes, so a scheduler polling
         // about once a minute still learns how it ended.
         assert_eq!(limits.finished_retention_secs, 300);
+        // An unanswered prompt releases after an hour rather than holding its
+        // run's slot until the daemon restarts (issue #204).
+        assert_eq!(limits.interaction_timeout_secs, 3600);
         // And the top-level Config carries the same defaults.
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
+    }
+
+    /// A config written before the field existed still gets the hour, and an
+    /// explicit `0` still means "wait for a person however long it takes".
+    #[test]
+    fn interaction_timeout_defaults_and_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let load = |body: String| {
+            let path = dir.path().join(format!("{}.toml", body.len()));
+            std::fs::write(&path, body).unwrap();
+            with_tracing(|| Config::load_from_path(&path)).unwrap()
+        };
+
+        let old = load(format!(
+            "{}\n[limits]\nmax_concurrent_tools = 4\n",
+            config_toml_without_limits()
+        ));
+        assert_eq!(old.limits.interaction_timeout_secs, 3600);
+
+        let disabled = load(format!(
+            "{}\n[limits]\ninteraction_timeout_secs = 0\n",
+            config_toml_without_limits()
+        ));
+        assert_eq!(disabled.limits.interaction_timeout_secs, 0);
     }
 
     #[test]
@@ -2969,6 +3020,7 @@ enabled = false
                 wedge_timeout_secs: 420,
                 provider_failures_before_open: 5,
                 provider_circuit_cooldown_secs: 120,
+                interaction_timeout_secs: 120,
             },
             batch_tool_hint: true,
             shell_hint: false,

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -143,6 +143,10 @@ pub fn build_host(
     now_secs: fn() -> i64,
 ) -> WorldHost {
     let hub = InteractionHub::new();
+    // How long a prompt may go unanswered before the hub resolves it itself, so
+    // an operator who walked away costs the run a delay rather than its slot
+    // for as long as the daemon lives (issue #204).
+    hub.set_timeout_secs(config.limits.interaction_timeout_secs);
     let tool_service = Arc::new(CliToolService::new());
     // The configured global fallback bounds concurrent inference for any model
     // without its own per-model pool entry (defaults to a small cap so a fresh

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -2067,6 +2067,49 @@ system = { kind = "pinned", max_tokens = 1000 }
         assert!(meta.unattended);
     }
 
+    /// A stage that kept a human tool through an unattended run has to reach the
+    /// tool state with that tool in hand: the cut takes it out of the advertised
+    /// set, and this set is what puts a call to it back in front of a person
+    /// instead of the auto-answering backend (issue #204).
+    #[tokio::test]
+    async fn build_agent_carries_required_tools_into_the_tool_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"asks\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+             available_tools = [\"read_file\", \"ask_user_text\"]\n\
+             required_tools = [\"ask_user_text\"]\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let mut args = spawn_args(&manifest.to_string_lossy());
+        args.yolo = true;
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            &[],
+            &InteractionHub::new(),
+            &args,
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let state = cli.take(entity).expect("tool state registered");
+        assert!(
+            state
+                .stage_required
+                .lock()
+                .unwrap()
+                .contains("ask_user_text")
+        );
+        assert_eq!(state.stage_required_by_index.len(), 1);
+    }
+
     #[tokio::test]
     async fn build_agent_without_yolo_keeps_prompts_interactive() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -834,6 +834,7 @@ fn build_agent_inner(
             &model_defaults(config),
             registry,
             &all_tool_defs,
+            args.yolo,
         )?
     };
 

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -262,6 +262,7 @@ fn build_tool_state(
     entry_stage: &str,
     entry_index: usize,
     stage_perms_by_index: Vec<HashMap<String, String>>,
+    stage_required_by_index: Vec<HashSet<String>>,
     agent_perms: HashMap<String, String>,
     agent_name: &str,
     launch_overrides: HashMap<String, crate::config::ToolPolicy>,
@@ -277,6 +278,10 @@ fn build_tool_state(
         .get(entry_index)
         .cloned()
         .unwrap_or_default();
+    let entry_required = stage_required_by_index
+        .get(entry_index)
+        .cloned()
+        .unwrap_or_default();
     Arc::new(AgentToolState {
         builtins,
         mcp,
@@ -285,6 +290,8 @@ fn build_tool_state(
         session_allows: Arc::new(Mutex::new(HashSet::new())),
         stage_perms: Arc::new(StdMutex::new(entry_perms)),
         stage_perms_by_index: Arc::new(stage_perms_by_index),
+        stage_required: Arc::new(StdMutex::new(entry_required)),
+        stage_required_by_index: Arc::new(stage_required_by_index),
         agent_perms: Arc::new(agent_perms),
         // The ceiling a blueprint may tighten but not loosen: the user's global
         // `[tool_permissions]` plus any `[agent_tool_permissions.<name>]` grant
@@ -898,6 +905,25 @@ fn build_agent_inner(
         .iter()
         .map(|s| s.available_tools.clone())
         .collect();
+    // Alongside it, each stage's `required_tools` - the human tools it keeps even
+    // when nobody is watching - so a refresh re-applies the same unattended cut.
+    let stage_required: Vec<Vec<String>> = blueprint
+        .stages
+        .iter()
+        .map(|s| s.required_tools.clone())
+        .collect();
+    // The same list as a lookup set, canonicalised, for the tool state: an
+    // interaction for a kept tool has to reach a real person rather than the
+    // auto-answering backend, and dispatch tests one name at a time.
+    let stage_required_by_index: Vec<HashSet<String>> = stage_required
+        .iter()
+        .map(|names| {
+            names
+                .iter()
+                .map(|n| leviath_tools::canonical_tool_name(n).to_string())
+                .collect()
+        })
+        .collect();
     let model_label = stages
         .first()
         .map(|s| format!("{}/{}", s.provider_name, s.model));
@@ -1107,6 +1133,8 @@ fn build_agent_inner(
             reserved_names: reserved_tool_names(&builtin_names, mcp_tool_defs),
             static_defs: static_tool_defs,
             stage_available,
+            stage_required,
+            unattended: args.yolo,
             dirty: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     });
@@ -1120,6 +1148,7 @@ fn build_agent_inner(
         &entry_stage,
         entry_index,
         stage_perms_by_index,
+        stage_required_by_index,
         agent_perms,
         &agent_name,
         launch_overrides,

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -56,15 +56,25 @@ pub struct AgentToolState {
     /// Every stage's `tool_permissions`, indexed by stage index; `sync_stage`
     /// copies the entered stage's map into `stage_perms`.
     pub stage_perms_by_index: Arc<Vec<HashMap<String, String>>>,
+    /// The current stage's `required_tools` - the human-in-the-loop tools it
+    /// keeps through an unattended run. Re-synced by `sync_stage`, and read on
+    /// every interaction so a kept tool reaches a real person instead of
+    /// [`UnattendedInteraction`]. Empty for an attended run, where nothing is
+    /// dropped and nothing needs keeping.
+    pub stage_required: Arc<StdMutex<HashSet<String>>>,
+    /// Every stage's `required_tools`, indexed by stage index.
+    pub stage_required_by_index: Arc<Vec<HashSet<String>>>,
     /// Blueprint-level `[tool_permissions]`.
     pub agent_perms: Arc<HashMap<String, String>>,
     /// Config-level tool permissions.
     pub global_perms: Arc<HashMap<String, ToolPolicy>>,
     /// The agent's interaction backend (ask_user + tool approvals).
     pub interaction: HubInteractionBackend,
-    /// `--yolo`: nobody is watching this run, so `ask_user_*` /
-    /// `present_for_review` / `edit_document` are answered by
-    /// [`UnattendedInteraction`] rather than parked on the hub forever.
+    /// `--yolo`: nobody is watching this run, so the tools that block on a
+    /// person are not advertised at all. Should one be called anyway, it is
+    /// answered by [`UnattendedInteraction`] rather than parked on the hub for
+    /// ever - unless the stage kept it in `required_tools`, in which case a real
+    /// prompt is exactly what the blueprint asked for.
     pub unattended: bool,
     /// The current stage name, for tagging interactions (re-synced on stage change).
     pub stage_name: Arc<StdMutex<String>>,
@@ -102,6 +112,12 @@ pub struct DynamicToolCtx {
     pub static_defs: Vec<leviath_providers::Tool>,
     /// Each stage's `available_tools` (Layer-1 allowlist), by stage index.
     pub stage_available: Vec<Vec<String>>,
+    /// Each stage's `required_tools` (human tools kept through an unattended
+    /// run), by stage index. Paired with `unattended` so a re-scan can't hand a
+    /// `--yolo` agent back the prompting tools spawn resolution took away.
+    pub stage_required: Vec<Vec<String>>,
+    /// Whether this run is unattended (`--yolo`).
+    pub unattended: bool,
     /// Set when the agent writes a tool file; drained by `wants_refresh`.
     pub dirty: Arc<AtomicBool>,
 }
@@ -237,7 +253,16 @@ pub async fn dispatch_tools(
         // ask_user_* / present_for_review are handled by the interaction backend -
         // the hub (a real person answers) or, for an unattended `--yolo` run,
         // the auto-answering one.
-        let interaction: &dyn InteractionBackend = match state.unattended {
+        //
+        // A tool the stage kept in `required_tools` goes to the hub even in an
+        // unattended run. Keeping it was the blueprint saying this stage needs a
+        // person; auto-answering it here would make the opt-out mean nothing.
+        let kept_for_a_person = state
+            .stage_required
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .contains(leviath_tools::canonical_tool_name(&tc.name));
+        let interaction: &dyn InteractionBackend = match state.unattended && !kept_for_a_person {
             true => &UnattendedInteraction,
             false => &state.interaction,
         };
@@ -422,6 +447,12 @@ impl ToolService for CliToolService {
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner) = perms.clone();
         }
+        if let Some(required) = state.stage_required_by_index.get(stage_index) {
+            *state
+                .stage_required
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = required.clone();
+        }
         *state
             .stage_name
             .lock()
@@ -502,10 +533,20 @@ impl ToolService for CliToolService {
             .unwrap_or_else(PoisonError::into_inner) = names;
         // Re-filter this stage's advertised tools = static defs + fresh script defs.
         let available = ctx.stage_available.get(stage_index)?;
+        // A stage that named no `required_tools` keeps none through an
+        // unattended run - the absence is an empty list, not a missing stage,
+        // so it must not turn the whole refresh into a no-op.
+        let required = ctx
+            .stage_required
+            .get(stage_index)
+            .map_or(&[][..], |r| r.as_slice());
         let mut all = ctx.static_defs.clone();
         all.extend(script_defs);
-        Some(leviath_runtime::pipeline::filter_tools_by_available(
-            &all, available,
+        Some(leviath_runtime::pipeline::filter_tools_for_stage(
+            &all,
+            available,
+            required,
+            ctx.unattended,
         ))
     }
 }
@@ -565,6 +606,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
@@ -640,6 +683,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
@@ -688,12 +733,33 @@ mod tests {
         }
     }
 
-    /// A state with a `DynamicToolCtx` scanning `scan_dir`, over `workdir`.
+    /// A state with a `DynamicToolCtx` scanning `scan_dir`, over `workdir`,
+    /// attended (a refresh keeps whatever `stage_available` names).
     fn dynamic_state(
         workdir: PathBuf,
         scan_dir: PathBuf,
         static_defs: Vec<leviath_providers::Tool>,
         stage_available: Vec<Vec<String>>,
+    ) -> Arc<AgentToolState> {
+        dynamic_state_unattended(
+            workdir,
+            scan_dir,
+            static_defs,
+            stage_available,
+            Vec::new(),
+            false,
+        )
+    }
+
+    /// The same, with the unattended cut in play: `stage_required` names the
+    /// human tools each stage keeps anyway.
+    fn dynamic_state_unattended(
+        workdir: PathBuf,
+        scan_dir: PathBuf,
+        static_defs: Vec<leviath_providers::Tool>,
+        stage_available: Vec<Vec<String>>,
+        stage_required: Vec<Vec<String>>,
+        unattended: bool,
     ) -> Arc<AgentToolState> {
         let hub = InteractionHub::new();
         let builtins = Arc::new(leviath_tools::BuiltinTools::new(
@@ -713,6 +779,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(allow),
             interaction: hub.backend_for("a"),
@@ -728,6 +796,8 @@ mod tests {
                 reserved_names: HashSet::new(),
                 static_defs,
                 stage_available,
+                stage_required,
+                unattended,
                 dirty: Arc::new(AtomicBool::new(false)),
             })),
         })
@@ -755,6 +825,41 @@ mod tests {
         // The live script set + names now include the freshly discovered tool.
         assert!(state.script_tool_names.lock().unwrap().contains("echo"));
         assert!(state.script_tools.lock().unwrap().contains("echo"));
+    }
+
+    /// A `dynamic_tools` agent re-filters its advertised set mid-run. That
+    /// refresh has to apply the same unattended cut spawn resolution did, or a
+    /// `--yolo` run would quietly get its prompting tools back on the first
+    /// re-scan (issue #204).
+    #[test]
+    fn refresh_tools_keeps_the_unattended_cut() {
+        let workdir = tempfile::tempdir().unwrap();
+        let tools = tempfile::tempdir().unwrap();
+        let state = dynamic_state_unattended(
+            workdir.path().to_path_buf(),
+            tools.path().to_path_buf(),
+            vec![
+                tool_def("read_file"),
+                tool_def("ask_user_text"),
+                tool_def("ask_user_choice"),
+            ],
+            vec![vec![
+                "read_file".to_string(),
+                "ask_user_text".to_string(),
+                "ask_user_choice".to_string(),
+            ]],
+            vec![vec!["ask_user_choice".to_string()]],
+            true,
+        );
+        let svc = CliToolService::new();
+        let e = Entity::from_raw_u32(2).expect("a small literal index is always a valid entity id");
+        svc.register(e, state);
+
+        let defs = svc.refresh_tools(e, 0).unwrap();
+        let mut names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        names.sort();
+        // `ask_user_text` is gone; the stage's opted-out `ask_user_choice` stays.
+        assert_eq!(names, vec!["ask_user_choice", "read_file"]);
     }
 
     #[test]
@@ -925,6 +1030,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(allow),
             interaction: hub.backend_for("a"),
@@ -1118,6 +1225,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(global),
             interaction: hub.backend_for("agent-a"),
@@ -1210,6 +1319,11 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(vec![HashMap::new(), deny.clone()]),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(vec![
+                HashSet::new(),
+                HashSet::from(["ask_user_text".to_string()]),
+            ]),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(HashMap::new()),
             interaction: hub.backend_for("a"),
@@ -1228,6 +1342,12 @@ mod tests {
         service.sync_stage(e, 1, "review");
         assert_eq!(*state.stage_perms.lock().unwrap(), deny);
         assert_eq!(*state.stage_name.lock().unwrap(), "review");
+        // And that stage's kept human tools, so an unattended run asks a person
+        // only where the stage it is actually in said to.
+        assert_eq!(
+            *state.stage_required.lock().unwrap(),
+            HashSet::from(["ask_user_text".to_string()])
+        );
 
         // An out-of-range index leaves perms as-is but still updates the name.
         service.sync_stage(e, 99, "ghost");
@@ -1489,6 +1609,63 @@ mod tests {
         assert!(!result.contains("[denied]"), "{result}");
     }
 
+    /// An unattended run answers a stray `ask_user_*` inline rather than
+    /// opening a prompt nobody would see. The tool is not advertised in the
+    /// first place, so this is the belt to that brace.
+    #[tokio::test]
+    async fn an_unattended_run_answers_a_stray_ask_itself() {
+        let hub = InteractionHub::new();
+        let mut state = state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new());
+        Arc::get_mut(&mut state)
+            .expect("sole owner before dispatch")
+            .unattended = true;
+
+        let out = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "ask_user_text",
+                serde_json::json!({"prompt": "which way?"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+
+        assert_eq!(out.len(), 1);
+        assert!(out[0].1.contains("unattended run"), "{}", out[0].1);
+        assert!(hub.pending().is_empty(), "nobody was asked");
+    }
+
+    /// A tool the stage kept in `required_tools` reaches a real person even
+    /// under `--yolo`. Without this the opt-out would advertise the tool and
+    /// then answer it on the user's behalf, which is no opt-out at all.
+    #[tokio::test]
+    async fn a_required_tool_reaches_a_person_even_when_unattended() {
+        let hub = InteractionHub::new();
+        let mut state = state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new());
+        {
+            let s = Arc::get_mut(&mut state).expect("sole owner before dispatch");
+            s.unattended = true;
+            s.stage_required =
+                Arc::new(StdMutex::new(HashSet::from(["ask_user_text".to_string()])));
+        }
+
+        let out = dispatch_answering(
+            state,
+            vec![call(
+                "c1",
+                "ask_user_text",
+                serde_json::json!({"prompt": "which way?"}),
+            )],
+            |req| InteractionResponse::text(&req.id, "go left"),
+            hub,
+        )
+        .await;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].1, "go left");
+    }
+
     #[tokio::test]
     async fn subagent_tool_without_a_handle_reports_unavailable() {
         let hub = InteractionHub::new();
@@ -1539,6 +1716,8 @@ mod tests {
             session_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_perms: Arc::new(StdMutex::new(HashMap::new())),
             stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
             global_perms: Arc::new(HashMap::new()),
             interaction: hub.backend_for("agent-a"),

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -1632,7 +1632,8 @@ mod tests {
         .await;
 
         assert_eq!(out.len(), 1);
-        assert!(out[0].1.contains("unattended run"), "{}", out[0].1);
+        let result = out[0].1.clone();
+        assert!(result.contains("unattended run"), "{result}");
         assert!(hub.pending().is_empty(), "nobody was asked");
     }
 

--- a/crates/leviath-cli/src/lint.rs
+++ b/crates/leviath-cli/src/lint.rs
@@ -430,6 +430,10 @@ fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFinding> {
         .available_tools
         .iter()
         .filter(|t| BLOCKING_INTERACTION_TOOLS.contains(&canonical_tool_name(t)))
+        // A tool kept in `required_tools` is the same statement of intent
+        // `allow_blocking_tools` makes, made one tool at a time - and it is the
+        // one that also survives an unattended run, so it is worth more.
+        .filter(|t| !stage.required_tools.contains(t))
         .map(|tool| {
             LintFinding::new(
                 LintSeverity::Warning,
@@ -441,7 +445,8 @@ fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFinding> {
             )
             .in_stage(&stage.name)
             .with_fix(
-                "drop the tool, switch the stage to an interactive mode, or set \
+                "drop the tool, switch the stage to an interactive mode, list it in \
+                 required_tools so it survives an unattended run too, or set \
                  allow_blocking_tools = true to say you meant it",
             )
         })

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -354,6 +354,31 @@ allow_blocking_tools = true
     assert!(lint(&toml, &LintEnv::default()).is_empty());
 }
 
+/// Naming the tool in `required_tools` says the same thing one tool at a time,
+/// and says it about the runtime too: the stage keeps that tool when the run is
+/// unattended. The lint has nothing left to point out.
+#[test]
+fn required_tools_silences_the_warning_for_that_tool() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["ask_user_text", "ask_user_confirm"]
+required_tools = ["ask_user_text"]
+"#,
+    );
+    // Only the tool that was *not* kept is still worth remarking on.
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["blocking-tool-in-autonomous-stage"]);
+    assert!(
+        findings[0].message.contains("ask_user_confirm"),
+        "{:?}",
+        findings[0].message
+    );
+}
+
 /// An interactive stage is where a person is expected, so the same grant is
 /// unremarkable there.
 #[test]

--- a/crates/leviath-cli/tests/manifest_integration.rs
+++ b/crates/leviath-cli/tests/manifest_integration.rs
@@ -458,6 +458,43 @@ fn branching_stages_explain_how_to_choose() {
     }
 }
 
+/// A human tool kept through an unattended run has to be one the stage can
+/// actually call, and it only makes sense where a person is genuinely expected.
+///
+/// `Blueprint::validate` already rejects the first half; this pins the intent
+/// for the shipped catalog: nothing opts out of the unattended cut except a
+/// stage that also declares an interaction point, so no bundled agent can start
+/// parking `--yolo` runs on a prompt by accident (issue #204).
+#[test]
+fn builtin_required_tools_are_offered_and_belong_to_an_interactive_stage() {
+    use leviath_core::blueprint::StageMode;
+
+    for (name, path) in &discover_agent_manifests() {
+        let content = std::fs::read_to_string(path).unwrap();
+        let blueprint = leviath_core::manifest::parse_manifest(&content).unwrap();
+
+        for stage in &blueprint.stages {
+            for tool in &stage.required_tools {
+                assert!(
+                    stage.available_tools.contains(tool),
+                    "agent '{name}' stage '{}' keeps '{tool}' through an unattended run \
+                     but never offers it",
+                    stage.name
+                );
+            }
+            assert!(
+                stage.required_tools.is_empty()
+                    || matches!(stage.mode, StageMode::InteractivePoints { .. }),
+                "agent '{name}' stage '{}' holds {:?} for a person, but declares no \
+                 interaction point - an unattended run would park there with nobody \
+                 watching",
+                stage.name,
+                stage.required_tools
+            );
+        }
+    }
+}
+
 #[test]
 fn at_least_nine_builtin_agents_exist() {
     let manifests = discover_agent_manifests();

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -607,6 +607,23 @@ impl PartialEq for InteractionStyle {
 }
 impl Eq for InteractionStyle {}
 
+/// What an interaction point does when the run is unattended (`--yolo`).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UnattendedPolicy {
+    /// Resolve the point as approved without opening a prompt. The default:
+    /// `--yolo` means nobody is watching, and a checkpoint nobody can answer
+    /// would park the run for as long as the daemon lives.
+    #[default]
+    AutoApprove,
+
+    /// Open the prompt anyway and wait for a person, even under `--yolo`. For a
+    /// checkpoint whose whole purpose is a human decision - a plan the user
+    /// signs off before any code is written. Pair it with `[limits]
+    /// interaction_timeout_secs` so an unanswered gate still releases.
+    Ask,
+}
+
 /// A point where a stage can request user input.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InteractionPoint {
@@ -616,8 +633,16 @@ pub struct InteractionPoint {
     /// Prompt to show the user
     pub prompt: String,
 
-    /// Whether input is required (vs optional)
+    /// Whether input is required (vs optional). A presentation hint carried on
+    /// the prompt - not to be confused with [`InteractionPoint::unattended`],
+    /// which decides whether the prompt is raised at all in a `--yolo` run.
     pub required: bool,
+
+    /// What this point does when nobody is watching. Defaults to
+    /// [`UnattendedPolicy::AutoApprove`]; set `unattended = "ask"` to hold the
+    /// run for a person even under `--yolo`.
+    #[serde(default)]
+    pub unattended: UnattendedPolicy,
 
     /// Style of interaction (free text, multiple choice, confirm)
     #[serde(default)]
@@ -689,6 +714,23 @@ pub struct Stage {
 
     /// Which tools are available in this stage
     pub available_tools: Vec<String>,
+
+    /// Human-in-the-loop tools (`ask_user_*`, `present_for_review`,
+    /// `edit_document`) that survive an unattended run.
+    ///
+    /// An unattended run - `lev run --yolo`, or a child of one - drops every
+    /// blocking human tool from the stage's advertised set, because a call to
+    /// one can only park the agent until the daemon dies (issue #204). Naming a
+    /// tool here says this stage genuinely needs a person and the run should
+    /// wait for one anyway. Pair it with `[limits] interaction_timeout_secs` so
+    /// an unanswered prompt still releases eventually.
+    ///
+    /// Entries must also appear in `available_tools` - listing a tool the stage
+    /// can't call in the first place is a validation error, not a silent no-op.
+    /// Matched verbatim against `available_tools` (this crate has no alias
+    /// table), so write the name the same way in both.
+    #[serde(default)]
+    pub required_tools: Vec<String>,
 
     /// Maximum iterations for this stage
     pub max_iterations: Option<usize>,
@@ -815,6 +857,7 @@ impl Stage {
             description: None,
             model,
             available_tools: Vec::new(),
+            required_tools: Vec::new(),
             max_iterations: None,
             mode: StageMode::Autonomous,
             context_layout: None,
@@ -868,6 +911,23 @@ impl Stage {
                 stage: "(empty)".to_string(),
                 message: "stage name cannot be empty".to_string(),
             });
+        }
+
+        // A `required_tools` entry the stage can't call is dead text: it looks
+        // like it keeps a tool through an unattended run, and keeps nothing.
+        // Rejected rather than ignored so the typo surfaces at `lev validate`
+        // instead of at 3am in a `--yolo` run.
+        for tool in &self.required_tools {
+            if !self.available_tools.contains(tool) {
+                return Err(ValidationError::Stage {
+                    stage: self.name.clone(),
+                    message: format!(
+                        "required_tools entry '{}' is not in available_tools - a tool the \
+                         stage cannot call can't be kept through an unattended run",
+                        tool
+                    ),
+                });
+            }
         }
 
         // Validate stage-specific context layout if present
@@ -1594,6 +1654,7 @@ mod tests {
             name: "plan_approval".to_string(),
             prompt: "Approve?".to_string(),
             required: true,
+            unattended: UnattendedPolicy::AutoApprove,
             style: InteractionStyle::MultipleChoice,
             options: vec!["Approve".to_string(), "Revise".to_string()],
             directives: HashMap::new(),
@@ -1617,6 +1678,7 @@ mod tests {
             name: "plan_approval".to_string(),
             prompt: "Approve?".to_string(),
             required: true,
+            unattended: UnattendedPolicy::Ask,
             style: InteractionStyle::MultipleChoice,
             options: vec!["Approve".to_string(), "Revise".to_string()],
             directives,
@@ -1632,6 +1694,9 @@ mod tests {
         );
         assert_eq!(back.abort_options, vec!["Abort".to_string()]);
         assert_eq!(back.edit_options, vec!["Add detail".to_string()]);
+        // A point that holds for a person under `--yolo` has to survive the
+        // round trip: this is what a restored run re-arms from.
+        assert_eq!(back.unattended, UnattendedPolicy::Ask);
     }
 
     #[test]
@@ -2129,6 +2194,32 @@ mod tests {
             .validate()
             .is_ok()
         );
+    }
+
+    /// `required_tools` keeps a blocking human tool through an unattended run.
+    /// Naming one the stage can't call keeps nothing, so it is rejected rather
+    /// than quietly ignored - the author meant something by writing it.
+    #[test]
+    fn validate_rejects_a_required_tool_the_stage_cannot_call() {
+        let mut stage = Stage::new("plan".to_string(), make_model());
+        stage.available_tools = vec!["read_file".to_string()];
+        stage.required_tools = vec!["ask_user_text".to_string()];
+        let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
+
+        let err = bp.validate().expect_err("a tool it cannot call");
+        let text = format!("{err:?}");
+        assert!(text.contains("ask_user_text"), "names the tool: {text}");
+        assert!(text.contains("available_tools"), "says why: {text}");
+    }
+
+    #[test]
+    fn validate_accepts_a_required_tool_the_stage_offers() {
+        let mut stage = Stage::new("plan".to_string(), make_model());
+        stage.available_tools = vec!["read_file".to_string(), "ask_user_text".to_string()];
+        stage.required_tools = vec!["ask_user_text".to_string()];
+        let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
+
+        bp.validate().expect("the tool is on offer");
     }
 
     #[test]

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -183,6 +183,28 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                                     .to_string();
                                 let pt_required =
                                     pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
+                                // What the point does when nobody is watching.
+                                // Absent means auto-approve, the behaviour every
+                                // `--yolo` run has had; `"ask"` opts a genuine
+                                // human checkpoint out of that. A misspelling
+                                // here would silently un-gate the checkpoint, so
+                                // it is an error rather than a fallback.
+                                let pt_unattended = match pt
+                                    .get("unattended")
+                                    .and_then(|v| v.as_str())
+                                {
+                                    None | Some("auto_approve") => {
+                                        crate::blueprint::UnattendedPolicy::AutoApprove
+                                    }
+                                    Some("ask") => crate::blueprint::UnattendedPolicy::Ask,
+                                    Some(other) => {
+                                        return Err(Error::Other(format!(
+                                            "stage '{stage_name}': interaction point '{pt_name}' \
+                                             has unattended = \"{other}\" - expected \"ask\" or \
+                                             \"auto_approve\""
+                                        )));
+                                    }
+                                };
                                 let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
                                     Some("multiple_choice") => {
                                         crate::blueprint::InteractionStyle::MultipleChoice
@@ -249,6 +271,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                                     name: pt_name,
                                     prompt: pt_prompt,
                                     required: pt_required,
+                                    unattended: pt_unattended,
                                     style: pt_style,
                                     options: pt_options,
                                     directives: pt_directives,
@@ -306,6 +329,15 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 .and_then(|v| v.as_array())
             {
                 stage.available_tools = tools_arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+            }
+
+            // Human tools this stage keeps even when the run is unattended.
+            // Validated against `available_tools` by `Stage::validate`.
+            if let Some(tools_arr) = stage_value.get("required_tools").and_then(|v| v.as_array()) {
+                stage.required_tools = tools_arr
                     .iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                     .collect();
@@ -2667,6 +2699,102 @@ directives = { "Revise" = "Call ask_user_text to find out what to change." }
         assert!(!points[0].directives.contains_key("Approve"));
         assert_eq!(points[0].abort_options, vec!["Abort".to_string()]);
         assert_eq!(points[0].edit_options, vec!["Edit".to_string()]);
+    }
+
+    /// The unattended opt-out (issue #204): absent means the point waves itself
+    /// through under `--yolo`, `"ask"` means it holds for a person.
+    #[test]
+    fn parse_manifest_interaction_point_unattended_policy() {
+        let toml = |line: &str| {
+            format!(
+                r#"
+[agent]
+name = "unattended-test"
+
+[stages.plan]
+mode = "interactive_points"
+
+[[stages.plan.interaction_points]]
+name     = "plan_approval"
+prompt   = "Approve?"
+required = true
+{line}
+"#
+            )
+        };
+        let policy_of = |line: &str| {
+            let bp = parse_manifest(&toml(line)).expect("valid manifest");
+            let stage = bp.find_stage("plan").expect("the plan stage");
+            unwrap_interactive_points(&stage.mode)[0].unattended
+        };
+
+        assert_eq!(
+            policy_of(""),
+            crate::blueprint::UnattendedPolicy::AutoApprove
+        );
+        assert_eq!(
+            policy_of("unattended = \"auto_approve\""),
+            crate::blueprint::UnattendedPolicy::AutoApprove
+        );
+        assert_eq!(
+            policy_of("unattended = \"ask\""),
+            crate::blueprint::UnattendedPolicy::Ask
+        );
+    }
+
+    /// A misspelling here would silently un-gate a checkpoint an author meant to
+    /// hold, so it is an error rather than a fallback to the default.
+    #[test]
+    fn parse_manifest_rejects_an_unknown_unattended_policy() {
+        let toml = r#"
+[agent]
+name = "unattended-typo"
+
+[stages.plan]
+mode = "interactive_points"
+
+[[stages.plan.interaction_points]]
+name     = "plan_approval"
+prompt   = "Approve?"
+required = true
+unattended = "always"
+"#;
+        let err = parse_manifest(toml).expect_err("unknown policy");
+        let text = err.to_string();
+        assert!(text.contains("plan_approval"), "names the point: {text}");
+        assert!(text.contains("always"), "quotes what was written: {text}");
+        assert!(text.contains("\"ask\""), "says what is allowed: {text}");
+    }
+
+    /// `required_tools` names the human tools a stage keeps when nobody is
+    /// watching.
+    #[test]
+    fn parse_manifest_reads_required_tools() {
+        let toml = r#"
+[agent]
+name = "required-tools-test"
+
+[stages.plan]
+mode = "autonomous"
+available_tools = ["read_file", "ask_user_text"]
+required_tools = ["ask_user_text"]
+
+[stages.build]
+mode = "autonomous"
+available_tools = ["read_file"]
+"#;
+        let bp = parse_manifest(toml).expect("valid manifest");
+        assert_eq!(
+            bp.find_stage("plan").expect("plan").required_tools,
+            vec!["ask_user_text".to_string()]
+        );
+        // A stage that says nothing keeps nothing - the default is the cut.
+        assert!(
+            bp.find_stage("build")
+                .expect("build")
+                .required_tools
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -44,6 +44,9 @@ async-trait = "0.1"
 [dev-dependencies]
 leviath-testkit = { workspace = true }
 async-trait = "0.1"
+# `start_paused` / `advance`, so the interaction deadline is tested by moving a
+# virtual clock rather than by sleeping through a real hour.
+tokio = { workspace = true, features = ["test-util"] }
 temp-env = { workspace = true, features = ["async_closure"] }
 tempfile = "3"
 

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -95,6 +95,7 @@ impl EmbedSpawner {
                 &self.defaults,
                 registry,
                 &all_tool_defs,
+                args.yolo,
             )?
         };
 

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -12,9 +12,16 @@
 //! a person at a keyboard can be a very long time. When the caller is a tool
 //! batch it waits [`off_lane`](crate::tool_bridge::off_lane), so a prompt nobody
 //! has answered yet costs the tool lane no capacity.
+//!
+//! "A very long time" used to mean "for ever": a run whose operator had walked
+//! away sat in `WaitingInput` until the daemon died, holding its slot the whole
+//! time (issue #204). [`InteractionHub::set_timeout_secs`] puts a deadline on
+//! that wait.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
+use std::time::Duration;
 
 use bevy_ecs::prelude::Resource;
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
@@ -44,7 +51,18 @@ pub struct InteractionHub {
     /// Opening, answering, or cancelling a request nudges it so the loop ticks
     /// (while otherwise parked) and reflects the change into agent status.
     wake: Arc<OnceLock<Arc<Notify>>>,
+    /// How long an open request may go unanswered before the hub resolves it
+    /// itself, in seconds. `0` (the default) waits indefinitely. Set once at
+    /// daemon start from `[limits] interaction_timeout_secs`.
+    timeout_secs: Arc<AtomicU64>,
 }
+
+/// The default deadline on an unanswered prompt, in seconds.
+///
+/// An hour is long enough that a person who is actually there answers well
+/// inside it, and short enough that a run whose operator has gone home releases
+/// its slot the same day rather than holding it until the daemon restarts.
+pub const DEFAULT_INTERACTION_TIMEOUT_SECS: u64 = 3600;
 
 impl InteractionHub {
     /// A fresh, empty hub.
@@ -58,6 +76,23 @@ impl InteractionHub {
         let _ = self.wake.set(wake);
     }
 
+    /// Set how long an open request may go unanswered before the hub resolves it
+    /// itself. `0` waits indefinitely - the behaviour before issue #204.
+    ///
+    /// Applies to requests opened from here on; a request already parked keeps
+    /// the deadline it was opened with.
+    pub fn set_timeout_secs(&self, secs: u64) {
+        self.timeout_secs.store(secs, Ordering::Relaxed);
+    }
+
+    /// The current deadline, or `None` when the hub waits indefinitely.
+    fn timeout(&self) -> Option<Duration> {
+        match self.timeout_secs.load(Ordering::Relaxed) {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        }
+    }
+
     /// Wake the tick loop if a handle is attached (no-op otherwise).
     fn nudge(&self) {
         if let Some(wake) = self.wake.get() {
@@ -66,7 +101,14 @@ impl InteractionHub {
     }
 
     /// Register a request from `agent_id` and await its answer. Returns a neutral
-    /// (empty-text) response if the request is cancelled before it is answered.
+    /// (empty-text) response if the request is cancelled before it is answered,
+    /// or if it goes unanswered past [`set_timeout_secs`](Self::set_timeout_secs).
+    ///
+    /// The timeout deliberately produces the *same* neutral response a cancel
+    /// does, so nothing downstream has to learn a third outcome: an approval or
+    /// a taint gate reads it as not-approved and denies, an `ask_user_*` tool
+    /// reports that no answer came, and an interaction point proceeds with empty
+    /// user text - each exactly as it already behaves for a cancelled request.
     async fn submit(&self, agent_id: &str, request: InteractionRequest) -> InteractionResponse {
         let id = request.id.clone();
         let (responder, rx) = oneshot::channel();
@@ -91,9 +133,50 @@ impl InteractionHub {
         // no other agent's tools could use (issue #191). Callers that are not
         // tool batches - the gate-prompt and interaction-point lanes - have no
         // ticket, and for them this is a plain await.
-        crate::tool_bridge::off_lane(rx)
-            .await
-            .unwrap_or_else(|_| InteractionResponse::text(id, ""))
+        let Some(deadline) = self.timeout() else {
+            return crate::tool_bridge::off_lane(rx)
+                .await
+                .unwrap_or_else(|_| InteractionResponse::text(id, ""));
+        };
+        // `&mut rx` rather than `rx`, so the receiver outlives an elapsed
+        // deadline and a reply that landed in that same instant can still be
+        // collected instead of thrown away.
+        let mut rx = rx;
+        match crate::tool_bridge::off_lane(tokio::time::timeout(deadline, &mut rx)).await {
+            Ok(answered) => answered.unwrap_or_else(|_| InteractionResponse::text(id, "")),
+            Err(_elapsed) => self.expire(agent_id, &id, &mut rx),
+        }
+    }
+
+    /// Resolve a request nobody answered in time: drop it from the open set so
+    /// the tick loop takes the agent out of `Waiting`, and hand its caller the
+    /// neutral response.
+    ///
+    /// A real answer that arrived as the deadline passed still wins. It is
+    /// already sitting in the channel, and handing back the neutral response
+    /// instead would throw away what a person actually said.
+    fn expire(
+        &self,
+        agent_id: &str,
+        id: &str,
+        rx: &mut oneshot::Receiver<InteractionResponse>,
+    ) -> InteractionResponse {
+        self.pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(id);
+        if let Ok(answered) = rx.try_recv() {
+            return answered;
+        }
+        tracing::warn!(
+            agent = %agent_id,
+            request = %id,
+            "no answer within the interaction timeout - resolving it as unanswered"
+        );
+        // Wake the driver so `reflect_interaction_status` moves the agent from
+        // Waiting back to Active now, rather than at the next re-drive.
+        self.nudge();
+        InteractionResponse::text(id, "")
     }
 
     /// Every open request, as `(agent_id, request)` pairs, for surfacing to
@@ -403,5 +486,107 @@ mod tests {
 
         // Cancelling again ⇒ nothing to cancel.
         assert!(!hub.cancel("q2"));
+    }
+
+    // ─── the deadline on an unanswered prompt (issue #204) ───────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn a_prompt_nobody_answers_is_released_when_the_deadline_passes() {
+        // The zombie in issue #204: six runs sat in `WaitingInput` for hours
+        // because nothing ever aged the request out. Now the hub resolves it
+        // itself and the agent goes back to work.
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(60);
+        let backend = hub.backend_for("agent-a");
+        let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
+
+        settle().await;
+        assert_eq!(hub.pending().len(), 1, "the prompt is open while it waits");
+
+        // The paused clock jumps to the deadline once nothing else can run.
+        let response = asking.await.unwrap();
+        assert_eq!(response.request_id, "q1");
+        // The same neutral answer a cancel produces: not approved, no text.
+        assert_eq!(response.value.as_deref(), Some(""));
+        assert_eq!(response.approved, None);
+        assert!(
+            hub.pending().is_empty(),
+            "the expired request is off the open list, so the agent leaves Waiting"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_deadline_changes_nothing_for_a_prompt_that_is_answered() {
+        // Setting a deadline must not alter the ordinary paths. Both of them run
+        // here: one prompt answered by a person, one cancelled under it.
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(3600);
+
+        let answered_backend = hub.backend_for("agent-a");
+        let answered = tokio::spawn(async move { answered_backend.ask(req("q1")).await });
+        let cancelled_backend = hub.backend_for("agent-b");
+        let cancelled = tokio::spawn(async move { cancelled_backend.ask(req("q2")).await });
+        settle().await;
+
+        assert!(hub.answer(InteractionResponse::text("q1", "yes, go on")));
+        assert_eq!(answered.await.unwrap().value.as_deref(), Some("yes, go on"));
+
+        assert!(hub.cancel("q2"));
+        assert_eq!(cancelled.await.unwrap().value.as_deref(), Some(""));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_zero_deadline_waits_for_a_person_however_long_it_takes() {
+        // `0` is the explicit "I will be here" setting, and it has to keep the
+        // old behaviour exactly: the prompt stays open until answered.
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(0);
+        let backend = hub.backend_for("agent-a");
+        let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
+
+        settle().await;
+        tokio::time::advance(Duration::from_secs(86_400)).await;
+        assert_eq!(hub.pending().len(), 1, "a day later, still waiting");
+
+        assert!(hub.answer(InteractionResponse::text("q1", "here I am")));
+        assert_eq!(asking.await.unwrap().value.as_deref(), Some("here I am"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_deadline_denies_rather_than_approves() {
+        // A timeout must never be read as consent: an approval prompt and a
+        // taint gate both go through `response_approved`, which reads the
+        // neutral response as "no".
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(30);
+        let backend = hub.backend_for("agent-a");
+        let asking = tokio::spawn(async move {
+            backend
+                .ask(InteractionRequest::tool_approval(
+                    "t1",
+                    "shell",
+                    serde_json::json!({"command": "rm -rf /"}),
+                    "implement",
+                ))
+                .await
+        });
+
+        let response = asking.await.unwrap();
+        assert!(!leviath_core::interaction::response_approved(&response));
+    }
+
+    #[tokio::test]
+    async fn an_answer_that_lands_as_the_deadline_passes_still_wins() {
+        // The race: `answer` took the entry out of the registry and sent its
+        // response an instant before the timer fired. Handing back the neutral
+        // response here would throw away what a person actually said.
+        let hub = InteractionHub::new();
+        let (responder, mut rx) = oneshot::channel();
+        responder
+            .send(InteractionResponse::text("q1", "approved by hand"))
+            .expect("the receiver is still alive");
+
+        let response = hub.expire("agent-a", "q1", &mut rx);
+        assert_eq!(response.value.as_deref(), Some("approved by hand"));
     }
 }

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bevy_ecs::prelude::*;
-use leviath_core::blueprint::{InteractionPoint, InteractionStyle, StageMode};
+use leviath_core::blueprint::{InteractionPoint, InteractionStyle, StageMode, UnattendedPolicy};
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
@@ -493,7 +493,13 @@ pub fn dispatch_interaction_point(
         // An unattended run (`--yolo`) approves the checkpoint instead of
         // opening a prompt nobody will answer. The document was published to its
         // region above, so what was approved is still on the record.
-        if auto_approve.is_some() {
+        //
+        // Unless the point declares `unattended = "ask"`: some checkpoints exist
+        // precisely because a person has to look - a plan signed off before any
+        // code is written - and their author would rather the run wait than have
+        // it wave itself through. `[limits] interaction_timeout_secs` is what
+        // keeps that wait from lasting for ever.
+        if auto_approve.is_some() && point.unattended == UnattendedPolicy::AutoApprove {
             tracing::info!(
                 agent = %state.agent_id,
                 point = %point.name,
@@ -709,6 +715,7 @@ mod tests {
             name: name.to_string(),
             prompt: "Choose".to_string(),
             required: true,
+            unattended: UnattendedPolicy::AutoApprove,
             style,
             options: options.iter().map(|s| s.to_string()).collect(),
             directives: HashMap::new(),
@@ -1145,6 +1152,48 @@ mod tests {
             .get_region("plan")
             .unwrap();
         assert_eq!(plan.content[0].content, "the plan");
+    }
+
+    #[tokio::test]
+    async fn dispatch_asks_an_unattended_run_when_the_point_opts_out() {
+        // `unattended = "ask"` is the escape hatch for a checkpoint that exists
+        // precisely because a person has to look - approving a plan unread is
+        // worse than waiting for one. The prompt opens even under `--yolo`.
+        let hub = InteractionHub::new();
+        let (tx, mut rx) = unbounded_channel();
+        let mut world = World::new();
+        world.insert_resource(hub.clone());
+        world.insert_resource(InteractionPointStage {
+            outcomes: tx,
+            wake: Arc::new(Notify::new()),
+            runtime: Handle::current(),
+        });
+        let mut point = plan_point();
+        point.unattended = UnattendedPolicy::Ask;
+        let e = world
+            .spawn((
+                agent_state(AgentStatus::Active),
+                blueprint_with(vec![point]),
+                window_with_plan(),
+                StageCursor { index: 0 },
+                infer("the plan"),
+                ReadyForInteractionPoint,
+                crate::components::InteractionAutoApprove,
+            ))
+            .id();
+        let mut s = Schedule::default();
+        s.add_systems(dispatch_interaction_point);
+        s.run(&mut world);
+
+        assert!(world.get::<AwaitingInteractionPoint>(e).is_some());
+        // Nothing was waved through: the run waits on a real prompt.
+        assert!(rx.try_recv().is_err(), "no outcome was published");
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        let pending = hub.pending();
+        assert_eq!(pending.len(), 1, "a person is being asked");
+        assert_eq!(pending[0].1.stage_name, "plan_approval");
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -197,8 +197,8 @@ pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool
 ///
 /// Same filter as [`filter_tools_by_available`], then - for an unattended run -
 /// minus every tool whose only outcome is a prompt for a person
-/// ([`leviath_tools::HUMAN_INTERACTION_TOOLS`]), unless the stage named it in
-/// `required_tools`.
+/// ([`BLOCKING_INTERACTION_TOOLS`](crate::dynamic_interaction::BLOCKING_INTERACTION_TOOLS)),
+/// unless the stage named it in `required_tools`.
 ///
 /// Dropping the definition rather than auto-answering the call is what makes the
 /// difference visible to the model: it never sees the tool, so it decides for
@@ -214,7 +214,7 @@ pub fn filter_tools_for_stage(
     let mut tools = filter_tools_by_available(all, available);
     if unattended {
         tools.retain(|t| {
-            !leviath_tools::is_human_interaction_tool(&t.name)
+            !crate::dynamic_interaction::BLOCKING_INTERACTION_TOOLS.contains(&t.name.as_str())
                 || required
                     .iter()
                     .any(|n| leviath_tools::canonical_tool_name(n) == t.name)

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -193,6 +193,36 @@ pub fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool
         .collect()
 }
 
+/// The stage's Layer-1 tool set for a run that may have nobody watching.
+///
+/// Same filter as [`filter_tools_by_available`], then - for an unattended run -
+/// minus every tool whose only outcome is a prompt for a person
+/// ([`leviath_tools::HUMAN_INTERACTION_TOOLS`]), unless the stage named it in
+/// `required_tools`.
+///
+/// Dropping the definition rather than auto-answering the call is what makes the
+/// difference visible to the model: it never sees the tool, so it decides for
+/// itself instead of spending a round trip to be told nobody is there. A call
+/// that arrives anyway (a model repeating itself from context) meets the ordinary
+/// unoffered-tool refusal.
+pub fn filter_tools_for_stage(
+    all: &[Tool],
+    available: &[String],
+    required: &[String],
+    unattended: bool,
+) -> Vec<Tool> {
+    let mut tools = filter_tools_by_available(all, available);
+    if unattended {
+        tools.retain(|t| {
+            !leviath_tools::is_human_interaction_tool(&t.name)
+                || required
+                    .iter()
+                    .any(|n| leviath_tools::canonical_tool_name(n) == t.name)
+        });
+    }
+    tools
+}
+
 /// Every provider a stage could have used, in the order they were tried, for
 /// the error message when none of them is configured.
 ///
@@ -240,12 +270,17 @@ pub fn providers_tried(
 /// spawned anyway: `Active`, iteration 0, and unable to take a single turn for
 /// as long as the host lived (issue #190). Catching it here turns a silently
 /// wedged run into an error the caller sees.
+///
+/// `unattended` is the run's `--yolo` setting: it decides whether a stage's
+/// human-in-the-loop tools are advertised at all (see
+/// [`filter_tools_for_stage`]).
 pub fn resolve_stages(
     blueprint: &Blueprint,
     model_override: Option<&str>,
     defaults: &ModelDefaults,
     registry: &ProviderRegistry,
     all_tool_defs: &[Tool],
+    unattended: bool,
 ) -> Result<Vec<ResolvedStage>, String> {
     blueprint
         .stages
@@ -267,8 +302,14 @@ pub fn resolve_stages(
             }
             // Empty `available_tools` exposes no tools; otherwise filter the full
             // set by name (alias-resolved). A name matching nothing (a typo, or an
-            // MCP tool whose server isn't installed) is simply omitted.
-            let tools = filter_tools_by_available(all_tool_defs, &stage.available_tools);
+            // MCP tool whose server isn't installed) is simply omitted. An
+            // unattended run also loses the tools that block on a person.
+            let tools = filter_tools_for_stage(
+                all_tool_defs,
+                &stage.available_tools,
+                &stage.required_tools,
+                unattended,
+            );
             Ok(ResolvedStage {
                 provider_name: head.provider,
                 model: head.model,
@@ -485,6 +526,7 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&["anthropic"]),
             &tools,
+            false,
         )
         .expect("anthropic is registered");
         assert!(resolved[0].tools.is_empty());
@@ -505,6 +547,7 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&[]),
             &[],
+            false,
         )
         .expect_err("no provider is configured");
 
@@ -528,6 +571,7 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&["anthropic"]),
             &[],
+            false,
         )
         .expect_err("the override names a provider that isn't registered");
 
@@ -594,6 +638,7 @@ mod tests {
             &ModelDefaults::default(),
             &registry_with(&["anthropic"]),
             &tools,
+            false,
         )
         .expect("anthropic is registered");
         let selected: Vec<&str> = resolved[0].tools.iter().map(|t| t.name.as_str()).collect();
@@ -630,6 +675,38 @@ mod tests {
                 ("anthropic", "sonnet"),
                 ("openai", "gpt"),
             ]
+        );
+    }
+
+    // ─── the unattended cut (issue #204) ─────────────────────────────────────
+
+    /// A stage's tool defs for the three tools every one of these tests uses.
+    fn ask_and_read_defs() -> Vec<Tool> {
+        ["read_file", "ask_user_text", "ask_user_choice"]
+            .iter()
+            .map(|n| Tool {
+                name: n.to_string(),
+                description: String::new(),
+                parameters: serde_json::Value::Null,
+            })
+            .collect()
+    }
+
+    fn names(tools: &[Tool]) -> Vec<&str> {
+        tools.iter().map(|t| t.name.as_str()).collect()
+    }
+
+    #[test]
+    fn an_attended_run_keeps_every_tool_the_stage_lists() {
+        let available = vec![
+            "read_file".to_string(),
+            "ask_user_text".to_string(),
+            "ask_user_choice".to_string(),
+        ];
+        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &[], false);
+        assert_eq!(
+            names(&tools),
+            vec!["read_file", "ask_user_text", "ask_user_choice"]
         );
     }
 
@@ -750,9 +827,95 @@ mod tests {
         let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
         let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
         let registry = registry_with(&["openrouter", "anthropic"]);
-        let resolved = resolve_stages(&bp, None, &ModelDefaults::default(), &registry, &[])
+        let resolved = resolve_stages(&bp, None, &ModelDefaults::default(), &registry, &[], false)
             .expect("both providers are registered");
         assert_eq!(resolved[0].provider_name, "openrouter");
         assert_eq!(pairs(&resolved[0].fallbacks), vec![("anthropic", "sonnet")]);
+    }
+
+    #[test]
+    fn an_unattended_run_loses_the_tools_that_wait_on_a_person() {
+        // The whole point of issue #204: with nobody watching, a call to
+        // `ask_user_text` can only park the agent, so the model never sees it.
+        let available = vec![
+            "read_file".to_string(),
+            "ask_user_text".to_string(),
+            "ask_user_choice".to_string(),
+        ];
+        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &[], true);
+        assert_eq!(names(&tools), vec!["read_file"]);
+    }
+
+    #[test]
+    fn required_tools_survive_an_unattended_run() {
+        // The opt-out: a stage that says it genuinely needs a person keeps the
+        // named tool, and only that one.
+        let available = vec![
+            "read_file".to_string(),
+            "ask_user_text".to_string(),
+            "ask_user_choice".to_string(),
+        ];
+        let required = vec!["ask_user_text".to_string()];
+        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &required, true);
+        assert_eq!(names(&tools), vec!["read_file", "ask_user_text"]);
+    }
+
+    #[test]
+    fn a_required_tool_the_stage_never_offered_adds_nothing() {
+        // `required_tools` narrows the unattended cut; it is not a second way to
+        // grant a tool. (`Stage::validate` rejects this combination outright -
+        // this is the belt to that pair of braces.)
+        let available = vec!["read_file".to_string()];
+        let required = vec!["ask_user_text".to_string()];
+        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &required, true);
+        assert_eq!(names(&tools), vec!["read_file"]);
+    }
+
+    #[test]
+    fn resolve_stages_applies_the_unattended_cut_per_stage() {
+        // Two stages, one opting out, resolved in a single unattended run: the
+        // cut is per stage, not per run.
+        let mut plan =
+            leviath_core::Stage::new("plan".to_string(), model_cfg(vec![("anthropic", "m")]));
+        plan.available_tools = vec!["read_file".to_string(), "ask_user_text".to_string()];
+        plan.required_tools = vec!["ask_user_text".to_string()];
+        let mut build =
+            leviath_core::Stage::new("build".to_string(), model_cfg(vec![("anthropic", "m")]));
+        build.available_tools = vec!["read_file".to_string(), "ask_user_text".to_string()];
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![plan, build], layout);
+
+        let resolved = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&["anthropic"]),
+            &ask_and_read_defs(),
+            true,
+        )
+        .expect("anthropic is registered");
+
+        assert_eq!(
+            names(&resolved[0].tools),
+            vec!["read_file", "ask_user_text"]
+        );
+        assert_eq!(names(&resolved[1].tools), vec!["read_file"]);
+    }
+
+    #[test]
+    fn the_unattended_cut_resolves_aliases_on_both_sides() {
+        // `edit_document` under an alias would be a hole in the cut, and a
+        // `required_tools` entry written as an alias would be a hole in the
+        // opt-out. Neither is: both sides canonicalise. `bash`/`shell` is the
+        // only alias pair that exists, so it stands in for the mechanism - a
+        // non-human tool is never cut whatever it is called.
+        let defs = vec![Tool {
+            name: "shell".to_string(),
+            description: String::new(),
+            parameters: serde_json::Value::Null,
+        }];
+        let available = vec!["bash".to_string()];
+        let tools = filter_tools_for_stage(&defs, &available, &[], true);
+        assert_eq!(names(&tools), vec!["shell"]);
     }
 }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -2144,6 +2144,7 @@ fn nudge_bp(reviewed: bool) -> AgentBlueprint {
             name: "plan_approval".to_string(),
             prompt: "Review the plan above.".to_string(),
             required: true,
+            unattended: leviath_core::blueprint::UnattendedPolicy::AutoApprove,
             style: leviath_core::blueprint::InteractionStyle::MultipleChoice,
             options: vec!["Approve".to_string()],
             directives: std::collections::HashMap::new(),

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -2011,6 +2011,7 @@ mod tests {
                 name: "plan_approval".to_string(),
                 prompt: "Approve?".to_string(),
                 required: true,
+                unattended: leviath_core::blueprint::UnattendedPolicy::AutoApprove,
                 style: InteractionStyle::MultipleChoice,
                 options: vec!["Approve".to_string(), "Abort".to_string()],
                 directives: std::collections::HashMap::new(),

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -41,6 +41,29 @@ fn resolved_shell_description() -> &'static str {
     DESCRIPTION.get_or_init(|| shell_tool_description(BuiltinTools::detect_shell().0))
 }
 
+/// The tools whose whole job is to block on a person: they open a prompt and the
+/// agent waits until someone answers it.
+///
+/// A run with nobody watching has no business being offered them - the call can
+/// only park the agent for as long as the daemon lives (issue #204). A stage
+/// resolved for an unattended run drops every name in this list that the stage
+/// hasn't explicitly asked to keep (`required_tools`).
+pub const HUMAN_INTERACTION_TOOLS: &[&str] = &[
+    "present_for_review",
+    "ask_user_text",
+    "ask_user_choice",
+    "ask_user_confirm",
+    "edit_document",
+];
+
+/// Whether `name` is a tool that blocks on a person.
+///
+/// Takes the name as written in a blueprint's `available_tools`, so it resolves
+/// aliases the same way the Layer-1 filter does.
+pub fn is_human_interaction_tool(name: &str) -> bool {
+    HUMAN_INTERACTION_TOOLS.contains(&crate::canonical_tool_name(name))
+}
+
 impl BuiltinTools {
     /// All tool definitions to advertise to the LLM, minus any whose required
     /// platform capabilities aren't provided by the current platform.

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -41,29 +41,6 @@ fn resolved_shell_description() -> &'static str {
     DESCRIPTION.get_or_init(|| shell_tool_description(BuiltinTools::detect_shell().0))
 }
 
-/// The tools whose whole job is to block on a person: they open a prompt and the
-/// agent waits until someone answers it.
-///
-/// A run with nobody watching has no business being offered them - the call can
-/// only park the agent for as long as the daemon lives (issue #204). A stage
-/// resolved for an unattended run drops every name in this list that the stage
-/// hasn't explicitly asked to keep (`required_tools`).
-pub const HUMAN_INTERACTION_TOOLS: &[&str] = &[
-    "present_for_review",
-    "ask_user_text",
-    "ask_user_choice",
-    "ask_user_confirm",
-    "edit_document",
-];
-
-/// Whether `name` is a tool that blocks on a person.
-///
-/// Takes the name as written in a blueprint's `available_tools`, so it resolves
-/// aliases the same way the Layer-1 filter does.
-pub fn is_human_interaction_tool(name: &str) -> bool {
-    HUMAN_INTERACTION_TOOLS.contains(&crate::canonical_tool_name(name))
-}
-
 impl BuiltinTools {
     /// All tool definitions to advertise to the LLM, minus any whose required
     /// platform capabilities aren't provided by the current platform.

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -19,9 +19,7 @@ mod exec;
 mod platform;
 mod validate;
 pub use context::*;
-pub use defs::{
-    HUMAN_INTERACTION_TOOLS, SUBAGENT_TOOLS, is_human_interaction_tool, is_subagent_tool,
-};
+pub use defs::{SUBAGENT_TOOLS, is_subagent_tool};
 pub use platform::*;
 pub use validate::*;
 
@@ -120,25 +118,6 @@ mod tests {
             assert!(is_subagent_tool(name));
         }
         assert!(!is_subagent_tool("read_file"));
-    }
-
-    /// The list an unattended run cuts against. Every name has to be a real
-    /// advertised tool, and the predicate has to see through an alias - a stage
-    /// naming one of these under an alias would otherwise slip through the cut.
-    #[test]
-    fn human_interaction_predicate_covers_the_blocking_tools_and_nothing_else() {
-        let dir = std::env::temp_dir();
-        let advertised = make_tools(&dir).names();
-        for name in HUMAN_INTERACTION_TOOLS {
-            assert!(is_human_interaction_tool(name));
-            assert!(
-                advertised.iter().any(|n| n == name),
-                "'{name}' is not a built-in tool"
-            );
-        }
-        assert!(!is_human_interaction_tool("read_file"));
-        // `bash` resolves to `shell`, which does not block on a person.
-        assert!(!is_human_interaction_tool("bash"));
     }
 
     // ── Tool definitions ──────────────────────────────────────────────────

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -19,7 +19,9 @@ mod exec;
 mod platform;
 mod validate;
 pub use context::*;
-pub use defs::{SUBAGENT_TOOLS, is_subagent_tool};
+pub use defs::{
+    HUMAN_INTERACTION_TOOLS, SUBAGENT_TOOLS, is_human_interaction_tool, is_subagent_tool,
+};
 pub use platform::*;
 pub use validate::*;
 
@@ -118,6 +120,25 @@ mod tests {
             assert!(is_subagent_tool(name));
         }
         assert!(!is_subagent_tool("read_file"));
+    }
+
+    /// The list an unattended run cuts against. Every name has to be a real
+    /// advertised tool, and the predicate has to see through an alias - a stage
+    /// naming one of these under an alias would otherwise slip through the cut.
+    #[test]
+    fn human_interaction_predicate_covers_the_blocking_tools_and_nothing_else() {
+        let dir = std::env::temp_dir();
+        let advertised = make_tools(&dir).names();
+        for name in HUMAN_INTERACTION_TOOLS {
+            assert!(is_human_interaction_tool(name));
+            assert!(
+                advertised.iter().any(|n| n == name),
+                "'{name}' is not a built-in tool"
+            );
+        }
+        assert!(!is_human_interaction_tool("read_file"));
+        // `bash` resolves to `shell`, which does not block on a person.
+        assert!(!is_human_interaction_tool("bash"));
     }
 
     // ── Tool definitions ──────────────────────────────────────────────────

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -113,7 +113,8 @@ whichever provider your config makes the default, which is rarely what the autho
 invisible until the run picks the wrong model. `lev validate` reports both.
 `available_tools` is what the stage may call. `required_tools` is the small exception to the
 unattended cut: a `--yolo` run drops every tool that blocks on a person, and a stage names here the
-ones it wants kept anyway. Every entry must also be in `available_tools`. See
+ones it wants kept anyway. Every entry must also be in `available_tools`, and naming one also
+settles the `blocking-tool-in-autonomous-stage` lint for it. See
 [human-in-the-loop tools](/docs/tools#these-tools-need-someone-there).
 
 ## Context regions

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -29,6 +29,7 @@ model = { models = [
   { provider = "openai",    model = "gpt-5.4-mini" },
 ] }
 available_tools = ["read_file", "list_dir"]
+required_tools = []                # human-in-the-loop tools kept in an unattended run
 max_iterations = 15
 system_prompt = """Understand the task and produce a short implementation plan."""
 
@@ -110,6 +111,10 @@ complaint and is then read by nothing, so the stages carry on using their own de
 that the block was ignored. A stage that omits `model` entirely does not fail either: it runs on
 whichever provider your config makes the default, which is rarely what the author had in mind and is
 invisible until the run picks the wrong model. `lev validate` reports both.
+`available_tools` is what the stage may call. `required_tools` is the small exception to the
+unattended cut: a `--yolo` run drops every tool that blocks on a person, and a stage names here the
+ones it wants kept anyway. Every entry must also be in `available_tools`. See
+[human-in-the-loop tools](/docs/tools#these-tools-need-someone-there).
 
 ## Context regions
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -28,7 +28,7 @@ Spawn an agent into the daemon. `PATH` is an installed agent name, a blueprint d
 | `-t`, `--task <TEXT\|FILE>` | The task prompt, or the path of a file holding it. Left off, your editor opens |
 | `-m`, `--model <MODEL>` | Model override, as `provider/model` or a bare model name |
 | `--workdir <DIR>` | Working directory for the run. Defaults to where you ran the command. File tools are confined to it, and relative `[read_paths]` entries resolve against it |
-| `--yolo` | Run unattended: approve every tool call and auto-answer the agent's own prompts (`ask_user_*`, plan approvals). Cannot lift a `deny` |
+| `--yolo` | Run unattended: approve every tool call, and take away the tools that wait on a person (`ask_user_*`, `present_for_review`, `edit_document`) so the run cannot park on a prompt. Plan approvals resolve themselves. A stage keeps what it lists in [`required_tools`](/docs/tools#these-tools-need-someone-there). Cannot lift a `deny` |
 | `--allow <TOOL>` | Allow one tool outright. Repeatable |
 | `--max-depth <N>` | Override the blueprint's maximum sub-agent tree depth |
 | `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions for this run |

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -108,6 +108,7 @@ finished_retention_secs   = 300  # keep a finished run in `lev ps` this long
 wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is off
 provider_failures_before_open  = 3     # pull a provider after this many failures in a row
 provider_circuit_cooldown_secs = 300   # how long before it is tried again
+interaction_timeout_secs  = 3600 # release a prompt nobody answered
 ```
 
 | Key | Default | Notes |
@@ -123,6 +124,7 @@ provider_circuit_cooldown_secs = 300   # how long before it is tried again
 | `wedge_timeout_secs` | `0` (off) | How long a run may sit in a state no part of the engine can reach before it is failed instead of left reported as running. Never fires on a run that is merely slow: an agent waiting on the model, a tool, its sub-agents, or a person is exempt however long it takes. Off by default because it fails runs; `300` is a sensible value if something outside Leviath tracks your slots. See [reconciling an external work queue](/docs/daemon#reconciling-an-external-work-queue) |
 | `provider_failures_before_open` | `3` | Consecutive failures that only you can fix (out of credits, rejected key) before a provider is taken out of service for every run. Three rather than one because a single payment error can be one oversized request. `0` disables it, leaving per-run failover on its own |
 | `provider_circuit_cooldown_secs` | `300` | How long a provider stays out before one request is let through to see whether it recovered. A success puts it straight back; a failure restarts the wait. See [Providers](/docs/providers#when-a-provider-keeps-failing) |
+| `interaction_timeout_secs` | `3600` | How long any prompt that waits on a person may go unanswered before the daemon resolves it and lets the run continue. Covers `ask_user_*`, tool approvals, taint gates, and interaction points. An expiry denies an approval and tells the model no answer came; it never counts as consent. See [when nobody answers](/docs/interaction#when-nobody-answers). `0` waits indefinitely |
 
 <a id="security"></a>
 

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -51,14 +51,35 @@ call until the answer comes back, then continues with it:
 - `present_for_review`: shows a markdown document (`title` + `markdown`) for review and collects optional feedback.
 
 > [!NOTE]
-> Under an unattended run (`--yolo`) nobody is watching, so these answer themselves rather than
-> parking the run forever: a confirmation is approved, an edit submits the document unchanged, a
-> review is acknowledged, and a free-text or choice question is told no one answered so the model
-> decides for itself; a choice is never picked blind.
+> Under an unattended run (`--yolo`) nobody is watching, so these five tools are not advertised to
+> the model at all. It never sees them and decides for itself, instead of spending a round trip to
+> be told no one is there. A call that arrives anyway (a model repeating itself out of its own
+> context) is refused the way any unoffered tool is.
+>
+> A stage that genuinely needs a person keeps the tools it names in
+> [`required_tools`](/docs/tools#these-tools-need-someone-there).
 >
 > Unattended applies to the whole run tree, not just the agent you launched: sub-agents and
 > fan-out workers inherit it, and it survives a daemon restart. Otherwise a child could stop
 > on a prompt nobody was watching for and take its parent down with it.
+
+## When nobody answers
+
+Every prompt on this page waits on a person, and until Leviath 0.1.2 it waited indefinitely - a run
+whose operator had gone home sat in `WaitingInput` holding its slot until the daemon restarted.
+
+`[limits] interaction_timeout_secs` puts a deadline on that wait (one hour by default; `0` waits
+indefinitely, the old behaviour). When it passes, the prompt resolves exactly as cancelling it
+would:
+
+| Prompt | What an expiry means |
+|---|---|
+| Tool approval | Denied. A timeout is never read as consent. |
+| Taint gate | Denied. |
+| `ask_user_*` | The model is told no answer came, and carries on. |
+| Interaction point | Proceeds with no user text, as a cancelled checkpoint does. |
+
+The deadline is read once when the daemon starts, so changing it needs a daemon restart.
 
 ## Tool approval
 
@@ -98,6 +119,7 @@ mode = "interactive_points"
 name     = "plan_approval"
 prompt   = "Approve the plan?"
 required = true
+unattended = "ask"                    # ask | auto_approve (default)
 style    = "multiple_choice"          # free_text | multiple_choice | confirm
 options  = ["Approve", "Revise", "Edit", "Abort"]
 abort_options = ["Abort"]
@@ -123,6 +145,14 @@ exactly first, then with dash/whitespace normalization:
 point's authoritative document. Each time the point is presented, the current text (the produced
 output, or the user's direct edit) replaces that region, so revisions and downstream stages build
 on the current version rather than regenerating from the task.
+
+`unattended` decides what the point does in a `--yolo` run. The default, `auto_approve`, resolves it
+as approved without opening a prompt: nobody is watching, and a checkpoint that waited would park
+the run. Set it to `ask` for a gate whose whole purpose is a human decision - a plan signed off
+before any code is written - and the prompt opens even under `--yolo`. The shipped
+`software-engineer` agent does exactly that for its plan approval. Give a run like that an
+[`interaction_timeout_secs`](/docs/configuration#limits), so an unanswered gate releases on its own
+terms instead of waiting for ever.
 
 > [!WARNING]
 > The revise and edit loops are bounded: after 4 revision rounds at a single point (`MAX_REVISION_ROUNDS`),

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -118,10 +118,13 @@ required_tools = ["ask_user_text", "ask_user_choice"]
 ```
 
 `required_tools` entries must also appear in `available_tools`; `lev validate` rejects a manifest
-where they do not, and warns about an autonomous stage that offers one of these tools without
-opting out. Pair the opt-out with
-[`interaction_timeout_secs`](/docs/configuration#limits) so a prompt nobody answers still releases
-the run rather than parking it for good.
+where they do not. It also warns (`blocking-tool-in-autonomous-stage`) about an autonomous stage
+that grants one of these tools without saying it meant to. Naming the tool in `required_tools`
+settles that, and keeps the tool through an unattended run; `allow_blocking_tools = true` on the
+stage settles the warning alone, for a stage that only ever runs attended.
+
+Pair the opt-out with [`interaction_timeout_secs`](/docs/configuration#limits) so a prompt nobody
+answers still releases the run rather than parking it for good.
 
 ## Sub-agents
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -98,6 +98,31 @@ Present work to the user for approval or direct editing.
 | `present_for_review` | Pause and display a markdown document (plan, design, report) for the user to read and approve. | `title`, `markdown` |
 | `edit_document` | Show a document in an editable field pre-filled with its current text; the returned text is the user's authoritative edit. | `content`, `prompt` (optional) |
 
+### These tools need someone there
+
+Every tool in the two tables above does the same thing: it opens a prompt and waits. That is fine
+when you are watching the run. When nobody is, the wait has no end - the agent sits in
+`WaitingInput`, holding a concurrency slot, until the daemon restarts.
+
+So an unattended run does not get them. A run launched with `--yolo` (and every sub-agent and
+fan-out worker under it) has these five tools removed from the set advertised to the model, per
+stage, before the first inference. The model never sees them and decides for itself instead.
+
+A stage that genuinely needs a person can opt out, tool by tool:
+
+```toml
+[stages.plan]
+available_tools = ["read_file", "ask_user_text", "ask_user_choice"]
+# Kept even when the run is unattended.
+required_tools = ["ask_user_text", "ask_user_choice"]
+```
+
+`required_tools` entries must also appear in `available_tools`; `lev validate` rejects a manifest
+where they do not, and warns about an autonomous stage that offers one of these tools without
+opting out. Pair the opt-out with
+[`interaction_timeout_secs`](/docs/configuration#limits) so a prompt nobody answers still releases
+the run rather than parking it for good.
+
 ## Sub-agents
 
 Spawn and coordinate [child agents](/docs/sub-agents) from within a run. These are advertised to the
@@ -194,7 +219,8 @@ exfiltration-capable call fires.
 > [!WARNING]
 > A tool set to `ask` in a headless context blocks until someone answers. It never auto-denies. For
 > unattended runs, either grant the tools explicitly with `--allow` or use `--yolo`, which cannot
-> override a `deny`.
+> override a `deny`. Set [`interaction_timeout_secs`](/docs/configuration#limits) to put a deadline
+> on any prompt that goes unanswered, whichever way it was raised.
 
 ## Argument validation
 


### PR DESCRIPTION
Closes #204. Also closes the duplicate #208.

## The problem

Six production runs sat in `WaitingInput` for three to five hours each, one concurrency slot apiece, because an agent had called `ask_user_text` with nobody there to answer. Two separate gaps let that happen:

1. **Nothing ages out a parked prompt.** `InteractionHub::submit` awaited its oneshot with no timeout: answered, cancelled, or waiting until the daemon restarts. The only watchdog in the daemon fires for `Active` agents whose provider is missing, so a `Waiting` agent was never touched. (The 30-second timeouts the issue points at are inside `#[cfg(test)]`.)
2. **`--yolo` still advertised the tools.** The model was offered `ask_user_text`, called it, and got back a canned "no user was available" string. A wasted round trip when the flag was set, and a permanent park when it was not.

`StageMode::Autonomous` exists but the runtime never read it, so a blueprint could declare an autonomous stage, hand it a blocking human tool, and hear nothing from anywhere.

## What changed

**An unattended run is not offered the tools that wait on a person.** `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `present_for_review`, and `edit_document` are dropped from the advertised set per stage, before the first inference. The model never sees them and decides for itself. A stray call meets the ordinary unoffered-tool refusal. The cut lives in the filter that spawn resolution and the mid-run tool-service refresh already share, so a `dynamic_tools` agent cannot re-acquire them on a re-scan.

**Two opt-outs, for the stages that really do need someone.**

- `required_tools` on a stage names the human tools it keeps when unattended. An entry that is not in `available_tools` is a validation error, not a silent no-op.
- `unattended = "ask"` on an interaction point holds the checkpoint for a real answer instead of approving itself. It is a new key rather than a reading of the existing `required`, which is a presentation hint several shipped points already set.

A kept tool also routes to the hub rather than the auto-answering backend. Without that the opt-out would advertise the tool and then answer it on the user's behalf, which is no opt-out at all — a live run showed exactly that before it was fixed.

**`[limits] interaction_timeout_secs`**, one hour by default, puts a deadline on every prompt that waits on a person: `ask_user_*`, tool approvals, taint gates, and interaction points. Expiry resolves the prompt exactly as cancelling it does, so an approval and a taint gate **deny**, the model is told no answer came, and a checkpoint proceeds with no user text. A timeout is never read as consent. `0` waits indefinitely. A real answer landing as the deadline passes still wins.

**`lev validate` says so** when an autonomous stage offers one of these tools without opting out, naming the stage and the tools. Two shipped agents draw it and both deserve it: coder's and software-engineer's `implement` stages really do lose those calls in an unattended run.

**software-engineer keeps its plan gate.** The point takes `unattended = "ask"` and the stage keeps the three tools its revise and add-detail branches depend on, because everything past that gate writes code.

## Verified live

Isolated daemon, Rhai mock provider, six scenarios:

1. Attended run parks; `lev ps` reads `waiting: user prompt`; `lev respond` lists and answers it; the run continues.
2. `--yolo` run is never offered the tool, takes the "decide alone" branch, and completes.
3. `required_tools` under `--yolo` reaches a real person — `waiting: user prompt`, answerable with `lev respond`. **This scenario is what caught the half-wired opt-out.**
4. `interaction_timeout_secs = 15`: the prompt releases itself, the agent returns to active, and the run reaches `complete` instead of parking. Before the change it parked at iteration 1 for ever.
5. Interaction point `unattended = "ask"` holds a `--yolo` run at `waiting: checkpoint`; the default still auto-approves and completes in seconds.
6. `lev validate` on coder and software-engineer prints the new advisory; the opted-out `plan` stage stays silent.

Full test suite and clippy are green locally across all 32 binaries. The 100% coverage gate could not be run here — nine sibling worktrees had the disk at 99% — so CI is the first full coverage pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cgfmDJ9RdTe1N9fU7G1No