### PR TITLE
Check what a blueprint leaves unsaid, not just what it gets wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,30 @@ requests since the previous version.
   `list_models` reported a rejected API key as a request failure, which reads as
   a transient network fault worth retrying. Ollama also gains the `429` handling
   it never had.
+- `lev validate` now checks the things a blueprint leaves unsaid, not just the
+  ones it gets wrong. A stage with no `[stages.X.model]` block parsed fine and
+  then ran on whatever the user's `default_provider` was; an agent-level
+  `[model]` block was read by nothing at all; a typo in `available_tools`
+  matched nothing, so the stage quietly advertised one tool fewer and the model
+  was told the tool did not exist. Each of those was invisible on inspection and
+  turned up hours later as a run behaving oddly. There are thirteen checks in
+  all, each with a stable code and a suggested fix.
+- Typos are errors and exit non-zero; everything else is a warning that does
+  not, or a note that never can. `lev validate --deny-warnings` makes warnings
+  fatal for CI.
+- The same findings are logged when the daemon spawns a run, so a blueprint
+  nobody validated still says what is wrong with it in `daemon.log`. No finding
+  refuses a spawn.
+- `lev validate` also warns when an autonomous stage grants `ask_user_text`,
+  `present_for_review` or another tool that suspends until a person answers.
+  Unattended, the run parks there until it is killed. New stage key
+  `allow_blocking_tools = true` records that the stage means it; it grants
+  nothing and changes no behaviour.
+- The lint found two defects in the shipped blueprints. `parallel-fixer` set
+  `bash = "ask"` while every stage granted `shell`: policy is matched on the
+  name the model calls, so the entry was never consulted. And
+  `software-engineer`'s review stage had no `max_iterations`.
+- `POST /api/blueprints/validate` returns a `warnings` list alongside `errors`.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -241,6 +241,10 @@ description = "Write code according to the plan, verifying continuously"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "context_write", "ask_user_confirm"]
 max_iterations = 50
 max_revisits = 3
+# ask_user_confirm suspends the run until a person answers, which is deliberate
+# here: this stage checks in before doing something it cannot undo. Declared so
+# `lev validate` reports it as a choice rather than an oversight.
+allow_blocking_tools = true
 system_prompt = """
 You are implementing the plan from the `plan` region. Write working,
 production-quality code that matches the project's `conventions`.

--- a/crates/leviath-cli/agents/parallel-fixer/agent.leviath
+++ b/crates/leviath-cli/agents/parallel-fixer/agent.leviath
@@ -10,7 +10,9 @@ list_dir = "allow"
 read_files = "allow"
 write_file = "ask"
 edit_file = "ask"
-bash = "ask"
+# `shell`, not `bash`: every stage here grants the canonical name, and policy is
+# matched on the name the model calls, so a `bash` key would never be consulted.
+shell = "ask"
 
 # ─── Stage 1: Discover ───────────────────────────────────────────────────────
 # Derive the test commands instead of making the caller spell them out in --task.

--- a/crates/leviath-cli/agents/software-engineer/agent.leviath
+++ b/crates/leviath-cli/agents/software-engineer/agent.leviath
@@ -312,6 +312,11 @@ description = "Write code according to the approved plan"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append"]
 max_iterations = 50
 max_revisits = 5
+# The ask_user_* tools suspend the run until a person answers, which is
+# deliberate here: this stage asks rather than guessing when the approved plan
+# turns out to be underspecified. Declared so `lev validate` reports it as a
+# choice rather than an oversight.
+allow_blocking_tools = true
 system_prompt = """
 You are the implementation stage. The plan in the `plan` region has been approved.
 Execute it step by step:
@@ -426,6 +431,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Review the implementation and evaluate code quality"
 available_tools = ["read_file", "list_dir", "bash"]
+max_iterations = 20
 max_revisits = 3
 # Lets the run end here (via "DONE") when the review approves the work,
 # instead of being forced down the only declared edge back to implement.

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -222,43 +222,49 @@ mod tests {
         }
     }
 
-    /// Every name in a stage's `available_tools` has to resolve to a tool that
-    /// exists, and every `[stages.X.tool_permissions]` key has to be a tool that
-    /// stage actually grants.
+    /// The lint env for a bundled agent: the built-ins, the sub-agent tools,
+    /// and the agent's own `tools/<name>.rhai`, each of which defines `<name>`.
     ///
-    /// A typo here is invisible on its own: `filter_tools_by_available` silently
-    /// omits a name matching nothing, so the stage just quietly advertises one
-    /// tool fewer. And because dispatch refuses anything a stage did not offer,
-    /// the same typo means the model is told the tool does not exist and the
-    /// stage cannot do its job - a silent omission that is really a silent
-    /// failure, which is worth a test. A permission entry for an ungranted tool is the same drift seen
-    /// from the other side: it reads as a grant and is not one.
-    ///
-    /// An invariant over all discovered agents rather than a list of names -
-    /// naming them would stop testing the property the moment the list drifted.
-    #[test]
-    fn every_stage_tool_name_resolves_and_every_permission_names_a_granted_tool() {
-        // Sub-agent tools are provided by the host, not `BuiltinTools`.
-        const SUBAGENT: &[&str] = &[
-            "spawn_agent",
-            "check_agent",
-            "wait_for_agent",
-            "send_to_agent",
-            "kill_agent",
-        ];
-        let builtin = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
-            std::path::PathBuf::from("."),
-        ))
-        .names();
-
-        for agent in BUNDLED_AGENTS {
-            // This agent's own Rhai tools: `tools/<name>.rhai` defines `<name>`.
-            let scripts: Vec<&str> = agent
+    /// Built by hand rather than through `LintEnv::offline`, which discovers
+    /// script tools by reading a directory: a bundled agent's files are
+    /// compiled into the binary and there is no directory to read.
+    fn lint_env_for(agent: &BundledAgent) -> crate::lint::LintEnv {
+        let mut known_tools: std::collections::HashSet<String> = leviath_tools::BuiltinTools::new(
+            leviath_tools::ToolContext::new(std::path::PathBuf::from(".")),
+        )
+        .names()
+        .into_iter()
+        .collect();
+        known_tools.extend(leviath_tools::BuiltinTools::subagent_tool_names());
+        known_tools.extend(
+            agent
                 .files
                 .iter()
                 .filter_map(|(rel, _)| rel.strip_prefix("tools/"))
                 .filter_map(|f| f.strip_suffix(".rhai"))
-                .collect();
+                .map(str::to_string),
+        );
+        crate::lint::LintEnv {
+            known_tools,
+            known_models: crate::commands::models::closed_catalog_models(),
+            available_providers: None,
+        }
+    }
+
+    /// No bundled agent ships a blueprint the linter calls broken.
+    ///
+    /// The errors this catches are the ones that are invisible on inspection: a
+    /// tool name matching nothing is silently dropped from what the stage
+    /// advertises, so the model is told the tool does not exist and the stage
+    /// cannot do its job. A permission for a tool the stage never granted is the
+    /// same drift from the other side, reading as a grant and not being one.
+    ///
+    /// Asserted by running the shipped linter rather than by a parallel copy of
+    /// its rules, and over all discovered agents rather than a list of names -
+    /// either would stop testing the property the moment it drifted.
+    #[test]
+    fn no_bundled_agent_has_a_lint_error() {
+        for agent in BUNDLED_AGENTS {
             let manifest = agent
                 .files
                 .iter()
@@ -272,48 +278,30 @@ mod tests {
                 agent.name
             );
             let blueprint = parsed.expect("asserted Ok just above");
-
-            for stage in &blueprint.stages {
-                for tool in &stage.available_tools {
-                    // `server__tool` is an MCP tool, resolvable only once that
-                    // server is installed - not something a manifest can be
-                    // checked against here.
-                    let known = tool.contains("__")
-                        || builtin.iter().any(|b| b == tool)
-                        || SUBAGENT.contains(&tool.as_str())
-                        || scripts.contains(&tool.as_str());
-                    assert!(
-                        known,
-                        "{}: stage '{}' grants '{}', which is not a built-in,                          a sub-agent tool, or one of this agent's own tools/*.rhai",
-                        agent.name, stage.name, tool
-                    );
-                }
-                for granted in stage.tool_permissions.keys() {
-                    assert!(
-                        stage.available_tools.contains(granted),
-                        "{}: stage '{}' sets a permission for '{}', which it does                          not grant in available_tools",
-                        agent.name,
-                        stage.name,
-                        granted
-                    );
-                }
-            }
+            // Every finding is rendered up front, and the errors are then
+            // *counted* rather than collected. Any per-error work - a `.map`
+            // that formats, a `.collect` into a list of messages - sits in a
+            // closure that only runs when the test is about to fail, which
+            // llvm-cov reads as an uncovered region for as long as the
+            // invariant holds. Counting has no such body.
+            let rendered: Vec<(bool, String)> =
+                crate::lint::lint_manifest(manifest, &blueprint, &lint_env_for(agent))
+                    .iter()
+                    .map(|f| (f.is_error(), format!("{} [{}]", f.one_line(), f.code)))
+                    .collect();
+            let error_count = rendered.iter().filter(|(is_error, _)| *is_error).count();
+            assert_eq!(
+                error_count, 0,
+                "bundled agent {} has lint errors, among {rendered:?}",
+                agent.name
+            );
         }
     }
 
     /// The invariant above can actually fail - a check over shipped data that
     /// happens to pass says nothing about whether it would catch drift.
     #[test]
-    fn the_stage_tool_invariant_rejects_a_typo_and_an_orphan_permission() {
-        let builtin = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(
-            std::path::PathBuf::from("."),
-        ))
-        .names();
-        assert!(
-            !builtin.iter().any(|b| b == "raed_file"),
-            "a misspelled tool must not resolve"
-        );
-
+    fn the_lint_invariant_catches_a_typo_and_an_orphan_permission() {
         let manifest = r#"
 [agent]
 name = "x"
@@ -321,19 +309,28 @@ version = "0.1.0"
 description = "x"
 
 [stages.only]
-model = { provider = "anthropic", model = "m" }
-available_tools = ["read_file"]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+max_iterations = 5
+available_tools = ["read_file", "raed_file"]
 
 [stages.only.tool_permissions]
 write_file = "allow"
 "#;
         let bp = leviath_core::manifest::parse_manifest(manifest)
-            .expect("the fixture parses; it is the invariant that should object");
-        let stage = &bp.stages[0];
-        assert!(
-            !stage.available_tools.contains(&"write_file".to_string()),
-            "the orphan-permission arm has something to catch"
-        );
+            .expect("the fixture parses; it is the lint that should object");
+        // Reuse the same env shape a real bundled agent gets, minus any scripts.
+        let env = lint_env_for(&BundledAgent {
+            name: "x",
+            version: "0.1.0",
+            files: &[],
+        });
+        let codes: Vec<&str> = crate::lint::lint_manifest(manifest, &bp, &env)
+            .iter()
+            .filter(|f| f.is_error())
+            .map(|f| f.code)
+            .collect();
+        assert_eq!(codes, ["unknown-tool", "orphan-stage-permission"]);
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -66,6 +66,26 @@ struct BuiltinEntry {
     caps: ModelCapabilities,
 }
 
+/// Providers whose entry in [`builtin_table`] is complete enough to say "this
+/// model does not exist" about.
+///
+/// Anthropic, OpenAI and Google publish a short list and this table tracks it.
+/// The rest do not: Ollama serves whatever has been pulled locally, OpenRouter
+/// proxies hundreds of models of which the table lists a sample, and a script
+/// provider defines its own catalog at run time. Naming a model those hosts
+/// have and this build has not heard of is normal, so they are never checked.
+const CLOSED_CATALOG_PROVIDERS: &[&str] = &["anthropic", "openai", "google"];
+
+/// The `(provider, model)` rows [`crate::lint`] checks a blueprint's model
+/// references against, limited to the providers with a closed catalog.
+pub fn closed_catalog_models() -> Vec<(String, String)> {
+    builtin_table()
+        .into_iter()
+        .filter(|e| CLOSED_CATALOG_PROVIDERS.contains(&e.provider))
+        .map(|e| (e.provider.to_string(), e.model_id.to_string()))
+        .collect()
+}
+
 /// Hard-coded capability table for well-known models.
 ///
 /// This is used when the provider API is not reachable or `--remote` is not

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -218,21 +218,40 @@ pub(super) async fn delete_blueprint(
 pub(super) async fn validate_blueprint(
     Json(body): Json<ValidateBlueprintReq>,
 ) -> Json<ValidateResponse> {
-    match parse_manifest(&body.manifest) {
-        Ok(bp) => match bp.validate() {
-            Ok(()) => Json(ValidateResponse {
-                valid: true,
-                errors: None,
-            }),
-            Err(e) => Json(ValidateResponse {
-                valid: false,
-                errors: Some(vec![e.to_string()]),
-            }),
-        },
-        Err(e) => Json(ValidateResponse {
-            valid: false,
-            errors: Some(vec![e.to_string()]),
-        }),
+    Json(validate_manifest_text(&body.manifest))
+}
+
+/// Parse, validate and lint a manifest posted as text.
+///
+/// A lint error is a real defect (a tool name that resolves to nothing, a
+/// permission for a tool the stage never granted), so it makes the response
+/// invalid alongside the structural errors. Warnings and notes are reported
+/// separately and do not.
+///
+/// The manifest arrives as text with no directory behind it, so the lint runs
+/// against the built-in tool set only: an agent's own `tools/*.rhai` cannot be
+/// resolved from a POST body, and an env that claimed otherwise would report
+/// every one of them as unknown.
+fn validate_manifest_text(manifest: &str) -> ValidateResponse {
+    let bp = match parse_manifest(manifest) {
+        Ok(bp) => bp,
+        Err(e) => return ValidateResponse::invalid(vec![e.to_string()]),
+    };
+    if let Err(e) = bp.validate() {
+        return ValidateResponse::invalid(vec![e.to_string()]);
+    }
+
+    let env = crate::lint::LintEnv::offline(std::path::Path::new("."));
+    let findings = crate::lint::lint_manifest(manifest, &bp, &env);
+    let (errors, warnings): (Vec<_>, Vec<_>) = findings
+        .iter()
+        .partition(|f| f.severity == crate::lint::LintSeverity::Error);
+    let render = |f: &&crate::lint::LintFinding| format!("{} [{}]", f.one_line(), f.code);
+
+    ValidateResponse {
+        valid: errors.is_empty(),
+        errors: (!errors.is_empty()).then(|| errors.iter().map(render).collect()),
+        warnings: (!warnings.is_empty()).then(|| warnings.iter().map(render).collect()),
     }
 }
 
@@ -902,6 +921,67 @@ prompt = "Run"
         let result: ValidateResponse = serde_json::from_slice(&bytes).unwrap();
         assert!(result.valid);
         assert!(result.errors.is_none());
+    }
+
+    /// A blueprint the lint objects to but `Blueprint::validate` does not.
+    /// `valid` follows the lint errors, and the warnings ride alongside without
+    /// affecting it.
+    #[tokio::test]
+    async fn validate_blueprint_reports_lint_errors_and_warnings_separately() {
+        // `raed_file` is an error (it resolves to nothing); the missing
+        // `max_iterations` and the unattended `ask_user_text` are warnings.
+        let manifest = r#"
+[agent]
+name = "linty"
+version = "0.1.0"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+available_tools = ["read_file", "raed_file", "ask_user_text"]
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+        let result = validate_manifest_text(manifest);
+        assert!(!result.valid);
+        let errors = result.errors.expect("the typo is an error");
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("unknown-tool"), "{errors:?}");
+        let warnings = result.warnings.expect("the defaults are warnings");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("stage-missing-max-iterations")),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("blocking-tool-in-autonomous-stage")),
+            "{warnings:?}"
+        );
+    }
+
+    /// Warnings alone leave the blueprint valid.
+    #[tokio::test]
+    async fn validate_blueprint_with_only_warnings_stays_valid() {
+        let manifest = r#"
+[agent]
+name = "warny"
+version = "0.1.0"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+        let result = validate_manifest_text(manifest);
+        assert!(result.valid);
+        assert!(result.errors.is_none());
+        assert_eq!(result.warnings.expect("no max_iterations").len(), 1);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -277,6 +277,22 @@ pub(super) struct ValidateResponse {
     pub(super) valid: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) errors: Option<Vec<String>>,
+    /// Lint findings that do not make the blueprint invalid: fields left to a
+    /// default, a stage that can block on a human, a broad `[read_paths]`
+    /// entry. Absent when there are none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) warnings: Option<Vec<String>>,
+}
+
+impl ValidateResponse {
+    /// The response for a manifest that did not parse or did not validate.
+    pub(super) fn invalid(errors: Vec<String>) -> Self {
+        Self {
+            valid: false,
+            errors: Some(errors),
+            warnings: None,
+        }
+    }
 }
 
 // ─── Agent types ────────────────────────────────────────────────────────────
@@ -539,23 +555,39 @@ mod tests {
         let resp = ValidateResponse {
             valid: true,
             errors: None,
+            warnings: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
+        // Neither list appears at all when there is nothing in it.
+        assert_eq!(json, r#"{"valid":true}"#);
         let parsed: ValidateResponse = serde_json::from_str(&json).unwrap();
         assert!(parsed.valid);
         assert!(parsed.errors.is_none());
+        assert!(parsed.warnings.is_none());
     }
 
     #[test]
     fn validate_response_with_errors_roundtrip() {
-        let resp = ValidateResponse {
-            valid: false,
-            errors: Some(vec!["bad field".to_string()]),
-        };
+        let resp = ValidateResponse::invalid(vec!["bad field".to_string()]);
         let json = serde_json::to_string(&resp).unwrap();
         let parsed: ValidateResponse = serde_json::from_str(&json).unwrap();
         assert!(!parsed.valid);
         assert_eq!(parsed.errors.unwrap().len(), 1);
+        assert!(parsed.warnings.is_none());
+    }
+
+    /// A blueprint can be valid and still have something worth saying about it.
+    #[test]
+    fn validate_response_with_warnings_roundtrip() {
+        let resp = ValidateResponse {
+            valid: true,
+            errors: None,
+            warnings: Some(vec!["stage 'main': no max_iterations".to_string()]),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: ValidateResponse = serde_json::from_str(&json).unwrap();
+        assert!(parsed.valid);
+        assert_eq!(parsed.warnings.unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -3,11 +3,17 @@
 use clap::Args;
 use std::path::PathBuf;
 
+use crate::lint::{LintEnv, LintFinding, LintSeverity, lint_manifest};
+
 #[derive(Args)]
 pub struct ValidateArgs {
     /// Path to the agent directory or agent.leviath file
     #[arg(default_value = ".")]
     pub(crate) path: String,
+
+    /// Fail on warnings too, not only errors. Notes never fail.
+    #[arg(long)]
+    pub(crate) deny_warnings: bool,
 }
 
 /// Resolve, read, parse, and validate the manifest at `path`. Distinguishes
@@ -21,7 +27,17 @@ enum ManifestCheckError {
     Validation(String),
 }
 
-fn check_manifest(path: &std::path::Path) -> Result<leviath_core::Blueprint, ManifestCheckError> {
+/// A manifest that parsed and validated, kept alongside the text it came from
+/// so the linter can ask what the author actually wrote.
+#[derive(Debug)]
+struct CheckedManifest {
+    blueprint: leviath_core::Blueprint,
+    content: String,
+    /// The directory holding the manifest: where its `tools/` live.
+    agent_dir: PathBuf,
+}
+
+fn check_manifest(path: &std::path::Path) -> Result<CheckedManifest, ManifestCheckError> {
     // Resolve manifest path
     let manifest_path = if path.is_file() {
         path.to_path_buf()
@@ -58,7 +74,15 @@ fn check_manifest(path: &std::path::Path) -> Result<leviath_core::Blueprint, Man
     crate::daemon::spawn::resolve_region_scripts(&blueprint, &manifest_path.to_string_lossy())
         .map_err(ManifestCheckError::Validation)?;
 
-    Ok(blueprint)
+    let agent_dir = manifest_path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
+    Ok(CheckedManifest {
+        blueprint,
+        content,
+        agent_dir,
+    })
 }
 
 /// Print the "valid blueprint" summary + non-fatal warnings.
@@ -103,79 +127,104 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
                 .join(" → ")
         );
     }
-
-    // Command seeds execute at spawn - surface them before anything else, so
-    // `lev validate` is a real audit step before `lev add`.
-    for line in command_seed_report(blueprint) {
-        println!("{line}");
-    }
-
-    // Warnings (non-fatal)
-    print_warnings(blueprint);
-}
-
-/// The report lines for a blueprint's `seed = { command = "..." }` regions.
-///
-/// Split out from the printer so it is directly assertable. Empty when the
-/// blueprint declares none - the overwhelmingly common case, which should print
-/// nothing at all.
-fn command_seed_report(blueprint: &leviath_core::Blueprint) -> Vec<String> {
-    let seeds: Vec<(&str, &str)> = blueprint
-        .context_layout
-        .regions
-        .iter()
-        .filter_map(|r| match &r.seed {
-            Some(leviath_core::layout::RegionSeed::Command { command }) => {
-                Some((r.name.as_str(), command.as_str()))
-            }
-            _ => None,
-        })
-        .collect();
-    if seeds.is_empty() {
-        return Vec::new();
-    }
-    let mut lines = vec![format!(
-        "  ⚠ {} region(s) run a shell command at spawn, before the first \
-         inference and before any tool-approval prompt:",
-        seeds.len()
-    )];
-    lines.extend(
-        seeds
-            .iter()
-            .map(|(region, command)| format!("      {region}: {command}")),
-    );
-    lines.push(
-        "    Disable with `--no-seed-commands`, or machine-wide via \
-         `[security] allow_seed_commands = false`."
-            .to_string(),
-    );
-    lines
 }
 
 /// Outcome of the real, testable logic in [`execute`]. Kept distinct from
-/// the actual `std::process::exit(1)` calls (which would kill the test
-/// process if exercised directly) so `execute_reporting_outcome` - and
-/// therefore every branch of `check_manifest`'s error handling - can be
-/// unit tested; only the thin `execute` wrapper below ever calls `exit`.
+/// the actual failure reporting so `execute_reporting_outcome` - and therefore
+/// every branch of `check_manifest`'s error handling - can be unit tested.
+#[derive(Debug)]
 enum ValidateOutcome {
     Success,
     ParseError(String),
     ValidationError(String),
+    /// The manifest is structurally fine but the lint found something fatal:
+    /// how many errors, and how many warnings (which only count when
+    /// `--deny-warnings` was passed).
+    LintFailed {
+        errors: usize,
+        warnings: usize,
+    },
 }
 
-fn execute_reporting_outcome(args: &ValidateArgs) -> anyhow::Result<ValidateOutcome> {
+/// Print `findings` worst-first, one per line with its fix indented under it.
+///
+/// Returns the counts so the caller can decide the exit status without walking
+/// the list again.
+fn print_findings(findings: &[LintFinding]) -> (usize, usize) {
+    let mut errors = 0;
+    let mut warnings = 0;
+    for finding in findings {
+        match finding.severity {
+            LintSeverity::Error => errors += 1,
+            LintSeverity::Warning => warnings += 1,
+            LintSeverity::Note => {}
+        }
+        println!(
+            "  {} {} [{}]",
+            finding.severity.label(),
+            finding.one_line(),
+            finding.code
+        );
+        if let Some(fix) = &finding.fix {
+            println!("       {fix}");
+        }
+    }
+    (errors, warnings)
+}
+
+/// The command core. `config` is the user's configuration when it could be
+/// loaded, and is only used to answer "can this install reach the providers
+/// this blueprint names" - a config that will not load is not a reason to
+/// refuse to lint, it only means that one check has nothing to say. Taking it
+/// as an argument keeps this function hermetic; the real
+/// [`Config::load`](crate::config::Config::load) happens in [`execute`].
+fn execute_reporting_outcome(
+    args: &ValidateArgs,
+    config: Option<&crate::config::Config>,
+) -> anyhow::Result<ValidateOutcome> {
     let path = PathBuf::from(&args.path);
 
-    let blueprint = match check_manifest(&path) {
-        Ok(bp) => bp,
+    let checked = match check_manifest(&path) {
+        Ok(c) => c,
         Err(ManifestCheckError::Io(e)) => return Err(e),
         Err(ManifestCheckError::Parse(e)) => return Ok(ValidateOutcome::ParseError(e)),
         Err(ManifestCheckError::Validation(e)) => return Ok(ValidateOutcome::ValidationError(e)),
     };
 
-    print_success(&blueprint);
+    print_success(&checked.blueprint);
     print_script_tool_report(&path);
+
+    let mut env = LintEnv::offline(&checked.agent_dir);
+    if let Some(config) = config {
+        env = env.with_providers(&checked.blueprint, config);
+    }
+    let findings = lint_manifest(&checked.content, &checked.blueprint, &env);
+    let (errors, warnings) = print_findings(&findings);
+
+    if errors > 0 || (args.deny_warnings && warnings > 0) {
+        return Ok(ValidateOutcome::LintFailed { errors, warnings });
+    }
     Ok(ValidateOutcome::Success)
+}
+
+/// The failure line for a lint that came back fatal. Split out so its
+/// pluralization is assertable without capturing stdout.
+fn lint_failure_message(errors: usize, warnings: usize, deny_warnings: bool) -> String {
+    let mut parts = Vec::new();
+    if errors > 0 {
+        parts.push(format!("{errors} error{}", plural(errors)));
+    }
+    if deny_warnings && warnings > 0 {
+        parts.push(format!(
+            "{warnings} warning{} (--deny-warnings)",
+            plural(warnings)
+        ));
+    }
+    format!("✗ Blueprint has {}", parts.join(" and "))
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
 }
 
 /// Validate the agent's own Rhai script tools: discover the agent
@@ -217,126 +266,14 @@ fn print_script_tool_report(path: &std::path::Path) {
     }
 }
 
-/// Report `[read_paths]` declarations: what the agent asks to read beyond its
-/// workdir, plus a sharper warning for entries so broad they amount to "my
-/// whole home directory" or "any absolute path". Pure over the blueprint so
-/// the wording is testable without capturing stdout.
-fn read_path_warning_lines(blueprint: &leviath_core::Blueprint) -> Vec<String> {
-    let Some(rp) = blueprint
-        .read_paths
-        .as_ref()
-        .filter(|rp| !rp.allow.is_empty())
-    else {
-        return Vec::new();
-    };
-    let mut lines = vec![format!(
-        "  ⚠ Note: declares [read_paths] (reads outside the run workdir): {} - refused \
-         unless your config grants them",
-        rp.allow.join(", ")
-    )];
-    for entry in &rp.allow {
-        if read_path_entry_is_broad(entry) {
-            lines.push(format!(
-                "  ⚠ Warning: read_paths entry '{entry}' is very broad - it can match your \
-                 entire home directory or any path on this machine"
-            ));
-        }
-    }
-    lines
-}
-
-/// Whether a `[read_paths]` entry grants effectively unlimited read access:
-/// the home directory itself, a filesystem root, or a pattern whose first
-/// component already matches anything.
-fn read_path_entry_is_broad(entry: &str) -> bool {
-    let pattern = entry
-        .strip_prefix("glob:")
-        .or_else(|| entry.strip_prefix("regex:"))
-        .unwrap_or(entry);
-    let pattern = pattern.replace('\\', "/");
-    let trimmed = pattern.trim_end_matches('/');
-    matches!(trimmed, "~" | "")
-        || trimmed == "/**"
-        || pattern.starts_with("**")
-        || pattern.starts_with("/.*")
-        || trimmed == "/.+"
-}
-
 pub async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
-    match execute_reporting_outcome(&args)? {
+    let config = crate::config::Config::load().ok();
+    match execute_reporting_outcome(&args, config.as_ref())? {
         ValidateOutcome::Success => Ok(()),
         ValidateOutcome::ParseError(e) => anyhow::bail!("✗ Parse error: {}", e),
         ValidateOutcome::ValidationError(e) => anyhow::bail!("✗ Validation failed: {}", e),
-    }
-}
-
-fn print_warnings(blueprint: &leviath_core::Blueprint) {
-    // Before the graph-only checks below: `[read_paths]` applies to any
-    // blueprint shape, so it is reported ahead of the `is_graph` early return.
-    for line in read_path_warning_lines(blueprint) {
-        println!("{line}");
-    }
-
-    let stage_names: std::collections::HashSet<&str> =
-        blueprint.stages.iter().map(|s| s.name.as_str()).collect();
-
-    let is_graph = blueprint.stages.iter().any(|s| s.transitions.is_some());
-    if !is_graph {
-        return;
-    }
-
-    let entry = blueprint.resolve_entry_stage_name();
-
-    // Check reachability via BFS from entry stage
-    let mut reachable = std::collections::HashSet::new();
-    let mut queue = std::collections::VecDeque::new();
-    queue.push_back(entry.clone());
-    while let Some(name) = queue.pop_front() {
-        if !reachable.insert(name.clone()) {
-            continue;
-        }
-        let Some(stage) = blueprint.find_stage(&name) else {
-            continue;
-        };
-        let Some(ref transitions) = stage.transitions else {
-            continue;
-        };
-        for target in transitions.keys() {
-            if !reachable.contains(target.as_str()) && stage_names.contains(target.as_str()) {
-                queue.push_back(target.clone());
-            }
-        }
-    }
-
-    for stage in &blueprint.stages {
-        if !reachable.contains(stage.name.as_str()) {
-            println!(
-                "  ⚠ Warning: stage '{}' is unreachable from entry stage '{}'",
-                stage.name, entry
-            );
-        }
-    }
-
-    // Check for loops without max_revisits
-    for stage in &blueprint.stages {
-        let Some(ref transitions) = stage.transitions else {
-            continue;
-        };
-        for target in transitions.keys() {
-            if target == &stage.name {
-                continue;
-            }
-            // Check if target can reach back to this stage (cycle)
-            let Some(target_stage) = blueprint.find_stage(target) else {
-                continue;
-            };
-            let Some(ref t2) = target_stage.transitions else {
-                continue;
-            };
-            if t2.contains_key(&stage.name) && target_stage.max_revisits.is_none() {
-                #[rustfmt::skip]
-                println!("  ⚠ Warning: stage '{}' is in a cycle but has no max_revisits set", target);
-            }
+        ValidateOutcome::LintFailed { errors, warnings } => {
+            anyhow::bail!(lint_failure_message(errors, warnings, args.deny_warnings))
         }
     }
 }
@@ -345,6 +282,49 @@ fn print_warnings(blueprint: &leviath_core::Blueprint) {
 mod tests {
     use super::*;
     use crate::test_support::write_test_agent;
+
+    /// A minimal manifest that lints clean, so a test can add exactly the one
+    /// defect it is about.
+    ///
+    /// Ollama is last in the models list because it registers with no
+    /// credential: under the isolated config these tests run against, a
+    /// blueprint naming only keyed providers would (correctly) warn that
+    /// nothing in its list is reachable.
+    const CLEAN_MANIFEST: &str = r#"
+[agent]
+name = "ok-agent"
+version = "0.1.0"
+description = "Valid"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Main"
+max_iterations = 5
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+"#;
+
+    fn write_manifest(dir: &std::path::Path, content: &str) -> std::path::PathBuf {
+        let path = dir.join("agent.leviath");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn args_for(dir: &std::path::Path) -> ValidateArgs {
+        ValidateArgs {
+            path: dir.to_str().unwrap().to_string(),
+            deny_warnings: false,
+        }
+    }
+
+    // ─── print_success ───────────────────────────────────────────────────
+
+    fn parse(toml: &str) -> leviath_core::Blueprint {
+        leviath_core::manifest::parse_manifest(toml).unwrap()
+    }
 
     /// Helper to create a minimal valid blueprint TOML with given stages.
     fn make_blueprint_toml(stages_toml: &str) -> String {
@@ -355,457 +335,162 @@ name = "test"
 version = "0.1.0"
 description = "test blueprint"
 
-{}
+{stages_toml}
 
 [context.regions]
 system = {{ kind = "pinned", max_tokens = 1000 }}
 conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
-"#,
-            stages_toml
+"#
         )
     }
 
-    fn parse(toml: &str) -> leviath_core::Blueprint {
-        leviath_core::manifest::parse_manifest(toml).unwrap()
-    }
-
-    /// The `[read_paths]` note fires for any blueprint shape - including the
-    /// linear ones the graph warnings skip - and lists the entries verbatim.
     #[test]
-    fn read_path_declarations_are_noted_for_linear_blueprints() {
-        let toml = format!(
-            "{}\n[read_paths]\nallow = [\"~/.leviath/runs\"]\n",
-            make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"")
-        );
-        let lines = read_path_warning_lines(&parse(&toml));
-        assert_eq!(lines.len(), 1);
-        assert!(lines[0].contains("~/.leviath/runs"), "{lines:?}");
-        assert!(
-            lines[0].contains("refused unless your config grants"),
-            "{lines:?}"
-        );
-    }
-
-    #[test]
-    fn no_read_paths_means_no_note() {
-        let toml = make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"");
-        assert!(read_path_warning_lines(&parse(&toml)).is_empty());
-    }
-
-    /// Entries that amount to "everything" get the sharper warning; scoped
-    /// ones do not.
-    #[test]
-    fn broad_read_path_entries_get_their_own_warning() {
-        let toml = format!(
-            "{}\n[read_paths]\nallow = [\"~\", \"~/.leviath/runs\"]\n",
-            make_blueprint_toml("[stages.plan]\nmode = \"autonomous\"")
-        );
-        let lines = read_path_warning_lines(&parse(&toml));
-        assert_eq!(lines.len(), 2, "{lines:?}");
-        assert!(lines[1].contains("very broad"), "{lines:?}");
-        assert!(lines[1].contains("'~'"), "{lines:?}");
-    }
-
-    #[test]
-    fn broad_entry_heuristic_covers_each_shape() {
-        for entry in [
-            "~",
-            "~/",
-            "/",
-            "glob:**",
-            "glob:/**",
-            "regex:/.*",
-            "regex:/.+",
-        ] {
-            assert!(read_path_entry_is_broad(entry), "{entry}");
-        }
-        for entry in [
-            "~/.leviath/runs",
-            "glob:~/docs/**",
-            "regex:/data/.*",
-            "../shared",
-            r"C:\data",
-        ] {
-            assert!(!read_path_entry_is_broad(entry), "{entry}");
-        }
-    }
-
-    #[test]
-    fn check_manifest_verifies_custom_region_scripts() {
-        // A custom region's script must exist and compile; the same failure a
-        // spawn would hit, surfaced by `lev validate`.
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("agent.leviath");
-        let toml = r#"
-[agent]
-name = "custom-validate"
-version = "0.1.0"
-description = "d"
-
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-5" }
-description = "Main stage"
-
-[context.regions]
-system = { kind = "pinned", max_tokens = 1000 }
-conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
-brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
-"#;
-        std::fs::write(&manifest_path, toml).unwrap();
-
-        // Missing script file → validation error naming region + path.
-        let err = format!("{:?}", check_manifest(&manifest_path).unwrap_err());
-        assert!(err.starts_with("Validation"), "{err}");
-        assert!(err.contains("region 'brain'"), "{err}");
-
-        // Present + compilable → passes.
-        std::fs::create_dir(dir.path().join("hooks")).unwrap();
-        std::fs::write(
-            dir.path().join("hooks/brain.rhai"),
-            "fn render(ctx) { \"ok\" }",
-        )
-        .unwrap();
-        let bp = check_manifest(&manifest_path).unwrap();
-        assert_eq!(bp.name, "custom-validate");
-    }
-
-    #[test]
-    fn command_seed_report_is_empty_without_command_seeds() {
-        let bp = parse(&make_blueprint_toml(
+    fn print_success_linear_mode_no_panic() {
+        let toml = make_blueprint_toml(
             r#"
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-5" }
-description = "Main stage"
-"#,
-        ));
-        assert!(command_seed_report(&bp).is_empty());
-    }
-
-    #[test]
-    fn command_seed_report_names_every_region_and_command() {
-        let toml = r#"
-[agent]
-name = "scanner"
-version = "0.1.0"
-
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-5" }
-description = "Main stage"
-
-[context.regions]
-facts = { kind = "pinned", max_tokens = 1000, seed = { command = "git ls-files" } }
-tests = { kind = "pinned", max_tokens = 1000, seed = { command = "ls tests" } }
-plain = { kind = "pinned", max_tokens = 1000 }
-conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
-"#;
-        let report = command_seed_report(&parse(toml)).join("\n");
-        assert!(report.contains("2 region(s)"), "got: {report}");
-        assert!(report.contains("facts: git ls-files"), "got: {report}");
-        assert!(report.contains("tests: ls tests"), "got: {report}");
-        // The escape hatches are named so the reader knows how to refuse.
-        assert!(report.contains("--no-seed-commands"), "got: {report}");
-        assert!(report.contains("allow_seed_commands"), "got: {report}");
-        // A region without a command seed is not reported.
-        assert!(!report.contains("plain"), "got: {report}");
-        // And the printer itself runs.
-        print_success(&parse(toml));
-    }
-
-    #[test]
-    fn print_warnings_linear_mode_no_panic() {
-        let toml = format!(
-            "{}\n[read_paths]\nallow = [\"~/.leviath/runs\", \"~\"]\n",
-            make_blueprint_toml(
-                r#"
 [stages.main]
 mode = "autonomous"
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 description = "Main stage"
-max_iterations = 10
+max_iterations = 5
+
+[stages.review]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "Review stage"
+max_iterations = 5
 "#,
-            )
         );
-        let bp = parse(&toml);
-        // Should not panic even though there's no graph, and the read_paths
-        // note (plus the broad-entry warning for "~") is printed before the
-        // graph-only checks bail.
-        print_warnings(&bp);
+        print_success(&parse(&toml));
     }
 
     #[test]
-    fn print_warnings_graph_all_reachable() {
+    fn print_success_graph_mode_with_terminal_and_revisits_no_panic() {
         let toml = make_blueprint_toml(
             r#"
 [stages.a]
 mode = "autonomous"
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage B"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        // No unreachable stages - should run without issues
-        print_warnings(&bp);
-    }
-
-    #[test]
-    fn validate_args_default_path() {
-        // ValidateArgs can be constructed with default path
-        let args = ValidateArgs {
-            path: ".".to_string(),
-        };
-        assert_eq!(args.path, ".");
-    }
-
-    // ─── print_warnings: unreachable stage ──────────────────────────────
-
-    #[test]
-    fn print_warnings_unreachable_stage_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage B"
-max_iterations = 5
-
-[stages.orphan]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Unreachable stage"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        // Should not panic; orphan stage is unreachable
-        print_warnings(&bp);
-    }
-
-    // ─── print_warnings: cycle without max_revisits ─────────────────────
-
-    #[test]
-    fn print_warnings_cycle_without_max_revisits_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage B"
-max_iterations = 5
-[stages.b.transitions]
-a = "true"
-"#,
-        );
-        let bp = parse(&toml);
-        // Should print warning about cycle but not panic
-        print_warnings(&bp);
-    }
-
-    // ─── print_warnings: cycle with max_revisits set ────────────────────
-
-    #[test]
-    fn print_warnings_cycle_with_max_revisits_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage B"
-max_iterations = 5
-max_revisits = 3
-[stages.b.transitions]
-a = "true"
-"#,
-        );
-        let bp = parse(&toml);
-        print_warnings(&bp);
-    }
-
-    // ─── print_warnings: terminal stage with empty transitions ──────────
-
-    #[test]
-    fn print_warnings_terminal_stage_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Terminal stage"
-max_iterations = 5
-[stages.b.transitions]
-"#,
-        );
-        let bp = parse(&toml);
-        print_warnings(&bp);
-    }
-
-    // ─── print_warnings: self-loop cycle (target == stage.name skip) ────
-
-    #[test]
-    fn print_warnings_self_loop_with_max_revisits_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Stage A"
+description = "A"
 max_iterations = 5
 entry = true
 max_revisits = 3
 [stages.a.transitions]
-a = "true"
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "B"
+max_iterations = 5
+"#,
+        );
+        // Exercises: graph mode header, an edge with a target ("-> b"), and
+        // stage "b" which has transitions = None ("(linear)" branch) as well
+        // as the max_revisits formatting on stage "a".
+        print_success(&parse(&toml));
+    }
+
+    #[test]
+    fn print_success_graph_mode_terminal_stage_no_panic() {
+        let toml = make_blueprint_toml(
+            r#"
+[stages.a]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "A"
+max_iterations = 5
+entry = true
+[stages.a.transitions]
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "B"
+max_iterations = 5
+[stages.b.transitions]
 "#,
         );
         let bp = parse(&toml);
-        // Self-loop transition should hit the `target == stage.name` skip in
-        // the cycle-detection loop without panicking or false-warning.
-        print_warnings(&bp);
+        // Stage "b" has an explicitly-empty transitions table -> Some(empty
+        // map) -> exercises the "(terminal)" formatting branch.
+        let b = bp.find_stage("b").unwrap();
+        assert!(matches!(&b.transitions, Some(t) if t.is_empty()));
+        print_success(&bp);
     }
 
-    // ─── print_warnings: Blueprint constructed directly (not via parse +
-    // validate), so it can carry invariants `Blueprint::validate` would
-    // normally reject. `print_warnings` takes a bare `&Blueprint` and has
-    // no way to know whether its caller validated it first, so these
-    // "malformed but structurally valid Rust" shapes are reachable through
-    // its public API even though `execute_reporting_outcome` (the only
-    // production caller) always validates first. ────────────────────────
+    // ─── print_findings ──────────────────────────────────────────────────
 
-    fn make_model() -> leviath_core::blueprint::ModelConfig {
-        leviath_core::blueprint::ModelConfig::new(
-            "anthropic".to_string(),
-            "claude-sonnet-4-6".to_string(),
-        )
+    /// One finding of each severity: the counts returned are errors and
+    /// warnings only, because a note must never fail anything.
+    #[test]
+    fn print_findings_counts_errors_and_warnings_but_not_notes() {
+        let findings = [
+            (LintSeverity::Error, "e"),
+            (LintSeverity::Error, "e2"),
+            (LintSeverity::Warning, "w"),
+            (LintSeverity::Note, "n"),
+        ]
+        .map(|(severity, code)| LintFinding {
+            severity,
+            code,
+            stage: Some("main".to_string()),
+            message: "something".to_string(),
+            // Alternating so both the with-fix and without-fix print arms run.
+            fix: (code == "e").then(|| "do the thing".to_string()),
+        });
+        assert_eq!(print_findings(&findings), (2, 1));
     }
 
     #[test]
-    fn print_warnings_entry_stage_missing_no_panic() {
-        use leviath_core::{Blueprint, ContextLayout, Stage};
-
-        // Stage "a" is valid on its own, but the blueprint's entry_stage
-        // points at a name that doesn't exist among `stages` - impossible
-        // via `Blueprint::validate`, but not impossible via this struct's
-        // public fields/constructors.
-        let mut stage_a = Stage::new("a".to_string(), make_model());
-        stage_a.transitions = Some(std::collections::HashMap::new());
-
-        let layout = ContextLayout::new(Vec::new(), 1000);
-        let mut bp = Blueprint::new(
-            "test".to_string(),
-            "test".to_string(),
-            vec![stage_a],
-            layout,
-        );
-        bp.entry_stage = Some("ghost".to_string());
-
-        // Hits the BFS's `find_stage(&name) else { continue }` arm: "ghost"
-        // is queued as the entry but resolves to no real stage.
-        print_warnings(&bp);
+    fn print_findings_on_an_empty_list_reports_nothing() {
+        assert_eq!(print_findings(&[]), (0, 0));
     }
+
+    // ─── lint_failure_message ────────────────────────────────────────────
 
     #[test]
-    fn print_warnings_transition_target_missing_no_panic() {
-        use leviath_core::{Blueprint, ContextLayout, Stage, TransitionEdge};
-
-        // Stage "a" transitions to "ghost", a name with no corresponding
-        // Stage entry - impossible via `Blueprint::validate` (which
-        // requires every transition target to exist), but constructible
-        // directly since `transitions` is a public field.
-        let mut transitions = std::collections::HashMap::new();
-        transitions.insert(
-            "ghost".to_string(),
-            TransitionEdge {
-                target: "ghost".to_string(),
-                condition: Default::default(),
-                hint: None,
-                transform: Default::default(),
-                gate: None,
-                stuck: None,
-            },
+    fn lint_failure_message_pluralizes_and_names_the_flag() {
+        assert_eq!(lint_failure_message(1, 0, false), "✗ Blueprint has 1 error");
+        assert_eq!(
+            lint_failure_message(2, 5, false),
+            "✗ Blueprint has 2 errors",
+            "warnings are not counted unless they were asked to be"
         );
-        let mut stage_a = Stage::new("a".to_string(), make_model());
-        stage_a.transitions = Some(transitions);
-
-        let layout = ContextLayout::new(Vec::new(), 1000);
-        let bp = Blueprint::new(
-            "test".to_string(),
-            "test".to_string(),
-            vec![stage_a],
-            layout,
+        assert_eq!(
+            lint_failure_message(0, 1, true),
+            "✗ Blueprint has 1 warning (--deny-warnings)"
         );
-
-        // Hits the cycle-check loop's `find_stage(target) else { continue }`
-        // arm: "ghost" is a transition target but not a real stage.
-        print_warnings(&bp);
+        assert_eq!(
+            lint_failure_message(1, 2, true),
+            "✗ Blueprint has 1 error and 2 warnings (--deny-warnings)"
+        );
     }
 
-    // ─── execute: parse and validation error arms ──────────────────────────
+    // ─── execute ─────────────────────────────────────────────────────────
     //
-    // These call execute() directly (not execute_reporting_outcome) so the
-    // ParseError and ValidationError match arms in execute() are exercised.
+    // `execute` loads the real config, so each of these runs inside
+    // `with_isolated_config_path_async`: it points the load at a scratch
+    // directory and takes the same process-wide lock every other env-touching
+    // test holds.
 
     #[tokio::test]
     async fn execute_parse_error_returns_error() {
-        let dir = tempfile::tempdir().unwrap();
-        write_manifest(dir.path(), "not valid toml [[[");
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let err = execute(args).await.unwrap_err();
-        assert!(err.to_string().contains("Parse error"));
+        crate::config::with_isolated_config_path_async("validate-parse-error", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            write_manifest(dir.path(), "not valid toml [[[");
+            let err = execute(args_for(dir.path())).await.unwrap_err();
+            assert!(err.to_string().contains("Parse error"));
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn execute_validation_error_returns_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest = r#"
+        crate::config::with_isolated_config_path_async("validate-validation-error", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            let manifest = r#"
 [agent]
 name = "bad-entry-agent"
 version = "0.1.0"
@@ -821,112 +506,135 @@ max_iterations = 5
 [context.regions]
 system = { kind = "pinned", max_tokens = 1000 }
 "#;
-        write_manifest(dir.path(), manifest);
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let err = execute(args).await.unwrap_err();
-        assert!(err.to_string().contains("Validation failed"));
+            write_manifest(dir.path(), manifest);
+            let err = execute(args_for(dir.path())).await.unwrap_err();
+            assert!(err.to_string().contains("Validation failed"));
+        })
+        .await;
     }
 
-    // ─── execute: no manifest ──────────────────────────────────────────
+    /// A tool name matching nothing is fatal, and the failure line says so.
+    #[tokio::test]
+    async fn execute_lint_error_fails_the_command() {
+        crate::config::with_isolated_config_path_async("validate-lint-error", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            write_manifest(
+                dir.path(),
+                &CLEAN_MANIFEST.replace(
+                    "max_iterations = 5",
+                    "max_iterations = 5\navailable_tools = [\"raed_file\"]",
+                ),
+            );
+            let err = execute(args_for(dir.path())).await.unwrap_err();
+            assert_eq!(err.to_string(), "✗ Blueprint has 1 error");
+        })
+        .await;
+    }
+
+    /// A warning alone exits zero, and the same manifest fails under
+    /// `--deny-warnings`. Asserted as a pair, since the whole point of the flag
+    /// is the difference between the two.
+    #[tokio::test]
+    async fn warnings_only_fail_when_denied() {
+        crate::config::with_isolated_config_path_async("validate-deny-warnings", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            // No max_iterations on the one stage: exactly one warning, no errors.
+            write_manifest(
+                dir.path(),
+                &CLEAN_MANIFEST.replace("max_iterations = 5", ""),
+            );
+
+            let mut args = args_for(dir.path());
+            assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
+
+            args.deny_warnings = true;
+            let err = execute(args).await.unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "✗ Blueprint has 1 warning (--deny-warnings)"
+            );
+        })
+        .await;
+    }
 
     #[tokio::test]
     async fn execute_no_manifest_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let result = execute(args).await;
-        assert!(result.is_err());
+        crate::config::with_isolated_config_path_async("validate-no-manifest", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            assert!(execute(args_for(dir.path())).await.is_err());
+        })
+        .await;
     }
 
-    // ─── execute: with file path pointing to manifest ───────────────────
-
+    /// The manifest may be named directly rather than by its directory.
     #[tokio::test]
     async fn execute_valid_manifest_file_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest = r#"
-[agent]
-name = "test-agent"
-version = "0.1.0"
-description = "A test agent"
-
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main"
-max_iterations = 5
-
-[context.regions]
-system = { kind = "pinned", max_tokens = 1000 }
-conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
-"#;
-        let manifest_path = dir.path().join("agent.leviath");
-        std::fs::write(&manifest_path, manifest).unwrap();
-
-        let args = ValidateArgs {
-            path: manifest_path.to_str().unwrap().to_string(),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async("validate-file-path", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            let manifest_path = write_manifest(dir.path(), CLEAN_MANIFEST);
+            let args = ValidateArgs {
+                path: manifest_path.to_str().unwrap().to_string(),
+                deny_warnings: false,
+            };
+            assert!(execute(args).await.is_ok());
+        })
+        .await;
     }
-
-    // ─── execute: with directory path ───────────────────────────────────
 
     #[tokio::test]
     async fn execute_valid_manifest_directory_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest = r#"
-[agent]
-name = "dir-agent"
-version = "0.2.0"
-description = "A directory agent"
-
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main"
-max_iterations = 5
-
-[context.regions]
-system = { kind = "pinned", max_tokens = 1000 }
-conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
-"#;
-        write_test_agent(dir.path(), manifest);
-
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let result = execute(args).await;
-        assert!(result.is_ok());
+        crate::config::with_isolated_config_path_async("validate-dir-path", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            write_test_agent(dir.path(), CLEAN_MANIFEST);
+            assert!(execute(args_for(dir.path())).await.is_ok());
+        })
+        .await;
     }
 
-    // ─── execute_reporting_outcome: Parse/Validation paths ──────────────
-    //
-    // `execute()` itself calls `std::process::exit(1)` on these two
-    // branches, which would kill the test process - `execute_reporting_outcome`
-    // exists precisely so these can be exercised without that.
+    // ─── execute_reporting_outcome ───────────────────────────────────────
 
-    fn assert_is_parse_error(outcome: &ValidateOutcome) {
-        assert!(matches!(outcome, ValidateOutcome::ParseError(_)));
+    impl ValidateOutcome {
+        /// Whether this is [`ValidateOutcome::Success`]. A method rather than a
+        /// `matches!` in each test: the never-taken arm of an inline `matches!`
+        /// reads to llvm-cov as an uncovered region.
+        fn is_success(&self) -> bool {
+            matches!(self, Self::Success)
+        }
+
+        fn is_parse_error(&self) -> bool {
+            matches!(self, Self::ParseError(_))
+        }
+
+        fn is_validation_error(&self) -> bool {
+            matches!(self, Self::ValidationError(_))
+        }
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn assert_is_parse_error_panics_on_non_parse_error() {
-        assert_is_parse_error(&ValidateOutcome::Success);
+    fn outcome_predicates_distinguish_the_variants() {
+        assert!(ValidateOutcome::Success.is_success());
+        assert!(!ValidateOutcome::Success.is_parse_error());
+        assert!(!ValidateOutcome::Success.is_validation_error());
+        assert!(ValidateOutcome::ParseError(String::new()).is_parse_error());
+        assert!(ValidateOutcome::ValidationError(String::new()).is_validation_error());
+        assert!(
+            !ValidateOutcome::LintFailed {
+                errors: 1,
+                warnings: 0
+            }
+            .is_success()
+        );
     }
 
     #[test]
     fn execute_reporting_outcome_malformed_toml_is_parse_error() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "not valid toml [[[");
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let outcome = execute_reporting_outcome(&args).unwrap();
-        assert_is_parse_error(&outcome);
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), None)
+                .unwrap()
+                .is_parse_error()
+        );
     }
 
     #[test]
@@ -949,61 +657,57 @@ max_iterations = 5
 system = { kind = "pinned", max_tokens = 1000 }
 "#;
         write_manifest(dir.path(), manifest);
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let outcome = execute_reporting_outcome(&args).unwrap();
-        assert_is_validation_error(&outcome);
-    }
-
-    fn assert_is_validation_error(outcome: &ValidateOutcome) {
-        assert!(matches!(outcome, ValidateOutcome::ValidationError(_)));
-    }
-
-    #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn assert_is_validation_error_panics_on_non_validation_error() {
-        assert_is_validation_error(&ValidateOutcome::Success);
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), None)
+                .unwrap()
+                .is_validation_error()
+        );
     }
 
     #[test]
     fn execute_reporting_outcome_missing_manifest_is_io_error() {
         let dir = tempfile::tempdir().unwrap();
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        assert!(execute_reporting_outcome(&args).is_err());
+        assert!(execute_reporting_outcome(&args_for(dir.path()), None).is_err());
     }
 
     #[test]
     fn execute_reporting_outcome_valid_manifest_is_success() {
         let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), CLEAN_MANIFEST);
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), None)
+                .unwrap()
+                .is_success()
+        );
+    }
+
+    /// A blueprint whose regions run shell commands at spawn: the note lands in
+    /// the findings, and does not fail the command.
+    #[test]
+    fn command_seed_regions_are_noted_without_failing() {
+        let dir = tempfile::tempdir().unwrap();
         let manifest = r#"
 [agent]
-name = "ok-agent"
+name = "scanner"
 version = "0.1.0"
-description = "Valid"
 
 [stages.main]
 mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+description = "Main stage"
 max_iterations = 5
 
 [context.regions]
-system = { kind = "pinned", max_tokens = 1000 }
+facts = { kind = "pinned", max_tokens = 1000, seed = { command = "git ls-files" } }
 conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
 "#;
         write_manifest(dir.path(), manifest);
+        // Even under --deny-warnings, a note is not a warning.
         let args = ValidateArgs {
             path: dir.path().to_str().unwrap().to_string(),
+            deny_warnings: true,
         };
-        let outcome = execute_reporting_outcome(&args).unwrap();
-        assert_is_success(&outcome);
-    }
-
-    fn assert_is_success(outcome: &ValidateOutcome) {
-        assert!(matches!(outcome, ValidateOutcome::Success));
+        assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
     }
 
     #[test]
@@ -1012,33 +716,45 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
         // validation still succeeds, and the script report's count + warning
         // branches both run.
         let dir = tempfile::tempdir().unwrap();
-        let manifest = r#"
-[agent]
-name = "with-tools"
-version = "0.1.0"
-description = "has script tools"
-
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main"
-max_iterations = 5
-
-[context.regions]
-system = { kind = "pinned", max_tokens = 1000 }
-"#;
-        write_manifest(dir.path(), manifest);
+        write_manifest(dir.path(), CLEAN_MANIFEST);
         let tools = dir.path().join("tools");
         std::fs::create_dir(&tools).unwrap();
         std::fs::write(tools.join("ok.rhai"), "// @tool ok\nparams.x").unwrap();
         std::fs::write(tools.join("bad.rhai"), "no directive\nlet").unwrap();
         // Compiles but requires an unsatisfiable capability → the won't-load warning.
         std::fs::write(tools.join("gpu.rhai"), "// @tool gpu\n// @requires gpu\n1").unwrap();
-        let args = ValidateArgs {
-            path: dir.path().to_str().unwrap().to_string(),
-        };
-        let outcome = execute_reporting_outcome(&args).unwrap();
-        assert_is_success(&outcome);
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), None)
+                .unwrap()
+                .is_success()
+        );
+    }
+
+    /// A tool the agent defines itself resolves, so granting it is not an
+    /// unknown-tool error. This is the reason the lint env is built from the
+    /// agent's own directory rather than from the built-ins alone.
+    #[test]
+    fn an_agents_own_script_tool_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            &CLEAN_MANIFEST.replace(
+                "max_iterations = 5",
+                "max_iterations = 5\navailable_tools = [\"stub_search\"]",
+            ),
+        );
+        let tools = dir.path().join("tools");
+        std::fs::create_dir(&tools).unwrap();
+        std::fs::write(
+            tools.join("stub_search.rhai"),
+            "// @tool stub_search\n// @description searches\n\"found\"",
+        )
+        .unwrap();
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), None)
+                .unwrap()
+                .is_success()
+        );
     }
 
     #[test]
@@ -1062,102 +778,49 @@ system = { kind = "pinned", max_tokens = 1000 }
         print_script_tool_report(dir.path());
     }
 
-    #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn assert_is_success_panics_on_non_success() {
-        assert_is_success(&ValidateOutcome::ParseError("x".to_string()));
-    }
-
-    // ─── print_warnings: multiple stages all reachable ──────────────────
-
-    #[test]
-    fn print_warnings_chain_all_reachable() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "B"
-max_iterations = 5
-[stages.b.transitions]
-c = "true"
-
-[stages.c]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "C"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        print_warnings(&bp);
-    }
-
-    // ─── print_warnings: BFS revisits an already-reached node (diamond) ──
-    //
-    // `entry` transitions to both `b` and `c`, and both `b` and `c`
-    // transition to `d` - `d` gets queued twice, so the *second* pop hits
-    // the `if !reachable.insert(name.clone()) { continue; }` early-exit that
-    // a simple linear chain or single-path graph never reaches.
-
-    #[test]
-    fn print_warnings_diamond_graph_revisits_shared_target_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.entry]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Entry"
-max_iterations = 5
-entry = true
-[stages.entry.transitions]
-b = "true"
-c = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "B"
-max_iterations = 5
-[stages.b.transitions]
-d = "true"
-
-[stages.c]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "C"
-max_iterations = 5
-[stages.c.transitions]
-d = "true"
-
-[stages.d]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "D"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        // All 4 stages reachable, no unreachable warnings expected; the
-        // point of this test is exercising the revisit-skip branch itself.
-        print_warnings(&bp);
-    }
-
     // ─── check_manifest ──────────────────────────────────────────────────
 
-    fn write_manifest(dir: &std::path::Path, content: &str) -> std::path::PathBuf {
-        let path = dir.join("agent.leviath");
-        std::fs::write(&path, content).unwrap();
-        path
+    #[test]
+    fn check_manifest_verifies_custom_region_scripts() {
+        // A custom region's script must exist and compile; the same failure a
+        // spawn would hit, surfaced by `lev validate`.
+        let dir = tempfile::tempdir().unwrap();
+        let toml = r#"
+[agent]
+name = "custom-validate"
+version = "0.1.0"
+description = "d"
+
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+description = "Main stage"
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
+"#;
+        let manifest_path = write_manifest(dir.path(), toml);
+
+        // Missing script file → validation error naming region + path.
+        let err = format!("{:?}", check_manifest(&manifest_path).unwrap_err());
+        assert!(err.starts_with("Validation"), "{err}");
+        assert!(err.contains("region 'brain'"), "{err}");
+
+        // Present + compilable → passes.
+        std::fs::create_dir(dir.path().join("hooks")).unwrap();
+        std::fs::write(
+            dir.path().join("hooks/brain.rhai"),
+            "fn render(ctx) { \"ok\" }",
+        )
+        .unwrap();
+        let checked = check_manifest(&manifest_path).unwrap();
+        assert_eq!(checked.blueprint.name, "custom-validate");
+        // The text is carried through for the linter, and the agent dir points
+        // at the manifest's own directory rather than the manifest file.
+        assert!(checked.content.contains("custom-validate"));
+        assert_eq!(checked.agent_dir, dir.path());
     }
 
     /// Extract the inner `anyhow::Error` from a `ManifestCheckError::Io`,
@@ -1210,144 +873,38 @@ max_iterations = 5
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("agent.leviath")).unwrap();
 
-        let result = check_manifest(dir.path());
-
-        let err = result.unwrap_err();
+        let err = check_manifest(dir.path()).unwrap_err();
         let e = unwrap_io_err(err);
         assert!(e.to_string().contains("Failed to read"));
+    }
+
+    impl ManifestCheckError {
+        /// Whether this is a parse failure. A method rather than an inline
+        /// `matches!` in the test: the arm the passing run does not take reads
+        /// to llvm-cov as an uncovered region, and so does a `{err:?}` argument
+        /// that only a failing assertion would format.
+        fn is_parse(&self) -> bool {
+            matches!(self, Self::Parse(_))
+        }
     }
 
     #[test]
     fn check_manifest_malformed_toml_is_parse_error() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "not valid toml [[[");
-        let err = check_manifest(dir.path()).unwrap_err();
-        assert_is_manifest_parse_error(&err);
-    }
-
-    fn assert_is_manifest_parse_error(err: &ManifestCheckError) {
-        assert!(matches!(err, ManifestCheckError::Parse(_)));
-    }
-
-    #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn assert_is_manifest_parse_error_panics_on_non_parse_error() {
-        assert_is_manifest_parse_error(&ManifestCheckError::Io(anyhow::anyhow!("x")));
+        assert!(check_manifest(dir.path()).unwrap_err().is_parse());
+        // And the other arm: a missing manifest is an I/O failure, not a parse
+        // one, so the predicate is deciding rather than always agreeing.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(!check_manifest(empty.path()).unwrap_err().is_parse());
     }
 
     #[test]
     fn check_manifest_direct_file_path_is_accepted() {
         let dir = tempfile::tempdir().unwrap();
-        let toml = make_blueprint_toml(
-            r#"
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main stage"
-max_iterations = 5
-"#,
-        );
-        let manifest_path = write_manifest(dir.path(), &toml);
+        let manifest_path = write_manifest(dir.path(), CLEAN_MANIFEST);
         // Pass the *file* path directly, not the directory.
-        let blueprint = check_manifest(&manifest_path).unwrap();
-        assert_eq!(blueprint.name, "test");
-    }
-
-    #[test]
-    fn check_manifest_valid_linear_blueprint_succeeds() {
-        let dir = tempfile::tempdir().unwrap();
-        let toml = make_blueprint_toml(
-            r#"
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main stage"
-max_iterations = 5
-"#,
-        );
-        write_manifest(dir.path(), &toml);
-        let blueprint = check_manifest(dir.path()).unwrap();
-        assert_eq!(blueprint.name, "test");
-        assert_eq!(blueprint.stages.len(), 1);
-    }
-
-    // ─── print_success ───────────────────────────────────────────────────
-
-    #[test]
-    fn print_success_linear_mode_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.main]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Main stage"
-max_iterations = 5
-
-[stages.review]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "Review stage"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        print_success(&bp);
-    }
-
-    #[test]
-    fn print_success_graph_mode_with_terminal_and_revisits_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "A"
-max_iterations = 5
-entry = true
-max_revisits = 3
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "B"
-max_iterations = 5
-"#,
-        );
-        let bp = parse(&toml);
-        // Exercises: graph mode header, an edge with a target ("-> b"), and
-        // stage "b" which has transitions = None ("(linear)" branch) as well
-        // as the max_revisits formatting on stage "a".
-        print_success(&bp);
-    }
-
-    #[test]
-    fn print_success_graph_mode_terminal_stage_no_panic() {
-        let toml = make_blueprint_toml(
-            r#"
-[stages.a]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "A"
-max_iterations = 5
-entry = true
-[stages.a.transitions]
-b = "true"
-
-[stages.b]
-mode = "autonomous"
-model = { provider = "anthropic", model = "claude-sonnet-4-6" }
-description = "B"
-max_iterations = 5
-[stages.b.transitions]
-"#,
-        );
-        let bp = parse(&toml);
-        // Stage "b" has an explicitly-empty transitions table -> Some(empty
-        // map) -> exercises the "(terminal)" formatting branch.
-        let b = bp.find_stage("b").unwrap();
-        assert!(matches!(&b.transitions, Some(t) if t.is_empty()));
-        print_success(&bp);
+        let checked = check_manifest(&manifest_path).unwrap();
+        assert_eq!(checked.blueprint.name, "ok-agent");
     }
 }

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -642,6 +642,40 @@ pub fn build_agent_for_reload(
     )
 }
 
+/// Log whatever `lev validate` would have reported about this manifest.
+///
+/// The lint env is built from the manifest's own directory so the agent's
+/// `tools/*.rhai` resolve, and deliberately without the provider check: the
+/// stage resolution a few steps later already fails a spawn outright when
+/// nothing in a stage's models list is registered, and re-deriving that here
+/// would cost a provider-registry build per agent to say the same thing more
+/// quietly.
+fn log_blueprint_lint(content: &str, blueprint: &Blueprint, manifest_path: &str) {
+    let agent_dir = std::path::Path::new(manifest_path)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
+    let env = crate::lint::LintEnv::offline(&agent_dir);
+    for finding in crate::lint::lint_manifest(content, blueprint, &env) {
+        // Notes describe things the blueprint means to do; only the checks that
+        // found something questionable are worth a daemon log line.
+        if finding.severity == crate::lint::LintSeverity::Note {
+            continue;
+        }
+        // Built before the macro rather than inside it: `tracing::warn!` only
+        // evaluates its arguments when the level is enabled, so a call in the
+        // argument list is a region that does not run under a subscriber that
+        // filters WARN out.
+        let line = format!(
+            "blueprint '{}': {} [{}]",
+            blueprint.name,
+            finding.one_line(),
+            finding.code
+        );
+        tracing::warn!("{line}");
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_agent_inner(
     world: &mut World,
@@ -674,6 +708,12 @@ fn build_agent_inner(
     blueprint
         .validate()
         .map_err(|e| format!("invalid blueprint: {e}"))?;
+    // What `lev validate` would have said, in the daemon log. Nothing here
+    // refuses a spawn: these are authoring mistakes whose cost is a run that
+    // behaves oddly hours later, and the whole point is that they are invisible
+    // until then. Logging them means the answer is already in `daemon.log`
+    // whenever someone goes looking for why a run stalled.
+    log_blueprint_lint(&content, &blueprint, &args.blueprint_path);
     // A request-level `--max-depth` overrides the blueprint's sub-agent depth cap.
     if let Some(md) = args.max_depth {
         blueprint.max_child_depth = Some(md);
@@ -1105,6 +1145,86 @@ mod tests {
     /// A throwaway sub-agent op sender for tests that don't exercise the bridge.
     fn sub_tx() -> UnboundedSender<SubAgentOp> {
         tokio::sync::mpsc::unbounded_channel().0
+    }
+
+    /// What the daemon logs about a blueprint at spawn. A run is never refused
+    /// for a lint finding, so the only way this surfaces is the log line - which
+    /// makes it worth exercising directly rather than through a whole spawn.
+    #[test]
+    fn log_blueprint_lint_warns_about_findings_and_skips_notes() {
+        crate::test_support::with_tracing(|| {});
+        let home = tempfile::tempdir().unwrap();
+        temp_env::with_var("LEVIATH_HOME", Some(home.path().to_str().unwrap()), || {
+            // No `mode`, no `max_iterations`, an unattended `ask_user_text` and
+            // a `[read_paths]` block: three warnings and one note.
+            let manifest = r#"
+[agent]
+name = "noisy"
+version = "0.1.0"
+
+[stages.main]
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+available_tools = ["ask_user_text"]
+
+[read_paths]
+allow = ["~/.leviath/runs"]
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+            let bp = leviath_core::manifest::parse_manifest(manifest).unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("agent.leviath");
+            std::fs::write(&path, manifest).unwrap();
+
+            // The findings the log walks, so the test asserts what is being
+            // logged rather than only that logging did not panic.
+            let env = crate::lint::LintEnv::offline(dir.path());
+            let findings = crate::lint::lint_manifest(manifest, &bp, &env);
+            assert!(
+                findings
+                    .iter()
+                    .any(|f| f.severity == crate::lint::LintSeverity::Note),
+                "the fixture needs a note for the skip arm to run"
+            );
+            assert!(
+                findings
+                    .iter()
+                    .any(|f| f.severity == crate::lint::LintSeverity::Warning),
+                "the fixture needs a warning for the log arm to run"
+            );
+
+            log_blueprint_lint(manifest, &bp, &path.to_string_lossy());
+        });
+    }
+
+    /// A blueprint with nothing to say produces no log lines at all.
+    #[test]
+    fn log_blueprint_lint_is_silent_for_a_clean_blueprint() {
+        crate::test_support::with_tracing(|| {});
+        let home = tempfile::tempdir().unwrap();
+        temp_env::with_var("LEVIATH_HOME", Some(home.path().to_str().unwrap()), || {
+            let manifest = r#"
+[agent]
+name = "quiet"
+version = "0.1.0"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+            let bp = leviath_core::manifest::parse_manifest(manifest).unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("agent.leviath");
+            std::fs::write(&path, manifest).unwrap();
+            let env = crate::lint::LintEnv::offline(dir.path());
+            assert!(crate::lint::lint_manifest(manifest, &bp, &env).is_empty());
+            log_blueprint_lint(manifest, &bp, &path.to_string_lossy());
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -516,17 +516,24 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_validate_variant_is_routed() {
-        let dir = tempfile::tempdir().unwrap();
-        let args = commands::validate::ValidateArgs {
-            path: dir
-                .path()
-                .join("does-not-exist")
-                .to_str()
-                .unwrap()
-                .to_string(),
-        };
-        let result = dispatch(Commands::Validate(args), &MockRisky).await;
-        assert!(result.is_err());
+        // `validate` loads the real config to answer "can this install reach
+        // the providers this blueprint names", so it needs the same isolation
+        // every other config-touching test takes.
+        crate::config::with_isolated_config_path_async("dispatch-validate", |_| async {
+            let dir = tempfile::tempdir().unwrap();
+            let args = commands::validate::ValidateArgs {
+                path: dir
+                    .path()
+                    .join("does-not-exist")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                deny_warnings: false,
+            };
+            let result = dispatch(Commands::Validate(args), &MockRisky).await;
+            assert!(result.is_err());
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod credentials;
 pub mod daemon;
 pub mod dispatch;
+pub mod lint;
 pub mod logging;
 pub mod render;
 pub mod runstate;

--- a/crates/leviath-cli/src/lint.rs
+++ b/crates/leviath-cli/src/lint.rs
@@ -1,0 +1,785 @@
+//! Blueprint lint: the checks [`Blueprint::validate`] deliberately does not make.
+//!
+//! `Blueprint::validate` answers "is this manifest structurally coherent" - the
+//! layout fits, the graph resolves, fan-out wiring points at real stages. It
+//! says nothing about the fields whose *absence* quietly changes what a run
+//! does, and those are what actually bite:
+//!
+//! - a stage with no `[stages.<name>.model]` table parses fine, because the
+//!   parser substitutes a default, and then runs on whatever the user's default
+//!   provider happens to be
+//! - an agent-level `[model]` block is never read at all, so the author's model
+//!   choice is discarded silently
+//! - a typo in `available_tools` matches nothing, and the stage just advertises
+//!   one tool fewer - the model is told the tool does not exist
+//! - an autonomous stage granting `ask_user_text` parks in `WaitingInput` the
+//!   first time it asks, with nobody there to answer
+//!
+//! Each of those is invisible on inspection and shows up hours later as a stuck
+//! run. This module names them at author time instead.
+//!
+//! Questions about what the author *declared* ("is there a `mode` key?") are
+//! answered from the manifest text, not from the parsed [`Blueprint`]: by then
+//! the parser has already filled in its defaults, and asking the struct cannot
+//! tell "wrote `autonomous`" apart from "wrote nothing".
+//!
+//! [`Blueprint::validate`]: leviath_core::Blueprint::validate
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use leviath_core::Blueprint;
+use leviath_core::blueprint::StageMode;
+use leviath_runtime::dynamic_interaction::BLOCKING_INTERACTION_TOOLS;
+use leviath_tools::canonical_tool_name;
+
+/// How much a finding matters. Only [`LintSeverity::Error`] fails
+/// `lev validate`; warnings are printed and the command still exits zero
+/// (unless `--deny-warnings` is passed); notes never fail anything.
+///
+/// Declared worst-first so sorting by it groups the report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LintSeverity {
+    /// The manifest says something that cannot be what the author meant - a
+    /// tool name matching nothing, a permission for a tool the stage never
+    /// granted.
+    Error,
+    /// The manifest leaves a decision to a default the author may not know
+    /// about.
+    Warning,
+    /// Nothing is wrong; the blueprint is doing something worth knowing before
+    /// you run it, like reaching outside its workdir or running a shell command
+    /// at spawn. A note must never fail a build, so `--deny-warnings` skips it.
+    Note,
+}
+
+impl LintSeverity {
+    /// Fixed-width label for the report, so the messages line up.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Error => "ERR ",
+            Self::Warning => "WARN",
+            Self::Note => "NOTE",
+        }
+    }
+}
+
+/// One thing worth telling the author about.
+#[derive(Debug, Clone)]
+pub struct LintFinding {
+    pub severity: LintSeverity,
+    /// Stable slug (`"unknown-tool"`), so a finding can be referenced in an
+    /// issue or grepped for in daemon logs without quoting prose.
+    pub code: &'static str,
+    /// The stage it belongs to, when it belongs to one.
+    pub stage: Option<String>,
+    /// What is wrong.
+    pub message: String,
+    /// What to do about it. Rendered on its own indented line.
+    pub fix: Option<String>,
+}
+
+impl LintFinding {
+    fn new(severity: LintSeverity, code: &'static str, message: String) -> Self {
+        Self {
+            severity,
+            code,
+            stage: None,
+            message,
+            fix: None,
+        }
+    }
+
+    fn in_stage(mut self, stage: &str) -> Self {
+        self.stage = Some(stage.to_string());
+        self
+    }
+
+    fn with_fix(mut self, fix: impl Into<String>) -> Self {
+        self.fix = Some(fix.into());
+        self
+    }
+
+    /// Whether this finding should fail the command.
+    pub fn is_error(&self) -> bool {
+        self.severity == LintSeverity::Error
+    }
+
+    /// One-line rendering for a log record: `stage 'x': message`.
+    pub fn one_line(&self) -> String {
+        match &self.stage {
+            Some(stage) => format!("stage '{stage}': {}", self.message),
+            None => self.message.clone(),
+        }
+    }
+}
+
+/// Facts about the machine the blueprint will run on, which the manifest alone
+/// cannot supply.
+///
+/// Every field is "unknown" when empty/`None`, and an unknown field skips its
+/// check entirely rather than guessing. A linter that cannot see the installed
+/// MCP servers must not claim their tools do not exist.
+#[derive(Debug, Default, Clone)]
+pub struct LintEnv {
+    /// Every tool name a manifest may legally write: canonical built-ins, their
+    /// aliases, the sub-agent tools, this agent's own `tools/*.rhai`, and any
+    /// MCP tools already resolved. Empty skips the unknown-tool check.
+    pub known_tools: HashSet<String>,
+
+    /// `(provider, model)` rows for providers whose catalog is closed enough to
+    /// check against. A provider with no row here is not checked at all, which
+    /// is what keeps open catalogs (Ollama, OpenRouter, script providers) from
+    /// producing noise.
+    pub known_models: Vec<(String, String)>,
+
+    /// The providers the blueprint names that this install can actually reach,
+    /// as answered by `ProviderRegistry::has`. `None` means nobody asked, so
+    /// the check is skipped. Resolution lives with the caller because script
+    /// providers are loaded on demand and cannot be enumerated up front.
+    pub available_providers: Option<HashSet<String>>,
+}
+
+impl LintEnv {
+    /// Everything that can be known without touching the user's config: the
+    /// built-in tools (aliases included), the sub-agent tools, the script tools
+    /// in `agent_dir/tools` and the global tools directory, and the model
+    /// catalogs this build ships.
+    ///
+    /// This is what the daemon lints against at spawn. It deliberately leaves
+    /// `available_providers` unset: the daemon already fails a spawn outright
+    /// when no listed provider is registered, so re-deriving that here would
+    /// cost a registry build per agent to say something the spawn will say
+    /// louder a moment later.
+    pub fn offline(agent_dir: &Path) -> Self {
+        let mut known_tools: HashSet<String> = leviath_tools::BuiltinTools::new(
+            leviath_tools::ToolContext::new(agent_dir.to_path_buf()),
+        )
+        .names()
+        .into_iter()
+        .collect();
+        known_tools.extend(leviath_tools::BuiltinTools::subagent_tool_names());
+
+        // The agent's own `tools/`, plus the global one every agent gets.
+        let dirs: Vec<PathBuf> = [Some(agent_dir.join("tools")), leviath_core::tools_dir()]
+            .into_iter()
+            .flatten()
+            .filter(|d| d.is_dir())
+            .collect();
+        let (set, _skipped) = leviath_scripting::ScriptToolSet::discover(&dirs);
+        known_tools.extend(set.names());
+
+        Self {
+            known_tools,
+            known_models: crate::commands::models::closed_catalog_models(),
+            available_providers: None,
+        }
+    }
+
+    /// Add the answer to "can this install reach the providers the blueprint
+    /// names", asked of the same registry the runtime resolves stages against
+    /// so a script provider counts exactly when it would really load.
+    pub fn with_providers(mut self, blueprint: &Blueprint, config: &crate::config::Config) -> Self {
+        let registry = crate::commands::run::build_provider_registry_from_config(config);
+        self.available_providers = Some(
+            blueprint
+                .stages
+                .iter()
+                .flat_map(|s| s.model.models.iter())
+                .map(|e| e.provider.clone())
+                .filter(|p| registry.has(p))
+                .collect(),
+        );
+        self
+    }
+}
+
+/// Lint `blueprint`, which was parsed from `content`.
+///
+/// The two arguments describe the same manifest: `blueprint` for what the
+/// engine will do with it, `content` for what the author actually wrote.
+pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec<LintFinding> {
+    let declared = Declared::from_text(content);
+    let mut findings = Vec::new();
+
+    if declared.agent_model_block {
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "agent-model-block-ignored",
+                "the top-level [model] block is not read by anything: model \
+                 selection is per stage"
+                    .to_string(),
+            )
+            .with_fix("move it into each [stages.<name>.model] that needs it"),
+        );
+    }
+
+    findings.extend(lint_command_seeds(blueprint));
+    findings.extend(lint_read_paths(blueprint));
+    findings.extend(lint_graph(blueprint));
+
+    let agent_permissions = blueprint.agent_tool_permissions();
+
+    for stage in &blueprint.stages {
+        let keys = declared.stage(&stage.name);
+        findings.extend(lint_declarations(stage, keys));
+        findings.extend(lint_tools(stage, env));
+        findings.extend(lint_blocking_tools(stage));
+        findings.extend(lint_tool_policies(stage, &agent_permissions));
+        findings.extend(lint_models(stage, env));
+    }
+
+    // Worst first, stable within a severity so the order a check ran in is the
+    // order its findings read in.
+    findings.sort_by_key(|f| f.severity);
+    findings
+}
+
+// ─── Declared keys ────────────────────────────────────────────────────────────
+
+/// Which optional keys the manifest text actually writes, per stage, plus the
+/// one agent-level block that is silently discarded.
+#[derive(Debug, Default)]
+struct Declared {
+    /// A top-level `[model]` table exists. Nothing reads it.
+    agent_model_block: bool,
+    /// Per stage name, the keys that stage wrote.
+    stages: HashMap<String, StageKeys>,
+    /// The manifest text could not be re-read. Every key is then reported as
+    /// declared, so an unreadable manifest produces no declaration warnings
+    /// rather than a full set of false ones.
+    opaque: bool,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct StageKeys {
+    mode: bool,
+    model: bool,
+}
+
+impl Declared {
+    fn from_text(content: &str) -> Self {
+        // `toml::from_str` and not `str::parse`: the latter deserializes a bare
+        // TOML *value*, not a document, and rejects every real manifest.
+        let Ok(root) = toml::from_str::<toml::Table>(content) else {
+            return Self {
+                opaque: true,
+                ..Self::default()
+            };
+        };
+        let agent_model_block = root.get("model").is_some_and(toml::Value::is_table);
+        let stages = root
+            .get("stages")
+            .and_then(toml::Value::as_table)
+            .map(|t| {
+                t.iter()
+                    .map(|(name, body)| {
+                        (
+                            name.clone(),
+                            StageKeys {
+                                mode: body.get("mode").is_some(),
+                                model: body.get("model").is_some(),
+                            },
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            agent_model_block,
+            stages,
+            opaque: false,
+        }
+    }
+
+    /// What `stage` declared. An unreadable manifest, or a stage the text has
+    /// no entry for, reports everything as declared so nothing is warned about.
+    fn stage(&self, stage: &str) -> StageKeys {
+        if self.opaque {
+            return StageKeys {
+                mode: true,
+                model: true,
+            };
+        }
+        self.stages.get(stage).copied().unwrap_or(StageKeys {
+            mode: true,
+            model: true,
+        })
+    }
+}
+
+// ─── Checks ───────────────────────────────────────────────────────────────────
+
+/// Fields the stage left to a default: `mode`, `model`, and `max_iterations`.
+fn lint_declarations(stage: &leviath_core::Stage, keys: StageKeys) -> Vec<LintFinding> {
+    let mut findings = Vec::new();
+
+    if !keys.mode {
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "stage-missing-mode",
+                "no mode is set, so the stage runs as autonomous".to_string(),
+            )
+            .in_stage(&stage.name)
+            .with_fix("write mode = \"autonomous\" if that is what you meant"),
+        );
+    }
+
+    if !keys.model {
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "stage-missing-model",
+                format!(
+                    "no [stages.{}.model] block, so the stage runs on your \
+                     configured default_provider, whatever that is",
+                    stage.name
+                ),
+            )
+            .in_stage(&stage.name)
+            .with_fix(format!(
+                "add model = {{ models = [{{ provider = \"...\", model = \"...\" }}] }} \
+                 to [stages.{}]",
+                stage.name
+            )),
+        );
+    }
+
+    // A fan_out stage does not run inference itself - it splits work and waits
+    // on its workers - so it has no iteration count to cap.
+    let counts_iterations = !matches!(stage.mode, StageMode::FanOut { .. });
+    if counts_iterations && stage.max_iterations.is_none() {
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "stage-missing-max-iterations",
+                "no max_iterations, so the stage is unbounded unless your config \
+                 sets [limits] default_max_iterations"
+                    .to_string(),
+            )
+            .in_stage(&stage.name)
+            .with_fix("give the stage a max_iterations it should never reach"),
+        );
+    }
+
+    findings
+}
+
+/// Tool names that resolve to nothing, and permissions for tools the stage
+/// never granted.
+fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<LintFinding> {
+    let mut findings = Vec::new();
+
+    if !env.known_tools.is_empty() {
+        for tool in &stage.available_tools {
+            // `server__tool` is an MCP name. It resolves only once that server
+            // is installed and connected, which is not a property of the
+            // manifest, so it is never this check's business.
+            if tool.contains("__") || env.known_tools.contains(tool) {
+                continue;
+            }
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Error,
+                    "unknown-tool",
+                    format!(
+                        "grants '{tool}', which is not a built-in, a sub-agent \
+                         tool, or one of this agent's own tools/*.rhai"
+                    ),
+                )
+                .in_stage(&stage.name)
+                .with_fix("check the spelling, or drop the entry"),
+            );
+        }
+    }
+
+    let granted: HashSet<&str> = stage.available_tools.iter().map(String::as_str).collect();
+    for tool in stage.tool_permissions.keys() {
+        if granted.contains(tool.as_str()) {
+            continue;
+        }
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Error,
+                "orphan-stage-permission",
+                format!(
+                    "sets a permission for '{tool}', which it does not grant in \
+                     available_tools - it reads as a grant and is not one"
+                ),
+            )
+            .in_stage(&stage.name)
+            .with_fix(format!(
+                "add '{tool}' to available_tools, or drop the permission"
+            )),
+        );
+    }
+
+    findings
+}
+
+/// Human-in-the-loop tools offered by a stage that runs with nobody attached.
+fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFinding> {
+    // Only autonomous stages are a problem: the interactive modes are where a
+    // person is expected, and a fan_out stage runs no tools of its own.
+    if !matches!(stage.mode, StageMode::Autonomous) || stage.allow_blocking_tools {
+        return Vec::new();
+    }
+    stage
+        .available_tools
+        .iter()
+        .filter(|t| BLOCKING_INTERACTION_TOOLS.contains(&canonical_tool_name(t)))
+        .map(|tool| {
+            LintFinding::new(
+                LintSeverity::Warning,
+                "blocking-tool-in-autonomous-stage",
+                format!(
+                    "is autonomous but grants '{tool}', which suspends the run \
+                     until a person answers"
+                ),
+            )
+            .in_stage(&stage.name)
+            .with_fix(
+                "drop the tool, switch the stage to an interactive mode, or set \
+                 allow_blocking_tools = true to say you meant it",
+            )
+        })
+        .collect()
+}
+
+/// Permissions that do not land on the tool they look like they land on, and
+/// shell grants left to the default.
+///
+/// Policy is resolved against the name the *model* calls the tool by, which is
+/// always the canonical one. A permission written under an alias of a tool the
+/// stage granted canonically (or the reverse) is looked up under a key nothing
+/// ever asks for, so the entry has no effect at all: it reads as a decision and
+/// is not one.
+fn lint_tool_policies(
+    stage: &leviath_core::Stage,
+    agent_permissions: &HashMap<String, String>,
+) -> Vec<LintFinding> {
+    let has_policy = |name: &str| {
+        stage.tool_permissions.contains_key(name) || agent_permissions.contains_key(name)
+    };
+
+    stage
+        .available_tools
+        .iter()
+        .filter(|t| !has_policy(t))
+        .filter_map(|tool| {
+            match alias_siblings(tool).into_iter().find(|s| has_policy(s)) {
+                Some(other) => Some(
+                    LintFinding::new(
+                        LintSeverity::Warning,
+                        "permission-name-mismatch",
+                        format!(
+                            "grants '{tool}' but its permission is written for \
+                             '{other}'. Policy is matched on the name the model \
+                             calls, which is '{tool}', so that entry has no effect"
+                        ),
+                    )
+                    .in_stage(&stage.name)
+                    .with_fix(format!("rename the permission key '{other}' to '{tool}'")),
+                ),
+                // No policy under any spelling. Only worth saying for the shell,
+                // whose default is `ask` - and an `ask` with nobody to answer
+                // waits rather than denying, so an unattended run hangs on the
+                // first command instead of failing it.
+                None if canonical_tool_name(tool) == "shell" => Some(
+                    LintFinding::new(
+                        LintSeverity::Warning,
+                        "implicit-shell-policy",
+                        format!(
+                            "grants '{tool}' with no permission set for it, so it \
+                             defaults to ask - and an unattended run waits on that \
+                             prompt rather than being denied"
+                        ),
+                    )
+                    .in_stage(&stage.name)
+                    .with_fix(format!(
+                        "set {tool} = \"allow\" or \"deny\" in [tool_permissions] or \
+                         [stages.{}.tool_permissions]",
+                        stage.name
+                    )),
+                ),
+                None => None,
+            }
+        })
+        .collect()
+}
+
+/// Every other name for the same built-in tool: the canonical name when `name`
+/// is an alias, plus every alias of it. Never includes `name` itself.
+fn alias_siblings(name: &str) -> Vec<String> {
+    let canonical = canonical_tool_name(name);
+    std::iter::once(canonical)
+        .chain(
+            leviath_tools::TOOL_ALIASES
+                .iter()
+                .filter(|(_, c)| *c == canonical)
+                .map(|(alias, _)| *alias),
+        )
+        .filter(|s| *s != name)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Regions whose `seed = { command = "..." }` runs a shell command at spawn.
+///
+/// This one is an audit line rather than a complaint: the commands run before
+/// the first inference and before any tool-approval prompt, so whoever is about
+/// to `lev add` a blueprint they did not write should see them first.
+fn lint_command_seeds(blueprint: &Blueprint) -> Vec<LintFinding> {
+    let seeds: Vec<String> = blueprint
+        .context_layout
+        .regions
+        .iter()
+        .filter_map(|r| match &r.seed {
+            Some(leviath_core::layout::RegionSeed::Command { command }) => {
+                Some(format!("{}: {command}", r.name))
+            }
+            _ => None,
+        })
+        .collect();
+    if seeds.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        LintFinding::new(
+            LintSeverity::Note,
+            "command-seed",
+            format!(
+                "{} region(s) run a shell command at spawn, before the first \
+                 inference and before any tool-approval prompt: {}",
+                seeds.len(),
+                seeds.join(", ")
+            ),
+        )
+        .with_fix(
+            "disable with `--no-seed-commands`, or machine-wide via \
+             `[security] allow_seed_commands = false`",
+        ),
+    ]
+}
+
+/// `[read_paths]` declarations, plus a sharper warning for an entry so broad it
+/// amounts to "my whole home directory" or "any absolute path".
+fn lint_read_paths(blueprint: &Blueprint) -> Vec<LintFinding> {
+    let Some(rp) = blueprint
+        .read_paths
+        .as_ref()
+        .filter(|rp| !rp.allow.is_empty())
+    else {
+        return Vec::new();
+    };
+    let mut findings = vec![
+        LintFinding::new(
+            LintSeverity::Note,
+            "read-paths-declared",
+            format!(
+                "declares [read_paths] (reads outside the run workdir): {}",
+                rp.allow.join(", ")
+            ),
+        )
+        .with_fix("these are refused unless your own config grants them"),
+    ];
+    findings.extend(
+        rp.allow
+            .iter()
+            .filter(|e| read_path_entry_is_broad(e))
+            .map(|entry| {
+                LintFinding::new(
+                    LintSeverity::Warning,
+                    "broad-read-path",
+                    format!(
+                        "read_paths entry '{entry}' is very broad - it can match \
+                     your entire home directory or any path on this machine"
+                    ),
+                )
+                .with_fix("name the directory it actually needs")
+            }),
+    );
+    findings
+}
+
+/// Whether a `[read_paths]` entry grants effectively unlimited read access:
+/// the home directory itself, a filesystem root, or a pattern whose first
+/// component already matches anything.
+fn read_path_entry_is_broad(entry: &str) -> bool {
+    let pattern = entry
+        .strip_prefix("glob:")
+        .or_else(|| entry.strip_prefix("regex:"))
+        .unwrap_or(entry);
+    let pattern = pattern.replace('\\', "/");
+    let trimmed = pattern.trim_end_matches('/');
+    matches!(trimmed, "~" | "")
+        || trimmed == "/**"
+        || pattern.starts_with("**")
+        || pattern.starts_with("/.*")
+        || trimmed == "/.+"
+}
+
+/// Graph shape: stages the entry can never reach, and cycles with no revisit
+/// cap. Both only mean anything for a blueprint that declares transitions at
+/// all - a linear one has no graph to walk.
+fn lint_graph(blueprint: &Blueprint) -> Vec<LintFinding> {
+    if !blueprint.stages.iter().any(|s| s.transitions.is_some()) {
+        return Vec::new();
+    }
+    let stage_names: HashSet<&str> = blueprint.stages.iter().map(|s| s.name.as_str()).collect();
+    let entry = blueprint.resolve_entry_stage_name();
+
+    // Breadth-first from the entry stage; whatever is left over is orphaned.
+    let mut reachable = HashSet::new();
+    let mut queue = std::collections::VecDeque::from([entry.clone()]);
+    while let Some(name) = queue.pop_front() {
+        if !reachable.insert(name.clone()) {
+            continue;
+        }
+        let Some(stage) = blueprint.find_stage(&name) else {
+            continue;
+        };
+        // A fan_out stage reaches its worker and merge stages through its own
+        // config rather than a transition edge, so following only `transitions`
+        // would report a perfectly wired worker as an orphan.
+        let fan_out = match &stage.mode {
+            StageMode::FanOut { config } => [
+                config.worker_stage.as_deref(),
+                config.merge_stage.as_deref(),
+            ],
+            _ => [None, None],
+        };
+        let edges = stage
+            .transitions
+            .iter()
+            .flat_map(|t| t.keys().map(String::as_str))
+            .chain(fan_out.into_iter().flatten());
+        for target in edges {
+            if !reachable.contains(target) && stage_names.contains(target) {
+                queue.push_back(target.to_string());
+            }
+        }
+    }
+
+    let mut findings: Vec<LintFinding> = blueprint
+        .stages
+        .iter()
+        .filter(|s| !reachable.contains(s.name.as_str()))
+        .map(|s| {
+            LintFinding::new(
+                LintSeverity::Warning,
+                "unreachable-stage",
+                format!("cannot be reached from entry stage '{entry}'"),
+            )
+            .in_stage(&s.name)
+            .with_fix("give some stage a transition to it, or delete it")
+        })
+        .collect();
+
+    // A pair of stages that each transition to the other, where the one being
+    // returned to has no revisit cap, can bounce forever.
+    for stage in &blueprint.stages {
+        let Some(transitions) = &stage.transitions else {
+            continue;
+        };
+        for target in transitions.keys().filter(|t| **t != stage.name) {
+            let Some(target_stage) = blueprint.find_stage(target) else {
+                continue;
+            };
+            let Some(t2) = &target_stage.transitions else {
+                continue;
+            };
+            if t2.contains_key(&stage.name) && target_stage.max_revisits.is_none() {
+                findings.push(
+                    LintFinding::new(
+                        LintSeverity::Warning,
+                        "cycle-without-max-revisits",
+                        format!(
+                            "is in a cycle with '{}' and has no max_revisits",
+                            stage.name
+                        ),
+                    )
+                    .in_stage(target)
+                    .with_fix("set max_revisits so the loop has to end"),
+                );
+            }
+        }
+    }
+
+    findings
+}
+
+/// Models and providers the install cannot resolve.
+fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<LintFinding> {
+    let mut findings = Vec::new();
+
+    for entry in &stage.model.models {
+        // A provider with no catalog here is open-ended (Ollama serves whatever
+        // is pulled, OpenRouter's list runs to hundreds, a script provider
+        // defines its own). Checking a model against a catalog that does not
+        // claim to be complete would only produce false alarms.
+        let catalog_known = env.known_models.iter().any(|(p, _)| *p == entry.provider);
+        let listed = env
+            .known_models
+            .iter()
+            .any(|(p, m)| *p == entry.provider && *m == entry.model);
+        if catalog_known && !listed {
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Warning,
+                    "unknown-model",
+                    format!(
+                        "names {}/{}, which is not a model this build knows about",
+                        entry.provider, entry.model
+                    ),
+                )
+                .in_stage(&stage.name)
+                .with_fix(
+                    "check `lev models list`, or `lev models list --remote` \
+                           if it is newer than this build",
+                ),
+            );
+        }
+    }
+
+    // Reported per stage, not per entry: the models list is an ordered set of
+    // fallbacks, so naming a provider this install cannot reach is normal and
+    // expected as long as something later in the list answers. What is worth
+    // saying is that *nothing* in the list does, which is the shape that
+    // reaches the runtime as "no usable provider" at spawn.
+    if let Some(available) = &env.available_providers
+        && !stage.model.models.is_empty()
+        && !stage
+            .model
+            .models
+            .iter()
+            .any(|e| available.contains(&e.provider))
+    {
+        let tried: Vec<&str> = stage
+            .model
+            .models
+            .iter()
+            .map(|e| e.provider.as_str())
+            .collect();
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "no-reachable-provider",
+                format!(
+                    "names no provider this install can reach (tried {}), so it \
+                     falls back to your default model",
+                    tried.join(", ")
+                ),
+            )
+            .in_stage(&stage.name)
+            .with_fix("run `lev setup` to configure one of them, or add a provider you have"),
+        );
+    }
+
+    findings
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1,0 +1,1038 @@
+use super::*;
+
+/// Wrap `stages_toml` in the smallest manifest that parses and validates.
+fn manifest(stages_toml: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "lint-fixture"
+version = "0.1.0"
+description = "a fixture"
+
+{stages_toml}
+
+[context.regions]
+system = {{ kind = "pinned", max_tokens = 1000 }}
+conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
+"#
+    )
+}
+
+/// Lint a manifest whose text and blueprint come from the same source, which is
+/// the only pairing production ever passes.
+fn lint(content: &str, env: &LintEnv) -> Vec<LintFinding> {
+    let bp = leviath_core::manifest::parse_manifest(content).expect("fixture parses");
+    lint_manifest(content, &bp, env)
+}
+
+/// The codes reported, in order, so a test can assert on the whole outcome
+/// rather than on one finding it went looking for.
+fn codes(findings: &[LintFinding]) -> Vec<&'static str> {
+    findings.iter().map(|f| f.code).collect()
+}
+
+/// Every finding carrying `code`.
+fn with_code<'a>(findings: &'a [LintFinding], code: &str) -> Vec<&'a LintFinding> {
+    findings.iter().filter(|f| f.code == code).collect()
+}
+
+/// A stage that declares everything the linter looks for, so a test can add a
+/// single defect and see only that.
+const CLEAN_STAGE: &str = r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main"
+max_iterations = 10
+available_tools = ["read_file"]
+"#;
+
+fn known_tools(names: &[&str]) -> HashSet<String> {
+    names.iter().map(|n| (*n).to_string()).collect()
+}
+
+// ─── Nothing to report ────────────────────────────────────────────────────────
+
+#[test]
+fn a_fully_declared_stage_reports_nothing() {
+    let findings = lint(&manifest(CLEAN_STAGE), &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// An empty [`LintEnv`] is "I don't know", and an unknown fact must never
+/// become a finding: no tool catalog means no unknown-tool errors, no model
+/// catalog means no unknown-model warnings.
+#[test]
+fn an_empty_env_skips_every_environment_dependent_check() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "madeup", model = "no-such-model" }] }
+max_iterations = 10
+available_tools = ["raed_file"]
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+// ─── Declaration checks ───────────────────────────────────────────────────────
+
+#[test]
+fn a_stage_with_no_mode_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["stage-missing-mode"]);
+    assert_eq!(findings[0].stage.as_deref(), Some("main"));
+    assert_eq!(findings[0].severity, LintSeverity::Warning);
+    assert!(findings[0].message.contains("autonomous"), "{findings:?}");
+}
+
+/// The defect from the report: no model block, so the engine invents one and
+/// the stage silently runs on the user's default provider.
+#[test]
+fn a_stage_with_no_model_block_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+max_iterations = 10
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["stage-missing-model"]);
+    assert!(
+        findings[0].message.contains("default_provider"),
+        "{findings:?}"
+    );
+    let fix = findings[0].fix.as_deref().expect("the fix names the block");
+    assert!(fix.contains("[stages.main]"), "{fix}");
+}
+
+/// The old single-model spelling (`provider`/`model` at the top of the table)
+/// still counts as declaring one.
+#[test]
+fn the_legacy_inline_model_spelling_counts_as_declared() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+max_iterations = 10
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+#[test]
+fn a_stage_with_no_max_iterations_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["stage-missing-max-iterations"]);
+    assert!(
+        findings[0].message.contains("default_max_iterations"),
+        "{findings:?}"
+    );
+}
+
+/// A fan_out stage runs no inference of its own, so it has no iteration count
+/// to cap and must not be nagged for one.
+#[test]
+fn a_fan_out_stage_needs_no_max_iterations() {
+    let toml = manifest(
+        r#"
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+allow_as_worker = true
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// An agent-level `[model]` block reads like it sets the agent's model. Nothing
+/// looks at it.
+#[test]
+fn an_agent_level_model_block_is_warned_about() {
+    let toml = format!(
+        "{}\n[model]\nprovider = \"anthropic\"\nmodel = \"claude-opus-5\"\n",
+        manifest(CLEAN_STAGE)
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["agent-model-block-ignored"]);
+    assert!(findings[0].stage.is_none(), "{findings:?}");
+}
+
+// ─── Declared: the fallbacks ──────────────────────────────────────────────────
+
+/// Text the linter cannot re-read yields no declaration findings at all, rather
+/// than a full set of false ones. Production never hits this (the caller only
+/// lints a manifest that already parsed) so it is asserted directly.
+#[test]
+fn unreadable_text_reports_every_key_as_declared() {
+    let declared = Declared::from_text("not valid toml [[[");
+    assert!(!declared.agent_model_block);
+    let keys = declared.stage("anything");
+    assert!(keys.mode);
+    assert!(keys.model);
+}
+
+/// Same for a stage the text has no entry for, which is how a blueprint built
+/// in code rather than parsed would arrive.
+#[test]
+fn a_stage_absent_from_the_text_reports_as_declared() {
+    let keys = Declared::from_text("[agent]\nname = \"x\"\n").stage("ghost");
+    assert!(keys.mode);
+    assert!(keys.model);
+}
+
+/// A manifest that parses to something other than a table (a bare TOML document
+/// cannot, but the parse is fallible in principle) takes the same path.
+#[test]
+fn text_with_no_stages_table_has_no_stage_keys() {
+    let declared = Declared::from_text("[agent]\nname = \"x\"\n");
+    assert!(declared.stages.is_empty());
+    assert!(!declared.opaque);
+}
+
+// ─── Tool checks ──────────────────────────────────────────────────────────────
+
+#[test]
+fn a_misspelled_tool_is_an_error() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["read_file", "raed_file"]
+"#,
+    );
+    let env = LintEnv {
+        known_tools: known_tools(&["read_file"]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["unknown-tool"]);
+    assert!(findings[0].is_error());
+    assert!(findings[0].message.contains("raed_file"), "{findings:?}");
+}
+
+/// `server__tool` names an MCP tool, which resolves only once that server is
+/// installed. That is not a property of the manifest, so it is never flagged.
+#[test]
+fn an_mcp_tool_name_is_never_unknown() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["github__create_issue"]
+"#,
+    );
+    let env = LintEnv {
+        known_tools: known_tools(&["read_file"]),
+        ..LintEnv::default()
+    };
+    assert!(lint(&toml, &env).is_empty());
+}
+
+#[test]
+fn a_permission_for_an_ungranted_tool_is_an_error() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["read_file"]
+
+[stages.main.tool_permissions]
+write_file = "allow"
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["orphan-stage-permission"]);
+    assert!(findings[0].is_error());
+    assert!(findings[0].message.contains("write_file"), "{findings:?}");
+}
+
+#[test]
+fn a_permission_for_a_granted_tool_is_fine() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["read_file"]
+
+[stages.main.tool_permissions]
+read_file = "allow"
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+// ─── Blocking tools ───────────────────────────────────────────────────────────
+
+#[test]
+fn an_autonomous_stage_granting_an_ask_tool_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["ask_user_text"]
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["blocking-tool-in-autonomous-stage"]);
+    assert!(
+        findings[0].message.contains("until a person answers"),
+        "{findings:?}"
+    );
+}
+
+/// Every name the runtime dispatches to a human is covered, not just the
+/// `ask_user_*` family.
+#[test]
+fn every_blocking_interaction_tool_is_flagged() {
+    for tool in BLOCKING_INTERACTION_TOOLS {
+        let toml = manifest(&format!(
+            r#"
+[stages.main]
+mode = "autonomous"
+model = {{ models = [{{ provider = "anthropic", model = "claude-sonnet-5" }}] }}
+max_iterations = 10
+available_tools = ["{tool}"]
+"#
+        ));
+        assert_eq!(
+            codes(&lint(&toml, &LintEnv::default())),
+            ["blocking-tool-in-autonomous-stage"],
+            "{tool}"
+        );
+    }
+}
+
+#[test]
+fn allow_blocking_tools_silences_the_warning() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["ask_user_text"]
+allow_blocking_tools = true
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// An interactive stage is where a person is expected, so the same grant is
+/// unremarkable there.
+#[test]
+fn an_interactive_stage_may_grant_ask_tools_freely() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "interactive"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["ask_user_text"]
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+// ─── Shell policy ─────────────────────────────────────────────────────────────
+
+/// The default for a shell grant is `ask`, and an `ask` nobody answers waits
+/// rather than denying, so an unattended run hangs on the first command.
+#[test]
+fn a_shell_grant_with_no_policy_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["bash"]
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["implicit-shell-policy"]);
+    assert!(findings[0].message.contains("'bash'"), "{findings:?}");
+}
+
+/// `bash` and `shell` are the same tool, so both spellings are checked.
+#[test]
+fn the_canonical_shell_spelling_is_checked_too() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["shell"]
+"#,
+    );
+    assert_eq!(
+        codes(&lint(&toml, &LintEnv::default())),
+        ["implicit-shell-policy"]
+    );
+}
+
+#[test]
+fn a_stage_level_shell_policy_settles_it() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["bash"]
+
+[stages.main.tool_permissions]
+bash = "allow"
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// The bug this check exists for, found in a shipped blueprint: the stage
+/// grants `shell` and the agent writes `bash = "ask"`. Policy is matched on the
+/// name the model calls, so the entry is dead.
+#[test]
+fn a_permission_written_under_the_other_spelling_is_warned_about() {
+    let toml = format!(
+        "{}\n[tool_permissions]\nbash = \"ask\"\n",
+        manifest(
+            r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["shell"]
+"#,
+        )
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["permission-name-mismatch"]);
+    assert!(
+        findings[0].message.contains("grants 'shell'"),
+        "{findings:?}"
+    );
+    assert!(findings[0].message.contains("'bash'"), "{findings:?}");
+}
+
+/// And the reverse: granted as `bash`, written as `shell`.
+#[test]
+fn the_mismatch_is_caught_in_either_direction() {
+    let toml = format!(
+        "{}\n[tool_permissions]\nshell = \"allow\"\n",
+        manifest(
+            r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["bash"]
+"#,
+        )
+    );
+    assert_eq!(
+        codes(&lint(&toml, &LintEnv::default())),
+        ["permission-name-mismatch"]
+    );
+}
+
+#[test]
+fn alias_siblings_never_include_the_name_itself() {
+    assert_eq!(alias_siblings("bash"), ["shell"]);
+    assert_eq!(alias_siblings("shell"), ["bash"]);
+    // A tool with no aliases has no siblings at all.
+    assert!(alias_siblings("read_file").is_empty());
+}
+
+#[test]
+fn an_agent_level_shell_policy_settles_it() {
+    let toml = format!(
+        "{}\n[tool_permissions]\nbash = \"deny\"\n",
+        manifest(
+            r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["bash"]
+"#,
+        )
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+// ─── Models and providers ─────────────────────────────────────────────────────
+
+#[test]
+fn a_model_missing_from_a_known_catalog_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-9" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        known_models: vec![("anthropic".to_string(), "claude-sonnet-5".to_string())],
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["unknown-model"]);
+    assert!(
+        findings[0].message.contains("anthropic/claude-sonnet-9"),
+        "{findings:?}"
+    );
+}
+
+/// Ollama serves whatever has been pulled and OpenRouter's catalog runs to
+/// hundreds of entries, so a provider with no rows is not checked at all.
+#[test]
+fn a_provider_with_no_catalog_is_not_checked() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "ollama", model = "qwen3.5:9b" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        known_models: vec![("anthropic".to_string(), "claude-sonnet-5".to_string())],
+        ..LintEnv::default()
+    };
+    assert!(lint(&toml, &env).is_empty());
+}
+
+#[test]
+fn a_model_present_in_the_catalog_passes() {
+    let env = LintEnv {
+        known_models: vec![("anthropic".to_string(), "claude-sonnet-5".to_string())],
+        ..LintEnv::default()
+    };
+    assert!(lint(&manifest(CLEAN_STAGE), &env).is_empty());
+}
+
+/// A stage with nothing reachable in its whole list is the shape the runtime
+/// rejects at spawn, so it is worth saying up front.
+#[test]
+fn a_stage_with_no_reachable_provider_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.5" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        available_providers: Some(known_tools(&["ollama"])),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["no-reachable-provider"]);
+    assert!(
+        findings[0].message.contains("anthropic, openai"),
+        "{findings:?}"
+    );
+}
+
+/// The models list is an ordered set of fallbacks. A provider the install
+/// cannot reach is unremarkable as long as something later in the list can, so
+/// only a list that is reachable nowhere is reported.
+#[test]
+fn an_unreachable_provider_is_fine_when_a_later_one_answers() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        available_providers: Some(known_tools(&["ollama"])),
+        ..LintEnv::default()
+    };
+    assert!(lint(&toml, &env).is_empty());
+}
+
+#[test]
+fn every_provider_reachable_reports_nothing() {
+    let env = LintEnv {
+        available_providers: Some(known_tools(&["anthropic"])),
+        ..LintEnv::default()
+    };
+    assert!(lint(&manifest(CLEAN_STAGE), &env).is_empty());
+}
+
+/// A stage with no model entries at all has no list to check, so the
+/// reachability question does not arise (the missing-model warning covers it).
+#[test]
+fn a_stage_with_an_empty_models_list_is_not_checked_for_reachability() {
+    let mut bp =
+        leviath_core::manifest::parse_manifest(&manifest(CLEAN_STAGE)).expect("the fixture parses");
+    bp.stages[0].model.models.clear();
+    let env = LintEnv {
+        available_providers: Some(HashSet::new()),
+        ..LintEnv::default()
+    };
+    let findings = lint_manifest(&manifest(CLEAN_STAGE), &bp, &env);
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+// ─── read_paths ───────────────────────────────────────────────────────────────
+
+/// Declaring `[read_paths]` is legitimate, so it is a note rather than a
+/// warning: it must survive `--deny-warnings` on an otherwise good blueprint.
+#[test]
+fn read_path_declarations_are_noted_not_warned() {
+    let toml = format!(
+        "{}\n[read_paths]\nallow = [\"~/.leviath/runs\"]\n",
+        manifest(CLEAN_STAGE)
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["read-paths-declared"]);
+    assert_eq!(findings[0].severity, LintSeverity::Note);
+    assert!(
+        findings[0].message.contains("~/.leviath/runs"),
+        "{findings:?}"
+    );
+}
+
+#[test]
+fn no_read_paths_means_no_note() {
+    assert!(
+        !codes(&lint(&manifest(CLEAN_STAGE), &LintEnv::default())).contains(&"read-paths-declared")
+    );
+}
+
+/// An entry amounting to "everything" gets its own warning on top of the note.
+#[test]
+fn a_broad_read_path_entry_gets_its_own_warning() {
+    let toml = format!(
+        "{}\n[read_paths]\nallow = [\"~\", \"~/.leviath/runs\"]\n",
+        manifest(CLEAN_STAGE)
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    // Warning sorts ahead of Note.
+    assert_eq!(codes(&findings), ["broad-read-path", "read-paths-declared"]);
+    assert!(findings[0].message.contains("'~'"), "{findings:?}");
+}
+
+#[test]
+fn the_broad_entry_heuristic_covers_each_shape() {
+    for entry in [
+        "~",
+        "~/",
+        "/",
+        "glob:**",
+        "glob:/**",
+        "regex:/.*",
+        "regex:/.+",
+    ] {
+        assert!(read_path_entry_is_broad(entry), "{entry}");
+    }
+    for entry in [
+        "~/.leviath/runs",
+        "glob:~/docs/**",
+        "regex:/data/.*",
+        "../shared",
+        r"C:\data",
+    ] {
+        assert!(!read_path_entry_is_broad(entry), "{entry}");
+    }
+}
+
+// ─── Command seeds ────────────────────────────────────────────────────────────
+
+#[test]
+fn command_seed_regions_are_named_in_one_note() {
+    let toml = r#"
+[agent]
+name = "scanner"
+version = "0.1.0"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main stage"
+max_iterations = 5
+
+[context.regions]
+facts = { kind = "pinned", max_tokens = 1000, seed = { command = "git ls-files" } }
+tests = { kind = "pinned", max_tokens = 1000, seed = { command = "ls tests" } }
+plain = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+"#;
+    let findings = lint(toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["command-seed"]);
+    let message = &findings[0].message;
+    assert!(message.contains("2 region(s)"), "{message}");
+    assert!(message.contains("facts: git ls-files"), "{message}");
+    assert!(message.contains("tests: ls tests"), "{message}");
+    // A region without a command seed is not named.
+    assert!(!message.contains("plain"), "{message}");
+    // The escape hatches are given, so the reader knows how to refuse.
+    let fix = findings[0]
+        .fix
+        .as_deref()
+        .expect("a seed note offers a fix");
+    assert!(fix.contains("--no-seed-commands"), "{fix}");
+    assert!(fix.contains("allow_seed_commands"), "{fix}");
+}
+
+#[test]
+fn no_command_seeds_means_no_note() {
+    assert!(!codes(&lint(&manifest(CLEAN_STAGE), &LintEnv::default())).contains(&"command-seed"));
+}
+
+// ─── Graph shape ──────────────────────────────────────────────────────────────
+
+/// A graph-shaped blueprint with the entry reaching everything reports nothing,
+/// including through a diamond where a shared target is queued twice.
+#[test]
+fn a_fully_reachable_graph_reports_nothing() {
+    let toml = manifest(
+        r#"
+[stages.entry]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+entry = true
+[stages.entry.transitions]
+b = "true"
+c = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.b.transitions]
+d = "true"
+
+[stages.c]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.c.transitions]
+d = "true"
+
+[stages.d]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// A fan_out stage reaches its worker and merge stages through its own config
+/// rather than a transition edge. Following only `transitions` reported both as
+/// orphans in a correctly wired blueprint.
+#[test]
+fn fan_out_worker_and_merge_stages_are_reachable() {
+    let toml = manifest(
+        r#"
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+merge_stage = "merge"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+entry = true
+[stages.split.transitions]
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+allow_as_worker = true
+
+[stages.merge]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+#[test]
+fn a_stage_the_entry_cannot_reach_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.a]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+entry = true
+[stages.a.transitions]
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+
+[stages.orphan]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["unreachable-stage"]);
+    assert_eq!(findings[0].stage.as_deref(), Some("orphan"));
+}
+
+#[test]
+fn a_cycle_with_no_revisit_cap_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.a]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+entry = true
+[stages.a.transitions]
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.b.transitions]
+a = "true"
+"#,
+    );
+    // Each stage is the "target" of the other's edge, and neither caps
+    // revisits, so both ends of the loop are named.
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(
+        codes(&findings),
+        ["cycle-without-max-revisits", "cycle-without-max-revisits"]
+    );
+}
+
+#[test]
+fn a_cycle_with_max_revisits_is_fine() {
+    let toml = manifest(
+        r#"
+[stages.a]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+max_revisits = 2
+entry = true
+[stages.a.transitions]
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+max_revisits = 3
+[stages.b.transitions]
+a = "true"
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// A self-loop is not a two-stage cycle, and a terminal stage has an empty
+/// transitions table rather than none. Both are shapes the walk has to step
+/// over without complaining.
+#[test]
+fn self_loops_and_terminal_stages_are_not_cycles() {
+    let toml = manifest(
+        r#"
+[stages.a]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+entry = true
+[stages.a.transitions]
+a = "true"
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.b.transitions]
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// A blueprint with no transitions anywhere is linear: there is no graph to
+/// walk, so the graph checks return before doing anything.
+#[test]
+fn a_linear_blueprint_has_no_graph_findings() {
+    let toml = manifest(
+        r#"
+[stages.a]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+
+[stages.b]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// `Blueprint::validate` rejects an entry_stage or transition target that names
+/// no real stage, so the graph walk only meets those through the struct's own
+/// public fields. It has to step over them rather than panic.
+#[test]
+fn the_graph_walk_steps_over_names_that_are_not_stages() {
+    use leviath_core::{Blueprint, ContextLayout, Stage, TransitionEdge};
+
+    let model = leviath_core::blueprint::ModelConfig::new(
+        "anthropic".to_string(),
+        "claude-sonnet-5".to_string(),
+    );
+
+    // entry_stage points at a name with no Stage: the BFS pops "ghost" and
+    // finds nothing to walk from.
+    let mut only = Stage::new("a".to_string(), model.clone());
+    only.transitions = Some(HashMap::new());
+    only.max_iterations = Some(5);
+    let mut bp = Blueprint::new(
+        "t".to_string(),
+        "t".to_string(),
+        vec![only],
+        ContextLayout::new(Vec::new(), 1000),
+    );
+    bp.entry_stage = Some("ghost".to_string());
+    // "a" is now unreachable, which is the only thing worth saying.
+    assert_eq!(
+        codes(&lint_manifest("", &bp, &LintEnv::default())),
+        ["unreachable-stage"]
+    );
+
+    // A transition target with no Stage: the cycle check finds nothing to ask
+    // about the other end of the edge.
+    let mut dangling = Stage::new("a".to_string(), model);
+    dangling.max_iterations = Some(5);
+    dangling.transitions = Some(HashMap::from([(
+        "ghost".to_string(),
+        TransitionEdge {
+            target: "ghost".to_string(),
+            condition: Default::default(),
+            hint: None,
+            transform: Default::default(),
+            gate: None,
+            stuck: None,
+        },
+    )]));
+    let bp = Blueprint::new(
+        "t".to_string(),
+        "t".to_string(),
+        vec![dangling],
+        ContextLayout::new(Vec::new(), 1000),
+    );
+    assert!(lint_manifest("", &bp, &LintEnv::default()).is_empty());
+}
+
+// ─── Finding rendering ────────────────────────────────────────────────────────
+
+#[test]
+fn severity_labels_are_the_same_width() {
+    assert_eq!(
+        LintSeverity::Error.label().len(),
+        LintSeverity::Warning.label().len()
+    );
+    assert_eq!(LintSeverity::Error.label().trim(), "ERR");
+    assert_eq!(LintSeverity::Warning.label().trim(), "WARN");
+}
+
+#[test]
+fn one_line_names_the_stage_when_there_is_one() {
+    let stageless = LintFinding::new(LintSeverity::Warning, "c", "something".to_string());
+    assert_eq!(stageless.one_line(), "something");
+    assert_eq!(
+        stageless.in_stage("main").one_line(),
+        "stage 'main': something"
+    );
+}
+
+#[test]
+fn is_error_distinguishes_the_severities() {
+    assert!(LintFinding::new(LintSeverity::Error, "c", String::new()).is_error());
+    assert!(!LintFinding::new(LintSeverity::Warning, "c", String::new()).is_error());
+}
+
+// ─── Several defects at once ──────────────────────────────────────────────────
+
+/// The reported blueprint, reconstructed: no mode, no model block, no iteration
+/// cap, an unattended stage that can ask a human, a shell grant with no policy,
+/// and a typo. Every finding lands, and only the typo is fatal.
+#[test]
+fn a_thoroughly_broken_stage_reports_each_defect_once() {
+    let toml = manifest(
+        r#"
+[stages.scope]
+available_tools = ["read_file", "bash", "ask_user_text", "raed_file"]
+"#,
+    );
+    let env = LintEnv {
+        known_tools: known_tools(&["read_file", "bash", "shell", "ask_user_text"]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    for code in [
+        "stage-missing-mode",
+        "stage-missing-model",
+        "stage-missing-max-iterations",
+        "unknown-tool",
+        "blocking-tool-in-autonomous-stage",
+        "implicit-shell-policy",
+    ] {
+        assert_eq!(with_code(&findings, code).len(), 1, "{code}: {findings:?}");
+    }
+    assert_eq!(findings.iter().filter(|f| f.is_error()).count(), 1);
+    assert_eq!(findings.len(), 6, "{:?}", codes(&findings));
+}

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -746,6 +746,19 @@ pub struct Stage {
     #[serde(default)]
     pub allow_as_worker: bool,
 
+    /// Whether this stage means to offer human-in-the-loop tools (`ask_user_*`,
+    /// `present_for_review`, `edit_document`) while running autonomously.
+    ///
+    /// Grants nothing and changes no runtime behavior: it only records the
+    /// author's intent, so `lev validate` stops flagging a deliberate choice.
+    /// An autonomous stage that calls one of those tools with nobody attached
+    /// parks in `WaitingInput` until someone kills the run, which is almost
+    /// always a mistake and occasionally exactly what was wanted (an agent
+    /// driven from the dashboard, say). Off by default so the flag has to be
+    /// written down.
+    #[serde(default)]
+    pub allow_blocking_tools: bool,
+
     /// Per-stage taint/security override. `None` inherits the agent-level
     /// `Blueprint.security` (which in turn inherits the global config toggle).
     /// Set `taint_tracking = false` here to opt a single stage out, or `true`
@@ -814,6 +827,7 @@ impl Stage {
             accepts_messages: true,
             allow_complete: false,
             allow_as_worker: false,
+            allow_blocking_tools: false,
             security: None,
             batch_tool_hint: None,
             shell_hint: None,

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -389,6 +389,16 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
                 stage.allow_as_worker = aw;
             }
 
+            // Parse allow_blocking_tools flag: says this autonomous stage means
+            // to offer `ask_user_*` / `present_for_review`, so `lev validate`
+            // stops warning about it.
+            if let Some(ab) = stage_value
+                .get("allow_blocking_tools")
+                .and_then(|v| v.as_bool())
+            {
+                stage.allow_blocking_tools = ab;
+            }
+
             // Parse per-stage security override: [stages.<name>.security]
             if let Some(sec_table) = stage_value.get("security").and_then(|v| v.as_table()) {
                 stage.security = Some(parse_security_config(sec_table));
@@ -3058,6 +3068,27 @@ allow_complete = true
         let bp = parse_manifest(toml).unwrap();
         let stage = bp.find_stage("review").unwrap();
         assert!(stage.allow_complete);
+    }
+
+    /// `allow_blocking_tools` is read off the stage table and defaults to false
+    /// for a stage that says nothing about it.
+    #[test]
+    fn parse_manifest_allow_blocking_tools() {
+        let toml = r#"
+[agent]
+name = "blocking-test"
+
+[stages.implement]
+mode = "autonomous"
+available_tools = ["ask_user_confirm"]
+allow_blocking_tools = true
+
+[stages.review]
+mode = "autonomous"
+"#;
+        let bp = parse_manifest(toml).unwrap();
+        assert!(bp.find_stage("implement").unwrap().allow_blocking_tools);
+        assert!(!bp.find_stage("review").unwrap().allow_blocking_tools);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -154,6 +154,23 @@ impl InteractionBackend for UnattendedInteraction {
     }
 }
 
+/// The tools that suspend the agent until a person answers.
+///
+/// Every name here is handled by [`dispatch_dynamic_interaction`] below, which
+/// hands the call to the interaction backend and awaits a human response - so a
+/// stage that offers one of these with nobody attached parks there for as long
+/// as the run lives. `all_dynamic_interaction_tool_names_are_handled` iterates
+/// this list, so the two cannot drift.
+///
+/// Blueprint linting reads it to flag an autonomous stage that grants one.
+pub const BLOCKING_INTERACTION_TOOLS: &[&str] = &[
+    "present_for_review",
+    "ask_user_text",
+    "ask_user_choice",
+    "ask_user_confirm",
+    "edit_document",
+];
+
 /// Dispatch a single dynamic-interaction tool call.
 ///
 /// Returns `Some(result_string)` if `tool_name` is one of
@@ -420,14 +437,7 @@ mod tests {
 
     #[tokio::test]
     async fn all_dynamic_interaction_tool_names_are_handled() {
-        let names = [
-            "present_for_review",
-            "ask_user_text",
-            "ask_user_choice",
-            "ask_user_confirm",
-            "edit_document",
-        ];
-        for name in names {
+        for name in BLOCKING_INTERACTION_TOOLS.iter().copied() {
             let backend = MockBackend::with_responses(vec![InteractionResponse::text("", "ok")]);
             let result = dispatch_dynamic_interaction(
                 &backend,

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -105,6 +105,12 @@ temperature = 0.2
 max_tokens  = 8000
 ```
 
+Model selection is per stage, and only per stage. A top-level `[model]` block parses without
+complaint and is then read by nothing, so the stages carry on using their own defaults with no sign
+that the block was ignored. A stage that omits `model` entirely does not fail either: it runs on
+whichever provider your config makes the default, which is rarely what the author had in mind and is
+invisible until the run picks the wrong model. `lev validate` reports both.
+
 ## Context regions
 
 `[context.regions]` defines the memory layout. There are eight region kinds (the default is
@@ -258,6 +264,13 @@ transform   = "summarize"
 ## Validate before you run
 
 ```bash
-lev validate .             # check the graph, print seeds + permissions
-lev test .                 # dry-run the blueprint
+lev validate .                    # check the graph, and what the manifest leaves unsaid
+lev validate . --deny-warnings    # for CI: warnings fail too
+lev test .                        # dry-run the blueprint
 ```
+
+Beyond the graph, `lev validate` reports the fields whose absence quietly changes what a run does: a
+stage with no model block, a tool name that matches nothing, an autonomous stage offering a tool
+that waits for a person. Errors exit non-zero, warnings do not, notes never can. The
+[CLI reference](/docs/cli#lev-validate-path) lists every check. The daemon logs the same findings
+when a run spawns, so a blueprint nobody validated still says what is wrong with it.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -42,8 +42,11 @@ with `@` is read from that file:
 lev run reviewer --task "Review the auth module" --standards @./team-standards.md
 ```
 
-A region only accepts a seed if the blueprint declares it as caller input. `lev validate` lists
-which ones do.
+A region only accepts a seed if the blueprint declares it as caller input: a string
+`seed = "<key>"` in its `[context.regions]` entry, or being named `task`, which asks for the `task`
+key implicitly. A table seed (`seed = { glob = ... }`, `{ command = ... }`, and so on) fills the
+region from somewhere else and takes no caller input, and a `--<name>` naming any other region is
+dropped.
 
 > [!NOTE]
 > `--task` fills the caller-input key `task`. A blueprint receives it only if some region asks for

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -80,8 +80,33 @@ Scaffold a new [blueprint](/docs/agents) directory.
 
 ### `lev validate [PATH]`
 
-Check a blueprint before running it: graph well-formedness and reachability, seed declarations,
-`[read_paths]` entries, and the tools each stage asks for. `PATH` defaults to `.`.
+Check a blueprint before running it. `PATH` defaults to `.`.
+
+Beyond parsing and structural validation, it reports what the manifest leaves unsaid. Findings come
+in three levels: an **error** exits non-zero, a **warning** does not, and a **note** never does.
+
+| Level | Code | What it means |
+|---|---|---|
+| error | `unknown-tool` | A name in `available_tools` matches no built-in, sub-agent tool, or `tools/*.rhai`. The stage silently advertises one tool fewer, so the model is told it does not exist. MCP names (`server__tool`) are skipped, since they resolve only once that server is installed. |
+| error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted. It reads as a grant and is not one. |
+| warning | `stage-missing-model` | No `[stages.X.model]` block, so the stage runs on whatever your `default_provider` is. |
+| warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
+| warning | `stage-missing-max-iterations` | Unbounded unless `[limits] default_max_iterations` is set. Fan-out stages are exempt. |
+| warning | `agent-model-block-ignored` | A top-level `[model]` block. Nothing reads it; model selection is per stage. |
+| warning | `blocking-tool-in-autonomous-stage` | An autonomous stage grants `ask_user_*`, `present_for_review` or `edit_document`. With nobody attached the run parks there until it is killed. Set `allow_blocking_tools = true` on the stage to say you meant it. |
+| warning | `permission-name-mismatch` | The permission is written for an alias of the granted tool (`bash` against a stage that grants `shell`, say). Policy is matched on the name the model calls, so the entry has no effect. |
+| warning | `implicit-shell-policy` | A shell grant with no policy behind it. The default is `ask`, and an unattended run waits on that prompt rather than being denied. |
+| warning | `unknown-model` | A model this build has not heard of, checked only against providers with a closed catalog. Ollama, OpenRouter and script providers are never checked. |
+| warning | `no-reachable-provider` | Nothing in the stage's models list is configured here, so it falls through to your default model. |
+| warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
+| note | `command-seed`, `read-paths-declared` | What the blueprint will do that you should know about before running it. |
+
+| Flag | Purpose |
+|---|---|
+| `--deny-warnings` | Exit non-zero on warnings too. Notes still never fail. |
+
+The same findings are written to `daemon.log` when a run spawns, so a blueprint that was never
+validated still says what is wrong with it. Nothing there refuses a spawn.
 
 ### `lev test [PATH]`
 

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -58,6 +58,21 @@ fails at `lev validate` instead of at 2am.
 | `requires_children` | `false` | Holds the stage until every sub-agent it spawned has finished |
 | `allow_as_worker` | `false` | Opts this stage in to being the target of a [fan-out](/docs/sub-agents). Off by default, so you can only fan out into a stage designed for it |
 | `accepts_messages` | `true` | Whether `lev msg` reaches this stage. See [Human-in-the-loop](/docs/interaction) |
+| `allow_blocking_tools` | `false` | Says this autonomous stage means to offer `ask_user_*` / `present_for_review`. It grants nothing and changes no behaviour: it only stops `lev validate` reporting a deliberate choice as an oversight |
+
+An autonomous stage that calls one of the human-in-the-loop tools suspends until somebody answers,
+and on an unattended run that is forever. `lev validate` warns about it for that reason. Set
+`allow_blocking_tools = true` when the stage is driven from the dashboard, or by somebody watching.
+
+### Every stage should name its own model
+
+`model` is per stage. There is no agent-level `[model]` block: writing one parses fine and is then
+read by nothing, so the stages go on using their own defaults with no sign that the block was
+ignored.
+
+A stage that omits `model` entirely does not fail either. It runs on whichever provider your
+`[providers]` config makes the default, which is rarely what the author had in mind and is invisible
+until the run picks the wrong model. `lev validate` reports both cases.
 
 ### Carrying context across an edge
 


### PR DESCRIPTION
Closes #203.

## The problem

`Blueprint::validate` answers whether a manifest is structurally coherent: the layout fits, the graph resolves, fan-out wiring points at real stages. It says nothing about the fields whose *absence* quietly changes what a run does, and those are the ones that bite.

- A stage with no `[stages.X.model]` block parses fine, because the parser substitutes `anthropic/claude-sonnet-4-6` out of thin air, and then runs on whatever the user's `default_provider` happens to be.
- An agent-level `[model]` block is read by nothing at all. Only `[stages.X.model]` exists, so the author's model choice is discarded with no signal.
- A typo in `available_tools` matches nothing, so the stage advertises one tool fewer and the model is told the tool does not exist.
- An autonomous stage granting `ask_user_text` parks in `WaitingInput` the first time it asks, with nobody there to answer.

Each is invisible on inspection and turns up hours later as a run behaving oddly.

One correction to the issue: the "iter=0 zombie forever" symptom it attributes to a missing `mode` was the unregistered-provider spawn, and #196 already fixed that. `resolve_stages` fails the spawn now instead of parking a dead agent. What was still missing is telling the author, before they run anything, which fields they left off and what the engine will silently do about them.

## What this does

`lev validate` makes thirteen checks, each with a stable code and a suggested fix:

```
✗ Blueprint 'tl' is valid.
  ERR  stage 'scope': grants 'raed_file', which is not a built-in, a sub-agent tool, or one of this agent's own tools/*.rhai [unknown-tool]
       check the spelling, or drop the entry
  WARN the top-level [model] block is not read by anything: model selection is per stage [agent-model-block-ignored]
       move it into each [stages.<name>.model] that needs it
  WARN stage 'scope': no [stages.scope.model] block, so the stage runs on your configured default_provider, whatever that is [stage-missing-model]
       add model = { models = [{ provider = "...", model = "..." }] } to [stages.scope]
  WARN stage 'scope': grants 'shell' but its permission is written for 'bash'. Policy is matched on the name the model calls, which is 'shell', so that entry has no effect [permission-name-mismatch]
       rename the permission key 'bash' to 'shell'
  ...
Error: ✗ Blueprint has 1 error
```

Typos are errors and exit non-zero. Everything else is a warning that does not, or a note that never can. `--deny-warnings` makes warnings fatal for CI; notes still never fail.

The same findings are logged when the daemon spawns a run, so a blueprint nobody validated still says what is wrong with it in `daemon.log`. Nothing there refuses a spawn: these are authoring mistakes whose cost shows up hours later, and refusing would break blueprints that run today.

`POST /api/blueprints/validate` returns a `warnings` list alongside `errors`.

New stage key `allow_blocking_tools = true` records that a stage means to offer the human-in-the-loop tools. It grants nothing and changes no runtime behaviour.

## Design notes

**The linter lives in `leviath-cli`, not `leviath-core`.** All three callers are here, and core cannot depend on `leviath-tools` (the dependency runs the other way), so a core linter would have to keep its own copy of the tool alias table and the policy defaults. Environment facts it cannot know — which tools exist, which models exist, which providers are configured — arrive in a `LintEnv`, and an empty field skips its check rather than guessing.

**Declaration questions are answered from the manifest text, not the parsed `Blueprint`.** By the time you have a `Blueprint` the parser has filled in its defaults, and the struct cannot tell "wrote `autonomous`" from "wrote nothing".

**The graph and `[read_paths]` checks `lev validate` already made move into the linter**, so there is one findings block rather than two reporting styles in one command.

**The provider check reports per stage, not per entry.** A models list is an ordered set of fallbacks, so naming a provider this install cannot reach is normal as long as something later answers. Only a list that is reachable nowhere is worth saying.

## Two defects it found in the shipped blueprints

Running the lint over the bundled agents turned up real problems, which is the point:

- **`parallel-fixer` set `bash = "ask"` while every stage granted `shell`.** Policy is resolved against the name the model calls, which is the canonical `shell`, so the entry was never consulted. Every other bundled agent uses `bash` consistently. Fixed by renaming the key; the policy value is unchanged.
- **`software-engineer`'s review stage had no `max_iterations`.** Now 20.

`coder` and `software-engineer` grant `ask_user_*` in their implement stages deliberately, so both get `allow_blocking_tools = true`.

The bundled-agent invariant test now runs the shipped linter and asserts zero errors over all discovered agents, replacing a hand-rolled parallel copy of the same rules.

## Verification

- `cargo test --workspace --all-features`: ~5,500 tests, 0 failures.
- `cargo xtask coverage`: **all 11 packages at 100%**. Four gaps had to be closed first, each the same trap — a closure or macro argument that only the failing path reaches. `tracing::warn!` was the interesting one: it does not evaluate its arguments unless the level is enabled, so a method call in the argument list never ran.
- **Live**, against a release binary and an isolated `LEVIATH_HOME`:
  - `lev validate` on all ten installed bundled agents: exit 0, informational notes only.
  - The reported broken blueprint reconstructed: 1 error, 7 warnings, exit 1, every defect from the issue named with a fix.
  - Warnings-only blueprint: exit 0 bare, exit 1 under `--deny-warnings`. A notes-only blueprint stays exit 0 under `--deny-warnings`.
  - `allow_blocking_tools = true` silences the warning; the blueprint then passes `--deny-warnings`.
  - Daemon spawn against a Rhai mock provider: the three findings appear as `WARN` in `daemon.log` and the run still reaches `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rpWgHe5uqLapiWF4CgX6S
