### PR TITLE
One command for the version, a label before it ships, and badges for what each channel carries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 - [ ] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
 - [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
 - [ ] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
-- [ ] Version bumped only if this PR is meant to ship — merging a bump cuts an alpha release (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))
+- [ ] Version bumped only if this PR is meant to ship — use `cargo xtask version <X.Y.Z>`, and apply the `allow-version-bump` label (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -359,6 +359,21 @@ jobs:
           prerelease: true
           files: release/*
 
+      # What the README badge reports for this channel. Published from here
+      # rather than read off the release by shields.io: shields can only ask for
+      # "newest release" or "newest prerelease", and alpha and beta are both
+      # prereleases on rolling tags, so it cannot tell them apart. This job
+      # already knows exactly what it just published.
+      - name: Update the alpha channel badge
+        uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: leviath-channel-alpha.json
+          label: alpha
+          message: ${{ steps.info.outputs.version }}
+          color: orange
+
   docs:
     name: Publish docs (alpha)
     needs: release
@@ -374,11 +389,17 @@ jobs:
 
   # See prod.yml for why the tap has to be told what shipped.
   #
-  # Alpha needs a per-build suffix that plain `X.Y.Z-alpha` cannot give it:
-  # nightly rebuilds carry the same Cargo version for days, so a constant
-  # string would leave every alpha user pinned to their first install until
-  # someone bumped Cargo.toml. The date makes it monotonic, and both Homebrew
-  # and Scoop order `0.1.1-alpha.20260802` after `0.1.1-alpha.20260801`.
+  # This used to append the build date - `0.1.1-alpha.20260802` - because alpha
+  # rebuilt the same source every night, so a constant `0.1.1-alpha` would have
+  # left every alpha user pinned to their first install until someone bumped
+  # Cargo.toml. `check-version` ended that: alpha only republishes when the
+  # workspace version moves, so plain `X.Y.Z-alpha` is already monotonic and
+  # both Homebrew and Scoop order `0.1.2-alpha` before `0.1.3-alpha`.
+  #
+  # The one thing lost with the date: a `force=true` republish of an unchanged
+  # version now writes an identical string and offers no upgrade. That is the
+  # right answer for the case force exists to serve - recovering from an
+  # infrastructure failure, where the source is the same either way.
   bump-tap:
     name: Bump tap manifests (alpha)
     needs: release
@@ -388,11 +409,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
-          DATE: ${{ needs.release.outputs.date }}
         run: |
           set -euo pipefail
-          jq -nc --arg version "$VERSION-alpha.$DATE" \
+          jq -nc --arg version "$VERSION-alpha" \
             '{event_type:"release-published",
               client_payload:{channel:"alpha", version:$version}}' \
             | gh api repos/GEMISIS/leviath-dist/dispatches --input -
-          echo "Asked leviath-dist to bump the alpha manifests to $VERSION-alpha.$DATE."
+          echo "Asked leviath-dist to bump the alpha manifests to $VERSION-alpha."

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -179,6 +179,20 @@ jobs:
           prerelease: true
           files: release/*
 
+      # See alpha.yml: the channel badges are published from the job that knows
+      # what it shipped, because shields.io cannot distinguish two prereleases
+      # on rolling tags.
+      - name: Update the beta channel badge
+        if: steps.alpha.outputs.skip != 'true'
+        uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: leviath-channel-beta.json
+          label: beta
+          message: ${{ steps.alpha.outputs.version }}
+          color: blue
+
   docs:
     name: Publish docs (beta)
     needs: promote

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,13 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          if git diff --name-only "$BASE" "$HEAD" | grep -qx 'crates/leviath-cli/src/main.rs'; then
+          # Three dots, so this asks "what did the PR change" rather than "how
+          # do these two trees differ". With two dots the diff also contains
+          # everything main gained since the branch point, so any PR would fail
+          # this the moment someone else's main.rs change landed on main first -
+          # and the fix looked like applying the override label to a PR that
+          # never touched the file.
+          if git diff --name-only "$BASE...$HEAD" | grep -qx 'crates/leviath-cli/src/main.rs'; then
             case ",$LABELS," in
               *,allow-main-rs-change,*)
                 echo "main.rs change approved via 'allow-main-rs-change' label." ;;
@@ -371,6 +377,52 @@ jobs:
           else
             echo "main.rs unchanged."
           fi
+
+  # Merging a version bump to main publishes an alpha within seconds, and a week
+  # later that same commit is a permanent `vX.Y.Z` tag and an immutable set of
+  # crates.io releases. That is a release decision, not a code change, so it gets
+  # the same deliberate sign-off main.rs does - via its own label, so approving a
+  # release never doubles as approving an entrypoint change.
+  #
+  # It compares the declared version rather than whether Cargo.toml was touched:
+  # dependency edits land in that file constantly and none of them ship anything.
+  guard-version-bump:
+    name: Guard release version bump
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Require maintainer override to bump the release version
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # The merge base, not the base branch tip: comparing against the tip
+          # would report a bump for every PR opened after someone else's release
+          # landed on main.
+          base=$(git merge-base "$BASE" "$HEAD")
+          read_version() {
+            git show "$1:Cargo.toml" | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || true
+          }
+          before=$(read_version "$base")
+          after=$(read_version "$HEAD")
+
+          if [ "$before" = "$after" ]; then
+            echo "Workspace version unchanged at $after."
+            exit 0
+          fi
+
+          case ",$LABELS," in
+            *,allow-version-bump,*)
+              echo "Release bump $before -> $after approved via 'allow-version-bump' label." ;;
+            *)
+              echo "::error file=Cargo.toml::This PR moves the workspace version $before -> $after, which cuts an alpha release the moment it merges and a permanent vX.Y.Z tag plus crates.io publishes on the following prod run. Apply the 'allow-version-bump' label to confirm that is intended."
+              exit 1 ;;
+          esac
 
   # `crates/leviath` is the re-export-only crates.io facade. It is exempt from
   # the 100% coverage gate because llvm-cov has no executable regions to count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,16 @@ jobs:
       - name: Verify Cargo.lock is up to date
         run: cargo metadata --locked --format-version 1 > /dev/null
 
+      # The same manifest, one level up: `[workspace.package] version` and the
+      # eleven `[workspace.dependencies]` pins that repeat it have to agree.
+      # A bump that moved only some of them is quiet within a `0.1.x` line -
+      # a stale `version = "0.1.2"` pin is a `^0.1.2` requirement that `0.1.3`
+      # satisfies, so it builds and publishes, just naming the wrong version -
+      # and only turns loud on a bump crossing the caret boundary, in the prod
+      # job, a week after the alpha shipped.
+      - name: Verify the version declarations agree
+        run: cargo xtask version --check
+
   # Rejects broken or private intra-doc links and stray HTML tags in doc
   # comments (`-D warnings` promotes every rustdoc lint to an error). Cheap and
   # OS-independent, so it runs once on ubuntu.

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -265,6 +265,19 @@ jobs:
           make_latest: false
           files: release/*
 
+      # See alpha.yml: the channel badges are published from the job that knows
+      # what it shipped, because shields.io cannot distinguish two prereleases
+      # on rolling tags.
+      - name: Update the stable channel badge
+        uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: leviath-channel-stable.json
+          label: stable
+          message: ${{ needs.check-beta.outputs.version }}
+          color: brightgreen
+
 
 
   # crates.io tracks the stable channel: same commit as the binaries, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,20 +101,28 @@ Releases are triggered by a version bump, not by a schedule. Merging a bump to
 commit rather than something that rides along with a feature.
 
 Everything ships in lockstep — all `leviath-*` crates plus the `lev` binary
-carry one version — so a bump is three edits:
+carry one version — so there is one command:
 
-1. `[workspace.package] version` in the root `Cargo.toml`.
-2. The eleven intra-workspace `version = "…"` pins in `[workspace.dependencies]`
-   just below it. `cargo publish` refuses a path dependency without a version,
-   and refuses one that disagrees with what is on crates.io, so these have to
-   move together with the line above.
-3. `cargo update --workspace` to bring `Cargo.lock` along. CI fails on a
-   lockfile that disagrees with the manifests.
+```bash
+cargo xtask version 0.1.3
+```
 
-Then move `## Unreleased` in `CHANGELOG.md` under a `## X.Y.Z - YYYY-MM-DD`
-heading and open a fresh empty `## Unreleased` above it.
+That writes `[workspace.package] version`, the eleven intra-workspace pins in
+`[workspace.dependencies]` just below it, and `Cargo.lock`, then moves
+`## Unreleased` in `CHANGELOG.md` under a dated `## 0.1.3` heading and opens a
+fresh empty one. The pins exist because `cargo publish` refuses a path
+dependency with no version requirement, and Cargo has no way to make those
+requirements inherit the workspace version — so they are written out, and they
+have to agree. `cargo xtask version --check` is the CI job that fails a
+hand-edit which moved only some of them.
 
-Merging that fires the alpha release for the bump commit; beta promotes it the
+Then write the changelog entries for what you are shipping, and open the PR.
+Because merging a bump publishes, CI requires the **`allow-version-bump`** label
+on any PR that moves the version — the same deliberate sign-off
+`allow-main-rs-change` asks for, with its own label so approving a release never
+doubles as approving an entrypoint change.
+
+Merging fires the alpha release for the bump commit; beta promotes it the
 following Monday and stable the Thursday after. Channels with nothing new to
 publish skip in seconds. See
 [Releases and channels](https://leviath.dev/docs/releases) for the full picture.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/GEMISIS/leviath/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-leviath.dev-8b5cf6)](https://leviath.dev)
 
+[![stable](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-channel-stable.json)](https://github.com/GEMISIS/leviath/releases/latest)
+[![beta](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-channel-beta.json)](https://github.com/GEMISIS/leviath/releases/tag/beta)
+[![alpha](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GEMISIS/b35e030175e78fad8e3562e58be21c60/raw/leviath-channel-alpha.json)](https://github.com/GEMISIS/leviath/releases/tag/alpha)
+
 **[Quick Start](#quick-start) · [Agents](#pre-built-agents) · [Features](#features) · [Dashboard](#dashboard) · [API](#api-server) · [Agent Client Protocol](#agent-client-protocol) · [Comparison](#how-it-compares) · [Why not Leviath](#why-you-might-not-want-leviath) · [Contributing](#contributing)**
 
 </div>

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,8 +5,11 @@
 //! Subcommands:
 //!   `coverage`                  Gate every workspace package at a hard 100%.
 //!   `coverage --package <pkg>`  Gate just one package (the CI per-package fan-out).
+//!   `version <X.Y.Z>`           Move the workspace version and roll the changelog.
+//!   `version --check`           Verify the version declarations agree (CI runs this).
 
 mod coverage;
+mod version;
 
 use anyhow::Result;
 
@@ -19,16 +22,17 @@ fn main() -> Result<()> {
 ///
 /// Extracted from `main` so it can be unit-tested without spawning processes.
 pub fn dispatch(args: &[String]) -> Result<()> {
-    dispatch_with(args, coverage::run)
+    dispatch_with(args, coverage::run, version::run)
 }
 
-/// Route the CLI arguments to the provided handler closure.
+/// Route the CLI arguments to the provided handler closures.
 ///
-/// `run_cov` replaces the real `coverage::run` in unit tests, making every
-/// match arm reachable without invoking external tooling.
+/// `run_cov` and `run_ver` replace the real handlers in unit tests, making
+/// every match arm reachable without invoking external tooling.
 pub fn dispatch_with(
     args: &[String],
     run_cov: impl FnOnce(coverage::CoverageMode) -> Result<()>,
+    run_ver: impl FnOnce(version::VersionMode) -> Result<()>,
 ) -> Result<()> {
     let subcommand = args.first().map(String::as_str).unwrap_or("help");
     match subcommand {
@@ -36,12 +40,18 @@ pub fn dispatch_with(
             let mode = coverage::CoverageMode::parse(&args[1..])?;
             run_cov(mode)
         }
+        "version" => {
+            let mode = version::VersionMode::parse(&args[1..])?;
+            run_ver(mode)
+        }
         "help" | "--help" | "-h" => {
             println!("Usage: cargo xtask <subcommand>");
             println!();
             println!("Subcommands:");
             println!("  coverage                  Gate every workspace package at 100%%");
             println!("  coverage --package <pkg>  Gate one package (CI per-package fan-out)");
+            println!("  version <X.Y.Z>           Move the workspace version, roll the changelog");
+            println!("  version --check           Verify the version declarations agree");
             Ok(())
         }
         other => anyhow::bail!("Unknown subcommand: '{other}'. Run `cargo xtask help` for usage."),
@@ -52,6 +62,7 @@ pub fn dispatch_with(
 mod tests {
     use super::*;
     use coverage::CoverageMode;
+    use version::VersionMode;
 
     // ── Named stub function ─────────────────────────────────────────────────────
     //
@@ -65,11 +76,17 @@ mod tests {
         Ok(())
     }
 
+    /// A `run_ver` stub matching `impl FnOnce(VersionMode) -> Result<()>`.
+    fn ver_ok(_mode: VersionMode) -> Result<()> {
+        Ok(())
+    }
+
     /// Covers the stub body so tests that pass it without calling it still get
     /// this single coverage hit.
     #[test]
     fn stub_returns_ok() {
         assert!(cov_ok(CoverageMode::All).is_ok());
+        assert!(ver_ok(VersionMode::Check).is_ok());
     }
 
     /// Build an owned-args slice from string literals (dispatch takes `&[String]`).
@@ -123,10 +140,14 @@ mod tests {
     #[test]
     fn dispatch_with_coverage_no_args_parses_all_and_calls_run_cov() {
         let mut got = None;
-        dispatch_with(&args(&["coverage"]), |mode| {
-            got = Some(mode);
-            Ok(())
-        })
+        dispatch_with(
+            &args(&["coverage"]),
+            |mode| {
+                got = Some(mode);
+                Ok(())
+            },
+            ver_ok,
+        )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::All));
     }
@@ -134,10 +155,14 @@ mod tests {
     #[test]
     fn dispatch_with_coverage_package_parses_package() {
         let mut got = None;
-        dispatch_with(&args(&["coverage", "--package", "leviath-core"]), |mode| {
-            got = Some(mode);
-            Ok(())
-        })
+        dispatch_with(
+            &args(&["coverage", "--package", "leviath-core"]),
+            |mode| {
+                got = Some(mode);
+                Ok(())
+            },
+            ver_ok,
+        )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::Package("leviath-core".to_owned())));
     }
@@ -148,6 +173,7 @@ mod tests {
         let result = dispatch_with(
             &args(&["coverage", "--bogus"]),
             cov_ok, // never called; covered by stub_returns_ok
+            ver_ok,
         );
         assert!(
             result.is_err(),
@@ -157,15 +183,63 @@ mod tests {
 
     #[test]
     fn dispatch_with_coverage_propagates_error() {
-        let result = dispatch_with(&args(&["coverage"]), |_mode| {
-            anyhow::bail!("simulated coverage failure")
-        });
+        let result = dispatch_with(
+            &args(&["coverage"]),
+            |_mode| anyhow::bail!("simulated coverage failure"),
+            ver_ok,
+        );
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
                 .contains("simulated coverage failure")
+        );
+    }
+
+    // ── version arm: mode parsing + dispatch ──────────────────────────────────
+
+    #[test]
+    fn dispatch_with_version_parses_the_target_version() {
+        let mut got = None;
+        dispatch_with(&args(&["version", "1.2.3"]), cov_ok, |mode| {
+            got = Some(mode);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(got, Some(VersionMode::Set("1.2.3".to_owned())));
+    }
+
+    #[test]
+    fn dispatch_with_version_check_parses_check() {
+        let mut got = None;
+        dispatch_with(&args(&["version", "--check"]), cov_ok, |mode| {
+            got = Some(mode);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(got, Some(VersionMode::Check));
+    }
+
+    #[test]
+    fn dispatch_with_version_bad_arg_returns_err_without_calling_run_ver() {
+        let result = dispatch_with(&args(&["version", "not-a-version"]), cov_ok, ver_ok);
+        assert!(
+            result.is_err(),
+            "a malformed version must error: {result:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_with_version_propagates_error() {
+        let result = dispatch_with(&args(&["version", "1.2.3"]), cov_ok, |_mode| {
+            anyhow::bail!("simulated version failure")
+        });
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("simulated version failure")
         );
     }
 }

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -1,0 +1,544 @@
+//! `cargo xtask version` - move the workspace version, or check it is coherent.
+//!
+//! A release is triggered by the workspace version moving, which makes the bump
+//! the single most consequential edit in the repo - and it is spread across
+//! twelve lines of the root manifest. `[workspace.package] version` is what
+//! every crate inherits, and the eleven `[workspace.dependencies]` entries each
+//! repeat it because `cargo publish` refuses a path dependency with no version
+//! requirement. Cargo offers no way to make those requirements inherit the
+//! workspace version, so they have to be written out, and they have to agree.
+//!
+//! Getting that wrong is quiet. Within a `0.1.x` line a stale `version =
+//! "0.1.2"` pin is a `^0.1.2` requirement that `0.1.3` satisfies, so everything
+//! builds and publishes - it just ships crates whose interdependencies name the
+//! previous version. It only turns loud on a bump that crosses the caret
+//! boundary (`0.1.x` to `0.2.0`), and by then the alpha shipped a week earlier.
+//!
+//! So: `set` writes all twelve at once, and `check` is the CI guard that fails
+//! a hand-edit which touched only some of them.
+
+use anyhow::{Context, Result};
+
+use crate::coverage::Runner;
+
+/// Path of the manifest holding every version declaration, relative to the
+/// workspace root.
+const MANIFEST: &str = "Cargo.toml";
+
+/// Path of the changelog whose `## Unreleased` heading a bump rolls over.
+const CHANGELOG: &str = "CHANGELOG.md";
+
+// ── CLI argument parsing ─────────────────────────────────────────────────────
+
+/// What `cargo xtask version` was asked to do.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VersionMode {
+    /// Rewrite every declaration to this version and roll the changelog.
+    Set(String),
+    /// Verify the declarations already agree. Changes nothing; CI runs this.
+    Check,
+}
+
+impl VersionMode {
+    /// Parse the arguments following `cargo xtask version`.
+    pub fn parse(args: &[String]) -> Result<Self> {
+        match args {
+            [] => anyhow::bail!("Usage: cargo xtask version <X.Y.Z> | cargo xtask version --check"),
+            [flag] if flag == "--check" => Ok(Self::Check),
+            [candidate] => {
+                validate_semver(candidate)?;
+                Ok(Self::Set(candidate.clone()))
+            }
+            _ => anyhow::bail!("cargo xtask version takes exactly one argument"),
+        }
+    }
+}
+
+/// Reject anything that is not a bare `X.Y.Z`.
+///
+/// Deliberately stricter than semver proper: the release workflows validate the
+/// version they read out of this manifest against the same shape before they
+/// tag with it, so a prerelease or build-metadata suffix written here would
+/// only fail later, in a release run.
+pub fn validate_semver(candidate: &str) -> Result<()> {
+    let parts: Vec<&str> = candidate.split('.').collect();
+    let well_formed = parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()));
+    anyhow::ensure!(
+        well_formed,
+        "'{candidate}' is not a bare X.Y.Z version (the release workflows reject anything else)"
+    );
+    Ok(())
+}
+
+// ── Reading what the manifest declares ───────────────────────────────────────
+
+/// The version `[workspace.package]` declares, which every crate inherits.
+///
+/// Found by the same line-anchored match the release workflows use, so what
+/// this reports and what a release tags with cannot diverge: only the
+/// workspace version sits at the start of a line, since a dependency entry
+/// always begins with the crate name.
+pub fn workspace_version(manifest: &str) -> Result<String> {
+    manifest
+        .lines()
+        .find_map(|line| line.strip_prefix("version = ").and_then(unquote))
+        .context("no `version = \"...\"` line in the root Cargo.toml")
+}
+
+/// Every intra-workspace path dependency that pins a version, as
+/// `(crate name, pinned version)`, in manifest order.
+///
+/// `leviath-testkit` is absent by design rather than by omission: it is
+/// path-only so cargo strips it when publishing, which is what keeps the
+/// testkit private to the repo. Having no version to pin, it has none to check.
+pub fn pinned_versions(manifest: &str) -> Vec<(String, String)> {
+    manifest
+        .lines()
+        .filter(|line| line.contains("path = \"crates/"))
+        .filter_map(|line| {
+            let name = line.split(" = ").next()?.trim();
+            let pinned = pin_of(line)?;
+            Some((name.to_owned(), pinned))
+        })
+        .collect()
+}
+
+/// The version a dependency line pins, if it pins one.
+fn pin_of(line: &str) -> Option<String> {
+    let (_, after) = line.split_once("version = ")?;
+    unquote(after)
+}
+
+/// The contents of the leading `"..."` of `text`.
+///
+/// Split rather than indexed: the workspace denies `clippy::string_slice`,
+/// because a byte range that lands mid-character panics.
+fn unquote(text: &str) -> Option<String> {
+    let rest = text.strip_prefix('"')?;
+    let (inner, _) = rest.split_once('"')?;
+    Some(inner.to_owned())
+}
+
+// ── Check ────────────────────────────────────────────────────────────────────
+
+/// Names of the dependencies whose pin disagrees with the workspace version.
+///
+/// Returned rather than reported so the caller owns the message and this stays
+/// a pure function over the manifest text.
+pub fn disagreeing_pins(manifest: &str) -> Result<Vec<String>> {
+    let expected = workspace_version(manifest)?;
+    Ok(pinned_versions(manifest)
+        .into_iter()
+        .filter(|(_, pinned)| *pinned != expected)
+        .map(|(name, pinned)| format!("{name} pins {pinned}"))
+        .collect())
+}
+
+// ── Set ──────────────────────────────────────────────────────────────────────
+
+/// Rewrite the workspace version and every intra-workspace pin to `new`.
+///
+/// Line-by-line rather than through a TOML round-trip on purpose: reserialising
+/// would reflow the comments that explain why each of these lines exists, and
+/// those comments are the only thing standing between a future reader and
+/// deleting the pins as redundant.
+pub fn set_versions(manifest: &str, new: &str) -> Result<String> {
+    validate_semver(new)?;
+    let mut rewrote_workspace = false;
+    let mut out: Vec<String> = Vec::with_capacity(manifest.lines().count());
+
+    for line in manifest.lines() {
+        if line.starts_with("version = ") && !rewrote_workspace {
+            rewrote_workspace = true;
+            out.push(format!("version = \"{new}\""));
+        } else if line.contains("path = \"crates/") && pin_of(line).is_some() {
+            out.push(replace_pin(line, new));
+        } else {
+            out.push(line.to_owned());
+        }
+    }
+
+    anyhow::ensure!(
+        rewrote_workspace,
+        "no `version = \"...\"` line in the root Cargo.toml"
+    );
+    let mut text = out.join("\n");
+    if manifest.ends_with('\n') {
+        text.push('\n');
+    }
+    Ok(text)
+}
+
+/// Swap the version a dependency line pins, leaving the rest of the line -
+/// path, features, trailing comment - exactly as it was.
+fn replace_pin(line: &str, new: &str) -> String {
+    let Some((before, after)) = line.split_once("version = \"") else {
+        return line.to_owned();
+    };
+    let Some((_, tail)) = after.split_once('"') else {
+        return line.to_owned();
+    };
+    format!("{before}version = \"{new}\"{tail}")
+}
+
+/// Roll `## Unreleased` under a dated heading and open a fresh empty one.
+///
+/// The entries themselves are left untouched: what was accumulating under
+/// `## Unreleased` is exactly what this version ships.
+pub fn roll_changelog(changelog: &str, version: &str, date: &str) -> Result<String> {
+    anyhow::ensure!(
+        changelog.contains("\n## Unreleased\n"),
+        "no `## Unreleased` heading in {CHANGELOG} - add one before bumping"
+    );
+    Ok(changelog.replacen(
+        "\n## Unreleased\n",
+        &format!("\n## Unreleased\n\n## {version} - {date}\n"),
+        1,
+    ))
+}
+
+// ── Dates ────────────────────────────────────────────────────────────────────
+
+/// Today in UTC as `YYYY-MM-DD`.
+pub fn today() -> String {
+    let days = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() / 86_400)
+        .unwrap_or(0) as i64;
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// The civil date `(year, month, day)` for a day number counted from the UNIX
+/// epoch, via Howard Hinnant's `civil_from_days`.
+///
+/// Arithmetic rather than a `date` subprocess or a calendar dependency, so the
+/// changelog heading is testable without a clock.
+pub fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let year = yoe + era * 400 + i64::from(month <= 2);
+    (year, month, day)
+}
+
+// ── Entry points ─────────────────────────────────────────────────────────────
+
+/// Real entry point: reads and writes the workspace files.
+pub fn run(mode: VersionMode) -> Result<()> {
+    run_with(&crate::coverage::RealRunner, mode)
+}
+
+/// Entry point with the subprocess runner injected, so tests can drive the
+/// `cargo update` step without spawning cargo.
+pub fn run_with(runner: &dyn Runner, mode: VersionMode) -> Result<()> {
+    let manifest = std::fs::read_to_string(MANIFEST)
+        .with_context(|| format!("reading {MANIFEST} - run this from the workspace root"))?;
+
+    match mode {
+        VersionMode::Check => {
+            let disagreeing = disagreeing_pins(&manifest)?;
+            if disagreeing.is_empty() {
+                println!(
+                    "Every intra-workspace pin matches [workspace.package] version {}.",
+                    workspace_version(&manifest)?
+                );
+                return Ok(());
+            }
+            anyhow::bail!(
+                "[workspace.package] version is {}, but {}. \
+                 Run `cargo xtask version <X.Y.Z>` rather than editing them by hand.",
+                workspace_version(&manifest)?,
+                disagreeing.join(", ")
+            )
+        }
+        VersionMode::Set(new) => {
+            let previous = workspace_version(&manifest)?;
+            std::fs::write(MANIFEST, set_versions(&manifest, &new)?)
+                .with_context(|| format!("writing {MANIFEST}"))?;
+
+            let changelog = std::fs::read_to_string(CHANGELOG)
+                .with_context(|| format!("reading {CHANGELOG}"))?;
+            std::fs::write(CHANGELOG, roll_changelog(&changelog, &new, &today())?)
+                .with_context(|| format!("writing {CHANGELOG}"))?;
+
+            // The lockfile records the workspace crates' own versions, and CI
+            // rejects a lockfile that disagrees with the manifests.
+            anyhow::ensure!(
+                runner.cargo(&["update", "--workspace"])?,
+                "cargo update --workspace failed; {MANIFEST} and {CHANGELOG} were still written"
+            );
+
+            println!("Version {previous} -> {new}.");
+            println!("Review the changes, then merging them to main cuts the alpha release.");
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A manifest shaped like the real root one: the workspace version at the
+    /// start of a line, intra-workspace pins, a path-only member, and
+    /// third-party entries that must never be rewritten.
+    const MANIFEST: &str = concat!(
+        "[workspace.package]\n",
+        "version = \"0.1.2\"\n",
+        "edition = \"2024\"\n",
+        "\n",
+        "[workspace.dependencies]\n",
+        "leviath = { path = \"crates/leviath\", version = \"0.1.2\" }\n",
+        "leviath-core = { path = \"crates/leviath-core\", version = \"0.1.2\" }\n",
+        "leviath-testkit = { path = \"crates/leviath-testkit\" }\n",
+        "serde = { version = \"1.0\", features = [\"derive\"] }\n",
+    );
+
+    // ── Argument parsing ──────────────────────────────────────────────────────
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn parse_no_args_explains_both_forms() {
+        let err = VersionMode::parse(&args(&[])).unwrap_err().to_string();
+        assert!(
+            err.contains("--check"),
+            "usage should mention --check: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_check_flag_selects_check() {
+        assert_eq!(
+            VersionMode::parse(&args(&["--check"])).unwrap(),
+            VersionMode::Check
+        );
+    }
+
+    #[test]
+    fn parse_version_selects_set() {
+        assert_eq!(
+            VersionMode::parse(&args(&["1.2.3"])).unwrap(),
+            VersionMode::Set("1.2.3".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_rejects_extra_arguments() {
+        assert!(VersionMode::parse(&args(&["1.2.3", "4.5.6"])).is_err());
+    }
+
+    // ── Semver validation ─────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_accepts_a_bare_triple() {
+        assert!(validate_semver("0.1.2").is_ok());
+        assert!(validate_semver("10.20.30").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_a_prerelease_suffix() {
+        // The release workflows tag from this value and reject anything that is
+        // not a bare triple, so accepting one here would only fail later.
+        assert!(validate_semver("0.1.2-alpha").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_wrong_component_counts() {
+        assert!(validate_semver("0.1").is_err());
+        assert!(validate_semver("0.1.2.3").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_and_non_numeric_components() {
+        assert!(validate_semver("0..2").is_err());
+        assert!(validate_semver("0.1.x").is_err());
+    }
+
+    // ── Reading declarations ──────────────────────────────────────────────────
+
+    #[test]
+    fn workspace_version_reads_the_line_anchored_entry() {
+        assert_eq!(workspace_version(MANIFEST).unwrap(), "0.1.2");
+    }
+
+    #[test]
+    fn workspace_version_errors_when_absent() {
+        assert!(workspace_version("[workspace]\nmembers = []\n").is_err());
+    }
+
+    #[test]
+    fn pinned_versions_finds_intra_workspace_pins_only() {
+        let pins = pinned_versions(MANIFEST);
+        assert_eq!(
+            pins,
+            vec![
+                ("leviath".to_owned(), "0.1.2".to_owned()),
+                ("leviath-core".to_owned(), "0.1.2".to_owned()),
+            ],
+            "path-only members and third-party crates must be left out"
+        );
+    }
+
+    // ── Check ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn disagreeing_pins_is_empty_when_everything_matches() {
+        assert!(disagreeing_pins(MANIFEST).unwrap().is_empty());
+    }
+
+    #[test]
+    fn disagreeing_pins_names_the_stale_entry() {
+        let stale = MANIFEST.replace(
+            "leviath-core\", version = \"0.1.2\"",
+            "leviath-core\", version = \"0.1.1\"",
+        );
+        let found = disagreeing_pins(&stale).unwrap();
+        assert_eq!(found, vec!["leviath-core pins 0.1.1".to_owned()]);
+    }
+
+    #[test]
+    fn disagreeing_pins_propagates_a_missing_workspace_version() {
+        assert!(
+            disagreeing_pins("leviath = { path = \"crates/leviath\", version = \"1.0.0\" }\n")
+                .is_err()
+        );
+    }
+
+    // ── Set ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_versions_rewrites_the_workspace_version_and_every_pin() {
+        let out = set_versions(MANIFEST, "0.2.0").unwrap();
+        assert_eq!(workspace_version(&out).unwrap(), "0.2.0");
+        assert!(disagreeing_pins(&out).unwrap().is_empty());
+    }
+
+    #[test]
+    fn set_versions_leaves_third_party_pins_alone() {
+        let out = set_versions(MANIFEST, "0.2.0").unwrap();
+        assert!(
+            out.contains("serde = { version = \"1.0\", features = [\"derive\"] }"),
+            "a third-party requirement must survive verbatim:\n{out}"
+        );
+        assert!(out.contains("leviath-testkit = { path = \"crates/leviath-testkit\" }"));
+    }
+
+    #[test]
+    fn set_versions_preserves_the_trailing_newline() {
+        assert!(set_versions(MANIFEST, "0.2.0").unwrap().ends_with('\n'));
+        assert!(
+            !set_versions("version = \"0.1.2\"", "0.2.0")
+                .unwrap()
+                .ends_with('\n')
+        );
+    }
+
+    #[test]
+    fn set_versions_rejects_a_malformed_version() {
+        assert!(set_versions(MANIFEST, "nope").is_err());
+    }
+
+    #[test]
+    fn set_versions_errors_when_there_is_no_workspace_version() {
+        assert!(set_versions("[workspace]\nmembers = []\n", "0.2.0").is_err());
+    }
+
+    #[test]
+    fn set_versions_rewrites_only_the_first_anchored_version() {
+        // `[package] version` further down a manifest must not be mistaken for
+        // the workspace one.
+        let two = "version = \"0.1.2\"\n[other]\nversion = \"9.9.9\"\n";
+        let out = set_versions(two, "0.2.0").unwrap();
+        assert!(out.starts_with("version = \"0.2.0\""));
+        assert!(
+            out.contains("version = \"9.9.9\""),
+            "second entry untouched:\n{out}"
+        );
+    }
+
+    #[test]
+    fn replace_pin_returns_lines_it_cannot_parse_unchanged() {
+        assert_eq!(replace_pin("no version here", "1.0.0"), "no version here");
+        assert_eq!(
+            replace_pin("version = \"unterminated", "1.0.0"),
+            "version = \"unterminated"
+        );
+    }
+
+    #[test]
+    fn unquote_rejects_text_that_is_not_a_quoted_string() {
+        assert_eq!(unquote("bare"), None);
+        assert_eq!(unquote("\"unterminated"), None);
+    }
+
+    // ── Changelog ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn roll_changelog_inserts_a_dated_heading_below_a_fresh_unreleased() {
+        let rolled = roll_changelog(
+            "# Changelog\n\n## Unreleased\n\n- did a thing\n\n## 0.1.1 - 2026-07-31\n",
+            "0.1.2",
+            "2026-08-02",
+        )
+        .unwrap();
+        assert!(rolled.contains("## Unreleased\n\n## 0.1.2 - 2026-08-02\n\n- did a thing"));
+        assert!(rolled.contains("## 0.1.1 - 2026-07-31"), "history is kept");
+    }
+
+    #[test]
+    fn roll_changelog_rolls_only_the_first_unreleased() {
+        let rolled =
+            roll_changelog("x\n## Unreleased\n## Unreleased\n", "1.0.0", "2026-01-01").unwrap();
+        assert_eq!(rolled.matches("## 1.0.0 - 2026-01-01").count(), 1);
+    }
+
+    #[test]
+    fn roll_changelog_errors_without_an_unreleased_heading() {
+        assert!(
+            roll_changelog(
+                "# Changelog\n\n## 0.1.1 - 2026-07-31\n",
+                "0.1.2",
+                "2026-08-02"
+            )
+            .is_err()
+        );
+    }
+
+    // ── Dates ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn civil_from_days_converts_known_dates() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(19_723), (2024, 1, 1));
+        // 2024 is a leap year: day 60 of it is 29 February.
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+        assert_eq!(civil_from_days(20_667), (2026, 8, 2));
+    }
+
+    #[test]
+    fn civil_from_days_handles_dates_before_the_epoch() {
+        assert_eq!(civil_from_days(-1), (1969, 12, 31));
+        assert_eq!(civil_from_days(-719_468), (0, 3, 1));
+    }
+
+    #[test]
+    fn today_is_a_zero_padded_iso_date() {
+        let today = today();
+        assert_eq!(today.len(), 10, "expected YYYY-MM-DD, got {today}");
+        let parts: Vec<&str> = today.split('-').collect();
+        assert_eq!(parts.len(), 3);
+        assert!(parts.iter().all(|p| p.bytes().all(|b| b.is_ascii_digit())));
+    }
+}


### PR DESCRIPTION
## What & why

Four related changes, all about the workspace version — which is now the thing that triggers a release, and so worth making hard to get wrong and easy to see.

**One command instead of twelve edits.** `[workspace.package] version` plus eleven `[workspace.dependencies]` pins that repeat it, because `cargo publish` refuses a path dependency with no version requirement and Cargo cannot make those inherit. Moving only some of them is *quiet*: inside a `0.1.x` line a stale `version = "0.1.2"` pin is a `^0.1.2` requirement that `0.1.3` satisfies, so it builds and publishes, just naming the previous version. It only turns loud on a bump crossing the caret boundary — in the prod job, a week after the alpha shipped.

`cargo xtask version <X.Y.Z>` writes all twelve, the lockfile and the changelog heading. `cargo xtask version --check` runs in `Supply chain` so a hand-edit that moved only some of them fails on the PR.

**A label before a PR turns into a release.** Merging a bump publishes an alpha within seconds, and a week later that commit is a permanent `vX.Y.Z` tag and immutable crates.io releases. `guard-version-bump` asks for that explicitly via `allow-version-bump`, the way main.rs changes already ask via their own label — separate labels so approving a release never doubles as approving an entrypoint change. It compares the *declared version* between merge base and head, not whether `Cargo.toml` was touched, since dependency edits land there constantly and ship nothing.

**A real bug in the existing main.rs guard, while I was next to it.** It diffs with two dots, which asks how two trees differ rather than what the PR changed — so every PR failed it the moment someone else's main.rs change landed on main first, and the fix looked like applying the override label to a PR that never touched the file. Three dots asks the intended question.

**Badges, and clean tap numbers.** Each release workflow writes what it published to the gist the test/coverage badges already use; shields.io can't do this from outside, since it can only ask for "newest release" or "newest prerelease" and alpha and beta are both prereleases on rolling tags. And the alpha tap version drops its date suffix: `0.1.1-alpha.20260802` existed because alpha rebuilt the same source nightly, which version-gating ended, so plain `X.Y.Z-alpha` is already monotonic.

## How it was tested

- **The `set` path, against a real copy of the manifest**: rewrote all twelve declarations to `0.2.0`, left `bevy_ecs = { version = "0.19" }` and the path-only `leviath-testkit` untouched, and rolled the changelog to `## 0.2.0 - 2026-08-02` under a fresh `## Unreleased`.
- **The `check` path** against the live manifest: `Every intra-workspace pin matches [workspace.package] version 0.1.2.`
- **The guard's logic against real commits**: the actual `Release 0.1.2` commit reads `0.1.1 -> 0.1.2` (fires), this branch against its merge base reads `0.1.2 -> 0.1.2` (silent).
- 57 xtask unit tests + 7 integration tests; full workspace suite green across 32 suites, fmt, clippy `--all-targets --all-features`, ast-grep.

> [!IMPORTANT]
> `Guard release version bump` is a new PR-only check and needs adding to the branch ruleset's required contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA33qJT7AypuNZH6xn3a1a