### PR TITLE
Take only the platform archives into the alpha release

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -266,18 +266,35 @@ jobs:
           # For the release title. Same line-anchored extraction prod.yml uses.
           echo "version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
 
-      - name: Download all artifacts
+      # Only the platform archives the `build` matrix uploaded. Unfiltered,
+      # this pulls every artifact in the run - and since the gate became a call
+      # to ci.yml, that includes the 33 `coverage-html-*` reports the coverage
+      # matrix uploads. `Prepare release files` below expects each directory to
+      # hold one file named after it, so a coverage directory made it fail.
+      - name: Download the platform archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts/
+          pattern: leviath-*
 
       - name: Prepare release files
         run: |
+          set -euo pipefail
           mkdir -p release/
           for dir in artifacts/*/; do
             name=$(basename "$dir")
             cp "$dir/$name" "release/$name"
           done
+          # A pattern that matches nothing leaves an empty release/, and a
+          # channel release carrying no binaries is worse than no release at
+          # all - the install script and both taps would resolve it and find
+          # nothing to download. Count what arrived against the build matrix.
+          found=$(find release -type f | wc -l)
+          if [ "$found" -ne 5 ]; then
+            echo "::error::expected 5 platform archives, found $found:"
+            ls -la release/
+            exit 1
+          fi
           # Generate checksums
           cd release && sha256sum * > SHA256SUMS
           # Write the commit SHA for downstream promotion


### PR DESCRIPTION
## What & why

The 0.1.2 alpha built all five targets and then failed on `Prepare release files` ([run 30759470557](https://github.com/GEMISIS/leviath/actions/runs/30759470557)).

Making the release gate a call to `ci.yml` also put `ci.yml`'s artifacts in the alpha run, and the coverage matrix uploads 33 `coverage-html-<os>-<pkg>` reports. `Download all artifacts` had no filter, so `artifacts/` ended up holding those alongside the five platform archives — and the loop below it expects every directory to contain one file named after the directory. The first coverage directory failed the `cp`.

Filtering the download to `leviath-*` is the fix.

The count check after it guards the failure this could have had instead. `pattern` matching nothing would have left `release/` empty and published a channel release with no binaries in it, which the install script and both taps would resolve and find nothing behind.

## How it was tested

The failure is reproducible from the run above; the fix cannot be verified without a full alpha run, so the plan is to merge this and dispatch `alpha.yml` (the published alpha is still 0.1.1, so `check-version` will proceed without `force`).

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [x] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [x] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
- [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`) — CI-only change
- [ ] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible — not user-visible
- [ ] Version bumped only if this PR is meant to ship — 0.1.2 is already bumped and unreleased

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA33qJT7AypuNZH6xn3a1a