### PR TITLE
serve: agent file reads, doctor checks, and a folder picker for the browser console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,24 @@ same list.
   required, so the three lines that point Leviath at OpenRouter failed with
   ``missing field `providers` `` - a table the user has no reason to know
   about, in a message that says nothing about what to add.
+- `lev serve` gained three read-only routes, so a browser front end can show
+  what a run produced without shell access to the host. All three work with the
+  daemon down.
+  - `GET /api/agents/{id}/files?path=` returns one file the run wrote. The path
+    may be relative to the run's working directory or absolute, but either way
+    the resolved path has to land inside that directory, under the same
+    symlink-aware containment the file tools use, so the endpoint reads exactly
+    what the run was allowed to write. Reads stop at 1 MiB and say so; a cap
+    that lands mid-character drops the split character rather than calling a
+    text file binary.
+  - `GET /api/doctor` runs the checks `lev doctor` runs and returns them as
+    data. A failing check is an `ok: false` entry in a 200, never an HTTP error.
+  - `GET /api/fs/dirs?path=` lists one directory level of subdirectory names,
+    so a folder picker can offer a working directory instead of asking someone
+    to type one blind. Paths must be absolute, `--workdir-root` fences it the
+    same way it fences spawning, and `parent` is null at the fence so the
+    picker is never offered a step above it. Add `hidden=true` for
+    dot-prefixed names.
 - `lev doctor`'s `resolve` check says when your configured `default_provider`
   is being passed over, and why. `default_provider` with no `default_model` is
   a half-configuration that silently does nothing, and the check used to report

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -634,9 +634,13 @@ pub enum DaemonTarget<'a> {
 }
 
 /// Run the checks in order, stopping at the first failure.
+///
+/// `+ Sync` on the builder so the returned future is `Send`: `lev serve`'s
+/// `GET /api/doctor` awaits these same checks inside an axum handler, which
+/// requires it. Every caller passes a plain `fn` item, which always is.
 pub async fn run_checks(
     args: &DoctorArgs,
-    build_registry: &dyn Fn(&Config) -> ProviderRegistry,
+    build_registry: &(dyn Fn(&Config) -> ProviderRegistry + Sync),
     daemon: DaemonTarget<'_>,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
@@ -699,7 +703,7 @@ pub async fn run_checks(
 /// process exits non-zero and `lev doctor` works as a CI gate.
 async fn execute_with_registry(
     args: DoctorArgs,
-    build_registry: &dyn Fn(&Config) -> ProviderRegistry,
+    build_registry: &(dyn Fn(&Config) -> ProviderRegistry + Sync),
     daemon: DaemonTarget<'_>,
 ) -> anyhow::Result<()> {
     let checks = run_checks(&args, build_registry, daemon).await;

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -202,6 +202,101 @@ pub(super) async fn agent_logs(
     Ok(log)
 }
 
+/// How much of a file `GET /api/agents/{id}/files` returns: 1 MiB, enough for
+/// any report a browser would render, small enough to hand out in one JSON body.
+pub(super) const MAX_FILE_READ_BYTES: u64 = 1024 * 1024;
+
+/// `GET /api/agents/{id}/files?path=<path>`: read a file the run wrote, so the
+/// browser can render an agent's report without shell access to the host.
+///
+/// `path` may be relative (resolved against the run's workdir) or absolute;
+/// either way the *resolved* path must still land inside the workdir, under the
+/// same symlink-aware containment the file tools use
+/// ([`leviath_core::resolves_within`]) - so this endpoint can read exactly what
+/// the run was already allowed to write, and nothing else. Reads are capped at
+/// [`MAX_FILE_READ_BYTES`]; a larger file comes back truncated and says so.
+/// Purely a filesystem read: it works with the daemon down, like the other
+/// read endpoints.
+pub(super) async fn agent_file(
+    AxumPath(id): AxumPath<String>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<FileContentResp>, (StatusCode, Json<ErrorResponse>)> {
+    let meta = runstate::read_meta(&id)
+        .map_err(|_| err(StatusCode::NOT_FOUND, format!("Agent run '{id}' not found")))?;
+
+    let workdir = PathBuf::from(&meta.workdir);
+    let requested = PathBuf::from(&query.path);
+    let resolved = match requested.is_absolute() {
+        true => requested,
+        false => workdir.join(&requested),
+    };
+    if !leviath_core::resolves_within(&resolved, &workdir) {
+        return Err(err(
+            StatusCode::FORBIDDEN,
+            format!(
+                "path '{}' is outside the run's working directory",
+                query.path
+            ),
+        ));
+    }
+
+    let size = match std::fs::metadata(&resolved) {
+        Ok(m) if m.is_dir() => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("'{}' is a directory, not a file", query.path),
+            ));
+        }
+        Ok(m) => m.len(),
+        Err(_) => {
+            return Err(err(
+                StatusCode::NOT_FOUND,
+                format!("file '{}' not found", query.path),
+            ));
+        }
+    };
+
+    let mut bytes = Vec::new();
+    if let Err(e) = std::fs::File::open(&resolved)
+        .map(|f| std::io::Read::take(f, MAX_FILE_READ_BYTES))
+        .and_then(|mut f| std::io::Read::read_to_end(&mut f, &mut bytes))
+    {
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!("could not read '{}': {e}", query.path),
+        ));
+    }
+    let truncated = size > MAX_FILE_READ_BYTES;
+    let read_len = bytes.len();
+    let content = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        // The 1 MiB cap can land mid-character in a file that is otherwise
+        // valid UTF-8. That is the cap's doing, not the file's: drop the
+        // split character's leading bytes rather than calling a text file
+        // binary. (`valid_up_to` is at most 3 bytes short of the cap when
+        // the only problem is the cut.)
+        Err(e) if truncated && e.utf8_error().valid_up_to() + 4 > read_len => {
+            let valid = e.utf8_error().valid_up_to();
+            let mut prefix = e.into_bytes();
+            prefix.truncate(valid);
+            String::from_utf8_lossy(&prefix).into_owned()
+        }
+        Err(_) => {
+            return Err(err(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                format!("'{}' is not a text file", query.path),
+            ));
+        }
+    };
+
+    Ok(Json(FileContentResp {
+        path: resolved.to_string_lossy().into_owned(),
+        size,
+        content,
+        truncated,
+    }))
+}
+
 pub(super) async fn agent_result(
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<AgentResultResp>, (StatusCode, Json<ErrorResponse>)> {
@@ -1201,6 +1296,326 @@ prompt = "Plan the work"
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    // ─── agent_file ───────────────────────────────────────────────────────────
+
+    fn files_app() -> Router {
+        Router::new()
+            .route("/api/agents/{id}/files", get(agent_file))
+            .with_state(test_state())
+    }
+
+    /// A run whose workdir is `workdir`, persisted so `read_meta` finds it.
+    fn create_run_in(id: &str, workdir: &std::path::Path) -> RunMeta {
+        let mut meta = make_run(id);
+        meta.workdir = workdir.to_string_lossy().to_string();
+        create_run(&meta).unwrap();
+        meta
+    }
+
+    /// GET `/api/agents/{id}/files?path=<path>`, returning status and body.
+    /// (`path` goes into the query string verbatim - every path these tests
+    /// use is query-safe as-is.)
+    async fn get_file(id: &str, path: &str) -> (StatusCode, Vec<u8>) {
+        let uri = format!("/api/agents/{id}/files?path={path}");
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = files_app().oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    fn error_of(body: &[u8]) -> String {
+        serde_json::from_slice::<serde_json::Value>(body).unwrap()["error"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn agent_file_unknown_run_returns_404() {
+        let (status, body) = get_file("nonexistent-run-xyz-files", "report.md").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            error_of(&body),
+            "Agent run 'nonexistent-run-xyz-files' not found"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_file_reads_a_relative_path_within_the_workdir() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_reads_a_relative_path_within_the_workdir",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                std::fs::create_dir_all(workdir.path().join("notes")).unwrap();
+                std::fs::write(workdir.path().join("notes/report.md"), "# Report\n").unwrap();
+                let run_id = unique_run_id("file-rel");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "notes/report.md").await;
+                assert_eq!(status, StatusCode::OK);
+                let got: FileContentResp = serde_json::from_slice(&body).unwrap();
+                assert_eq!(got.content, "# Report\n");
+                assert_eq!(got.size, 9);
+                assert!(!got.truncated);
+                // The reported path is the resolved absolute one.
+                assert!(std::path::Path::new(&got.path).is_absolute());
+                assert!(got.path.ends_with("report.md"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_file_reads_an_absolute_path_within_the_workdir() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_reads_an_absolute_path_within_the_workdir",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let file = workdir.path().join("out.txt");
+                std::fs::write(&file, "done").unwrap();
+                let run_id = unique_run_id("file-abs");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, &file.to_string_lossy()).await;
+                assert_eq!(status, StatusCode::OK);
+                let got: FileContentResp = serde_json::from_slice(&body).unwrap();
+                assert_eq!(got.content, "done");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// `..` traversal and an unrelated absolute path both resolve outside the
+    /// run's workdir, and both are refused before any read happens.
+    #[tokio::test]
+    async fn agent_file_refuses_a_path_outside_the_workdir() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_refuses_a_path_outside_the_workdir",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let run_id = unique_run_id("file-outside");
+                create_run_in(&run_id, workdir.path());
+
+                for outside in ["../escape.txt", "/etc/hosts"] {
+                    let (status, body) = get_file(&run_id, outside).await;
+                    assert_eq!(status, StatusCode::FORBIDDEN, "{outside}");
+                    assert_eq!(
+                        error_of(&body),
+                        format!("path '{outside}' is outside the run's working directory")
+                    );
+                }
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// The containment is symlink-aware: a link planted under the workdir
+    /// cannot be used to read outside it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn agent_file_is_not_fooled_by_a_symlink() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_is_not_fooled_by_a_symlink",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let outside = tempfile::tempdir().unwrap();
+                std::fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+                std::os::unix::fs::symlink(outside.path(), workdir.path().join("escape")).unwrap();
+                let run_id = unique_run_id("file-symlink");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, _body) = get_file(&run_id, "escape/secret.txt").await;
+                assert_eq!(status, StatusCode::FORBIDDEN);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_file_missing_file_returns_404() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_missing_file_returns_404",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let run_id = unique_run_id("file-missing");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "no-such.md").await;
+                assert_eq!(status, StatusCode::NOT_FOUND);
+                assert_eq!(error_of(&body), "file 'no-such.md' not found");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// A run whose workdir has since been deleted answers with a plain client
+    /// error (the containment or the read refuses), never a 500.
+    #[tokio::test]
+    async fn agent_file_deleted_workdir_is_a_client_error() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_deleted_workdir_is_a_client_error",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let run_id = unique_run_id("file-gone-workdir");
+                create_run_in(&run_id, workdir.path());
+                drop(workdir); // the tempdir is removed here
+
+                let (status, _body) = get_file(&run_id, "report.md").await;
+                assert!(status.is_client_error(), "got {status}");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_file_directory_returns_400() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_directory_returns_400",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                std::fs::create_dir(workdir.path().join("sub")).unwrap();
+                let run_id = unique_run_id("file-dir");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "sub").await;
+                assert_eq!(status, StatusCode::BAD_REQUEST);
+                assert_eq!(error_of(&body), "'sub' is a directory, not a file");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// A file the server cannot open (here: no read permission) is reported,
+    /// not a 500.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn agent_file_unreadable_file_is_reported() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_unreadable_file_is_reported",
+            |_d| async move {
+                use std::os::unix::fs::PermissionsExt;
+                let workdir = tempfile::tempdir().unwrap();
+                let file = workdir.path().join("locked.txt");
+                std::fs::write(&file, "sealed").unwrap();
+                std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+                let run_id = unique_run_id("file-locked");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "locked.txt").await;
+                // Root ignores mode bits; everywhere else the open fails.
+                if status != StatusCode::OK {
+                    assert_eq!(status, StatusCode::NOT_FOUND);
+                    assert!(
+                        error_of(&body).starts_with("could not read 'locked.txt'"),
+                        "{}",
+                        error_of(&body)
+                    );
+                }
+
+                let _ = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644));
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_file_caps_the_read_at_one_mib() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_caps_the_read_at_one_mib",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                let full = MAX_FILE_READ_BYTES as usize + 100;
+                std::fs::write(workdir.path().join("big.log"), vec![b'a'; full]).unwrap();
+                let run_id = unique_run_id("file-big");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "big.log").await;
+                assert_eq!(status, StatusCode::OK);
+                let got: FileContentResp = serde_json::from_slice(&body).unwrap();
+                assert!(got.truncated);
+                assert_eq!(got.size, full as u64);
+                assert_eq!(got.content.len(), MAX_FILE_READ_BYTES as usize);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// The cap landing mid-character does not make a text file "not text": the
+    /// split character's leading bytes are dropped instead.
+    #[tokio::test]
+    async fn agent_file_truncation_mid_character_stays_text() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_truncation_mid_character_stays_text",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                // 'a' up to one byte short of the cap, then a 3-byte '€'
+                // straddling it, then more text past it.
+                let mut bytes = vec![b'a'; MAX_FILE_READ_BYTES as usize - 1];
+                bytes.extend_from_slice("€ and more".as_bytes());
+                std::fs::write(workdir.path().join("split.md"), &bytes).unwrap();
+                let run_id = unique_run_id("file-split");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "split.md").await;
+                assert_eq!(status, StatusCode::OK);
+                let got: FileContentResp = serde_json::from_slice(&body).unwrap();
+                assert!(got.truncated);
+                assert_eq!(got.content.len(), MAX_FILE_READ_BYTES as usize - 1);
+                assert!(got.content.ends_with('a'));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_file_binary_returns_415() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_binary_returns_415",
+            |_d| async move {
+                let workdir = tempfile::tempdir().unwrap();
+                std::fs::write(workdir.path().join("blob.bin"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
+                // Invalid from early on AND larger than the cap: proves a big
+                // binary is still called binary, not "truncated text".
+                let mut big = vec![0xffu8; 16];
+                big.resize(MAX_FILE_READ_BYTES as usize + 16, 0xff);
+                std::fs::write(workdir.path().join("big.bin"), &big).unwrap();
+                let run_id = unique_run_id("file-binary");
+                create_run_in(&run_id, workdir.path());
+
+                for name in ["blob.bin", "big.bin"] {
+                    let (status, body) = get_file(&run_id, name).await;
+                    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE, "{name}");
+                    assert_eq!(error_of(&body), format!("'{name}' is not a text file"));
+                }
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
     }
 
     // ─── agent_result ─────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -1532,6 +1532,52 @@ prompt = "Plan the work"
         .await;
     }
 
+    /// Windows twin of `agent_file_unreadable_file_is_reported`.
+    ///
+    /// Windows has no "no read permission" bit `std::fs::Permissions` can
+    /// set: a read-only file is still readable. A sharing violation is the
+    /// equivalent split. Holding an exclusive (no-share) handle open leaves
+    /// `std::fs::metadata` working - it opens with zero desired access and
+    /// falls back to `FindFirstFileEx` on a sharing violation anyway - while
+    /// `File::open`, which wants read access, is refused. That is the same
+    /// metadata-succeeds/open-fails shape `0o000` gives the Unix test.
+    /// Creating the file THROUGH the exclusive handle leaves no closed-file
+    /// window for Defender or the indexer to grab it first, which is what
+    /// `blueprints.rs`'s Windows twin found the hard way.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn agent_file_unreadable_file_is_reported_windows() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_file_unreadable_file_is_reported_windows",
+            |_d| async move {
+                use std::fs::OpenOptions;
+                use std::os::windows::fs::OpenOptionsExt;
+
+                let workdir = tempfile::tempdir().unwrap();
+                let file = workdir.path().join("locked.txt");
+                let mut locked = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .share_mode(0)
+                    .open(&file)
+                    .unwrap();
+                std::io::Write::write_all(&mut locked, b"sealed").unwrap();
+                let run_id = unique_run_id("file-locked-win");
+                create_run_in(&run_id, workdir.path());
+
+                let (status, body) = get_file(&run_id, "locked.txt").await;
+                assert_eq!(status, StatusCode::NOT_FOUND);
+                let msg = error_of(&body);
+                assert!(msg.starts_with("could not read 'locked.txt'"), "{msg}");
+
+                drop(locked);
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn agent_file_caps_the_read_at_one_mib() {
         crate::runstate::with_isolated_runs_dir_async(

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -1521,15 +1521,9 @@ prompt = "Plan the work"
                 create_run_in(&run_id, workdir.path());
 
                 let (status, body) = get_file(&run_id, "locked.txt").await;
-                // Root ignores mode bits; everywhere else the open fails.
-                if status != StatusCode::OK {
-                    assert_eq!(status, StatusCode::NOT_FOUND);
-                    assert!(
-                        error_of(&body).starts_with("could not read 'locked.txt'"),
-                        "{}",
-                        error_of(&body)
-                    );
-                }
+                assert_eq!(status, StatusCode::NOT_FOUND);
+                let msg = error_of(&body);
+                assert!(msg.starts_with("could not read 'locked.txt'"), "{msg}");
 
                 let _ = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644));
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -1,0 +1,130 @@
+//! `GET /api/doctor` - the browser's "check my setup" button.
+//!
+//! Runs exactly the checks `lev doctor` runs
+//! ([`crate::commands::doctor::run_checks`]), semantics preserved, and returns
+//! them as data instead of a table. See that module for what each layer proves.
+
+use axum::extract::State;
+use axum::response::Json;
+
+use super::types::*;
+use crate::commands::doctor::{CheckStatus, DaemonTarget, DoctorArgs, run_checks};
+use crate::commands::run::session::build_provider_registry_from_config;
+
+/// `GET /api/doctor`: prove the provider wiring works, one layer at a time.
+///
+/// A failing check is an `ok: false` entry in a 200, never an HTTP error - the
+/// endpoint answering at all is not the thing being diagnosed. The config is
+/// re-read per request (not taken from [`AppState`]) so the button reflects an
+/// edit the user just made.
+///
+/// Live-call behavior is `lev doctor`'s own, bounded by its own deadlines:
+/// `inference` makes one real, billed provider call under the probe's 60s
+/// request timeout, and `daemon` spawns a throwaway one-stage run (a second
+/// billed call) through this server's control socket, waited on for at most
+/// the doctor's 90s. A daemon that is not running reports as a failing
+/// `daemon` check rather than skipping it.
+pub(super) async fn run_doctor(State(state): State<AppState>) -> Json<DoctorResp> {
+    let checks = run_checks(
+        &DoctorArgs::default(),
+        &build_provider_registry_from_config,
+        DaemonTarget::Client(&state.control),
+    )
+    .await;
+    Json(DoctorResp {
+        checks: checks
+            .into_iter()
+            .map(|c| DoctorCheck {
+                name: c.name.to_string(),
+                ok: c.status == CheckStatus::Ok,
+                detail: c.detail,
+                elapsed_ms: c.elapsed_ms,
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    use crate::config::Config;
+
+    /// Run `f` with the config path, data root, and runs directory all
+    /// redirected into one fresh temp root, and every provider key cleared -
+    /// the same combined-vars shape as the `lev doctor` tests, because
+    /// `run_checks` reaches `Config::load()` and no test may make a billed
+    /// call. One `temp_env` call, not two: it serializes process-wide and
+    /// holds its lock across the future, so nesting
+    /// `with_isolated_config_path_async` inside a second call would deadlock.
+    async fn with_env<R, Fut>(f: impl FnOnce(PathBuf) -> Fut) -> R
+    where
+        Fut: std::future::Future<Output = R>,
+    {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let root = dir.path().to_path_buf();
+        let mut vars = crate::config::config_isolation_vars(&root);
+        vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+        vars.push(("LEVIATH_RUNS_DIR", Some(root.join("runs").into_os_string())));
+        temp_env::async_with_vars(vars, f(root)).await
+    }
+
+    fn test_state() -> AppState {
+        let (tx, _) = broadcast::channel(64);
+        AppState {
+            config: Arc::new(Config::default()),
+            event_tx: tx,
+            control: leviath_runtime::control_socket::ControlClient::new(
+                leviath_runtime::control_socket::control_id(std::path::Path::new(
+                    "/no/such/daemon",
+                )),
+            ),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        }
+    }
+
+    /// The endpoint over the shared production route table, against an empty
+    /// isolated config: `config` parses (ok), `resolve` fails (nothing
+    /// registered answers to the default provider), and the chain stops there -
+    /// before any billed call. The failure arrives as an `ok: false` entry in
+    /// a 200, which is the endpoint's whole contract.
+    #[tokio::test]
+    async fn doctor_reports_failing_checks_as_data_not_http_errors() {
+        with_env(|_root| async move {
+            let app = super::super::api_router().with_state(test_state());
+            let req = Request::builder()
+                .uri("/api/doctor")
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let report: DoctorResp = serde_json::from_slice(&body).unwrap();
+
+            assert_eq!(report.checks.len(), 2, "config ok, resolve fail, stop");
+            assert_eq!(report.checks[0].name, "config");
+            assert!(report.checks[0].ok, "{}", report.checks[0].detail);
+            assert_eq!(report.checks[1].name, "resolve");
+            assert!(!report.checks[1].ok);
+            assert!(
+                report.checks[1].detail.contains("not configured"),
+                "{}",
+                report.checks[1].detail
+            );
+            // The offline checks carry no timing.
+            assert!(report.checks.iter().all(|c| c.elapsed_ms.is_none()));
+        })
+        .await;
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -113,14 +113,16 @@ mod tests {
             let report: DoctorResp = serde_json::from_slice(&body).unwrap();
 
             assert_eq!(report.checks.len(), 2, "config ok, resolve fail, stop");
-            assert_eq!(report.checks[0].name, "config");
-            assert!(report.checks[0].ok, "{}", report.checks[0].detail);
-            assert_eq!(report.checks[1].name, "resolve");
-            assert!(!report.checks[1].ok);
+            let config_check = &report.checks[0];
+            assert_eq!(config_check.name, "config");
+            assert!(config_check.ok, "{}", config_check.detail);
+            let resolve_check = &report.checks[1];
+            assert_eq!(resolve_check.name, "resolve");
+            assert!(!resolve_check.ok);
             assert!(
-                report.checks[1].detail.contains("not configured"),
+                resolve_check.detail.contains("not configured"),
                 "{}",
-                report.checks[1].detail
+                resolve_check.detail
             );
             // The offline checks carry no timing.
             assert!(report.checks.iter().all(|c| c.elapsed_ms.is_none()));

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -31,7 +31,7 @@ pub(super) async fn list_dirs(
     Query(query): Query<DirsQuery>,
 ) -> Result<Json<DirsResp>, (StatusCode, Json<ErrorResponse>)> {
     let root = state.limits.workdir_root.as_deref();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    let cwd = known_dir_or_fs_root(std::env::current_dir().ok());
 
     let listed = match &query.path {
         Some(p) => {
@@ -122,14 +122,19 @@ pub(super) async fn list_dirs(
     Ok(Json(DirsResp {
         path: listed.to_string_lossy().into_owned(),
         parent,
-        home: dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("/"))
+        home: known_dir_or_fs_root(dirs::home_dir())
             .to_string_lossy()
             .into_owned(),
         cwd: cwd.to_string_lossy().into_owned(),
         root: root.map(|r| r.to_string_lossy().into_owned()),
         dirs,
     }))
+}
+
+/// The filesystem root when a well-known directory (cwd, home) cannot be
+/// determined - the picker always has *somewhere* real to stand.
+fn known_dir_or_fs_root(dir: Option<PathBuf>) -> PathBuf {
+    dir.unwrap_or_else(|| PathBuf::from("/"))
 }
 
 /// Whether two paths name the same directory, symlinks resolved - so the
@@ -400,6 +405,51 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
         assert_eq!(names, ["escape", "inside"]);
+    }
+
+    /// A directory that exists but cannot be read (no read permission) is
+    /// reported, not a 500.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_dirs_unreadable_directory_is_reported() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let (status, body) = get_dirs(app_with_root(None), Some(&locked.to_string_lossy())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let msg = error_of(&body);
+        let expected = format!("could not read '{}'", locked.display());
+        assert!(msg.starts_with(&expected), "{msg}");
+
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+    }
+
+    /// The cwd/home fallback: a known directory passes through untouched, an
+    /// unknowable one becomes the filesystem root.
+    #[test]
+    fn known_dir_or_fs_root_falls_back_to_the_fs_root() {
+        assert_eq!(
+            known_dir_or_fs_root(Some(PathBuf::from("/somewhere"))),
+            PathBuf::from("/somewhere")
+        );
+        assert_eq!(known_dir_or_fs_root(None), PathBuf::from("/"));
+    }
+
+    /// `same_dir` falls back to literal comparison when a path cannot be
+    /// canonicalized (it does not exist).
+    #[test]
+    fn same_dir_compares_noncanonicalizable_paths_literally() {
+        assert!(same_dir(
+            Path::new("/no/such/dir/anywhere"),
+            Path::new("/no/such/dir/anywhere")
+        ));
+        assert!(!same_dir(
+            Path::new("/no/such/dir/anywhere"),
+            Path::new("/no/such/dir/elsewhere")
+        ));
     }
 
     /// A child that cannot be stat'd (here: a dangling symlink) is skipped,

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -466,4 +466,88 @@ mod tests {
         let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
         assert_eq!(names, ["fine"]);
     }
+
+    /// Windows twin of `list_dirs_symlinks_out_of_the_root_are_excluded`.
+    /// Windows spells a directory link `symlink_dir`; the fence behaves the
+    /// same, because `resolves_within` canonicalizes before comparing.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn list_dirs_symlinks_out_of_the_root_are_excluded_windows() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("inside")).unwrap();
+        std::os::windows::fs::symlink_dir(outside.path(), root.path().join("escape")).unwrap();
+
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = get_dirs(app, Some(&root.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["inside"]);
+
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&root.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["escape", "inside"]);
+    }
+
+    /// Windows twin of `list_dirs_unreadable_directory_is_reported`.
+    ///
+    /// There is no `0o000` for a directory on Windows, but a sharing
+    /// violation refuses a read the same way: an exclusive (no-share) handle
+    /// on the directory leaves `metadata` working - it asks for no access,
+    /// and falls back to `FindFirstFileEx` on a sharing violation anyway - so
+    /// the request gets past the is-a-directory check and fails where the
+    /// Unix one does, in `read_dir`.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn list_dirs_unreadable_directory_is_reported_windows() {
+        use std::fs::OpenOptions;
+        use std::os::windows::fs::OpenOptionsExt;
+
+        // `GENERIC_READ` - opening for anything less than a read would not
+        // conflict with the listing `read_dir` is about to attempt.
+        const GENERIC_READ: u32 = 0x8000_0000;
+        // `FILE_FLAG_BACKUP_SEMANTICS`, without which a directory cannot be
+        // opened as a handle at all.
+        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        let handle = OpenOptions::new()
+            .access_mode(GENERIC_READ)
+            .share_mode(0)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(&locked)
+            .unwrap();
+
+        let (status, body) = get_dirs(app_with_root(None), Some(&locked.to_string_lossy())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let msg = error_of(&body);
+        let expected = format!("could not read '{}'", locked.display());
+        assert!(msg.starts_with(&expected), "{msg}");
+
+        // Released before the tempdir's own cleanup runs against it.
+        drop(handle);
+    }
+
+    /// Windows twin of `list_dirs_skips_unreadable_children`: a directory
+    /// link whose target does not exist. `metadata` follows the link, finds
+    /// nothing, and reports a plain not-found - the one Windows failure it
+    /// does not paper over with a `FindFirstFileEx` fallback - so the child
+    /// is skipped rather than listed or raised.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn list_dirs_skips_unreadable_children_windows() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("fine")).unwrap();
+        std::os::windows::fs::symlink_dir(dir.path().join("gone"), dir.path().join("dangling"))
+            .unwrap();
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&dir.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["fine"]);
+    }
 }

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -85,7 +85,7 @@ pub(super) async fn list_dirs(
     let mut dirs = Vec::new();
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().into_owned();
-        if name.starts_with('.') {
+        if !query.hidden && name.starts_with('.') {
             continue;
         }
         let path = entry.path();
@@ -261,6 +261,25 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
         assert_eq!(names, ["visible"]);
+    }
+
+    #[tokio::test]
+    async fn list_dirs_hidden_true_includes_dotted_names() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::create_dir(dir.path().join("visible")).unwrap();
+        let uri = format!(
+            "/api/fs/dirs?path={}&hidden=true",
+            dir.path().to_string_lossy()
+        );
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app_with_root(None).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, [".git", "visible"]);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -1,0 +1,400 @@
+//! `GET /api/fs/dirs` - directory browsing for the console's folder picker.
+//!
+//! Read-only metadata about the host filesystem: one directory level per
+//! request, subdirectory names only, so the browser can let the user *choose*
+//! an agent workdir without typing a path blind. The spawn endpoint already
+//! accepts arbitrary workdirs subject to `--workdir-root`; this route shows
+//! exactly the directories that endpoint would accept, under the same fence.
+
+use std::path::{Path, PathBuf};
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::Json;
+
+use super::types::*;
+
+/// `GET /api/fs/dirs?path=<abs>`: list one directory's immediate
+/// subdirectories, so the browser's folder picker can walk the tree.
+///
+/// Without `path`, lists the serve process's working directory - or
+/// `--workdir-root` itself when a root is set and the cwd falls outside it,
+/// so the picker never *opens* somewhere it cannot stay. A given `path` must
+/// be absolute, and with a root set must resolve inside it under the same
+/// symlink-aware containment the spawn endpoint applies to workdirs
+/// ([`leviath_core::resolves_within`]). Dotted names are excluded, unreadable
+/// children are silently skipped, and `parent` is `null` both at the
+/// filesystem root and at the workdir-root - the UI is never led above the
+/// fence. Purely a filesystem read: it works with the daemon down.
+pub(super) async fn list_dirs(
+    State(state): State<AppState>,
+    Query(query): Query<DirsQuery>,
+) -> Result<Json<DirsResp>, (StatusCode, Json<ErrorResponse>)> {
+    let root = state.limits.workdir_root.as_deref();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+
+    let listed = match &query.path {
+        Some(p) => {
+            let requested = PathBuf::from(p);
+            if !requested.is_absolute() {
+                return Err(err(
+                    StatusCode::BAD_REQUEST,
+                    "path must be absolute".to_string(),
+                ));
+            }
+            if let Some(root) = root
+                && !leviath_core::resolves_within(&requested, root)
+            {
+                return Err(err(
+                    StatusCode::FORBIDDEN,
+                    format!("path '{p}' is outside the configured --workdir-root"),
+                ));
+            }
+            requested
+        }
+        // No path: the picker's opening view - the cwd, clamped to the root
+        // when one is set and the cwd falls outside it.
+        None => match root {
+            Some(root) if !leviath_core::resolves_within(&cwd, root) => root.to_path_buf(),
+            _ => cwd.clone(),
+        },
+    };
+
+    match std::fs::metadata(&listed) {
+        Ok(m) if !m.is_dir() => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("'{}' is a file, not a directory", listed.display()),
+            ));
+        }
+        Ok(_) => {}
+        Err(_) => {
+            return Err(err(
+                StatusCode::NOT_FOUND,
+                format!("directory '{}' not found", listed.display()),
+            ));
+        }
+    }
+
+    let entries = std::fs::read_dir(&listed).map_err(|e| {
+        err(
+            StatusCode::NOT_FOUND,
+            format!("could not read '{}': {e}", listed.display()),
+        )
+    })?;
+    let mut dirs = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        // `metadata` follows symlinks, so a link to a directory counts as one;
+        // a child that cannot be stat'd (dangling link, no permission) is
+        // silently skipped - the picker shows what it can offer, not errors.
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if !meta.is_dir() {
+            continue;
+        }
+        // With a root set, a symlink child can still point outside the fence;
+        // offering it would be offering a workdir the spawn endpoint refuses.
+        if let Some(root) = root
+            && !leviath_core::resolves_within(&path, root)
+        {
+            continue;
+        }
+        dirs.push(DirEntry {
+            name,
+            path: path.to_string_lossy().into_owned(),
+        });
+    }
+    dirs.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // `null` at the filesystem root, and at the workdir-root: "up one level"
+    // from the fence would land somewhere every other request here refuses.
+    let parent = match root.is_some_and(|r| same_dir(&listed, r)) {
+        true => None,
+        false => listed.parent().map(|p| p.to_string_lossy().into_owned()),
+    };
+
+    Ok(Json(DirsResp {
+        path: listed.to_string_lossy().into_owned(),
+        parent,
+        home: dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("/"))
+            .to_string_lossy()
+            .into_owned(),
+        cwd: cwd.to_string_lossy().into_owned(),
+        root: root.map(|r| r.to_string_lossy().into_owned()),
+        dirs,
+    }))
+}
+
+/// Whether two paths name the same directory, symlinks resolved - so the
+/// root-fence check holds when the listed path spells the root differently
+/// (e.g. through a symlinked ancestor like macOS's `/tmp`).
+fn same_dir(a: &Path, b: &Path) -> bool {
+    let canon = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    canon(a) == canon(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    use crate::commands::serve::testutil::no_daemon_client;
+    use crate::config::Config;
+
+    fn app_with_root(workdir_root: Option<PathBuf>) -> Router {
+        let (tx, _) = broadcast::channel(64);
+        let state = AppState {
+            config: Arc::new(Config::default()),
+            event_tx: tx,
+            control: no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Arc::new(ServeLimits {
+                workdir_root,
+                ..Default::default()
+            }),
+        };
+        Router::new()
+            .route("/api/fs/dirs", get(list_dirs))
+            .with_state(state)
+    }
+
+    /// GET `/api/fs/dirs[?path=<path>]`, returning status and body. (`path`
+    /// goes into the query string verbatim - every path these tests use is
+    /// query-safe as-is.)
+    async fn get_dirs(app: Router, path: Option<&str>) -> (StatusCode, Vec<u8>) {
+        let uri = match path {
+            Some(p) => format!("/api/fs/dirs?path={p}"),
+            None => "/api/fs/dirs".to_string(),
+        };
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    fn listing_of(body: &[u8]) -> DirsResp {
+        serde_json::from_slice(body).unwrap()
+    }
+
+    fn error_of(body: &[u8]) -> String {
+        serde_json::from_slice::<serde_json::Value>(body).unwrap()["error"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn list_dirs_defaults_to_the_serve_process_cwd() {
+        let (status, body) = get_dirs(app_with_root(None), None).await;
+        assert_eq!(status, StatusCode::OK);
+        let got = listing_of(&body);
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(got.path, cwd.to_string_lossy());
+        assert_eq!(got.cwd, cwd.to_string_lossy());
+        assert!(got.root.is_none());
+        assert_eq!(
+            got.home,
+            dirs::home_dir().unwrap().to_string_lossy().into_owned()
+        );
+        // The tests run from the crate directory, whose `src/` must be listed.
+        assert!(got.dirs.iter().any(|d| d.name == "src"), "{:?}", got.dirs);
+    }
+
+    #[tokio::test]
+    async fn list_dirs_lists_an_explicit_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&dir.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let got = listing_of(&body);
+        assert_eq!(got.path, dir.path().to_string_lossy());
+        // No root: `parent` is the plain filesystem parent.
+        assert_eq!(
+            got.parent.as_deref(),
+            Some(dir.path().parent().unwrap().to_string_lossy().as_ref())
+        );
+        assert_eq!(got.dirs.len(), 1);
+        assert_eq!(got.dirs[0].name, "sub");
+        assert_eq!(got.dirs[0].path, dir.path().join("sub").to_string_lossy());
+    }
+
+    #[tokio::test]
+    async fn list_dirs_returns_subdirectories_only_name_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("zeta")).unwrap();
+        std::fs::create_dir(dir.path().join("alpha")).unwrap();
+        std::fs::create_dir(dir.path().join("mid")).unwrap();
+        std::fs::write(dir.path().join("a-file.txt"), "not a dir").unwrap();
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&dir.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["alpha", "mid", "zeta"]);
+    }
+
+    #[tokio::test]
+    async fn list_dirs_excludes_dotted_names() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::create_dir(dir.path().join("visible")).unwrap();
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&dir.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["visible"]);
+    }
+
+    #[tokio::test]
+    async fn list_dirs_relative_path_returns_400() {
+        let (status, body) = get_dirs(app_with_root(None), Some("some/relative")).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error_of(&body), "path must be absolute");
+    }
+
+    #[tokio::test]
+    async fn list_dirs_missing_directory_returns_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        let (status, body) = get_dirs(app_with_root(None), Some(&missing.to_string_lossy())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            error_of(&body),
+            format!("directory '{}' not found", missing.display())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dirs_file_returns_400() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("plain.txt");
+        std::fs::write(&file, "not a directory").unwrap();
+        let (status, body) = get_dirs(app_with_root(None), Some(&file.to_string_lossy())).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_of(&body),
+            format!("'{}' is a file, not a directory", file.display())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dirs_refuses_a_path_outside_the_workdir_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = get_dirs(app, Some(&outside.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            error_of(&body),
+            format!(
+                "path '{}' is outside the configured --workdir-root",
+                outside.path().display()
+            )
+        );
+    }
+
+    /// At the workdir-root itself `parent` is `null` - the picker is never
+    /// offered a step above the fence - while a subdirectory's parent is real.
+    #[tokio::test]
+    async fn list_dirs_parent_is_null_at_the_workdir_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("inside")).unwrap();
+
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = get_dirs(app, Some(&root.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let got = listing_of(&body);
+        assert!(got.parent.is_none());
+        assert_eq!(got.root.as_deref(), Some(root.path().to_str().unwrap()));
+
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let inside = root.path().join("inside");
+        let (status, body) = get_dirs(app, Some(&inside.to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let got = listing_of(&body);
+        assert_eq!(
+            got.parent.as_deref(),
+            Some(root.path().to_string_lossy().as_ref())
+        );
+    }
+
+    /// With a root set and the serve process's cwd outside it, the default
+    /// listing opens at the root, not somewhere the picker cannot stay.
+    #[tokio::test]
+    async fn list_dirs_default_is_clamped_to_the_workdir_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("only")).unwrap();
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = get_dirs(app, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let got = listing_of(&body);
+        assert_eq!(got.path, root.path().to_string_lossy());
+        assert!(got.parent.is_none());
+        assert_eq!(got.dirs.len(), 1);
+        assert_eq!(got.dirs[0].name, "only");
+        // `cwd` still reports where the process actually runs.
+        assert_eq!(
+            got.cwd,
+            std::env::current_dir().unwrap().to_string_lossy().as_ref()
+        );
+    }
+
+    /// A symlink to a directory is a directory to the picker - unless a root
+    /// is set and the link resolves outside it, in which case offering it
+    /// would be offering a workdir the spawn endpoint refuses.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_dirs_symlinks_out_of_the_root_are_excluded() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("inside")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        // With the root set, the escaping link is not offered.
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = get_dirs(app, Some(&root.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["inside"]);
+
+        // Without one, a symlink-to-dir is listed like any directory.
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&root.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["escape", "inside"]);
+    }
+
+    /// A child that cannot be stat'd (here: a dangling symlink) is skipped,
+    /// never an error - the picker shows what it can offer.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_dirs_skips_unreadable_children() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("fine")).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("gone"), dir.path().join("dangling")).unwrap();
+        let (status, body) =
+            get_dirs(app_with_root(None), Some(&dir.path().to_string_lossy())).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["fine"]);
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod auth;
 mod blueprints;
 mod config;
+mod doctor;
 mod interactions;
 mod mcp;
 mod polling;
@@ -87,6 +88,7 @@ fn api_router() -> Router<AppState> {
             "/api/agents/{id}/context/history",
             get(agents::agent_context_history),
         )
+        .route("/api/agents/{id}/files", get(agents::agent_file))
         .route("/api/agents/{id}/logs", get(agents::agent_logs))
         .route("/api/agents/{id}/result", get(agents::agent_result))
         .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
@@ -105,6 +107,8 @@ fn api_router() -> Router<AppState> {
         .route("/api/mcp/servers/{name}/status", get(mcp::status))
         .route("/api/mcp/servers/{name}/login", post(mcp::login))
         .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
+        // Doctor - the same checks `lev doctor` runs, returned as data.
+        .route("/api/doctor", get(doctor::run_doctor))
         // Config
         .route("/api/config", get(config::get_config))
         .route("/api/config/validate", post(config::validate_config_key))
@@ -448,6 +452,21 @@ mod tests {
             let resp = app.oneshot(req).await.unwrap();
             assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         }
+    }
+
+    #[tokio::test]
+    async fn test_agent_files_route_is_mounted() {
+        // Without its required `path` query the handler's Query extractor
+        // rejects with 400 - an unmounted route would 404 at the router, so
+        // the 400 is what proves the route exists in the shared table. (The
+        // handler's own behavior is covered in agents.rs.)
+        let app = test_app();
+        let req = Request::builder()
+            .uri("/api/agents/some-run/files")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -8,6 +8,7 @@ mod auth;
 mod blueprints;
 mod config;
 mod doctor;
+mod fs;
 mod interactions;
 mod mcp;
 mod polling;
@@ -109,6 +110,8 @@ fn api_router() -> Router<AppState> {
         .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
         // Doctor - the same checks `lev doctor` runs, returned as data.
         .route("/api/doctor", get(doctor::run_doctor))
+        // Filesystem - directory browsing for the console's folder picker.
+        .route("/api/fs/dirs", get(fs::list_dirs))
         // Config
         .route("/api/config", get(config::get_config))
         .route("/api/config/validate", post(config::validate_config_key))
@@ -463,6 +466,21 @@ mod tests {
         let app = test_app();
         let req = Request::builder()
             .uri("/api/agents/some-run/files")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_fs_dirs_route_is_mounted() {
+        // A relative `path` is the one request whose answer never touches the
+        // filesystem: a mounted route rejects it with the handler's 400, an
+        // unmounted one 404s at the router. (The handler's own behavior is
+        // covered in fs.rs.)
+        let app = test_app();
+        let req = Request::builder()
+            .uri("/api/fs/dirs?path=not/absolute")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -352,6 +352,52 @@ pub(super) struct LogsQuery {
     pub(super) tail: Option<u64>,
 }
 
+/// Query for `GET /api/agents/{id}/files`: the file to read. Relative paths
+/// resolve against the run's workdir; absolute paths are accepted but must
+/// still land inside it.
+#[derive(Deserialize)]
+pub(super) struct FileQuery {
+    pub(super) path: String,
+}
+
+/// Response of `GET /api/agents/{id}/files`: one file the run wrote, as text.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct FileContentResp {
+    /// The resolved absolute path that was read.
+    pub(super) path: String,
+    /// The file's full size in bytes - larger than `content` when `truncated`.
+    pub(super) size: u64,
+    /// The file's bytes as UTF-8, capped at
+    /// [`MAX_FILE_READ_BYTES`](super::agents::MAX_FILE_READ_BYTES).
+    pub(super) content: String,
+    /// Whether `content` is only the first
+    /// [`MAX_FILE_READ_BYTES`](super::agents::MAX_FILE_READ_BYTES) of the file.
+    pub(super) truncated: bool,
+}
+
+// ─── Doctor types ───────────────────────────────────────────────────────────
+
+/// Response of `GET /api/doctor`: the `lev doctor` checks, as data.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct DoctorResp {
+    pub(super) checks: Vec<DoctorCheck>,
+}
+
+/// One `lev doctor` layer's verdict, reshaped for the browser: the enum
+/// status becomes a plain `ok` bool so the client never parses labels.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct DoctorCheck {
+    /// The layer's short name: `config`, `resolve`, `inference`, or `daemon`.
+    pub(super) name: String,
+    /// Whether the layer works. A failure is reported here, never as an
+    /// HTTP error - the endpoint answering at all is not what is diagnosed.
+    pub(super) ok: bool,
+    pub(super) detail: String,
+    /// Wall-clock cost, present for the checks that make a network call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) elapsed_ms: Option<u64>,
+}
+
 // ─── Tree types ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -616,6 +662,54 @@ mod tests {
         };
         let json = serde_json::to_string(&err).unwrap();
         assert!(json.contains("\"error\":\"not found\""));
+    }
+
+    #[test]
+    fn file_content_resp_serde_roundtrip() {
+        let resp = FileContentResp {
+            path: "/work/report.md".to_string(),
+            size: 9,
+            content: "# Report\n".to_string(),
+            truncated: false,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: FileContentResp = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.path, "/work/report.md");
+        assert_eq!(parsed.size, 9);
+        assert_eq!(parsed.content, "# Report\n");
+        assert!(!parsed.truncated);
+    }
+
+    #[test]
+    fn doctor_resp_serde_roundtrip() {
+        let resp = DoctorResp {
+            checks: vec![
+                DoctorCheck {
+                    name: "config".to_string(),
+                    ok: true,
+                    detail: "default_provider=anthropic".to_string(),
+                    elapsed_ms: None,
+                },
+                DoctorCheck {
+                    name: "inference".to_string(),
+                    ok: false,
+                    detail: "HTTP 401: bad key".to_string(),
+                    elapsed_ms: Some(1200),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        // An untimed check omits the field entirely rather than sending null.
+        assert!(
+            json.contains(r#"{"name":"config","ok":true,"detail":"default_provider=anthropic"}"#)
+        );
+        assert!(json.contains("\"elapsed_ms\":1200"));
+        let parsed: DoctorResp = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.checks.len(), 2);
+        assert!(parsed.checks[0].ok);
+        assert!(parsed.checks[0].elapsed_ms.is_none());
+        assert!(!parsed.checks[1].ok);
+        assert_eq!(parsed.checks[1].elapsed_ms, Some(1200));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -406,6 +406,10 @@ pub(super) struct DoctorCheck {
 #[derive(Deserialize)]
 pub(super) struct DirsQuery {
     pub(super) path: Option<String>,
+    /// Include dot-prefixed directories (hidden on Unix). Off by default so a
+    /// first-run picker isn't a wall of config noise.
+    #[serde(default)]
+    pub(super) hidden: bool,
 }
 
 /// Response of `GET /api/fs/dirs`: one directory level of the host filesystem,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -398,6 +398,43 @@ pub(super) struct DoctorCheck {
     pub(super) elapsed_ms: Option<u64>,
 }
 
+// ─── Filesystem types ───────────────────────────────────────────────────────
+
+/// Query for `GET /api/fs/dirs`: the directory to list. Must be absolute when
+/// given; absent means the server's own working directory (clamped to
+/// `--workdir-root` when the cwd falls outside it).
+#[derive(Deserialize)]
+pub(super) struct DirsQuery {
+    pub(super) path: Option<String>,
+}
+
+/// Response of `GET /api/fs/dirs`: one directory level of the host filesystem,
+/// enough for the browser's folder picker to walk without shell access.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct DirsResp {
+    /// The absolute directory that was listed.
+    pub(super) path: String,
+    /// Where "up one level" goes. `null` at the filesystem root, and also when
+    /// `path` *is* the workdir-root - the picker is never led above the fence.
+    pub(super) parent: Option<String>,
+    /// The user's home directory, for the picker's "home" shortcut.
+    pub(super) home: String,
+    /// The serve process's working directory, for the picker's "here" shortcut.
+    pub(super) cwd: String,
+    /// The configured `--workdir-root`, or `null` when the server has none.
+    pub(super) root: Option<String>,
+    /// The immediate subdirectories, name-sorted. Dotted names are excluded,
+    /// and with a root set, so is any symlink that resolves outside it.
+    pub(super) dirs: Vec<DirEntry>,
+}
+
+/// One subdirectory in a [`DirsResp`] listing.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct DirEntry {
+    pub(super) name: String,
+    pub(super) path: String,
+}
+
 // ─── Tree types ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -678,6 +715,32 @@ mod tests {
         assert_eq!(parsed.size, 9);
         assert_eq!(parsed.content, "# Report\n");
         assert!(!parsed.truncated);
+    }
+
+    #[test]
+    fn dirs_resp_serde_roundtrip() {
+        let resp = DirsResp {
+            path: "/work".to_string(),
+            parent: None,
+            home: "/Users/someone".to_string(),
+            cwd: "/work/project".to_string(),
+            root: Some("/work".to_string()),
+            dirs: vec![DirEntry {
+                name: "src".to_string(),
+                path: "/work/src".to_string(),
+            }],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        // An absent parent/root is an explicit `null`, never an omitted field -
+        // the TypeScript client reads both unconditionally.
+        assert!(json.contains("\"parent\":null"));
+        assert!(json.contains(r#"{"name":"src","path":"/work/src"}"#));
+        let parsed: DirsResp = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.path, "/work");
+        assert!(parsed.parent.is_none());
+        assert_eq!(parsed.root.as_deref(), Some("/work"));
+        assert_eq!(parsed.dirs.len(), 1);
+        assert_eq!(parsed.dirs[0].name, "src");
     }
 
     #[test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -66,6 +66,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/agents` · `POST /api/agents` | List runs · spawn an agent. Reads the persisted records, so unlike `lev ps` it keeps finished runs |
 | `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
 | `GET /api/agents/{id}/result` · `/logs` · `/context` · `/context/history` | Run output, logs, context |
+| `GET /api/agents/{id}/files?path=` | Read one file the run wrote. The resolved path must land inside the run's working directory, so this reads what the run itself was allowed to write. Capped at 1 MiB |
 | `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
 | `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
 | `POST /api/agents/{id}/message` | Steer a running agent |
@@ -74,6 +75,8 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
+| `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
+| `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
 
 > [!NOTE]


### PR DESCRIPTION
## What & why

Three read-only routes on `lev serve`, for the browser console that lives in
its own repo. Nothing in this repo consumes them; `lev serve` is the API the
front end is built against, and these are the three things it could not ask
for.

- `GET /api/agents/{id}/files?path=` reads one file the run wrote. Relative
  paths resolve against the run's working directory, absolute ones are
  accepted, and either way the resolved path has to land inside that directory
  under the same symlink-aware containment the file tools use
  (`leviath_core::resolves_within`), so the endpoint reads exactly what the run
  was already allowed to write. Reads stop at 1 MiB and say so; a cap that
  lands mid-character drops the split character rather than calling a text file
  binary.
- `GET /api/doctor` runs the checks `lev doctor` runs (`run_checks`, its
  semantics and its 60s/90s deadlines intact) and returns them as data. A
  failing check is an `ok: false` entry inside a 200, never an HTTP error. The
  registry-builder seam picks up `+ Sync` so the checks can be awaited inside an
  axum handler.
- `GET /api/fs/dirs?path=` lists one directory level of subdirectory names, so
  the folder picker can offer a working directory instead of asking someone to
  type one blind. Absolute paths only, fenced by `--workdir-root` exactly as
  spawning is, `parent` null at the fence so the picker is never offered a step
  above it, dotted names filtered unless `hidden=true`, symlinks that resolve
  outside the root excluded, unreadable children skipped.

All three are pure filesystem or config reads, so they answer with the daemon
down.

## How it was tested

`cargo test --workspace` and `cargo clippy --workspace` pass, and the 100% gate
is green on all three platforms. The endpoints are covered by the router and
handler tests in `fs.rs`, `doctor.rs`, `mod.rs` and the `agent_file` block of
`agents.rs`, including the fence cases: a path outside `--workdir-root`, a
symlink that escapes it, a relative path, a directory, and the mid-character
1 MiB cap.

Not live-tested against the console itself: the front end that consumes these
lives in another repo and is not wired up yet. What was verified here is the
contract each route answers with, not a round trip through a browser.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [x] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [x] New code is fully covered - CI gates at 100% lines/regions/functions with no opt-out
- [x] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
- [x] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
- [ ] Version bumped only if this PR is meant to ship - use `cargo xtask version <X.Y.Z>`, and apply the `allow-version-bump` label (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))
