### PR TITLE
fix: make OpenRouter work end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ same list.
 
 ## Unreleased
 
+- OpenRouter works end to end. Several separate faults added up to an install
+  that was configured correctly and still did nothing useful:
+  - `default_provider` is now honoured. It was only consulted after every
+    registered entry a blueprint listed, and the bundled agents all list
+    Anthropic, OpenAI and Ollama, so setting it to `openrouter` changed
+    nothing. Registered candidates on your default provider now head the
+    stage's list, with the blueprint's own entries kept behind them as
+    fallbacks. A stage pins its own provider with `allow_user_default = false`,
+    which suppresses this as it always did.
+  - A provider that cannot be reached at all now counts as unavailable, so the
+    run fails over instead of dying. Ollama registers with no key whether or
+    not a server is running, so a refused connection to `localhost:11434` used
+    to kill runs at iteration 0 with a working provider sitting unused behind
+    it in the same list.
+  - Reasoning models no longer answer with nothing. They return `content: null`
+    and put their text under `reasoning`, which reached the runtime as an empty
+    response: the agent was nudged to use its tools, looped, and the run
+    finished having said nothing. The field is read when the message carries no
+    content and no tool calls, so it never displaces real output.
+  - An error a gateway delivers with a 200 status is reported. OpenRouter
+    answers `{"error":{...}}` with a success status when an upstream provider
+    rejects a request it had already accepted, and that read as
+    "No choices in response", throwing away the only text that said why. The
+    envelope's own status code is classified as a real one, so a 402 arriving
+    this way fails over and trips the circuit breaker like any other.
+  - Errors delivered mid-stream surface instead of silently truncating the
+    stream.
+  - Requests carry the `X-Title` header OpenRouter pairs with `HTTP-Referer`,
+    so calls are attributed to Leviath on the account's activity page.
+- A hand-written `config.toml` parses. Every field on the top-level config was
+  required, so the three lines that point Leviath at OpenRouter failed with
+  ``missing field `providers` `` - a table the user has no reason to know
+  about, in a message that says nothing about what to add.
+- `lev doctor`'s `resolve` check says when your configured `default_provider`
+  is being passed over, and why. `default_provider` with no `default_model` is
+  a half-configuration that silently does nothing, and the check used to report
+  `OK` next to a provider you never asked for.
+
 ## 0.1.2 - 2026-08-02
 
 - `lev run <agent>` with no `--task` now opens your editor on a commented

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -268,7 +268,13 @@ fn resolve_check(
 
     match registry.get(&provider_name) {
         Some(provider) => (
-            Check::ok("resolve", format!("{provider_name} / {model}")),
+            Check::ok(
+                "resolve",
+                format!(
+                    "{provider_name} / {model}{}",
+                    default_provider_note(config, &provider_name, model_override, registry)
+                ),
+            ),
             Some(Resolved {
                 provider_name,
                 model,
@@ -287,6 +293,44 @@ fn resolve_check(
             None,
         ),
     }
+}
+
+/// The note appended when the resolved provider is not the one the user named
+/// as their default.
+///
+/// `default_provider` without a `default_model` is a half-configuration that
+/// silently does nothing: the resolver needs a model to send and has none, so
+/// it falls through to the hard-coded last resort. Someone who set
+/// `default_provider = "openrouter"`, pasted their key, and watched every run
+/// go to Anthropic (or, with no Anthropic key either, to a localhost Ollama
+/// that was not running) had no way to see that from here - the check said
+/// `resolve OK` and printed a provider they never asked for.
+///
+/// Not a failure: the resolution is legitimate and the run will work. It is
+/// only worth saying because it is not what the config appears to ask for.
+/// Silent while `--model` is in play, which is the caller overriding on purpose.
+fn default_provider_note(
+    config: &Config,
+    resolved: &str,
+    model_override: Option<&str>,
+    registry: &ProviderRegistry,
+) -> String {
+    if model_override.is_some() || resolved == config.default_provider {
+        return String::new();
+    }
+    // The missing model is the only reason a registered default provider loses
+    // from here: this check resolves an empty `ModelConfig`, so one with a
+    // model set has no competition to lose to. An *unregistered* default
+    // provider is a different complaint, and one the `config` line already
+    // makes by listing what is registered.
+    if config.default_model.is_some() || !registry.has(&config.default_provider) {
+        return String::new();
+    }
+    let named = &config.default_provider;
+    format!(
+        "  (note: default_provider is '{named}' but no default_model is set, \
+         so it is never chosen - add `default_model` to config.toml)"
+    )
 }
 
 // ─── Check 3: inference ───────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -263,6 +263,75 @@ fn resolve_check_reports_an_unconfigured_provider_and_what_was_tried() {
     assert!(resolved.is_none());
 }
 
+#[test]
+fn resolve_check_says_so_when_the_configured_default_never_wins() {
+    // `default_provider = "openrouter"` with no `default_model`: the resolver
+    // has no model to send, falls through to its hard-coded last resort, and
+    // used to report `resolve OK anthropic / claude-sonnet-4-6` with nothing
+    // anywhere saying the configured provider had been passed over.
+    let config = Config {
+        default_provider: "openrouter".to_string(),
+        default_model: None,
+        ..Config::default()
+    };
+    let mut registry = registry_with("openrouter", StubProvider::replying("hi"));
+    registry.register("anthropic".to_string(), StubProvider::replying("hi"));
+    let (check, _) = resolve_check(&config, None, &registry);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.detail.contains("no default_model"),
+        "{}",
+        check.detail
+    );
+    assert!(check.detail.contains("openrouter"), "{}", check.detail);
+}
+
+#[test]
+fn resolve_check_is_quiet_when_the_configured_default_does_win() {
+    let config = Config {
+        default_provider: "openrouter".to_string(),
+        default_model: Some("openai/gpt-4o-mini".to_string()),
+        ..Config::default()
+    };
+    let registry = registry_with("openrouter", StubProvider::replying("hi"));
+    let (check, _) = resolve_check(&config, None, &registry);
+    assert_eq!(check.detail, "openrouter / openai/gpt-4o-mini");
+}
+
+#[test]
+fn resolve_check_does_not_second_guess_an_unregistered_default_provider() {
+    // Landing somewhere other than a default provider that has no key is not
+    // news - the `config` line already lists what is registered, and this
+    // check's fail arm covers the case where nothing usable is left. Saying it
+    // again here would put a note on every install with a stale provider name
+    // in its config.
+    for default_model in [None, Some("m-1".to_string())] {
+        let config = Config {
+            default_provider: "ghost".to_string(),
+            default_model,
+            ..Config::default()
+        };
+        let registry = registry_with("anthropic", StubProvider::replying("hi"));
+        let (check, _) = resolve_check(&config, None, &registry);
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert!(!check.detail.contains("note:"), "{}", check.detail);
+    }
+}
+
+#[test]
+fn resolve_check_stays_quiet_under_an_explicit_model_override() {
+    // `--model` is the caller overriding on purpose; telling them their
+    // default was passed over is noise.
+    let config = Config {
+        default_provider: "openrouter".to_string(),
+        default_model: None,
+        ..Config::default()
+    };
+    let registry = registry_with("stub", StubProvider::replying("hi"));
+    let (check, _) = resolve_check(&config, Some("stub/m-2"), &registry);
+    assert_eq!(check.detail, "stub / m-2");
+}
+
 // ─── inference_check ──────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -86,18 +86,23 @@ pub struct ScriptToolPermissions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Default provider
+    #[serde(default = "default_provider_name")]
     pub default_provider: String,
 
     /// Provider API keys
+    #[serde(default)]
     pub providers: ProviderConfig,
 
     /// Agent project paths
+    #[serde(default)]
     pub agent_paths: Vec<PathBuf>,
 
     /// OpenRouter API key
+    #[serde(default)]
     pub openrouter_api_key: Option<String>,
 
     /// Ollama base URL (default http://localhost:11434)
+    #[serde(default)]
     pub ollama_base_url: Option<String>,
 
     /// MCP server configurations
@@ -105,6 +110,7 @@ pub struct Config {
     pub mcp_servers: Vec<MCPServerConfig>,
 
     /// Default model override
+    #[serde(default)]
     pub default_model: Option<String>,
 
     /// Per-model capability overrides. Key is model ID (e.g. "my-local-llama").
@@ -161,6 +167,7 @@ pub struct Config {
     /// always SOME timeout, because a call that never completes wedges its
     /// run with no error. A stage's `[stages.<name>.model]
     /// request_timeout_secs` overrides either value for that stage's requests.
+    #[serde(default)]
     pub request_timeout_secs: Option<u64>,
 
     /// Client-side rate limits for the built-in providers, keyed by provider
@@ -448,6 +455,19 @@ fn default_wedge_timeout_secs() -> u64 {
     leviath_runtime::pipeline::DEFAULT_WEDGE_TIMEOUT_SECS
 }
 
+/// The provider a config that names none is assumed to mean.
+///
+/// Exists so `default_provider` can carry `#[serde(default)]`: without one,
+/// every field on [`Config`] that lacked a default made a hand-written
+/// `config.toml` a parse error. Writing three lines to point Leviath at
+/// OpenRouter used to fail with `missing field `providers``, which names a
+/// table the user has no reason to know about and says nothing about what to
+/// add. Kept in sync with [`Config::default`] by
+/// `an_empty_config_file_parses_to_the_defaults`.
+fn default_provider_name() -> String {
+    "anthropic".to_string()
+}
+
 fn default_provider_failures_before_open() -> u32 {
     leviath_runtime::pipeline::DEFAULT_FAILURES_BEFORE_OPEN
 }
@@ -689,15 +709,18 @@ impl Default for WebhookConfig {
 /// Provider configuration.
 ///
 /// `Debug` is hand-written (see below) so the keys cannot be printed.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct ProviderConfig {
     /// Anthropic API key
+    #[serde(default)]
     pub anthropic_api_key: Option<String>,
 
     /// OpenAI API key
+    #[serde(default)]
     pub openai_api_key: Option<String>,
 
     /// Google AI (Gemini) API key
+    #[serde(default)]
     pub google_api_key: Option<String>,
 
     /// Whether the Claude Code CLI transport is enabled.
@@ -2514,6 +2537,48 @@ agent_paths = []
         let config: Config = toml::from_str(toml_content).unwrap();
         assert_eq!(config.default_provider, "anthropic");
         assert!(config.providers.anthropic_api_key.is_none());
+    }
+
+    #[test]
+    fn the_three_lines_that_point_leviath_at_openrouter_are_enough() {
+        // What a user writes by hand after reading the OpenRouter docs. Every
+        // field on Config used to be required, so this failed with `missing
+        // field `providers`` - a table they have no reason to know about, in a
+        // message that says nothing about what to add.
+        let config: Config = toml::from_str(
+            r#"
+default_provider = "openrouter"
+default_model = "openai/gpt-4o-mini"
+openrouter_api_key = "sk-or-test"
+"#,
+        )
+        .expect("a hand-written OpenRouter config parses");
+        assert_eq!(config.default_provider, "openrouter");
+        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or-test"));
+        assert_eq!(config.default_model.as_deref(), Some("openai/gpt-4o-mini"));
+    }
+
+    #[test]
+    fn an_empty_config_file_parses_to_the_defaults() {
+        // Pins the serde defaults against `Config::default` in both
+        // directions: a field that gains one but not the other means a fresh
+        // file and a fresh struct disagree about the same install.
+        let parsed: Config = toml::from_str("").expect("an empty config parses");
+        let default = Config::default();
+        assert_eq!(parsed.default_provider, default.default_provider);
+        assert_eq!(parsed.agent_paths, default.agent_paths);
+        assert_eq!(parsed.openrouter_api_key, default.openrouter_api_key);
+        assert_eq!(parsed.ollama_base_url, default.ollama_base_url);
+        assert_eq!(parsed.default_model, default.default_model);
+        assert_eq!(parsed.request_timeout_secs, default.request_timeout_secs);
+        assert_eq!(
+            parsed.providers.anthropic_api_key,
+            default.providers.anthropic_api_key
+        );
+        assert_eq!(
+            parsed.providers.claude_code_enabled,
+            default.providers.claude_code_enabled
+        );
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -317,7 +317,76 @@ pub fn merge_extra_params(
 }
 
 /// Parse a Chat Completions response body into an `InferenceResponse`.
+/// Turn an OpenAI-style `error` envelope into the right [`ProviderError`].
+///
+/// Split out because it is reached from three places that never see a status
+/// code: a 200 response whose body is an error, an SSE chunk carrying one, and
+/// the truncated-stream case. The code inside the envelope is the status the
+/// upstream provider used, so it feeds [`UnavailableReason::classify`] exactly
+/// as a real status line would - which is what lets a 402 delivered this way
+/// still fail over and trip the circuit breaker instead of killing the run.
+pub(crate) fn openai_error_envelope(err: &serde_json::Value) -> ProviderError {
+    let message = err
+        .get("message")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    // OpenRouter sends `code` as a number; other gateways send the string form.
+    let code = err
+        .get("code")
+        .and_then(|c| {
+            c.as_u64()
+                .or_else(|| c.as_str().and_then(|s| s.parse::<u64>().ok()))
+        })
+        .and_then(|c| u16::try_from(c).ok())
+        .unwrap_or(0);
+
+    let detail = match (code, message) {
+        (0, "") => err.to_string(),
+        (0, m) => m.to_string(),
+        (c, "") => format!("HTTP {c}: {err}"),
+        (c, m) => format!("HTTP {c}: {m}"),
+    };
+
+    // `classify` reads the body when the code alone is innocent, so a 0 here
+    // still catches a credits message the gateway reported as a 200.
+    match crate::provider::UnavailableReason::classify(code, message) {
+        Some(reason) => ProviderError::Unavailable { reason, detail },
+        None => ProviderError::ApiError(detail),
+    }
+}
+
+/// The reasoning text of a message, when it carries any.
+///
+/// Two shapes are in the wild: a flat `reasoning` string, and the
+/// `reasoning_details` array OpenRouter uses to preserve per-block structure.
+/// Prefers the flat field and falls back to joining the array's text blocks.
+fn reasoning_text(message: &serde_json::Value) -> Option<String> {
+    if let Some(text) = message.get("reasoning").and_then(|v| v.as_str())
+        && !text.trim().is_empty()
+    {
+        return Some(text.to_string());
+    }
+    let joined: String = message
+        .get("reasoning_details")?
+        .as_array()?
+        .iter()
+        .filter_map(|d| d.get("text").and_then(|v| v.as_str()))
+        .collect::<Vec<_>>()
+        .join("");
+    (!joined.trim().is_empty()).then_some(joined)
+}
+
 pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceResponse> {
+    // A gateway does not always use the status line to report a failure.
+    // OpenRouter answers 200 with `{"error":{"code":…,"message":…}}` when an
+    // upstream provider rejects a request it had already accepted, and reading
+    // that as "No choices in response" threw away the one field that says what
+    // actually went wrong. Unpack it before looking for choices.
+    if let Some(err) = body.get("error").filter(|e| !e.is_null()) {
+        return Err(openai_error_envelope(err));
+    }
+
     let choice = body
         .get("choices")
         .and_then(|c| c.as_array())
@@ -328,7 +397,7 @@ pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceRespon
         .get("message")
         .ok_or_else(|| ProviderError::InvalidResponse("No message in choice".to_string()))?;
 
-    let content = message
+    let mut content = message
         .get("content")
         .and_then(|c| c.as_str())
         .unwrap_or("")
@@ -370,6 +439,16 @@ pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceRespon
                 thought_signature,
             });
         }
+    }
+
+    // Reasoning models answer with `content: null` and put their text under
+    // `reasoning`, so reading `content` alone handed the runtime an empty
+    // response: the agent got nudged to use its tools, looped, and the run
+    // finished having said nothing. Only used when the message is otherwise
+    // empty - a response carrying tool calls is not empty, and its reasoning
+    // is working-out rather than output.
+    if content.trim().is_empty() && tool_calls.is_empty() {
+        content = reasoning_text(message).unwrap_or_default();
     }
 
     let usage = body.get("usage");
@@ -447,7 +526,7 @@ impl Stream for OpenAiSseStream {
         loop {
             // Check for complete SSE events
             if let Some(chunk) = parse_openai_sse_event(&mut this.buffer) {
-                return std::task::Poll::Ready(chunk.map(Ok));
+                return std::task::Poll::Ready(chunk);
             }
 
             match this.inner.as_mut().poll_next(cx) {
@@ -463,7 +542,7 @@ impl Stream for OpenAiSseStream {
                 }
                 std::task::Poll::Ready(None) => {
                     if let Some(chunk) = parse_openai_sse_event(&mut this.buffer) {
-                        return std::task::Poll::Ready(chunk.map(Ok));
+                        return std::task::Poll::Ready(chunk);
                     }
                     return std::task::Poll::Ready(None);
                 }
@@ -474,13 +553,23 @@ impl Stream for OpenAiSseStream {
 }
 
 /// Parse a single SSE event from the buffer.
-/// Returns `Some(Some(chunk))` for data, `Some(None)` for stream end, `None` for incomplete.
+///
+/// Returns `Some(Some(Ok(chunk)))` for data, `Some(Some(Err(..)))` for an error
+/// the gateway delivered inside the stream, `Some(None)` for stream end, and
+/// `None` when the buffer does not yet hold a complete event.
+///
+/// The error case exists because a stream is where OpenRouter reports a failure
+/// it only discovered after committing to a 200: the upstream provider goes
+/// down mid-generation, or the account runs out of credits between chunks. That
+/// arrives as a `data:` line whose object is `{"error":{…}}` and no `choices`,
+/// which used to fall through the usage-only branch and simply end the stream -
+/// a truncated answer with nothing anywhere saying why.
 #[expect(
     clippy::string_slice,
     reason = "`event_end` is a `find` hit for the ASCII \"\\n\\n\" terminator, so it and \
               `event_end + 2` are char boundaries"
 )]
-pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>> {
+pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<StreamChunk>>> {
     let event_end = buffer.find("\n\n")?;
     let event_text = buffer[..event_end].to_string();
     *buffer = buffer[event_end + 2..].to_string();
@@ -496,6 +585,10 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>
                 Ok(j) => j,
                 Err(_) => continue,
             };
+
+            if let Some(err) = json.get("error").filter(|e| !e.is_null()) {
+                return Some(Some(Err(openai_error_envelope(err))));
+            }
 
             let choice = json
                 .get("choices")
@@ -518,7 +611,7 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>
                         .and_then(|d| d.get("cached_tokens"))
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0) as usize;
-                    return Some(Some(StreamChunk {
+                    return Some(Some(Ok(StreamChunk {
                         delta: String::new(),
                         tool_calls: Vec::new(),
                         tokens: Some(TokenUsage {
@@ -529,7 +622,7 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>
                             cache_write_tokens: 0,
                         }),
                         finish_reason: None,
-                    }));
+                    })));
                 }
                 continue;
             }
@@ -595,12 +688,12 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<StreamChunk>
                 }
             });
 
-            return Some(Some(StreamChunk {
+            return Some(Some(Ok(StreamChunk {
                 delta: content,
                 tool_calls: tool_call_deltas,
                 tokens,
                 finish_reason,
-            }));
+            })));
         }
     }
 
@@ -760,6 +853,185 @@ mod tests {
         assert!(err.to_string().contains("No choices"));
     }
 
+    // ─── reasoning-only responses ──────────────────────────────────────────
+
+    #[test]
+    fn reasoning_fills_in_for_a_null_content() {
+        // What a reasoning model on OpenRouter actually sends: `content: null`
+        // and the answer under `reasoning`. Reading `content` alone handed the
+        // runtime an empty response, so the agent was nudged, looped, and the
+        // run finished having said nothing.
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": serde_json::Value::Null,
+                    "reasoning": "2 + 2 is 4.",
+                },
+                "finish_reason": "length"
+            }]
+        });
+        let resp = parse_openai_response(&body).unwrap();
+        assert_eq!(resp.content, "2 + 2 is 4.");
+    }
+
+    #[test]
+    fn reasoning_details_are_joined_when_the_flat_field_is_absent() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_details": [
+                        { "type": "reasoning.text", "text": "first " },
+                        { "type": "reasoning.text", "text": "second" },
+                        { "type": "reasoning.encrypted" },
+                    ],
+                }
+            }]
+        });
+        let resp = parse_openai_response(&body).unwrap();
+        assert_eq!(resp.content, "first second");
+    }
+
+    #[test]
+    fn reasoning_never_displaces_real_content_or_a_tool_call() {
+        // Reasoning is working-out, not output. A message that has either of
+        // the two things the runtime acts on is not empty, and appending the
+        // model's scratchpad to it would put the scratchpad in the transcript.
+        let with_content = serde_json::json!({
+            "choices": [{
+                "message": { "content": "the answer", "reasoning": "scratchpad" }
+            }]
+        });
+        assert_eq!(
+            parse_openai_response(&with_content).unwrap().content,
+            "the answer"
+        );
+
+        let with_tool_call = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "reasoning": "scratchpad",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "function": { "name": "read_file", "arguments": "{}" }
+                    }]
+                }
+            }]
+        });
+        let resp = parse_openai_response(&with_tool_call).unwrap();
+        assert_eq!(resp.content, "");
+        assert_eq!(resp.tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn blank_reasoning_is_not_treated_as_content() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": { "content": serde_json::Value::Null, "reasoning": "   " }
+            }]
+        });
+        assert_eq!(parse_openai_response(&body).unwrap().content, "");
+
+        let empty_details = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "reasoning_details": [{ "type": "reasoning.encrypted" }]
+                }
+            }]
+        });
+        assert_eq!(parse_openai_response(&empty_details).unwrap().content, "");
+
+        // A `reasoning_details` that is not an array at all. Nothing sends this
+        // today; the point is that a shape change upstream degrades to an empty
+        // answer rather than a panic in the middle of a run.
+        let not_an_array = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "reasoning_details": "unexpected"
+                }
+            }]
+        });
+        assert_eq!(parse_openai_response(&not_an_array).unwrap().content, "");
+    }
+
+    // ─── error envelopes delivered with a success status ───────────────────
+
+    #[test]
+    fn an_error_envelope_beats_the_missing_choices_message() {
+        // OpenRouter answers 200 with this shape when an upstream provider
+        // rejects a request it had already accepted. "No choices in response"
+        // threw away the only text that said why.
+        let body = serde_json::json!({
+            "error": { "code": 400, "message": "nonexistent/model-xyz is not a valid model ID" }
+        });
+        let err = parse_openai_response(&body).unwrap_err();
+        assert!(err.to_string().contains("not a valid model ID"), "{err}");
+        assert!(err.to_string().contains("400"), "{err}");
+        // A bad model id is this request's problem, not the provider's, so it
+        // must not fail over or count against the circuit breaker.
+        assert!(err.unavailable_reason().is_none(), "{err}");
+    }
+
+    #[test]
+    fn a_402_envelope_still_fails_over() {
+        // The whole point of reading the envelope: a drained account reported
+        // this way has to reach the same failover path a 402 status does.
+        let body = serde_json::json!({
+            "error": { "code": 402, "message": "Insufficient credits" }
+        });
+        let err = parse_openai_response(&body).unwrap_err();
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(crate::provider::UnavailableReason::CreditsExhausted)
+        );
+    }
+
+    #[test]
+    fn an_envelope_without_a_code_falls_back_to_its_message() {
+        let body = serde_json::json!({ "error": { "message": "upstream timed out" } });
+        let err = parse_openai_response(&body).unwrap_err();
+        assert_eq!(err.to_string(), "API error: upstream timed out");
+
+        // A string code is read too - not every gateway sends a number.
+        let stringly = serde_json::json!({
+            "error": { "code": "401", "message": "no auth" }
+        });
+        assert_eq!(
+            parse_openai_response(&stringly)
+                .unwrap_err()
+                .unavailable_reason(),
+            Some(crate::provider::UnavailableReason::AuthFailed)
+        );
+    }
+
+    #[test]
+    fn an_envelope_with_no_readable_fields_still_reports_something() {
+        let body = serde_json::json!({ "error": { "kind": "weird" } });
+        let err = parse_openai_response(&body).unwrap_err();
+        assert!(err.to_string().contains("weird"), "{err}");
+
+        let coded_only = serde_json::json!({ "error": { "code": 503 } });
+        let err = parse_openai_response(&coded_only).unwrap_err();
+        assert!(err.to_string().contains("503"), "{err}");
+    }
+
+    #[test]
+    fn a_null_error_field_is_not_an_error() {
+        // Every successful OpenAI-compatible response from some gateways
+        // carries `"error": null`; treating that as a failure would reject
+        // every good response.
+        let body = serde_json::json!({
+            "error": serde_json::Value::Null,
+            "choices": [{ "message": { "content": "fine" } }]
+        });
+        assert_eq!(parse_openai_response(&body).unwrap().content, "fine");
+    }
+
     #[test]
     fn parse_response_no_message_returns_error() {
         let body = serde_json::json!({
@@ -872,7 +1144,7 @@ mod tests {
             })
         );
         let result = parse_openai_sse_event(&mut buf);
-        let chunk = result.unwrap().unwrap();
+        let chunk = result.unwrap().unwrap().unwrap();
         assert_eq!(chunk.delta, "Hello");
         assert!(chunk.finish_reason.is_none());
         assert!(chunk.tool_calls.is_empty());
@@ -889,7 +1161,7 @@ mod tests {
                 }]
             })
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(
             chunk.finish_reason,
             Some(crate::provider::FinishReason::Complete)
@@ -915,7 +1187,7 @@ mod tests {
                 }]
             })
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk.tool_calls.len(), 1);
         assert_eq!(chunk.tool_calls[0].index, 0);
         assert_eq!(chunk.tool_calls[0].id.as_deref(), Some("call_abc"));
@@ -935,7 +1207,7 @@ mod tests {
                 }
             })
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk.delta, "");
         let tokens = chunk.tokens.unwrap();
         assert_eq!(tokens.prompt_tokens, 50);
@@ -950,10 +1222,10 @@ mod tests {
             serde_json::json!({"choices": [{"delta": {"content": "A"}}]}),
             serde_json::json!({"choices": [{"delta": {"content": "B"}}]})
         );
-        let chunk1 = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk1 = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk1.delta, "A");
 
-        let chunk2 = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk2 = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk2.delta, "B");
     }
 
@@ -970,7 +1242,7 @@ mod tests {
                 }
             })
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk.delta, "X");
         let tokens = chunk.tokens.unwrap();
         assert_eq!(tokens.prompt_tokens, 100);
@@ -1062,7 +1334,7 @@ mod tests {
             "data: {}\n\ndata: [DONE]\n\n",
             serde_json::json!({"choices": [{"delta": {"content": "X"}}]})
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk.delta, "X");
         // Buffer should still have the [DONE] event
         assert!(buf.contains("[DONE]"));
@@ -1092,11 +1364,48 @@ mod tests {
                 }]
             })
         );
-        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap();
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
         assert_eq!(chunk.tool_calls.len(), 1);
         assert_eq!(chunk.tool_calls[0].index, 1);
         assert!(chunk.tool_calls[0].id.is_none());
         assert!(chunk.tool_calls[0].name.is_none());
+    }
+
+    #[test]
+    fn sse_event_error_chunk_surfaces_as_an_error() {
+        // A stream is where OpenRouter reports a failure it only found after
+        // committing to a 200 - the upstream provider going down, or the
+        // account draining between chunks. It has no `choices` and no `usage`,
+        // so it used to fall through to `continue` and simply end the stream:
+        // a truncated answer with nothing anywhere saying why.
+        let mut buf = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "error": { "code": 402, "message": "Insufficient credits" }
+            })
+        );
+        let err = parse_openai_sse_event(&mut buf)
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(crate::provider::UnavailableReason::CreditsExhausted),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn sse_event_null_error_field_is_ignored() {
+        let mut buf = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "error": serde_json::Value::Null,
+                "choices": [{ "delta": { "content": "hi" } }]
+            })
+        );
+        let chunk = parse_openai_sse_event(&mut buf).unwrap().unwrap().unwrap();
+        assert_eq!(chunk.delta, "hi");
     }
 
     #[test]

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -177,7 +177,11 @@ impl Provider for OpenRouterProvider {
             &url,
             &[
                 ("Authorization", format!("Bearer {}", self.api_key)),
+                // OpenRouter attributes a request to an app by this pair, and
+                // sending only the referer left every Leviath call unnamed on
+                // the account's activity page.
                 ("HTTP-Referer", "https://leviath.dev".to_string()),
+                ("X-Title", "Leviath".to_string()),
                 ("Content-Type", "application/json".to_string()),
             ],
             &body,
@@ -220,7 +224,11 @@ impl Provider for OpenRouterProvider {
             &url,
             &[
                 ("Authorization", format!("Bearer {}", self.api_key)),
+                // OpenRouter attributes a request to an app by this pair, and
+                // sending only the referer left every Leviath call unnamed on
+                // the account's activity page.
                 ("HTTP-Referer", "https://leviath.dev".to_string()),
+                ("X-Title", "Leviath".to_string()),
                 ("Content-Type", "application/json".to_string()),
             ],
             &body,

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -25,6 +25,14 @@ pub enum UnavailableReason {
     AuthFailed,
     /// The key authenticated but is not allowed to do this.
     Forbidden,
+    /// The provider could not be reached at all: connection refused, DNS
+    /// failure, TLS failure, or a timeout that outlived every retry.
+    ///
+    /// Unlike the three above, this is not something the provider told us - it
+    /// is the absence of the provider. It still belongs here because the
+    /// consequence is identical: the next request will fail the same way, so
+    /// the run should move to a different provider rather than die.
+    Unreachable,
 }
 
 impl UnavailableReason {
@@ -34,6 +42,7 @@ impl UnavailableReason {
             UnavailableReason::CreditsExhausted => "credits-exhausted",
             UnavailableReason::AuthFailed => "auth-failed",
             UnavailableReason::Forbidden => "forbidden",
+            UnavailableReason::Unreachable => "unreachable",
         }
     }
 
@@ -51,6 +60,10 @@ impl UnavailableReason {
             UnavailableReason::Forbidden => {
                 "the API key is not allowed to use this model: check the \
                  account's plan and model permissions"
+            }
+            UnavailableReason::Unreachable => {
+                "the provider could not be reached: check the network and the \
+                 base URL, and whether a local server (ollama) is running"
             }
         }
     }
@@ -199,10 +212,22 @@ impl ProviderError {
     /// The runtime uses this to decide whether to fail over to the next
     /// configured provider and to count the failure against that provider's
     /// circuit breaker. A bad request or a malformed response says nothing
-    /// about the provider, so only [`ProviderError::Unavailable`] qualifies.
+    /// about the provider, so [`ProviderError::Unavailable`] and a transport
+    /// failure are the only two that qualify.
     pub fn unavailable_reason(&self) -> Option<UnavailableReason> {
         match self {
             ProviderError::Unavailable { reason, .. } => Some(*reason),
+            // A provider we could not open a connection to has told us nothing
+            // about this request and everything about itself. The retry policy
+            // has already tried four times with backoff by the time one of
+            // these surfaces, so the next attempt belongs somewhere else.
+            //
+            // This is what broke an OpenRouter-only install: `ollama` is
+            // registered whether or not a server is running, every bundled
+            // blueprint lists it, and a refused connection to localhost:11434
+            // counted as an ordinary error - so the run died at iteration 0
+            // with a usable OpenRouter fallback sitting untouched behind it.
+            ProviderError::RequestFailed(_) => Some(UnavailableReason::Unreachable),
             _ => None,
         }
     }
@@ -915,6 +940,31 @@ mod tests {
     }
 
     #[test]
+    fn a_transport_failure_counts_as_an_unreachable_provider() {
+        // A refused connection says nothing about the request and everything
+        // about the provider, and the retry policy has already spent four
+        // attempts on it. Leaving it as an ordinary error is what made an
+        // OpenRouter-only install die at iteration 0: `ollama` registers with
+        // no key, every bundled blueprint lists it, and a dead localhost:11434
+        // killed the run instead of falling over to the model behind it.
+        assert_eq!(
+            ProviderError::RequestFailed("error sending request".into()).unavailable_reason(),
+            Some(UnavailableReason::Unreachable)
+        );
+        // Still worth retrying first - the two questions are separate.
+        assert!(ProviderError::RequestFailed("error sending request".into()).is_transient());
+        // Everything that is genuinely about the request stays put.
+        for err in [
+            ProviderError::InvalidResponse("garbage".into()),
+            ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+            ProviderError::RateLimitExceeded,
+            ProviderError::Other("mystery".into()),
+        ] {
+            assert_eq!(err.unavailable_reason(), None, "{err}");
+        }
+    }
+
+    #[test]
     fn unavailable_display_leads_with_the_remedy_and_keeps_the_detail() {
         // The whole complaint in issue #201 was a raw JSON blob as the run's
         // status. The message must say what to do; the blob stays available.
@@ -934,6 +984,7 @@ mod tests {
             UnavailableReason::CreditsExhausted,
             UnavailableReason::AuthFailed,
             UnavailableReason::Forbidden,
+            UnavailableReason::Unreachable,
         ] {
             assert!(!reason.label().is_empty());
             assert!(!reason.remedy().is_empty());

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -128,6 +128,24 @@ pub fn resolve_stage_candidates(
         }
     }
 
+    // `default_provider = "openrouter"` is the user saying where their runs
+    // should go. It was only ever consulted after every registered entry the
+    // blueprint listed, so on a machine with an OpenRouter key it never won
+    // anything: the bundled blueprints all name anthropic, openai and ollama,
+    // and ollama registers with no key at all, so an OpenRouter-only install
+    // dispatched every stage at a localhost server that was not running.
+    //
+    // Registered candidates on the user's default provider therefore move to
+    // the front, keeping their relative order. A blueprint that must pin its
+    // own provider already has the way to say so - `allow_user_default =
+    // false` - and that suppresses this too.
+    if model_cfg.allow_user_default && registry.has(&defaults.provider) {
+        let (preferred, rest): (Vec<ModelEntry>, Vec<ModelEntry>) = candidates
+            .into_iter()
+            .partition(|c| c.provider == defaults.provider);
+        candidates = preferred.into_iter().chain(rest).collect();
+    }
+
     if candidates.is_empty() {
         // Nothing registered. Hand back the blueprint's own first entry so the
         // caller reports "no usable provider" against a name the user wrote,
@@ -752,13 +770,86 @@ mod tests {
         };
         let registry = registry_with(&["openrouter", "anthropic", "openai"]);
         let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        // The user default heads the list (it is on `default_provider`), the
+        // stage's own entry follows, and the host-wide chain is last - which is
+        // the ordering this test exists to pin.
         assert_eq!(
             pairs(&got),
             vec![
-                ("openrouter", "deepseek"),
                 ("anthropic", "sonnet"),
+                ("openrouter", "deepseek"),
                 ("openai", "gpt"),
             ]
+        );
+    }
+
+    #[test]
+    fn the_default_provider_outranks_the_stages_own_list() {
+        // `default_provider = "openrouter"` used to buy nothing: the bundled
+        // blueprints all name anthropic/openai/ollama, ollama registers with no
+        // key, so an OpenRouter-only install dispatched every stage at a
+        // localhost server that was not running.
+        let cfg = model_cfg(vec![
+            ("anthropic", "claude-sonnet-5"),
+            ("ollama", "qwen3.5:9b"),
+        ]);
+        let defaults = ModelDefaults {
+            provider: "openrouter".to_string(),
+            model: Some("openai/gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
+        let registry = registry_with(&["openrouter", "ollama"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("openrouter", "openai/gpt-4o-mini"),
+                ("ollama", "qwen3.5:9b"),
+            ],
+            "the user's default provider heads the list; the registered stage \
+             entry stays behind it as a fallback"
+        );
+    }
+
+    #[test]
+    fn a_stage_that_forbids_the_user_default_keeps_its_own_order() {
+        // `allow_user_default = false` is the existing way a blueprint pins its
+        // provider, and it has to suppress the preference too - otherwise there
+        // is no way left to say "this stage runs where I said".
+        let cfg = ModelConfig {
+            allow_user_default: false,
+            ..model_cfg(vec![("anthropic", "sonnet"), ("openrouter", "deepseek")])
+        };
+        let defaults = ModelDefaults {
+            provider: "openrouter".to_string(),
+            model: Some("deepseek".to_string()),
+            ..Default::default()
+        };
+        let registry = registry_with(&["openrouter", "anthropic"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![("anthropic", "sonnet"), ("openrouter", "deepseek")]
+        );
+    }
+
+    #[test]
+    fn an_unregistered_default_provider_changes_nothing() {
+        // The preference is over *registered* candidates only: a default
+        // provider with no key must not reorder anything, and must certainly
+        // not promote itself into the head where dispatch would park the run
+        // on `ProviderMissing`.
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("ollama", "qwen")]);
+        let defaults = ModelDefaults {
+            provider: "openrouter".to_string(),
+            model: Some("deepseek".to_string()),
+            ..Default::default()
+        };
+        let registry = registry_with(&["anthropic", "ollama"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![("anthropic", "sonnet"), ("ollama", "qwen")]
         );
     }
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -89,8 +89,9 @@ provider = "anthropic"
 model    = "claude-sonnet-5"
 ```
 
-"Stops being usable" means the account is out of credits, or the key was rejected or is not allowed
-to use that model. An ordinary bad request is not that, and never spends a fallback.
+"Stops being usable" means the account is out of credits, the key was rejected or is not allowed to
+use that model, or the provider could not be reached at all after every retry. An ordinary bad
+request is not that, and never spends a fallback.
 
 ## A host-wide fallback chain
 
@@ -147,44 +148,44 @@ In order:
 
 1. `lev run --model <provider>/<model>`, which overrides everything and skips the check entirely. A
    bare `--model <model>` replaces only the model name and keeps the provider resolved below.
-2. The first entry in `models` whose provider is configured.
-3. Your `default_provider` / `default_model` from `config.toml`, if `default_model` is set, its
+2. Your `default_provider` / `default_model` from `config.toml`, when `default_model` is set, the
    provider is configured, and the stage did not set `allow_user_default = false`.
-4. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
+3. The first entry in `models` whose provider is configured.
+4. The host-wide `fallback_order`, for the stages that got past everything above with nothing left.
+5. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
    spawn with `stage '<name>' has no usable provider`.
 
+Everything below the first line is the failover chain, in that same order, so a stage that starts on
+your default still has the blueprint's own entries to fall back to.
+
 > [!IMPORTANT]
-> Step 3 is only reached when **no** listed provider is configured. Ollama needs no key and is
-> therefore registered unconditionally, so any stage listing Ollama matches at step 2 whether or not
-> Ollama is actually installed, and your `default_model` is never consulted for that stage.
+> `default_provider` on its own buys nothing. The resolver needs a model to send and has none, so it
+> falls through to whatever the blueprint listed. Set `default_model` alongside it. `lev doctor`
+> says so when you have not.
 
 ### Running the bundled agents on another provider
 
 The [bundled agents](/docs/agent-catalog) list Anthropic, OpenAI, and Ollama, in that order. None of
-them lists OpenRouter, Google, or a custom Rhai provider, so a key for one of those does not make
-them use it. On an install whose only key is an OpenRouter one:
+them lists OpenRouter, Google, or a custom Rhai provider. Naming yours as the default is what makes
+them use it:
 
-- Almost every stage matches Ollama at step 2 and runs against `http://localhost:11434`. If Ollama
-  is not installed, the run spawns fine and then fails at its first call.
-- `parallel-fixer`'s `parallel_fix` and `fix_worker` stages list only Anthropic and OpenAI, so they
-  fail at spawn: `stage 'parallel_fix' has no usable provider (tried: anthropic)`.
+```toml
+default_provider = "openrouter"
+default_model = "deepseek/deepseek-v4-flash"
+openrouter_api_key = "sk-or-..."
+```
 
-Setting `default_provider` and `default_model` does **not** fix this, for the reason in the note
-above. Three things do. A full override, per run:
+Every stage now starts on OpenRouter and keeps the blueprint's own list behind it. A stage that must
+stay on the provider its author picked opts out with `allow_user_default = false`.
+
+Two other ways in. A full override, for one run:
 
 ```bash
 lev run coder -t "fix the failing test" --model openrouter/deepseek/deepseek-v4-flash
 ```
 
-A host-wide `fallback_order`, which catches a stage once its own entries are exhausted:
-
-```toml
-[providers]
-fallback_order = ["openrouter/deepseek/deepseek-v4-flash"]
-```
-
-Or, for something permanent, copying the blueprint and naming your provider on the stages you care
-about:
+Or, for something permanent and per stage, copying the blueprint and naming your provider on the
+stages you care about:
 
 ```toml
 model = { models = [
@@ -192,6 +193,12 @@ model = { models = [
   { provider = "anthropic",  model = "claude-sonnet-5" },
 ] }
 ```
+
+> [!WARNING]
+> Ollama needs no key, so it is registered whether or not a server is running. Leave
+> `default_model` unset on a machine with no Ollama and every stage that lists it starts against
+> `http://localhost:11434`. The run now moves on to its next candidate instead of dying there, but
+> it still spends four attempts finding out.
 
 ## Where credentials live
 

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -56,7 +56,8 @@ local [Ollama](https://ollama.com) for a no-key start.
 `lev doctor` says which provider your defaults actually resolve to, and which ones it tried to get
 there. That matters because a stage naming no model of its own falls back to `anthropic`. So a
 machine with only an OpenRouter key can resolve to a provider it has no credential for, spawn, and
-sit at iteration 0.
+sit at iteration 0. When your configured `default_provider` is the one being passed over, the
+`resolve` line says that too.
 
 ## Every run dies immediately with a payment or auth error
 
@@ -91,19 +92,39 @@ That stage's `models` list simply never mentions the provider you configured. A 
 on a provider it lists, and the [bundled agents](/docs/agent-catalog) list Anthropic, OpenAI, and
 Ollama only, so a Google or OpenRouter key does not qualify.
 
-Pass `--model <provider>/<model>` for the run, add a `[providers] fallback_order` entry, or copy the
-blueprint and name your provider on the stage. Setting `default_model` often will not help: it is
-only consulted when no listed provider is configured at all. See
+Set `default_provider` and `default_model` together, which puts your provider ahead of the
+blueprint's list for every stage that has not opted out. `--model <provider>/<model>` does it for
+one run, and copying the blueprint does it per stage. See
 [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on).
 
 ## My run went to Ollama and I never asked for it
 
-Ollama needs no key, so it is registered unconditionally, and every bundled agent lists it as its
-last entry. On an install with no Anthropic or OpenAI key, that is the first entry that matches, and
-the run starts against `http://localhost:11434` whether or not Ollama is installed.
+Ollama needs no key, so it is registered whether or not a server is running, and every bundled agent
+lists it last. With nothing else configured that is the first entry that matches, and the run starts
+against `http://localhost:11434`.
 
-`lev doctor` reports the provider a run would start on before you spawn one, and a run records the
-model it actually used in its `meta.json`. The fixes are the same as the entry above.
+Set `default_model` alongside your `default_provider`. Without a model to send, `default_provider`
+is never consulted and Ollama wins by default. `lev doctor` says so in its `resolve` line when your
+configured provider is being passed over.
+
+A run that does start on a dead Ollama no longer dies there: an unreachable provider is treated the
+same as one out of credits, so the stage moves to its next candidate. You will see the swap in the
+stage log:
+
+```
+[failover] ollama/qwen3.5:9b is unusable (Request failed: error sending request for url
+(http://localhost:11434/api/chat)); retrying on openrouter/openai/gpt-4o-mini
+```
+
+## My OpenRouter agent finishes without saying anything
+
+Reasoning models on OpenRouter answer with `content: null` and put their text under `reasoning`.
+Leviath reads that field when the message carries nothing else, so a reasoning-only turn is no
+longer an empty response. If you are on an older build, an agent that loops and finishes silently
+on a `deepseek-r1`-style model is this.
+
+The reasoning text is only used when the turn has no content and no tool calls of its own, so it
+never displaces real output or a tool call.
 
 ## The provider says my model doesn't exist
 


### PR DESCRIPTION
An OpenRouter-only install was configured correctly and still did nothing useful. Reproduced against the real API in an isolated home: `lev run coder` went straight to `error_recovery` at iteration 0, against a localhost Ollama nobody asked for.

Several independent faults were stacked on the same path.

## `default_provider` was never honoured

It was only consulted after every registered entry a blueprint listed. The bundled agents all name anthropic, openai and ollama, and ollama registers with no key, so `default_provider = "openrouter"` changed nothing at all.

Registered candidates on the user's default provider now head the stage's list, with the blueprint's own entries kept behind them as fallbacks. `allow_user_default = false` still pins a stage and suppresses this, the same way it always suppressed the default.

## An unreachable provider killed the run instead of failing over

A refused connection to `localhost:11434` was an ordinary error, so a run died at iteration 0 with a working provider sitting unused behind it in the same candidate list. A provider we cannot open a connection to has said nothing about the request and everything about itself, and the retry policy has already spent four attempts by the time one of these surfaces, so it now counts as `UnavailableReason::Unreachable` and the stage moves on.

## Reasoning models answered with nothing

They return `content: null` with the text under `reasoning`. That reached the runtime as an empty response: the agent got nudged toward its tools, looped, and the run finished having said nothing. The field is read only when the message carries no content and no tool calls, so it never displaces real output or a call.

## Errors delivered with a 200 status were swallowed

OpenRouter answers `{"error":{...}}` with a success status when an upstream provider rejects a request it had already accepted. That read as `No choices in response`, throwing away the only text that said why. The envelope's own code is now classified like a real status line, so a 402 arriving this way fails over and trips the circuit breaker as usual. Same treatment for an error delivered mid-stream, which used to end the stream silently.

## Smaller things on the same path

- Requests carry the `X-Title` header OpenRouter pairs with `HTTP-Referer`, so calls are attributed on the account's activity page.
- A hand-written `config.toml` parses. Every top-level field was required, so the three lines that point Leviath at OpenRouter failed with ``missing field `providers` `` - a table the user has no reason to know about, in a message saying nothing about what to add.
- `lev doctor`'s `resolve` check says when the configured `default_provider` is being passed over for want of a `default_model`. It used to report `OK` next to a provider the user never named.

## Live verification

Against the real API, in a `LEVIATH_HOME` whose only key is OpenRouter's:

- `lev doctor` passes all four checks on `openrouter / openai/gpt-4o-mini`.
- `lev run coder` completes all five stages (54K prompt tokens billed) and never enters `error_recovery`. The same command failed at iteration 0 before.
- `lev run parallel-fixer`, which used to fail at spawn with `no usable provider (tried: anthropic)`, runs through to `verify`.
- The failover shows up in the stage log as a swap off the dead Ollama:
  ```
  [failover] ollama/qwen3.5:9b is unusable (Request failed: error sending request for url
  (http://localhost:11434/api/chat)); retrying on openrouter/openai/gpt-4o-mini
  ```
- A reasoning model returns 217 characters where the wire body has `content: null` and it used to return nothing.

`cargo xtask coverage`: all 11 packages at 100%. Clippy clean, `cargo xtask docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRude3mAoT9y8AUFah6ogS