### PR TITLE
Fail over and trip a breaker when a provider runs out of credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,42 @@ requests since the previous version.
 - The probe cleans up after itself: the throwaway agent is staged in a temp
   directory and its run is deleted on every path out, including the failing
   ones, so nothing is left in `lev ps` or on disk.
+- A provider that runs out of credits no longer takes every agent down with it.
+  A `402` arrived as an opaque API error carrying the raw JSON body, so the
+  runtime had nothing to branch on and each run died at iteration 0 with the
+  blob as its status. Out-of-credits, rejected-key, and not-permitted responses
+  are now told apart from an ordinary bad request, including the ones that
+  arrive under an innocent status (Anthropic reports a drained balance as a
+  `400` saying the credit balance is too low). The message says what to do about
+  it and keeps the provider's response for the logs.
+- A stage now fails over instead of failing. Its ordered `models` list was only
+  ever consulted once, at spawn, to pick the first provider with a key; a
+  provider that was configured but unusable was chosen and then never abandoned.
+  The rest of the list is kept and used. An ordinary error still cannot spend a
+  fallback, and a stage that exhausts its list ends as before, with a readable
+  message.
+- New `[providers] fallback_order`, a host-wide list of `provider/model` pairs
+  tried after a stage's own entries and the default model. A blueprint that
+  names a single model has nowhere to go without it. It is per-run policy, so it
+  reloads with no daemon restart.
+- Providers that keep failing are taken out of service. Failing over rescues one
+  run; the next one would start on the same dead provider and rediscover it.
+  After `[limits] provider_failures_before_open` consecutive failures (default
+  3, since a single payment error can be one oversized request) no run is
+  dispatched there. `provider_circuit_cooldown_secs` (default 300) later lets
+  one request through as a probe, so topping up an account brings the factory
+  back with no restart. Runs with no candidate left are failed with an
+  explanation rather than left running forever.
+- `lev ps` names any provider currently out of service, with the reason and the
+  retry countdown; `lev ps --json` carries it under `health.providers_down`. New
+  `leviath.provider.circuit.open` and `leviath.provider.circuit.opened.total`
+  metrics report the same per provider. Ten runs dying in a row used to produce
+  ten identical error rows and nothing that said the account was empty.
+- Anthropic and Ollama now classify HTTP failures through the same shared path
+  as every other provider. Both had hand-rolled copies; a side effect was that
+  `list_models` reported a rejected API key as a request failure, which reads as
+  a transient network fault worth retrying. Ollama also gains the `429` handling
+  it never had.
 - A run is no longer reported as having produced nothing when it never had a
   way to produce anything. `empty_output` in `meta.json` has meant "modified no
   files" since it was added for coding agents, so a router that delegates to

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -59,6 +59,13 @@ an interval learns how a run ended rather than finding it gone. Set
 moment it finishes. The record is held in memory, so a daemon restart clears it;
 `meta.json` and the REST API keep the durable copy.
 
+An `out of service` block under the table lists providers the daemon has stopped
+sending work to, because each failed several times in a row for something only
+you can fix: an account out of credits, or a key that was rejected. Runs move to
+the next provider a stage lists (or one from `[providers] fallback_order`); a run
+with none left is failed rather than left waiting. Each entry says how long until
+that provider is tried again, and topping up the account needs no restart.
+
 A `lanes:` line under the table means the daemon itself is worth a look. It
 shows the tool lane's occupancy - batches running, parked on a wait, and queued
 behind them - and, if the daemon has stopped getting anywhere, how many re-drive
@@ -271,6 +278,40 @@ fn stage_cell(entry: &RunListEntry) -> String {
     }
 }
 
+/// The providers currently out of service, with why and when each is retried.
+///
+/// This is the line that would have answered issue #201 on sight. Ten runs
+/// dying in a row produced ten identical error rows and nothing that said "the
+/// OpenRouter account is empty", so the shape of the problem was invisible from
+/// the listing.
+fn providers_footer(health: &DaemonHealth) -> Option<String> {
+    if health.providers_down.is_empty() {
+        return None;
+    }
+    let each = health
+        .providers_down
+        .iter()
+        .map(|c| {
+            format!(
+                "  {} ({}, {} failures) - retrying in {}",
+                c.provider,
+                c.reason.label(),
+                c.consecutive_failures,
+                humanize_age(c.retry_in_secs as i64)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let noun = match health.providers_down.len() {
+        1 => "provider is",
+        _ => "providers are",
+    };
+    Some(format!(
+        "{} {noun} out of service:\n{each}",
+        health.providers_down.len()
+    ))
+}
+
 /// The daemon-wide footer: what the tool lane is holding, and whether the daemon
 /// as a whole has stopped getting anywhere.
 ///
@@ -382,6 +423,9 @@ pub fn format_runs(
         1 => format!("{table}\n\n1 run needs an answer: lev respond"),
         n => format!("{table}\n\n{n} runs need an answer: lev respond"),
     };
+    if let Some(footer) = providers_footer(health) {
+        out.push_str(&format!("\n\n{footer}"));
+    }
     if let Some(footer) = health_footer(health) {
         out.push_str(&format!("\n\n{footer}"));
     }

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -363,7 +363,15 @@ pub fn format_runs(
     now: i64,
 ) -> String {
     if runs.is_empty() && finished.is_empty() {
-        return "no agents running".to_string();
+        // "no agents running" on its own is the most misleading thing this
+        // command can say while a provider is down: it is what an operator sees
+        // once even the finished records have aged out, and it reads as an idle
+        // daemon rather than a factory that cannot start anything (issue #201).
+        // Say why the list is empty.
+        return match providers_footer(health) {
+            Some(footer) => format!("no agents running\n\n{footer}"),
+            None => "no agents running".to_string(),
+        };
     }
     let headers = ["RUN", "STATUS", "STAGE", "ITER", "TOOLS", "AGE"];
     let rows: Vec<[String; 6]> = runs

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use leviath_runtime::components::WaitReason;
 use leviath_runtime::control_socket::{ControlId, bind_control_listener, control_id};
+use leviath_runtime::pipeline::ProviderCircuitState;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 
@@ -372,6 +373,81 @@ fn the_footer_and_the_answer_call_out_coexist() {
     };
     let out = format_runs(&[blocked], &[], &health, 0);
     assert!(out.contains("1 run needs an answer: lev respond"), "{out}");
+    assert!(out.contains("no progress for 2 cycles"), "{out}");
+}
+
+// ── providers out of service (issue #201) ─────────────────────────────────
+
+fn down(provider: &str, reason: leviath_providers::UnavailableReason) -> ProviderCircuitState {
+    ProviderCircuitState {
+        provider: provider.to_string(),
+        reason,
+        consecutive_failures: 3,
+        retry_in_secs: 240,
+    }
+}
+
+#[test]
+fn a_provider_out_of_service_is_named_under_the_table() {
+    // The line that would have answered the issue on sight: ten identical
+    // error rows never said "the OpenRouter account is empty".
+    let health = DaemonHealth {
+        providers_down: vec![down(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+        )],
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    assert!(out.contains("1 provider is out of service:"), "{out}");
+    assert!(
+        out.contains("openrouter (credits-exhausted, 3 failures)"),
+        "{out}"
+    );
+    assert!(out.contains("retrying in 4m"), "{out}");
+}
+
+#[test]
+fn several_providers_out_of_service_are_listed_and_pluralized() {
+    let health = DaemonHealth {
+        providers_down: vec![
+            down(
+                "anthropic",
+                leviath_providers::UnavailableReason::AuthFailed,
+            ),
+            down(
+                "openrouter",
+                leviath_providers::UnavailableReason::CreditsExhausted,
+            ),
+        ],
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    assert!(out.contains("2 providers are out of service:"), "{out}");
+    assert!(out.contains("anthropic (auth-failed"), "{out}");
+    assert!(out.contains("openrouter (credits-exhausted"), "{out}");
+}
+
+#[test]
+fn healthy_providers_add_no_block() {
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &healthy_daemon(), 0);
+    assert!(!out.contains("out of service"), "{out}");
+}
+
+#[test]
+fn the_provider_block_and_the_lane_footer_coexist() {
+    // Different questions, and a wedged daemon with a dead provider is exactly
+    // when an operator needs both answers at once.
+    let health = DaemonHealth {
+        dead_cycles: 2,
+        providers_down: vec![down(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+        )],
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    assert!(out.contains("out of service"), "{out}");
     assert!(out.contains("no progress for 2 cycles"), "{out}");
 }
 

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -179,6 +179,24 @@ fn format_runs_lists_finished_runs_after_the_live_ones() {
     assert!(!out.contains("needs an answer"), "{out}");
 }
 
+/// An empty listing while a provider is down is the reporter's end state:
+/// every run dead and reaped, and `lev ps` saying only "no agents running",
+/// which reads as an idle daemon rather than one that cannot start anything.
+#[test]
+fn an_empty_listing_still_says_why_nothing_is_running() {
+    let health = DaemonHealth {
+        providers_down: vec![down(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+        )],
+        ..healthy_daemon()
+    };
+    let out = format_runs(&[], &[], &health, 0);
+    assert!(out.starts_with("no agents running"), "{out}");
+    assert!(out.contains("1 provider is out of service:"), "{out}");
+    assert!(out.contains("openrouter (credits-exhausted"), "{out}");
+}
+
 /// The whole point of the change: two runs both `Waiting`, telling the operator
 /// which one needs them and which one is fine.
 #[test]
@@ -398,7 +416,7 @@ fn a_provider_out_of_service_is_named_under_the_table() {
         )],
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &health, 0);
     assert!(out.contains("1 provider is out of service:"), "{out}");
     assert!(
         out.contains("openrouter (credits-exhausted, 3 failures)"),
@@ -422,7 +440,7 @@ fn several_providers_out_of_service_are_listed_and_pluralized() {
         ],
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &health, 0);
     assert!(out.contains("2 providers are out of service:"), "{out}");
     assert!(out.contains("anthropic (auth-failed"), "{out}");
     assert!(out.contains("openrouter (credits-exhausted"), "{out}");
@@ -430,7 +448,12 @@ fn several_providers_out_of_service_are_listed_and_pluralized() {
 
 #[test]
 fn healthy_providers_add_no_block() {
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &healthy_daemon(), 0);
+    let out = format_runs(
+        &[entry("run-a", AgentStatus::Active)],
+        &[],
+        &healthy_daemon(),
+        0,
+    );
     assert!(!out.contains("out of service"), "{out}");
 }
 
@@ -446,7 +469,7 @@ fn the_provider_block_and_the_lane_footer_coexist() {
         )],
         ..healthy_daemon()
     };
-    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &health, 0);
+    let out = format_runs(&[entry("run-a", AgentStatus::Active)], &[], &health, 0);
     assert!(out.contains("out of service"), "{out}");
     assert!(out.contains("no progress for 2 cycles"), "{out}");
 }

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -309,6 +309,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("sk-or-test".to_string()),
             ollama_base_url: Some("http://custom:11434".to_string()),
@@ -487,6 +488,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..crate::config::Config::default()
         };

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -169,6 +169,7 @@ mod tests {
                     claude_code_enabled: false,
                     claude_code_binary: None,
                     claude_code_effort: None,
+                    fallback_order: Vec::new(),
                 },
                 openrouter_api_key: Some("sk-or-test".to_string()),
                 ollama_base_url: Some("http://localhost:11434".to_string()),
@@ -454,6 +455,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Default::default()
         };

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -2472,6 +2472,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("fake-openrouter-key".to_string()),
             ollama_base_url: Some("http://localhost:12345".to_string()),

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -651,6 +651,20 @@ pub struct ProviderConfig {
     /// `None` uses [`leviath_providers::claude_code::DEFAULT_EFFORT`].
     #[serde(default)]
     pub claude_code_effort: Option<String>,
+
+    /// Host-wide failover chain, as `"provider/model"` entries, best first.
+    ///
+    /// Tried after a stage's own `models` list and the default model when the
+    /// provider in use stops answering (out of credits, rejected key). Entries
+    /// naming an unregistered provider are skipped, and a malformed entry is
+    /// ignored with a warning rather than failing the load.
+    ///
+    /// `provider/model` rather than a bare provider name because a failover
+    /// target needs a model to send; there is no sensible default per provider.
+    /// A blueprint that names one model has nowhere to go without this, which
+    /// is exactly how issue #201 took every agent down at once.
+    #[serde(default)]
+    pub fallback_order: Vec<String>,
 }
 
 /// Hand-written so the API keys can never be printed.
@@ -672,6 +686,7 @@ impl std::fmt::Debug for ProviderConfig {
             .field("claude_code_enabled", &self.claude_code_enabled)
             .field("claude_code_binary", &self.claude_code_binary)
             .field("claude_code_effort", &self.claude_code_effort)
+            .field("fallback_order", &self.fallback_order)
             .finish()
     }
 }
@@ -725,6 +740,7 @@ impl Default for Config {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             agent_paths: Vec::new(),
             openrouter_api_key: None,
@@ -2134,6 +2150,7 @@ google_api_key = "AIza-existing"
             claude_code_enabled: true,
             claude_code_binary: None,
             claude_code_effort: None,
+            fallback_order: Vec::new(),
         };
         let rendered = format!("{providers:?}");
         assert!(!rendered.contains("SECRET-VALUE"), "key leaked: {rendered}");
@@ -2150,6 +2167,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             }
         );
         assert!(empty.contains("<unset>"), "{empty}");
@@ -2197,6 +2215,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2213,6 +2232,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2231,6 +2251,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2247,6 +2268,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2515,6 +2537,7 @@ max_output_tokens = 2048
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2550,6 +2573,7 @@ max_output_tokens = 2048
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             tool_permissions: {
                 let mut m = HashMap::new();
@@ -2584,6 +2608,7 @@ max_output_tokens = 2048
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2602,6 +2627,7 @@ max_output_tokens = 2048
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             ..Config::default()
         };
@@ -2802,6 +2828,7 @@ enabled = false
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("sk-or-test".to_string()),
             default_model: Some("gpt-5".to_string()),
@@ -2863,6 +2890,7 @@ enabled = false
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                fallback_order: Vec::new(),
             },
             agent_paths: vec![std::path::PathBuf::from("/my/agents")],
             openrouter_api_key: None,

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -435,6 +435,14 @@ fn default_wedge_timeout_secs() -> u64 {
     leviath_runtime::pipeline::DEFAULT_WEDGE_TIMEOUT_SECS
 }
 
+fn default_provider_failures_before_open() -> u32 {
+    leviath_runtime::pipeline::DEFAULT_FAILURES_BEFORE_OPEN
+}
+
+fn default_provider_circuit_cooldown_secs() -> u64 {
+    leviath_runtime::pipeline::DEFAULT_CIRCUIT_COOLDOWN_SECS
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -542,6 +550,30 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_wedge_timeout_secs")]
     pub wedge_timeout_secs: u64,
+    /// How many consecutive provider-fatal failures (out of credits, rejected
+    /// key) take a provider out of service for every run.
+    ///
+    /// Defaults to `3`. One 402 can just be a request asking for more output
+    /// tokens than the balance covers; three in a row is the account. While a
+    /// provider is out, runs move to their next candidate, and runs with none
+    /// left are failed by the stall watchdog rather than left "running".
+    ///
+    /// `0` disables the breaker, leaving per-run failover on its own.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_provider_failures_before_open")]
+    pub provider_failures_before_open: u32,
+
+    /// How long a provider stays out of service before one request is let
+    /// through to see whether it recovered.
+    ///
+    /// Defaults to `300` (five minutes). That probe either succeeds, which puts
+    /// the provider straight back into service, or fails and restarts the wait,
+    /// so topping up an account brings the factory back with no restart.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_provider_circuit_cooldown_secs")]
+    pub provider_circuit_cooldown_secs: u64,
 }
 
 impl Default for LimitsConfig {
@@ -556,6 +588,8 @@ impl Default for LimitsConfig {
             dead_cycles_before_relief: default_dead_cycles_before_relief(),
             finished_retention_secs: default_finished_retention_secs(),
             wedge_timeout_secs: default_wedge_timeout_secs(),
+            provider_failures_before_open: default_provider_failures_before_open(),
+            provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
         }
     }
 }
@@ -2919,6 +2953,8 @@ enabled = false
                 dead_cycles_before_relief: 6,
                 finished_retention_secs: 120,
                 wedge_timeout_secs: 420,
+                provider_failures_before_open: 5,
+                provider_circuit_cooldown_secs: 120,
             },
             batch_tool_hint: true,
             nudge: leviath_core::NudgeConfig {

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -174,6 +174,18 @@ pub fn build_host(
         .insert_resource(leviath_runtime::pipeline::WedgeTimeout(
             config.limits.wedge_timeout_secs,
         ));
+    // Take a provider out of service after it has failed this many times in a
+    // row for a reason only a person can fix, so the next run does not have to
+    // rediscover it (issue #201).
+    world
+        .world_mut()
+        .insert_resource(leviath_runtime::pipeline::CircuitPolicy {
+            failures_before_open: config.limits.provider_failures_before_open,
+            cooldown_secs: config.limits.provider_circuit_cooldown_secs,
+        });
+    world
+        .world_mut()
+        .init_resource::<leviath_runtime::pipeline::ProviderCircuits>();
     // Share the hub with the tick loop so a blocked agent's open prompt is
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1105,6 +1105,50 @@ mod tests {
     }
 
     #[test]
+    fn fallback_order_parses_provider_slash_model_and_drops_junk() {
+        // The `tracing::warn!` on the reject path evaluates its field
+        // expressions only under a real subscriber.
+        crate::test_support::with_tracing(|| {
+            let parsed = parse_fallback_order(&[
+                // A model id containing a slash must survive intact, which is
+                // the common OpenRouter shape.
+                "openrouter/deepseek/deepseek-v4-flash".to_string(),
+                "anthropic/claude-sonnet-5".to_string(),
+                // Rejected: a bare provider gives us no model to send.
+                "anthropic".to_string(),
+                "/no-provider".to_string(),
+                "no-model/".to_string(),
+                String::new(),
+            ]);
+            assert_eq!(
+                parsed
+                    .iter()
+                    .map(|e| (e.provider.as_str(), e.model.as_str()))
+                    .collect::<Vec<_>>(),
+                vec![
+                    ("openrouter", "deepseek/deepseek-v4-flash"),
+                    ("anthropic", "claude-sonnet-5"),
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn model_defaults_carries_the_fallback_chain_from_config() {
+        let mut config = Config {
+            default_provider: "openrouter".to_string(),
+            default_model: Some("deepseek".to_string()),
+            ..Default::default()
+        };
+        config.providers.fallback_order = vec!["anthropic/claude-sonnet-5".to_string()];
+        let defaults = model_defaults(&config);
+        assert_eq!(defaults.provider, "openrouter");
+        assert_eq!(defaults.model.as_deref(), Some("deepseek"));
+        assert_eq!(defaults.fallback_order.len(), 1);
+        assert_eq!(defaults.fallback_order[0].provider, "anthropic");
+    }
+
+    #[test]
     fn discover_script_tools_registers_and_drops_collisions() {
         crate::test_support::with_tracing(|| {});
         // Point LEVIATH_HOME at an empty temp dir so the global tools/ scan is

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -41,7 +41,33 @@ pub(crate) fn model_defaults(config: &Config) -> ModelDefaults {
     ModelDefaults {
         provider: config.default_provider.clone(),
         model: config.default_model.clone(),
+        fallback_order: parse_fallback_order(&config.providers.fallback_order),
     }
+}
+
+/// Parse `[providers] fallback_order` entries (`"provider/model"`) into the
+/// runtime's own form.
+///
+/// A malformed entry is dropped with a warning rather than failing the load: a
+/// typo in a *safety net* should not stop the daemon from starting, and the
+/// warning says which entry went nowhere. Splitting on the first `/` keeps
+/// model ids that contain one (`deepseek/deepseek-v4-flash`) intact.
+fn parse_fallback_order(entries: &[String]) -> Vec<leviath_core::blueprint::ModelEntry> {
+    entries
+        .iter()
+        .filter_map(|raw| match raw.split_once('/') {
+            Some((provider, model)) if !provider.is_empty() && !model.is_empty() => Some(
+                leviath_core::blueprint::ModelEntry::new(provider.to_string(), model.to_string()),
+            ),
+            _ => {
+                tracing::warn!(
+                    entry = %raw,
+                    "ignoring [providers] fallback_order entry: expected \"provider/model\""
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 /// The directories scanned for an agent's Rhai script tools, in precedence order

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -851,7 +851,7 @@ impl Stage {
 }
 
 /// A single model entry within a [`ModelConfig`] models list.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModelEntry {
     /// Provider name (e.g., "anthropic", "openai")
     pub provider: String,

--- a/crates/leviath-core/src/telemetry.rs
+++ b/crates/leviath-core/src/telemetry.rs
@@ -175,6 +175,27 @@ pub struct LaneHealth {
     pub relief_granted: usize,
 }
 
+/// One provider the daemon has stopped sending work to, sampled alongside
+/// [`LaneHealth`].
+///
+/// Daemon-wide for the same reason as `LaneHealth`: a provider out of credits
+/// belongs to no single run, and the runs it kills emit nothing useful because
+/// they die before doing anything (issue #201).
+///
+/// `reason` is the label rather than the runtime's own enum: this crate sits
+/// below `leviath-providers`, so the type that names it is not in scope here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderHealth {
+    /// The provider taken out of service.
+    pub provider: String,
+    /// Why, as a stable lowercase label (`credits-exhausted`, `auth-failed`).
+    pub reason: String,
+    /// Consecutive failures accumulated against it.
+    pub consecutive_failures: u32,
+    /// Seconds until it is probed again.
+    pub retry_in_secs: u64,
+}
+
 /// Where telemetry events go.
 ///
 /// Implementations must tolerate being called from the engine's tick loop:
@@ -186,6 +207,11 @@ pub trait TelemetrySink: Send + Sync {
     /// Record one daemon-wide health sample. Default: ignore it, so a sink that
     /// only cares about runs needs no changes.
     fn observe_lanes(&self, _health: LaneHealth) {}
+
+    /// Record which providers are currently out of service, sampled on the same
+    /// re-drive tick as [`TelemetrySink::observe_lanes`]. Default: ignore it,
+    /// so an existing sink keeps compiling unchanged.
+    fn observe_providers(&self, _down: &[ProviderHealth]) {}
 
     /// Flush any buffered export before shutdown. Default: nothing buffered.
     fn force_flush(&self) {}
@@ -203,6 +229,7 @@ impl TelemetrySink for NoopSink {
 pub struct MemorySink {
     events: std::sync::Mutex<Vec<TelemetryEvent>>,
     lanes: std::sync::Mutex<Vec<LaneHealth>>,
+    providers: std::sync::Mutex<Vec<Vec<ProviderHealth>>>,
     flushes: std::sync::atomic::AtomicUsize,
 }
 
@@ -215,6 +242,14 @@ impl MemorySink {
     /// Every lane-health sample recorded so far, in order.
     pub fn lane_samples(&self) -> Vec<LaneHealth> {
         self.lanes.lock().expect("telemetry lane lock").clone()
+    }
+
+    /// Every provider-health sample recorded so far, in order.
+    pub fn provider_samples(&self) -> Vec<Vec<ProviderHealth>> {
+        self.providers
+            .lock()
+            .expect("telemetry provider lock")
+            .clone()
     }
 
     /// How many times `force_flush` was called.
@@ -233,6 +268,13 @@ impl TelemetrySink for MemorySink {
 
     fn observe_lanes(&self, health: LaneHealth) {
         self.lanes.lock().expect("telemetry lane lock").push(health);
+    }
+
+    fn observe_providers(&self, down: &[ProviderHealth]) {
+        self.providers
+            .lock()
+            .expect("telemetry provider lock")
+            .push(down.to_vec());
     }
 
     fn force_flush(&self) {
@@ -285,6 +327,27 @@ mod tests {
 
         // The default trait body: a sink that only cares about runs drops it.
         NoopSink.observe_lanes(LaneHealth::default());
+    }
+
+    #[test]
+    fn memory_sink_records_provider_samples_and_the_noop_ignores_them() {
+        let sink = MemorySink::default();
+        assert!(sink.provider_samples().is_empty());
+        let down = ProviderHealth {
+            provider: "openrouter".to_string(),
+            reason: "credits-exhausted".to_string(),
+            consecutive_failures: 3,
+            retry_in_secs: 240,
+        };
+        sink.observe_providers(std::slice::from_ref(&down));
+        // The empty sample matters too: it is how a collector sees a provider
+        // come back, not just go away.
+        sink.observe_providers(&[]);
+        assert_eq!(sink.provider_samples().len(), 2);
+        assert_eq!(sink.provider_samples()[0], vec![down]);
+        assert!(sink.provider_samples()[1].is_empty());
+
+        NoopSink.observe_providers(&[]);
     }
 
     #[test]

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -587,30 +587,12 @@ impl Provider for AnthropicProvider {
             start.elapsed(),
         );
 
-        let status = response.status();
-
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.parse::<u64>().ok());
-            if let Some(limiter) = &self.rate_limiter {
-                limiter.handle_rate_limit(retry_after).await;
-            }
-            return Err(ProviderError::RateLimitExceeded);
-        }
-
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Shared with every other HTTP provider so a 402/401/403 (or a 400
+        // whose body says the credit balance is too low) classifies the same
+        // way everywhere - the runtime keys failover and the circuit breaker
+        // off that classification (issue #201).
+        let response =
+            crate::provider::check_http_response(response, self.rate_limiter.as_ref()).await?;
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.reset_backoff().await;
@@ -681,29 +663,9 @@ impl Provider for AnthropicProvider {
             start.elapsed(),
         );
 
-        let status = response.status();
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.parse::<u64>().ok());
-            if let Some(limiter) = &self.rate_limiter {
-                limiter.handle_rate_limit(retry_after).await;
-            }
-            return Err(ProviderError::RateLimitExceeded);
-        }
-
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Same shared classification as the non-streaming path above.
+        let response =
+            crate::provider::check_http_response(response, self.rate_limiter.as_ref()).await?;
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.reset_backoff().await;
@@ -756,17 +718,10 @@ impl Provider for AnthropicProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::RequestFailed(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Shared classification here too. This used to be `RequestFailed`,
+        // which `is_transient` treats as retryable, so a revoked key looked
+        // like a flaky network rather than something only the operator can fix.
+        let response = crate::provider::check_http_response(response, None).await?;
 
         let body: serde_json::Value = response
             .json()
@@ -2717,17 +2672,25 @@ mod tests {
     async fn list_models_non_success_status_returns_error() {
         let url = spawn_mock_server(401, "Unauthorized", b"bad key").await;
         let provider = provider_with_url(url);
-        let msg = provider.list_models().await.unwrap_err().to_string();
-        assert!(msg.contains("401"));
-        assert!(msg.contains("bad key"));
+        let err = provider.list_models().await.unwrap_err();
+        // A rejected key is the provider's problem, not a flaky connection:
+        // it must not classify as transient (issue #201).
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(crate::provider::UnavailableReason::AuthFailed)
+        );
+        assert!(!err.is_transient());
+        let msg = err.to_string();
+        assert!(msg.contains("401"), "{msg}");
+        assert!(msg.contains("bad key"), "{msg}");
     }
 
     #[tokio::test]
-    async fn list_models_non_success_status_body_read_error_falls_back_to_unknown_error() {
+    async fn list_models_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(401, "Unauthorized").await;
         let provider = provider_with_url(url);
         let msg = provider.list_models().await.unwrap_err().to_string();
-        assert!(msg.starts_with("Request failed:"));
+        assert!(msg.contains("401"), "{msg}");
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -38,6 +38,6 @@ pub use provider::{
     ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FinishReason, InferenceRequest,
     InferenceResponse, Message, MessageContent, ModelCapabilities, ModelInfo, Provider,
     ProviderConfig, ProviderError, RateLimitConfig, Result, SystemBlock, TokenUsage, Tool,
-    ToolCall, build_http_client,
+    ToolCall, UnavailableReason, build_http_client,
 };
 pub use rhai_provider::RhaiProvider;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -316,17 +316,9 @@ impl Provider for OllamaProvider {
             start.elapsed(),
         );
 
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Shared classification, which also gives Ollama the 429 handling it
+        // never had: every non-2xx used to collapse into one `ApiError`.
+        let response = crate::provider::check_http_response(response, None).await?;
 
         let response_body: serde_json::Value = response
             .json()
@@ -380,17 +372,8 @@ impl Provider for OllamaProvider {
             start.elapsed(),
         );
 
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Same shared classification as the non-streaming path above.
+        let response = crate::provider::check_http_response(response, None).await?;
 
         let byte_stream = response.bytes_stream();
         let stream = OllamaNdjsonStream::new(byte_stream);
@@ -426,17 +409,9 @@ impl Provider for OllamaProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::RequestFailed(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
-        }
+        // Shared classification, as above: a non-2xx here used to be
+        // `RequestFailed`, which reads as a retryable network fault.
+        let response = crate::provider::check_http_response(response, None).await?;
 
         let body: serde_json::Value = response
             .json()
@@ -1957,11 +1932,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn infer_non_success_status_body_read_error_falls_back_to_unknown_error() {
+    async fn infer_non_success_status_body_read_error_still_reports_the_status() {
+        // The body never arrives, so the shared helper substitutes the read
+        // error for it. The status is what matters and must survive.
         let url = spawn_mock_server_truncated_error_body(500, "Internal Server Error").await;
         let provider = OllamaProvider::with_base_url(url);
         let err = provider.infer(mock_request()).await.unwrap_err();
-        assert!(err.to_string().contains("unknown error"));
+        assert!(err.to_string().contains("500"), "{err}");
     }
 
     #[tokio::test]
@@ -1982,12 +1959,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn infer_stream_non_success_status_body_read_error_falls_back_to_unknown_error() {
+    async fn infer_stream_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(503, "Service Unavailable").await;
         let provider = OllamaProvider::with_base_url(url);
         let result = provider.infer_stream(mock_request()).await;
-        assert!(result.is_err());
-        assert!(result.err().unwrap().to_string().contains("unknown error"));
+        let err = result.err().expect("a truncated error body is still an error");
+        assert!(err.to_string().contains("503"), "{err}");
     }
 
     #[tokio::test]
@@ -2041,15 +2018,20 @@ mod tests {
         let url = spawn_mock_server(401, "Unauthorized", b"nope").await;
         let provider = OllamaProvider::with_base_url(url);
         let err = provider.list_models().await.unwrap_err();
-        assert!(err.to_string().contains("Request failed:"));
+        // Was `RequestFailed`, which reads as retryable; a rejected key is not.
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(crate::provider::UnavailableReason::AuthFailed)
+        );
+        assert!(!err.is_transient());
     }
 
     #[tokio::test]
-    async fn list_models_non_success_status_body_read_error_falls_back_to_unknown_error() {
+    async fn list_models_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(401, "Unauthorized").await;
         let provider = OllamaProvider::with_base_url(url);
         let err = provider.list_models().await.unwrap_err();
-        assert!(err.to_string().contains("unknown error"));
+        assert!(err.to_string().contains("401"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -1963,7 +1963,9 @@ mod tests {
         let url = spawn_mock_server_truncated_error_body(503, "Service Unavailable").await;
         let provider = OllamaProvider::with_base_url(url);
         let result = provider.infer_stream(mock_request()).await;
-        let err = result.err().expect("a truncated error body is still an error");
+        let err = result
+            .err()
+            .expect("a truncated error body is still an error");
         assert!(err.to_string().contains("503"), "{err}");
     }
 

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -85,6 +85,29 @@ impl UnavailableReason {
         .any(|s| b.contains(s))
         .then_some(UnavailableReason::CreditsExhausted)
     }
+
+    /// Classify a formatted error *message*, for the paths that never see the
+    /// status code on its own.
+    ///
+    /// A Rhai script provider throws `#{ kind: "api", message: "HTTP 402 ..." }`
+    /// and hands us the whole thing as one string, so the status has to be read
+    /// back out of it. A script talking to an OpenAI-compatible endpoint must
+    /// fail over and trip the breaker exactly as the built-in providers do
+    /// (issue #201).
+    pub fn from_message(message: &str) -> Option<Self> {
+        Self::classify(leading_http_status(message).unwrap_or(0), message)
+    }
+}
+
+/// The status code in an `HTTP <code>` prefix, if the message carries one.
+///
+/// Anchored on the `HTTP ` marker that every provider in this crate formats,
+/// rather than the first number anywhere in the text: an error body quoting a
+/// token count must not be mistaken for a status.
+fn leading_http_status(message: &str) -> Option<u16> {
+    let rest = message.strip_prefix("HTTP ")?;
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
 }
 
 /// Errors that can occur during provider operations.
@@ -822,6 +845,45 @@ mod tests {
                 "{body}"
             );
         }
+    }
+
+    #[test]
+    fn from_message_reads_the_status_back_out_of_the_text() {
+        // The Rhai path hands over one formatted string, so the status has to
+        // come from the message or a script provider never fails over.
+        assert_eq!(
+            UnavailableReason::from_message("HTTP 402 Payment Required: {}"),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        assert_eq!(
+            UnavailableReason::from_message("HTTP 401: bad key"),
+            Some(UnavailableReason::AuthFailed)
+        );
+        assert_eq!(
+            UnavailableReason::from_message("HTTP 403: not allowed"),
+            Some(UnavailableReason::Forbidden)
+        );
+        // No prefix, but the body still says what happened.
+        assert_eq!(
+            UnavailableReason::from_message("your credit balance is too low"),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        assert_eq!(UnavailableReason::from_message("HTTP 400: bad field"), None);
+        assert_eq!(UnavailableReason::from_message("something broke"), None);
+    }
+
+    #[test]
+    fn a_number_in_the_body_is_not_mistaken_for_a_status() {
+        // "402" appearing in a token count must not read as Payment Required;
+        // only the `HTTP ` prefix every provider formats counts.
+        assert_eq!(leading_http_status("you requested 402 tokens"), None);
+        assert_eq!(leading_http_status("HTTP 402 Payment Required"), Some(402));
+        assert_eq!(leading_http_status("HTTP notanumber"), None);
+        assert_eq!(leading_http_status(""), None);
+        assert_eq!(
+            UnavailableReason::from_message("you requested 402 tokens"),
+            None
+        );
     }
 
     #[test]

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -713,10 +713,12 @@ pub async fn check_http_response(
         // An out-of-credits or bad-key response is worth telling apart: the
         // runtime fails over on it and counts it against the provider's
         // circuit breaker, where a plain `ApiError` would just kill the run.
-        return Err(match UnavailableReason::classify(status.as_u16(), &error_body) {
-            Some(reason) => ProviderError::Unavailable { reason, detail },
-            None => ProviderError::ApiError(detail),
-        });
+        return Err(
+            match UnavailableReason::classify(status.as_u16(), &error_body) {
+                Some(reason) => ProviderError::Unavailable { reason, detail },
+                None => ProviderError::ApiError(detail),
+            },
+        );
     }
     Ok(response)
 }
@@ -826,7 +828,10 @@ mod tests {
     fn classify_leaves_an_ordinary_failure_alone() {
         // A plain bad request says nothing about the provider's usability, so
         // it must not trip failover or the circuit breaker.
-        assert_eq!(UnavailableReason::classify(400, "unknown field `foo`"), None);
+        assert_eq!(
+            UnavailableReason::classify(400, "unknown field `foo`"),
+            None
+        );
         assert_eq!(UnavailableReason::classify(404, "no such model"), None);
         assert_eq!(UnavailableReason::classify(500, "boom"), None);
     }
@@ -837,7 +842,10 @@ mod tests {
             reason: UnavailableReason::AuthFailed,
             detail: "HTTP 401: bad key".into(),
         };
-        assert_eq!(err.unavailable_reason(), Some(UnavailableReason::AuthFailed));
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(UnavailableReason::AuthFailed)
+        );
         assert_eq!(
             ProviderError::ApiError("HTTP 400".into()).unavailable_reason(),
             None

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -9,6 +9,84 @@ use thiserror::Error;
 /// Result type for provider operations.
 pub type Result<T> = std::result::Result<T, ProviderError>;
 
+/// Why a provider cannot serve requests until someone intervenes.
+///
+/// These are the failures that no amount of retrying, waiting, or falling back
+/// to a smaller request will fix: the account is out of money, or the key is
+/// wrong. Keeping them apart from a generic [`ProviderError::ApiError`] is what
+/// lets the runtime fail over to another provider and trip a circuit breaker
+/// instead of killing every run with a raw JSON blob (issue #201).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnavailableReason {
+    /// The account is out of credits, or the request costs more than is left.
+    CreditsExhausted,
+    /// The API key is missing, malformed, or revoked.
+    AuthFailed,
+    /// The key authenticated but is not allowed to do this.
+    Forbidden,
+}
+
+impl UnavailableReason {
+    /// A short, stable label for logs, metrics attributes, and `lev ps`.
+    pub fn label(self) -> &'static str {
+        match self {
+            UnavailableReason::CreditsExhausted => "credits-exhausted",
+            UnavailableReason::AuthFailed => "auth-failed",
+            UnavailableReason::Forbidden => "forbidden",
+        }
+    }
+
+    /// What the operator should actually do about it.
+    fn remedy(self) -> &'static str {
+        match self {
+            UnavailableReason::CreditsExhausted => {
+                "out of credits: top up the account, or lower max_tokens so the \
+                 request costs less"
+            }
+            UnavailableReason::AuthFailed => {
+                "the API key was rejected: check it with `lev auth status` and \
+                 re-enter it with `lev setup`"
+            }
+            UnavailableReason::Forbidden => {
+                "the API key is not allowed to use this model: check the \
+                 account's plan and model permissions"
+            }
+        }
+    }
+
+    /// Classify an HTTP failure as a provider-fatal one, or `None` if it is an
+    /// ordinary error that says nothing about the provider's usability.
+    ///
+    /// Status alone is not enough. Anthropic reports a drained balance as a
+    /// **400** whose body says "credit balance is too low", so a status-only
+    /// check would read it as a malformed request and kill the run rather than
+    /// failing over. The body scan catches that and its cousins across
+    /// providers; every phrase is specific enough that a prompt quoting it
+    /// verbatim is not a realistic concern (the body here is the provider's own
+    /// error envelope, not the conversation).
+    pub fn classify(status: u16, body: &str) -> Option<Self> {
+        match status {
+            402 => return Some(UnavailableReason::CreditsExhausted),
+            401 => return Some(UnavailableReason::AuthFailed),
+            403 => return Some(UnavailableReason::Forbidden),
+            _ => {}
+        }
+        let b = body.to_ascii_lowercase();
+        [
+            "credit balance is too low",
+            "insufficient credits",
+            "requires more credits",
+            "insufficient_quota",
+            "exceeded your current quota",
+            "billing",
+        ]
+        .iter()
+        .any(|s| b.contains(s))
+        .then_some(UnavailableReason::CreditsExhausted)
+    }
+}
+
 /// Errors that can occur during provider operations.
 #[derive(Error, Debug)]
 pub enum ProviderError {
@@ -19,6 +97,15 @@ pub enum ProviderError {
     /// API returned an error
     #[error("API error: {0}")]
     ApiError(String),
+
+    /// The provider cannot serve any request until someone intervenes - the
+    /// account is out of credits, or the key is bad. `detail` keeps the raw
+    /// provider response for the logs; the message leads with what to do.
+    #[error("{} ({detail})", .reason.remedy())]
+    Unavailable {
+        reason: UnavailableReason,
+        detail: String,
+    },
 
     /// Rate limit exceeded
     #[error("Rate limit exceeded")]
@@ -74,11 +161,26 @@ impl ProviderError {
                 .iter()
                 .any(|s| m.contains(s))
             }
-            // A malformed response, an over-limit request, or an unknown error
-            // won't be fixed by retrying.
+            // A malformed response, an over-limit request, an unusable
+            // provider, or an unknown error won't be fixed by retrying.
             ProviderError::InvalidResponse(_)
             | ProviderError::TokenLimitExceeded { .. }
+            | ProviderError::Unavailable { .. }
             | ProviderError::Other(_) => false,
+        }
+    }
+
+    /// Whether this failure means the *provider itself* is unusable, rather
+    /// than this one request being bad.
+    ///
+    /// The runtime uses this to decide whether to fail over to the next
+    /// configured provider and to count the failure against that provider's
+    /// circuit breaker. A bad request or a malformed response says nothing
+    /// about the provider, so only [`ProviderError::Unavailable`] qualifies.
+    pub fn unavailable_reason(&self) -> Option<UnavailableReason> {
+        match self {
+            ProviderError::Unavailable { reason, .. } => Some(*reason),
+            _ => None,
         }
     }
 }
@@ -583,6 +685,7 @@ pub fn parse_openai_finish_reason(reason: &str) -> FinishReason {
 /// Check an HTTP response for errors and return it on success.
 ///
 /// - On 429 (rate limit): notifies the optional rate limiter and returns `RateLimitExceeded`.
+/// - On a provider-fatal failure (see [`UnavailableReason::classify`]): returns `Unavailable`.
 /// - On any other non-2xx: reads the body and returns `ApiError`.
 /// - On 2xx: returns `Ok(response)` so the caller can read the body.
 ///
@@ -606,10 +709,14 @@ pub async fn check_http_response(
     }
     if !status.is_success() {
         let error_body = response.text().await.unwrap_or_else(|e| e.to_string());
-        return Err(ProviderError::ApiError(format!(
-            "HTTP {}: {}",
-            status, error_body
-        )));
+        let detail = format!("HTTP {}: {}", status, error_body);
+        // An out-of-credits or bad-key response is worth telling apart: the
+        // runtime fails over on it and counts it against the provider's
+        // circuit breaker, where a plain `ApiError` would just kill the run.
+        return Err(match UnavailableReason::classify(status.as_u16(), &error_body) {
+            Some(reason) => ProviderError::Unavailable { reason, detail },
+            None => ProviderError::ApiError(detail),
+        });
     }
     Ok(response)
 }
@@ -659,6 +766,123 @@ mod tests {
         assert!(!ProviderError::InvalidResponse("garbage".into()).is_transient());
         assert!(!ProviderError::TokenLimitExceeded { used: 9, max: 8 }.is_transient());
         assert!(!ProviderError::Other("mystery".into()).is_transient());
+        // An unusable provider is permanent: retrying just burns the job
+        // timeout against an account that has no money in it.
+        assert!(
+            !ProviderError::Unavailable {
+                reason: UnavailableReason::CreditsExhausted,
+                detail: "HTTP 402".into(),
+            }
+            .is_transient()
+        );
+    }
+
+    // ─── Provider-fatal classification (issue #201) ─────────────────────────
+
+    #[test]
+    fn classify_maps_the_provider_fatal_statuses() {
+        assert_eq!(
+            UnavailableReason::classify(402, ""),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        assert_eq!(
+            UnavailableReason::classify(401, ""),
+            Some(UnavailableReason::AuthFailed)
+        );
+        assert_eq!(
+            UnavailableReason::classify(403, ""),
+            Some(UnavailableReason::Forbidden)
+        );
+    }
+
+    #[test]
+    fn classify_reads_the_body_when_the_status_alone_is_innocent() {
+        // Anthropic reports a drained balance as a 400. Without the body scan
+        // this reads as a malformed request and kills the run instead of
+        // failing over.
+        assert_eq!(
+            UnavailableReason::classify(
+                400,
+                r#"{"error":{"message":"Your credit balance is too low to access the API"}}"#
+            ),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        for body in [
+            "insufficient credits",
+            "This request requires more credits, or fewer max_tokens",
+            r#"{"error":{"code":"insufficient_quota"}}"#,
+            "You exceeded your current quota",
+            "please check your billing details",
+        ] {
+            assert_eq!(
+                UnavailableReason::classify(400, body),
+                Some(UnavailableReason::CreditsExhausted),
+                "{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_leaves_an_ordinary_failure_alone() {
+        // A plain bad request says nothing about the provider's usability, so
+        // it must not trip failover or the circuit breaker.
+        assert_eq!(UnavailableReason::classify(400, "unknown field `foo`"), None);
+        assert_eq!(UnavailableReason::classify(404, "no such model"), None);
+        assert_eq!(UnavailableReason::classify(500, "boom"), None);
+    }
+
+    #[test]
+    fn unavailable_reason_is_reported_only_for_unavailable() {
+        let err = ProviderError::Unavailable {
+            reason: UnavailableReason::AuthFailed,
+            detail: "HTTP 401: bad key".into(),
+        };
+        assert_eq!(err.unavailable_reason(), Some(UnavailableReason::AuthFailed));
+        assert_eq!(
+            ProviderError::ApiError("HTTP 400".into()).unavailable_reason(),
+            None
+        );
+    }
+
+    #[test]
+    fn unavailable_display_leads_with_the_remedy_and_keeps_the_detail() {
+        // The whole complaint in issue #201 was a raw JSON blob as the run's
+        // status. The message must say what to do; the blob stays available.
+        let err = ProviderError::Unavailable {
+            reason: UnavailableReason::CreditsExhausted,
+            detail: "HTTP 402 Payment Required: {\"error\":{}}".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.starts_with("out of credits:"), "{msg}");
+        assert!(msg.contains("top up the account"), "{msg}");
+        assert!(msg.contains("HTTP 402 Payment Required"), "{msg}");
+    }
+
+    #[test]
+    fn every_unavailable_reason_has_a_label_and_a_remedy() {
+        for reason in [
+            UnavailableReason::CreditsExhausted,
+            UnavailableReason::AuthFailed,
+            UnavailableReason::Forbidden,
+        ] {
+            assert!(!reason.label().is_empty());
+            assert!(!reason.remedy().is_empty());
+            // The label is a metrics attribute and a `lev ps` cell, so it must
+            // stay a single lowercase token.
+            assert_eq!(reason.label(), reason.label().to_ascii_lowercase());
+            assert!(!reason.label().contains(' '));
+        }
+    }
+
+    #[test]
+    fn unavailable_reason_round_trips_through_serde() {
+        // It rides on `DaemonHealth`, which crosses the control socket.
+        let json = serde_json::to_string(&UnavailableReason::CreditsExhausted)
+            .expect("UnavailableReason serializes");
+        assert_eq!(json, "\"credits_exhausted\"");
+        let back: UnavailableReason =
+            serde_json::from_str(&json).expect("UnavailableReason deserializes");
+        assert_eq!(back, UnavailableReason::CreditsExhausted);
     }
 
     // ─── ProviderError Display ──────────────────────────────────────────────
@@ -1070,6 +1294,44 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("500"));
         assert!(msg.contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn check_http_response_402_becomes_unavailable_not_api_error() {
+        // The exact shape from issue #201: OpenRouter answering 402 with its
+        // credit-balance JSON. Before, this was an `ApiError` whose whole
+        // message was the blob, and one of them killed the run.
+        let body = br#"{"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 28."}}"#;
+        let response = spawn_mock_response(402, "Payment Required", &[], body).await;
+        let err = check_http_response(response, None).await.unwrap_err();
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        assert!(!err.is_transient());
+        let msg = err.to_string();
+        assert!(msg.starts_with("out of credits:"), "{msg}");
+        assert!(msg.contains("402"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn check_http_response_400_with_a_credit_body_is_still_unavailable() {
+        // Anthropic's shape: the status is innocent, the body is not.
+        let body = br#"{"error":{"message":"Your credit balance is too low to access the Anthropic API"}}"#;
+        let response = spawn_mock_response(400, "Bad Request", &[], body).await;
+        let err = check_http_response(response, None).await.unwrap_err();
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+    }
+
+    #[tokio::test]
+    async fn check_http_response_ordinary_4xx_stays_an_api_error() {
+        let response = spawn_mock_response(404, "Not Found", &[], b"no such model").await;
+        let err = check_http_response(response, None).await.unwrap_err();
+        assert_eq!(err.unavailable_reason(), None);
+        assert!(err.to_string().starts_with("API error:"), "{err}");
     }
 
     fn assert_contains_500(msg: &str) {

--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -199,7 +199,20 @@ pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
             return match kind.as_deref() {
                 Some("rate_limited") => ProviderError::RateLimitExceeded,
                 Some("transport") | Some("server") => ProviderError::RequestFailed(message),
-                Some("api") => ProviderError::ApiError(message),
+                // A script's `api` error is the same shape a built-in provider
+                // gets back from an HTTP call, so it classifies the same way:
+                // an OpenAI-compatible endpoint answering 402 through a Rhai
+                // provider must fail over and trip the breaker exactly as the
+                // native OpenRouter provider does (issue #201). The script has
+                // no status code to hand us separately, so it is read back out
+                // of the message.
+                Some("api") => match crate::provider::UnavailableReason::from_message(&message) {
+                    Some(reason) => ProviderError::Unavailable {
+                        reason,
+                        detail: message,
+                    },
+                    None => ProviderError::ApiError(message),
+                },
                 Some("invalid_response") => ProviderError::InvalidResponse(message),
                 _ if transient => ProviderError::RequestFailed(message),
                 _ => ProviderError::Other(message),

--- a/crates/leviath-providers/src/rhai_provider/convert/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert/tests.rs
@@ -142,6 +142,38 @@ fn map_err_kinds() {
     assert!(matches!(map_rhai_err(mk("weird")), ProviderError::Other(_)));
 }
 
+/// A script talking to an OpenAI-compatible endpoint must fail over and trip
+/// the breaker exactly as a built-in provider does (issue #201). It throws one
+/// formatted string, so the classification has to come out of the message.
+#[test]
+fn a_scripts_payment_error_classifies_like_a_built_in_providers() {
+    let api = |message: &str| {
+        let mut m = Map::new();
+        m.insert("kind".into(), "api".into());
+        m.insert("message".into(), message.into());
+        map_rhai_err(Box::new(EvalAltResult::ErrorRuntime(
+            Dynamic::from_map(m),
+            Position::NONE,
+        )))
+    };
+
+    let err = api("HTTP 402 Payment Required: {\"error\":{\"message\":\"no credits\"}}");
+    assert_eq!(
+        err.unavailable_reason(),
+        Some(crate::provider::UnavailableReason::CreditsExhausted)
+    );
+    assert!(!err.is_transient());
+
+    assert_eq!(
+        api("HTTP 401: bad key").unavailable_reason(),
+        Some(crate::provider::UnavailableReason::AuthFailed)
+    );
+    // An ordinary API error is still an ordinary API error.
+    let plain = api("HTTP 400: unknown field `foo`");
+    assert_eq!(plain.unavailable_reason(), None);
+    assert!(matches!(plain, ProviderError::ApiError(_)));
+}
+
 #[test]
 fn map_err_transient_flag_without_kind() {
     let mut m = Map::new();

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -915,6 +915,27 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         }
     }
 
+    /// The failover chain is ordered and additive, and setting a default model
+    /// afterwards must not wipe it (issue #201).
+    #[test]
+    fn fallback_models_accumulate_in_order_beside_the_default() {
+        let builder = AgentWorldBuilder::new()
+            .fallback_model("anthropic", "sonnet")
+            .fallback_model("openai", "gpt")
+            .default_model("openrouter", "deepseek");
+        assert_eq!(builder.defaults.provider, "openrouter");
+        assert_eq!(builder.defaults.model.as_deref(), Some("deepseek"));
+        assert_eq!(
+            builder
+                .defaults
+                .fallback_order
+                .iter()
+                .map(|e| (e.provider.as_str(), e.model.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("anthropic", "sonnet"), ("openai", "gpt")]
+        );
+    }
+
     #[tokio::test]
     async fn every_builder_option_composes_and_state_dir_persists_runs() {
         let dir = tempfile::tempdir().unwrap();
@@ -936,6 +957,10 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
                 }),
             )
             .default_model("mock", "m")
+            // Repeated on purpose: the chain is ordered, so it must accumulate
+            // rather than replace, and it must not disturb the default model.
+            .fallback_model("ollama", "llama")
+            .fallback_model("mock", "spare")
             .state_dir(state.path())
             .inference_pool(InferencePoolConfig::new())
             .tool_concurrency(2)

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -138,10 +138,24 @@ impl AgentWorldBuilder {
     /// The user-default provider/model, the fallback when none of a stage's
     /// listed models has a registered provider.
     pub fn default_model(mut self, provider: impl Into<String>, model: impl Into<String>) -> Self {
-        self.defaults = ModelDefaults {
-            provider: provider.into(),
-            model: Some(model.into()),
-        };
+        self.defaults.provider = provider.into();
+        self.defaults.model = Some(model.into());
+        self
+    }
+
+    /// Append a host-wide failover target, tried after a stage's own entries
+    /// and the default model when the provider in use stops answering.
+    ///
+    /// Call it once per target, best first. This is what keeps a blueprint
+    /// that names exactly one model running when that provider runs out of
+    /// credits (issue #201).
+    pub fn fallback_model(mut self, provider: impl Into<String>, model: impl Into<String>) -> Self {
+        self.defaults
+            .fallback_order
+            .push(leviath_core::blueprint::ModelEntry::new(
+                provider.into(),
+                model.into(),
+            ));
         self
     }
 

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -575,6 +575,7 @@ mod tests {
             model: "m".to_string(),
             tools: vec![],
             tool_filter: None,
+            fallbacks: Vec::new(),
         }
     }
 

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -188,6 +188,12 @@ pub struct DaemonHealth {
     /// How often the daemon re-drives itself, so a client can turn
     /// `dead_cycles` into wall-clock time.
     pub redrive_secs: u64,
+    /// Providers currently out of service, and when each is probed again.
+    ///
+    /// Empty on a healthy daemon. `#[serde(default)]` so an older client still
+    /// parses a newer daemon's response (issue #201).
+    #[serde(default)]
+    pub providers_down: Vec<crate::pipeline::ProviderCircuitState>,
 }
 
 /// The daemon-installed function that turns [`SpawnArgs`] into a live agent:
@@ -845,6 +851,25 @@ impl WorldHost {
                 dead_cycles: self.dead_cycles,
                 relief_granted: relief,
             });
+        // Sampled on the same tick, and unconditionally: a collector needs the
+        // empty sample to see that a provider came *back*, not just that it
+        // went away (issue #201).
+        let down: Vec<leviath_core::telemetry::ProviderHealth> = self
+            .world
+            .open_circuits()
+            .into_iter()
+            .map(|c| leviath_core::telemetry::ProviderHealth {
+                provider: c.provider,
+                reason: c.reason.label().to_string(),
+                consecutive_failures: c.consecutive_failures,
+                retry_in_secs: c.retry_in_secs,
+            })
+            .collect();
+        self.world
+            .world()
+            .resource::<crate::telemetry::Telemetry>()
+            .0
+            .observe_providers(&down);
     }
 
     /// The daemon's own health: lane occupancy plus the dead-cycle count.
@@ -864,6 +889,7 @@ impl WorldHost {
             dead_cycles: self.dead_cycles,
             relief_granted: self.relief_granted,
             redrive_secs: self.redrive.as_secs(),
+            providers_down: self.world.open_circuits(),
         }
     }
 

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -2636,6 +2636,52 @@ mod tests {
         assert_eq!(samples[1].agents_active, 2);
     }
 
+    /// The same tick reports which providers are out of service, and reports
+    /// the empty case too: a collector needs that to see a provider come back,
+    /// not merely stop being mentioned (issue #201).
+    #[tokio::test]
+    async fn each_re_drive_reports_providers_out_of_service() {
+        let sink = Arc::new(leviath_core::telemetry::MemorySink::default());
+        let mut host = host_with(vec![]);
+        host.world_mut()
+            .world_mut()
+            .insert_resource(crate::telemetry::Telemetry(sink.clone()));
+        let policy = crate::pipeline::CircuitPolicy {
+            failures_before_open: 1,
+            cooldown_secs: 300,
+        };
+        let mut circuits = crate::pipeline::ProviderCircuits::default();
+        circuits.record_failure(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+            chrono::Utc::now().timestamp(),
+            &policy,
+        );
+        host.world_mut().world_mut().insert_resource(circuits);
+        host.world_mut().world_mut().insert_resource(policy);
+
+        host.observe_redrive();
+
+        let samples = sink.provider_samples();
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].len(), 1);
+        assert_eq!(samples[0][0].provider, "openrouter");
+        assert_eq!(samples[0][0].reason, "credits-exhausted");
+        assert_eq!(samples[0][0].consecutive_failures, 1);
+        assert!(samples[0][0].retry_in_secs > 0);
+        // It also reaches `lev ps` through the health snapshot.
+        assert_eq!(host.health().providers_down.len(), 1);
+
+        // The provider recovers, and the empty sample says so.
+        host.world_mut()
+            .world_mut()
+            .resource_mut::<crate::pipeline::ProviderCircuits>()
+            .record_success("openrouter");
+        host.observe_redrive();
+        assert!(sink.provider_samples()[1].is_empty());
+        assert!(host.health().providers_down.is_empty());
+    }
+
     /// Stillness on its own is not a dead cycle. An idle daemon has nothing
     /// queued and nothing to do, and counting it would fire relief at every quiet
     /// spell.

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1922,6 +1922,7 @@ mod tests {
             model: "m".to_string(),
             tools: vec![],
             tool_filter: None,
+            fallbacks: Vec::new(),
         }
     }
 

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -1,0 +1,573 @@
+//! Per-provider circuit breakers: stop hammering a provider that has told us,
+//! repeatedly, that it cannot serve anyone.
+//!
+//! Failing over (see [`super::response::collect_inference`]) rescues one run.
+//! It does nothing for the *next* run, which starts on the same dead provider
+//! and burns its own failure discovering the same thing. Issue #201 is what
+//! that looks like at scale: ten consecutive workers, every one of them dying
+//! at iteration 0 against an OpenRouter account with no credits left.
+//!
+//! So failures are counted per provider. Past a threshold the circuit opens and
+//! dispatch stops choosing that provider at all, which turns a silent stream of
+//! dead runs into one visible state an operator can act on (`lev ps`, the
+//! `leviath.provider.circuit.open` gauge, and a `tracing::error!`).
+//!
+//! There is no half-open *state*, on purpose. `is_open` simply stops answering
+//! true once the cooldown has elapsed, so the next dispatch is the probe: it
+//! either succeeds and closes the circuit, or fails and re-opens it with a
+//! fresh timestamp. One less state machine to keep correct.
+
+use super::*;
+
+use std::collections::HashMap;
+
+use leviath_providers::UnavailableReason;
+use serde::{Deserialize, Serialize};
+
+/// When to open a provider's circuit, and how long to leave it open.
+///
+/// A world resource rather than constants because the daemon serves it from
+/// `[limits]`.
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CircuitPolicy {
+    /// Consecutive provider-fatal failures before the circuit opens. Zero
+    /// disables the breaker entirely, leaving only per-run failover.
+    pub failures_before_open: u32,
+    /// How long an open circuit is left alone before the next request is
+    /// allowed through as a probe.
+    pub cooldown_secs: u64,
+}
+
+/// Default consecutive failures before a provider's circuit opens.
+///
+/// Three rather than one: a single 402 can be a request that asked for more
+/// output tokens than the remaining balance covers, which a smaller request
+/// would survive. Three in a row is an account, not a request.
+pub const DEFAULT_FAILURES_BEFORE_OPEN: u32 = 3;
+
+/// Default time an open circuit waits before probing again.
+///
+/// Long enough that a drained account is not probed every few seconds, short
+/// enough that topping it up brings the factory back without a daemon restart.
+pub const DEFAULT_CIRCUIT_COOLDOWN_SECS: u64 = 300;
+
+impl Default for CircuitPolicy {
+    fn default() -> Self {
+        Self {
+            failures_before_open: DEFAULT_FAILURES_BEFORE_OPEN,
+            cooldown_secs: DEFAULT_CIRCUIT_COOLDOWN_SECS,
+        }
+    }
+}
+
+/// One provider's failure record. Absent from [`ProviderCircuits`] means
+/// healthy, so a success can simply drop the entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Circuit {
+    /// Provider-fatal failures since the last success.
+    pub consecutive_failures: u32,
+    /// When the circuit opened, if it is open. `None` while the count is still
+    /// below the threshold.
+    pub opened_at: Option<i64>,
+    /// What the provider last complained about, for the operator-facing text.
+    pub reason: UnavailableReason,
+}
+
+/// What an open circuit looks like to a client (`lev ps`, `--json`, telemetry).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderCircuitState {
+    /// The provider whose circuit is open.
+    pub provider: String,
+    /// Why it was taken out of service.
+    pub reason: UnavailableReason,
+    /// How many consecutive failures it has accumulated.
+    pub consecutive_failures: u32,
+    /// Seconds until the next probe is allowed through.
+    pub retry_in_secs: u64,
+}
+
+/// Every provider's breaker state, as a world resource.
+///
+/// Written by the (serial) collect system and read by dispatch, so plain
+/// `Res`/`ResMut` access is enough - no interior mutability, no locks.
+#[derive(Resource, Debug, Clone, Default)]
+pub struct ProviderCircuits(HashMap<String, Circuit>);
+
+impl ProviderCircuits {
+    /// Count a provider-fatal failure against `provider`.
+    ///
+    /// Returns `true` on the transition into the open state, so the caller can
+    /// log and alert exactly once rather than on every subsequent failure.
+    pub fn record_failure(
+        &mut self,
+        provider: &str,
+        reason: UnavailableReason,
+        now: i64,
+        policy: &CircuitPolicy,
+    ) -> bool {
+        let entry = self.0.entry(provider.to_string()).or_insert(Circuit {
+            consecutive_failures: 0,
+            opened_at: None,
+            reason,
+        });
+        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+        entry.reason = reason;
+        if policy.failures_before_open == 0 {
+            return false; // breaker disabled; keep counting for the record
+        }
+        let was_open = entry.opened_at.is_some();
+        if entry.consecutive_failures >= policy.failures_before_open {
+            // Re-stamp on every failure at or past the threshold: a probe that
+            // fails must restart the cooldown, not inherit the old one.
+            entry.opened_at = Some(now);
+        }
+        !was_open && entry.opened_at.is_some()
+    }
+
+    /// Forget `provider`'s failures. Any success proves it is serving again.
+    pub fn record_success(&mut self, provider: &str) {
+        self.0.remove(provider);
+    }
+
+    /// Whether `provider` should be skipped right now.
+    ///
+    /// False once the cooldown has elapsed, which is what makes the next
+    /// request a probe without needing a distinct half-open state.
+    pub fn is_open(&self, provider: &str, now: i64, policy: &CircuitPolicy) -> bool {
+        self.0
+            .get(provider)
+            .and_then(|c| c.opened_at)
+            .is_some_and(|at| now.saturating_sub(at) < policy.cooldown_secs as i64)
+    }
+
+    /// Every currently-open circuit, provider-sorted so the rendering is
+    /// stable across ticks (a `HashMap` iteration order is not).
+    pub fn open_circuits(&self, now: i64, policy: &CircuitPolicy) -> Vec<ProviderCircuitState> {
+        let mut open: Vec<ProviderCircuitState> = self
+            .0
+            .iter()
+            .filter_map(|(provider, c)| {
+                let at = c.opened_at?;
+                let elapsed = now.saturating_sub(at);
+                let remaining = (policy.cooldown_secs as i64).saturating_sub(elapsed);
+                (remaining > 0).then(|| ProviderCircuitState {
+                    provider: provider.clone(),
+                    reason: c.reason,
+                    consecutive_failures: c.consecutive_failures,
+                    retry_in_secs: remaining as u64,
+                })
+            })
+            .collect();
+        open.sort_by(|a, b| a.provider.cmp(&b.provider));
+        open
+    }
+}
+
+/// Move any ready agent off a provider whose circuit is open, before dispatch
+/// gets to it.
+///
+/// This runs *serially*, unlike [`super::inference::dispatch_inference`], which
+/// fans out over `par_iter` and so cannot take the `&mut StageInference` a swap
+/// needs. Keeping the rotation here also means dispatch stays a pure decision:
+/// by the time it looks at an agent, the agent is already pointed at the best
+/// provider still standing.
+///
+/// An agent with nowhere left to go is left alone, and dispatch parks it on
+/// [`super::StallReason::ProviderCircuitOpen`].
+pub fn rotate_open_circuits(
+    mut agents: Query<(Entity, &AgentState, &mut StageInference), With<super::ReadyToInfer>>,
+    circuits: Option<Res<ProviderCircuits>>,
+    policy: Option<Res<CircuitPolicy>>,
+) {
+    crate::tick_scope::clear();
+    let Some(circuits) = circuits else {
+        return; // no breaker installed
+    };
+    let policy = policy.map(|p| *p).unwrap_or_default();
+    let now = chrono::Utc::now().timestamp();
+    for (entity, state, mut si) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        if state.status != crate::components::AgentStatus::Active {
+            continue;
+        }
+        if !circuits.is_open(&si.provider_name, now, &policy) {
+            continue;
+        }
+        // First candidate whose own circuit is closed. Everything skipped on
+        // the way is dropped: it is no better than what we are leaving.
+        let Some(next) = si
+            .fallbacks
+            .iter()
+            .position(|e| !circuits.is_open(&e.provider, now, &policy))
+        else {
+            continue; // nowhere to go; dispatch will park it
+        };
+        let entry = si.fallbacks.remove(next);
+        si.fallbacks.drain(..next);
+        tracing::warn!(
+            from_provider = %si.provider_name,
+            to_provider = %entry.provider,
+            to_model = %entry.model,
+            "provider circuit is open; moving this run to the next candidate"
+        );
+        si.provider_name = entry.provider;
+        si.model = entry.model;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> CircuitPolicy {
+        CircuitPolicy {
+            failures_before_open: 3,
+            cooldown_secs: 300,
+        }
+    }
+
+    fn fail(circuits: &mut ProviderCircuits, now: i64) -> bool {
+        circuits.record_failure(
+            "openrouter",
+            UnavailableReason::CreditsExhausted,
+            now,
+            &policy(),
+        )
+    }
+
+    #[test]
+    fn the_circuit_opens_only_at_the_threshold() {
+        let mut circuits = ProviderCircuits::default();
+        assert!(!fail(&mut circuits, 0));
+        assert!(!circuits.is_open("openrouter", 0, &policy()));
+        assert!(!fail(&mut circuits, 1));
+        assert!(!circuits.is_open("openrouter", 1, &policy()));
+        // Third strike: opens, and says so exactly once.
+        assert!(fail(&mut circuits, 2), "the transition is reported");
+        assert!(circuits.is_open("openrouter", 2, &policy()));
+        assert!(
+            !fail(&mut circuits, 3),
+            "already open, not a new transition"
+        );
+    }
+
+    #[test]
+    fn an_untouched_provider_is_never_open() {
+        let circuits = ProviderCircuits::default();
+        assert!(!circuits.is_open("anthropic", 0, &policy()));
+        assert!(circuits.open_circuits(0, &policy()).is_empty());
+    }
+
+    #[test]
+    fn a_success_closes_the_circuit() {
+        let mut circuits = ProviderCircuits::default();
+        for t in 0..3 {
+            fail(&mut circuits, t);
+        }
+        assert!(circuits.is_open("openrouter", 2, &policy()));
+        circuits.record_success("openrouter");
+        assert!(!circuits.is_open("openrouter", 2, &policy()));
+        // And the count restarts, so one later failure does not re-open it.
+        assert!(!fail(&mut circuits, 10));
+        assert!(!circuits.is_open("openrouter", 10, &policy()));
+    }
+
+    #[test]
+    fn the_cooldown_lets_a_probe_through() {
+        let mut circuits = ProviderCircuits::default();
+        for t in 0..3 {
+            fail(&mut circuits, t);
+        }
+        assert!(circuits.is_open("openrouter", 2 + 299, &policy()));
+        // Cooldown elapsed: the next dispatch is the probe.
+        assert!(!circuits.is_open("openrouter", 2 + 300, &policy()));
+    }
+
+    #[test]
+    fn a_failed_probe_restarts_the_cooldown() {
+        let mut circuits = ProviderCircuits::default();
+        for t in 0..3 {
+            fail(&mut circuits, t);
+        }
+        // Probe at the end of the cooldown, and it fails again.
+        assert!(
+            !fail(&mut circuits, 302),
+            "already open: not a new transition"
+        );
+        // The clock restarted from the probe rather than the original opening.
+        assert!(circuits.is_open("openrouter", 400, &policy()));
+        assert!(!circuits.is_open("openrouter", 602, &policy()));
+    }
+
+    #[test]
+    fn a_zero_threshold_disables_the_breaker() {
+        let disabled = CircuitPolicy {
+            failures_before_open: 0,
+            cooldown_secs: 300,
+        };
+        let mut circuits = ProviderCircuits::default();
+        for t in 0..10 {
+            assert!(!circuits.record_failure(
+                "openrouter",
+                UnavailableReason::CreditsExhausted,
+                t,
+                &disabled
+            ));
+        }
+        assert!(!circuits.is_open("openrouter", 10, &disabled));
+        assert!(circuits.open_circuits(10, &disabled).is_empty());
+    }
+
+    #[test]
+    fn open_circuits_reports_what_the_operator_needs() {
+        let mut circuits = ProviderCircuits::default();
+        for t in 0..3 {
+            fail(&mut circuits, t);
+        }
+        let open = circuits.open_circuits(102, &policy());
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].provider, "openrouter");
+        assert_eq!(open[0].reason, UnavailableReason::CreditsExhausted);
+        assert_eq!(open[0].consecutive_failures, 3);
+        // Opened at t=2, cooldown 300, now 102 ⇒ 200 left.
+        assert_eq!(open[0].retry_in_secs, 200);
+    }
+
+    #[test]
+    fn open_circuits_is_sorted_and_drops_expired_ones() {
+        let mut circuits = ProviderCircuits::default();
+        for name in ["openrouter", "anthropic"] {
+            for t in 0..3 {
+                circuits.record_failure(name, UnavailableReason::AuthFailed, t, &policy());
+            }
+        }
+        let open = circuits.open_circuits(10, &policy());
+        assert_eq!(
+            open.iter().map(|c| c.provider.as_str()).collect::<Vec<_>>(),
+            vec!["anthropic", "openrouter"],
+            "a HashMap's order is not stable; the report must be"
+        );
+        // Past the cooldown they are no longer open, so nothing is reported.
+        assert!(circuits.open_circuits(1_000, &policy()).is_empty());
+    }
+
+    #[test]
+    fn the_latest_reason_wins() {
+        let mut circuits = ProviderCircuits::default();
+        circuits.record_failure("p", UnavailableReason::CreditsExhausted, 0, &policy());
+        circuits.record_failure("p", UnavailableReason::AuthFailed, 1, &policy());
+        circuits.record_failure("p", UnavailableReason::AuthFailed, 2, &policy());
+        let open = circuits.open_circuits(2, &policy());
+        assert_eq!(open[0].reason, UnavailableReason::AuthFailed);
+    }
+
+    #[test]
+    fn the_default_policy_is_three_strikes_and_five_minutes() {
+        let p = CircuitPolicy::default();
+        assert_eq!(p.failures_before_open, DEFAULT_FAILURES_BEFORE_OPEN);
+        assert_eq!(p.cooldown_secs, DEFAULT_CIRCUIT_COOLDOWN_SECS);
+    }
+
+    // ── the rotation system ────────────────────────────────────────────────
+
+    fn agent_state() -> AgentState {
+        AgentState {
+            agent_id: "a".to_string(),
+            current_stage: "s".to_string(),
+            iteration: 0,
+            status: crate::components::AgentStatus::Active,
+            spawned_children_ids: vec![],
+            pending_wait: None,
+            accepts_messages: true,
+        }
+    }
+
+    fn stage_on(provider: &str, fallbacks: &[&str]) -> StageInference {
+        StageInference {
+            provider_name: provider.to_string(),
+            model: format!("{provider}-model"),
+            tools: Vec::new(),
+            tool_filter: None,
+            fallbacks: fallbacks
+                .iter()
+                .map(|p| {
+                    leviath_core::blueprint::ModelEntry::new((*p).to_string(), format!("{p}-model"))
+                })
+                .collect(),
+        }
+    }
+
+    /// A world with `open` providers already tripped.
+    fn world_with_open(open: &[&str]) -> World {
+        let mut world = World::new();
+        let mut circuits = ProviderCircuits::default();
+        let now = chrono::Utc::now().timestamp();
+        for name in open {
+            for _ in 0..policy().failures_before_open {
+                circuits.record_failure(name, UnavailableReason::CreditsExhausted, now, &policy());
+            }
+        }
+        world.insert_resource(circuits);
+        world.insert_resource(policy());
+        world
+    }
+
+    fn run_rotate(world: &mut World) {
+        let mut schedule = Schedule::default();
+        schedule.add_systems(rotate_open_circuits);
+        schedule.run(world);
+    }
+
+    #[test]
+    fn rotation_moves_a_ready_agent_off_a_tripped_provider() {
+        let mut world = world_with_open(&["openrouter"]);
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("openrouter", &["anthropic"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        let si = world.get::<StageInference>(e).unwrap();
+        assert_eq!(si.provider_name, "anthropic");
+        assert_eq!(si.model, "anthropic-model");
+        assert!(si.fallbacks.is_empty());
+    }
+
+    #[test]
+    fn rotation_skips_past_candidates_that_are_also_tripped() {
+        let mut world = world_with_open(&["openrouter", "openai"]);
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("openrouter", &["openai", "anthropic"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        let si = world.get::<StageInference>(e).unwrap();
+        assert_eq!(si.provider_name, "anthropic");
+        // The tripped candidate is dropped rather than left to be tried next:
+        // it is no better than what we just left.
+        assert!(si.fallbacks.is_empty());
+    }
+
+    #[test]
+    fn rotation_leaves_an_agent_with_nowhere_to_go_alone() {
+        // Dispatch parks it on ProviderCircuitOpen; rotating to nothing would
+        // just lose the provider name the operator needs to see.
+        let mut world = world_with_open(&["openrouter"]);
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("openrouter", &[]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        assert_eq!(
+            world.get::<StageInference>(e).unwrap().provider_name,
+            "openrouter"
+        );
+    }
+
+    #[test]
+    fn rotation_leaves_a_healthy_provider_alone() {
+        let mut world = world_with_open(&["openrouter"]);
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("anthropic", &["openai"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        let si = world.get::<StageInference>(e).unwrap();
+        assert_eq!(si.provider_name, "anthropic");
+        assert_eq!(si.fallbacks.len(), 1, "no candidate was spent");
+    }
+
+    #[test]
+    fn rotation_ignores_an_agent_that_is_not_active() {
+        // A paused run must not have its provider changed underneath it.
+        let mut world = world_with_open(&["openrouter"]);
+        let mut state = agent_state();
+        state.status = crate::components::AgentStatus::Paused;
+        let e = world
+            .spawn((
+                state,
+                super::ReadyToInfer,
+                stage_on("openrouter", &["anthropic"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        assert_eq!(
+            world.get::<StageInference>(e).unwrap().provider_name,
+            "openrouter"
+        );
+    }
+
+    #[test]
+    fn rotation_is_a_no_op_without_the_breaker_installed() {
+        // An embedder that never inserts the resource keeps the old behavior.
+        let mut world = World::new();
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("openrouter", &["anthropic"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        assert_eq!(
+            world.get::<StageInference>(e).unwrap().provider_name,
+            "openrouter"
+        );
+    }
+
+    #[test]
+    fn rotation_falls_back_to_the_default_policy() {
+        // Circuits present, policy absent: the default must apply rather than
+        // the breaker silently doing nothing.
+        let mut world = World::new();
+        let mut circuits = ProviderCircuits::default();
+        let now = chrono::Utc::now().timestamp();
+        let default_policy = CircuitPolicy::default();
+        for _ in 0..default_policy.failures_before_open {
+            circuits.record_failure(
+                "openrouter",
+                UnavailableReason::CreditsExhausted,
+                now,
+                &default_policy,
+            );
+        }
+        world.insert_resource(circuits);
+        let e = world
+            .spawn((
+                agent_state(),
+                super::ReadyToInfer,
+                stage_on("openrouter", &["anthropic"]),
+            ))
+            .id();
+
+        run_rotate(&mut world);
+
+        assert_eq!(
+            world.get::<StageInference>(e).unwrap().provider_name,
+            "anthropic"
+        );
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -174,6 +174,8 @@ pub fn dispatch_inference(
     >,
     stage: Res<InferenceStage>,
     providers: Res<Providers>,
+    circuits: Option<Res<ProviderCircuits>>,
+    policy: Option<Res<CircuitPolicy>>,
     par_commands: ParallelCommands,
 ) {
     // Fan out across ready agents: request assembly (`build_request`) is the
@@ -190,6 +192,8 @@ pub fn dispatch_inference(
     // previous system left recorded.
     crate::tick_scope::clear();
     let now = chrono::Utc::now().timestamp();
+    let circuit_policy = policy.map(|p| *p).unwrap_or_default();
+    let circuits = circuits.as_deref();
     agents.par_iter().for_each(
         |(entity, state, window, config, si, in_flight, progress, stalled)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
@@ -205,6 +209,19 @@ pub fn dispatch_inference(
                         commands.entity(entity).insert(noted);
                     });
                 };
+                // The rotation system already moved this agent onto the best
+                // provider still standing. Reaching a tripped one here means
+                // every candidate is out of service, so park rather than send
+                // a request that is going to fail the same way as the last
+                // three (issue #201). The stall watchdog ends the wait.
+                if circuits.is_some_and(|c| c.is_open(&si.provider_name, now, &circuit_policy)) {
+                    tracing::debug!(
+                        provider = %si.provider_name,
+                        "inference waiting: the provider's circuit is open"
+                    );
+                    stall(StallReason::ProviderCircuitOpen);
+                    return;
+                }
                 let Some(provider) = providers.0.get(&si.provider_name) else {
                     // Leave ready and retry later - but say so. A silently
                     // starved agent reads as a wedged run with no error.

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -56,6 +56,8 @@ mod stall;
 pub use stall::*;
 mod wedge;
 pub use wedge::*;
+mod circuit;
+pub use circuit::*;
 
 // ─── Phase marker components (an agent is in exactly one) ────────────────────
 //

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -101,6 +101,10 @@ pub struct StageInference {
     pub tools: Vec<Tool>,
     /// Optional allow-list of tool names (`None`/empty = all `tools`).
     pub tool_filter: Option<Vec<String>>,
+    /// Providers to fail over to, best first, when the current one turns out
+    /// to be unusable. Consumed from the front by `collect_inference`, so an
+    /// exhausted list means "nowhere left to go" (issue #201).
+    pub fallbacks: Vec<leviath_core::blueprint::ModelEntry>,
 }
 
 // ─── World resources for the inference stage ─────────────────────────────────

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -8,7 +8,7 @@
 //! provider/model - arrives as a plain [`ModelDefaults`] value instead.
 
 use leviath_core::Blueprint;
-use leviath_core::blueprint::ModelConfig;
+use leviath_core::blueprint::{ModelConfig, ModelEntry};
 
 use super::ResolvedStage;
 use crate::providers::ProviderRegistry;
@@ -24,6 +24,14 @@ pub struct ModelDefaults {
     pub provider: String,
     /// The default model, if the user configured one.
     pub model: Option<String>,
+    /// The host-wide failover chain, from `[providers] fallback_order`.
+    ///
+    /// Appended after a stage's own entries and the user default, so a
+    /// blueprint that names exactly one model still has somewhere to go when
+    /// that provider stops answering. This is the case issue #201 reported:
+    /// every stage named a single OpenRouter model, so there was nothing to
+    /// fall back to when the account ran out of credits.
+    pub fallback_order: Vec<ModelEntry>,
 }
 
 /// Resolve a stage's [`ModelConfig`] to a concrete `(provider, model)` against
@@ -38,39 +46,112 @@ pub fn resolve_stage_model(
     defaults: &ModelDefaults,
     registry: &ProviderRegistry,
 ) -> (String, String) {
+    let first = resolve_stage_candidates(model_cfg, model_override, defaults, registry)
+        .into_iter()
+        .next()
+        .expect("resolve_stage_candidates always yields at least one entry");
+    (first.provider, first.model)
+}
+
+/// Every provider/model this stage may run on, best first.
+///
+/// [`resolve_stage_model`] is this list's head. The tail is what the runtime
+/// fails over to when a provider turns out to be unusable mid-run: the ordered
+/// list in `ModelConfig.models` was only ever consulted for *registration* at
+/// spawn time, so a provider that was configured but out of credits was picked
+/// and then never abandoned (issue #201).
+///
+/// Order: the stage's own registered entries, then the user default, then the
+/// host-wide `fallback_order`. Deduplicated, because the same pair reaching the
+/// list twice would spend a failover step going nowhere. Never empty: with
+/// nothing registered it yields the blueprint's own first entry, exactly as
+/// before, and `resolve_stages` rejects that unusable case with a clear error.
+pub fn resolve_stage_candidates(
+    model_cfg: &ModelConfig,
+    model_override: Option<&str>,
+    defaults: &ModelDefaults,
+    registry: &ProviderRegistry,
+) -> Vec<ModelEntry> {
     let (override_provider, override_model) = match model_override {
         Some(ov) if ov.contains('/') => {
-            let (p, m) = ov.split_once('/').unwrap();
+            let (p, m) = ov
+                .split_once('/')
+                .expect("the `contains('/')` guard splits");
             (Some(p.to_string()), Some(m.to_string()))
         }
         Some(ov) => (None, Some(ov.to_string())),
         None => (None, None),
     };
 
-    // Full provider/model override wins outright.
+    // A full provider/model override names exactly one pair and deliberately
+    // skips every fallback: the caller asked for that model, not a substitute.
     if let Some(provider) = override_provider {
-        return (provider, override_model.unwrap_or_default());
+        return vec![ModelEntry::new(
+            provider,
+            override_model.unwrap_or_default(),
+        )];
     }
 
-    // First listed model whose provider is registered.
+    let mut candidates: Vec<ModelEntry> = Vec::new();
+    let mut push = |provider: String, model: String| {
+        let entry = ModelEntry::new(provider, model);
+        if !candidates
+            .iter()
+            .any(|c| c.provider == entry.provider && c.model == entry.model)
+        {
+            candidates.push(entry);
+        }
+    };
+
+    // Every listed model whose provider is registered, in blueprint order. A
+    // bare `--model` override renames the model but keeps the provider order.
     for entry in &model_cfg.models {
         if registry.has(&entry.provider) {
             let model = override_model
                 .clone()
                 .unwrap_or_else(|| entry.model.clone());
-            return (entry.provider.clone(), model);
+            push(entry.provider.clone(), model);
         }
     }
 
-    // Fall back to the user's default model, or finally the first listed entry.
-    user_default_model(model_cfg, override_model.as_deref(), defaults, registry).unwrap_or_else(
-        || {
-            (
-                model_cfg.provider().to_string(),
-                model_cfg.model().to_string(),
-            )
-        },
-    )
+    if let Some((provider, model)) =
+        user_default_model(model_cfg, override_model.as_deref(), defaults, registry)
+    {
+        push(provider, model);
+    }
+
+    // The host-wide chain last: it is the safety net for a blueprint that names
+    // one model, not a preference over what the blueprint asked for.
+    for entry in &defaults.fallback_order {
+        if registry.has(&entry.provider) {
+            push(entry.provider.clone(), entry.model.clone());
+        }
+    }
+
+    if candidates.is_empty() {
+        // Nothing registered. Hand back the blueprint's own first entry so the
+        // caller reports "no usable provider" against a name the user wrote,
+        // rather than an empty list.
+        candidates.push(ModelEntry::new(
+            model_cfg.provider().to_string(),
+            model_cfg.model().to_string(),
+        ));
+    }
+
+    // The head keeps whatever `resolve_stage_model` has always produced, up to
+    // and including an unregistered provider that `resolve_stages` then
+    // rejects with a readable error. The *tail* is different: every entry in
+    // it is somewhere the runtime will actually dispatch to, so an
+    // unregistered one is not a fallback but a phantom that parks the run on
+    // `StallReason::ProviderMissing`. `user_default_model` hands one back
+    // whenever a bare `--model` override is in play, so filter here.
+    let tail: Vec<ModelEntry> = candidates
+        .split_off(1)
+        .into_iter()
+        .filter(|e| registry.has(&e.provider))
+        .collect();
+    candidates.extend(tail);
+    candidates
 }
 
 /// The user-default fallback for [`resolve_stage_model`]: `None` when the stage
@@ -170,12 +251,13 @@ pub fn resolve_stages(
         .stages
         .iter()
         .map(|stage| {
-            let (provider_name, model) =
-                resolve_stage_model(&stage.model, model_override, defaults, registry);
+            let mut candidates =
+                resolve_stage_candidates(&stage.model, model_override, defaults, registry);
+            let head = candidates.remove(0);
             // `registry.has` also consults the script layer, so a `.rhai`
             // provider sitting on disk counts as usable and is never
             // false-rejected here.
-            if !registry.has(&provider_name) {
+            if !registry.has(&head.provider) {
                 return Err(format!(
                     "stage '{}' has no usable provider (tried: {}). Configure one \
                      with `lev setup`, or add it to config.toml and restart the daemon.",
@@ -188,9 +270,10 @@ pub fn resolve_stages(
             // MCP tool whose server isn't installed) is simply omitted.
             let tools = filter_tools_by_available(all_tool_defs, &stage.available_tools);
             Ok(ResolvedStage {
-                provider_name,
-                model,
+                provider_name: head.provider,
+                model: head.model,
                 tools,
+                fallbacks: candidates,
             })
         })
         .collect()
@@ -314,6 +397,7 @@ mod tests {
         let defaults = ModelDefaults {
             provider: "anthropic".to_string(),
             model: Some("claude-default".to_string()),
+            fallback_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -329,6 +413,7 @@ mod tests {
         let defaults = ModelDefaults {
             provider: "anthropic".to_string(),
             model: None,
+            fallback_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -346,6 +431,7 @@ mod tests {
         let defaults = ModelDefaults {
             provider: "ghost-default".to_string(),
             model: Some("dm".to_string()),
+            fallback_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -375,6 +461,7 @@ mod tests {
         let defaults = ModelDefaults {
             provider: "anthropic".to_string(),
             model: Some("would-be-default".to_string()),
+            fallback_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(&cfg, None, &defaults, &registry_with(&["anthropic"]));
         assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
@@ -456,6 +543,7 @@ mod tests {
         let defaults = ModelDefaults {
             provider: "fallback".to_string(),
             model: None,
+            fallback_order: Vec::new(),
         };
         let cfg = model_cfg(vec![("one", "m"), ("two", "m")]);
         assert_eq!(providers_tried(&cfg, None, &defaults), "one, two, fallback");
@@ -512,5 +600,159 @@ mod tests {
         // `bash` resolved to `shell`; the unknown MCP name and unlisted
         // `read_file` were both excluded.
         assert_eq!(selected, vec!["shell"]);
+    }
+
+    // ── failover candidates (issue #201) ──────────────────────────────────
+
+    /// `[(provider, model), ...]` for readable assertions.
+    fn pairs(entries: &[ModelEntry]) -> Vec<(&str, &str)> {
+        entries
+            .iter()
+            .map(|e| (e.provider.as_str(), e.model.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn candidates_keep_every_registered_entry_in_blueprint_order() {
+        let cfg = model_cfg(vec![
+            ("openrouter", "deepseek"),
+            ("anthropic", "sonnet"),
+            ("openai", "gpt"),
+        ]);
+        let registry = registry_with(&["openrouter", "anthropic", "openai"]);
+        let got = resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry);
+        // The head is what `resolve_stage_model` picks; the tail is where
+        // failover goes. Before this, the tail was discarded at spawn.
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("openrouter", "deepseek"),
+                ("anthropic", "sonnet"),
+                ("openai", "gpt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidates_skip_providers_that_are_not_registered() {
+        let cfg = model_cfg(vec![("ghost", "nope"), ("anthropic", "sonnet")]);
+        let registry = registry_with(&["anthropic"]);
+        let got = resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry);
+        assert_eq!(pairs(&got), vec![("anthropic", "sonnet")]);
+    }
+
+    #[test]
+    fn the_global_chain_rescues_a_single_model_stage() {
+        // The reported configuration: every stage names one OpenRouter model,
+        // so the blueprint alone offers nowhere to fail over to.
+        let cfg = ModelConfig {
+            allow_user_default: false,
+            ..model_cfg(vec![("openrouter", "deepseek")])
+        };
+        let defaults = ModelDefaults {
+            fallback_order: vec![
+                ModelEntry::new("anthropic".to_string(), "sonnet".to_string()),
+                ModelEntry::new("ghost".to_string(), "nope".to_string()),
+            ],
+            ..Default::default()
+        };
+        let registry = registry_with(&["openrouter", "anthropic"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![("openrouter", "deepseek"), ("anthropic", "sonnet")],
+            "the unregistered global entry is skipped"
+        );
+    }
+
+    #[test]
+    fn the_global_chain_comes_after_the_user_default() {
+        let cfg = model_cfg(vec![("openrouter", "deepseek")]);
+        let defaults = ModelDefaults {
+            provider: "anthropic".to_string(),
+            model: Some("sonnet".to_string()),
+            fallback_order: vec![ModelEntry::new("openai".to_string(), "gpt".to_string())],
+        };
+        let registry = registry_with(&["openrouter", "anthropic", "openai"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("openrouter", "deepseek"),
+                ("anthropic", "sonnet"),
+                ("openai", "gpt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidates_are_deduplicated() {
+        // The same pair arriving twice would spend a failover step going
+        // nowhere, which reads to the operator as a swap that did nothing.
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("anthropic", "sonnet")]);
+        let defaults = ModelDefaults {
+            provider: "anthropic".to_string(),
+            model: Some("sonnet".to_string()),
+            fallback_order: vec![ModelEntry::new(
+                "anthropic".to_string(),
+                "sonnet".to_string(),
+            )],
+        };
+        let registry = registry_with(&["anthropic"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(pairs(&got), vec![("anthropic", "sonnet")]);
+    }
+
+    #[test]
+    fn a_full_override_names_exactly_one_candidate() {
+        // `--model provider/model` asked for that model, not a substitute.
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("openai", "gpt")]);
+        let defaults = ModelDefaults {
+            fallback_order: vec![ModelEntry::new("openai".to_string(), "gpt".to_string())],
+            ..Default::default()
+        };
+        let registry = registry_with(&["anthropic", "openai", "ollama"]);
+        let got = resolve_stage_candidates(&cfg, Some("ollama/llama"), &defaults, &registry);
+        assert_eq!(pairs(&got), vec![("ollama", "llama")]);
+    }
+
+    #[test]
+    fn a_bare_override_renames_the_model_on_every_candidate() {
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("openai", "gpt")]);
+        let registry = registry_with(&["anthropic", "openai"]);
+        let got =
+            resolve_stage_candidates(&cfg, Some("haiku"), &ModelDefaults::default(), &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![("anthropic", "haiku"), ("openai", "haiku")]
+        );
+    }
+
+    #[test]
+    fn candidates_are_never_empty_even_with_nothing_registered() {
+        // `resolve_stages` needs a name the user wrote to report against.
+        let cfg = ModelConfig {
+            allow_user_default: false,
+            ..model_cfg(vec![("ghost", "nope")])
+        };
+        let got =
+            resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry_with(&[]));
+        assert_eq!(pairs(&got), vec![("ghost", "nope")]);
+    }
+
+    #[test]
+    fn resolve_stages_carries_the_tail_onto_the_resolved_stage() {
+        let mut stage = leviath_core::Stage::new(
+            "work".to_string(),
+            model_cfg(vec![("openrouter", "deepseek"), ("anthropic", "sonnet")]),
+        );
+        stage.available_tools = vec![];
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+        let registry = registry_with(&["openrouter", "anthropic"]);
+        let resolved = resolve_stages(&bp, None, &ModelDefaults::default(), &registry, &[])
+            .expect("both providers are registered");
+        assert_eq!(resolved[0].provider_name, "openrouter");
+        assert_eq!(pairs(&resolved[0].fallbacks), vec![("anthropic", "sonnet")]);
     }
 }

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -54,9 +54,13 @@ pub fn collect_inference(
         ),
         With<AwaitingInference>,
     >,
+    mut circuits: Option<ResMut<ProviderCircuits>>,
+    policy: Option<Res<CircuitPolicy>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
+    let policy = policy.map(|p| *p).unwrap_or_default();
+    let now = chrono::Utc::now().timestamp();
     while let Ok(outcome) = results.0.try_recv() {
         let Ok((mut state, totals, cursor, mut ledger, buffer, mut inference, activity)) =
             agents.get_mut(outcome.entity)
@@ -96,6 +100,37 @@ pub fn collect_inference(
                     cached_tokens: usage.map_or(0, |u| u.cached_tokens),
                     success: outcome.result.is_ok(),
                 });
+        }
+        // Breaker bookkeeping, before the arms below consume the outcome. Any
+        // answer at all proves the provider is serving; a provider-fatal one
+        // counts against it and may take it out of service for everyone.
+        if let Some(circuits) = circuits.as_deref_mut() {
+            match outcome
+                .result
+                .as_ref()
+                .err()
+                .and_then(|e| e.unavailable_reason())
+            {
+                Some(reason) => {
+                    if circuits.record_failure(&called_provider, reason, now, &policy) {
+                        // Loud and once, on the transition only. This is the
+                        // alert issue #201 asked for: without it, ten dead
+                        // runs in a row look like ten unrelated failures.
+                        tracing::error!(
+                            provider = %called_provider,
+                            reason = reason.label(),
+                            failures = policy.failures_before_open,
+                            cooldown_secs = policy.cooldown_secs,
+                            "provider circuit opened; no run will be dispatched to it \
+                             until it recovers"
+                        );
+                    }
+                }
+                None if outcome.result.is_ok() => circuits.record_success(&called_provider),
+                // An ordinary error says nothing about the provider either
+                // way, so it neither counts against it nor clears its record.
+                None => {}
+            }
         }
         match outcome.result {
             Ok(response) => {

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -49,7 +49,7 @@ pub fn collect_inference(
             Option<&StageCursor>,
             Option<&mut StageLedger>,
             Option<&mut StageIoBuffer>,
-            Option<&StageInference>,
+            Option<&mut StageInference>,
             Option<&mut crate::telemetry::StageActivity>,
         ),
         With<AwaitingInference>,
@@ -58,7 +58,7 @@ pub fn collect_inference(
 ) {
     crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
-        let Ok((mut state, totals, cursor, mut ledger, buffer, inference, activity)) =
+        let Ok((mut state, totals, cursor, mut ledger, buffer, mut inference, activity)) =
             agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -75,6 +75,12 @@ pub fn collect_inference(
             continue;
         }
         let idx = cursor.map_or(0, |c| c.index);
+        // Whoever we actually called. Read before the error arm below, which
+        // may swap the component over to the next provider.
+        let (called_provider, called_model) = inference
+            .as_deref()
+            .map(|i| (i.provider_name.clone(), i.model.clone()))
+            .unwrap_or_default();
         // Record the call for the telemetry observer while the provider and
         // timing are still at hand (the observer only sees components).
         if let Some(mut activity) = activity {
@@ -82,10 +88,8 @@ pub fn collect_inference(
             activity
                 .0
                 .push(crate::telemetry::ActivityRecord::Inference {
-                    provider: inference
-                        .map(|i| i.provider_name.clone())
-                        .unwrap_or_default(),
-                    model: inference.map(|i| i.model.clone()).unwrap_or_default(),
+                    provider: called_provider.clone(),
+                    model: called_model.clone(),
                     latency_ms: u64::try_from(outcome.latency.as_millis()).unwrap_or(u64::MAX),
                     prompt_tokens: usage.map_or(0, |u| u.prompt_tokens),
                     completion_tokens: usage.map_or(0, |u| u.completion_tokens),
@@ -128,6 +132,51 @@ pub fn collect_inference(
                     .insert(ProcessResponse);
             }
             Err(err) => {
+                // A provider that is out of credits or holding a rejected key
+                // is not this request's problem: every later request to it
+                // fails the same way. Move the stage to the next candidate and
+                // try again rather than killing the run (issue #201).
+                let next = err.unavailable_reason().and_then(|_| {
+                    let si = inference.as_deref_mut()?;
+                    (!si.fallbacks.is_empty()).then(|| si.fallbacks.remove(0))
+                });
+                if let Some(next) = next {
+                    // Loud on purpose. Silently swapping providers is how a
+                    // factory ends up running on a model nobody chose.
+                    tracing::warn!(
+                        from_provider = %called_provider,
+                        from_model = %called_model,
+                        to_provider = %next.provider,
+                        to_model = %next.model,
+                        error = %err,
+                        "provider unusable; failing over to the next configured model"
+                    );
+                    if let Some(mut buffer) = buffer {
+                        buffer.logs.push((
+                            idx,
+                            format!(
+                                "[failover] {called_provider}/{called_model} is unusable \
+                                 ({err}); retrying on {}/{}",
+                                next.provider, next.model
+                            ),
+                        ));
+                    }
+                    let si = inference
+                        .as_deref_mut()
+                        .expect("the failover branch only runs with a StageInference");
+                    si.provider_name = next.provider;
+                    si.model = next.model;
+                    // Back to ready, not errored: the next tick dispatches it
+                    // against the new provider and takes that model's permit.
+                    // The iteration is deliberately not bumped - the agent has
+                    // still not had a turn.
+                    commands
+                        .entity(outcome.entity)
+                        .remove::<AwaitingInference>()
+                        .remove::<InFlightWork>()
+                        .insert(ReadyToInfer);
+                    continue;
+                }
                 if let Some(mut buffer) = buffer {
                     buffer.logs.push((idx, format!("[error] {err}")));
                 }

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -208,6 +208,7 @@ mod tests {
             model: "m".to_string(),
             tools: vec![],
             tool_filter: None,
+            fallbacks: Vec::new(),
         }
     }
 

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -18,6 +18,15 @@ pub enum StallReason {
     /// resolves itself: every permit is held by a job that the job timeout
     /// bounds, and releasing one wakes the driver.
     PoolFull,
+    /// Every provider this stage could use has an open circuit: they have each
+    /// failed enough consecutive times to be taken out of service, and the
+    /// stage has no candidate left to move to (issue #201).
+    ///
+    /// Unlike `PoolFull` this will not clear on its own within a tick or two -
+    /// somebody has to top up an account or fix a key - so the watchdog fails
+    /// it like `ProviderMissing`. Unlike `ProviderMissing` it *can* recover
+    /// without a restart, which is what the grace period is for.
+    ProviderCircuitOpen,
 }
 
 impl StallReason {
@@ -26,6 +35,37 @@ impl StallReason {
         match self {
             StallReason::ProviderMissing => "provider-missing",
             StallReason::PoolFull => "pool-full",
+            StallReason::ProviderCircuitOpen => "provider-circuit-open",
+        }
+    }
+
+    /// Whether the runtime can resolve this on its own given time.
+    ///
+    /// `PoolFull` clears itself the moment a permit frees, so failing a run for
+    /// it would be failing backpressure. The other two need a person, and a run
+    /// that waits on one for ever reads as healthy while going nowhere.
+    fn needs_a_person(self) -> bool {
+        match self {
+            StallReason::ProviderMissing | StallReason::ProviderCircuitOpen => true,
+            StallReason::PoolFull => false,
+        }
+    }
+
+    /// The operator-facing explanation used when the watchdog gives up.
+    fn give_up_message(self, provider: &str) -> String {
+        match self {
+            StallReason::ProviderCircuitOpen => format!(
+                "every provider this stage can use is out of service (last was \
+                 '{provider}'), so this run has nowhere to go; check the account's \
+                 credits and API key, or add another provider to \
+                 `[providers] fallback_order`"
+            ),
+            // `PoolFull` never reaches the watchdog (see `needs_a_person`), so
+            // the missing-provider wording covers the remaining case.
+            _ => format!(
+                "provider '{provider}' is not configured, so this run has no way to \
+                 go on; add it to config.toml (or run `lev setup`) and restart the daemon"
+            ),
         }
     }
 }
@@ -150,7 +190,7 @@ pub fn fail_stalled_dispatch(
     let now = chrono::Utc::now().timestamp();
     for (entity, stall, si, mut state, buffer) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
-        if state.status != AgentStatus::Active || stall.reason != StallReason::ProviderMissing {
+        if state.status != AgentStatus::Active || !stall.reason.needs_a_person() {
             continue;
         }
         if now.saturating_sub(stall.last_seen) > STALL_FRESHNESS_SECS {
@@ -165,13 +205,10 @@ pub fn fail_stalled_dispatch(
         if now.saturating_sub(stall.since) < limit as i64 {
             continue; // still inside the grace period
         }
-        let message = format!(
-            "provider '{}' is not configured, so this run has no way to go on; \
-             add it to config.toml (or run `lev setup`) and restart the daemon",
-            si.provider_name
-        );
+        let message = stall.reason.give_up_message(&si.provider_name);
         tracing::error!(
             provider = %si.provider_name,
+            reason = stall.reason.label(),
             stalled_secs = now.saturating_sub(stall.since),
             "failing a run whose provider will never resolve"
         );
@@ -435,6 +472,63 @@ mod tests {
     fn stall_reasons_have_labels() {
         assert_eq!(StallReason::ProviderMissing.label(), "provider-missing");
         assert_eq!(StallReason::PoolFull.label(), "pool-full");
+        assert_eq!(
+            StallReason::ProviderCircuitOpen.label(),
+            "provider-circuit-open"
+        );
+    }
+
+    #[test]
+    fn only_the_reasons_a_person_must_fix_are_failed() {
+        // Failing `PoolFull` would be failing backpressure.
+        assert!(StallReason::ProviderMissing.needs_a_person());
+        assert!(StallReason::ProviderCircuitOpen.needs_a_person());
+        assert!(!StallReason::PoolFull.needs_a_person());
+    }
+
+    #[test]
+    fn a_run_with_every_provider_out_of_service_is_failed_not_left_running() {
+        // The end state of issue #201: nothing left to fail over to. Waiting
+        // for ever reads as a healthy run that is going nowhere.
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
+
+        run(&mut world);
+
+        let status = &world.get::<AgentState>(e).unwrap().status;
+        assert!(
+            matches!(status, AgentStatus::Error { message }
+                if message.contains("out of service") && message.contains("fallback_order")),
+            "got: {status:?}"
+        );
+        assert!(world.get::<ReadyToInfer>(e).is_none());
+    }
+
+    #[test]
+    fn an_open_circuit_inside_the_grace_period_gets_its_chance_to_recover() {
+        // Unlike a missing provider, this one can come back on its own once
+        // the cooldown lets a probe through, so the grace period matters.
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 59);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Active
+        );
+    }
+
+    #[test]
+    fn the_give_up_message_names_the_provider() {
+        let missing = StallReason::ProviderMissing.give_up_message("ghost");
+        assert!(missing.contains("ghost") && missing.contains("not configured"));
+        let open = StallReason::ProviderCircuitOpen.give_up_message("openrouter");
+        assert!(open.contains("openrouter") && open.contains("out of service"));
+        // `PoolFull` never reaches the watchdog, but the arm must still answer.
+        assert!(StallReason::PoolFull.give_up_message("x").contains("x"));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -391,6 +391,76 @@ async fn dispatch_skips_when_provider_missing() {
 }
 
 #[tokio::test]
+async fn dispatch_parks_an_agent_whose_provider_circuit_is_open() {
+    // Reaching dispatch on a tripped provider means rotation found nowhere
+    // else to go, so sending the request would just burn another failure.
+    let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    let policy = CircuitPolicy {
+        failures_before_open: 1,
+        cooldown_secs: 300,
+    };
+    let mut circuits = ProviderCircuits::default();
+    circuits.record_failure(
+        "cfg",
+        leviath_providers::UnavailableReason::CreditsExhausted,
+        chrono::Utc::now().timestamp(),
+        &policy,
+    );
+    world.insert_resource(circuits);
+    world.insert_resource(policy);
+    let e = world
+        .spawn((
+            agent_state(),
+            window(),
+            stage("m", vec![], None),
+            ReadyToInfer,
+        ))
+        .id();
+
+    run(&mut world);
+
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    assert!(world.get::<AwaitingInference>(e).is_none());
+    assert_eq!(
+        world.get::<DispatchStall>(e).map(|s| s.reason),
+        Some(StallReason::ProviderCircuitOpen),
+        "the park reason is what `lev ps` and the watchdog read"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_proceeds_once_the_cooldown_lets_a_probe_through() {
+    // The probe is what closes the circuit again, so it must reach the wire.
+    let (mut world, mut rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    let policy = CircuitPolicy {
+        failures_before_open: 1,
+        cooldown_secs: 60,
+    };
+    let mut circuits = ProviderCircuits::default();
+    circuits.record_failure(
+        "cfg",
+        leviath_providers::UnavailableReason::CreditsExhausted,
+        chrono::Utc::now().timestamp() - 61,
+        &policy,
+    );
+    world.insert_resource(circuits);
+    world.insert_resource(policy);
+    let e = world
+        .spawn((
+            agent_state(),
+            window(),
+            stage("m", vec![], None),
+            ReadyToInfer,
+        ))
+        .id();
+
+    run(&mut world);
+
+    assert!(world.get::<AwaitingInference>(e).is_some());
+    assert!(rx.recv().await.expect("outcome").result.is_ok());
+}
+
+#[tokio::test]
 async fn dispatch_inference_skips_non_active_agent() {
     let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
     let mut st = agent_state();
@@ -726,6 +796,111 @@ fn an_ordinary_error_does_not_burn_a_fallback() {
     assert_eq!(si.provider_name, "dead", "the provider is untouched");
     assert_eq!(si.fallbacks.len(), 1, "the candidate is still available");
     assert!(world.get::<ResolveTransition>(e).is_some());
+}
+
+#[test]
+fn provider_fatal_failures_trip_the_breaker_and_a_success_clears_it() {
+    // Failing over rescues *this* run. The breaker is what stops the next ten
+    // runs each rediscovering the same dead account (issue #201).
+    let (mut world, tx) = world_with_results();
+    let policy = CircuitPolicy {
+        failures_before_open: 2,
+        cooldown_secs: 300,
+    };
+    world.insert_resource(ProviderCircuits::default());
+    world.insert_resource(policy);
+    let now = chrono::Utc::now().timestamp();
+
+    for _ in 0..2 {
+        let e = world
+            .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+            .id();
+        tx.send(InferenceOutcome {
+            latency: std::time::Duration::ZERO,
+            entity: e,
+            result: Err(credits_exhausted()),
+        })
+        .unwrap();
+        run_collect(&mut world);
+    }
+    assert!(
+        world
+            .resource::<ProviderCircuits>()
+            .is_open("dead", now, &policy),
+        "two strikes at a threshold of two opens the circuit"
+    );
+
+    // A later success on that provider puts it straight back into service.
+    let e = world
+        .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(resp("hi")),
+    })
+    .unwrap();
+    run_collect(&mut world);
+    assert!(
+        !world
+            .resource::<ProviderCircuits>()
+            .is_open("dead", now, &policy)
+    );
+}
+
+#[test]
+fn an_ordinary_error_does_not_count_against_the_provider() {
+    // A malformed request is our fault, not the provider's. Counting it would
+    // take a perfectly healthy provider out of service.
+    let (mut world, tx) = world_with_results();
+    let policy = CircuitPolicy {
+        failures_before_open: 1,
+        cooldown_secs: 300,
+    };
+    world.insert_resource(ProviderCircuits::default());
+    world.insert_resource(policy);
+    let e = world
+        .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::ApiError(
+            "HTTP 400: bad request".to_string(),
+        )),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert!(!world.resource::<ProviderCircuits>().is_open(
+        "dead",
+        chrono::Utc::now().timestamp(),
+        &policy
+    ));
+}
+
+#[test]
+fn collect_works_without_the_breaker_installed() {
+    // The resources are optional, so an embedder that never inserts them keeps
+    // the plain failover behavior.
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<StageInference>(e).unwrap().provider_name,
+        "alive"
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -69,6 +69,7 @@ fn stage(model: &str, tools: Vec<Tool>, filter: Option<Vec<String>>) -> StageInf
         model: model.to_string(),
         tools,
         tool_filter: filter,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -588,6 +589,162 @@ fn collect_marks_error_on_failure() {
         world.get::<StageOutcome>(e).unwrap(),
         &StageOutcome::Errored("boom".to_string())
     );
+}
+
+// ── provider failover on an unusable provider (issue #201) ──
+
+/// A stage on `dead/model-a` with one place left to go.
+fn stage_with_fallback() -> StageInference {
+    StageInference {
+        provider_name: "dead".to_string(),
+        model: "model-a".to_string(),
+        tools: Vec::new(),
+        tool_filter: None,
+        fallbacks: vec![leviath_core::blueprint::ModelEntry::new(
+            "alive".to_string(),
+            "model-b".to_string(),
+        )],
+    }
+}
+
+fn credits_exhausted() -> leviath_providers::ProviderError {
+    leviath_providers::ProviderError::Unavailable {
+        reason: leviath_providers::UnavailableReason::CreditsExhausted,
+        detail: "HTTP 402 Payment Required".to_string(),
+    }
+}
+
+#[test]
+fn an_unusable_provider_fails_over_instead_of_killing_the_run() {
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    // The stage now points at the fallback and is ready to be dispatched
+    // again; the run is still alive.
+    let si = world.get::<StageInference>(e).unwrap();
+    assert_eq!(si.provider_name, "alive");
+    assert_eq!(si.model, "model-b");
+    assert!(si.fallbacks.is_empty(), "the candidate was consumed");
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    assert!(world.get::<AwaitingInference>(e).is_none());
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Active
+    );
+    assert!(world.get::<StageOutcome>(e).is_none());
+    assert!(world.get::<ResolveTransition>(e).is_none());
+    // The agent never got a turn, so the iteration must not move.
+    assert_eq!(world.get::<AgentState>(e).unwrap().iteration, 0);
+}
+
+#[test]
+fn failover_is_recorded_in_the_stage_log() {
+    // A silent swap is how a factory ends up on a model nobody chose.
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((
+            agent_state(),
+            AwaitingInference,
+            stage_with_fallback(),
+            StageIoBuffer::default(),
+        ))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+    let line = logs
+        .iter()
+        .map(|(_, l)| l.as_str())
+        .find(|l| l.starts_with("[failover]"))
+        .expect("the swap is written to the stage log");
+    assert!(line.contains("dead/model-a"), "{line}");
+    assert!(line.contains("alive/model-b"), "{line}");
+}
+
+#[test]
+fn an_exhausted_fallback_list_still_terminates() {
+    // Last provider standing: the run ends, but with the readable message
+    // rather than the raw JSON body the issue reported.
+    let (mut world, tx) = world_with_results();
+    let mut si = stage_with_fallback();
+    si.fallbacks.clear();
+    let e = world.spawn((agent_state(), AwaitingInference, si)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert!(world.get::<ReadyToInfer>(e).is_none());
+    assert!(world.get::<ResolveTransition>(e).is_some());
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).unwrap().status else {
+        panic!("an exhausted chain is a terminal error");
+    };
+    assert!(message.starts_with("out of credits:"), "{message}");
+}
+
+#[test]
+fn an_ordinary_error_does_not_burn_a_fallback() {
+    // Failing over on a malformed request would waste the one provider that
+    // still works, so only a provider-fatal error may consume a candidate.
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::ApiError(
+            "HTTP 400: bad request".to_string(),
+        )),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let si = world.get::<StageInference>(e).unwrap();
+    assert_eq!(si.provider_name, "dead", "the provider is untouched");
+    assert_eq!(si.fallbacks.len(), 1, "the candidate is still available");
+    assert!(world.get::<ResolveTransition>(e).is_some());
+}
+
+#[test]
+fn an_unusable_provider_without_a_stage_component_still_terminates() {
+    // `StageInference` is optional on the query, so the failover branch has to
+    // cope with its absence rather than assuming one is attached.
+    let (mut world, tx) = world_with_results();
+    let e = world.spawn((agent_state(), AwaitingInference)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert!(world.get::<ReadyToInfer>(e).is_none());
+    assert!(world.get::<ResolveTransition>(e).is_some());
 }
 
 // ── stage-io persistence (#1) ──
@@ -2146,6 +2303,7 @@ fn stage_inf(tools: &[&str]) -> StageInference {
             })
             .collect(),
         tool_filter: None,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -2610,6 +2768,7 @@ fn offering(names: &[&str]) -> StageInference {
             })
             .collect(),
         tool_filter: None,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -2944,6 +3103,7 @@ fn offering_with_schemas(tools: &[(&str, serde_json::Value)]) -> StageInference 
             })
             .collect(),
         tool_filter: None,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -4150,6 +4310,7 @@ fn si(model: &str) -> StageInference {
         model: model.to_string(),
         tools: vec![],
         tool_filter: None,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -4648,6 +4809,7 @@ fn resolved(model: &str) -> ResolvedStage {
         provider_name: "p".to_string(),
         model: model.to_string(),
         tools: vec![],
+        fallbacks: Vec::new(),
     }
 }
 
@@ -8118,6 +8280,7 @@ fn stage_infs_head() -> StageInference {
         model: "m".to_string(),
         tools: vec![],
         tool_filter: None,
+        fallbacks: Vec::new(),
     }
 }
 
@@ -8228,6 +8391,7 @@ async fn dispatch_choice_stays_when_provider_missing() {
         model: "m".to_string(),
         tools: vec![],
         tool_filter: None,
+        fallbacks: Vec::new(),
     });
 
     let mut schedule = Schedule::default();
@@ -8563,6 +8727,7 @@ fn collect_inference_records_activity_with_provider_and_latency() {
                 model: "m1".to_string(),
                 tools: vec![],
                 tool_filter: None,
+                fallbacks: Vec::new(),
             },
             crate::telemetry::StageActivity::default(),
         ))

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -1234,6 +1234,9 @@ pub struct ResolvedStage {
     pub model: String,
     /// The effective tool set for this stage (already filtered).
     pub tools: Vec<Tool>,
+    /// Where to go if `provider_name` turns out to be unusable, best first.
+    /// See [`crate::pipeline::resolve_stage_candidates`].
+    pub fallbacks: Vec<leviath_core::blueprint::ModelEntry>,
 }
 
 /// Fallback context window used when a stage's provider isn't registered (so
@@ -1429,6 +1432,7 @@ pub fn spawn_agent_seeded(
             model: rs.model,
             tools: rs.tools,
             tool_filter: None, // tools already resolved to the effective set
+            fallbacks: rs.fallbacks,
         })
         .collect();
     let agent_batch_tool_hint = blueprint.batch_tool_hint;

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -313,6 +313,7 @@ mod tests {
             model: model.to_string(),
             tools: vec![],
             tool_filter: None,
+            fallbacks: Vec::new(),
         }
     }
 

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1122,6 +1122,7 @@ mod tests {
                 })
                 .collect(),
             tool_filter: None,
+            fallbacks: Vec::new(),
         }
     }
 
@@ -1748,6 +1749,7 @@ mod tests {
                     provider_name: "script".to_string(),
                     model: "m".to_string(),
                     tools: vec![],
+                    fallbacks: Vec::new(),
                 }],
                 true,
             )
@@ -2254,6 +2256,7 @@ mod tests {
                 provider_name: "script".to_string(),
                 model: "m".to_string(),
                 tools: vec![],
+                fallbacks: Vec::new(),
             }],
             true,
         );

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -322,7 +322,12 @@ impl PipelineWorld {
                 // so a newly-discovered tool is visible.
                 poll_dynamic_tool_refresh,
                 refresh_advertised_tools,
-                dispatch_inference,
+                // Move ready agents off any provider whose circuit is open, so
+                // dispatch only ever considers one still in service. Serial,
+                // because it needs `&mut StageInference` and dispatch fans out.
+                // Nested rather than inline: the outer tuple is at bevy's
+                // 20-system limit for `.chain()`.
+                (crate::pipeline::rotate_open_circuits, dispatch_inference).chain(),
                 collect_inference,
                 // Intercept a fan-out stage's split response before normal routing.
                 crate::fanout::fan_out_split,

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -541,6 +541,25 @@ impl PipelineWorld {
     /// on: agents by status, per-model inference-pool occupancy, and tool-lane
     /// occupancy.
     ///
+    /// Providers currently taken out of service by their circuit breaker.
+    ///
+    /// Empty when the breaker is not installed, so an embedded world that never
+    /// inserted the resource simply reports nothing wrong (issue #201).
+    pub fn open_circuits(&self) -> Vec<crate::pipeline::ProviderCircuitState> {
+        let Some(circuits) = self
+            .world
+            .get_resource::<crate::pipeline::ProviderCircuits>()
+        else {
+            return Vec::new();
+        };
+        let policy = self
+            .world
+            .get_resource::<crate::pipeline::CircuitPolicy>()
+            .copied()
+            .unwrap_or_default();
+        circuits.open_circuits(chrono::Utc::now().timestamp(), &policy)
+    }
+
     /// This is the answer to "the daemon has been quiet for hours - is anything
     /// actually running?", which issue #189 had no way to ask.
     pub fn lane_snapshot(&self) -> LaneSnapshot {
@@ -1192,6 +1211,60 @@ mod tests {
             None,
             Handle::current(),
         )
+    }
+
+    #[tokio::test]
+    async fn open_circuits_reports_nothing_without_the_breaker() {
+        // An embedded world that never installed the resource must report a
+        // clean bill of health rather than panicking on a missing resource.
+        let world = build_world(ProviderRegistry::new());
+        assert!(world.open_circuits().is_empty());
+    }
+
+    #[tokio::test]
+    async fn open_circuits_reports_a_tripped_provider() {
+        let mut world = build_world(ProviderRegistry::new());
+        let policy = crate::pipeline::CircuitPolicy {
+            failures_before_open: 1,
+            cooldown_secs: 300,
+        };
+        let mut circuits = crate::pipeline::ProviderCircuits::default();
+        circuits.record_failure(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+            chrono::Utc::now().timestamp(),
+            &policy,
+        );
+        world.world_mut().insert_resource(circuits);
+        world.world_mut().insert_resource(policy);
+
+        let open = world.open_circuits();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].provider, "openrouter");
+        assert_eq!(
+            open[0].reason,
+            leviath_providers::UnavailableReason::CreditsExhausted
+        );
+    }
+
+    #[tokio::test]
+    async fn open_circuits_falls_back_to_the_default_policy() {
+        // Circuits installed, policy not: the default must apply rather than
+        // the report silently coming back empty.
+        let mut world = build_world(ProviderRegistry::new());
+        let default_policy = crate::pipeline::CircuitPolicy::default();
+        let mut circuits = crate::pipeline::ProviderCircuits::default();
+        for _ in 0..default_policy.failures_before_open {
+            circuits.record_failure(
+                "openrouter",
+                leviath_providers::UnavailableReason::AuthFailed,
+                chrono::Utc::now().timestamp(),
+                &default_policy,
+            );
+        }
+        world.world_mut().insert_resource(circuits);
+
+        assert_eq!(world.open_circuits().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/leviath-telemetry/src/log_sink.rs
+++ b/crates/leviath-telemetry/src/log_sink.rs
@@ -7,7 +7,7 @@
 //! the same reason this is hand-rolled rather than `opentelemetry-stdout`,
 //! which writes to stdout unconditionally.)
 
-use leviath_core::telemetry::{LaneHealth, LogKind, TelemetryEvent, TelemetrySink};
+use leviath_core::telemetry::{LaneHealth, LogKind, ProviderHealth, TelemetryEvent, TelemetrySink};
 
 /// One readable line for an event.
 pub(crate) fn format_event(event: &TelemetryEvent) -> String {
@@ -112,6 +112,27 @@ pub(crate) fn format_lane_health(health: &LaneHealth) -> String {
     )
 }
 
+/// One readable line for the providers currently out of service.
+///
+/// `None` while everything is serving, so a healthy daemon does not narrate a
+/// line saying nothing is wrong on every re-drive.
+pub(crate) fn format_providers_down(down: &[ProviderHealth]) -> Option<String> {
+    if down.is_empty() {
+        return None;
+    }
+    let each = down
+        .iter()
+        .map(|p| {
+            format!(
+                "{} ({}, {} failures, retry in {}s)",
+                p.provider, p.reason, p.consecutive_failures, p.retry_in_secs
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("providers out of service: {each}"))
+}
+
 /// [`TelemetrySink`] that narrates events as `tracing` lines (→ stderr).
 pub struct LogSink;
 
@@ -122,6 +143,12 @@ impl TelemetrySink for LogSink {
 
     fn observe_lanes(&self, health: LaneHealth) {
         tracing::info!(target: "leviath::telemetry", "{}", format_lane_health(&health));
+    }
+
+    fn observe_providers(&self, down: &[ProviderHealth]) {
+        if let Some(line) = format_providers_down(down) {
+            tracing::warn!(target: "leviath::telemetry", "{line}");
+        }
     }
 }
 
@@ -328,5 +355,49 @@ mod tests {
     fn observe_lanes_routes_through_tracing_without_panicking() {
         let _guard = leviath_testkit::tracing_guard();
         LogSink.observe_lanes(LaneHealth::default());
+    }
+
+    #[test]
+    fn providers_down_formats_to_one_line() {
+        let line = format_providers_down(&[
+            ProviderHealth {
+                provider: "openrouter".to_string(),
+                reason: "credits-exhausted".to_string(),
+                consecutive_failures: 3,
+                retry_in_secs: 240,
+            },
+            ProviderHealth {
+                provider: "anthropic".to_string(),
+                reason: "auth-failed".to_string(),
+                consecutive_failures: 5,
+                retry_in_secs: 30,
+            },
+        ])
+        .expect("something is down");
+        assert_eq!(
+            line,
+            "providers out of service: openrouter (credits-exhausted, 3 failures, retry in 240s), \
+             anthropic (auth-failed, 5 failures, retry in 30s)"
+        );
+        assert!(!line.contains('\n'), "one line: {line}");
+    }
+
+    /// A healthy daemon must not narrate "nothing is wrong" every 30 seconds.
+    #[test]
+    fn nothing_down_is_no_line_at_all() {
+        assert_eq!(format_providers_down(&[]), None);
+        let _guard = leviath_testkit::tracing_guard();
+        LogSink.observe_providers(&[]);
+    }
+
+    #[test]
+    fn observe_providers_routes_through_tracing_without_panicking() {
+        let _guard = leviath_testkit::tracing_guard();
+        LogSink.observe_providers(&[ProviderHealth {
+            provider: "openrouter".to_string(),
+            reason: "credits-exhausted".to_string(),
+            consecutive_failures: 3,
+            retry_in_secs: 240,
+        }]);
     }
 }

--- a/crates/leviath-telemetry/src/otel.rs
+++ b/crates/leviath-telemetry/src/otel.rs
@@ -9,12 +9,12 @@
 //! parented to the open stage. A daemon crash loses whatever was open;
 //! recovered runs start a fresh trace tagged `leviath.recovered = true`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use leviath_core::config::ObservabilityConfig;
-use leviath_core::telemetry::{LaneHealth, LogKind, TelemetryEvent, TelemetrySink};
+use leviath_core::telemetry::{LaneHealth, LogKind, ProviderHealth, TelemetryEvent, TelemetrySink};
 use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter};
 use opentelemetry::trace::{
@@ -117,6 +117,7 @@ struct Instruments {
     /// rather than plain counters because these go both ways, and the sink adds
     /// the delta from the previous sample so a scrape reads the current value.
     lane: LaneInstruments,
+    providers: ProviderInstruments,
 }
 
 /// The daemon-wide instruments, kept together because they share the
@@ -191,6 +192,58 @@ impl LaneInstruments {
     }
 }
 
+/// Providers taken out of service by their circuit breaker (issue #201).
+///
+/// Per-provider levels rather than one total, because "which provider is down"
+/// is the whole question an operator has; a bare count answers none of it.
+struct ProviderInstruments {
+    open: UpDownCounter<i64>,
+    opened: Counter<u64>,
+    /// Which providers were reported open last sample, so each can be turned
+    /// into a delta the same way [`LaneInstruments`] does.
+    last: Mutex<HashSet<String>>,
+}
+
+impl ProviderInstruments {
+    fn new(meter: &Meter) -> Self {
+        Self {
+            open: meter
+                .i64_up_down_counter("leviath.provider.circuit.open")
+                .with_description("Providers currently out of service, by provider")
+                .build(),
+            opened: meter
+                .u64_counter("leviath.provider.circuit.opened.total")
+                .with_description("Times a provider's circuit has opened, by provider and reason")
+                .build(),
+            last: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn record(&self, down: &[ProviderHealth]) {
+        let now: HashSet<String> = down.iter().map(|p| p.provider.clone()).collect();
+        let mut last = self.last.lock().expect("telemetry provider level lock");
+        for p in down {
+            let attrs = [KeyValue::new("leviath.provider", p.provider.clone())];
+            if !last.contains(&p.provider) {
+                self.open.add(1, &attrs);
+                self.opened.add(
+                    1,
+                    &[
+                        KeyValue::new("leviath.provider", p.provider.clone()),
+                        KeyValue::new("leviath.reason", p.reason.clone()),
+                    ],
+                );
+            }
+        }
+        // Anything that was open and is not any more came back.
+        for provider in last.difference(&now) {
+            self.open
+                .add(-1, &[KeyValue::new("leviath.provider", provider.clone())]);
+        }
+        *last = now;
+    }
+}
+
 impl Instruments {
     fn new(meter: &Meter) -> Self {
         Self {
@@ -227,6 +280,7 @@ impl Instruments {
                 )
                 .build(),
             lane: LaneInstruments::new(meter),
+            providers: ProviderInstruments::new(meter),
         }
     }
 }
@@ -650,6 +704,10 @@ impl TelemetrySink for OtelSink {
         self.instruments.lane.record(&health);
     }
 
+    fn observe_providers(&self, down: &[ProviderHealth]) {
+        self.instruments.providers.record(down);
+    }
+
     fn force_flush(&self) {
         let _ = self.tracer_provider.force_flush();
         let _ = self.meter_provider.force_flush();
@@ -1070,6 +1128,68 @@ mod tests {
         ] {
             assert!(names.contains(&expected.to_string()), "{names:?}");
         }
+    }
+
+    fn down(provider: &str, reason: &str) -> ProviderHealth {
+        ProviderHealth {
+            provider: provider.to_string(),
+            reason: reason.to_string(),
+            consecutive_failures: 3,
+            retry_in_secs: 240,
+        }
+    }
+
+    #[test]
+    fn provider_circuit_samples_export() {
+        let h = harness();
+        h.sink
+            .observe_providers(&[down("openrouter", "credits-exhausted")]);
+        h.sink.observe_providers(&[]);
+        h.sink.force_flush();
+
+        let exported = h.metrics.get_finished_metrics().unwrap();
+        let names: Vec<String> = exported
+            .iter()
+            .flat_map(|rm| rm.scope_metrics())
+            .flat_map(|sm| sm.metrics())
+            .map(|m| m.name().to_string())
+            .collect();
+        for expected in [
+            "leviath.provider.circuit.open",
+            "leviath.provider.circuit.opened.total",
+        ] {
+            assert!(names.contains(&expected.to_string()), "{names:?}");
+        }
+    }
+
+    /// The level arithmetic on its own. The gauge must go back down when a
+    /// provider recovers, or a topped-up account reads as still broken.
+    #[test]
+    fn a_provider_that_recovers_brings_the_gauge_back_down() {
+        let meter = SdkMeterProvider::builder().build().meter("test");
+        let providers = ProviderInstruments::new(&meter);
+        let open = |p: &ProviderInstruments| p.last.lock().unwrap().clone();
+
+        providers.record(&[down("openrouter", "credits-exhausted")]);
+        assert_eq!(open(&providers).len(), 1);
+
+        // Still down, plus a second one. Re-reporting the first must not count
+        // it as newly opened.
+        providers.record(&[
+            down("openrouter", "credits-exhausted"),
+            down("anthropic", "auth-failed"),
+        ]);
+        assert_eq!(open(&providers).len(), 2);
+
+        // One recovers.
+        providers.record(&[down("anthropic", "auth-failed")]);
+        let still = open(&providers);
+        assert_eq!(still.len(), 1);
+        assert!(still.contains("anthropic"));
+
+        // Everything recovers.
+        providers.record(&[]);
+        assert!(open(&providers).is_empty());
     }
 
     /// The delta arithmetic on its own, where the numbers are readable.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -55,10 +55,17 @@ google_api_key      = "..."          # env fallback: GOOGLE_API_KEY
 claude_code_enabled = false          # opt in to the Claude Code CLI transport
 claude_code_binary  = "/usr/local/bin/claude"   # unset resolves `claude` on PATH
 claude_code_effort  = "medium"       # low | medium | high | xhigh | max
+fallback_order      = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
 ```
 
 `claude_code_enabled` is off unless you turn it on. See
 [Providers](/docs/providers#claude-code-transport) for the terms note that goes with it.
+
+`fallback_order` is where a run goes when the provider it is using stops being usable: out of
+credits, or a rejected key. Entries are `provider/model` pairs, best first, tried after the stage's
+own model list and your default model. One naming a provider you have not configured is skipped.
+It is read per run, so a change takes effect on the next `lev run` with no restart. See
+[Providers](/docs/providers#a-host-wide-fallback-chain).
 
 ## `[limits]`
 
@@ -73,6 +80,8 @@ stall_timeout_secs        = 60   # fail a run that can never dispatch
 dead_cycles_before_relief = 10   # widen the tool lane after this long going nowhere
 finished_retention_secs   = 300  # keep a finished run in `lev ps` this long
 wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is off
+provider_failures_before_open  = 3     # pull a provider after this many failures in a row
+provider_circuit_cooldown_secs = 300   # how long before it is tried again
 ```
 
 | Key | Default | Notes |
@@ -86,6 +95,8 @@ wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is o
 | `dead_cycles_before_relief` | `10` | How many consecutive 30-second cycles the daemon may spend with a full tool lane and no run moving before it widens the lane. See [the tool lane](/docs/engine#the-tool-lane). `0` never widens it; the count is still reported either way |
 | `finished_retention_secs` | `300` | How long a run stays in [`lev ps`](/docs/cli#runs-that-have-finished) after it ends, so a script polling on an interval can see how it ended instead of finding it gone. `0` drops it as soon as it finishes. Held in memory, so a daemon restart clears it whatever this is set to |
 | `wedge_timeout_secs` | `0` (off) | How long a run may sit in a state no part of the engine can reach before it is failed instead of left reported as running. Never fires on a run that is merely slow: an agent waiting on the model, a tool, its sub-agents, or a person is exempt however long it takes. Off by default because it fails runs; `300` is a sensible value if something outside Leviath tracks your slots. See [reconciling an external work queue](/docs/daemon#reconciling-an-external-work-queue) |
+| `provider_failures_before_open` | `3` | Consecutive failures that only you can fix (out of credits, rejected key) before a provider is taken out of service for every run. Three rather than one because a single payment error can be one oversized request. `0` disables it, leaving per-run failover on its own |
+| `provider_circuit_cooldown_secs` | `300` | How long a provider stays out before one request is let through to see whether it recovered. A success puts it straight back; a failure restarts the wait. See [Providers](/docs/providers#when-a-provider-keeps-failing) |
 
 <a id="security"></a>
 

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -96,7 +96,10 @@ process-wide state once at startup rather than per run:
   `[security] allow_local_network` (the outbound-network policy)
 - `[limits] stall_timeout_secs`, `wedge_timeout_secs` and `dead_cycles_before_relief`, along with
   the other limits the world is built with (`max_concurrent_inferences`, `max_concurrent_tools`,
-  `exact_token_counting`)
+  `exact_token_counting`, `provider_failures_before_open`, `provider_circuit_cooldown_secs`)
+
+`[providers] fallback_order` is per-run policy, so it reloads with everything else in the first
+group. Adding a fallback provider takes effect on the next `lev run`.
 
 ## Control surface
 

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -61,6 +61,15 @@ the one number that separates a busy daemon from a wedged one, and it is worth
 alerting on: a healthy factory sits at zero, and anything sustained above it
 means work is arriving that nothing is getting to.
 
+On the same 30-second tick: `leviath.provider.circuit.open`, one per provider
+Leviath has stopped sending work to, and `leviath.provider.circuit.opened.total`
+counting each time one was pulled, attributed by `leviath.provider` and
+`leviath.reason` (`credits-exhausted`, `auth-failed`, `forbidden`). Alert on the
+first: it goes to zero on its own when the provider recovers, so a non-zero
+reading means somebody has to top up an account or fix a key. This is the signal
+that a drained account otherwise hides, because the runs it kills die before
+producing any per-run telemetry at all.
+
 **Logs.** Log records carry the run's trace ID, so a collector that joins the
 three signals can jump from a log line to the exact span that produced it.
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -35,6 +35,65 @@ flowchart LR
 
 This is why a blueprint written against Anthropic still runs for someone who only has OpenAI keys.
 
+The rest of the list is kept, not discarded. If the provider in use stops being usable partway
+through a run, the stage moves to the next entry and carries on rather than failing:
+
+```toml
+[[stages.analyze.model.models]]
+provider = "openrouter"
+model    = "deepseek/deepseek-v4-flash"
+
+[[stages.analyze.model.models]]
+provider = "anthropic"
+model    = "claude-sonnet-5"
+```
+
+"Stops being usable" means the account is out of credits, or the key was rejected or is not allowed
+to use that model. An ordinary bad request is not that, and never spends a fallback.
+
+## A host-wide fallback chain
+
+A stage that names a single model has nowhere to go on its own. Give the whole host somewhere to
+fall back to:
+
+```toml
+[providers]
+fallback_order = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
+```
+
+Entries are `provider/model` pairs, best first, and are tried after the stage's own list and your
+default model. A failover target needs a model to send, so a bare provider name is not enough. An
+entry naming a provider you have not configured is skipped, and a malformed one is ignored with a
+warning rather than stopping the daemon.
+
+This is read per run, so editing it takes effect on the next `lev run` with no restart.
+
+## When a provider keeps failing
+
+Failing over saves the run in front of you. It does nothing for the next one, which would start on
+the same dead provider and fail the same way. So Leviath counts consecutive failures per provider,
+and after a few takes it out of service for every run:
+
+```toml
+[limits]
+provider_failures_before_open  = 3    # consecutive failures before it is pulled
+provider_circuit_cooldown_secs = 300  # how long before it is tried again
+```
+
+Three rather than one because a single "payment required" can be one request asking for more output
+tokens than the balance covers, which a smaller request would survive. Three in a row is the
+account.
+
+While a provider is out, runs move to their next candidate. A run with none left is failed with an
+error saying so, rather than left sitting there looking healthy. Once the cooldown passes, the next
+request goes through as a probe: if it works the provider is back immediately, and if it fails the
+wait restarts. Topping up an account needs no restart.
+
+`lev ps` lists anything currently out of service under the table, with why and how long until it is
+retried. `lev ps --json` carries the same under `health.providers_down`, and the
+`leviath.provider.circuit.open` metric reports it per provider. Set `provider_failures_before_open`
+to `0` to switch the whole thing off and keep only per-run failover.
+
 ## Where credentials live
 
 Keys live in `~/.leviath/config.toml` by default, or (to keep them out of a plaintext file) in

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -56,6 +56,33 @@ there. That matters because a stage naming no model of its own falls back to `an
 machine with only an OpenRouter key can resolve to a provider it has no credential for, spawn, and
 sit at iteration 0.
 
+## Every run dies immediately with a payment or auth error
+
+The account behind that provider is out of credits, or its key was rejected. Every run starts,
+fails on its first request, and ends at iteration 0 with no tool calls.
+
+Run `lev ps`. A provider in this state is listed under the table with the reason and how long until
+it is tried again, and `lev ps --json` carries the same under `health.providers_down`. After a few
+failures in a row Leviath stops sending work there at all, so the flood of dead runs stops.
+
+To keep working through it, give the host somewhere else to go:
+
+```toml
+[providers]
+fallback_order = ["anthropic/claude-sonnet-5"]
+```
+
+Runs then move to that model instead of failing. This is read per run, so it takes effect on the
+next `lev run` without a restart, and so does topping the original account back up. See
+[Providers](/docs/providers#when-a-provider-keeps-failing) for the thresholds.
+
+A run that has nowhere left to go is failed after `[limits] stall_timeout_secs` with a message
+saying every provider it could use is out of service, rather than being left to sit there.
+
+If the runs are failing on the very first request and you are not sure the credential is the
+problem at all, `lev doctor` checks the provider wiring layer by layer and names the first one that
+breaks.
+
 ## A run says `running` but never does anything
 
 Check its provider first, with `lev doctor`. If a stage's model list names only providers you


### PR DESCRIPTION
## What & why

Fixes #201.

A `402` from OpenRouter took every agent down and left nothing behind that said why. Three separate things were wrong, and all three are fixed here.

**Nothing to branch on.** `check_http_response` flattened every non-429, non-2xx response into `ProviderError::ApiError` carrying the raw JSON body, so the runtime could not tell an empty account from a typo in a request, and each run died with the blob as its status. There is now an `Unavailable { reason, detail }` variant, classified in one shared helper: 402/401/403 by status, plus a body scan for the cases that arrive under an innocent status (Anthropic reports a drained balance as a **400** saying "credit balance is too low"). The message leads with what to do; the provider's response stays in `detail` for the logs.

**The advertised fallback was selection-time only.** A stage's ordered `models` list was consulted once, at spawn, to pick the first provider with a key. The rest was discarded, so a provider that was configured but unusable got chosen and then never abandoned. The whole list is kept now: `collect_inference` swaps the stage to the next candidate and goes back to `ReadyToInfer` instead of `Errored`. An ordinary error still cannot spend a fallback, and an exhausted chain terminates as before, now with a readable message.

**One dead provider, N dead runs.** Failing over rescues the run in front of you; the next one starts on the same dead provider and rediscovers it. That is the reported shape: ten consecutive workers, all dead at iteration 0. Provider-fatal failures are now counted per provider, and past a threshold no run is dispatched there at all.

Also here: a host-wide `[providers] fallback_order`, because the reporter's stages each named a single model and had nowhere to go; and the state is surfaced in `lev ps`, `lev ps --json`, and two new metrics, since a breaker nobody can see is not much better than the silent failures it replaces.

### Notes on the design

- **No half-open state.** `is_open` stops answering true once the cooldown elapses, so the next dispatch *is* the probe: it either succeeds and closes the circuit or fails and restarts the wait. Topping up an account brings the factory back with no restart.
- **`rotate_open_circuits` is deliberately serial.** `dispatch_inference` fans out over `par_iter` and cannot take the `&mut StageInference` a swap needs.
- **A run with every candidate down parks and is then failed** by the existing `stall_timeout_secs` watchdog, rather than sitting there looking healthy. That was the failure mode #190 and #191 were about.
- **The fallback tail is filtered to registered providers; the head deliberately is not**, so `resolve_stages` still reports "no usable provider" against a name the user wrote. An unregistered entry in the *tail* would be a phantom target that parks the run.
- Threshold defaults to 3, not 1: a single payment error can be one request asking for more output tokens than the balance covers.

Two smaller fixes fell out: Anthropic and Ollama now classify through the same shared path instead of hand-rolling it (which also fixes `list_models` reporting a rejected key as a *retryable* request failure, and gives Ollama the 429 handling it never had), and a Rhai script provider's `api` error classifies like a built-in one.

For the record, `pid=0` in the report is normal for every daemon-hosted run, not a symptom, and `tool_calls=0` just means the run died before its first call.

The issue's only comment is promotional spam from a bot account and was disregarded.

## How it was tested

CI-green is not evidence a behavior change works, so this was driven end to end against a real daemon with two Rhai mock providers: one that always throws the exact 402 body from the issue, one that answers normally.

1. **Failover** — stage on the dead provider, healthy one in `fallback_order`. Run **completed** instead of dying, and the stage log recorded the swap:
   `[failover] deadpay/dead-1 is unusable (out of credits: top up the account, or lower max_tokens ... (HTTP 402 Payment Required: ...)); retrying on healthy/healthy-1`
2. **Breaker** — `fallback_order` removed, threshold 2. Two runs failed, the circuit opened, and `lev ps --json` reported `{"provider":"deadpay","reason":"credits_exhausted","consecutive_failures":2,"retry_in_secs":102}`. The table footer read `1 provider is out of service: deadpay (credits-exhausted, 2 failures) - retrying in 1m`.
3. **Parked run** — the second run, with nowhere to go, was failed by the watchdog with `every provider this stage can use is out of service (last was 'deadpay'), so this run has nowhere to go; check the account's credits and API key, or add another provider to [providers] fallback_order`.
4. **Recovery** — provider swapped to a working one, cooldown allowed to elapse, next run **completed on the original provider**, no daemon restart.

The live run found two things the unit tests had not, both fixed and covered here: the Rhai path bypassed the classifier entirely, and `lev ps` said only "no agents running" once the dead runs aged out, which reads as an idle daemon rather than one that cannot start anything.

Full workspace suite: **5666 passing**. `cargo xtask coverage` at 100% lines/functions/regions for all five touched crates (`leviath-core`, `leviath-providers`, `leviath-runtime`, `leviath-telemetry`, `leviath-cli`). Rebased onto current `main` (which moved a lot mid-flight, including #205 reshaping `format_runs`).

## Checklist

- [x] Tests added or updated
- [x] `cargo xtask coverage` passes for every touched crate
- [x] Docs updated (`providers.md`, `configuration.md`, `troubleshooting.md`, `observability.md`, `daemon.md`, `CHANGELOG.md`)
- [x] Verified against a running daemon, not only in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD7HE2iXnCK5JWJ8afSDNQ
