### PR TITLE
TUI kit: shared keymap/widgets, terminal guard, and the setup wizard rework

### DIFF
--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -1,15 +1,26 @@
 //! Key handling for the setup wizard.
 //!
-//! One entry point, [`Wizard::handle_key`], split into a text-editing mode and
-//! a navigation mode. Editing takes priority: while a field is open, letters
-//! are letters, so `q` types a `q` rather than quitting - losing a
-//! half-entered API key to a quit shortcut would be a genuinely bad way to find
-//! out about modal input.
+//! One entry point, [`Wizard::handle_key`], with a strict priority order:
+//! Ctrl-C, then an open confirmation dialog, then an open text edit, then the
+//! help overlay, then navigation. Editing before navigation matters: while a
+//! field is open, letters are letters, so `q` types a `q` rather than
+//! quitting - losing a half-entered API key to a quit shortcut would be a
+//! genuinely bad way to find out about modal input.
+//!
+//! Navigation resolves shared keys through `crate::tui::keymap`, so arrows,
+//! vim aliases, Space, Enter, Esc, Tab, `?`, and `q` mean here exactly what
+//! they mean in every other Leviath TUI. Enter acts on the focused row - it
+//! toggles a provider, opens an editor, cycles a choice - and only advances
+//! the screen when the cursor is visibly on the step's Continue button.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::catalog::Credential;
-use super::state::{Edit, EditTarget, FieldValue, Step, Wizard};
+use super::state::{ConfirmPurpose, Edit, EditTarget, FieldValue, Step, Wizard};
+use crate::tui::keymap;
+use crate::tui::widgets::confirm::ConfirmOutcome;
+use crate::tui::widgets::help::dismisses_help;
+use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
 
 /// What the loop should do after a key press.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,118 +34,186 @@ pub enum Action {
 impl Wizard {
     /// Handle one key press.
     pub fn handle_key(&mut self, key: KeyEvent) -> Action {
-        // Ctrl-C always quits, even mid-edit: it is the one binding a user
-        // reaches for expecting it to work no matter what.
+        // Ctrl-C always works, even mid-edit and even inside a dialog: it is
+        // the one binding a user reaches for expecting it to obey no matter
+        // what. With unsaved choices it asks once; pressed again (the dialog
+        // is then open), it quits unconditionally.
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-            self.should_quit = true;
+            if self.confirm.is_some() || !self.dirty {
+                self.should_quit = true;
+            } else {
+                self.open_quit_confirm();
+            }
             return Action::Continue;
+        }
+        // Ctrl-R also works mid-edit: revealing what you are typing is most
+        // useful precisely while you are typing it.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+            self.reveal = !self.reveal;
+            self.message = Some(if self.reveal {
+                "Credentials shown.".to_string()
+            } else {
+                "Credentials hidden.".to_string()
+            });
+            return Action::Continue;
+        }
+        if self.confirm.is_some() {
+            return self.handle_confirm_key(key);
         }
         if let Some(edit) = self.edit.take() {
             self.handle_edit_key(key, edit);
             return Action::Continue;
         }
-        if self.show_tos_confirm {
-            // A hard gate: nothing else means anything until it is answered.
-            return self.handle_tos_key(key);
-        }
         if self.show_help {
-            // Any key dismisses the help overlay.
-            self.show_help = false;
+            if dismisses_help(&key) {
+                self.show_help = false;
+            }
             return Action::Continue;
         }
         self.handle_nav_key(key)
     }
 
+    /// Keys while a confirmation dialog is open. Its Yes routes by purpose;
+    /// No always just closes it.
+    fn handle_confirm_key(&mut self, key: KeyEvent) -> Action {
+        let Some(mut pending) = self.confirm.take() else {
+            return Action::Continue;
+        };
+        match pending.dialog.handle(&key) {
+            ConfirmOutcome::Pending => {
+                self.confirm = Some(pending);
+                Action::Continue
+            }
+            ConfirmOutcome::No => Action::Continue,
+            ConfirmOutcome::Yes => match pending.purpose {
+                ConfirmPurpose::QuitDiscard => {
+                    self.should_quit = true;
+                    Action::Continue
+                }
+                ConfirmPurpose::SaveTos => {
+                    self.claude_code_tos_accepted = true;
+                    Action::Save
+                }
+                ConfirmPurpose::NoProviders => {
+                    self.next_step();
+                    Action::Continue
+                }
+            },
+        }
+    }
+
     /// Keys while a text field is open.
     ///
-    /// Takes the buffer rather than re-reading `self.edit`: the caller already
+    /// Takes the edit rather than re-reading `self.edit`: the caller already
     /// established there is one, so re-checking would add arms nothing can
     /// reach.
     fn handle_edit_key(&mut self, key: KeyEvent, mut edit: Edit) {
-        match key.code {
-            KeyCode::Enter => {
+        match edit.line.handle_key(&key) {
+            EditOutcome::Commit => {
                 self.edit = Some(edit);
                 self.commit_edit();
                 self.message = None;
+                self.dirty = true;
             }
-            KeyCode::Esc => {
+            EditOutcome::Cancel => {
                 self.message = Some("Edit cancelled.".to_string());
             }
-            KeyCode::Backspace => {
-                edit.buffer.pop();
-                self.edit = Some(edit);
-            }
-            KeyCode::Char(c) => {
-                edit.buffer.push(c);
-                self.edit = Some(edit);
-            }
-            _ => self.edit = Some(edit),
+            EditOutcome::Pending => self.edit = Some(edit),
         }
     }
 
-    /// Keys while navigating.
+    /// Keys while navigating: surface-specific bindings first, then the
+    /// crate-wide keymap.
     fn handle_nav_key(&mut self, key: KeyEvent) -> Action {
-        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-
         match key.code {
-            KeyCode::Char('s') if ctrl => {
-                if self.needs_tos_confirmation() {
-                    self.show_tos_confirm = true;
-                    return Action::Continue;
-                }
-                return Action::Save;
-            }
-            KeyCode::Char('q') => self.should_quit = true,
-            KeyCode::Char('?') => self.show_help = true,
-            KeyCode::Char('r') if ctrl => {
-                self.reveal = !self.reveal;
-                self.message = Some(if self.reveal {
-                    "Credentials shown.".to_string()
-                } else {
-                    "Credentials hidden.".to_string()
-                });
-            }
-            KeyCode::Up | KeyCode::Char('k') => self.move_cursor(-1),
-            KeyCode::Down | KeyCode::Char('j') => self.move_cursor(1),
-            KeyCode::Left | KeyCode::Char('h') => self.adjust(-1),
-            KeyCode::Right | KeyCode::Char('l') => self.adjust(1),
-            KeyCode::Char(' ') => self.toggle(),
+            KeyCode::Char('s') if ctrl => return self.try_save(),
             KeyCode::Char('o') => self.open_signup_page(),
             KeyCode::Char('v') => self.verify_current(),
-            KeyCode::BackTab => self.back(),
-            KeyCode::Tab if shift => self.back(),
-            KeyCode::Tab => self.forward(),
-            KeyCode::Esc => self.back(),
-            KeyCode::Enter => return self.activate(),
-            _ => {}
+            _ => match keymap::resolve(&key) {
+                Some(keymap::Action::Up) => self.move_cursor(-1),
+                Some(keymap::Action::Down) => self.move_cursor(1),
+                Some(keymap::Action::Left) => self.adjust(-1),
+                Some(keymap::Action::Right) => self.adjust(1),
+                Some(keymap::Action::Toggle) => self.toggle(),
+                Some(keymap::Action::Activate) => return self.activate(),
+                Some(keymap::Action::Back) | Some(keymap::Action::Prev) => self.back(),
+                Some(keymap::Action::Next) => self.forward_guarded(),
+                Some(keymap::Action::Help) => self.show_help = true,
+                Some(keymap::Action::Quit) => self.request_quit(),
+                // Ctrl-C is intercepted in `handle_key`; this arm only fires
+                // when `handle_nav_key` is driven directly (tests do).
+                Some(keymap::Action::ForceQuit) => self.should_quit = true,
+                None => {}
+            },
         }
         Action::Continue
     }
 
-    /// `Enter`: open an editor, or advance.
-    ///
-    /// A screen with nothing to type into - a toggle, a choice, a list - falls
-    /// through to "next screen" rather than doing nothing at all, so Enter is
-    /// always the key that moves forward.
-    fn activate(&mut self) -> Action {
-        let opened = match self.step {
-            Step::Review => {
-                if self.needs_tos_confirmation() {
-                    self.show_tos_confirm = true;
-                    return Action::Continue;
-                }
-                return Action::Save;
-            }
-            Step::ProviderDetail => self.open_credential_editor(),
-            Step::Defaults | Step::Limits => self.open_field_editor(),
-            _ => false,
-        };
-        if opened {
+    /// `q`: quit - after a confirmation when there are unsaved choices.
+    fn request_quit(&mut self) {
+        if self.dirty {
+            self.open_quit_confirm();
+        } else {
+            self.should_quit = true;
+        }
+    }
+
+    /// Save, unless the Claude Code terms still need confirming first.
+    fn try_save(&mut self) -> Action {
+        if self.needs_tos_confirmation() {
+            self.open_tos_confirm();
             return Action::Continue;
         }
-        self.forward();
+        Action::Save
+    }
+
+    /// `Enter`: act on the focused row, or - only from the visible Continue
+    /// button - move on.
+    fn activate(&mut self) -> Action {
+        if self.on_continue() {
+            return match self.step {
+                Step::Review => self.try_save(),
+                Step::Providers => {
+                    self.forward_guarded();
+                    Action::Continue
+                }
+                _ => {
+                    self.forward();
+                    Action::Continue
+                }
+            };
+        }
+        match self.step {
+            Step::Providers | Step::Agents | Step::Mcp => self.toggle(),
+            Step::ProviderDetail => {
+                // The credential row opens its editor; the Claude Code row has
+                // nothing to type, so Enter cycles its effort instead.
+                if !self.open_credential_editor() {
+                    self.adjust(1);
+                }
+            }
+            Step::Defaults | Step::Limits => self.activate_field(),
+            // Rowless steps put the cursor on their button, so these arms are
+            // reachable only with a hand-forced cursor; acting on nothing is
+            // correct then.
+            Step::Welcome | Step::Review => {}
+        }
         Action::Continue
+    }
+
+    /// Enter on a Defaults/Limits row always acts on that row's kind: toggle
+    /// a bool, cycle a choice, open the editor for a number.
+    fn activate_field(&mut self) {
+        match self.fields().get(self.cursor).map(|f| &f.value) {
+            Some(FieldValue::Bool(_)) => self.toggle(),
+            Some(FieldValue::Choice { .. }) => self.adjust(1),
+            Some(FieldValue::Number(_)) => {
+                self.open_field_editor();
+            }
+            // Reachable only with a hand-forced cursor past the fields.
+            None => {}
+        }
     }
 
     /// Open the credential editor for the provider on screen. Returns false
@@ -151,8 +230,7 @@ impl Wizard {
         }
         self.edit = Some(Edit {
             target: EditTarget::Credential(index),
-            buffer: value,
-            masked: credential == Credential::ApiKey,
+            line: LineEdit::new(value, credential == Credential::ApiKey),
         });
         true
     }
@@ -167,33 +245,18 @@ impl Wizard {
         let buffer = current.map(|n| n.to_string()).unwrap_or_default();
         self.edit = Some(Edit {
             target: EditTarget::Field(cursor),
-            buffer,
-            masked: false,
+            line: LineEdit::new(buffer, false),
         });
         true
     }
 
-    /// Handle a key while the ToS confirmation overlay is showing.
-    ///
-    /// Y accepts the terms and lets the interrupted save proceed - the user
-    /// already asked to save; confirming is the last word, not a detour. Any
-    /// other key dismisses the overlay and stays put, leaving the transport
-    /// selected but unsaveable until it is either confirmed or deselected.
-    fn handle_tos_key(&mut self, key: KeyEvent) -> Action {
-        self.show_tos_confirm = false;
-        if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
-            self.claude_code_tos_accepted = true;
-            return Action::Save;
-        }
-        Action::Continue
-    }
-
-    /// `Space`: toggle whatever the cursor is on.
+    /// `Space` (or Enter on a row): toggle whatever the cursor is on.
     fn toggle(&mut self) {
         match self.step {
             Step::Providers => {
                 if let Some(row) = self.providers.get_mut(self.cursor) {
                     row.selected = !row.selected;
+                    self.dirty = true;
                     // Deselecting the Claude Code transport withdraws the
                     // terms acceptance so it must be re-confirmed if
                     // re-enabled.
@@ -209,20 +272,27 @@ impl Wizard {
             Step::Agents => {
                 if let Some(row) = self.agents.get_mut(self.cursor) {
                     row.selected = !row.selected;
+                    self.dirty = true;
                 }
             }
             Step::Mcp => {
                 if let Some(row) = self.mcp.get_mut(self.cursor) {
                     row.selected = !row.selected;
+                    self.dirty = true;
                 }
             }
             Step::Defaults | Step::Limits => {
                 let cursor = self.cursor;
+                let mut changed = false;
                 if let Some(fields) = self.fields_mut()
                     && let Some(field) = fields.get_mut(cursor)
                     && let FieldValue::Bool(b) = &mut field.value
                 {
                     *b = !*b;
+                    changed = true;
+                }
+                if changed {
+                    self.dirty = true;
                 }
             }
             Step::Welcome | Step::ProviderDetail | Step::Review => {}
@@ -242,6 +312,7 @@ impl Wizard {
                     let count = super::state::effort_options().len();
                     let next = row.effort as isize + delta;
                     row.effort = next.rem_euclid(count as isize) as usize;
+                    self.dirty = true;
                 }
             }
             Step::Defaults | Step::Limits => {
@@ -256,6 +327,9 @@ impl Wizard {
                     *index = next.rem_euclid(options.len() as isize) as usize;
                     changed_provider = true;
                 }
+                if changed_provider {
+                    self.dirty = true;
+                }
                 // Changing the default provider re-picks the concurrency
                 // default, so an Ollama-first setup does not inherit a number
                 // meant for hosted APIs.
@@ -265,6 +339,16 @@ impl Wizard {
             }
             _ => {}
         }
+    }
+
+    /// Advance, but guard the one advance that is almost always a slip:
+    /// leaving the Providers screen with nothing selected.
+    fn forward_guarded(&mut self) {
+        if self.step == Step::Providers && self.selected_providers().is_empty() {
+            self.open_no_providers_confirm();
+            return;
+        }
+        self.forward();
     }
 
     /// `Tab`: next provider on the credential screen, otherwise next step.
@@ -339,823 +423,4 @@ impl Wizard {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::commands::setup::state::{Edit, EditTarget, FieldValue};
-    fn press(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, KeyModifiers::empty())
-    }
-
-    fn press_with(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
-        KeyEvent::new(code, modifiers)
-    }
-
-    fn wizard() -> (tempfile::TempDir, Wizard) {
-        let dir = tempfile::tempdir().unwrap();
-        let wizard = crate::commands::setup::state::tests::test_wizard(dir.path());
-        (dir, wizard)
-    }
-
-    // ─── quitting and saving ────────────────────────────────────────────────
-
-    #[test]
-    fn ctrl_c_quits_from_anywhere_including_mid_edit() {
-        // The one binding a user reaches for expecting it to always work.
-        let (_dir, mut w) = wizard();
-        w.edit = Some(Edit {
-            target: EditTarget::Credential(0),
-            buffer: "half-typed".to_string(),
-            masked: true,
-        });
-
-        let action = w.handle_key(press_with(KeyCode::Char('c'), KeyModifiers::CONTROL));
-
-        assert_eq!(action, Action::Continue);
-        assert!(w.should_quit);
-    }
-
-    #[test]
-    fn q_quits_while_navigating() {
-        let (_dir, mut w) = wizard();
-        w.handle_key(press(KeyCode::Char('q')));
-        assert!(w.should_quit);
-    }
-
-    #[test]
-    fn q_types_a_letter_while_editing_rather_than_quitting() {
-        // Losing a half-entered API key to a quit shortcut would be a bad way
-        // to find out about modal input.
-        let (_dir, mut w) = wizard();
-        w.edit = Some(Edit {
-            target: EditTarget::Credential(0),
-            buffer: String::new(),
-            masked: true,
-        });
-
-        w.handle_key(press(KeyCode::Char('q')));
-
-        assert!(!w.should_quit);
-        assert_eq!(w.edit.as_ref().expect("still editing").buffer, "q");
-    }
-
-    #[test]
-    fn ctrl_s_saves_from_any_screen() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Providers);
-
-        let action = w.handle_key(press_with(KeyCode::Char('s'), KeyModifiers::CONTROL));
-
-        assert_eq!(action, Action::Save);
-    }
-
-    #[test]
-    fn enter_on_the_review_screen_saves() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Review);
-
-        assert_eq!(w.handle_key(press(KeyCode::Enter)), Action::Save);
-    }
-
-    // ─── help overlay ───────────────────────────────────────────────────────
-
-    #[test]
-    fn the_help_overlay_opens_and_any_key_closes_it() {
-        let (_dir, mut w) = wizard();
-
-        w.handle_key(press(KeyCode::Char('?')));
-        assert!(w.show_help);
-
-        // The dismissing key must not also do its normal job.
-        w.handle_key(press(KeyCode::Char('q')));
-        assert!(!w.show_help);
-        assert!(!w.should_quit);
-    }
-
-    // ─── editing ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn typing_backspacing_and_committing_a_credential() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Enter));
-        assert!(w.edit.is_some(), "Enter opens the editor");
-        for c in "sk-antX".chars() {
-            w.handle_key(press(KeyCode::Char(c)));
-        }
-        w.handle_key(press(KeyCode::Backspace));
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(w.edit.is_none());
-        assert_eq!(w.providers[0].value, "sk-ant");
-    }
-
-    #[test]
-    fn escape_abandons_an_edit_without_changing_the_value() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        w.providers[0].value = "sk-ant-original".to_string();
-        w.enter(Step::ProviderDetail);
-        w.handle_key(press(KeyCode::Enter));
-        w.handle_key(press(KeyCode::Char('z')));
-
-        w.handle_key(press(KeyCode::Esc));
-
-        assert!(w.edit.is_none());
-        assert_eq!(w.providers[0].value, "sk-ant-original");
-        assert_eq!(w.message.as_deref(), Some("Edit cancelled."));
-    }
-
-    #[test]
-    fn an_unhandled_key_while_editing_is_ignored() {
-        let (_dir, mut w) = wizard();
-        w.edit = Some(Edit {
-            target: EditTarget::Credential(0),
-            buffer: "abc".to_string(),
-            masked: false,
-        });
-
-        w.handle_key(press(KeyCode::F(5)));
-
-        assert_eq!(w.edit.as_ref().expect("still editing").buffer, "abc");
-    }
-
-    #[test]
-    fn backspace_on_an_empty_buffer_is_harmless() {
-        let (_dir, mut w) = wizard();
-        w.edit = Some(Edit {
-            target: EditTarget::Credential(0),
-            buffer: String::new(),
-            masked: false,
-        });
-
-        w.handle_key(press(KeyCode::Backspace));
-
-        assert!(w.edit.as_ref().expect("still editing").buffer.is_empty());
-    }
-
-    #[test]
-    fn the_claude_code_transport_has_nothing_to_type_so_enter_moves_on() {
-        let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(w.edit.is_none());
-        assert_ne!(w.step, Step::ProviderDetail);
-    }
-
-    #[test]
-    fn enter_on_a_toggle_moves_on_rather_than_doing_nothing() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-        w.cursor = 3; // a boolean
-
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(w.edit.is_none());
-        assert_ne!(w.step, Step::Limits);
-    }
-
-    #[test]
-    fn enter_on_a_number_field_opens_it_seeded_with_the_current_value() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-
-        w.handle_key(press(KeyCode::Enter));
-
-        let edit = w.edit.as_ref().expect("the editor opened");
-        assert_eq!(edit.target, EditTarget::Field(0));
-        assert!(!edit.buffer.is_empty(), "seeded from the current value");
-        assert!(!edit.masked, "a limit is not a secret");
-    }
-
-    #[test]
-    fn an_unset_number_field_opens_empty() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-        w.limits[0].value = FieldValue::Number(None);
-
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(
-            w.edit
-                .as_ref()
-                .expect("the editor opened")
-                .buffer
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn opening_an_editor_out_of_range_is_a_no_op() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-        w.cursor = 99;
-
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(w.edit.is_none());
-    }
-
-    #[test]
-    fn the_credential_editor_declines_when_no_provider_is_on_screen() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Enter));
-
-        assert!(w.edit.is_none());
-    }
-
-    // ─── selection ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn space_toggles_a_provider_and_resets_the_credential_walk() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Providers);
-        w.detail = 3;
-
-        w.handle_key(press(KeyCode::Char(' ')));
-
-        assert!(w.providers[0].selected);
-        assert_eq!(w.detail, 0, "the walk is relative to the new selection");
-
-        w.handle_key(press(KeyCode::Char(' ')));
-        assert!(!w.providers[0].selected);
-    }
-
-    #[test]
-    fn space_toggles_agents_and_mcp_rows_and_booleans() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut w = Wizard::new(
-            crate::config::Config::default(),
-            &|_| None,
-            vec![(
-                "A".to_string(),
-                crate::commands::setup::import::Candidate {
-                    config: leviath_mcp::MCPServerConfig::stdio("fs", "npx", vec![]),
-                    scope: String::new(),
-                    inline_secrets: Vec::new(),
-                },
-            )],
-            Vec::new(),
-            dir.path(),
-            std::sync::Arc::new(|_| true),
-        );
-
-        w.enter(Step::Agents);
-        let before = w.agents[0].selected;
-        w.handle_key(press(KeyCode::Char(' ')));
-        assert_ne!(w.agents[0].selected, before);
-
-        w.enter(Step::Mcp);
-        w.handle_key(press(KeyCode::Char(' ')));
-        assert!(!w.mcp[0].selected);
-
-        w.enter(Step::Limits);
-        w.cursor = 3;
-        let before = w.limits[3].value.clone();
-        w.handle_key(press(KeyCode::Char(' ')));
-        assert_ne!(w.limits[3].value, before);
-    }
-
-    #[test]
-    fn space_on_a_screen_with_nothing_to_toggle_is_harmless() {
-        let (_dir, mut w) = wizard();
-        for step in [Step::Welcome, Step::ProviderDetail, Step::Review] {
-            w.enter(step);
-            w.handle_key(press(KeyCode::Char(' ')));
-        }
-        // Also out-of-range cursors on each list step.
-        for step in [Step::Providers, Step::Agents, Step::Mcp] {
-            w.enter(step);
-            w.cursor = 999;
-            w.handle_key(press(KeyCode::Char(' ')));
-        }
-        assert!(!w.should_quit);
-    }
-
-    // ─── movement ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn both_arrow_and_vim_keys_move_the_cursor() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Providers);
-
-        w.handle_key(press(KeyCode::Down));
-        assert_eq!(w.cursor, 1);
-        w.handle_key(press(KeyCode::Char('j')));
-        assert_eq!(w.cursor, 2);
-        w.handle_key(press(KeyCode::Up));
-        assert_eq!(w.cursor, 1);
-        w.handle_key(press(KeyCode::Char('k')));
-        assert_eq!(w.cursor, 0);
-    }
-
-    #[test]
-    fn left_and_right_cycle_a_choice_in_both_directions() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        let ollama = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "ollama")
-            .expect("ollama is offered");
-        w.providers[ollama].selected = true;
-        w.enter(Step::Defaults);
-
-        w.handle_key(press(KeyCode::Right));
-        assert_eq!(w.defaults[0].value.display(), "ollama");
-        w.handle_key(press(KeyCode::Char('h')));
-        assert_eq!(w.defaults[0].value.display(), "anthropic");
-        // Wrapping backwards from the first option lands on the last.
-        w.handle_key(press(KeyCode::Left));
-        assert_eq!(w.defaults[0].value.display(), "ollama");
-    }
-
-    #[test]
-    fn choosing_ollama_as_the_default_lowers_the_concurrency_limit() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        let ollama = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "ollama")
-            .expect("ollama is offered");
-        w.providers[ollama].selected = true;
-        w.enter(Step::Defaults);
-        w.cursor = 0;
-
-        w.handle_key(press(KeyCode::Right));
-
-        assert_eq!(w.defaults[0].value.display(), "ollama");
-        assert_eq!(
-            w.limits[0].value,
-            FieldValue::Number(Some(
-                crate::commands::setup::catalog::OLLAMA_MAX_CONCURRENT_INFERENCES as u64
-            ))
-        );
-    }
-
-    #[test]
-    fn left_and_right_cycle_the_claude_code_effort() {
-        let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        w.enter(Step::ProviderDetail);
-        let before = w.providers[index].effort;
-
-        w.handle_key(press(KeyCode::Right));
-        assert_ne!(w.providers[index].effort, before);
-        w.handle_key(press(KeyCode::Left));
-        assert_eq!(w.providers[index].effort, before);
-        // Wrapping backwards from the first level lands on the last.
-        w.providers[index].effort = 0;
-        w.handle_key(press(KeyCode::Left));
-        assert_eq!(
-            w.providers[index].effort,
-            crate::commands::setup::state::effort_options().len() - 1
-        );
-    }
-
-    #[test]
-    fn arrows_on_a_keyed_provider_do_not_change_anything() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        w.enter(Step::ProviderDetail);
-        let before = w.providers[0].effort;
-
-        w.handle_key(press(KeyCode::Right));
-
-        assert_eq!(w.providers[0].effort, before);
-    }
-
-    #[test]
-    fn arrows_on_a_non_choice_field_or_empty_screen_are_harmless() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-        w.cursor = 0; // a number, not a choice
-        w.handle_key(press(KeyCode::Right));
-        assert_eq!(w.limits[0].value.display(), "8");
-
-        w.enter(Step::Welcome);
-        w.handle_key(press(KeyCode::Right));
-
-        w.enter(Step::ProviderDetail);
-        w.handle_key(press(KeyCode::Right));
-
-        assert!(!w.should_quit);
-    }
-
-    #[test]
-    fn an_empty_choice_list_does_not_divide_by_zero() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Defaults);
-        w.defaults[0].value = FieldValue::Choice {
-            options: Vec::new(),
-            index: 0,
-        };
-
-        w.handle_key(press(KeyCode::Right));
-
-        assert_eq!(w.defaults[0].value.display(), "(none)");
-    }
-
-    // ─── moving between screens ─────────────────────────────────────────────
-
-    #[test]
-    fn tab_and_shift_tab_walk_the_steps() {
-        let (_dir, mut w) = wizard();
-
-        w.handle_key(press(KeyCode::Tab));
-        assert_eq!(w.step, Step::Providers);
-        w.handle_key(press(KeyCode::BackTab));
-        assert_eq!(w.step, Step::Welcome);
-        w.handle_key(press(KeyCode::Tab));
-        w.handle_key(press_with(KeyCode::Tab, KeyModifiers::SHIFT));
-        assert_eq!(w.step, Step::Welcome);
-    }
-
-    #[test]
-    fn escape_goes_back_a_step() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Agents);
-
-        w.handle_key(press(KeyCode::Esc));
-
-        assert_eq!(w.step, Step::Limits);
-    }
-
-    #[test]
-    fn tab_on_the_credential_screen_walks_providers_then_leaves() {
-        let (_dir, mut w) = wizard();
-        let (mut requests, _replies) = w.take_verify_ends().expect("first take");
-        w.providers[0].selected = true;
-        w.providers[0].value = "sk-ant".to_string();
-        w.providers[1].selected = true;
-        w.providers[1].value = "sk-oai".to_string();
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Tab));
-        assert_eq!(w.step, Step::ProviderDetail);
-        assert_eq!(w.detail, 1, "moved to the second provider");
-
-        w.handle_key(press(KeyCode::Tab));
-        assert_eq!(w.step, Step::Defaults, "past the last provider");
-
-        // Moving on verifies what was just entered, so the answer is waiting
-        // rather than starting when the user asks for it.
-        let mut checked = Vec::new();
-        while let Ok(request) = requests.try_recv() {
-            checked.push(request.provider_id);
-        }
-        assert_eq!(checked, vec!["anthropic", "openai"]);
-    }
-
-    #[test]
-    fn escape_on_the_credential_screen_walks_back_through_providers() {
-        let (_dir, mut w) = wizard();
-        w.providers[0].selected = true;
-        w.providers[1].selected = true;
-        w.enter(Step::ProviderDetail);
-        w.detail = 1;
-
-        w.handle_key(press(KeyCode::Esc));
-        assert_eq!(w.step, Step::ProviderDetail);
-        assert_eq!(w.detail, 0);
-
-        w.handle_key(press(KeyCode::Esc));
-        assert_eq!(w.step, Step::Providers);
-    }
-
-    // ─── reveal, verify, open ───────────────────────────────────────────────
-
-    #[test]
-    fn ctrl_r_toggles_credential_visibility_and_says_which_way() {
-        let (_dir, mut w) = wizard();
-
-        w.handle_key(press_with(KeyCode::Char('r'), KeyModifiers::CONTROL));
-        assert!(w.reveal);
-        assert_eq!(w.message.as_deref(), Some("Credentials shown."));
-
-        w.handle_key(press_with(KeyCode::Char('r'), KeyModifiers::CONTROL));
-        assert!(!w.reveal);
-        assert_eq!(w.message.as_deref(), Some("Credentials hidden."));
-    }
-
-    #[test]
-    fn v_rechecks_the_provider_on_screen() {
-        let (_dir, mut w) = wizard();
-        let (mut requests, _replies) = w.take_verify_ends().expect("first take");
-        w.providers[0].selected = true;
-        w.providers[0].value = "sk-ant".to_string();
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Char('v')));
-
-        assert_eq!(w.message.as_deref(), Some("Checking…"));
-        assert_eq!(
-            requests.try_recv().expect("queued").provider_id,
-            "anthropic"
-        );
-    }
-
-    #[test]
-    fn v_on_the_list_and_review_screens_rechecks_everything() {
-        let (_dir, mut w) = wizard();
-        let (mut requests, _replies) = w.take_verify_ends().expect("first take");
-        w.providers[0].selected = true;
-        w.providers[0].value = "sk-ant".to_string();
-
-        w.enter(Step::Providers);
-        w.handle_key(press(KeyCode::Char('v')));
-        assert!(requests.try_recv().is_ok());
-
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Char('v')));
-        assert!(requests.try_recv().is_ok());
-    }
-
-    #[test]
-    fn v_elsewhere_does_nothing() {
-        let (_dir, mut w) = wizard();
-        let (mut requests, _replies) = w.take_verify_ends().expect("first take");
-        w.enter(Step::Limits);
-
-        w.handle_key(press(KeyCode::Char('v')));
-
-        assert!(requests.try_recv().is_err());
-    }
-
-    #[test]
-    fn v_on_the_credential_screen_with_no_provider_does_nothing() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Char('v')));
-
-        assert!(w.message.is_none());
-    }
-
-    #[test]
-    fn o_opens_the_signup_page_from_both_provider_screens() {
-        let dir = tempfile::tempdir().unwrap();
-        let opened = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let sink = opened.clone();
-        let mut w = Wizard::new(
-            crate::config::Config::default(),
-            &|_| None,
-            Vec::new(),
-            Vec::new(),
-            dir.path(),
-            std::sync::Arc::new(move |url: &str| {
-                sink.lock().expect("not poisoned").push(url.to_string());
-                true
-            }),
-        );
-
-        w.enter(Step::Providers);
-        w.handle_key(press(KeyCode::Char('o')));
-
-        w.providers[0].selected = true;
-        w.enter(Step::ProviderDetail);
-        w.handle_key(press(KeyCode::Char('o')));
-
-        let urls = opened.lock().expect("not poisoned").clone();
-        assert_eq!(urls.len(), 2);
-        assert!(urls.iter().all(|u| u.starts_with("https://")));
-        assert!(
-            w.message
-                .as_deref()
-                .unwrap_or_default()
-                .starts_with("Opened"),
-            "the user is told which page opened"
-        );
-    }
-
-    #[test]
-    fn a_browser_that_will_not_open_prints_the_url_instead() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut w = Wizard::new(
-            crate::config::Config::default(),
-            &|_| None,
-            Vec::new(),
-            Vec::new(),
-            dir.path(),
-            std::sync::Arc::new(|_| false),
-        );
-        w.enter(Step::Providers);
-
-        w.handle_key(press(KeyCode::Char('o')));
-
-        let message = w.message.as_deref().unwrap_or_default();
-        assert!(message.contains("Couldn't open"), "{message}");
-        assert!(message.contains("https://"), "{message}");
-    }
-
-    #[test]
-    fn o_where_there_is_nothing_to_open_says_so() {
-        let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        w.enter(Step::ProviderDetail);
-
-        w.handle_key(press(KeyCode::Char('o')));
-        assert_eq!(w.message.as_deref(), Some("Nothing to open here."));
-
-        w.enter(Step::Limits);
-        w.message = None;
-        w.handle_key(press(KeyCode::Char('o')));
-        assert_eq!(w.message.as_deref(), Some("Nothing to open here."));
-    }
-
-    #[test]
-    fn enter_on_a_list_screen_moves_on_rather_than_opening_an_editor() {
-        // Welcome, Providers, Agents and MCP have nothing to type into.
-        for step in [Step::Welcome, Step::Providers, Step::Agents] {
-            let (_dir, mut w) = wizard();
-            w.enter(step);
-
-            w.handle_key(press(KeyCode::Enter));
-
-            assert!(w.edit.is_none());
-            assert_ne!(w.step, step, "{step:?} should have advanced");
-        }
-    }
-
-    #[test]
-    fn space_on_a_number_field_leaves_it_alone() {
-        // Only booleans toggle; a count would have nothing to toggle *to*.
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Limits);
-        w.cursor = 0;
-        let before = w.limits[0].value.clone();
-
-        w.handle_key(press(KeyCode::Char(' ')));
-
-        assert_eq!(w.limits[0].value, before);
-    }
-
-    #[test]
-    fn an_unbound_key_does_nothing() {
-        let (_dir, mut w) = wizard();
-        let before = w.step;
-
-        w.handle_key(press(KeyCode::F(9)));
-
-        assert_eq!(w.step, before);
-        assert!(!w.should_quit);
-    }
-
-    // ─── Claude Code ToS confirmation gate ──────────────────────────────────
-
-    fn wizard_with_claude_code() -> (tempfile::TempDir, Wizard) {
-        let (dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        (dir, w)
-    }
-
-    #[test]
-    fn enter_on_review_with_claude_code_shows_tos_confirmation() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-
-        let action = w.handle_key(press(KeyCode::Enter));
-
-        assert_eq!(
-            action,
-            Action::Continue,
-            "must not save without ToS acceptance"
-        );
-        assert!(w.show_tos_confirm, "the overlay should be showing");
-    }
-
-    #[test]
-    fn ctrl_s_with_claude_code_shows_tos_confirmation() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Providers);
-
-        let action = w.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
-
-        assert_eq!(action, Action::Continue);
-        assert!(w.show_tos_confirm);
-    }
-
-    #[test]
-    fn pressing_y_on_tos_confirmation_accepts_and_saves() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Enter));
-        assert!(w.show_tos_confirm);
-
-        let action = w.handle_key(press(KeyCode::Char('y')));
-
-        assert!(w.claude_code_tos_accepted);
-        assert!(!w.show_tos_confirm);
-        assert_eq!(
-            action,
-            Action::Save,
-            "confirming is the last word on the save the user already asked for"
-        );
-    }
-
-    #[test]
-    fn pressing_uppercase_y_also_accepts_and_saves() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Enter));
-
-        let action = w.handle_key(press(KeyCode::Char('Y')));
-
-        assert!(w.claude_code_tos_accepted);
-        assert!(!w.show_tos_confirm);
-        assert_eq!(action, Action::Save);
-    }
-
-    #[test]
-    fn dismissing_the_tos_confirmation_stays_put_without_accepting() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Enter));
-
-        let action = w.handle_key(press(KeyCode::Char('n')));
-
-        assert!(!w.claude_code_tos_accepted);
-        assert!(!w.show_tos_confirm);
-        assert_eq!(action, Action::Continue, "the save stays blocked");
-        assert_eq!(w.step, Step::Review, "declining must not navigate away");
-    }
-
-    #[test]
-    fn second_enter_on_review_after_accepting_saves() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Enter)); // shows overlay
-        w.handle_key(press(KeyCode::Char('y'))); // accept, goes back
-
-        w.enter(Step::Review);
-        let action = w.handle_key(press(KeyCode::Enter));
-
-        assert_eq!(action, Action::Save, "should save after ToS accepted");
-    }
-
-    #[test]
-    fn deselecting_claude_code_resets_tos_acceptance() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.claude_code_tos_accepted = true;
-
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .unwrap();
-        w.enter(Step::Providers);
-        w.cursor = index;
-        w.handle_key(press(KeyCode::Char(' '))); // deselect
-
-        assert!(!w.claude_code_tos_accepted);
-    }
-
-    #[test]
-    fn tos_overlay_blocks_all_other_keys() {
-        let (_dir, mut w) = wizard_with_claude_code();
-        w.enter(Step::Review);
-        w.handle_key(press(KeyCode::Enter));
-        assert!(w.show_tos_confirm);
-
-        // q should NOT quit - the overlay eats it
-        w.handle_key(press(KeyCode::Char('q')));
-        assert!(!w.should_quit, "q must not quit while overlay is showing");
-        assert!(!w.show_tos_confirm, "overlay dismissed");
-    }
-
-    #[test]
-    fn without_claude_code_review_saves_immediately() {
-        let (_dir, mut w) = wizard();
-        w.enter(Step::Review);
-
-        let action = w.handle_key(press(KeyCode::Enter));
-        assert_eq!(action, Action::Save, "no claude-code means no gate");
-    }
-}
+mod tests;

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1,0 +1,1074 @@
+use super::*;
+use crate::commands::setup::state::{ConfirmPurpose, Edit, EditTarget, FieldValue};
+
+fn press(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::empty())
+}
+
+fn press_with(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+    KeyEvent::new(code, modifiers)
+}
+
+fn wizard() -> (tempfile::TempDir, Wizard) {
+    let dir = tempfile::tempdir().unwrap();
+    let wizard = crate::commands::setup::state::tests::test_wizard(dir.path());
+    (dir, wizard)
+}
+
+fn credential_edit(value: &str, masked: bool) -> Edit {
+    Edit {
+        target: EditTarget::Credential(0),
+        line: LineEdit::new(value, masked),
+    }
+}
+
+// ─── quitting and saving ────────────────────────────────────────────────
+
+#[test]
+fn ctrl_c_quits_immediately_when_nothing_was_changed() {
+    let (_dir, mut w) = wizard();
+    w.edit = Some(credential_edit("half-typed", true));
+
+    let action = w.handle_key(press_with(KeyCode::Char('c'), KeyModifiers::CONTROL));
+
+    assert_eq!(action, Action::Continue);
+    assert!(w.should_quit);
+}
+
+#[test]
+fn ctrl_c_with_unsaved_changes_asks_once_then_quits() {
+    let (_dir, mut w) = wizard();
+    w.dirty = true;
+
+    w.handle_key(press_with(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    assert!(!w.should_quit, "first Ctrl-C asks");
+    let pending = w.confirm.as_ref().expect("the quit dialog is open");
+    assert_eq!(pending.purpose, ConfirmPurpose::QuitDiscard);
+    assert!(!pending.dialog.focus_yes, "the safe answer holds focus");
+
+    // A second Ctrl-C, with the dialog open, obeys unconditionally.
+    w.handle_key(press_with(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    assert!(w.should_quit);
+}
+
+#[test]
+fn q_quits_while_navigating_with_nothing_changed() {
+    let (_dir, mut w) = wizard();
+    w.handle_key(press(KeyCode::Char('q')));
+    assert!(w.should_quit);
+}
+
+#[test]
+fn q_with_unsaved_changes_opens_the_quit_dialog() {
+    let (_dir, mut w) = wizard();
+    w.dirty = true;
+
+    w.handle_key(press(KeyCode::Char('q')));
+
+    assert!(!w.should_quit);
+    assert_eq!(
+        w.confirm.as_ref().expect("dialog open").purpose,
+        ConfirmPurpose::QuitDiscard
+    );
+
+    // Enter on the default (No / Stay) button closes the dialog and stays.
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.confirm.is_none());
+    assert!(!w.should_quit);
+
+    // Asking again and confirming with `y` quits.
+    w.handle_key(press(KeyCode::Char('q')));
+    w.handle_key(press(KeyCode::Char('y')));
+    assert!(w.should_quit);
+}
+
+#[test]
+fn q_types_a_letter_while_editing_rather_than_quitting() {
+    // Losing a half-entered API key to a quit shortcut would be a bad way
+    // to find out about modal input.
+    let (_dir, mut w) = wizard();
+    w.edit = Some(credential_edit("", true));
+
+    w.handle_key(press(KeyCode::Char('q')));
+
+    assert!(!w.should_quit);
+    assert_eq!(w.edit.as_ref().expect("still editing").line.value(), "q");
+}
+
+#[test]
+fn ctrl_s_saves_from_any_screen() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+
+    let action = w.handle_key(press_with(KeyCode::Char('s'), KeyModifiers::CONTROL));
+
+    assert_eq!(action, Action::Save);
+}
+
+#[test]
+fn enter_on_the_review_screen_saves() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Review);
+
+    assert_eq!(w.handle_key(press(KeyCode::Enter)), Action::Save);
+}
+
+#[test]
+fn confirm_and_editor_guards_hold_when_driven_directly() {
+    let (_dir, mut w) = wizard();
+
+    // No dialog open: the confirm handler declines to act.
+    assert_eq!(
+        w.handle_confirm_key(press(KeyCode::Enter)),
+        Action::Continue
+    );
+    assert!(w.confirm.is_none());
+
+    // The field editor refuses a non-text (Bool) row.
+    w.enter(Step::Limits);
+    w.cursor = 3;
+    assert!(!w.open_field_editor());
+
+    // The credential editor refuses an empty credential screen.
+    w.enter(Step::ProviderDetail);
+    assert!(!w.open_credential_editor());
+}
+
+#[test]
+fn enter_on_a_forced_credential_row_with_no_provider_is_harmless() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::ProviderDetail);
+    w.cursor = 1; // not the Continue button (row_count is 0 here)
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.edit.is_none());
+    assert_eq!(w.step, Step::ProviderDetail);
+}
+
+#[test]
+fn a_direct_force_quit_action_sets_the_quit_flag() {
+    // `handle_key` intercepts Ctrl-C before navigation; the nav arm still
+    // behaves correctly when driven directly.
+    let (_dir, mut w) = wizard();
+    w.handle_nav_key(press_with(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    assert!(w.should_quit);
+}
+
+// ─── help overlay ───────────────────────────────────────────────────────
+
+#[test]
+fn the_help_overlay_opens_and_only_deliberate_keys_close_it() {
+    let (_dir, mut w) = wizard();
+
+    w.handle_key(press(KeyCode::Char('?')));
+    assert!(w.show_help);
+
+    // A random key is ignored: it neither closes help nor acts underneath.
+    w.handle_key(press(KeyCode::Char('x')));
+    assert!(w.show_help);
+
+    // A dismissing key closes the overlay without also doing its normal job.
+    w.handle_key(press(KeyCode::Char('q')));
+    assert!(!w.show_help);
+    assert!(!w.should_quit);
+}
+
+// ─── editing ────────────────────────────────────────────────────────────
+
+#[test]
+fn typing_backspacing_and_committing_a_credential() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.edit.is_some(), "Enter opens the editor");
+    for c in "sk-antX".chars() {
+        w.handle_key(press(KeyCode::Char(c)));
+    }
+    w.handle_key(press(KeyCode::Backspace));
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.edit.is_none());
+    assert_eq!(w.providers[0].value, "sk-ant");
+    assert!(w.dirty, "a committed edit is an unsaved change");
+}
+
+#[test]
+fn escape_abandons_an_edit_without_changing_the_value() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.providers[0].value = "sk-ant-original".to_string();
+    w.enter(Step::ProviderDetail);
+    w.handle_key(press(KeyCode::Enter));
+    w.handle_key(press(KeyCode::Char('z')));
+
+    w.handle_key(press(KeyCode::Esc));
+
+    assert!(w.edit.is_none());
+    assert_eq!(w.providers[0].value, "sk-ant-original");
+    assert_eq!(w.message.as_deref(), Some("Edit cancelled."));
+}
+
+#[test]
+fn an_unhandled_key_while_editing_is_ignored() {
+    let (_dir, mut w) = wizard();
+    w.edit = Some(credential_edit("abc", false));
+
+    w.handle_key(press(KeyCode::F(5)));
+
+    assert_eq!(w.edit.as_ref().expect("still editing").line.value(), "abc");
+}
+
+#[test]
+fn the_cursor_moves_within_an_edit() {
+    // The shared LineEdit brings real cursor movement; prove it is wired.
+    let (_dir, mut w) = wizard();
+    w.edit = Some(credential_edit("ad", false));
+
+    w.handle_key(press(KeyCode::Left));
+    w.handle_key(press(KeyCode::Char('c')));
+
+    assert_eq!(w.edit.as_ref().expect("still editing").line.value(), "acd");
+}
+
+#[test]
+fn the_claude_code_transport_has_nothing_to_type_so_enter_cycles_effort() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "claude-code")
+        .expect("the transport is offered");
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+    let before = w.providers[index].effort;
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.edit.is_none());
+    assert_eq!(
+        w.step,
+        Step::ProviderDetail,
+        "acting on a row never advances"
+    );
+    assert_ne!(w.providers[index].effort, before, "Enter acts on the row");
+}
+
+#[test]
+fn enter_on_a_toggle_flips_it_and_stays() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+    w.cursor = 3; // a boolean
+    let before = w.limits[3].value.clone();
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.edit.is_none());
+    assert_eq!(w.step, Step::Limits, "acting on a row never advances");
+    assert_ne!(w.limits[3].value, before);
+}
+
+#[test]
+fn enter_on_a_choice_cycles_it_and_stays() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    let ollama = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "ollama")
+        .expect("ollama is offered");
+    w.providers[ollama].selected = true;
+    w.enter(Step::Defaults);
+    w.cursor = 0; // the provider choice
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(w.step, Step::Defaults);
+    assert_eq!(w.defaults[0].value.display(), "ollama");
+}
+
+#[test]
+fn enter_on_a_number_field_opens_it_seeded_with_the_current_value() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+
+    w.handle_key(press(KeyCode::Enter));
+
+    let edit = w.edit.as_ref().expect("the editor opened");
+    assert_eq!(edit.target, EditTarget::Field(0));
+    assert!(
+        !edit.line.value().is_empty(),
+        "seeded from the current value"
+    );
+    assert!(!edit.line.masked, "a limit is not a secret");
+}
+
+#[test]
+fn an_unset_number_field_opens_empty() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+    w.limits[0].value = FieldValue::Number(None);
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(
+        w.edit
+            .as_ref()
+            .expect("the editor opened")
+            .line
+            .value()
+            .is_empty()
+    );
+}
+
+#[test]
+fn a_cursor_forced_out_of_range_acts_on_nothing() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+    w.cursor = 99;
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.edit.is_none());
+    assert_eq!(w.step, Step::Limits);
+
+    // The rowless steps have the same guard.
+    for step in [Step::Welcome, Step::Review] {
+        w.enter(step);
+        w.cursor = 99;
+        w.handle_key(press(KeyCode::Enter));
+        assert_eq!(w.step, step);
+    }
+}
+
+#[test]
+fn the_credential_screen_with_no_provider_continues_on_enter() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.edit.is_none());
+    assert_ne!(w.step, Step::ProviderDetail);
+}
+
+// ─── selection ──────────────────────────────────────────────────────────
+
+#[test]
+fn space_toggles_a_provider_and_resets_the_credential_walk() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    w.detail = 3;
+
+    w.handle_key(press(KeyCode::Char(' ')));
+
+    assert!(w.providers[0].selected);
+    assert!(w.dirty, "a toggle is an unsaved change");
+    assert_eq!(w.detail, 0, "the walk is relative to the new selection");
+
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert!(!w.providers[0].selected);
+}
+
+#[test]
+fn enter_on_a_provider_row_selects_it_rather_than_advancing() {
+    // The reported trap: users pressed Enter expecting to select, and the
+    // wizard advanced past the credentials screen instead.
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(w.step, Step::Providers, "Enter on a row must not advance");
+    assert!(w.providers[0].selected, "Enter selects like Space");
+}
+
+#[test]
+fn enter_on_agent_and_mcp_rows_toggles_like_space() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut w = Wizard::new(
+        crate::config::Config::default(),
+        &|_| None,
+        vec![(
+            "A".to_string(),
+            crate::commands::setup::import::Candidate {
+                config: leviath_mcp::MCPServerConfig::stdio("fs", "npx", vec![]),
+                scope: String::new(),
+                inline_secrets: Vec::new(),
+            },
+        )],
+        Vec::new(),
+        dir.path(),
+        std::sync::Arc::new(|_| true),
+    );
+
+    w.enter(Step::Agents);
+    let before = w.agents[0].selected;
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.step, Step::Agents);
+    assert_ne!(w.agents[0].selected, before);
+
+    w.enter(Step::Mcp);
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.step, Step::Mcp);
+    assert!(!w.mcp[0].selected);
+}
+
+#[test]
+fn space_toggles_agents_and_mcp_rows_and_booleans() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut w = Wizard::new(
+        crate::config::Config::default(),
+        &|_| None,
+        vec![(
+            "A".to_string(),
+            crate::commands::setup::import::Candidate {
+                config: leviath_mcp::MCPServerConfig::stdio("fs", "npx", vec![]),
+                scope: String::new(),
+                inline_secrets: Vec::new(),
+            },
+        )],
+        Vec::new(),
+        dir.path(),
+        std::sync::Arc::new(|_| true),
+    );
+
+    w.enter(Step::Agents);
+    let before = w.agents[0].selected;
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert_ne!(w.agents[0].selected, before);
+
+    w.enter(Step::Mcp);
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert!(!w.mcp[0].selected);
+
+    w.enter(Step::Limits);
+    w.cursor = 3;
+    let before = w.limits[3].value.clone();
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert_ne!(w.limits[3].value, before);
+}
+
+#[test]
+fn space_on_a_screen_with_nothing_to_toggle_is_harmless() {
+    let (_dir, mut w) = wizard();
+    for step in [Step::Welcome, Step::ProviderDetail, Step::Review] {
+        w.enter(step);
+        w.handle_key(press(KeyCode::Char(' ')));
+    }
+    // Also out-of-range cursors on each list step.
+    for step in [Step::Providers, Step::Agents, Step::Mcp] {
+        w.enter(step);
+        w.cursor = 999;
+        w.handle_key(press(KeyCode::Char(' ')));
+    }
+    assert!(!w.should_quit);
+}
+
+// ─── the Continue button ────────────────────────────────────────────────
+
+#[test]
+fn enter_on_the_continue_button_advances() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::Providers);
+    w.cursor = w.row_count(); // the button
+    assert!(w.on_continue());
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(w.step, Step::ProviderDetail);
+}
+
+#[test]
+fn the_cursor_walks_past_the_last_row_onto_the_button() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    let rows = w.row_count();
+    for _ in 0..rows + 5 {
+        w.handle_key(press(KeyCode::Down));
+    }
+    assert_eq!(w.cursor, rows, "clamped to the button, not past it");
+    assert!(w.on_continue());
+}
+
+#[test]
+fn continuing_with_no_providers_asks_first() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    w.cursor = w.row_count();
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(w.step, Step::Providers, "blocked behind the dialog");
+    let pending = w.confirm.as_ref().expect("the guard dialog is open");
+    assert_eq!(pending.purpose, ConfirmPurpose::NoProviders);
+    assert!(!pending.dialog.focus_yes, "Go back holds focus");
+
+    // Enter on the default answer goes back to picking providers.
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.step, Step::Providers);
+    assert!(w.confirm.is_none());
+
+    // Asking again and explicitly confirming continues anyway; with no
+    // provider selected the credential screen self-skips, with a message.
+    w.handle_key(press(KeyCode::Enter));
+    w.handle_key(press(KeyCode::Char('y')));
+    assert_eq!(w.step, Step::Defaults);
+    assert_eq!(
+        w.message.as_deref(),
+        Some("Skipped Credentials: no selected provider needs setup.")
+    );
+}
+
+#[test]
+fn tab_from_providers_with_none_selected_hits_the_same_guard() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+
+    w.handle_key(press(KeyCode::Tab));
+
+    assert_eq!(w.step, Step::Providers);
+    assert_eq!(
+        w.confirm.as_ref().expect("dialog open").purpose,
+        ConfirmPurpose::NoProviders
+    );
+}
+
+#[test]
+fn tab_with_a_provider_selected_advances_without_asking() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::Providers);
+
+    w.handle_key(press(KeyCode::Tab));
+
+    assert!(w.confirm.is_none());
+    assert_eq!(w.step, Step::ProviderDetail);
+}
+
+// ─── movement ───────────────────────────────────────────────────────────
+
+#[test]
+fn both_arrow_and_vim_keys_move_the_cursor() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+
+    w.handle_key(press(KeyCode::Down));
+    assert_eq!(w.cursor, 1);
+    w.handle_key(press(KeyCode::Char('j')));
+    assert_eq!(w.cursor, 2);
+    w.handle_key(press(KeyCode::Up));
+    assert_eq!(w.cursor, 1);
+    w.handle_key(press(KeyCode::Char('k')));
+    assert_eq!(w.cursor, 0);
+}
+
+#[test]
+fn left_and_right_cycle_a_choice_in_both_directions() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    let ollama = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "ollama")
+        .expect("ollama is offered");
+    w.providers[ollama].selected = true;
+    w.enter(Step::Defaults);
+
+    w.handle_key(press(KeyCode::Right));
+    assert_eq!(w.defaults[0].value.display(), "ollama");
+    w.handle_key(press(KeyCode::Char('h')));
+    assert_eq!(w.defaults[0].value.display(), "anthropic");
+    // Wrapping backwards from the first option lands on the last.
+    w.handle_key(press(KeyCode::Left));
+    assert_eq!(w.defaults[0].value.display(), "ollama");
+}
+
+#[test]
+fn choosing_ollama_as_the_default_lowers_the_concurrency_limit() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    let ollama = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "ollama")
+        .expect("ollama is offered");
+    w.providers[ollama].selected = true;
+    w.enter(Step::Defaults);
+    w.cursor = 0;
+
+    w.handle_key(press(KeyCode::Right));
+
+    assert_eq!(w.defaults[0].value.display(), "ollama");
+    assert_eq!(
+        w.limits[0].value,
+        FieldValue::Number(Some(
+            crate::commands::setup::catalog::OLLAMA_MAX_CONCURRENT_INFERENCES as u64
+        ))
+    );
+}
+
+#[test]
+fn left_and_right_cycle_the_claude_code_effort() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "claude-code")
+        .expect("the transport is offered");
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+    let before = w.providers[index].effort;
+
+    w.handle_key(press(KeyCode::Right));
+    assert_ne!(w.providers[index].effort, before);
+    w.handle_key(press(KeyCode::Left));
+    assert_eq!(w.providers[index].effort, before);
+    // Wrapping backwards from the first level lands on the last.
+    w.providers[index].effort = 0;
+    w.handle_key(press(KeyCode::Left));
+    assert_eq!(
+        w.providers[index].effort,
+        crate::commands::setup::state::effort_options().len() - 1
+    );
+}
+
+#[test]
+fn arrows_on_a_keyed_provider_do_not_change_anything() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::ProviderDetail);
+    let before = w.providers[0].effort;
+
+    w.handle_key(press(KeyCode::Right));
+
+    assert_eq!(w.providers[0].effort, before);
+}
+
+#[test]
+fn arrows_on_a_non_choice_field_or_empty_screen_are_harmless() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+    w.cursor = 0; // a number, not a choice
+    w.handle_key(press(KeyCode::Right));
+    assert_eq!(w.limits[0].value.display(), "8");
+
+    w.enter(Step::Welcome);
+    w.handle_key(press(KeyCode::Right));
+
+    w.enter(Step::ProviderDetail);
+    w.handle_key(press(KeyCode::Right));
+
+    assert!(!w.should_quit);
+}
+
+#[test]
+fn an_empty_choice_list_does_not_divide_by_zero() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Defaults);
+    w.defaults[0].value = FieldValue::Choice {
+        options: Vec::new(),
+        index: 0,
+    };
+
+    w.handle_key(press(KeyCode::Right));
+
+    assert_eq!(w.defaults[0].value.display(), "(none)");
+}
+
+// ─── moving between screens ─────────────────────────────────────────────
+
+#[test]
+fn tab_and_shift_tab_walk_the_steps() {
+    let (_dir, mut w) = wizard();
+
+    w.handle_key(press(KeyCode::Tab));
+    assert_eq!(w.step, Step::Providers);
+    w.handle_key(press(KeyCode::BackTab));
+    assert_eq!(w.step, Step::Welcome);
+    w.handle_key(press(KeyCode::Tab));
+    w.handle_key(press_with(KeyCode::Tab, KeyModifiers::SHIFT));
+    assert_eq!(w.step, Step::Welcome);
+}
+
+#[test]
+fn escape_goes_back_a_step() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Agents);
+
+    w.handle_key(press(KeyCode::Esc));
+
+    assert_eq!(w.step, Step::Limits);
+}
+
+#[test]
+fn tab_on_the_credential_screen_walks_providers_then_leaves() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    w.providers[0].selected = true;
+    w.providers[0].value = "sk-ant".to_string();
+    w.providers[1].selected = true;
+    w.providers[1].value = "sk-oai".to_string();
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Tab));
+    assert_eq!(w.step, Step::ProviderDetail);
+    assert_eq!(w.detail, 1, "moved to the second provider");
+
+    w.handle_key(press(KeyCode::Tab));
+    assert_eq!(w.step, Step::Defaults, "past the last provider");
+
+    // Moving on verifies what was just entered, so the answer is waiting
+    // rather than starting when the user asks for it.
+    let mut checked = Vec::new();
+    while let Ok(request) = requests.try_recv() {
+        checked.push(request.provider_id);
+    }
+    assert_eq!(checked, vec!["anthropic", "openai"]);
+}
+
+#[test]
+fn escape_on_the_credential_screen_walks_back_through_providers() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.providers[1].selected = true;
+    w.enter(Step::ProviderDetail);
+    w.detail = 1;
+
+    w.handle_key(press(KeyCode::Esc));
+    assert_eq!(w.step, Step::ProviderDetail);
+    assert_eq!(w.detail, 0);
+
+    w.handle_key(press(KeyCode::Esc));
+    assert_eq!(w.step, Step::Providers);
+}
+
+// ─── reveal, verify, open ───────────────────────────────────────────────
+
+#[test]
+fn ctrl_r_toggles_credential_visibility_and_says_which_way() {
+    let (_dir, mut w) = wizard();
+
+    w.handle_key(press_with(KeyCode::Char('r'), KeyModifiers::CONTROL));
+    assert!(w.reveal);
+    assert_eq!(w.message.as_deref(), Some("Credentials shown."));
+
+    w.handle_key(press_with(KeyCode::Char('r'), KeyModifiers::CONTROL));
+    assert!(!w.reveal);
+    assert_eq!(w.message.as_deref(), Some("Credentials hidden."));
+}
+
+#[test]
+fn ctrl_r_reveals_even_while_typing_a_credential() {
+    // Revealing is most useful mid-typo; the chord must not be eaten (or
+    // inserted as a literal 'r') by the open editor.
+    let (_dir, mut w) = wizard();
+    w.edit = Some(credential_edit("sk-", true));
+
+    w.handle_key(press_with(KeyCode::Char('r'), KeyModifiers::CONTROL));
+
+    assert!(w.reveal);
+    assert_eq!(w.edit.as_ref().expect("still editing").line.value(), "sk-");
+}
+
+#[test]
+fn v_rechecks_the_provider_on_screen() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    w.providers[0].selected = true;
+    w.providers[0].value = "sk-ant".to_string();
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Char('v')));
+
+    assert_eq!(w.message.as_deref(), Some("Checking…"));
+    assert_eq!(
+        requests.try_recv().expect("queued").provider_id,
+        "anthropic"
+    );
+}
+
+#[test]
+fn v_on_the_list_and_review_screens_rechecks_everything() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    w.providers[0].selected = true;
+    w.providers[0].value = "sk-ant".to_string();
+
+    w.enter(Step::Providers);
+    w.handle_key(press(KeyCode::Char('v')));
+    assert!(requests.try_recv().is_ok());
+
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Char('v')));
+    assert!(requests.try_recv().is_ok());
+}
+
+#[test]
+fn v_elsewhere_does_nothing() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    w.enter(Step::Limits);
+
+    w.handle_key(press(KeyCode::Char('v')));
+
+    assert!(requests.try_recv().is_err());
+}
+
+#[test]
+fn v_on_the_credential_screen_with_no_provider_does_nothing() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Char('v')));
+
+    assert!(w.message.is_none());
+}
+
+#[test]
+fn o_opens_the_signup_page_from_both_provider_screens() {
+    let dir = tempfile::tempdir().unwrap();
+    let opened = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = opened.clone();
+    let mut w = Wizard::new(
+        crate::config::Config::default(),
+        &|_| None,
+        Vec::new(),
+        Vec::new(),
+        dir.path(),
+        std::sync::Arc::new(move |url: &str| {
+            sink.lock().expect("not poisoned").push(url.to_string());
+            true
+        }),
+    );
+
+    w.enter(Step::Providers);
+    w.handle_key(press(KeyCode::Char('o')));
+
+    w.providers[0].selected = true;
+    w.enter(Step::ProviderDetail);
+    w.handle_key(press(KeyCode::Char('o')));
+
+    let urls = opened.lock().expect("not poisoned").clone();
+    assert_eq!(urls.len(), 2);
+    assert!(urls.iter().all(|u| u.starts_with("https://")));
+    assert!(
+        w.message
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("Opened"),
+        "the user is told which page opened"
+    );
+}
+
+#[test]
+fn a_browser_that_will_not_open_prints_the_url_instead() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut w = Wizard::new(
+        crate::config::Config::default(),
+        &|_| None,
+        Vec::new(),
+        Vec::new(),
+        dir.path(),
+        std::sync::Arc::new(|_| false),
+    );
+    w.enter(Step::Providers);
+
+    w.handle_key(press(KeyCode::Char('o')));
+
+    let message = w.message.as_deref().unwrap_or_default();
+    assert!(message.contains("Couldn't open"), "{message}");
+    assert!(message.contains("https://"), "{message}");
+}
+
+#[test]
+fn o_where_there_is_nothing_to_open_says_so() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "claude-code")
+        .expect("the transport is offered");
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Char('o')));
+    assert_eq!(w.message.as_deref(), Some("Nothing to open here."));
+
+    w.enter(Step::Limits);
+    w.message = None;
+    w.handle_key(press(KeyCode::Char('o')));
+    assert_eq!(w.message.as_deref(), Some("Nothing to open here."));
+}
+
+#[test]
+fn space_on_a_number_field_leaves_it_alone() {
+    // Only booleans toggle; a count would have nothing to toggle *to*.
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Limits);
+    w.cursor = 0;
+    let before = w.limits[0].value.clone();
+
+    w.handle_key(press(KeyCode::Char(' ')));
+
+    assert_eq!(w.limits[0].value, before);
+}
+
+#[test]
+fn an_unbound_key_does_nothing() {
+    let (_dir, mut w) = wizard();
+    let before = w.step;
+
+    w.handle_key(press(KeyCode::F(9)));
+
+    assert_eq!(w.step, before);
+    assert!(!w.should_quit);
+}
+
+// ─── Claude Code ToS confirmation gate ──────────────────────────────────
+
+fn wizard_with_claude_code() -> (tempfile::TempDir, Wizard) {
+    let (dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "claude-code")
+        .expect("the transport is offered");
+    w.providers[index].selected = true;
+    (dir, w)
+}
+
+#[test]
+fn enter_on_review_with_claude_code_shows_tos_confirmation() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+
+    let action = w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(
+        action,
+        Action::Continue,
+        "must not save without ToS acceptance"
+    );
+    assert_eq!(
+        w.confirm.as_ref().expect("dialog open").purpose,
+        ConfirmPurpose::SaveTos
+    );
+}
+
+#[test]
+fn ctrl_s_with_claude_code_shows_tos_confirmation() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Providers);
+
+    let action = w.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+
+    assert_eq!(action, Action::Continue);
+    assert_eq!(
+        w.confirm.as_ref().expect("dialog open").purpose,
+        ConfirmPurpose::SaveTos
+    );
+}
+
+#[test]
+fn pressing_y_on_tos_confirmation_accepts_and_saves() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.confirm.is_some());
+
+    let action = w.handle_key(press(KeyCode::Char('y')));
+
+    assert!(w.claude_code_tos_accepted);
+    assert!(w.confirm.is_none());
+    assert_eq!(
+        action,
+        Action::Save,
+        "confirming is the last word on the save the user already asked for"
+    );
+}
+
+#[test]
+fn moving_focus_and_pressing_enter_also_accepts() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Enter));
+
+    w.handle_key(press(KeyCode::Right)); // focus Accept
+    let action = w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.claude_code_tos_accepted);
+    assert_eq!(action, Action::Save);
+}
+
+#[test]
+fn dismissing_the_tos_confirmation_stays_put_without_accepting() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Enter));
+
+    let action = w.handle_key(press(KeyCode::Char('n')));
+
+    assert!(!w.claude_code_tos_accepted);
+    assert!(w.confirm.is_none());
+    assert_eq!(action, Action::Continue, "the save stays blocked");
+    assert_eq!(w.step, Step::Review, "declining must not navigate away");
+}
+
+#[test]
+fn second_enter_on_review_after_accepting_saves() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Enter)); // shows the dialog
+    w.handle_key(press(KeyCode::Char('y'))); // accept
+
+    w.enter(Step::Review);
+    let action = w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(action, Action::Save, "should save after ToS accepted");
+}
+
+#[test]
+fn deselecting_claude_code_resets_tos_acceptance() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.claude_code_tos_accepted = true;
+
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "claude-code")
+        .unwrap();
+    w.enter(Step::Providers);
+    w.cursor = index;
+    w.handle_key(press(KeyCode::Char(' '))); // deselect
+
+    assert!(!w.claude_code_tos_accepted);
+}
+
+#[test]
+fn a_dialog_holds_focus_against_stray_keys() {
+    let (_dir, mut w) = wizard_with_claude_code();
+    w.enter(Step::Review);
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.confirm.is_some());
+
+    // q neither quits nor dismisses: a stray key never answers a dialog.
+    w.handle_key(press(KeyCode::Char('q')));
+    assert!(!w.should_quit, "q must not quit while a dialog is open");
+    assert!(w.confirm.is_some(), "and must not dismiss it either");
+
+    // Esc explicitly declines.
+    w.handle_key(press(KeyCode::Esc));
+    assert!(w.confirm.is_none());
+    assert!(!w.claude_code_tos_accepted);
+}
+
+#[test]
+fn without_claude_code_review_saves_immediately() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Review);
+
+    let action = w.handle_key(press(KeyCode::Enter));
+    assert_eq!(action, Action::Save, "no claude-code means no gate");
+}

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -8,15 +8,17 @@
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
 
 use super::catalog::{self, Credential};
 use super::state::{FieldValue, Step, Wizard};
 use crate::tui::theme::*;
+use crate::tui::widgets::footer::{Hint, draw_hint_bar, hint};
+use crate::tui::widgets::help::{HelpSection, draw_help};
 
 /// Draw one frame.
 pub fn draw(frame: &mut Frame, wizard: &Wizard) {
@@ -33,11 +35,65 @@ pub fn draw(frame: &mut Frame, wizard: &Wizard) {
     draw_body(frame, chunks[1], wizard);
     draw_footer(frame, chunks[2], wizard);
 
-    if wizard.show_tos_confirm {
-        draw_tos_confirm(frame, frame.area());
+    if let Some(pending) = &wizard.confirm {
+        pending.dialog.draw(frame, frame.area());
     } else if wizard.show_help {
-        draw_help(frame, frame.area());
+        draw_help(frame, frame.area(), &help_sections());
     }
+}
+
+/// The help overlay's content, matching the bindings in `input.rs`.
+fn help_sections() -> [HelpSection; 3] {
+    [
+        HelpSection {
+            title: "Navigate",
+            entries: vec![
+                ("↑ ↓ / k j", "move"),
+                ("← → / h l", "change a choice"),
+                ("space", "select / toggle"),
+                ("enter", "act on the focused row; Continue moves on"),
+                ("tab", "next screen"),
+                ("shift-tab / esc", "previous screen"),
+            ],
+        },
+        HelpSection {
+            title: "Providers",
+            entries: vec![
+                ("v", "re-check a credential"),
+                ("o", "open a signup page"),
+                ("ctrl-r", "show or hide credentials"),
+            ],
+        },
+        HelpSection {
+            title: "Finish",
+            entries: vec![
+                ("ctrl-s", "write and finish, from anywhere"),
+                (
+                    "q / ctrl-c",
+                    "quit without writing (asks if you changed things)",
+                ),
+            ],
+        },
+    ]
+}
+
+/// The step's Continue/action button, rendered as the last cursor row.
+fn continue_line(wizard: &Wizard) -> Line<'static> {
+    let focused = wizard.on_continue();
+    let style = if focused {
+        Style::default()
+            .fg(C_ACCENT)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(C_MUTED)
+    };
+    Line::from(vec![
+        Span::styled(
+            if focused { "› " } else { "  " },
+            Style::default().fg(C_ACCENT),
+        ),
+        Span::styled(format!("[ {} ]", wizard.continue_label()), style),
+    ])
 }
 
 /// The step breadcrumb.
@@ -141,10 +197,8 @@ fn draw_welcome(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         "Nothing is written until the last screen.",
         Style::default().fg(C_DIM),
     )));
-    lines.push(Line::from(Span::styled(
-        "Press Enter to begin.",
-        Style::default().fg(C_ACCENT),
-    )));
+    lines.push(Line::from(""));
+    lines.push(continue_line(wizard));
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
@@ -199,7 +253,7 @@ fn wrap_plain(text: &str, width: usize) -> Vec<String> {
 }
 
 fn draw_providers(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let items: Vec<ListItem> = wizard
+    let mut items: Vec<ListItem> = wizard
         .providers
         .iter()
         .enumerate()
@@ -237,12 +291,15 @@ fn draw_providers(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             ListItem::new(item_lines)
         })
         .collect();
+    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
 
     frame.render_widget(List::new(items), area);
 }
 
 fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     let Some(index) = wizard.detail_row() else {
+        // Forced onto an empty credential screen (tests do): only the button.
+        frame.render_widget(Paragraph::new(vec![continue_line(wizard)]), area);
         return;
     };
     // `detail_row` yields an index into `providers`, so this is a read rather
@@ -269,6 +326,9 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         Line::from(""),
     ];
 
+    // The credential (or effort) row is the screen's one cursor row; the
+    // marker shows whether it or the Continue button holds focus.
+    let row_marker = if wizard.on_continue() { "  " } else { "› " };
     match row.provider.credential {
         Credential::ApiKey | Credential::BaseUrl => {
             let label = if row.provider.credential == Credential::ApiKey {
@@ -276,11 +336,20 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             } else {
                 "Base URL"
             };
-            let shown = credential_display(wizard, index);
-            lines.push(Line::from(vec![
+            let mut spans = vec![
+                Span::styled(row_marker, Style::default().fg(C_ACCENT)),
                 Span::styled(format!("{label}: "), Style::default().fg(C_MUTED)),
-                Span::styled(shown, Style::default().fg(C_WHITE)),
-            ]));
+            ];
+            match &wizard.edit {
+                Some(edit) if edit.target == super::state::EditTarget::Credential(index) => {
+                    spans.extend(edit.line.display_spans(wizard.reveal).spans);
+                }
+                _ => spans.push(Span::styled(
+                    credential_display(wizard, index),
+                    Style::default().fg(C_WHITE),
+                )),
+            }
+            lines.push(Line::from(spans));
             if let Some(var) = row.from_env {
                 lines.push(Line::from(Span::styled(
                     format!("Supplied by ${var} - it will not be written to the config."),
@@ -294,6 +363,7 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         }
         Credential::None => {
             lines.push(Line::from(vec![
+                Span::styled(row_marker, Style::default().fg(C_ACCENT)),
                 Span::styled("Reasoning effort: ", Style::default().fg(C_MUTED)),
                 Span::styled(
                     super::state::effort_options()[row.effort],
@@ -322,22 +392,15 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
 
     lines.push(Line::from(""));
     lines.push(status_line(wizard, index));
+    lines.push(Line::from(""));
+    lines.push(continue_line(wizard));
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
-/// What to print in place of a credential.
+/// What to print in place of a credential when it is not being edited.
 fn credential_display(wizard: &Wizard, index: usize) -> String {
     let row = &wizard.providers[index];
-    if let Some(edit) = &wizard.edit
-        && edit.target == super::state::EditTarget::Credential(index)
-    {
-        return if edit.masked && !wizard.reveal {
-            format!("{}▌", "•".repeat(edit.buffer.chars().count()))
-        } else {
-            format!("{}▌", edit.buffer)
-        };
-    }
     if row.value.is_empty() {
         return match row.from_env {
             Some(_) => "(from the environment)".to_string(),
@@ -377,33 +440,39 @@ fn status_line(wizard: &Wizard, index: usize) -> Line<'static> {
 }
 
 fn draw_fields(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let items: Vec<ListItem> = wizard
+    let mut items: Vec<ListItem> = wizard
         .fields()
         .iter()
         .enumerate()
         .map(|(index, field)| {
             let selected = index == wizard.cursor;
-            let value = match &wizard.edit {
-                Some(edit) if edit.target == super::state::EditTarget::Field(index) => {
-                    format!("{}▌", edit.buffer)
-                }
-                _ => field.value.display(),
-            };
             let hint = match &field.value {
-                FieldValue::Bool(_) => "space",
-                FieldValue::Choice { .. } => "← →",
+                FieldValue::Bool(_) => "enter/space",
+                FieldValue::Choice { .. } => "enter/← →",
                 _ => "enter",
             };
+            let mut spans = vec![
+                Span::styled(
+                    if selected { "› " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                ),
+                Span::styled(format!("{:<28}", field.label), name_style(selected)),
+            ];
+            match &wizard.edit {
+                Some(edit) if edit.target == super::state::EditTarget::Field(index) => {
+                    spans.extend(edit.line.display_spans(wizard.reveal).spans);
+                }
+                _ => spans.push(Span::styled(
+                    field.value.display(),
+                    Style::default().fg(C_ACCENT),
+                )),
+            }
+            spans.push(Span::styled(
+                format!("   [{hint}]"),
+                Style::default().fg(C_DIM),
+            ));
             ListItem::new(vec![
-                Line::from(vec![
-                    Span::styled(
-                        if selected { "› " } else { "  " },
-                        Style::default().fg(C_ACCENT),
-                    ),
-                    Span::styled(format!("{:<28}", field.label), name_style(selected)),
-                    Span::styled(value, Style::default().fg(C_ACCENT)),
-                    Span::styled(format!("   [{hint}]"), Style::default().fg(C_DIM)),
-                ]),
+                Line::from(spans),
                 Line::from(Span::styled(
                     format!("    {}", field.help),
                     Style::default().fg(C_DIM),
@@ -411,12 +480,13 @@ fn draw_fields(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             ])
         })
         .collect();
+    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
 
     frame.render_widget(List::new(items), area);
 }
 
 fn draw_agents(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let items: Vec<ListItem> = wizard
+    let mut items: Vec<ListItem> = wizard
         .agents
         .iter()
         .enumerate()
@@ -445,6 +515,7 @@ fn draw_agents(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             ]))
         })
         .collect();
+    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
 
     frame.render_widget(List::new(items), area);
 }
@@ -515,6 +586,7 @@ fn draw_mcp(frame: &mut Frame, area: Rect, wizard: &Wizard) {
             Style::default().fg(C_WARN),
         ))));
     }
+    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
 
     frame.render_widget(List::new(items), area);
 }
@@ -589,157 +661,73 @@ fn draw_review(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     }
 
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "Enter or Ctrl-S to write.  Esc to go back.",
-        Style::default().fg(C_ACCENT),
-    )));
+    lines.push(continue_line(wizard));
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
+/// The footer's key hints for the wizard's current mode.
+fn footer_hints(wizard: &Wizard) -> Vec<Hint> {
+    if wizard.confirm.is_some() {
+        return vec![
+            hint("←→", "choose"),
+            hint("enter", "confirm"),
+            hint("esc", "cancel"),
+        ];
+    }
+    if wizard.edit.is_some() {
+        return vec![
+            hint("enter", "save"),
+            hint("esc", "cancel"),
+            hint("←→", "move cursor"),
+        ];
+    }
+    match wizard.step {
+        Step::Welcome => vec![hint("enter", "begin"), hint("?", "help"), hint("q", "quit")],
+        Step::Providers => vec![
+            hint("↑↓", "move"),
+            hint("space/enter", "select"),
+            hint("o", "signup"),
+            hint("v", "check"),
+            hint("tab", "next"),
+            hint("q", "quit"),
+        ],
+        Step::ProviderDetail => vec![
+            hint("enter", "edit"),
+            hint("v", "check"),
+            hint("o", "signup"),
+            hint("tab", "next"),
+            hint("esc", "back"),
+            hint("q", "quit"),
+        ],
+        Step::Defaults | Step::Limits => vec![
+            hint("↑↓", "move"),
+            hint("enter", "change"),
+            hint("←→", "cycle"),
+            hint("tab", "next"),
+            hint("esc", "back"),
+            hint("q", "quit"),
+        ],
+        Step::Agents | Step::Mcp => vec![
+            hint("↑↓", "move"),
+            hint("space/enter", "select"),
+            hint("tab", "next"),
+            hint("esc", "back"),
+            hint("q", "quit"),
+        ],
+        Step::Review => vec![
+            hint("enter", "apply"),
+            hint("v", "re-check"),
+            hint("esc", "back"),
+            hint("q", "quit"),
+        ],
+    }
+}
+
 fn draw_footer(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let hints = if wizard.edit.is_some() {
-        "enter save field · esc cancel"
-    } else {
-        match wizard.step {
-            Step::Providers => "space select · o signup page · tab next · ? help · q quit",
-            Step::ProviderDetail => "enter edit · v check · o signup page · tab next · q quit",
-            Step::Defaults | Step::Limits => "↑↓ move · enter/space/←→ change · tab next · q quit",
-            Step::Agents | Step::Mcp => "space select · tab next · esc back · q quit",
-            Step::Review => "enter write · esc back · q quit",
-            Step::Welcome => "enter begin · ? help · q quit",
-        }
-    };
-
-    let message = wizard.message.clone().unwrap_or_default();
-    frame.render_widget(
-        Paragraph::new(vec![Line::from(vec![
-            Span::styled(message, Style::default().fg(C_WARN)),
-            Span::styled(
-                if wizard.message.is_some() { "  " } else { "" },
-                Style::default(),
-            ),
-            Span::styled(hints, Style::default().fg(C_DIM)),
-        ])])
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(C_BORDER)),
-        ),
-        area,
-    );
-}
-
-fn draw_help(frame: &mut Frame, area: Rect) {
-    let popup = centered(64, 60, area);
-    frame.render_widget(Clear, popup);
-    let lines = vec![
-        Line::from(Span::styled("Keys", Style::default().fg(C_ACCENT))),
-        Line::from(""),
-        Line::from("  ↑ ↓ / k j     move"),
-        Line::from("  ← → / h l     change a choice"),
-        Line::from("  space         select / toggle"),
-        Line::from("  enter         edit, or go on"),
-        Line::from("  tab / esc     next / previous screen"),
-        Line::from("  v             re-check a provider"),
-        Line::from("  o             open a signup page"),
-        Line::from("  ctrl-r        show or hide credentials"),
-        Line::from("  ctrl-s        write and finish, from anywhere"),
-        Line::from("  q / ctrl-c    quit without writing"),
-        Line::from(""),
-        Line::from(Span::styled(
-            "  any key closes this",
-            Style::default().fg(C_DIM),
-        )),
-    ];
-    frame.render_widget(
-        Paragraph::new(lines).alignment(Alignment::Left).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(C_BORDER_FOCUS))
-                .title(" Help "),
-        ),
-        popup,
-    );
-}
-
-/// Confirmation overlay for the Claude Code transport's terms risk.
-fn draw_tos_confirm(frame: &mut Frame, area: Rect) {
-    let popup = centered(70, 50, area);
-    frame.render_widget(Clear, popup);
-    let lines = vec![
-        Line::from(Span::styled(
-            "⚠️  Terms of Service",
-            Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-        Line::from(Span::styled(
-            "Anthropic's terms prohibit third-party developers from offering",
-            Style::default().fg(C_WARN),
-        )),
-        Line::from(Span::styled(
-            "claude.ai subscription auth for their products without prior",
-            Style::default().fg(C_WARN),
-        )),
-        Line::from(Span::styled(
-            "approval. The Claude Code transport routes inference through your",
-            Style::default().fg(C_WARN),
-        )),
-        Line::from(Span::styled(
-            "subscription via the CLI's OAuth session.",
-            Style::default().fg(C_WARN),
-        )),
-        Line::from(""),
-        Line::from(Span::styled(
-            "For unambiguous compliance, use a direct Anthropic API key.",
-            Style::default().fg(C_WHITE),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("Press ", Style::default().fg(C_DIM)),
-            Span::styled(
-                "Y",
-                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " to accept responsibility for compliance,",
-                Style::default().fg(C_DIM),
-            ),
-        ]),
-        Line::from(Span::styled(
-            "or any other key to cancel.",
-            Style::default().fg(C_DIM),
-        )),
-    ];
-    frame.render_widget(
-        Paragraph::new(lines).wrap(Wrap { trim: false }).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(C_WARN))
-                .title(" Confirm "),
-        ),
-        popup,
-    );
-}
-
-/// A centred rectangle covering `percent_x`/`percent_y` of `area`.
-fn centered(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(area);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(vertical[1])[1]
+    let hints = footer_hints(wizard);
+    let message = wizard.message.as_deref().map(|m| (m, C_WARN));
+    draw_hint_bar(frame, area, message, &hints, true);
 }
 
 /// Highlight style for the row under the cursor.
@@ -913,8 +901,7 @@ mod tests {
         w.enter(Step::ProviderDetail);
         w.edit = Some(Edit {
             target: EditTarget::Credential(0),
-            buffer: "sk-typing".to_string(),
-            masked: true,
+            line: crate::tui::widgets::line_edit::LineEdit::new("sk-typing".to_string(), true),
         });
 
         let hidden = rendered(&w);
@@ -1028,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn the_tos_confirmation_overlay_draws_over_the_review_screen() {
+    fn the_tos_confirmation_dialog_draws_over_the_review_screen() {
         let (_dir, mut w) = wizard();
         let index = w
             .providers
@@ -1036,22 +1023,38 @@ mod tests {
             .position(|r| r.provider.id == "claude-code")
             .expect("the transport is offered");
         w.providers[index].selected = true;
-        w.show_tos_confirm = true;
         w.enter(Step::Review);
+        w.open_tos_confirm();
 
         let screen = rendered(&w);
         assert!(
-            screen.contains("Terms of Service"),
-            "overlay title missing:\n{screen}"
+            screen.contains("terms of service"),
+            "dialog title missing:\n{screen}"
         );
         assert!(
-            screen.contains("Press"),
-            "call to action missing:\n{screen}"
+            screen.contains("[ Accept and save ]"),
+            "the affirmative button is missing:\n{screen}"
         );
         assert!(
-            screen.contains("any other key"),
-            "dismissal hint missing:\n{screen}"
+            screen.contains("[ Cancel ]"),
+            "the safe button is missing:\n{screen}"
         );
+    }
+
+    #[test]
+    fn the_quit_and_no_provider_dialogs_draw_their_buttons() {
+        let (_dir, mut w) = wizard();
+        w.open_quit_confirm();
+        let screen = rendered(&w);
+        assert!(screen.contains("Quit setup?"), "{screen}");
+        assert!(screen.contains("[ Stay ]"), "{screen}");
+
+        w.confirm = None;
+        w.open_no_providers_confirm();
+        let screen = rendered(&w);
+        assert!(screen.contains("No providers selected"), "{screen}");
+        assert!(screen.contains("[ Go back ]"), "{screen}");
+        assert!(screen.contains("[ Continue anyway ]"), "{screen}");
     }
 
     #[test]
@@ -1059,8 +1062,24 @@ mod tests {
         let (_dir, mut w) = wizard();
         w.enter(Step::ProviderDetail);
 
-        // Just the chrome, no panic.
+        // Just the chrome and the Continue button, no panic.
         assert!(rendered(&w).contains("Credentials"));
+    }
+
+    #[test]
+    fn the_credential_screen_moves_the_focus_marker_onto_the_continue_button() {
+        let (_dir, mut w) = wizard();
+        w.providers[0].selected = true;
+        w.enter(Step::ProviderDetail);
+
+        // Cursor on the credential row: the row carries the marker.
+        assert!(rendered(&w).contains("› API key:"));
+
+        // Cursor on the Continue button: the row loses it, the button gains it.
+        w.cursor = w.row_count();
+        let screen = rendered(&w);
+        assert!(!screen.contains("› API key:"), "{screen}");
+        assert!(screen.contains("› [ Continue: Defaults ]"), "{screen}");
     }
 
     #[test]
@@ -1069,8 +1088,7 @@ mod tests {
         w.enter(Step::Limits);
         w.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: "42".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("42".to_string(), false),
         });
 
         assert!(rendered(&w).contains("42"));
@@ -1082,11 +1100,11 @@ mod tests {
         w.enter(Step::Limits);
         let screen = rendered(&w);
         assert!(screen.contains("[enter]"), "numbers are typed");
-        assert!(screen.contains("[space]"), "booleans are toggled");
+        assert!(screen.contains("[enter/space]"), "booleans are toggled");
 
         w.providers[0].selected = true;
         w.enter(Step::Defaults);
-        assert!(rendered(&w).contains("← →"), "choices are cycled");
+        assert!(rendered(&w).contains("enter/← →"), "choices are cycled");
     }
 
     #[test]
@@ -1213,13 +1231,13 @@ mod tests {
         w.message = None;
         for (step, expected) in [
             (Step::Welcome, "enter begin"),
-            (Step::Providers, "space select"),
+            (Step::Providers, "space/enter select"),
             (Step::ProviderDetail, "enter edit"),
-            (Step::Defaults, "↑↓ move"),
-            (Step::Limits, "↑↓ move"),
-            (Step::Agents, "space select"),
-            (Step::Mcp, "space select"),
-            (Step::Review, "enter write"),
+            (Step::Defaults, "enter change"),
+            (Step::Limits, "enter change"),
+            (Step::Agents, "space/enter select"),
+            (Step::Mcp, "space/enter select"),
+            (Step::Review, "enter apply"),
         ] {
             w.enter(step);
             let screen = rendered(&w);
@@ -1231,10 +1249,14 @@ mod tests {
 
         w.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: String::new(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new(String::new(), false),
         });
         assert!(rendered(&w).contains("esc cancel"));
+
+        // A dialog swaps the footer for its own answer hints.
+        w.edit = None;
+        w.open_quit_confirm();
+        assert!(rendered(&w).contains("enter confirm"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -187,9 +187,26 @@ pub enum EditTarget {
 #[derive(Debug, Clone)]
 pub struct Edit {
     pub target: EditTarget,
-    pub buffer: String,
-    /// Draw the buffer masked. Set for API keys.
-    pub masked: bool,
+    /// The shared single-line editor (cursor movement, masking).
+    pub(crate) line: crate::tui::widgets::line_edit::LineEdit,
+}
+
+/// Why a confirmation dialog is on screen, so its Yes can be routed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmPurpose {
+    /// `q`/Ctrl-C with unsaved choices: quit and discard?
+    QuitDiscard,
+    /// Saving with the Claude Code transport selected: accept the terms risk?
+    SaveTos,
+    /// Leaving the Providers screen with nothing selected: continue anyway?
+    NoProviders,
+}
+
+/// A pending confirmation: the dialog plus what its Yes means.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingConfirm {
+    pub purpose: ConfirmPurpose,
+    pub(crate) dialog: crate::tui::widgets::confirm::Confirm,
 }
 
 /// The whole wizard.
@@ -209,9 +226,12 @@ pub struct Wizard {
     /// Show credentials in clear text.
     pub reveal: bool,
     pub show_help: bool,
-    /// The Claude Code terms-of-service confirmation is on screen, and is the
-    /// only thing keys mean until it is answered.
-    pub show_tos_confirm: bool,
+    /// A confirmation dialog is on screen, and (after Ctrl-C) it is the only
+    /// thing keys mean until it is answered.
+    pub confirm: Option<PendingConfirm>,
+    /// The user has changed something since the wizard opened, so quitting
+    /// silently would discard real choices.
+    pub dirty: bool,
     /// The user has acknowledged the Claude Code transport's terms risk. A
     /// hard gate on saving: the transport cannot be written to the config
     /// without it, and deselecting the transport withdraws it.
@@ -333,7 +353,8 @@ impl Wizard {
             edit: None,
             reveal: false,
             show_help: false,
-            show_tos_confirm: false,
+            confirm: None,
+            dirty: false,
             claude_code_tos_accepted: false,
             should_quit: false,
             finished: false,
@@ -424,18 +445,69 @@ impl Wizard {
         }
     }
 
-    /// Move the selection, clamped to the step's rows.
-    pub fn move_cursor(&mut self, delta: isize) {
-        let count = self.row_count();
-        if count == 0 {
-            self.cursor = 0;
-            return;
+    /// How many cursor positions the current step has: its rows plus the
+    /// Continue/action button that every step ends with.
+    pub fn nav_rows(&self) -> usize {
+        self.row_count() + 1
+    }
+
+    /// Whether the cursor sits on the step's Continue/action button (the
+    /// virtual row after the last real one).
+    pub fn on_continue(&self) -> bool {
+        self.cursor == self.row_count()
+    }
+
+    /// The label of the current step's Continue/action button. It carries
+    /// state (selection counts, what screen is next) so advancing is never a
+    /// surprise.
+    pub fn continue_label(&self) -> String {
+        match self.step {
+            Step::Welcome => "Get started".to_string(),
+            Step::Review => "Apply and finish".to_string(),
+            Step::Providers => {
+                let count = self.selected_providers().len();
+                if count == 0 {
+                    "Continue (no providers selected)".to_string()
+                } else {
+                    format!("Continue: {} ({count} selected)", self.next_step_title())
+                }
+            }
+            Step::ProviderDetail => {
+                let selected = self.selected_providers();
+                match selected.get(self.detail + 1) {
+                    Some(&next) => format!("Next: {}", self.providers[next].provider.display),
+                    None => format!("Continue: {}", self.next_step_title()),
+                }
+            }
+            Step::Defaults | Step::Limits | Step::Agents | Step::Mcp => {
+                format!("Continue: {}", self.next_step_title())
+            }
         }
+    }
+
+    /// The title of the step `next_step` would land on.
+    fn next_step_title(&self) -> &'static str {
+        let mut index = self.step.index();
+        while index + 1 < Step::ALL.len() {
+            index += 1;
+            let step = Step::ALL[index];
+            if !self.is_empty_step(step) {
+                return step.title();
+            }
+        }
+        Step::Review.title()
+    }
+
+    /// Move the selection, clamped to the step's rows plus its button.
+    pub fn move_cursor(&mut self, delta: isize) {
+        let count = self.nav_rows();
         let next = self.cursor as isize + delta;
         self.cursor = next.clamp(0, count as isize - 1) as usize;
     }
 
-    /// Advance to the next step, skipping ones with nothing to show.
+    /// Advance to the next step, skipping ones with nothing to show. Skipping
+    /// the credential screen is announced rather than silent: it looks exactly
+    /// like a bug when a screen the breadcrumb promises never appears.
     pub fn next_step(&mut self) {
         let mut index = self.step.index();
         while index + 1 < Step::ALL.len() {
@@ -444,6 +516,10 @@ impl Wizard {
             if !self.is_empty_step(step) {
                 self.enter(step);
                 return;
+            }
+            if step == Step::ProviderDetail {
+                self.message =
+                    Some("Skipped Credentials: no selected provider needs setup.".to_string());
             }
         }
         // Past the last step: the Review screen's action is to save.
@@ -720,6 +796,68 @@ impl Wizard {
         }
     }
 
+    // ── Confirmations ───────────────────────────────────────────────────────
+
+    /// `q`/Ctrl-C with unsaved choices: ask before discarding them.
+    pub fn open_quit_confirm(&mut self) {
+        use ratatui::text::Line;
+        self.confirm = Some(PendingConfirm {
+            purpose: ConfirmPurpose::QuitDiscard,
+            dialog: crate::tui::widgets::confirm::Confirm::new(
+                "Quit setup?",
+                vec![Line::from(
+                    "Nothing has been written yet. Your choices so far will be discarded.",
+                )],
+                "Quit",
+                "Stay",
+            ),
+        });
+    }
+
+    /// Saving with the Claude Code transport selected: the terms risk is
+    /// confirmed once, explicitly, on a dialog with real buttons.
+    pub fn open_tos_confirm(&mut self) {
+        use ratatui::text::Line;
+        self.confirm = Some(PendingConfirm {
+            purpose: ConfirmPurpose::SaveTos,
+            dialog: crate::tui::widgets::confirm::Confirm::new(
+                "Claude Code terms of service",
+                vec![
+                    Line::from("Anthropic's terms prohibit third-party developers from offering"),
+                    Line::from("claude.ai subscription auth for their products without prior"),
+                    Line::from("approval. The Claude Code transport routes inference through"),
+                    Line::from("your subscription via the CLI's OAuth session."),
+                    Line::from(""),
+                    Line::from("For unambiguous compliance, use a direct Anthropic API key."),
+                    Line::from(""),
+                    Line::from("Accepting means you take responsibility for compliance."),
+                ],
+                "Accept and save",
+                "Cancel",
+            )
+            .danger(),
+        });
+    }
+
+    /// Leaving the Providers screen with nothing selected: Leviath cannot run
+    /// an agent without a provider, so this is almost always a slip.
+    pub fn open_no_providers_confirm(&mut self) {
+        use ratatui::text::Line;
+        self.confirm = Some(PendingConfirm {
+            purpose: ConfirmPurpose::NoProviders,
+            dialog: crate::tui::widgets::confirm::Confirm::new(
+                "No providers selected",
+                vec![
+                    Line::from("Without a provider, Leviath cannot run any agent."),
+                    Line::from("Select one with Space or Enter, or continue anyway to"),
+                    Line::from("configure providers later."),
+                ],
+                "Continue anyway",
+                "Go back",
+            ),
+        });
+    }
+
     /// Commit an edited text buffer into wherever it belongs.
     pub fn commit_edit(&mut self) {
         let Some(edit) = self.edit.take() else {
@@ -728,7 +866,7 @@ impl Wizard {
         match edit.target {
             EditTarget::Credential(index) => {
                 if let Some(row) = self.providers.get_mut(index) {
-                    row.value = edit.buffer.trim().to_string();
+                    row.value = edit.line.value().trim().to_string();
                     // A typed credential replaces the environment's, and the
                     // row stops claiming the environment supplies it.
                     if !row.value.is_empty() {
@@ -744,7 +882,7 @@ impl Wizard {
                 if let Some(field) = fields.get_mut(index) {
                     match &mut field.value {
                         FieldValue::Number(n) => {
-                            let trimmed = edit.buffer.trim();
+                            let trimmed = edit.line.value().trim();
                             *n = if trimmed.is_empty() {
                                 None
                             } else {
@@ -1302,7 +1440,12 @@ pub(super) mod tests {
         wizard.move_cursor(-5);
         assert_eq!(wizard.cursor, 0);
         wizard.move_cursor(100);
-        assert_eq!(wizard.cursor, wizard.providers.len() - 1);
+        assert_eq!(
+            wizard.cursor,
+            wizard.providers.len(),
+            "clamped to the Continue button after the last row"
+        );
+        assert!(wizard.on_continue());
     }
 
     #[test]
@@ -1316,6 +1459,47 @@ pub(super) mod tests {
 
         assert_eq!(wizard.cursor, 0);
         assert_eq!(wizard.row_count(), 0);
+    }
+
+    #[test]
+    fn the_continue_label_names_where_it_goes() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+
+        wizard.enter(Step::Welcome);
+        assert_eq!(wizard.continue_label(), "Get started");
+
+        wizard.enter(Step::Providers);
+        assert_eq!(wizard.continue_label(), "Continue (no providers selected)");
+        wizard.providers[0].selected = true;
+        wizard.providers[1].selected = true;
+        assert_eq!(
+            wizard.continue_label(),
+            "Continue: Credentials (2 selected)"
+        );
+
+        // On the credential walk: the next selected provider, then the next step.
+        wizard.enter(Step::ProviderDetail);
+        assert_eq!(
+            wizard.continue_label(),
+            format!("Next: {}", wizard.providers[1].provider.display)
+        );
+        wizard.detail = 1;
+        assert_eq!(wizard.continue_label(), "Continue: Defaults");
+
+        wizard.enter(Step::Limits);
+        assert_eq!(wizard.continue_label(), "Continue: Agents");
+
+        wizard.enter(Step::Review);
+        assert_eq!(wizard.continue_label(), "Apply and finish");
+    }
+
+    #[test]
+    fn next_step_title_past_the_last_step_falls_back_to_review() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        wizard.enter(Step::Review);
+        assert_eq!(wizard.next_step_title(), "Review");
     }
 
     #[test]
@@ -1848,8 +2032,7 @@ pub(super) mod tests {
         };
         wizard.edit = Some(Edit {
             target: EditTarget::Credential(0),
-            buffer: "  sk-ant-new  ".to_string(),
-            masked: true,
+            line: crate::tui::widgets::line_edit::LineEdit::new("  sk-ant-new  ".to_string(), true),
         });
 
         wizard.commit_edit();
@@ -1877,8 +2060,7 @@ pub(super) mod tests {
         assert!(wizard.providers[0].from_env.is_some());
         wizard.edit = Some(Edit {
             target: EditTarget::Credential(0),
-            buffer: "sk-ant-typed".to_string(),
-            masked: true,
+            line: crate::tui::widgets::line_edit::LineEdit::new("sk-ant-typed".to_string(), true),
         });
 
         wizard.commit_edit();
@@ -1898,8 +2080,7 @@ pub(super) mod tests {
 
         wizard.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: "16".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("16".to_string(), false),
         });
         wizard.commit_edit();
         assert_eq!(wizard.limits[0].value, FieldValue::Number(Some(16)));
@@ -1907,8 +2088,7 @@ pub(super) mod tests {
         // Garbage keeps the previous value rather than silently unsetting it.
         wizard.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: "not a number".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("not a number".to_string(), false),
         });
         wizard.commit_edit();
         assert_eq!(wizard.limits[0].value, FieldValue::Number(Some(16)));
@@ -1916,8 +2096,7 @@ pub(super) mod tests {
         // Blank means unset, which is a real and different choice.
         wizard.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: "   ".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("   ".to_string(), false),
         });
         wizard.commit_edit();
         assert_eq!(wizard.limits[0].value, FieldValue::Number(None));
@@ -1931,16 +2110,14 @@ pub(super) mod tests {
 
         wizard.edit = Some(Edit {
             target: EditTarget::Credential(999),
-            buffer: "x".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("x".to_string(), false),
         });
         wizard.commit_edit();
 
         wizard.enter(Step::Limits);
         wizard.edit = Some(Edit {
             target: EditTarget::Field(999),
-            buffer: "x".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("x".to_string(), false),
         });
         wizard.commit_edit();
 
@@ -1948,8 +2125,7 @@ pub(super) mod tests {
         wizard.enter(Step::Welcome);
         wizard.edit = Some(Edit {
             target: EditTarget::Field(0),
-            buffer: "x".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("x".to_string(), false),
         });
         wizard.commit_edit();
 
@@ -1994,8 +2170,7 @@ pub(super) mod tests {
 
         wizard.edit = Some(Edit {
             target: EditTarget::Field(2),
-            buffer: "45".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("45".to_string(), false),
         });
         wizard.commit_edit();
 
@@ -2017,8 +2192,7 @@ pub(super) mod tests {
         );
         wizard.edit = Some(Edit {
             target: EditTarget::Credential(0),
-            buffer: "   ".to_string(),
-            masked: true,
+            line: crate::tui::widgets::line_edit::LineEdit::new("   ".to_string(), true),
         });
 
         wizard.commit_edit();
@@ -2075,8 +2249,7 @@ pub(super) mod tests {
 
         wizard.edit = Some(Edit {
             target: EditTarget::Field(3),
-            buffer: "yes".to_string(),
-            masked: false,
+            line: crate::tui::widgets::line_edit::LineEdit::new("yes".to_string(), false),
         });
         wizard.commit_edit();
 

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -556,6 +556,8 @@ async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
     let control = control_client()?;
     let mut setup = CrosstermSetup {
         viewport: Viewport::Fullscreen,
+        mouse_capture: true,
+        enabled: false,
     };
     let mut events = CrosstermEventSource::new();
     commands::dashboard::execute_with(control, &mut setup, &mut events, real_yank).await
@@ -620,6 +622,8 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
             &env,
             &mut CrosstermSetup {
                 viewport: Viewport::Fullscreen,
+                mouse_capture: false,
+                enabled: false,
             },
             &mut CrosstermEventSource::new(),
             false,
@@ -637,6 +641,8 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
     }
     let mut setup = CrosstermSetup {
         viewport: Viewport::Fullscreen,
+        mouse_capture: false,
+        enabled: false,
     };
     let mut events = CrosstermEventSource::new();
     commands::setup::execute_core(&mut wizard, &env, &mut setup, &mut events).await
@@ -645,25 +651,70 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
 /// Real [`TerminalSetup`]: enables raw mode, enters/leaves the real alternate
 /// screen, and builds a real `CrosstermBackend` on `stdout`. Lives in the
 /// binary because it can only be exercised against a real terminal.
+///
+/// `mouse_capture` is per-surface: the dashboard wants wheel events and its
+/// own click-drag selection, while the setup wizard handles no mouse events
+/// at all - capturing there would only steal the terminal's native
+/// drag-to-select (copying an error or a signup URL) for nothing.
 struct CrosstermSetup {
     viewport: Viewport,
+    mouse_capture: bool,
+    /// True between a successful `enable()` and the matching `disable()`, so
+    /// teardown (explicit, `Drop`, or the panic hook) runs exactly once.
+    enabled: bool,
+}
+
+/// Restore the terminal from raw mode / alternate screen / mouse capture.
+/// Safe to call redundantly: every step is a no-op when already released.
+fn restore_terminal() {
+    io::stdout().execute(DisableMouseCapture).ok();
+    disable_raw_mode().ok();
+    io::stdout().execute(LeaveAlternateScreen).ok();
+}
+
+/// Whether a `CrosstermSetup` currently holds the terminal; read by the panic
+/// hook so a panic after clean teardown doesn't re-issue restore sequences
+/// into a healthy shell.
+static TERMINAL_HELD: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Install (once) a chained panic hook that restores the terminal *before*
+/// the default hook prints the panic message - otherwise a panic mid-loop
+/// leaves the shell in raw mode with the message drawn into the vanished
+/// alternate screen.
+fn install_terminal_restore_panic_hook() {
+    static INSTALL: std::sync::Once = std::sync::Once::new();
+    INSTALL.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if TERMINAL_HELD.load(std::sync::atomic::Ordering::SeqCst) {
+                restore_terminal();
+            }
+            previous(info);
+        }));
+    });
 }
 
 impl TerminalSetup for CrosstermSetup {
     type B = ratatui::backend::CrosstermBackend<io::Stdout>;
 
     fn enable(&mut self) -> anyhow::Result<()> {
+        install_terminal_restore_panic_hook();
         enable_raw_mode().map_err(anyhow::Error::from)?;
         io::stdout()
             .execute(EnterAlternateScreen)
             .map_err(anyhow::Error::from)?;
-        // Mouse capture is what delivers wheel events, and it routes click-drag
-        // to the dashboard's own text selection (drag to highlight, release to
-        // copy). Hold Shift (or Option on macOS Terminal) to bypass capture and
-        // use the terminal's native selection instead.
-        io::stdout()
-            .execute(EnableMouseCapture)
-            .map_err(anyhow::Error::from)?;
+        if self.mouse_capture {
+            // Mouse capture is what delivers wheel events, and it routes
+            // click-drag to the dashboard's own text selection (drag to
+            // highlight, release to copy). Hold Shift (or Option on macOS
+            // Terminal) to bypass capture and use the terminal's native
+            // selection instead.
+            io::stdout()
+                .execute(EnableMouseCapture)
+                .map_err(anyhow::Error::from)?;
+        }
+        self.enabled = true;
+        TERMINAL_HELD.store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 
@@ -679,15 +730,28 @@ impl TerminalSetup for CrosstermSetup {
     }
 
     fn disable(&mut self) {
-        // Released before leaving the alternate screen, and unconditionally: a
-        // terminal left in mouse-reporting mode emits escape sequences into the
-        // user's shell on every click afterwards.
-        io::stdout().execute(DisableMouseCapture).ok();
-        disable_raw_mode().ok();
-        io::stdout().execute(LeaveAlternateScreen).ok();
+        if !self.enabled {
+            return;
+        }
+        self.enabled = false;
+        TERMINAL_HELD.store(false, std::sync::atomic::Ordering::SeqCst);
+        // Mouse release runs before leaving the alternate screen, and
+        // unconditionally (even when capture was never enabled - it's a
+        // no-op then): a terminal left in mouse-reporting mode emits escape
+        // sequences into the user's shell on every click afterwards.
+        restore_terminal();
     }
 
     fn print_done(&self) {
         println!("Dashboard closed.");
+    }
+}
+
+/// Covers early-return paths (`?` between `enable()` and the loop's own
+/// teardown): the terminal is restored on unwind, and the `enabled` guard
+/// makes the common explicit-`disable()`-then-drop sequence a single restore.
+impl Drop for CrosstermSetup {
+    fn drop(&mut self) {
+        self.disable();
     }
 }

--- a/crates/leviath-cli/src/tui/keymap.rs
+++ b/crates/leviath-cli/src/tui/keymap.rs
@@ -1,0 +1,139 @@
+//! The crate's single key → semantic-action table.
+//!
+//! Every Leviath TUI resolves navigation and app-level keys through
+//! [`resolve`], so "what does Esc do" has exactly one answer across surfaces:
+//! arrows move (with `k`/`j`/`h`/`l` as vim aliases), Space toggles, Enter
+//! acts on the focused thing, Esc goes back, Tab/Shift-Tab step between
+//! screens or panes, `?` opens help, `q` quits, and Ctrl-C force-quits.
+//!
+//! Surfaces match their surface-specific keys (`o` signup, `x` kill, …)
+//! *before* calling [`resolve`], and only fall through to it for the shared
+//! set. That keeps this table frozen while surfaces evolve, and it means a
+//! surface can shadow an alias that clashes with a local binding (the
+//! dashboard's `l` = Logs wins over "l = Right") without touching this
+//! module.
+//!
+//! [`resolve`] must never be called while a text field is being edited -
+//! letters are letters there; text inputs own the raw key stream.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// A key's shared meaning, independent of which surface received it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Action {
+    /// `↑` / `k`: move the cursor up, or scroll up.
+    Up,
+    /// `↓` / `j`: move the cursor down, or scroll down.
+    Down,
+    /// `←` / `h`: adjust a value down, move focus left, or previous tab.
+    Left,
+    /// `→` / `l`: adjust a value up, move focus right, or next tab.
+    Right,
+    /// Space: toggle the focused row in a multi-select.
+    Toggle,
+    /// Enter: act on / affirm the focused thing. Never "silently advance".
+    Activate,
+    /// Esc: back / dismiss. Never quit-from-main.
+    Back,
+    /// Tab: next screen / pane.
+    Next,
+    /// Shift-Tab / BackTab: previous screen / pane.
+    Prev,
+    /// `?`: open the help overlay.
+    Help,
+    /// `q`: quit the app (surfaces confirm first when there is unsaved state).
+    Quit,
+    /// Ctrl-C: quit immediately, honored in every mode.
+    ForceQuit,
+}
+
+/// Resolve a key event to its shared [`Action`], or `None` when the key has
+/// no crate-wide meaning (the surface then handles or ignores it).
+pub(crate) fn resolve(key: &KeyEvent) -> Option<Action> {
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return match key.code {
+            KeyCode::Char('c') => Some(Action::ForceQuit),
+            _ => None,
+        };
+    }
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => Some(Action::Up),
+        KeyCode::Down | KeyCode::Char('j') => Some(Action::Down),
+        KeyCode::Left | KeyCode::Char('h') => Some(Action::Left),
+        KeyCode::Right | KeyCode::Char('l') => Some(Action::Right),
+        KeyCode::Char(' ') => Some(Action::Toggle),
+        KeyCode::Enter => Some(Action::Activate),
+        KeyCode::Esc => Some(Action::Back),
+        // BackTab already implies Shift on most terminals; some deliver
+        // Tab + SHIFT instead, so both spellings mean "previous".
+        KeyCode::BackTab => Some(Action::Prev),
+        KeyCode::Tab if key.modifiers.contains(KeyModifiers::SHIFT) => Some(Action::Prev),
+        KeyCode::Tab => Some(Action::Next),
+        KeyCode::Char('?') => Some(Action::Help),
+        KeyCode::Char('q') => Some(Action::Quit),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn arrows_and_vim_aliases_resolve_to_the_same_movement() {
+        for (code, alias, action) in [
+            (KeyCode::Up, 'k', Action::Up),
+            (KeyCode::Down, 'j', Action::Down),
+            (KeyCode::Left, 'h', Action::Left),
+            (KeyCode::Right, 'l', Action::Right),
+        ] {
+            assert_eq!(resolve(&press(code)), Some(action));
+            assert_eq!(resolve(&press(KeyCode::Char(alias))), Some(action));
+        }
+    }
+
+    #[test]
+    fn the_shared_app_keys_resolve() {
+        assert_eq!(resolve(&press(KeyCode::Char(' '))), Some(Action::Toggle));
+        assert_eq!(resolve(&press(KeyCode::Enter)), Some(Action::Activate));
+        assert_eq!(resolve(&press(KeyCode::Esc)), Some(Action::Back));
+        assert_eq!(resolve(&press(KeyCode::Tab)), Some(Action::Next));
+        assert_eq!(resolve(&press(KeyCode::BackTab)), Some(Action::Prev));
+        assert_eq!(resolve(&press(KeyCode::Char('?'))), Some(Action::Help));
+        assert_eq!(resolve(&press(KeyCode::Char('q'))), Some(Action::Quit));
+    }
+
+    #[test]
+    fn shift_tab_spelled_as_tab_plus_shift_means_previous() {
+        let key = KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT);
+        assert_eq!(resolve(&key), Some(Action::Prev));
+    }
+
+    #[test]
+    fn question_mark_still_resolves_when_the_terminal_reports_shift() {
+        // Shift+/ produces '?' and some terminals set the SHIFT modifier.
+        let key = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::SHIFT);
+        assert_eq!(resolve(&key), Some(Action::Help));
+    }
+
+    #[test]
+    fn ctrl_c_force_quits_and_other_ctrl_chords_resolve_to_nothing() {
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(resolve(&ctrl_c), Some(Action::ForceQuit));
+
+        // Ctrl-K must NOT read as movement: chords are not plain keys.
+        let ctrl_k = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL);
+        assert_eq!(resolve(&ctrl_k), None);
+    }
+
+    #[test]
+    fn unmapped_keys_resolve_to_nothing() {
+        assert_eq!(resolve(&press(KeyCode::Char('z'))), None);
+        assert_eq!(resolve(&press(KeyCode::F(5))), None);
+        assert_eq!(resolve(&press(KeyCode::Home)), None);
+    }
+}

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -24,7 +24,9 @@
 //! single instantiation. Both doubles therefore carry an injectable-failure
 //! switch rather than having an always-failing sibling type.
 
+pub(crate) mod keymap;
 pub mod theme;
+pub(crate) mod widgets;
 
 use crossterm::event::Event;
 use ratatui::Terminal;

--- a/crates/leviath-cli/src/tui/widgets/confirm.rs
+++ b/crates/leviath-cli/src/tui/widgets/confirm.rs
@@ -1,0 +1,240 @@
+//! The crate's one confirmation dialog: two explicit buttons, focus on the
+//! safe answer by default.
+//!
+//! This replaces the "`y` accepts, anything else dismisses" pattern, which
+//! made a stray keypress a silent cancel - or, focus-inverted, made a stray
+//! `y` destructive. Here the user always sees which button is focused,
+//! Enter activates only the focused button, and `y`/`n` remain as explicit
+//! accelerators.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Wrap};
+
+use super::popup::{centered, popup_frame};
+use crate::tui::theme::{C_DIM, C_ERROR, C_WARN, C_WHITE};
+
+/// What a keypress did to the dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConfirmOutcome {
+    /// The dialog is still open (focus may have moved).
+    Pending,
+    /// The user confirmed the action.
+    Yes,
+    /// The user declined / dismissed.
+    No,
+}
+
+/// A modal Yes/No question. Construct with [`Confirm::new`]; focus starts on
+/// the No button (the safe answer) and [`Confirm::danger`] switches the
+/// styling from warning to destructive.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Confirm {
+    pub(crate) title: String,
+    pub(crate) body: Vec<Line<'static>>,
+    pub(crate) yes_label: &'static str,
+    pub(crate) no_label: &'static str,
+    pub(crate) focus_yes: bool,
+    pub(crate) danger: bool,
+}
+
+impl Confirm {
+    pub(crate) fn new(
+        title: impl Into<String>,
+        body: Vec<Line<'static>>,
+        yes_label: &'static str,
+        no_label: &'static str,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            body,
+            yes_label,
+            no_label,
+            focus_yes: false,
+            danger: false,
+        }
+    }
+
+    /// Style the dialog as destructive (red border, red Yes button).
+    pub(crate) fn danger(mut self) -> Self {
+        self.danger = true;
+        self
+    }
+
+    /// `←`/`→`/`h`/`l`/Tab move focus between the two buttons; Enter activates
+    /// the focused one; `y`/`n` answer directly; Esc declines. Everything else
+    /// is ignored - a stray key never answers a confirmation.
+    pub(crate) fn handle(&mut self, key: &KeyEvent) -> ConfirmOutcome {
+        match key.code {
+            KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Tab
+            | KeyCode::BackTab
+            | KeyCode::Char('h')
+            | KeyCode::Char('l') => {
+                self.focus_yes = !self.focus_yes;
+                ConfirmOutcome::Pending
+            }
+            KeyCode::Enter => {
+                if self.focus_yes {
+                    ConfirmOutcome::Yes
+                } else {
+                    ConfirmOutcome::No
+                }
+            }
+            KeyCode::Char('y') | KeyCode::Char('Y') => ConfirmOutcome::Yes,
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => ConfirmOutcome::No,
+            _ => ConfirmOutcome::Pending,
+        }
+    }
+
+    /// Draw the dialog centered in `area` (pass the whole frame area).
+    pub(crate) fn draw(&self, frame: &mut Frame, area: Rect) {
+        let accent = if self.danger { C_ERROR } else { C_WARN };
+        // Size the popup to the body: title border + body + blank + buttons.
+        let popup = centered(60, 50, area);
+        let inner = popup_frame(frame, popup, &self.title, accent);
+
+        let mut lines = self.body.clone();
+        lines.push(Line::from(""));
+        lines.push(self.button_row(accent));
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    }
+
+    fn button_row(&self, accent: ratatui::style::Color) -> Line<'static> {
+        let focused = Style::default()
+            .fg(accent)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED);
+        let blurred = Style::default().fg(C_WHITE);
+        let (no_style, yes_style) = if self.focus_yes {
+            (blurred, focused)
+        } else {
+            (focused, blurred)
+        };
+        Line::from(vec![
+            Span::styled(format!("[ {} ]", self.no_label), no_style),
+            Span::styled("   ", Style::default()),
+            Span::styled(format!("[ {} ]", self.yes_label), yes_style),
+            Span::styled("   ", Style::default()),
+            Span::styled(
+                "←→ choose · enter confirm · esc cancel",
+                Style::default().fg(C_DIM),
+            ),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::test_terminal;
+    use crossterm::event::KeyModifiers;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn dialog() -> Confirm {
+        Confirm::new(
+            "Kill agent?",
+            vec![Line::from("run-1 is still active.")],
+            "Kill",
+            "Cancel",
+        )
+    }
+
+    #[test]
+    fn focus_starts_on_no_and_enter_declines() {
+        let mut confirm = dialog();
+        assert!(!confirm.focus_yes);
+        assert_eq!(confirm.handle(&press(KeyCode::Enter)), ConfirmOutcome::No);
+    }
+
+    #[test]
+    fn every_focus_movement_key_flips_the_focused_button() {
+        for code in [
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Tab,
+            KeyCode::BackTab,
+            KeyCode::Char('h'),
+            KeyCode::Char('l'),
+        ] {
+            let mut confirm = dialog();
+            assert_eq!(confirm.handle(&press(code)), ConfirmOutcome::Pending);
+            assert!(confirm.focus_yes, "{code:?} should move focus to Yes");
+        }
+    }
+
+    #[test]
+    fn enter_activates_the_focused_button() {
+        let mut confirm = dialog();
+        confirm.handle(&press(KeyCode::Right));
+        assert_eq!(confirm.handle(&press(KeyCode::Enter)), ConfirmOutcome::Yes);
+    }
+
+    #[test]
+    fn y_and_n_answer_directly_and_esc_declines() {
+        assert_eq!(
+            dialog().handle(&press(KeyCode::Char('y'))),
+            ConfirmOutcome::Yes
+        );
+        assert_eq!(
+            dialog().handle(&press(KeyCode::Char('Y'))),
+            ConfirmOutcome::Yes
+        );
+        assert_eq!(
+            dialog().handle(&press(KeyCode::Char('n'))),
+            ConfirmOutcome::No
+        );
+        assert_eq!(
+            dialog().handle(&press(KeyCode::Char('N'))),
+            ConfirmOutcome::No
+        );
+        assert_eq!(dialog().handle(&press(KeyCode::Esc)), ConfirmOutcome::No);
+    }
+
+    #[test]
+    fn stray_keys_never_answer() {
+        let mut confirm = dialog();
+        for code in [
+            KeyCode::Char('x'),
+            KeyCode::Char(' '),
+            KeyCode::Up,
+            KeyCode::F(1),
+        ] {
+            assert_eq!(confirm.handle(&press(code)), ConfirmOutcome::Pending);
+        }
+        assert!(!confirm.focus_yes);
+    }
+
+    #[test]
+    fn draw_shows_title_body_and_both_buttons() {
+        let mut terminal = test_terminal();
+        let confirm = dialog();
+        terminal
+            .draw(|frame| confirm.draw(frame, frame.area()))
+            .unwrap();
+
+        let text = terminal.backend().text();
+        assert!(text.contains(" Kill agent? "));
+        assert!(text.contains("run-1 is still active."));
+        assert!(text.contains("[ Cancel ]"));
+        assert!(text.contains("[ Kill ]"));
+    }
+
+    #[test]
+    fn draw_renders_the_danger_variant_and_the_yes_focused_state() {
+        let mut terminal = test_terminal();
+        let mut confirm = dialog().danger();
+        confirm.handle(&press(KeyCode::Tab));
+        assert!(confirm.focus_yes);
+        terminal
+            .draw(|frame| confirm.draw(frame, frame.area()))
+            .unwrap();
+        assert!(terminal.backend().text().contains("[ Kill ]"));
+    }
+}

--- a/crates/leviath-cli/src/tui/widgets/footer.rs
+++ b/crates/leviath-cli/src/tui/widgets/footer.rs
@@ -1,0 +1,116 @@
+//! The crate's one footer hint bar.
+//!
+//! Every surface keeps a one-line bar of `key label` hints on screen at all
+//! times; this renders it consistently (keys emphasized, labels dim,
+//! `·`-separated) with an optional leading status/warning message.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::tui::theme::{C_BORDER, C_DIM, C_MUTED};
+
+/// One `key label` pair in the bar, e.g. `("space", "select")`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Hint {
+    pub(crate) key: &'static str,
+    pub(crate) label: &'static str,
+}
+
+/// Shorthand constructor so hint tables stay one line per hint.
+pub(crate) fn hint(key: &'static str, label: &'static str) -> Hint {
+    Hint { key, label }
+}
+
+/// Render the bar. `message` (colored) leads when present; `bordered` wraps
+/// the line in the standard dim border (the setup wizard's footer) or leaves
+/// it bare (the dashboard's bottom line).
+pub(crate) fn draw_hint_bar(
+    frame: &mut Frame,
+    area: Rect,
+    message: Option<(&str, Color)>,
+    hints: &[Hint],
+    bordered: bool,
+) {
+    let mut spans = Vec::new();
+    if let Some((text, color)) = message {
+        spans.push(Span::styled(text.to_string(), Style::default().fg(color)));
+        spans.push(Span::raw("  "));
+    }
+    for (i, h) in hints.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" · ", Style::default().fg(C_DIM)));
+        }
+        spans.push(Span::styled(h.key, Style::default().fg(C_MUTED)));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(h.label, Style::default().fg(C_DIM)));
+    }
+
+    let paragraph = Paragraph::new(vec![Line::from(spans)]);
+    if bordered {
+        frame.render_widget(
+            paragraph.block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(C_BORDER)),
+            ),
+            area,
+        );
+    } else {
+        frame.render_widget(paragraph, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::test_terminal;
+    use crate::tui::theme::C_WARN;
+
+    #[test]
+    fn hints_render_as_dot_separated_key_label_pairs() {
+        let mut terminal = test_terminal();
+        let hints = [
+            hint("space", "select"),
+            hint("tab", "next"),
+            hint("q", "quit"),
+        ];
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, frame.area().width, 3);
+                draw_hint_bar(frame, area, None, &hints, true);
+            })
+            .unwrap();
+
+        assert!(
+            terminal
+                .backend()
+                .text()
+                .contains("space select · tab next · q quit")
+        );
+    }
+
+    #[test]
+    fn a_message_leads_the_bar_and_unbordered_renders_bare() {
+        let mut terminal = test_terminal();
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, frame.area().width, 1);
+                draw_hint_bar(
+                    frame,
+                    area,
+                    Some(("Skipped Credentials", C_WARN)),
+                    &[hint("q", "quit")],
+                    false,
+                );
+            })
+            .unwrap();
+
+        let text = terminal.backend().text();
+        assert!(text.contains("Skipped Credentials  q quit"));
+        // Bare bar: the first row is content, not a border.
+        assert!(!text.lines().next().unwrap().contains('─'));
+    }
+}

--- a/crates/leviath-cli/src/tui/widgets/help.rs
+++ b/crates/leviath-cli/src/tui/widgets/help.rs
@@ -1,0 +1,110 @@
+//! The crate's one help overlay: sections of `(key, description)` pairs.
+//!
+//! Surfaces build their overlay from the same tables that drive their key
+//! handling, so the help text cannot drift from the real bindings. Dismissal
+//! is deliberate (`Esc`, `q`, `?`, or Enter) rather than "any key" - a user
+//! reading help should not trigger an action underneath by accident.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use super::popup::{centered, popup_frame};
+use crate::tui::theme::{C_ACCENT, C_BORDER_FOCUS, C_DIM, C_MUTED, C_WHITE};
+
+/// A titled group of key bindings shown in the help overlay.
+pub(crate) struct HelpSection {
+    pub(crate) title: &'static str,
+    pub(crate) entries: Vec<(&'static str, &'static str)>,
+}
+
+/// True when `key` closes the help overlay. Every other key is ignored while
+/// help is open - never executed underneath.
+pub(crate) fn dismisses_help(key: &KeyEvent) -> bool {
+    matches!(
+        key.code,
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') | KeyCode::Enter
+    )
+}
+
+/// Draw the overlay centered in `area` (pass the whole frame area).
+pub(crate) fn draw_help(frame: &mut Frame, area: Rect, sections: &[HelpSection]) {
+    let popup = centered(64, 70, area);
+    let inner = popup_frame(frame, popup, "Help", C_BORDER_FOCUS);
+
+    let mut lines = Vec::new();
+    for (i, section) in sections.iter().enumerate() {
+        if i > 0 {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(Span::styled(
+            section.title,
+            Style::default().fg(C_ACCENT),
+        )));
+        for (key, description) in &section.entries {
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {key:<14}"), Style::default().fg(C_MUTED)),
+                Span::styled(*description, Style::default().fg(C_WHITE)),
+            ]));
+        }
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  esc closes",
+        Style::default().fg(C_DIM),
+    )));
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::test_terminal;
+    use crossterm::event::KeyModifiers;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn only_the_deliberate_dismiss_keys_close_help() {
+        assert!(dismisses_help(&press(KeyCode::Esc)));
+        assert!(dismisses_help(&press(KeyCode::Char('q'))));
+        assert!(dismisses_help(&press(KeyCode::Char('?'))));
+        assert!(dismisses_help(&press(KeyCode::Enter)));
+
+        assert!(!dismisses_help(&press(KeyCode::Char('x'))));
+        assert!(!dismisses_help(&press(KeyCode::Char(' '))));
+        assert!(!dismisses_help(&press(KeyCode::Up)));
+    }
+
+    #[test]
+    fn draw_help_renders_sections_keys_and_the_dismiss_hint() {
+        let sections = [
+            HelpSection {
+                title: "Navigate",
+                entries: vec![("↑ ↓ / k j", "move"), ("enter", "open")],
+            },
+            HelpSection {
+                title: "Actions",
+                entries: vec![("x", "kill (asks first)")],
+            },
+        ];
+        let mut terminal = test_terminal();
+        terminal
+            .draw(|frame| draw_help(frame, frame.area(), &sections))
+            .unwrap();
+
+        let text = terminal.backend().text();
+        assert!(text.contains(" Help "));
+        assert!(text.contains("Navigate"));
+        assert!(text.contains("Actions"));
+        assert!(text.contains("↑ ↓ / k j"));
+        assert!(text.contains("kill (asks first)"));
+        assert!(text.contains("esc closes"));
+    }
+}

--- a/crates/leviath-cli/src/tui/widgets/line_edit.rs
+++ b/crates/leviath-cli/src/tui/widgets/line_edit.rs
@@ -1,0 +1,246 @@
+//! The crate's one single-line text input: cursor movement, masking, and a
+//! visible cursor cell.
+//!
+//! Replaces the surfaces' hand-rolled `String` push/pop editors (which had no
+//! cursor at all). Multi-line editing stays on `ratatui-textarea` where it
+//! already earns its keep; this covers the far more common one-line field.
+//! The cursor is a char index and all splicing goes through char boundaries -
+//! this crate denies `clippy::string_slice` precisely because byte-index
+//! slicing of user input is how multibyte panics happen.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use crate::tui::theme::C_WHITE;
+
+/// What a keypress did to the field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditOutcome {
+    /// Still editing.
+    Pending,
+    /// Enter: accept the current value.
+    Commit,
+    /// Esc: discard the edit.
+    Cancel,
+}
+
+/// A single-line editor. `masked` renders bullets unless the caller passes
+/// `reveal` at draw time (the wizard's Ctrl-R).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LineEdit {
+    buffer: String,
+    /// Char index (not byte) of the insertion point, `0..=char_len`.
+    cursor: usize,
+    pub(crate) masked: bool,
+}
+
+impl LineEdit {
+    pub(crate) fn new(initial: impl Into<String>, masked: bool) -> Self {
+        let buffer = initial.into();
+        let cursor = buffer.chars().count();
+        Self {
+            buffer,
+            cursor,
+            masked,
+        }
+    }
+
+    pub(crate) fn value(&self) -> &str {
+        &self.buffer
+    }
+
+    fn char_len(&self) -> usize {
+        self.buffer.chars().count()
+    }
+
+    /// Byte offset of the `char_idx`-th char (or the end of the buffer).
+    fn byte_at(&self, char_idx: usize) -> usize {
+        self.buffer
+            .char_indices()
+            .nth(char_idx)
+            .map_or(self.buffer.len(), |(i, _)| i)
+    }
+
+    /// Chars insert at the cursor; Backspace/Delete remove around it;
+    /// `←`/`→`/Home/End move it; Enter commits; Esc cancels. Control chords
+    /// and other keys are ignored, preserving the buffer.
+    pub(crate) fn handle_key(&mut self, key: &KeyEvent) -> EditOutcome {
+        match key.code {
+            KeyCode::Enter => return EditOutcome::Commit,
+            KeyCode::Esc => return EditOutcome::Cancel,
+            KeyCode::Left => self.cursor = self.cursor.saturating_sub(1),
+            KeyCode::Right => self.cursor = (self.cursor + 1).min(self.char_len()),
+            KeyCode::Home => self.cursor = 0,
+            KeyCode::End => self.cursor = self.char_len(),
+            KeyCode::Backspace => {
+                if self.cursor > 0 {
+                    let start = self.byte_at(self.cursor - 1);
+                    let end = self.byte_at(self.cursor);
+                    self.buffer.replace_range(start..end, "");
+                    self.cursor -= 1;
+                }
+            }
+            KeyCode::Delete => {
+                if self.cursor < self.char_len() {
+                    let start = self.byte_at(self.cursor);
+                    let end = self.byte_at(self.cursor + 1);
+                    self.buffer.replace_range(start..end, "");
+                }
+            }
+            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let at = self.byte_at(self.cursor);
+                self.buffer.insert(at, c);
+                self.cursor += 1;
+            }
+            _ => {}
+        }
+        EditOutcome::Pending
+    }
+
+    /// The field's visible content with a reversed cursor cell. Masked fields
+    /// render one bullet per char unless `reveal`.
+    pub(crate) fn display_spans(&self, reveal: bool) -> Line<'static> {
+        let shown: String = if self.masked && !reveal {
+            "•".repeat(self.char_len())
+        } else {
+            self.buffer.clone()
+        };
+        let before: String = shown.chars().take(self.cursor).collect();
+        let at: String = shown.chars().skip(self.cursor).take(1).collect();
+        let after: String = shown.chars().skip(self.cursor + 1).collect();
+        let cursor_cell = if at.is_empty() { " ".to_string() } else { at };
+        let plain = Style::default().fg(C_WHITE);
+        Line::from(vec![
+            Span::styled(before, plain),
+            Span::styled(cursor_cell, plain.add_modifier(Modifier::REVERSED)),
+            Span::styled(after, plain),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn type_str(edit: &mut LineEdit, s: &str) {
+        for c in s.chars() {
+            assert_eq!(
+                edit.handle_key(&press(KeyCode::Char(c))),
+                EditOutcome::Pending
+            );
+        }
+    }
+
+    #[test]
+    fn typing_appends_and_the_cursor_starts_at_the_end_of_the_initial_value() {
+        let mut edit = LineEdit::new("sk-", true);
+        type_str(&mut edit, "abc");
+        assert_eq!(edit.value(), "sk-abc");
+    }
+
+    #[test]
+    fn arrows_home_and_end_move_the_insertion_point() {
+        let mut edit = LineEdit::new("ad", false);
+        edit.handle_key(&press(KeyCode::Left));
+        type_str(&mut edit, "bc");
+        assert_eq!(edit.value(), "abcd");
+
+        edit.handle_key(&press(KeyCode::Home));
+        type_str(&mut edit, "x");
+        assert_eq!(edit.value(), "xabcd");
+
+        edit.handle_key(&press(KeyCode::End));
+        type_str(&mut edit, "z");
+        assert_eq!(edit.value(), "xabcdz");
+
+        // Movement clamps at both edges.
+        for _ in 0..20 {
+            edit.handle_key(&press(KeyCode::Left));
+        }
+        edit.handle_key(&press(KeyCode::Left));
+        for _ in 0..20 {
+            edit.handle_key(&press(KeyCode::Right));
+        }
+        edit.handle_key(&press(KeyCode::Right));
+        assert_eq!(edit.value(), "xabcdz");
+    }
+
+    #[test]
+    fn backspace_and_delete_remove_around_the_cursor() {
+        let mut edit = LineEdit::new("abc", false);
+        edit.handle_key(&press(KeyCode::Backspace));
+        assert_eq!(edit.value(), "ab");
+
+        edit.handle_key(&press(KeyCode::Home));
+        edit.handle_key(&press(KeyCode::Delete));
+        assert_eq!(edit.value(), "b");
+
+        // At the edges both are no-ops.
+        edit.handle_key(&press(KeyCode::Backspace));
+        assert_eq!(edit.value(), "b");
+        edit.handle_key(&press(KeyCode::End));
+        edit.handle_key(&press(KeyCode::Delete));
+        assert_eq!(edit.value(), "b");
+    }
+
+    #[test]
+    fn multibyte_input_splices_on_char_boundaries() {
+        let mut edit = LineEdit::new("", false);
+        type_str(&mut edit, "héllo wörld");
+        assert_eq!(edit.value(), "héllo wörld");
+
+        // Move left to just after the multibyte 'ö' and delete it.
+        for _ in 0..3 {
+            edit.handle_key(&press(KeyCode::Left));
+        }
+        edit.handle_key(&press(KeyCode::Backspace));
+        assert_eq!(edit.value(), "héllo wrld");
+
+        // Insert a multibyte char mid-string.
+        type_str(&mut edit, "ø");
+        assert_eq!(edit.value(), "héllo wørld");
+    }
+
+    #[test]
+    fn enter_commits_and_esc_cancels() {
+        let mut edit = LineEdit::new("v", false);
+        assert_eq!(edit.handle_key(&press(KeyCode::Enter)), EditOutcome::Commit);
+        assert_eq!(edit.handle_key(&press(KeyCode::Esc)), EditOutcome::Cancel);
+        assert_eq!(edit.value(), "v");
+    }
+
+    #[test]
+    fn control_chords_and_unmapped_keys_leave_the_buffer_alone() {
+        let mut edit = LineEdit::new("keep", false);
+        let ctrl_s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
+        assert_eq!(edit.handle_key(&ctrl_s), EditOutcome::Pending);
+        assert_eq!(edit.handle_key(&press(KeyCode::F(2))), EditOutcome::Pending);
+        assert_eq!(edit.value(), "keep");
+    }
+
+    #[test]
+    fn display_masks_bullets_reveals_on_demand_and_shows_a_cursor_cell() {
+        let edit = LineEdit::new("ab", true);
+        let masked = edit.display_spans(false);
+        let masked_text: String = masked.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(masked_text, "•• ");
+
+        let revealed = edit.display_spans(true);
+        let revealed_text: String = revealed.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(revealed_text, "ab ");
+
+        // Unmasked fields always show plain text; mid-string cursor renders
+        // the char under it as the cursor cell instead of a trailing space.
+        let mut plain = LineEdit::new("xy", false);
+        plain.handle_key(&press(KeyCode::Home));
+        let line = plain.display_spans(false);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "xy");
+        assert_eq!(line.spans[1].content.as_ref(), "x");
+    }
+}

--- a/crates/leviath-cli/src/tui/widgets/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/mod.rs
@@ -1,0 +1,12 @@
+//! Shared ratatui widgets for every Leviath TUI surface.
+//!
+//! Each widget here exists because at least two surfaces were carrying their
+//! own copy (popups, help overlays, confirm dialogs, footers, list cursors,
+//! line editors) and the copies had already drifted apart. One implementation,
+//! one behavior.
+
+pub(crate) mod confirm;
+pub(crate) mod footer;
+pub(crate) mod help;
+pub(crate) mod line_edit;
+pub(crate) mod popup;

--- a/crates/leviath-cli/src/tui/widgets/popup.rs
+++ b/crates/leviath-cli/src/tui/widgets/popup.rs
@@ -1,0 +1,80 @@
+//! Centered popup geometry and the standard cleared, bordered popup frame.
+//!
+//! Every overlay in every surface starts the same way: compute a centered
+//! rectangle, `Clear` what's underneath, draw a bordered block, and render
+//! content into the block's inner area. This module is that shared start.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Clear};
+
+/// A centred rectangle covering `percent_x`/`percent_y` of `area`.
+pub(crate) fn centered(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+/// Clear `area`, draw a bordered block titled ` {title} ` in `border_color`,
+/// and return the inner rect for the caller's content.
+pub(crate) fn popup_frame(frame: &mut Frame, area: Rect, title: &str, border_color: Color) -> Rect {
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(format!(" {title} "));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    inner
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::test_terminal;
+    use crate::tui::theme::C_WARN;
+
+    #[test]
+    fn centered_produces_a_rect_inside_the_area() {
+        let area = Rect::new(0, 0, 100, 40);
+        let popup = centered(60, 50, area);
+
+        assert!(popup.width <= 60);
+        assert!(popup.height <= 20);
+        assert!(popup.x >= 20);
+        assert!(popup.y >= 10);
+        assert!(popup.right() <= area.right());
+        assert!(popup.bottom() <= area.bottom());
+    }
+
+    #[test]
+    fn popup_frame_draws_the_title_and_returns_the_inner_rect() {
+        let mut terminal = test_terminal();
+        let mut inner = Rect::default();
+        terminal
+            .draw(|frame| {
+                let popup = centered(60, 50, frame.area());
+                inner = popup_frame(frame, popup, "Confirm", C_WARN);
+            })
+            .unwrap();
+
+        let text = terminal.backend().text();
+        assert!(text.contains(" Confirm "));
+        // The inner rect sits strictly inside the bordered popup.
+        assert!(inner.width > 0 && inner.height > 0);
+    }
+}

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -431,6 +431,26 @@ lev setup --non-interactive --anthropic-key sk-ant-... --install-agents
 > The bundled agents are **not** installed unless `--install-agents` is passed in non-interactive
 > mode. That is deliberate, so a scripted setup does not write blueprints you did not ask for.
 
+Inside the wizard, the keys work the same way on every screen:
+
+| Key | Meaning |
+|---|---|
+| `↑` `↓` (or `k` `j`) | Move between rows |
+| `←` `→` (or `h` `l`) | Cycle a choice or the reasoning effort |
+| Space or Enter | Select the focused row; Enter also opens editors for typed values |
+| Enter on `[ Continue ]` | Move to the next screen (the button is the last row) |
+| Tab / Shift-Tab | Next / previous screen |
+| Esc | Previous screen, or cancel an edit or dialog |
+| `v` | Re-check a credential against the provider's API |
+| `o` | Open the provider's signup page |
+| Ctrl-R | Show or hide credentials |
+| Ctrl-S | Write the config and finish, from anywhere |
+| `?` | Help overlay |
+| `q` / Ctrl-C | Quit without writing. If you changed anything, it asks first |
+
+Nothing is written until you confirm on the Review screen. Leaving the provider screen with
+nothing selected asks before letting you continue, since an agent cannot run without one.
+
 ### `lev mcp`
 
 Manage [MCP tool servers](/docs/mcp).

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -246,6 +246,7 @@ claude_code_binary  = "/usr/local/bin/claude"   # unset resolves `claude` on PAT
 claude_code_effort  = "medium"                  # low | medium | high | xhigh | max
 ```
 
-It is off unless you turn it on, and `lev setup` defaults to declining, so pressing Enter through
-the wizard leaves it off. `claude_code_effort` is always sent explicitly: left to itself the CLI
-picks `high` with adaptive thinking, spending output tokens and latency Leviath never asked for.
+It is off unless you turn it on: the wizard never selects it for you, and saving with it selected
+first asks you to accept the terms risk on an explicit dialog. `claude_code_effort` is always sent
+explicitly: left to itself the CLI picks `high` with adaptive thinking, spending output tokens and
+latency Leviath never asked for.


### PR DESCRIPTION
First of a series making every Leviath TUI consistent (setup wizard here; the dashboard follows in the next PRs).

## Shared TUI kit (`crates/leviath-cli/src/tui/`)

- **`keymap.rs`** — the crate's single key → action table: arrows first with `k`/`j`/`h`/`l` aliases, Space toggles, Enter acts on the focused thing, Esc goes back, Tab/Shift-Tab step screens, `?` help, `q` quit, Ctrl-C force-quit. Surfaces match their own keys first and fall through, so a local binding can shadow an alias without touching the table.
- **`widgets/confirm.rs`** — one confirmation dialog: two visible buttons, focus starts on the safe answer, `←`/`→`/Tab move focus, Enter activates, `y`/`n` accelerate, stray keys do nothing. Replaces the "`y` accepts, anything else dismisses" pattern.
- **`widgets/help.rs`** — help overlays built from `(key, description)` tables, so the overlay cannot drift from the real bindings; closed by Esc/`q`/`?`/Enter only.
- **`widgets/footer.rs`** — the one hint bar.
- **`widgets/line_edit.rs`** — single-line editor with a real cursor (char-boundary splicing, masking, Home/End). Replaces the wizard's push/pop `String` editor.
- **`widgets/popup.rs`** — shared centered rect + cleared bordered frame.

`main.rs`'s `CrosstermSetup` now installs a chained panic hook and implements `Drop`, so a panic or early return can no longer leave the shell in raw mode. Mouse capture became per-surface: the wizard never handled mouse events, so capturing there only stole native drag-to-select.

## Setup wizard rework

Fixes the reported trap where pressing Enter on the provider list (expecting to select) silently advanced past the credentials screen and produced a zero-provider install.

- Enter on a provider/agent/MCP row now **selects** it, same as Space. Advancing is a visible `[ Continue → … ]` button at the end of every list, which names the next screen and carries state (`Continue: Credentials (2 selected)`).
- Leaving Providers with nothing selected raises a confirm (`Go back` focused / `Continue anyway`).
- Skipping the Credentials screen is announced in the footer instead of silent.
- Enter on a Defaults/Limits row always acts on that row: toggles a bool, cycles a choice, opens the editor for a number (the footer used to promise this and not do it).
- `q`/Ctrl-C with unsaved choices asks before discarding (Ctrl-C again quits unconditionally); clean state quits immediately.
- The Claude Code ToS gate is a real dialog with explicit buttons; `y`/`n` still work.
- Ctrl-R (reveal credentials) now also works while typing one.
- Docs: `lev setup` key table added to `cli.md`; `providers.md` no longer documents the Enter fall-through as behavior.

## Testing

- `cargo xtask coverage --package leviath-cli` green (100% gate).
- (The full-workspace run flaked once on `leviath-tools`' `the_shell_tool_advertises_the_shell_this_host_resolved` — a pre-existing parallel-test `SHELL` env race, unrelated to this diff; it passes in isolation.)
- Live pty verification on a fresh `LEVIATH_HOME` (both scenarios scripted end to end): zero-provider guard, Enter-selects, masked entry + mid-edit Ctrl-R reveal (a regression the live run caught), dirty-quit confirm, Ctrl-S save landing the credential in `config.toml`, clean quit writing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwH4m95gceUhfrvgAUmEzE