### PR TITLE
Lint every platform, and let a version bump be what ships

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,5 @@
 - [ ] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
 - [ ] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
 - [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
+- [ ] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
+- [ ] Version bumped only if this PR is meant to ship — merging a bump cuts an alpha release (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -15,26 +15,20 @@ permissions:
   contents: read
 
 jobs:
-  # Re-run all CI gates before building alpha
+  # The gate is CI itself, not a restatement of it. This job used to spell out
+  # its own build + test + clippy, and the two definitions drifted: it linted
+  # all three OSes while ci.yml's clippy job linted only ubuntu, so a
+  # `#[cfg(windows)]` lint failure that no PR could ever see took the nightly
+  # down. Calling the workflow means "green here" and "green on main" are the
+  # same statement by construction.
+  #
+  # Two jobs inside ci.yml self-handle being called from here: `guard-main-rs`
+  # is `if: github.event_name == 'pull_request'`, and the badge steps carry a
+  # `github.workflow == 'CI'` guard.
   gate:
-    name: Gate (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Build
-        run: cargo build --all-targets
-      - name: Test
-        run: cargo test
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+    name: Gate
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,20 +1,122 @@
 name: Alpha (Nightly)
 
 on:
+  # A release is something a maintainer decides, not something a clock
+  # decides. Bumping `[workspace.package] version` and merging that is the
+  # decision; this trigger is how it reaches the channel without waiting for
+  # the next cron. The path filter is only a prefilter - the workspace version
+  # lives nowhere but the root manifest, and `check-version` below is what
+  # actually rules on whether anything ships.
+  push:
+    branches: [main]
+    paths: ['Cargo.toml']
   schedule:
-    # Every day at 2am PST (9am UTC)
+    # Every day at 2am PST (9am UTC). Kept as a backstop: a bump that landed
+    # while Actions was down, or one whose push run was cancelled, still gets
+    # picked up the following morning.
     - cron: '0 9 * * *'
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Publish even if the version was not bumped
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+
+# A bump merged shortly before 09:00 UTC can put the push run and the cron run
+# in flight at once, and both would read the same pre-bump version off the
+# published alpha and both would publish. Serialising them fixes that without
+# a lock: the queued run starts fresh after the first finishes, re-reads the
+# now-updated alpha release, and skips itself.
+concurrency:
+  group: alpha-release
+  cancel-in-progress: false
 
 # Default to read-only; the release job elevates itself explicitly.
 permissions:
   contents: read
 
 jobs:
+  # Nothing below this job runs unless the workspace version at HEAD differs
+  # from the version the current alpha release was built at. That is the whole
+  # release trigger: a maintainer bumps `[workspace.package] version`, and the
+  # commit carrying that bump is the one that ships.
+  #
+  # The comparison reads the version out of a COMMIT, not out of a stored
+  # string, because every one of these workflows already does exactly that
+  # (beta and prod read `git show <sha>:Cargo.toml` to title their releases)
+  # and the `COMMIT_SHA` asset that names the commit is already published with
+  # every channel. Nothing new to write, nothing new to keep in sync.
+  #
+  # It fails OPEN. A missing release, a missing COMMIT_SHA, a commit that no
+  # longer resolves: any of those means "we cannot prove this was already
+  # released", and the safe answer to that is to publish, not to go quiet.
+  check-version:
+    name: Check for a version bump
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # `git show <alpha sha>:Cargo.toml` needs that commit present, and it
+          # can be many commits behind main by the time this runs.
+          fetch-depth: 0
+      - name: Compare HEAD's version against the published alpha
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$version' in Cargo.toml is not a valid semver version."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # One assignment, one write at the end: `skip` appearing twice in
+          # $GITHUB_OUTPUT would leave which value wins up to the runner.
+          skip=false
+
+          if [ "$FORCE" = "true" ]; then
+            echo "force=true: publishing $version regardless of the current alpha."
+          elif ! gh release view alpha --json tagName >/dev/null 2>&1; then
+            echo "No alpha release yet - publishing $version."
+          else
+            gh release download alpha --pattern COMMIT_SHA --dir /tmp/alpha/ 2>/dev/null || true
+            if [ ! -f /tmp/alpha/COMMIT_SHA ]; then
+              echo "The current alpha carries no COMMIT_SHA - cannot compare, publishing $version."
+            else
+              sha=$(cat /tmp/alpha/COMMIT_SHA)
+              # A release asset is writable by anyone who can write a release,
+              # and this value goes straight into `git show`. Pin its shape
+              # first, the same way beta.yml and prod.yml do.
+              if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+                echo "::error::COMMIT_SHA in the alpha release is not a 40-hex commit id."
+                exit 1
+              fi
+              prev=$(git show "$sha:Cargo.toml" 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+              if [ -z "$prev" ]; then
+                echo "No readable version at $sha - publishing $version."
+              elif [ "$version" = "$prev" ]; then
+                skip=true
+                echo "Alpha already shipped $version. Bump [workspace.package] version to"
+                echo "release again, or re-run this workflow manually with force=true."
+              else
+                echo "Version moved $prev -> $version. Publishing."
+              fi
+            fi
+          fi
+
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
   # The gate is CI itself, not a restatement of it. This job used to spell out
   # its own build + test + clippy, and the two definitions drifted: it linted
   # all three OSes while ci.yml's clippy job linted only ubuntu, so a
@@ -25,8 +127,14 @@ jobs:
   # Two jobs inside ci.yml self-handle being called from here: `guard-main-rs`
   # is `if: github.event_name == 'pull_request'`, and the badge steps carry a
   # `github.workflow == 'CI'` guard.
+  #
+  # Only `gate` needs the skip condition spelled out: `build` needs `gate`,
+  # `release` needs `build`, and `docs`/`bump-tap` need `release`, so a skipped
+  # gate takes the whole chain with it.
   gate:
     name: Gate
+    needs: check-version
+    if: needs.check-version.outputs.skip != 'true'
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -4,7 +4,12 @@ on:
   schedule:
     # Every Monday at 9am PST (4pm UTC)
     - cron: '0 16 * * 1'
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Promote even if the version was not bumped
+        type: boolean
+        default: false
 
 # Read-only by default; only the job that publishes a release elevates, matching
 # alpha.yml and prod.yml. A workflow-level `contents: write` grants it to every
@@ -34,6 +39,7 @@ jobs:
         id: alpha
         env:
           GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
         run: |
           # Get the alpha release
           alpha_info=$(gh release view alpha --json tagName,assets,body 2>/dev/null || echo "")
@@ -58,11 +64,41 @@ jobs:
             echo "sha_short=${sha:0:7}" >> $GITHUB_OUTPUT
             # Version at the promoted commit, for the release title. Same
             # extraction prod.yml applies to the beta SHA.
-            echo "version=$(git show "$sha:Cargo.toml" | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+            version=$(git show "$sha:Cargo.toml" | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
+            echo "version=$version" >> $GITHUB_OUTPUT
           else
             echo "No COMMIT_SHA in alpha release. Skipping."
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
+          fi
+
+          # A promotion has to have something to promote. Alpha is a rolling
+          # tag that gets republished whenever the version moves, so "is this
+          # alpha newer than what beta already carries" is the same question as
+          # "did the version change" - and the answer lives in the same place
+          # for both channels: the Cargo.toml of the commit each one names.
+          # Without this, every Monday republished beta from an alpha it had
+          # already promoted, churning the tag and the tap for nothing.
+          if [ "$FORCE" != "true" ]; then
+            gh release download beta --pattern "COMMIT_SHA" --dir /tmp/beta/ 2>/dev/null || true
+            if [ -f /tmp/beta/COMMIT_SHA ]; then
+              beta_sha=$(cat /tmp/beta/COMMIT_SHA)
+              if ! printf '%s' "$beta_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+                echo "ERROR: COMMIT_SHA in the beta release is not a 40-hex commit id."
+                exit 1
+              fi
+              beta_version=$(git show "$beta_sha:Cargo.toml" 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+              if [ "$version" = "$beta_version" ]; then
+                echo "Beta already carries $version. Nothing to promote."
+                echo "skip=true" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+              echo "Version moves $beta_version -> $version. Promoting."
+            else
+              echo "No comparable beta release - promoting $version."
+            fi
+          else
+            echo "force=true: promoting $version regardless of what beta carries."
           fi
 
           echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
   # The merge queue runs required checks against a temporary `merge_group` ref.
   # Without this trigger those checks never run, so queued PRs block forever.
   merge_group:
+  # The release workflows call this file instead of restating a gate of their
+  # own. alpha.yml used to hand-roll build + test + clippy, which drifted: its
+  # clippy ran on all three OSes while the `clippy` job below ran only on
+  # ubuntu, so a `#[cfg(windows)]` lint failure took down two nightly alphas
+  # while every PR stayed green. One definition, called from both places, is
+  # the only way that stays fixed.
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,8 +56,16 @@ jobs:
       # below: `job.status` reflects the real accumulated pass/fail state of
       # this job's steps so far, checked with `if: always()` so it runs
       # (and reports failure) even when the Test step above failed.
+      #
+      # `github.workflow == 'CI'` is what keeps a release run out of the
+      # badges. A called workflow inherits the CALLER's `github` context, so
+      # when alpha.yml runs this file off a push to main both `event_name`
+      # and `ref` still match and the badges would be republished from a
+      # release run. `github.workflow` resolves to the caller's name
+      # ("Alpha (Nightly)"), so it is the one thing that tells them apart.
+      # Same guard on every badge step below.
       - name: Publish test status badge
-        if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
@@ -66,7 +81,7 @@ jobs:
   test-badge:
     name: Publish combined test badge
     needs: [test]
-    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
     runs-on: ubuntu-latest
     steps:
       - name: Publish combined test status badge
@@ -79,9 +94,24 @@ jobs:
           message: ${{ needs.test.result == 'success' && 'passing' || 'failing' }}
           color: ${{ needs.test.result == 'success' && 'brightgreen' || 'red' }}
 
+  # Every OS, because a lint can only be reported for code the compiler
+  # actually builds. `#[cfg(windows)]` bodies, the `#[cfg(target_os =
+  # "macos")]` launchd plumbing, and the `#[cfg(not(any(macos, linux)))]`
+  # arms are each invisible to at least one of the three legs; running only
+  # ubuntu meant nothing outside the Linux configuration was ever linted.
+  #
+  # `--all-features` for the same reason one level up: `debug-http` code is
+  # off by default, so `--all-targets` alone never compiles it. The coverage
+  # jobs already build with `--all-features` (xtask/src/coverage.rs), and so
+  # does the pre-commit hook, so this only aligns CI with what was already
+  # being tested locally and measured.
   clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
+    name: Clippy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -90,7 +120,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   fmt:
     name: Format
@@ -236,7 +266,7 @@ jobs:
       - name: Confirm every package gated 100%
         run: echo "All packages gated at a hard 100% in the per-package coverage jobs."
       - name: Update lines coverage badge
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
@@ -246,7 +276,7 @@ jobs:
           message: 100%
           color: brightgreen
       - name: Update regions coverage badge
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
@@ -256,7 +286,7 @@ jobs:
           message: 100%
           color: brightgreen
       - name: Update functions coverage badge
-        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,7 +4,12 @@ on:
   schedule:
     # Every Thursday at 9am PST (4pm UTC)
     - cron: '0 16 * * 4'
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Deploy even if the version was not bumped
+        type: boolean
+        default: false
 
 # Default to read-only; only the deploy job needs to write releases.
 permissions:
@@ -28,6 +33,7 @@ jobs:
         id: beta
         env:
           GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
         run: |
           # Get the beta release
           beta_info=$(gh release view beta --json tagName 2>/dev/null || echo "")
@@ -57,6 +63,13 @@ jobs:
             exit 0
           fi
 
+          if [ "$FORCE" = "true" ]; then
+            echo "force=true: deploying $sha regardless of what stable carries."
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Check if this SHA was already released as prod
           current_prod_sha=""
           gh release download latest --pattern "COMMIT_SHA" --dir /tmp/prod/ 2>/dev/null || true
@@ -68,6 +81,28 @@ jobs:
             echo "Beta SHA matches current prod. Nothing new to deploy."
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
+          fi
+
+          # A different commit is not by itself a release. What makes a build
+          # worth cutting a permanent `vX.Y.Z` tag for is a deliberate version
+          # bump, and both channels record theirs the same way: in the
+          # Cargo.toml of the commit their COMMIT_SHA names. Without this,
+          # every Thursday shipped whatever beta happened to hold and fell back
+          # to a `+date` tag suffix to avoid colliding with a version that had
+          # already been released.
+          if [ -n "$current_prod_sha" ]; then
+            if ! printf '%s' "$current_prod_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "ERROR: COMMIT_SHA in the stable release is not a 40-hex commit id."
+              exit 1
+            fi
+            beta_version=$(git show "$sha:Cargo.toml" 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+            prod_version=$(git show "$current_prod_sha:Cargo.toml" 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
+            if [ -n "$prod_version" ] && [ "$beta_version" = "$prod_version" ]; then
+              echo "Stable already shipped $prod_version. Nothing new to deploy."
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "Version moves $prod_version -> $beta_version. Deploying."
           fi
 
           echo "skip=false" >> $GITHUB_OUTPUT
@@ -141,9 +176,11 @@ jobs:
             exit 1
           fi
           VERSION="v$BETA_VERSION"
-          # If the tag was already released (version not bumped since the
-          # last prod deploy), disambiguate with the date rather than
-          # moving the existing tag.
+          # `check-beta` now skips an un-bumped promotion outright, so in normal
+          # operation the tag cannot already exist. This is the fallback for the
+          # one case that still reaches here - a `force=true` re-deploy of a
+          # version already released - and it disambiguates with the date rather
+          # than moving an immutable tag.
           if gh api "repos/$REPO/git/refs/tags/$VERSION" >/dev/null 2>&1; then
             VERSION="${VERSION}+$(date -u +%Y%m%d)"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and the `lev` binary.
 Release binaries ship through the alpha, beta, and stable channels described
 in [the release docs](https://leviath.dev/docs/releases); each versioned
 GitHub release also carries auto-generated notes listing the merged pull
-requests since the previous version.
+requests since the previous version. A channel publishes only when the version
+below it has moved, so the headings here and the releases on GitHub are the
+same list.
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.1.2 - 2026-08-02
+
 - `lev run <agent>` with no `--task` now opens your editor on a commented
   template instead of refusing to start, so a task longer than a sentence no
   longer has to survive shell quoting. Saving an empty file cancels the run.
@@ -315,6 +317,13 @@ same list.
   interrupted result the model is told to verify first.
 - Completion webhooks now carry a stable delivery id, so a receiver can
   deduplicate retries of the same delivery.
+- Releases are cut by a version bump rather than by a schedule. Alpha now
+  publishes as soon as a commit bumping `[workspace.package] version` lands on
+  `main`, and beta and stable promote it on their usual weekly cadence; a
+  channel with nothing new finishes in seconds having published nothing. That
+  ends the nightly churn of rebuilding identical source and re-promoting an
+  already-promoted build, and with it the `vX.Y.Z+date` tags that existed only
+  to avoid colliding with a version already released.
 
 ## 0.1.1 - 2026-07-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,31 @@ cargo llvm-cov --package <crate> --lib --html --open   # browsable per-crate rep
 
 > Branch coverage isn't collected: `cargo llvm-cov --branch` reliably SIGSEGVs inside LLVM's own coverage-mapping code ([open upstream bug](https://github.com/llvm/llvm-project/issues/119558)). See the doc comment atop `xtask/src/coverage.rs` for the full investigation.
 
+## Cutting a release
+
+Releases are triggered by a version bump, not by a schedule. Merging a bump to
+`main` is what puts a build in front of users, so it is a deliberate, separate
+commit rather than something that rides along with a feature.
+
+Everything ships in lockstep — all `leviath-*` crates plus the `lev` binary
+carry one version — so a bump is three edits:
+
+1. `[workspace.package] version` in the root `Cargo.toml`.
+2. The eleven intra-workspace `version = "…"` pins in `[workspace.dependencies]`
+   just below it. `cargo publish` refuses a path dependency without a version,
+   and refuses one that disagrees with what is on crates.io, so these have to
+   move together with the line above.
+3. `cargo update --workspace` to bring `Cargo.lock` along. CI fails on a
+   lockfile that disagrees with the manifests.
+
+Then move `## Unreleased` in `CHANGELOG.md` under a `## X.Y.Z - YYYY-MM-DD`
+heading and open a fresh empty `## Unreleased` above it.
+
+Merging that fires the alpha release for the bump commit; beta promotes it the
+following Monday and stable the Thursday after. Channels with nothing new to
+publish skip in seconds. See
+[Releases and channels](https://leviath.dev/docs/releases) for the full picture.
+
 ## Regenerating the workflow diagrams
 
 The agent workflow SVGs in `docs/assets/agents/` are rendered from the Mermaid sources in `docs/assets/agents/src/`. See `docs/assets/agents/src/README.md` for the render command and theme configs. If you change an agent's stage graph in `crates/leviath-cli/agents/<name>/agent.leviath`, update its `.mmd` source and re-render both the light and dark variants.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "keyring",
  "keyring-core",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tokio",
  "tracing",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -60,17 +60,17 @@ string_slice = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.1.1" }
-leviath-core = { path = "crates/leviath-core", version = "0.1.1" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.1.1" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.1.1" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.1.1" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.1.1" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.1.1" }
-leviath-package = { path = "crates/leviath-package", version = "0.1.1" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.1.1" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.1.1" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.1.1" }
+leviath = { path = "crates/leviath", version = "0.1.2" }
+leviath-core = { path = "crates/leviath-core", version = "0.1.2" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.1.2" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.1.2" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.1.2" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.1.2" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.1.2" }
+leviath-package = { path = "crates/leviath-package", version = "0.1.2" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.1.2" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.1.2" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.1.2" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -837,6 +837,7 @@ prompt = "Run"
         let mut locked = OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .share_mode(0)
             .open(&manifest_path)
             .unwrap();

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -15,16 +15,37 @@ through both earlier channels.
 
 | Channel | Cadence | GitHub release tag | What it is |
 |---|---|---|---|
-| alpha | nightly | `alpha` (rolling) | Last night's `main`, fresh from CI |
-| beta | weekly (Monday) | `beta` (rolling) | The alpha build that survived a week of nightlies |
+| alpha | on a version bump, checked nightly | `alpha` (rolling) | The commit that bumped the version, fresh from CI |
+| beta | weekly (Monday) | `beta` (rolling) | The alpha build that survived a week |
 | stable | weekly (Thursday, approval-gated) | `latest` (rolling) + `vX.Y.Z` (immutable) | The promoted beta |
+
+## What starts a release
+
+A version bump does. Nothing else. Bumping `[workspace.package] version` in
+the root `Cargo.toml` and merging that to `main` is the decision to ship, and
+the commit carrying the bump is the one that gets built.
+
+Alpha picks it up as soon as the merge lands, and re-checks every night in case
+it missed one. Beta and stable stay on their weekly cadence, but each one asks
+the same question before it does anything: is the version at the build I would
+publish different from the version at the build I last published? When the
+answer is no, the run finishes in seconds having touched nothing. A quiet
+Monday means there was nothing new to promote, not that something failed.
+
+So a bump merged on Tuesday is an alpha that day, a beta the following Monday,
+and stable the Thursday after that. A week with no bump publishes nothing on
+any channel.
 
 Rolling tags (`alpha`, `beta`, `latest`) are recreated on every publish and
 always point at the current build for that channel. Each stable deploy also
-cuts an immutable versioned release; if the version was not bumped since the
-last deploy, the tag gets a date suffix (`v0.1.0+20260731`) so history is
-never overwritten. Release titles follow the same scheme: `Leviath
-v0.1.0-Alpha`, `Leviath v0.1.0-Beta`, and `Leviath v0.1.0` for stable.
+cuts an immutable versioned release. Release titles follow the same scheme:
+`Leviath v0.1.2-Alpha`, `Leviath v0.1.2-Beta`, and `Leviath v0.1.2` for stable.
+
+Maintainers can re-cut a channel without a bump - to recover from an
+infrastructure failure, say - by running the workflow by hand with its `force`
+input. That is the only path that can land on a version already released, and
+the versioned tag gets a date suffix (`v0.1.2+20260802`) when it does, so an
+immutable tag is never moved.
 
 ## Installing a specific channel
 


### PR DESCRIPTION
## What & why

The nightly alpha died two nights running on a clippy error CI could not see. `ci.yml` linted `ubuntu-latest` alone; `alpha.yml` linted all three OSes. The failing code sits in a `#[cfg(windows)]` test, so main stayed green while the release broke.

Fixing the lint is one line. The rest of this PR is about the two problems it exposed:

**CI didn't require what the release required.** Clippy is now a three-OS matrix, with `--all-features` so the `debug-http` code gets linted too — the coverage jobs and the pre-commit hook already built with it, so CI was the odd one out. And `alpha.yml` no longer restates the gate at all: it calls `ci.yml`, so the two cannot drift again.

**Releases fired on a clock, not on a decision.** Alpha rebuilt identical source nightly, beta re-promoted an alpha it had already promoted, and prod cut `vX.Y.Z+date` tags precisely because the version it was shipping had already been released. Each channel now compares the version at the commit it would ship against the version at the commit it last shipped, and goes quiet when they match. Both halves come from things that already existed: the `COMMIT_SHA` asset every channel publishes, and the `git show <sha>:Cargo.toml` read beta and prod already did to title their releases.

Alpha also grows a push trigger on the root manifest, so the bump commit ships immediately instead of waiting for 2am, with the cron as a backstop and a concurrency group so a bump landing just before 09:00 UTC cannot publish twice. All three workflows get a `force` dispatch input — without one, an infrastructure failure was unrecoverable short of a fake bump.

Last commit bumps to 0.1.2, which is what puts the accumulated `## Unreleased` work in front of users.

## How it was tested

Both paths run live against this branch before merging:

- [`30758750286`](https://github.com/GEMISIS/leviath/actions/runs/30758750286) — dispatched with the branch still at `0.1.1`. `check-version` reported `Alpha already shipped 0.1.1`, every downstream job skipped, no release touched. 13 seconds.
- [`30758794238`](https://github.com/GEMISIS/leviath/actions/runs/30758794238) — same branch, `force=true`. Proceeded into `Gate`, which ran the whole of `ci.yml` as a called workflow: `Clippy (ubuntu-latest)`, `Clippy (macos-latest)` and `Clippy (windows-latest)` all green, confirming the `.truncate(true)` fix was the only Windows lint error and that `--all-features` introduces none. Cancelled before it could publish an alpha off a branch.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [x] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [x] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
- [x] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
- [x] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
- [x] Version bumped only if this PR is meant to ship — merging a bump cuts an alpha release

> [!IMPORTANT]
> The required status check named `Clippy` no longer exists — the matrix reports `Clippy (ubuntu-latest)`, `Clippy (macos-latest)` and `Clippy (windows-latest)`. The branch ruleset has to be updated before this can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA33qJT7AypuNZH6xn3a1a