### PR TITLE
Dashboard: stable run ordering, confirmed kills, scrollable log, consistent keys

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -11,30 +11,35 @@ use leviath_core::interaction;
 impl Dashboard {
     pub(super) fn handle_key(&mut self, key: crossterm::event::KeyEvent) {
         let key_code = key.code;
-        // Help overlay takes priority
+        // Ctrl-C quits from anywhere - dialogs, text inputs, every screen. It
+        // is the one binding a user reaches for expecting it to always work.
+        if key
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL)
+            && key_code == KeyCode::Char('c')
+        {
+            self.should_quit = true;
+            return;
+        }
+
+        // Help overlay: closed deliberately (Esc/q/?/Enter), never by a key
+        // that would also act underneath.
         if self.show_help {
-            self.show_help = false;
+            if crate::tui::widgets::help::dismisses_help(&key) {
+                self.show_help = false;
+            }
+            return;
+        }
+
+        // A confirmation dialog owns the keys until answered.
+        if self.pending_confirm.is_some() {
+            self.handle_confirm_key(&key);
             return;
         }
 
         // MCP management screen is modal: it owns all keys while open.
         if self.mcp_screen {
             self.handle_mcp_screen_key(key_code);
-            return;
-        }
-
-        // Delete confirmation popup has highest priority
-        if self.confirm_delete {
-            match key_code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    self.confirm_delete = false;
-                    self.delete_selected_agent();
-                }
-                _ => {
-                    self.confirm_delete = false;
-                    self.add_log("Delete cancelled".to_string());
-                }
-            }
             return;
         }
 
@@ -101,7 +106,50 @@ impl Dashboard {
             return;
         }
 
+        if self.main_focus == MainPane::LogPane {
+            self.handle_log_pane_key(key_code);
+            return;
+        }
         self.handle_main_list_key(key_code);
+    }
+
+    /// Keys while a confirmation dialog is open: the dialog decides, then the
+    /// confirmed action runs against the run id it was opened for.
+    fn handle_confirm_key(&mut self, key: &crossterm::event::KeyEvent) {
+        use crate::tui::widgets::confirm::ConfirmOutcome;
+        let Some((action, mut dialog)) = self.pending_confirm.take() else {
+            return;
+        };
+        match dialog.handle(key) {
+            ConfirmOutcome::Pending => self.pending_confirm = Some((action, dialog)),
+            ConfirmOutcome::No => self.add_log("Cancelled".to_string()),
+            ConfirmOutcome::Yes => match action {
+                ConfirmAction::Kill { run_id } => self.perform_kill(&run_id),
+                ConfirmAction::Delete { run_id } => self.perform_delete(&run_id),
+                ConfirmAction::McpRemove { name } => self.mcp_remove_named(&name),
+            },
+        }
+    }
+
+    /// Keys while the log panel holds focus: scroll history, End/G resumes
+    /// tailing, Tab/Esc hand focus back to the run list.
+    fn handle_log_pane_key(&mut self, key_code: KeyCode) {
+        let len = self.log.len();
+        let viewport = self.log_viewport.max(1);
+        match key_code {
+            KeyCode::Up | KeyCode::Char('k') => self.log_scroll.scroll_up(1, len, viewport),
+            KeyCode::Down | KeyCode::Char('j') => self.log_scroll.scroll_down(1),
+            KeyCode::PageUp => self.log_scroll.scroll_up(viewport, len, viewport),
+            KeyCode::PageDown => self.log_scroll.scroll_down(viewport),
+            KeyCode::Home | KeyCode::Char('g') => self.log_scroll.jump_to_top(len, viewport),
+            KeyCode::End | KeyCode::Char('G') => self.log_scroll.jump_to_tail(),
+            KeyCode::Tab | KeyCode::BackTab | KeyCode::Esc => {
+                self.main_focus = MainPane::RunList;
+            }
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('?') => self.show_help = true,
+            _ => {}
+        }
     }
 
     /// Seed the input textarea when entering input mode. For an `EditText`
@@ -356,15 +404,18 @@ impl Dashboard {
             // decides which pane a gesture moves. Each carrying its own copy of
             // that decision is how the keyboard and the renderer come to
             // disagree about where the document is.
-            KeyCode::Up => self.scroll_by(1),
-            KeyCode::Down => self.scroll_by(-1),
+            KeyCode::Up | KeyCode::Char('k') => self.scroll_by(1),
+            KeyCode::Down | KeyCode::Char('j') => self.scroll_by(-1),
             KeyCode::PageUp => self.scroll_by(10),
             KeyCode::PageDown => self.scroll_by(-10),
-            KeyCode::Char('b') => {
+            // Home/End are the documented jumps; b/e stay as the historical
+            // aliases. (`detail_scroll` counts up from the bottom, so "top of
+            // the document" is the maximum offset.)
+            KeyCode::Char('b') | KeyCode::Home => {
                 self.detail_scroll = usize::MAX;
                 self.review_scroll = usize::MAX;
             }
-            KeyCode::Char('e') => {
+            KeyCode::Char('e') | KeyCode::End => {
                 self.detail_scroll = 0;
                 self.review_scroll = 0;
             }
@@ -391,9 +442,10 @@ impl Dashboard {
             KeyCode::Char('y') => {
                 self.handle_yank();
             }
-            KeyCode::Char('k') => {
-                self.handle_kill_from_detail();
-            }
+            // `x` kills, behind a real confirmation (`k` is unbound here: in a
+            // view whose neighbors are l/o/c, a vim-reflex `k` killing the run
+            // is exactly the accident this replaces).
+            KeyCode::Char('x') => self.request_kill(),
             KeyCode::Char('p') => {
                 self.handle_pause();
             }
@@ -446,36 +498,6 @@ impl Dashboard {
                     level: ToastLevel::Error,
                 });
             }
-        }
-    }
-
-    fn handle_kill_from_detail(&mut self) {
-        if let Some(agent) = self.selected_agent()
-            && agent.status.is_killable()
-        {
-            let agent_id = agent.id.clone();
-            let _ = self.cmd_tx.send(DaemonCommand::Cancel {
-                run_id: agent_id.clone(),
-            });
-            // The index came from `display_indices`/`agents` just above, via the
-            // `self.selected_agent()` lookup that got us into this branch, and
-            // the `cmd_tx.send` in between does not mutate either collection or
-            // `self.selected` - so it's always still valid. An `if let` guard
-            // here would add an "index went stale" branch that can never
-            // actually be exercised.
-            let idx = self
-                .selected_agent_raw_idx()
-                .expect("selected_agent() returned Some above");
-            let a = self
-                .agents
-                .get_mut(idx)
-                .expect("index snapshotted from the still-unchanged display_indices/agents above");
-            a.status = AgentDisplayStatus::Cancelled;
-            a.waiting_prompt = None;
-            a.pending_request = None;
-            self.input_mode = false;
-            self.input_textarea = ratatui_textarea::TextArea::default();
-            self.add_log(format!("{}: kill requested", agent_id));
         }
     }
 
@@ -535,29 +557,44 @@ impl Dashboard {
 
     fn handle_main_list_key(&mut self, key_code: KeyCode) {
         match key_code {
+            // Esc dismisses (the filter); it does not quit - `q` quits, the
+            // same as every other Leviath TUI.
             KeyCode::Esc => {
                 if !self.list_search_query.is_empty() {
-                    // First Esc clears the filter; second exits (quit)
                     self.list_search_query.clear();
                     self.selected = 0;
                     self.update_display_indices();
-                } else {
-                    self.should_quit = true;
                 }
             }
-            KeyCode::Up => {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Up | KeyCode::Char('k') => {
                 if !self.display_indices.is_empty() && self.selected > 0 {
                     self.selected -= 1;
                     self.table_state.select(Some(self.selected));
                 }
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 if !self.display_indices.is_empty()
                     && self.selected < self.display_indices.len() - 1
                 {
                     self.selected += 1;
                     self.table_state.select(Some(self.selected));
                 }
+            }
+            KeyCode::Home | KeyCode::Char('g') => {
+                if !self.display_indices.is_empty() {
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
+                }
+            }
+            KeyCode::End | KeyCode::Char('G') => {
+                if !self.display_indices.is_empty() {
+                    self.selected = self.display_indices.len() - 1;
+                    self.table_state.select(Some(self.selected));
+                }
+            }
+            KeyCode::Tab | KeyCode::BackTab => {
+                self.main_focus = MainPane::LogPane;
             }
             KeyCode::Enter => {
                 if !self.display_indices.is_empty() {
@@ -573,21 +610,11 @@ impl Dashboard {
                 self.selected = 0;
                 self.update_display_indices();
             }
-            KeyCode::Char('d') => {
-                if let Some(id) = self.selected_agent().map(|a| a.id.clone()) {
-                    self.confirm_delete = true;
-                    self.add_log(format!(
-                        "Delete run '{}'? This cancels it and is PERMANENT. (y/n)",
-                        id
-                    ));
-                }
-            }
-            KeyCode::Char('c') => {
-                self.handle_cancel_from_list();
-            }
-            KeyCode::Char('k') => {
-                self.handle_kill_from_list();
-            }
+            KeyCode::Char('s') => self.cycle_sort_mode(),
+            KeyCode::Char('d') => self.request_delete(),
+            // `x` kills, behind a real confirmation. `k` deliberately does
+            // not: it is list navigation here, like everywhere else.
+            KeyCode::Char('x') => self.request_kill(),
             KeyCode::Char('p') => {
                 self.handle_pause();
             }
@@ -635,13 +662,17 @@ impl Dashboard {
         }
 
         match key_code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+            // Esc closes the screen (back); `q` quits the app, the same as
+            // everywhere else.
+            KeyCode::Esc => {
                 self.mcp_screen = false;
             }
-            KeyCode::Up => {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('?') => self.show_help = true,
+            KeyCode::Up | KeyCode::Char('k') => {
                 self.mcp_selected = self.mcp_selected.saturating_sub(1);
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 if !self.mcp_rows.is_empty() && self.mcp_selected + 1 < self.mcp_rows.len() {
                     self.mcp_selected += 1;
                 }
@@ -651,7 +682,7 @@ impl Dashboard {
                 self.mcp_add_input.clear();
             }
             KeyCode::Char('d') => {
-                self.mcp_remove_selected();
+                self.mcp_request_remove();
             }
             KeyCode::Char('l') => {
                 self.mcp_login_selected();
@@ -663,56 +694,6 @@ impl Dashboard {
                 self.refresh_mcp_rows();
             }
             _ => {}
-        }
-    }
-
-    fn handle_cancel_from_list(&mut self) {
-        if let Some(agent) = self.selected_agent()
-            && agent.status.is_killable()
-        {
-            let agent_id = agent.id.clone();
-            let _ = self.cmd_tx.send(DaemonCommand::Cancel {
-                run_id: agent_id.clone(),
-            });
-            // See the comment in `handle_kill_from_detail` - the index is still
-            // valid because the `cmd_tx.send` above does not touch
-            // `display_indices`/`agents`/`selected`.
-            let idx = self
-                .selected_agent_raw_idx()
-                .expect("selected_agent() returned Some above");
-            let a = self
-                .agents
-                .get_mut(idx)
-                .expect("index snapshotted from the still-unchanged display_indices/agents above");
-            a.status = AgentDisplayStatus::Cancelled;
-            a.waiting_prompt = None;
-            a.pending_request = None;
-            self.add_log(format!("{}: Cancel requested", agent_id));
-        }
-    }
-
-    fn handle_kill_from_list(&mut self) {
-        if let Some(agent) = self.selected_agent()
-            && agent.status.is_killable()
-        {
-            let agent_id = agent.id.clone();
-            let _ = self.cmd_tx.send(DaemonCommand::Cancel {
-                run_id: agent_id.clone(),
-            });
-            // See the comment in `handle_kill_from_detail` - the index is still
-            // valid because the `cmd_tx.send` above does not touch
-            // `display_indices`/`agents`/`selected`.
-            let idx = self
-                .selected_agent_raw_idx()
-                .expect("selected_agent() returned Some above");
-            let a = self
-                .agents
-                .get_mut(idx)
-                .expect("index snapshotted from the still-unchanged display_indices/agents above");
-            a.status = AgentDisplayStatus::Cancelled;
-            a.waiting_prompt = None;
-            a.pending_request = None;
-            self.add_log(format!("{}: kill requested", agent_id));
         }
     }
 
@@ -877,6 +858,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: 1000,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -916,10 +898,25 @@ mod tests {
     }
 
     #[test]
-    fn key_esc_quits_from_main_list() {
+    fn q_quits_from_the_main_list_and_esc_does_not() {
         let mut dash = make_test_dashboard();
         dash.handle_key(key(KeyCode::Esc));
+        assert!(!dash.should_quit, "Esc dismisses; it never quits");
+        dash.handle_key(key(KeyCode::Char('q')));
         assert!(dash.should_quit);
+    }
+
+    #[test]
+    fn ctrl_c_quits_from_anywhere() {
+        for setup in [false, true] {
+            let mut dash = make_test_dashboard();
+            dash.detail_view = setup;
+            dash.handle_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('c'),
+                crossterm::event::KeyModifiers::CONTROL,
+            ));
+            assert!(dash.should_quit, "detail={setup}");
+        }
     }
 
     #[test]
@@ -988,10 +985,14 @@ mod tests {
     }
 
     #[test]
-    fn help_overlay_dismissed_by_any_key() {
+    fn help_overlay_dismissed_only_deliberately() {
         let mut dash = make_test_dashboard();
         dash.show_help = true;
+        // A stray key is ignored: it neither closes help nor acts underneath.
         dash.handle_key(key(KeyCode::Char('x')));
+        assert!(dash.show_help);
+        assert!(dash.pending_confirm.is_none(), "x did not open a dialog");
+        dash.handle_key(key(KeyCode::Esc));
         assert!(!dash.show_help);
     }
 
@@ -1133,20 +1134,38 @@ mod tests {
     }
 
     #[test]
-    fn confirm_delete_y_confirms() {
+    fn the_delete_dialog_confirms_with_y_and_deletes() {
         let mut dash = make_test_dashboard();
-        dash.confirm_delete = true;
-        // No agent to actually delete, but the flag should clear
+        dash.agents
+            .push(make_test_agent("run-del", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char('d')));
+        assert!(dash.pending_confirm.is_some(), "d opens the dialog");
+
         dash.handle_key(key(KeyCode::Char('y')));
-        assert!(!dash.confirm_delete);
+        assert!(dash.pending_confirm.is_none());
+        assert!(
+            dash.agents.is_empty(),
+            "confirming removes the run from the list"
+        );
     }
 
     #[test]
-    fn confirm_delete_any_key_cancels() {
+    fn the_delete_dialog_ignores_stray_keys_and_enter_declines() {
         let mut dash = make_test_dashboard();
-        dash.confirm_delete = true;
-        dash.handle_key(key(KeyCode::Char('x')));
-        assert!(!dash.confirm_delete);
+        dash.agents
+            .push(make_test_agent("run-keep", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char('d')));
+
+        // A stray key neither confirms nor dismisses.
+        dash.handle_key(key(KeyCode::Char('z')));
+        assert!(dash.pending_confirm.is_some());
+
+        // Enter activates the focused button, which defaults to No.
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(dash.pending_confirm.is_none());
+        assert_eq!(dash.agents.len(), 1, "declining deletes nothing");
     }
 
     #[test]
@@ -1732,61 +1751,75 @@ mod tests {
         assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
     }
 
-    // ─── handle_cancel_from_list ──────────────────────────────────────────
+    // ─── kill via x + confirmation ────────────────────────────────────────
 
+    /// `c` no longer cancels from the list (it was an unconfirmed kill by
+    /// another name); it is simply unbound there.
     #[test]
-    fn cancel_from_list_active_agent() {
-        let mut dash = make_test_dashboard();
+    fn c_in_the_main_list_does_nothing() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
         dash.agents
             .push(make_test_agent("run-1", AgentDisplayStatus::Active));
         dash.update_display_indices();
         dash.handle_key(key(KeyCode::Char('c')));
-        // Agent should be cancelled (is_run_state = true, pid = 0)
-        assert_cancelled(&dash.agents[0].status);
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+        assert!(cmd_rx.try_recv().is_err());
     }
 
+    /// `k` navigates; it must never kill. The kill key is `x`, behind a
+    /// confirmation.
     #[test]
-    fn cancel_from_list_complete_agent_no_op() {
-        let mut dash = make_test_dashboard();
+    fn k_in_the_main_list_moves_the_cursor_not_the_daemon() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
         dash.agents
-            .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
         dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('c')));
-        // Should remain Complete
-        assert_complete(&dash.agents[0].status);
+        dash.selected = 1;
+        dash.table_state.select(Some(1));
+        dash.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(dash.selected, 0, "k moves up");
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+        assert!(cmd_rx.try_recv().is_err(), "nothing was killed");
     }
 
     /// Every state that is not a finished one can be killed. A gate of only
     /// `Active | Waiting` would make a run showing IDLE or STALE - exactly the
     /// states a user reaches for the kill key in - unkillable.
     #[test]
-    fn every_unfinished_state_can_be_killed() {
+    fn every_unfinished_state_can_be_killed_after_confirming() {
         for status in [
             AgentDisplayStatus::Active,
             AgentDisplayStatus::Waiting,
             AgentDisplayStatus::Idle,
             AgentDisplayStatus::Stale,
         ] {
-            for key_code in ['c', 'k'] {
-                let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
-                let mut dash = Dashboard::new(cmd_tx);
-                dash.agents.push(make_test_agent("run-1", status.clone()));
-                dash.update_display_indices();
-                dash.handle_key(key(KeyCode::Char(key_code)));
+            let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+            let mut dash = Dashboard::new(cmd_tx);
+            dash.agents.push(make_test_agent("run-1", status.clone()));
+            dash.update_display_indices();
+            dash.handle_key(key(KeyCode::Char('x')));
+            assert!(
+                dash.pending_confirm.is_some(),
+                "{status:?} must open the kill dialog"
+            );
+            dash.handle_key(key(KeyCode::Char('y')));
 
-                assert_eq!(
-                    cmd_rx.try_recv().unwrap(),
-                    DaemonCommand::Cancel {
-                        run_id: "run-1".to_string()
-                    },
-                    "{status:?} must be killable via '{key_code}'"
-                );
-            }
+            assert_eq!(
+                cmd_rx.try_recv().unwrap(),
+                DaemonCommand::Cancel {
+                    run_id: "run-1".to_string()
+                },
+                "{status:?} must be killable via x + confirm"
+            );
         }
     }
 
-    /// …and a finished run is left alone: there is nothing to kill, and asking
-    /// the daemon would just produce a spurious failure toast.
+    /// …and a finished run is left alone: `x` does not even open the dialog,
+    /// so there is nothing to mis-confirm.
     #[test]
     fn a_finished_run_is_not_killed() {
         for status in [
@@ -1799,8 +1832,9 @@ mod tests {
             let mut dash = Dashboard::new(cmd_tx);
             dash.agents.push(make_test_agent("run-1", status.clone()));
             dash.update_display_indices();
-            dash.handle_key(key(KeyCode::Char('k')));
+            dash.handle_key(key(KeyCode::Char('x')));
 
+            assert!(dash.pending_confirm.is_none(), "{status:?}: no dialog");
             assert!(
                 cmd_rx.try_recv().is_err(),
                 "{status:?} must not be re-killed"
@@ -1808,8 +1842,24 @@ mod tests {
         }
     }
 
+    /// Declining the kill dialog leaves the run exactly as it was.
     #[test]
-    fn cancel_from_list_waiting_agent_clears_local_state_and_cancels() {
+    fn declining_the_kill_dialog_kills_nothing() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Esc));
+
+        assert!(dash.pending_confirm.is_none());
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn confirmed_kill_clears_local_waiting_state_and_cancels() {
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
         let mut dash = Dashboard::new(cmd_tx);
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
@@ -1819,10 +1869,12 @@ mod tests {
         ));
         dash.agents.push(agent);
         dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('c')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert_cancelled(&dash.agents[0].status);
         assert!(dash.agents[0].pending_request.is_none());
+        assert!(dash.agents[0].waiting_prompt.is_none());
         assert_eq!(
             cmd_rx.try_recv().unwrap(),
             DaemonCommand::Cancel {
@@ -1832,92 +1884,134 @@ mod tests {
     }
 
     #[test]
-    fn cancel_from_list_with_pid_sends_signal() {
-        // See kill_from_detail_with_pid_sends_signal for why this PID value
-        // is safe: implausibly large, guaranteed ESRCH no-op.
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent("run-1", AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('c')));
-        assert_cancelled(&dash.agents[0].status);
-    }
-
-    // ─── handle_kill_from_list ─────────────────────────────────────────────
-
-    #[test]
-    fn kill_from_list_active_agent() {
-        let mut dash = make_test_dashboard();
-        dash.agents
-            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert_cancelled(&dash.agents[0].status);
-    }
-
-    #[test]
-    fn kill_from_list_waiting_agent() {
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
-        agent.waiting_prompt = Some("prompt".to_string());
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert_cancelled(&dash.agents[0].status);
-        assert!(dash.agents[0].waiting_prompt.is_none());
-    }
-
-    #[test]
-    fn kill_from_list_complete_agent_no_op() {
-        let mut dash = make_test_dashboard();
-        dash.agents
-            .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert_complete(&dash.agents[0].status);
-    }
-
-    #[test]
-    fn kill_from_list_with_pid_sends_signal() {
-        // See kill_from_detail_with_pid_sends_signal for why this PID value
-        // is safe: implausibly large, guaranteed ESRCH no-op.
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent("run-1", AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert_cancelled(&dash.agents[0].status);
-    }
-
-    #[test]
     fn main_list_d_no_agent_selected_is_noop() {
         let mut dash = make_test_dashboard();
         dash.handle_key(key(KeyCode::Char('d')));
-        assert!(!dash.confirm_delete);
+        assert!(dash.pending_confirm.is_none());
         assert!(dash.agents.is_empty());
     }
 
     #[test]
-    fn cancel_from_list_no_agent_selected_is_noop() {
+    fn x_with_no_agent_selected_is_a_noop() {
         let mut dash = make_test_dashboard();
-        // No agents at all - selected_agent() is None.
-        dash.handle_key(key(KeyCode::Char('c')));
-        assert!(dash.agents.is_empty());
-    }
+        dash.handle_key(key(KeyCode::Char('x')));
+        assert!(dash.pending_confirm.is_none());
 
-    #[test]
-    fn kill_from_list_no_agent_selected_is_noop() {
-        let mut dash = make_test_dashboard();
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert!(dash.agents.is_empty());
-    }
-
-    #[test]
-    fn kill_from_detail_no_agent_selected_is_noop() {
-        let mut dash = make_test_dashboard();
         dash.detail_view = true;
+        dash.handle_key(key(KeyCode::Char('x')));
+        assert!(dash.pending_confirm.is_none());
+    }
+
+    #[test]
+    fn tab_focuses_the_log_pane_and_its_keys_scroll() {
+        let mut dash = make_test_dashboard();
+        // The seeded log tail is shared test state; a known length makes the
+        // scroll arithmetic below deterministic.
+        dash.log.clear();
+        for i in 0..50 {
+            dash.log.push(LogEntry {
+                timestamp: "12:00:00".to_string(),
+                message: format!("line {i}"),
+            });
+        }
+        dash.log_viewport = 10;
+        dash.handle_key(key(KeyCode::Tab));
+        assert_eq!(dash.main_focus, MainPane::LogPane);
+
+        dash.handle_key(key(KeyCode::Up));
         dash.handle_key(key(KeyCode::Char('k')));
-        assert!(dash.agents.is_empty());
+        assert_eq!(dash.log_scroll.offset_from_tail, 2);
+        dash.handle_key(key(KeyCode::PageUp));
+        assert_eq!(dash.log_scroll.offset_from_tail, 12);
+        dash.handle_key(key(KeyCode::Down));
+        dash.handle_key(key(KeyCode::Char('j')));
+        dash.handle_key(key(KeyCode::PageDown));
+        assert_eq!(dash.log_scroll.offset_from_tail, 0);
+
+        dash.handle_key(key(KeyCode::Home));
+        assert_eq!(dash.log_scroll.offset_from_tail, 40);
+        dash.handle_key(key(KeyCode::End));
+        assert!(dash.log_scroll.is_tailing());
+        dash.handle_key(key(KeyCode::Char('g')));
+        assert!(!dash.log_scroll.is_tailing());
+        dash.handle_key(key(KeyCode::Char('G')));
+        assert!(dash.log_scroll.is_tailing());
+
+        // ? opens help from the log pane; a stray key is ignored.
+        dash.handle_key(key(KeyCode::Char('?')));
+        assert!(dash.show_help);
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(!dash.show_help);
+        dash.handle_key(key(KeyCode::Char('z')));
+
+        // Esc hands focus back to the list; q quits from the pane.
+        dash.handle_key(key(KeyCode::Esc));
+        assert_eq!(dash.main_focus, MainPane::RunList);
+        dash.handle_key(key(KeyCode::Tab));
+        dash.handle_key(key(KeyCode::Char('q')));
+        assert!(dash.should_quit);
+    }
+
+    #[test]
+    fn home_end_and_enter_navigate_the_main_list() {
+        let mut dash = make_test_dashboard();
+        let mut a = make_test_agent("run-1", AgentDisplayStatus::Active);
+        a.stage_index = 1;
+        a.num_stages = 3;
+        dash.agents.push(a);
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-3", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+
+        dash.handle_key(key(KeyCode::End));
+        assert_eq!(dash.selected, 2);
+        dash.handle_key(key(KeyCode::Home));
+        assert_eq!(dash.selected, 0);
+        dash.handle_key(key(KeyCode::Char('G')));
+        assert_eq!(dash.selected, 2);
+        dash.handle_key(key(KeyCode::Char('g')));
+        assert_eq!(dash.selected, 0);
+
+        // Enter opens the detail view at the selected run's current stage.
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(dash.detail_view);
+        assert_eq!(dash.selected_stage, 1);
+
+        // With no rows at all, the same keys are no-ops.
+        let mut empty = make_test_dashboard();
+        for code in [KeyCode::Home, KeyCode::End, KeyCode::Enter] {
+            empty.handle_key(key(code));
+        }
+        assert!(!empty.detail_view);
+    }
+
+    #[test]
+    fn s_cycles_the_sort_mode_from_the_keyboard() {
+        let mut dash = make_test_dashboard();
+        assert_eq!(dash.sort_mode, SortMode::StartedAt);
+        dash.handle_key(key(KeyCode::Char('s')));
+        assert_eq!(dash.sort_mode, SortMode::RecentActivity);
+    }
+
+    #[test]
+    fn the_confirm_handler_declines_to_act_without_a_dialog() {
+        let mut dash = make_test_dashboard();
+        dash.handle_confirm_key(&crossterm::event::KeyEvent::new(
+            KeyCode::Enter,
+            crossterm::event::KeyModifiers::empty(),
+        ));
+        assert!(dash.pending_confirm.is_none());
+        assert!(!dash.should_quit);
+    }
+
+    #[test]
+    fn question_mark_opens_help_on_the_mcp_screen() {
+        let mut dash = make_test_dashboard();
+        dash.mcp_screen = true;
+        dash.handle_key(key(KeyCode::Char('?')));
+        assert!(dash.show_help);
     }
 
     #[test]
@@ -1940,7 +2034,7 @@ mod tests {
         assert!(dash.agents.is_empty());
     }
 
-    // ─── handle_kill_from_detail ──────────────────────────────────────────
+    // ─── kill from the detail view ────────────────────────────────────────
 
     #[test]
     fn kill_from_detail_active_agent() {
@@ -1949,7 +2043,8 @@ mod tests {
             .push(make_test_agent("run-1", AgentDisplayStatus::Active));
         dash.update_display_indices();
         dash.detail_view = true;
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
         assert_cancelled(&dash.agents[0].status);
     }
 
@@ -1960,28 +2055,13 @@ mod tests {
             .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
         dash.update_display_indices();
         dash.detail_view = true;
-        dash.handle_key(key(KeyCode::Char('k')));
-        // Should remain complete
+        dash.handle_key(key(KeyCode::Char('x')));
+        assert!(dash.pending_confirm.is_none());
         assert_complete(&dash.agents[0].status);
     }
 
     #[test]
-    fn kill_from_detail_with_pid_sends_signal() {
-        // Exercise the `pid > 0` unix-kill branch. Use an implausibly large
-        // PID (near i32::MAX, far beyond any real PID_MAX) so `libc::kill`
-        // is guaranteed to be a harmless no-op (ESRCH) rather than risking
-        // sending SIGTERM to a real, unrelated process.
-        let mut dash = make_test_dashboard();
-        let agent = make_test_agent("run-1", AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-        dash.detail_view = true;
-        dash.handle_key(key(KeyCode::Char('k')));
-        assert_cancelled(&dash.agents[0].status);
-    }
-
-    #[test]
-    fn kill_from_detail_waiting_agent_clears_local_state_and_cancels() {
+    fn confirmed_kill_from_detail_resets_input_state() {
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
         let mut dash = Dashboard::new(cmd_tx);
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
@@ -1992,10 +2072,12 @@ mod tests {
         dash.agents.push(agent);
         dash.update_display_indices();
         dash.detail_view = true;
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert_cancelled(&dash.agents[0].status);
         assert!(dash.agents[0].pending_request.is_none());
+        assert!(!dash.input_mode);
         assert_eq!(
             cmd_rx.try_recv().unwrap(),
             DaemonCommand::Cancel {
@@ -2118,7 +2200,7 @@ mod tests {
             .push(make_test_agent("run-1", AgentDisplayStatus::Active));
         dash.update_display_indices();
         dash.handle_key(key(KeyCode::Char('d')));
-        assert!(dash.confirm_delete);
+        assert!(dash.pending_confirm.is_some());
     }
 
     // ─── detail view: review scroll ───────────────────────────────────────
@@ -2500,7 +2582,8 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
 
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert_eq!(dash.agents[0].status, AgentDisplayStatus::Cancelled);
 
@@ -2509,24 +2592,7 @@ mod tests {
         assert!(cmd.is_ok());
     }
 
-    // ─── handle_cancel_from_list for in-process agent ─────────────────────
-
-    #[test]
-    fn cancel_from_list_in_process_agent_sends_command() {
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
-        let mut dash = Dashboard::new(cmd_tx);
-        let agent = make_test_agent("run-1", AgentDisplayStatus::Active);
-        dash.agents.push(agent);
-        dash.update_display_indices();
-
-        dash.handle_key(key(KeyCode::Char('c')));
-
-        // Should have sent CancelAgent command (no status change for in-process cancel)
-        let cmd = cmd_rx.try_recv();
-        assert!(cmd.is_ok());
-    }
-
-    // ─── handle_kill_from_list for in-process agent ───────────────────────
+    // ─── x + confirm from the list for in-process agent ───────────────────
 
     #[test]
     fn kill_from_list_in_process_agent_sends_command() {
@@ -2536,7 +2602,8 @@ mod tests {
         dash.agents.push(agent);
         dash.update_display_indices();
 
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert_eq!(dash.agents[0].status, AgentDisplayStatus::Cancelled);
 
@@ -2974,30 +3041,10 @@ mod tests {
         assert_eq!(dash.selected, 2);
     }
 
-    // ─── handle_cancel_from_list: pending_request cleared for run-state ───
-
-    #[test]
-    fn cancel_from_list_run_state_agent_clears_pending_request() {
-        // Exercises line 493: `a.pending_request = None;` in handle_cancel_from_list.
-        let mut dash = make_test_dashboard();
-        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Active);
-        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::free_text(
-            "r1", "?", "main", true,
-        ));
-        dash.agents.push(agent);
-        dash.update_display_indices();
-
-        dash.handle_key(key(KeyCode::Char('c')));
-
-        assert!(dash.agents[0].pending_request.is_none());
-        assert_cancelled(&dash.agents[0].status);
-    }
-
-    // ─── handle_kill_from_list: pending_request cleared ───────────────────
+    // ─── confirmed kill clears pending_request (list and detail) ──────────
 
     #[test]
     fn kill_from_list_run_state_agent_clears_pending_request() {
-        // Exercises line 531: `a.pending_request = None;` in handle_kill_from_list.
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Active);
         agent.pending_request = Some(leviath_core::interaction::InteractionRequest::free_text(
@@ -3006,17 +3053,15 @@ mod tests {
         dash.agents.push(agent);
         dash.update_display_indices();
 
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert!(dash.agents[0].pending_request.is_none());
         assert_cancelled(&dash.agents[0].status);
     }
 
-    // ─── handle_kill_from_detail: pending_request cleared ─────────────────
-
     #[test]
     fn kill_from_detail_run_state_agent_clears_pending_request() {
-        // Exercises line 392: `a.pending_request = None;` in handle_kill_from_detail.
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Active);
         agent.pending_request = Some(leviath_core::interaction::InteractionRequest::free_text(
@@ -3026,7 +3071,8 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
 
-        dash.handle_key(key(KeyCode::Char('k')));
+        dash.handle_key(key(KeyCode::Char('x')));
+        dash.handle_key(key(KeyCode::Char('y')));
 
         assert!(dash.agents[0].pending_request.is_none());
         assert_cancelled(&dash.agents[0].status);
@@ -3085,16 +3131,17 @@ mod tests {
     }
 
     #[test]
-    fn q_and_esc_close_the_mcp_screen() {
+    fn esc_closes_the_mcp_screen_and_q_quits_the_app() {
         let dir = tempfile::tempdir().unwrap();
         let mut dash = mcp_dash(dir.path());
         dash.mcp_screen = true;
-        dash.handle_key(key(KeyCode::Char('q')));
-        assert!(!dash.mcp_screen);
-
-        dash.mcp_screen = true;
         dash.handle_key(key(KeyCode::Esc));
         assert!(!dash.mcp_screen);
+        assert!(!dash.should_quit);
+
+        dash.mcp_screen = true;
+        dash.handle_key(key(KeyCode::Char('q')));
+        assert!(dash.should_quit, "q means quit here like everywhere else");
     }
 
     #[test]
@@ -3166,7 +3213,7 @@ mod tests {
     }
 
     #[test]
-    fn d_deletes_the_selected_server() {
+    fn d_removes_the_selected_server_after_confirming() {
         let dir = tempfile::tempdir().unwrap();
         let mut dash = mcp_dash(dir.path());
         dash.mcp_add_from_line("gone npx");
@@ -3174,6 +3221,9 @@ mod tests {
         dash.mcp_screen = true;
         dash.mcp_selected = 0;
         dash.handle_key(key(KeyCode::Char('d')));
+        assert!(dash.pending_confirm.is_some(), "d asks first");
+        assert_eq!(dash.mcp_rows.len(), 1, "nothing removed yet");
+        dash.handle_key(key(KeyCode::Char('y')));
         assert!(dash.mcp_rows.is_empty());
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -10,7 +10,7 @@
 use tokio::sync::mpsc;
 
 use super::state::Dashboard;
-use super::types::{McpCommand, McpContext, McpOutcome, McpRow, ToastLevel};
+use super::types::{ConfirmAction, McpCommand, McpContext, McpOutcome, McpRow, ToastLevel};
 use crate::config::Config;
 use leviath_mcp::{AuthStore, MCPClient, MCPServerConfig, OAuthClient};
 
@@ -74,12 +74,30 @@ impl Dashboard {
         true
     }
 
-    /// Remove the selected server and any stored credentials.
-    pub(super) fn mcp_remove_selected(&mut self) {
+    /// Open the remove confirmation for the selected server.
+    pub(super) fn mcp_request_remove(&mut self) {
+        use crate::tui::widgets::confirm::Confirm;
+        use ratatui::text::Line;
         let Some(row) = self.mcp_rows.get(self.mcp_selected) else {
             return;
         };
         let name = row.name.clone();
+        let dialog = Confirm::new(
+            "Remove MCP server?",
+            vec![Line::from(format!(
+                "Remove '{name}' from the config (and forget its login)?"
+            ))],
+            "Remove",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((ConfirmAction::McpRemove { name }, dialog));
+    }
+
+    /// Remove `name` from the config and the auth store. Runs after its
+    /// confirmation dialog; keyed by name, not the current selection.
+    pub(super) fn mcp_remove_named(&mut self, name: &str) {
+        let name = name.to_string();
         let ctx = &self.mcp_ctx;
         let mut config = match Config::load_from_path_public(&ctx.config_path) {
             Ok(config) => config,
@@ -424,7 +442,7 @@ mod tests {
         assert_eq!(dash.mcp_rows[0].auth, "none");
 
         dash.mcp_selected = 0;
-        dash.mcp_remove_selected();
+        dash.mcp_remove_named("remote");
         assert!(dash.mcp_rows.is_empty());
     }
 
@@ -473,8 +491,9 @@ mod tests {
     fn remove_with_no_selection_is_a_noop() {
         let dir = tempfile::tempdir().unwrap();
         let mut dash = dash_at(dir.path());
-        // No rows loaded; removing selection 0 does nothing.
-        dash.mcp_remove_selected();
+        // No rows loaded; requesting a removal opens nothing.
+        dash.mcp_request_remove();
+        assert!(dash.pending_confirm.is_none());
         assert!(dash.mcp_rows.is_empty());
     }
 
@@ -489,7 +508,7 @@ mod tests {
         dash.refresh_mcp_rows();
 
         dash.mcp_selected = 0;
-        dash.mcp_remove_selected();
+        dash.mcp_remove_named("remote");
         assert!(
             AuthStore::load(&dash.mcp_ctx.store_path)
                 .unwrap()
@@ -508,7 +527,7 @@ mod tests {
         std::fs::remove_file(&dash.mcp_ctx.config_path).unwrap();
         std::fs::create_dir(&dash.mcp_ctx.config_path).unwrap();
         dash.mcp_selected = 0;
-        dash.mcp_remove_selected();
+        dash.mcp_remove_named("x");
         // Rows unchanged (still the pre-remove snapshot is fine); the point is
         // it did not panic and toasted an error.
     }
@@ -525,7 +544,7 @@ mod tests {
         perms.set_readonly(true);
         std::fs::set_permissions(&dash.mcp_ctx.config_path, perms).unwrap();
         dash.mcp_selected = 0;
-        dash.mcp_remove_selected();
+        dash.mcp_remove_named("x");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -637,6 +637,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: 0,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -663,12 +664,12 @@ mod tests {
     use crossterm::event::KeyCode;
 
     #[tokio::test]
-    async fn run_dashboard_loop_quits_on_esc_from_main_list() {
+    async fn run_dashboard_loop_quits_on_q_from_main_list() {
         let mut dashboard = make_test_dashboard();
         let control = no_daemon_control();
         let mut terminal = test_terminal();
         // A no-op Resize tick, then both wheel directions, a full
-        // press-drag-release selection over the log panel, and the Esc that
+        // press-drag-release selection over the log panel, and the q that
         // triggers quit - covers every arm of the event match, including the
         // mouse one that carries scrolling and selection.
         let mouse = |kind, column, row| {
@@ -690,7 +691,7 @@ mod tests {
             mouse(MouseEventKind::Down(MouseButton::Left), 3, 15),
             mouse(MouseEventKind::Drag(MouseButton::Left), 20, 16),
             mouse(MouseEventKind::Up(MouseButton::Left), 20, 16),
-            key(KeyCode::Esc),
+            key(KeyCode::Char('q')),
         ]);
 
         let result = run_dashboard_loop(
@@ -709,14 +710,14 @@ mod tests {
     #[tokio::test]
     async fn run_dashboard_loop_no_event_tick_then_quits() {
         // Tick 1: `poll_event` returns `None` (simulated poll-timeout - no input
-        // pending); tick 2: Esc quits.  The `None` entry exercises the
+        // pending); tick 2: q quits.  The `None` entry exercises the
         // `if let Some(event)` fallthrough path (line 127 in mod.rs).
         let mut dashboard = make_test_dashboard();
         let control = no_daemon_control();
         let mut terminal = test_terminal();
         // `None` entry → poll returns Ok(None) on tick 1 (no-event path);
-        // `Some(Esc)` → poll returns Ok(Some(Esc)) on tick 2 → quit.
-        let mut events = TestEventSource::new_with_nones(vec![None, Some(key(KeyCode::Esc))]);
+        // `Some(q)` → poll returns Ok(Some(q)) on tick 2 → quit.
+        let mut events = TestEventSource::new_with_nones(vec![None, Some(key(KeyCode::Char('q')))]);
 
         let result = run_dashboard_loop(
             &mut dashboard,
@@ -734,7 +735,7 @@ mod tests {
     #[tokio::test]
     async fn run_dashboard_loop_ignores_non_press_and_other_events() {
         // A key release (not Press) and a mouse-like "other" event are both
-        // ignored by the `_ => {}` arm; only the trailing Esc actually quits.
+        // ignored by the `_ => {}` arm; only the trailing q actually quits.
         let mut dashboard = make_test_dashboard();
         let control = no_daemon_control();
         let mut terminal = test_terminal();
@@ -743,7 +744,8 @@ mod tests {
             crossterm::event::KeyModifiers::empty(),
             crossterm::event::KeyEventKind::Release,
         ));
-        let mut events = TestEventSource::new(vec![release, Event::FocusGained, key(KeyCode::Esc)]);
+        let mut events =
+            TestEventSource::new(vec![release, Event::FocusGained, key(KeyCode::Char('q'))]);
 
         let result = run_dashboard_loop(
             &mut dashboard,
@@ -849,7 +851,7 @@ mod tests {
                 let control = no_daemon_control();
                 let mut dashboard = init_dashboard(control.clone(), |_| false);
                 let mut setup = TestSetup::new();
-                let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
+                let mut events = TestEventSource::new(vec![key(KeyCode::Char('q'))]);
                 let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;
                 assert!(result.is_ok());
                 assert!(dashboard.should_quit);
@@ -871,7 +873,7 @@ mod tests {
                     "execute_with_dashboard",
                     |_d| async move {
                         let mut setup = TestSetup::new();
-                        let mut events = TestEventSource::new(vec![key(KeyCode::Esc)]);
+                        let mut events = TestEventSource::new(vec![key(KeyCode::Char('q'))]);
                         let result =
                             execute_with(no_daemon_control(), &mut setup, &mut events, |_| false)
                                 .await;

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -775,6 +775,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -200,6 +200,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -248,6 +248,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -24,11 +24,21 @@ impl Dashboard {
         // scroll) drops the selection.
         self.selection_regions.clear();
         self.selection_regions.push(frame.area());
+        // Wheel hit-testing rects are also per-frame: each pane's renderer
+        // registers where it actually drew.
+        self.pane_rects.clear();
 
         if self.mcp_screen {
             self.draw_mcp_screen(frame, frame.area());
             self.apply_selection_overlay(frame);
             self.draw_toasts(frame);
+            if self.show_help {
+                self.draw_help_overlay(frame);
+            }
+            // The remove confirmation can be open over the MCP screen.
+            if let Some((_, dialog)) = &self.pending_confirm {
+                dialog.draw(frame, frame.area());
+            }
             return;
         }
         if self.detail_view {
@@ -65,9 +75,9 @@ impl Dashboard {
             self.draw_help_overlay(frame);
         }
 
-        // Delete confirmation popup
-        if self.confirm_delete {
-            self.draw_confirm_popup(frame);
+        // Kill / delete / remove confirmation dialog
+        if let Some((_, dialog)) = &self.pending_confirm {
+            dialog.draw(frame, frame.area());
         }
     }
 
@@ -277,6 +287,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -611,8 +622,37 @@ mod tests {
         dash.agents
             .push(make_test_agent("run-del", AgentDisplayStatus::Complete));
         dash.update_display_indices();
-        dash.confirm_delete = true;
+        dash.request_delete();
         terminal.draw(|f| dash.draw(f)).unwrap();
+    }
+
+    #[test]
+    fn draw_mcp_screen_with_help_and_confirm_overlays() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.mcp_screen = true;
+        dash.show_help = true;
+        dash.pending_confirm = Some((
+            crate::commands::dashboard::types::ConfirmAction::McpRemove {
+                name: "srv".to_string(),
+            },
+            crate::tui::widgets::confirm::Confirm::new(
+                "Remove MCP server?",
+                vec![ratatui::text::Line::from("Remove 'srv'?")],
+                "Remove",
+                "Cancel",
+            ),
+        ));
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(text.contains("Remove MCP server?"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -4,7 +4,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
+use ratatui::widgets::{Clear, Paragraph};
 
 use crate::commands::dashboard::helpers::truncate;
 use crate::commands::dashboard::state::Dashboard;
@@ -59,293 +59,74 @@ impl Dashboard {
         }
     }
 
+    /// The page-scoped help overlay, built from `(key, description)` tables
+    /// via the shared builder so it cannot drift from the bindings.
     pub(in crate::commands::dashboard) fn draw_help_overlay(&self, frame: &mut Frame) {
-        let area = frame.area();
-        let w: u16 = 62.min(area.width.saturating_sub(4));
-        let h: u16 = 38.min(area.height.saturating_sub(4));
-        let x = (area.width.saturating_sub(w)) / 2;
-        let y = (area.height.saturating_sub(h)) / 2;
-        let popup = Rect {
-            x,
-            y,
-            width: w,
-            height: h,
-        };
-        frame.render_widget(Clear, popup);
-
-        // Only show keybindings relevant to the page the user is currently on.
-        let mut lines = if self.detail_view {
-            self.detail_view_help_lines()
+        use crate::tui::widgets::help::{HelpSection, draw_help};
+        let sections: Vec<HelpSection> = if self.mcp_screen {
+            vec![HelpSection {
+                title: "MCP servers",
+                entries: vec![
+                    ("↑ ↓ / k j", "move"),
+                    ("a", "add a server"),
+                    ("d", "remove (asks first)"),
+                    ("l", "browser login"),
+                    ("t", "test the connection"),
+                    ("r", "refresh the list"),
+                    ("esc", "back to the run list"),
+                    ("q / ctrl-c", "quit"),
+                ],
+            }]
+        } else if self.detail_view {
+            vec![
+                HelpSection {
+                    title: "Detail view",
+                    entries: vec![
+                        ("← →", "switch stage tab"),
+                        ("1-9", "jump to stage by number"),
+                        ("↑ ↓ / k j", "scroll (review doc when shown)"),
+                        ("pgup / pgdn", "scroll 10 lines"),
+                        ("home / end (b / e)", "jump to begin / end"),
+                        ("o / l / c", "output / logs / context"),
+                        (", / .", "older / newer context point"),
+                        ("/", "search; n / N step matches"),
+                        ("y", "yank pane to the clipboard"),
+                        ("drag", "select text; release copies"),
+                        ("i", "respond / send input"),
+                        ("x", "kill the run (asks first)"),
+                        ("p / r", "pause / resume"),
+                        ("esc", "clear search, then back"),
+                    ],
+                },
+                HelpSection {
+                    title: "While typing input",
+                    entries: vec![
+                        ("enter", "send response / message"),
+                        ("alt+enter", "insert a newline"),
+                        ("esc", "cancel input"),
+                    ],
+                },
+            ]
         } else {
-            self.main_list_help_lines()
+            vec![HelpSection {
+                title: "Run list",
+                entries: vec![
+                    ("↑ ↓ / k j", "select a run"),
+                    ("home / end (g / G)", "first / last run"),
+                    ("enter", "open the detail view"),
+                    ("tab", "focus the log panel (scrollable)"),
+                    ("/", "filter runs"),
+                    ("s", "cycle sort: started / activity / status"),
+                    ("x", "kill the run (asks first)"),
+                    ("d", "delete the run (asks first)"),
+                    ("p / r", "pause / resume"),
+                    ("m", "manage MCP servers"),
+                    ("esc", "clear the filter"),
+                    ("q / ctrl-c", "quit"),
+                ],
+            }]
         };
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "  Any key to dismiss",
-            Style::default().fg(C_DIM),
-        )));
-
-        let widget = Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(C_ACCENT))
-                .title(Span::styled(
-                    " Help  ? ",
-                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-                ))
-                .padding(Padding::uniform(0)),
-        );
-        frame.render_widget(widget, popup);
-    }
-
-    fn main_list_help_lines(&self) -> Vec<Line<'static>> {
-        vec![
-            Line::from(Span::styled(
-                "  Main list",
-                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    "  ↑/↓      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Select agent (sorted: active first)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  Enter    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Open detail view"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  /        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Filter agents by name/status"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  d        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Delete run (permanent)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  c / k    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Cancel / Kill agent"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  p / r    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Pause / Resume agent"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  m        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Manage MCP servers"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  Esc      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Clear filter / Quit"),
-            ]),
-        ]
-    }
-
-    fn detail_view_help_lines(&self) -> Vec<Line<'static>> {
-        vec![
-            Line::from(Span::styled(
-                "  Detail view",
-                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    "  ←/→      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Switch stage tab"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  1-9      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Jump to stage by number"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  ↑/↓      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Scroll output (review doc when shown)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  PgUp/Dn  ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Scroll 10 lines"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  b / e    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Jump to begin / end"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  l / o    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Toggle Logs / Output"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  /        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Search output/logs"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  n / N    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Next / previous search match"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  y        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Yank output/logs to clipboard (OSC52)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  drag     ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Select text; release copies (Shift+drag: terminal select)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  i        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Respond / provide input (when supported)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  k        ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Kill agent"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  p / r    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Pause / Resume agent"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  Esc      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Clear search / back to list"),
-            ]),
-            Line::from(""),
-            Line::from(Span::styled(
-                "  Input",
-                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    "  Enter    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Send response / message"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  Alt+↵    ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Insert newline (multi-line)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "  Esc      ",
-                    Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Cancel input"),
-            ]),
-        ]
-    }
-
-    pub(in crate::commands::dashboard) fn draw_confirm_popup(&self, frame: &mut Frame) {
-        let area = frame.area();
-        let w: u16 = 56.min(area.width.saturating_sub(4));
-        let h: u16 = 5;
-        let x = (area.width.saturating_sub(w)) / 2;
-        let y = (area.height.saturating_sub(h)) / 2;
-        let popup = Rect {
-            x,
-            y,
-            width: w,
-            height: h,
-        };
-        frame.render_widget(Clear, popup);
-
-        let agent_id = self.selected_agent().map(|a| a.id.as_str()).unwrap_or("?");
-        let lines = vec![
-            Line::from(""),
-            Line::from(Span::styled(
-                format!(
-                    "  Delete run '{}'?  This is permanent.",
-                    truncate(agent_id, 24)
-                ),
-                Style::default().fg(C_WARN),
-            )),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    "  [y]",
-                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(" confirm  "),
-                Span::styled("[any key]", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" cancel"),
-            ]),
-        ];
-        let widget = Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(C_ERROR))
-                .title(Span::styled(
-                    " Confirm Delete ",
-                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
-                )),
-        );
-        frame.render_widget(widget, popup);
+        draw_help(frame, frame.area(), &sections);
     }
 }
 
@@ -380,6 +161,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -464,31 +246,29 @@ mod tests {
     }
 
     #[test]
-    fn draw_confirm_popup_with_agent() {
+    fn the_delete_dialog_renders_over_the_frame() {
         let backend = TestBackend::new(120, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         dash.agents
             .push(make_test_agent("run-del-123", AgentDisplayStatus::Complete));
         dash.update_display_indices();
-        dash.confirm_delete = true;
+        dash.request_delete();
+        let (_, dialog) = dash.pending_confirm.as_ref().expect("dialog open").clone();
         terminal
             .draw(|f| {
-                dash.draw_confirm_popup(f);
+                dialog.draw(f, f.area());
             })
             .unwrap();
-    }
-
-    #[test]
-    fn draw_confirm_popup_no_agent() {
-        let backend = TestBackend::new(120, 40);
-        let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
-        terminal
-            .draw(|f| {
-                dash.draw_confirm_popup(f);
-            })
-            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(text.contains("Delete run?"));
+        assert!(text.contains("[ Cancel ]"));
     }
 
     // ─── Regression: help overlay must scope to the current page ──────────
@@ -521,10 +301,11 @@ mod tests {
             .unwrap();
 
         let rendered = rendered_buffer(&terminal);
-        assert!(rendered.contains("Main list"));
-        assert!(rendered.contains("Pause / Resume agent"));
+        assert!(rendered.contains("Run list"));
+        assert!(rendered.contains("cycle sort"));
+        assert!(rendered.contains("kill the run (asks first)"));
         assert!(!rendered.contains("Detail view"));
-        assert!(!rendered.contains("Switch stage tab"));
+        assert!(!rendered.contains("switch stage tab"));
     }
 
     #[test]
@@ -541,9 +322,26 @@ mod tests {
 
         let rendered = rendered_buffer(&terminal);
         assert!(rendered.contains("Detail view"));
-        assert!(rendered.contains("Switch stage tab"));
-        assert!(rendered.contains("Pause / Resume agent"));
-        assert!(!rendered.contains("Main list"));
-        assert!(!rendered.contains("Select agent"));
+        assert!(rendered.contains("switch stage tab"));
+        assert!(rendered.contains("While typing input"));
+        assert!(!rendered.contains("Run list"));
+        assert!(!rendered.contains("cycle sort"));
+    }
+
+    #[test]
+    fn draw_help_overlay_mcp_screen_shows_its_own_keys() {
+        let backend = TestBackend::new(120, 50);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.mcp_screen = true;
+        terminal
+            .draw(|f| {
+                dash.draw_help_overlay(f);
+            })
+            .unwrap();
+
+        let rendered = rendered_buffer(&terminal);
+        assert!(rendered.contains("MCP servers"));
+        assert!(rendered.contains("remove (asks first)"));
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -547,6 +547,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -126,14 +126,24 @@ impl Dashboard {
             " Agents ".to_string()
         };
 
+        // Register for wheel hit-testing and show which pane holds focus.
+        self.pane_rects.push((PaneId::RunTable, area));
+        let focused = self.main_focus == MainPane::RunList;
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(C_BORDER))
+            .border_style(Style::default().fg(if focused { C_BORDER_FOCUS } else { C_BORDER }))
             .title(Span::styled(
                 list_title,
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-            ));
+            ))
+            .title_top(
+                Line::from(Span::styled(
+                    format!(" sort: {} ▾ ", self.sort_mode.label()),
+                    Style::default().fg(C_DIM),
+                ))
+                .right_aligned(),
+            );
 
         if let Some(msg) = empty_state_msg {
             let widget = Paragraph::new(Line::from(Span::styled(msg, Style::default().fg(C_DIM))))
@@ -164,13 +174,15 @@ impl Dashboard {
         frame.render_stateful_widget(table, area, &mut self.table_state);
     }
 
-    pub(in crate::commands::dashboard) fn draw_log_panel(&self, frame: &mut Frame, area: Rect) {
-        let log_lines: Vec<Line> = self
-            .log
+    pub(in crate::commands::dashboard) fn draw_log_panel(&mut self, frame: &mut Frame, area: Rect) {
+        self.pane_rects.push((PaneId::LogPanel, area));
+        let viewport = area.height.saturating_sub(2) as usize;
+        self.log_viewport = viewport;
+        let window = self.log_scroll.window(self.log.len(), viewport);
+        let scrolled_back = !self.log_scroll.is_tailing();
+
+        let log_lines: Vec<Line> = self.log[window.clone()]
             .iter()
-            .rev()
-            .take(area.height.saturating_sub(2) as usize)
-            .rev()
             .map(|entry| {
                 Line::from(vec![
                     Span::styled(format!(" {} ", entry.timestamp), Style::default().fg(C_DIM)),
@@ -179,28 +191,81 @@ impl Dashboard {
             })
             .collect();
 
+        let focused = self.main_focus == MainPane::LogPane;
+        let title = if scrolled_back {
+            format!(" Log  ↑{} (End resumes) ", self.log_scroll.offset_from_tail)
+        } else {
+            " Log ".to_string()
+        };
         let log = Paragraph::new(log_lines).block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(C_BORDER))
-                .title(Span::styled(" Log ", Style::default().fg(C_DIM))),
+                .border_style(Style::default().fg(if focused { C_BORDER_FOCUS } else { C_BORDER }))
+                .title(Span::styled(
+                    title,
+                    Style::default().fg(if scrolled_back { C_WARN } else { C_DIM }),
+                )),
         );
         frame.render_widget(log, area);
+
+        // A scrollbar whenever there is history beyond the window.
+        if self.log.len() > viewport && viewport > 0 {
+            let mut sb_state =
+                ratatui::widgets::ScrollbarState::new(self.log.len().saturating_sub(viewport))
+                    .position(window.start);
+            frame.render_stateful_widget(
+                ratatui::widgets::Scrollbar::new(
+                    ratatui::widgets::ScrollbarOrientation::VerticalRight,
+                ),
+                area.inner(ratatui::layout::Margin {
+                    vertical: 1,
+                    horizontal: 0,
+                }),
+                &mut sb_state,
+            );
+        }
     }
 
     pub(in crate::commands::dashboard) fn draw_help_bar(&self, frame: &mut Frame, area: Rect) {
         use interaction::InteractionKind;
 
-        let help = if self.confirm_delete {
+        let help = if self.pending_confirm.is_some() {
             Line::from(vec![
                 Span::styled(
-                    "[y]",
-                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
+                    "[←/→]",
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
                 ),
-                Span::raw(" confirm delete  "),
-                Span::styled("[any key]", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" choose  "),
+                Span::styled(
+                    "[Enter]",
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" confirm  "),
+                Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(" cancel"),
+            ])
+        } else if self.main_focus == MainPane::LogPane && !self.detail_view && !self.mcp_screen {
+            Line::from(vec![
+                Span::styled(
+                    "[↑↓]",
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" scroll log  "),
+                Span::styled("[End]", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" newest  "),
+                Span::styled("[Home]", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" oldest  "),
+                Span::styled(
+                    "[Tab/Esc]",
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" back to list  "),
+                Span::styled(
+                    "[q]",
+                    Style::default().fg(C_DIM).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" quit"),
             ])
         } else if self.detail_view && self.input_mode {
             let kind = self
@@ -360,7 +425,7 @@ impl Dashboard {
         }
         if can_kill {
             spans.push(Span::styled(
-                "[k]",
+                "[x]",
                 Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
             ));
             spans.push(Span::raw(" kill  "));
@@ -425,21 +490,23 @@ impl Dashboard {
             ),
             Span::raw(" detail  "),
             Span::styled(
+                "[Tab]",
+                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" log  "),
+            Span::styled(
                 "[/]",
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
             ),
             Span::raw(" filter  "),
+            Span::styled("[s]", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" sort  "),
             Span::styled("[d]", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" delete  "),
         ];
         if can_kill {
             spans.push(Span::styled(
-                "[c]",
-                Style::default().add_modifier(Modifier::BOLD),
-            ));
-            spans.push(Span::raw(" cancel  "));
-            spans.push(Span::styled(
-                "[k]",
+                "[x]",
                 Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
             ));
             spans.push(Span::raw(" kill  "));
@@ -451,7 +518,7 @@ impl Dashboard {
         ));
         spans.push(Span::raw(" help  "));
         spans.push(Span::styled(
-            "[Esc]",
+            "[q]",
             Style::default().add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" quit"));
@@ -490,6 +557,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: chrono::Utc::now().timestamp() - 60,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -670,6 +738,67 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn draw_log_panel_scrolled_back_shows_position_and_scrollbar() {
+        let backend = TestBackend::new(120, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.log.clear();
+        for i in 0..50 {
+            dash.log.push(LogEntry {
+                timestamp: "12:00:00".to_string(),
+                message: format!("line {i}"),
+            });
+        }
+        dash.main_focus = MainPane::LogPane;
+        dash.log_scroll.scroll_up(7, 50, 10);
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_log_panel(f, area);
+            })
+            .unwrap();
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("↑7"), "{text}");
+        assert!(text.contains("End resumes"), "{text}");
+        assert!(!dash.pane_rects.is_empty(), "the pane registered its rect");
+    }
+
+    #[test]
+    fn draw_help_bar_log_pane_focused() {
+        let backend = TestBackend::new(200, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.main_focus = MainPane::LogPane;
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 200, 1);
+                dash.draw_help_bar(f, area);
+            })
+            .unwrap();
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("scroll log"), "{text}");
+        assert!(text.contains("back to list"), "{text}");
+    }
+
+    #[test]
+    fn draw_agent_table_unfocused_when_log_holds_focus() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.main_focus = MainPane::LogPane;
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        assert!(rendered_buffer(&terminal).contains("sort: started"));
     }
 
     #[test]
@@ -856,7 +985,10 @@ mod tests {
         let backend = TestBackend::new(120, 2);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
-        dash.confirm_delete = true;
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.request_delete();
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 120, 1);
@@ -951,8 +1083,8 @@ mod tests {
         dash.update_display_indices();
         let line = dash.build_main_list_help_bar();
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("[x]"));
         assert!(text.contains("kill"));
-        assert!(text.contains("cancel"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -132,13 +132,13 @@ fn highlight_in_buffer(buf: &mut Buffer, region: Rect, a: (u16, u16), b: (u16, u
 
 impl Dashboard {
     /// Single entry point for every mouse event, so the wheel and selection
-    /// cannot disagree about state. The wheel arms are the pre-selection
-    /// behavior, unchanged: three lines per notch into whichever pane the
-    /// keyboard would scroll.
+    /// cannot disagree about state. The wheel scrolls the pane under the
+    /// cursor, hit-tested against the rects each renderer registered this
+    /// frame - not whichever pane the keyboard last touched.
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
         match event.kind {
-            MouseEventKind::ScrollUp => self.scroll_by(3),
-            MouseEventKind::ScrollDown => self.scroll_by(-3),
+            MouseEventKind::ScrollUp => self.wheel_scroll(event.column, event.row, 3),
+            MouseEventKind::ScrollDown => self.wheel_scroll(event.column, event.row, -3),
             MouseEventKind::Down(MouseButton::Left) => {
                 self.selection_begin(event.column, event.row);
             }
@@ -149,6 +149,44 @@ impl Dashboard {
                 self.selection_release(event.column, event.row);
             }
             _ => {}
+        }
+    }
+
+    /// Route a wheel notch to the pane under the cursor. `lines > 0` scrolls
+    /// back through history (up), matching the keyboard convention.
+    fn wheel_scroll(&mut self, column: u16, row: u16, lines: i32) {
+        let hit = self
+            .pane_rects
+            .iter()
+            .find(|(_, rect)| {
+                column >= rect.x
+                    && column < rect.x + rect.width
+                    && row >= rect.y
+                    && row < rect.y + rect.height
+            })
+            .map(|(id, _)| *id);
+        match hit {
+            Some(super::types::PaneId::LogPanel) => {
+                let (len, viewport) = (self.log.len(), self.log_viewport.max(1));
+                if lines >= 0 {
+                    self.log_scroll
+                        .scroll_up(lines.unsigned_abs() as usize, len, viewport);
+                } else {
+                    self.log_scroll.scroll_down(lines.unsigned_abs() as usize);
+                }
+                self.selection = None;
+            }
+            Some(super::types::PaneId::RunTable) => {
+                // The wheel moves the selection through the run list.
+                let delta = if lines >= 0 { -1isize } else { 1isize };
+                if !self.display_indices.is_empty() {
+                    let max = self.display_indices.len() - 1;
+                    self.selected = self.selected.saturating_add_signed(delta).min(max);
+                    self.table_state.select(Some(self.selected));
+                }
+            }
+            // Detail content, or anywhere unregistered: the keyboard's target.
+            _ => self.scroll_by(lines),
         }
     }
 
@@ -249,6 +287,92 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::super::test_support::make_test_dashboard;
+    use super::super::types::{AgentDisplayStatus, DashboardAgent, LogEntry, PaneId};
+
+    fn wheel(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    fn plain_agent(id: &str) -> DashboardAgent {
+        DashboardAgent {
+            id: id.to_string(),
+            blueprint_name: "test-agent".to_string(),
+            stage: "main".to_string(),
+            stage_index: 0,
+            num_stages: 1,
+            status: AgentDisplayStatus::Active,
+            tokens_in: 0,
+            tokens_out: 0,
+            cached_tokens: 0,
+            iteration: 0,
+            waiting_prompt: None,
+            pending_request: None,
+            last_answered_request_id: None,
+            context_snapshot: None,
+            stages: vec![],
+            workdir: "/tmp".to_string(),
+            task: "task".to_string(),
+            title: None,
+            model: None,
+            parent_id: None,
+            depth: 0,
+            started_at: 1000,
+            last_progress_at: None,
+            active_until: None,
+            waiting_secs: 0,
+            graph_info: None,
+            accepts_messages: true,
+            taint_summary: vec![],
+        }
+    }
+
+    #[test]
+    fn the_wheel_scrolls_the_pane_under_the_cursor() {
+        let mut dash = make_test_dashboard();
+        dash.log.clear();
+        for i in 0..50 {
+            dash.log.push(LogEntry {
+                timestamp: "t".to_string(),
+                message: format!("line {i}"),
+            });
+        }
+        dash.log_viewport = 10;
+        let mut second = plain_agent("run-2");
+        second.started_at = 900;
+        dash.agents.push(plain_agent("run-1"));
+        dash.agents.push(second);
+        dash.update_display_indices();
+        dash.pane_rects = vec![
+            (PaneId::RunTable, Rect::new(0, 0, 80, 20)),
+            (PaneId::LogPanel, Rect::new(0, 20, 80, 15)),
+        ];
+
+        // Over the log: wheel up scrolls history, wheel down returns.
+        dash.handle_mouse(wheel(MouseEventKind::ScrollUp, 5, 25));
+        assert_eq!(dash.log_scroll.offset_from_tail, 3);
+        dash.handle_mouse(wheel(MouseEventKind::ScrollDown, 5, 25));
+        assert!(dash.log_scroll.is_tailing());
+
+        // Over the run table: the wheel moves the selection.
+        dash.handle_mouse(wheel(MouseEventKind::ScrollDown, 5, 5));
+        assert_eq!(dash.selected, 1);
+        dash.handle_mouse(wheel(MouseEventKind::ScrollUp, 5, 5));
+        assert_eq!(dash.selected, 0);
+        // …and clamps at both ends.
+        dash.handle_mouse(wheel(MouseEventKind::ScrollUp, 5, 5));
+        assert_eq!(dash.selected, 0);
+
+        // Outside both rects: falls back to the keyboard target.
+        dash.detail_view = true;
+        dash.handle_mouse(wheel(MouseEventKind::ScrollUp, 100, 38));
+        assert_eq!(dash.detail_scroll, 3);
+    }
+
     use super::*;
     use crossterm::event::KeyModifiers;
     use ratatui::Terminal;

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -36,8 +36,21 @@ pub(crate) struct Dashboard {
     pub(super) pending_interactions: HashMap<String, interaction::InteractionRequest>,
     pub(super) table_state: TableState,
     pub(super) should_quit: bool,
-    /// True when the delete-agent confirmation popup is open
-    pub(super) confirm_delete: bool,
+    /// A destructive action (kill / delete / MCP remove) waiting on its
+    /// confirmation dialog. While open, the dialog owns the keys.
+    pub(super) pending_confirm: Option<(ConfirmAction, crate::tui::widgets::confirm::Confirm)>,
+    /// How the run list is ordered; `s` cycles it.
+    pub(super) sort_mode: SortMode,
+    /// Which main-screen pane holds keyboard focus (Tab toggles).
+    pub(super) main_focus: MainPane,
+    /// Scroll position of the log panel (tail-anchored; End resumes tailing).
+    pub(super) log_scroll: crate::tui::widgets::scroll::ScrollState,
+    /// Wheel-scroll hit-testing rects, re-registered by each pane's renderer
+    /// every frame so the wheel always moves the pane under the cursor.
+    pub(super) pane_rects: Vec<(PaneId, ratatui::layout::Rect)>,
+    /// The log panel's viewport height as of the last draw, so key scrolling
+    /// pages by what is actually visible.
+    pub(super) log_viewport: usize,
     /// Scroll offset for detail view content: 0 = bottom (auto-scroll), >0 = scrolled up
     pub(super) detail_scroll: usize,
     /// Selected option index for MultipleChoice/ToolApproval/Confirm input
@@ -202,7 +215,12 @@ impl Dashboard {
             pending_interactions: HashMap::new(),
             table_state,
             should_quit: false,
-            confirm_delete: false,
+            pending_confirm: None,
+            sort_mode: SortMode::StartedAt,
+            main_focus: MainPane::RunList,
+            log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
+            pane_rects: Vec::new(),
+            log_viewport: 0,
             detail_scroll: 0,
             choice_selected: 0,
             selected_stage: 0,
@@ -312,7 +330,9 @@ impl Dashboard {
         entries
     }
 
-    /// Recompute display_indices: sorted by status priority then recency, filtered by list_search_query.
+    /// Recompute display_indices: ordered by [`SortMode`], filtered by
+    /// list_search_query. Every mode's order is total (id tie-break), so a
+    /// status change alone never reshuffles rows.
     pub(super) fn update_display_indices(&mut self) {
         let query = self.list_search_query.to_lowercase();
         let status_priority = |s: &AgentDisplayStatus| -> u8 {
@@ -348,11 +368,28 @@ impl Dashboard {
                     || a.status.to_string().to_lowercase().contains(&query)
             })
             .collect();
+        let sort_mode = self.sort_mode;
         indices.sort_by(|&a, &b| {
-            let pa = status_priority(&self.agents[a].status);
-            let pb = status_priority(&self.agents[b].status);
-            pa.cmp(&pb)
-                .then(self.agents[b].started_at.cmp(&self.agents[a].started_at))
+            let (a, b) = (&self.agents[a], &self.agents[b]);
+            let newest_first = b
+                .started_at
+                .cmp(&a.started_at)
+                .then_with(|| a.id.cmp(&b.id));
+            match sort_mode {
+                // A run keeps its row for its whole life: nothing about this
+                // key ever changes after start.
+                SortMode::StartedAt => newest_first,
+                // Most recent progress first; a run that never progressed
+                // sorts by its start time. Rows move only when work happens.
+                SortMode::RecentActivity => {
+                    let ka = a.last_progress_at.unwrap_or(a.started_at);
+                    let kb = b.last_progress_at.unwrap_or(b.started_at);
+                    kb.cmp(&ka).then(newest_first)
+                }
+                SortMode::StatusGrouped => status_priority(&a.status)
+                    .cmp(&status_priority(&b.status))
+                    .then(newest_first),
+            }
         });
         // With no filter, re-order into a parent → child tree so sub-agents and
         // fan-out workers nest under their parent (roots keep their recency order);
@@ -658,6 +695,7 @@ impl Dashboard {
                 agent.workdir = run.workdir.clone();
                 agent.context_snapshot = runstate::read_context_snapshot(&run.run_id);
                 agent.stages = stages;
+                agent.last_progress_at = run.last_progress_at;
 
                 if now_needs_input {
                     if waiting_prompt.is_some() {
@@ -747,6 +785,7 @@ impl Dashboard {
                     parent_id: run.parent_run_id.clone(),
                     depth: 0,
                     started_at: run.started_at,
+                    last_progress_at: run.last_progress_at,
                     // Freeze the elapsed timer for agents that are already waiting
                     // or terminal when first observed; only genuinely-running
                     // agents tick against the wall clock.
@@ -801,13 +840,87 @@ impl Dashboard {
         };
     }
 
-    /// Cancel (via the daemon) then delete all on-disk state for the selected
-    /// agent.
-    pub(super) fn delete_selected_agent(&mut self) {
-        let (raw_idx, id) = match self.selected_agent_raw_idx() {
-            Some(i) => (i, self.agents[i].id.clone()),
-            None => return,
+    /// Cycle the run-list sort mode and say so in the log.
+    pub(super) fn cycle_sort_mode(&mut self) {
+        self.sort_mode = self.sort_mode.next();
+        self.add_log(format!("Sort: {}", self.sort_mode.label()));
+        self.update_display_indices();
+    }
+
+    /// Open the kill confirmation for the selected agent, if it is killable.
+    pub(super) fn request_kill(&mut self) {
+        use crate::tui::widgets::confirm::Confirm;
+        use ratatui::text::Line;
+        let Some(agent) = self.selected_agent() else {
+            return;
         };
+        if !agent.status.is_killable() {
+            return;
+        }
+        let run_id = agent.id.clone();
+        let name = agent
+            .title
+            .clone()
+            .unwrap_or_else(|| truncate(&agent.blueprint_name, 24));
+        let dialog = Confirm::new(
+            "Kill run?",
+            vec![Line::from(format!(
+                "Cancel '{name}' ({})? Its state stays on disk.",
+                truncate(&run_id, 20)
+            ))],
+            "Kill",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((ConfirmAction::Kill { run_id }, dialog));
+    }
+
+    /// Open the delete confirmation for the selected agent.
+    pub(super) fn request_delete(&mut self) {
+        use crate::tui::widgets::confirm::Confirm;
+        use ratatui::text::Line;
+        let Some(agent) = self.selected_agent() else {
+            return;
+        };
+        let run_id = agent.id.clone();
+        let dialog = Confirm::new(
+            "Delete run?",
+            vec![Line::from(format!(
+                "Delete '{}' and all of its on-disk state? This is permanent.",
+                truncate(&run_id, 24)
+            ))],
+            "Delete",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((ConfirmAction::Delete { run_id }, dialog));
+    }
+
+    /// Ask the daemon to cancel `run_id` and mark the row cancelled. The one
+    /// implementation behind the list's and the detail view's kill key.
+    pub(super) fn perform_kill(&mut self, run_id: &str) {
+        let _ = self.cmd_tx.send(DaemonCommand::Cancel {
+            run_id: run_id.to_string(),
+        });
+        if let Some(a) = self.agents.iter_mut().find(|a| a.id == run_id) {
+            a.status = AgentDisplayStatus::Cancelled;
+            a.waiting_prompt = None;
+            a.pending_request = None;
+        }
+        // Any half-typed response to the killed run is moot.
+        self.input_mode = false;
+        self.input_textarea = TextArea::default();
+        self.add_log(format!("{run_id}: kill requested"));
+    }
+
+    /// Cancel (via the daemon) then delete all on-disk state for `run_id`.
+    /// Keyed by id rather than the current selection so the action confirmed
+    /// in the dialog is the one that runs, whatever the list did since.
+    pub(super) fn perform_delete(&mut self, run_id: &str) {
+        let Some(raw_idx) = self.agents.iter().position(|a| a.id == run_id) else {
+            return;
+        };
+        let id = run_id.to_string();
         // Record the run terminal on disk *before* removing it, and ask the
         // daemon to cancel it too.
         //
@@ -972,6 +1085,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: 1000,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,
@@ -988,7 +1102,7 @@ mod tests {
         assert!(!dash.input_mode);
         assert!(!dash.detail_view);
         assert!(!dash.should_quit);
-        assert!(!dash.confirm_delete);
+        assert!(dash.pending_confirm.is_none());
         assert_eq!(dash.detail_scroll, 0);
         assert_eq!(dash.choice_selected, 0);
         assert_eq!(dash.selected_stage, 0);
@@ -1022,7 +1136,10 @@ mod tests {
 
     #[test]
     fn update_display_indices_with_agents() {
+        // The status-grouped mode is opt-in; the default (StartedAt) is tested
+        // separately for stability.
         let mut dash = make_test_dashboard();
+        dash.sort_mode = SortMode::StatusGrouped;
         dash.agents
             .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
         dash.agents
@@ -1038,11 +1155,87 @@ mod tests {
         assert_eq!(dash.agents[dash.display_indices[2]].id, "run-1"); // Complete
     }
 
+    /// The default order: newest start first, and a run keeps its row when its
+    /// status changes - finishing must not move it.
+    #[test]
+    fn the_default_sort_is_stable_across_status_changes() {
+        let mut dash = make_test_dashboard();
+        let mut old = make_test_agent("run-old", AgentDisplayStatus::Active);
+        old.started_at = 1_000;
+        let mut new = make_test_agent("run-new", AgentDisplayStatus::Active);
+        new.started_at = 2_000;
+        dash.agents.push(old);
+        dash.agents.push(new);
+        dash.update_display_indices();
+        let before: Vec<String> = dash
+            .display_indices
+            .iter()
+            .map(|&i| dash.agents[i].id.clone())
+            .collect();
+        assert_eq!(before, ["run-new", "run-old"]);
+
+        // The newest run finishes; in the old bucket sort it would leap below
+        // the still-active one. Here it stays exactly where it was.
+        dash.agents[1].status = AgentDisplayStatus::Complete;
+        dash.update_display_indices();
+        let after: Vec<String> = dash
+            .display_indices
+            .iter()
+            .map(|&i| dash.agents[i].id.clone())
+            .collect();
+        assert_eq!(after, before, "a status change must not reshuffle rows");
+    }
+
+    /// Recent-activity mode: the run that progressed most recently leads;
+    /// one that never progressed falls back to its start time.
+    #[test]
+    fn recent_activity_sorts_by_last_progress() {
+        let mut dash = make_test_dashboard();
+        dash.sort_mode = SortMode::RecentActivity;
+        let mut a = make_test_agent("run-a", AgentDisplayStatus::Active);
+        a.started_at = 1_000;
+        a.last_progress_at = Some(5_000);
+        let mut b = make_test_agent("run-b", AgentDisplayStatus::Active);
+        b.started_at = 2_000;
+        b.last_progress_at = Some(3_000);
+        let mut c = make_test_agent("run-c", AgentDisplayStatus::Active);
+        c.started_at = 4_000;
+        c.last_progress_at = None;
+        dash.agents.push(a);
+        dash.agents.push(b);
+        dash.agents.push(c);
+        dash.update_display_indices();
+
+        let ids: Vec<&str> = dash
+            .display_indices
+            .iter()
+            .map(|&i| dash.agents[i].id.as_str())
+            .collect();
+        assert_eq!(ids, ["run-a", "run-c", "run-b"]);
+    }
+
+    #[test]
+    fn cycle_sort_mode_walks_all_three_and_logs() {
+        let mut dash = make_test_dashboard();
+        assert_eq!(dash.sort_mode, SortMode::StartedAt);
+        dash.cycle_sort_mode();
+        assert_eq!(dash.sort_mode, SortMode::RecentActivity);
+        dash.cycle_sort_mode();
+        assert_eq!(dash.sort_mode, SortMode::StatusGrouped);
+        dash.cycle_sort_mode();
+        assert_eq!(dash.sort_mode, SortMode::StartedAt);
+        assert!(dash.log.iter().any(|l| l.message.contains("Sort:")));
+        assert_eq!(SortMode::StartedAt.label(), "started");
+        assert_eq!(SortMode::RecentActivity.label(), "activity");
+        assert_eq!(SortMode::StatusGrouped.label(), "status");
+    }
+
     /// Paused sorts with Stale: above the finished states (it is the user's
     /// deliberately parked unfinished business), below Active/Waiting.
     #[test]
     fn update_display_indices_ranks_paused_above_finished_runs() {
         let mut dash = make_test_dashboard();
+        dash.sort_mode = SortMode::StatusGrouped;
         dash.agents
             .push(make_test_agent("run-done", AgentDisplayStatus::Complete));
         dash.agents
@@ -1606,9 +1799,9 @@ mod tests {
     // ─── delete_selected_agent: no agent selected ─────────────────────────
 
     #[test]
-    fn delete_selected_agent_empty_list_is_noop() {
+    fn delete_of_an_unknown_run_id_is_a_noop() {
         let mut dash = make_test_dashboard();
-        dash.delete_selected_agent();
+        dash.perform_delete("no-such-run");
         // Should not panic, just no-op
     }
 
@@ -1617,6 +1810,7 @@ mod tests {
     #[test]
     fn update_display_indices_sort_order_comprehensive() {
         let mut dash = make_test_dashboard();
+        dash.sort_mode = SortMode::StatusGrouped;
         dash.agents
             .push(make_test_agent("cancelled", AgentDisplayStatus::Cancelled));
         dash.agents
@@ -1631,9 +1825,14 @@ mod tests {
         ));
         dash.agents
             .push(make_test_agent("complete", AgentDisplayStatus::Complete));
+        dash.agents.push(make_test_agent(
+            "interactive",
+            AgentDisplayStatus::CompleteInteractive,
+        ));
         dash.update_display_indices();
 
-        // Expected priority: Active(0) < Waiting(1) < Complete(3) < Error(4) < Idle(5) < Cancelled(6)
+        // Expected priority: Active(0) < Waiting(1) < CompleteInteractive(2)
+        // < Complete(3) < Error(4) < Idle(5) < Cancelled(6)
         let ids: Vec<&str> = dash
             .display_indices
             .iter()
@@ -1641,10 +1840,24 @@ mod tests {
             .collect();
         assert_eq!(ids[0], "active");
         assert_eq!(ids[1], "waiting");
-        assert_eq!(ids[2], "complete");
-        assert_eq!(ids[3], "error");
-        assert_eq!(ids[4], "idle");
-        assert_eq!(ids[5], "cancelled");
+        assert_eq!(ids[2], "interactive");
+        assert_eq!(ids[3], "complete");
+        assert_eq!(ids[4], "error");
+        assert_eq!(ids[5], "idle");
+        assert_eq!(ids[6], "cancelled");
+    }
+
+    #[test]
+    fn perform_kill_of_an_unknown_run_id_still_sends_and_logs() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.perform_kill("no-such-run");
+        assert!(cmd_rx.try_recv().is_ok(), "the daemon is still asked");
+        assert!(
+            dash.log
+                .iter()
+                .any(|l| l.message.contains("kill requested"))
+        );
     }
 
     // ─── selected_stage_can_respond: stage_name matching ──────────────────
@@ -1876,7 +2089,7 @@ mod tests {
                 dash.agents.push(agent);
                 dash.update_display_indices();
 
-                dash.delete_selected_agent();
+                dash.perform_delete(&tmp_id);
 
                 // Agent should have been removed from the list
                 assert!(dash.agents.is_empty());
@@ -1898,7 +2111,7 @@ mod tests {
             dash.agents.push(agent);
             dash.update_display_indices();
 
-            dash.delete_selected_agent();
+            dash.perform_delete("test-run-missing");
 
             assert!(dash.log.iter().any(|l| l.message.contains("Delete failed")));
         });
@@ -2157,6 +2370,7 @@ mod tests {
             .push(make_test_agent("stale", AgentDisplayStatus::Stale));
         dash.agents
             .push(make_test_agent("live", AgentDisplayStatus::Active));
+        dash.sort_mode = SortMode::StatusGrouped;
         dash.update_display_indices();
 
         let order: Vec<&str> = dash

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -22,6 +22,67 @@ pub(super) enum StageContentMode {
     Context,
 }
 
+/// How the main run list is ordered. Whatever the mode, the order is a total
+/// one (unique tie-break by id), so a status change alone never reshuffles
+/// rows within a mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SortMode {
+    /// Newest run first, and a run keeps its row for its whole life. The
+    /// default: predictable, nothing ever jumps.
+    StartedAt,
+    /// Most recently progressed run first: whatever just did something is on
+    /// top. Rows move only on real progress, never on a status flip alone.
+    RecentActivity,
+    /// The old grouping: active first, finished below, stable within a group.
+    StatusGrouped,
+}
+
+impl SortMode {
+    pub(super) fn next(self) -> Self {
+        match self {
+            Self::StartedAt => Self::RecentActivity,
+            Self::RecentActivity => Self::StatusGrouped,
+            Self::StatusGrouped => Self::StartedAt,
+        }
+    }
+
+    /// Short label for the table title.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::StartedAt => "started",
+            Self::RecentActivity => "activity",
+            Self::StatusGrouped => "status",
+        }
+    }
+}
+
+/// Which pane of the main screen holds keyboard focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MainPane {
+    RunList,
+    LogPane,
+}
+
+/// A pane with its own wheel-scroll behavior, hit-tested against the rects
+/// each renderer registers per frame. Panes not listed here (detail content,
+/// review) share the keyboard's scroll target via `scroll_by`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PaneId {
+    RunTable,
+    LogPanel,
+}
+
+/// A destructive action waiting on its confirmation dialog.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum ConfirmAction {
+    /// Cancel the run via the daemon (the row stays, marked cancelled).
+    Kill { run_id: String },
+    /// Cancel and permanently delete the run's on-disk state.
+    Delete { run_id: String },
+    /// Remove an MCP server from the config.
+    McpRemove { name: String },
+}
+
 /// Display status for agents in the dashboard.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentDisplayStatus {
@@ -132,6 +193,9 @@ pub struct DashboardAgent {
     pub depth: usize,
     /// Unix timestamp when the run started (for elapsed display)
     pub started_at: i64,
+    /// Unix timestamp of the run's last recorded progress (`None` before the
+    /// first progress mark). Drives the recent-activity sort.
+    pub last_progress_at: Option<i64>,
     /// Frozen wall-clock time (Unix seconds) when the agent entered a waiting state.
     /// Used to prevent the elapsed timer from incrementing while waiting for input.
     pub active_until: Option<i64>,
@@ -369,6 +433,7 @@ mod tests {
             parent_id: None,
             depth: 0,
             started_at: 1000,
+            last_progress_at: None,
             active_until: None,
             waiting_secs: 0,
             graph_info: None,

--- a/crates/leviath-cli/src/tui/widgets/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod footer;
 pub(crate) mod help;
 pub(crate) mod line_edit;
 pub(crate) mod popup;
+pub(crate) mod scroll;

--- a/crates/leviath-cli/src/tui/widgets/scroll.rs
+++ b/crates/leviath-cli/src/tui/widgets/scroll.rs
@@ -1,0 +1,111 @@
+//! Tail-anchored scroll state for append-only panes (logs, output).
+//!
+//! The offset is measured from the tail: `0` means pinned to the newest
+//! content (the pane follows appends), anything greater holds a position
+//! relative to the end. Anchoring to the tail rather than the head means a
+//! bounded buffer dropping its oldest entries never yanks the view around.
+
+/// Scroll position for a pane whose content appends at the bottom.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScrollState {
+    /// Rows between the bottom of the view and the newest entry. `0` = tailing.
+    pub(crate) offset_from_tail: usize,
+}
+
+impl ScrollState {
+    /// Whether the pane is pinned to the newest content.
+    pub(crate) fn is_tailing(&self) -> bool {
+        self.offset_from_tail == 0
+    }
+
+    /// Scroll back through history by `n` rows, clamped so the view never
+    /// scrolls past the oldest entry.
+    pub(crate) fn scroll_up(&mut self, n: usize, len: usize, viewport: usize) {
+        let max = len.saturating_sub(viewport);
+        self.offset_from_tail = (self.offset_from_tail + n).min(max);
+    }
+
+    /// Scroll toward the newest content; landing on it resumes tailing.
+    pub(crate) fn scroll_down(&mut self, n: usize) {
+        self.offset_from_tail = self.offset_from_tail.saturating_sub(n);
+    }
+
+    /// Jump to the oldest entry.
+    pub(crate) fn jump_to_top(&mut self, len: usize, viewport: usize) {
+        self.offset_from_tail = len.saturating_sub(viewport);
+    }
+
+    /// Jump back to the newest entry and resume tailing.
+    pub(crate) fn jump_to_tail(&mut self) {
+        self.offset_from_tail = 0;
+    }
+
+    /// The range of entries to draw in a `viewport`-row window.
+    pub(crate) fn window(&mut self, len: usize, viewport: usize) -> std::ops::Range<usize> {
+        // Re-clamp against the current length: the content may have shrunk
+        // since the last scroll (a cleared buffer).
+        self.offset_from_tail = self.offset_from_tail.min(len.saturating_sub(viewport));
+        let end = len - self.offset_from_tail.min(len);
+        end.saturating_sub(viewport)..end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_state_tails_and_windows_the_newest_rows() {
+        let mut s = ScrollState::default();
+        assert!(s.is_tailing());
+        assert_eq!(s.window(10, 4), 6..10);
+        // Content shorter than the viewport: the whole thing.
+        assert_eq!(s.window(2, 4), 0..2);
+        assert_eq!(s.window(0, 4), 0..0);
+    }
+
+    #[test]
+    fn scrolling_up_holds_a_position_and_clamps_at_the_oldest_entry() {
+        let mut s = ScrollState::default();
+        s.scroll_up(3, 10, 4);
+        assert_eq!(s.window(10, 4), 3..7);
+        assert!(!s.is_tailing());
+
+        s.scroll_up(100, 10, 4);
+        assert_eq!(s.window(10, 4), 0..4, "clamped at the top");
+    }
+
+    #[test]
+    fn scrolling_down_returns_to_the_tail() {
+        let mut s = ScrollState::default();
+        s.scroll_up(5, 10, 4);
+        s.scroll_down(2);
+        assert_eq!(s.window(10, 4), 3..7);
+        s.scroll_down(100);
+        assert!(s.is_tailing());
+        assert_eq!(s.window(10, 4), 6..10);
+    }
+
+    #[test]
+    fn top_and_tail_jumps() {
+        let mut s = ScrollState::default();
+        s.jump_to_top(10, 4);
+        assert_eq!(s.window(10, 4), 0..4);
+        s.jump_to_tail();
+        assert_eq!(s.window(10, 4), 6..10);
+        // A tiny list makes to_top a no-op rather than an underflow.
+        let mut short = ScrollState::default();
+        short.jump_to_top(2, 4);
+        assert!(short.is_tailing());
+    }
+
+    #[test]
+    fn a_shrinking_buffer_reclamps_the_held_position() {
+        let mut s = ScrollState::default();
+        s.scroll_up(6, 10, 4);
+        assert_eq!(s.offset_from_tail, 6);
+        // The buffer shrank underneath the held position.
+        assert_eq!(s.window(5, 4), 0..4);
+        assert_eq!(s.offset_from_tail, 1);
+    }
+}

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -45,14 +45,21 @@ same list in the app.
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` | Select an agent. Active runs sort first |
+| `↑` / `↓` (or `k` / `j`) | Select a run |
+| `Home` / `End` (or `g` / `G`) | Jump to the first / last run |
 | `Enter` | Open detail view |
-| `/` | Filter agents by name or status |
-| `c` / `k` | Cancel the selected run |
+| `Tab` | Focus the log panel. Arrows scroll it, `End` resumes tailing, `Esc` comes back |
+| `/` | Filter runs by name or status |
+| `s` | Cycle the sort: start time (default), recent activity, or status groups |
+| `x` | Kill the selected run. Asks first |
+| `d` | Delete the run. Permanent, and asks first |
 | `p` / `r` | Pause / resume the selected run |
-| `d` | Delete the run. Permanent, and asks `y` to confirm |
 | `m` | Manage MCP servers |
-| `Esc` | Clear the filter, or quit |
+| `Esc` | Clear the filter |
+| `q` / `Ctrl-C` | Quit |
+
+By default runs are listed newest first and keep their row for their whole life, so nothing jumps
+around when a run finishes. The sort indicator sits in the table's top-right corner.
 
 ### Detail view
 
@@ -60,22 +67,21 @@ same list in the app.
 |---|---|
 | `←` / `→` | Switch stage tab |
 | `1`–`9` | Jump to that stage tab |
-| `↑` / `↓` | Scroll the pane |
-| `b` / `e` | Jump to the beginning / end |
+| `↑` / `↓` (or `k` / `j`) | Scroll the pane |
+| `Home` / `End` (or `b` / `e`) | Jump to the beginning / end |
 | `l` / `o` / `c` | Switch the pane to Logs / Output / Context |
 | `,` / `.` | Step back and forward through context history |
 | `/` , then `n` / `N` | Search, then next / previous match |
 | `y` | Copy the pane to the clipboard |
 | `i` | Respond to or message the agent |
-| `k` | Kill the run |
+| `x` | Kill the run. Asks first |
 | `p` / `r` | Pause / resume the run |
 | `Esc` | Clear the search, or go back to the list |
 
 While you are typing a response, `Enter` sends it, `Alt+Enter` inserts a newline, and `Esc` cancels.
 
-> [!WARNING]
-> `c` does two different things depending on where you are. In the main list it cancels the run. In
-> detail view it switches the pane to Context. `k` kills the run on both screens.
+Destructive keys always confirm on a dialog with real buttons: `←`/`→` pick an answer, `Enter`
+activates it, and a stray keypress does nothing. The safe answer holds focus to start.
 
 > [!TIP]
 > Prefer a browser, or want to drive Leviath from another machine? The [agent console](/app)


### PR DESCRIPTION
Second in the TUI consistency series (after #230). All four reported dashboard problems in one pass, plus the keymap alignment with the setup wizard.

## Run list no longer jumps

- Default sort is **start time, newest first** with an id tie-break: a run keeps its row for its whole life, so finishing no longer makes it leap down the list mid-glance.
- `s` cycles the sort: `started` (default) → `activity` (most recent progress first, from `last_progress_at`) → `status` (the old active-first grouping, now stable within each group). The active mode shows in the table's top-right corner.

## Destructive actions confirm

- `x` kills, in the list and the detail view, behind the shared Yes/No dialog from #230: focus starts on Cancel, `←`/`→`/Enter or `y`/`n` answer, stray keys do nothing.
- `k` no longer kills **anywhere** — it is list/scroll navigation (the vim alias), which is exactly why it kept killing runs by wizard muscle memory. `c` no longer cancels from the list.
- Delete (`d`) and MCP server removal use the same dialog; the `y`-or-anything popup is gone.

## Log panel scrolls

- Tab focuses it (focused border); arrows / PgUp / PgDn move through history, Home jumps to the oldest entry, End or `G` resumes tailing, the title shows `↑N (End resumes)` while scrolled back, and a scrollbar appears when there is history beyond the window.
- The mouse wheel scrolls **the pane under the cursor** — log panel, run table (moves the selection), or the detail document — via per-frame hit-test rects, instead of always scrolling the detail pane.

## Consistent keys

- Esc dismisses (filter, dialog, pane focus, MCP screen) and never quits. `q` quits everywhere, `Ctrl-C` always works. `j`/`k`/`g`/`G` and Home/End navigate wherever they cannot collide.
- Help overlays are built from the same `(key, description)` tables as the bindings via the shared builder, and are dismissed deliberately (Esc/`q`/`?`/Enter), not by any key. Hint bars updated to match, including a dedicated log-pane bar and dialog bar.
- `docs/content/dashboard.md` key tables updated.

## Testing

- `cargo xtask coverage --package leviath-cli` green (100% gate); full lib suite (2,62x tests) green; workspace clippy `-D warnings` clean.
- **Live pty verification against a real daemon hosting real runs** (deterministic Rhai mock providers: one run parked Waiting on `ask_user_text`, several Complete): confirmed no row movement when the newest run is finished, sort cycling with real reordering, the kill dialog ignoring stray keys / declining on Esc / genuinely cancelling the waiting run on confirm (daemon state checked), log scrolling incl. through a live resize, wheel-per-pane, help overlay behavior, and the Esc/q/Ctrl-C rules end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwH4m95gceUhfrvgAUmEzE