### PR TITLE
docs: make Leviath navigable by an agent arriving cold

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -68,6 +68,17 @@ jobs:
       - name: Render docs
         run: node site/packages/docs-ssg/dist/cli.mjs docs/content docs-out "${{ inputs.channel }}"
 
+      # The machine-readable half: JSON Schemas for agent.leviath and
+      # config.toml, and the OpenAPI spec for `lev serve`. llms.txt links these
+      # by name, and the sync below uses --delete, so anything not copied in
+      # here becomes a 404 that the index still advertises.
+      - name: Add the machine-readable schemas
+        run: |
+          cp docs/schema/*.json docs-out/
+          for f in blueprint.schema.json config.schema.json openapi.json; do
+            test -s "docs-out/$f" || { echo "missing docs-out/$f"; exit 1; }
+          done
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ dependencies = [
  "glob",
  "hex",
  "hmac 0.13.0",
+ "jsonschema",
  "keyring-core",
  "leviath-agent-client",
  "leviath-core",

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -83,6 +83,10 @@ keyring-core = "1"
 
 tempfile = "3"
 temp-env = { workspace = true, features = ["async_closure"] }
+# Validates the bundled blueprints against the published JSON Schema. A test
+# dependency only: nothing at runtime reads that schema, it exists so an agent
+# authoring a blueprint has something to write against.
+jsonschema = { workspace = true }
 # In-memory OTLP exporters for the logging reload-slot test - it asserts a
 # tracing event actually comes out of the installed bridge layer.
 opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "coder"
-version = "0.0.1"
+version = "0.0.2"
 description = "Multi-stage coding agent - discover, analyze, optionally prototype, implement, and review, with stuck detection and graph-based error recovery"
 entry_stage = "discover"
 
@@ -23,7 +23,7 @@ bash       = "ask"
 # single non-error edge so the runtime auto-follows it without a routing call.
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the codebase and synthesize a verification workflow"
 available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 8
@@ -93,7 +93,7 @@ transform = "direct"
 # ─── Stage 2: Analyze ─────────────────────────────────────────────────────────
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Understand requirements and plan the implementation"
 available_tools = ["read_file", "list_dir"]
 max_iterations = 15
@@ -170,7 +170,7 @@ transform = "direct"
 # rather than a guess.
 [stages.prototype]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Spike the riskiest assumption in the plan before committing to it"
 available_tools = ["read_file", "list_dir", "write_file", "edit_file", "bash", "context_write", "context_append"]
 max_iterations = 15
@@ -236,7 +236,7 @@ transform = "direct"
 # ─── Stage 3: Implement ───────────────────────────────────────────────────────
 [stages.implement]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Write code according to the plan, verifying continuously"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "context_write", "ask_user_confirm"]
 max_iterations = 50
@@ -350,7 +350,7 @@ transform = "direct"
 # back into another implementation pass by a lone outgoing edge.
 [stages.review]
 mode = "interactive"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Review the code before finalizing"
 available_tools = ["read_file", "list_dir", "bash"]
 max_iterations = 10
@@ -431,7 +431,7 @@ transform = "direct"
 # the plan before handing back to implement.
 [stages.reassess]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Step back after no progress: diagnose the dead end and re-plan"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
 max_iterations = 8
@@ -492,7 +492,7 @@ transform = "direct"
 # Only reachable via error edges - invisible during normal flow.
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and resolve errors encountered during implementation"
 available_tools = ["read_file", "bash", "context_append"]
 max_iterations = 10

--- a/crates/leviath-cli/agents/daily-briefer/agent.leviath
+++ b/crates/leviath-cli/agents/daily-briefer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "daily-briefer"
-version = "0.0.1"
+version = "0.0.2"
 description = "Morning summary agent - gathers from local + web sources, prioritizes into a running index, and delivers a concise briefing"
 entry_stage = "collect"
 
@@ -15,7 +15,7 @@ write_file = "ask"
 # ─── Stage 1: Collect ─────────────────────────────────────────────────────────
 [stages.collect]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather information from configured local + web sources"
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "bash", "context_append"]
 max_iterations = 20
@@ -52,7 +52,7 @@ transform = "direct"
 # ─── Stage 2: Prioritize ──────────────────────────────────────────────────────
 [stages.prioritize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Rank items by urgency and relevance into the priorities index"
 available_tools = ["context_write", "context_append"]
 max_iterations = 12
@@ -92,7 +92,7 @@ transform = "direct"
 # ─── Stage 3: Brief (terminal) ────────────────────────────────────────────────
 [stages.brief]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Compose the final briefing"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -121,7 +121,7 @@ If a source failed, add a short "⚠️ Gaps" note listing what couldn't be chec
 # ─── Stage 4: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch or parse"
 available_tools = ["read_file", "bash"]
 max_iterations = 8

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.0.1"
+version = "0.0.2"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -16,7 +16,7 @@ bash       = "ask"
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
@@ -60,7 +60,7 @@ transform = "direct"
 # (follow_citations), or write the report (synthesize).
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Analyze findings, cross-reference claims, and decide the next move"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 20
@@ -111,7 +111,7 @@ transform = "direct"
 # sources analyze flagged, then hand back.
 [stages.follow_citations]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Pull and read specific cited sources flagged during analysis"
 available_tools = ["web_fetch", "web_search", "read_file", "context_append"]
 max_iterations = 12
@@ -144,7 +144,7 @@ transform = "direct"
 # ─── Stage 4: Synthesize (terminal) ───────────────────────────────────────────
 [stages.synthesize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Produce a structured, cited research report"
 available_tools = ["write_file", "read_file"]
 max_iterations = 15
@@ -169,7 +169,7 @@ Write for a technical audience. Be precise. Distinguish evidence from inference.
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch or parse during research"
 available_tools = ["read_file", "bash"]
 max_iterations = 8

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.0.2"
+version = "0.0.3"
 description = "Analyzes log files - identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
@@ -13,7 +13,7 @@ write_file = "ask"
 # ─── Stage 1: Ingest ──────────────────────────────────────────────────────────
 [stages.ingest]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Read log files, identify format and structure"
 available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 15
@@ -48,7 +48,7 @@ transform = "direct"
 # ─── Stage 2: Analyze ─────────────────────────────────────────────────────────
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Identify anomalies, trends, and error patterns"
 available_tools = ["read_file", "bash", "context_write", "context_append"]
 max_iterations = 25
@@ -97,7 +97,7 @@ transform = "direct"
 # ─── Stage 3: Script ──────────────────────────────────────────────────────────
 [stages.script]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Write and execute scripts to parse, filter, and aggregate log data"
 available_tools = ["read_file", "bash"]
 max_iterations = 20
@@ -140,7 +140,7 @@ transform = "direct"
 # ─── Stage 4: Report (terminal) ───────────────────────────────────────────────
 [stages.report]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Produce a structured analysis report with findings"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -167,7 +167,7 @@ severity counts must match `severity_index`.
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed read or script execution"
 available_tools = ["read_file", "bash"]
 max_iterations = 10

--- a/crates/leviath-cli/agents/parallel-fixer/agent.leviath
+++ b/crates/leviath-cli/agents/parallel-fixer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "parallel-fixer"
-version = "0.0.1"
+version = "0.0.2"
 description = "Fixes failing tests in parallel: discover → validate → fan out one worker per failure → merge → verify (re-round until the suite is green)"
 entry_stage = "discover"
 
@@ -20,7 +20,7 @@ shell = "ask"
 # call). This agent has no error_recovery stage, so there is no error edge.
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Work out how this project runs its tests"
 available_tools = ["read_file", "read_files", "list_dir", "shell", "context_write"]
 max_iterations = 6
@@ -62,7 +62,7 @@ transform = "direct"
 # Run the test suite and record the set of failing tests + their diagnoses.
 [stages.validate]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Run the tests and diagnose each failure"
 available_tools = ["read_file", "read_files", "list_dir", "shell", "context_write"]
 max_iterations = 20
@@ -97,7 +97,7 @@ transform = "direct"
 # locking prevents concurrent writes to the same file from clobbering.
 [stages.parallel_fix]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fix each failing test in parallel"
 worker_stage = "fix_worker"
 merge_stage = "merge_fixes"
@@ -123,7 +123,7 @@ If `diagnosis` is exactly "NO FAILURES" (or lists none), output exactly: []
 # ─── Worker stage: fix one failing test ──────────────────────────────────────
 [stages.fix_worker]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fix a single failing test"
 available_tools = ["read_file", "read_files", "edit_file", "shell"]
 max_iterations = 50
@@ -146,7 +146,7 @@ files in parallel.
 # ─── Stage 4: Merge ──────────────────────────────────────────────────────────
 [stages.merge_fixes]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Reconcile the workers' fixes and resolve conflicts"
 available_tools = ["read_file", "read_files", "edit_file", "shell", "context_append"]
 max_iterations = 30
@@ -175,7 +175,7 @@ transform = "compact"
 # residual/interacting failures remain (bounded by validate's max_revisits).
 [stages.verify]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Run the full suite and decide: done, or another fix round"
 available_tools = ["read_file", "read_files", "shell"]
 max_iterations = 10

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.0.1"
+version = "0.0.2"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -16,7 +16,7 @@ bash       = "ask"
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
@@ -57,7 +57,7 @@ transform = "direct"
 # whether it needs more sources or is ready to summarize.
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Analyze and synthesize findings"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 20
@@ -103,7 +103,7 @@ transform = "direct"
 # ─── Stage 3: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Create a concise, well-organized summary"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -127,7 +127,7 @@ Keep it tight and skimmable. Every non-obvious claim must carry a [n] citation.
 # ─── Stage 4: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and recover from errors during gathering or analysis"
 available_tools = ["read_file", "bash"]
 max_iterations = 8

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.0.1"
+version = "0.0.2"
 description = "Code review agent - discover, scan, deep review, and report with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
@@ -16,7 +16,7 @@ bash      = "ask"
 # iteration cap, one non-error edge (auto-followed, no routing call).
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the project and work out how to verify a hypothesis in it"
 available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 6
@@ -57,7 +57,7 @@ transform = "direct"
 # ─── Stage 2: Scan ────────────────────────────────────────────────────────────
 [stages.scan]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fast first pass for obvious issues"
 available_tools = ["read_file", "list_dir", "context_append"]
 max_iterations = 12
@@ -94,7 +94,7 @@ transform = "direct"
 # ─── Stage 3: Deep review ─────────────────────────────────────────────────────
 [stages.deep_review]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "In-depth analysis of correctness, security, and architecture"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
 max_iterations = 25
@@ -142,7 +142,7 @@ transform = "direct"
 # ─── Stage 4: Report (terminal) ───────────────────────────────────────────────
 [stages.report]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce an actionable, ranked review report"
 available_tools = ["read_file"]
 max_iterations = 10
@@ -169,7 +169,7 @@ went unreviewed.
 # ─── Stage 5: Error handler ───────────────────────────────────────────────────
 [stages.error_handler]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Handle errors encountered during scanning or review"
 available_tools = ["read_file", "bash"]
 max_iterations = 10

--- a/crates/leviath-cli/agents/software-engineer/agent.leviath
+++ b/crates/leviath-cli/agents/software-engineer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "software-engineer"
-version = "0.0.2"
+version = "0.0.3"
 description = "Plan-then-implement agent - mirrors the Claude Code discover→plan→approve→code→review workflow"
 entry_stage = "discover"
 
@@ -20,7 +20,7 @@ bash       = "ask"
 # hard iteration cap, and a single non-error edge (auto-followed, no routing call).
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the codebase and synthesize a verification workflow"
 available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 8
@@ -100,7 +100,7 @@ transform = "direct"
 
 [stages.plan]
 mode = "interactive_points"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Explore the codebase and produce a step-by-step implementation plan"
 available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document"]
 # Planning is the one place this agent genuinely needs its user, so these three
@@ -249,7 +249,7 @@ edit_options = ["Add detail - expand a section"]
 # user's approved GOAL is never renegotiated here, only the technical route.
 [stages.prototype]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Spike the riskiest assumption in the approved plan before executing it"
 available_tools = ["read_file", "list_dir", "write_file", "edit_file", "bash", "context_write", "context_append"]
 max_iterations = 15
@@ -319,7 +319,7 @@ transform = "direct"
 
 [stages.implement]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Write code according to the approved plan"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append"]
 max_iterations = 50
@@ -440,7 +440,7 @@ transform = "direct"
 
 [stages.review]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Review the implementation and evaluate code quality"
 available_tools = ["read_file", "list_dir", "bash"]
 max_iterations = 20
@@ -524,7 +524,7 @@ transform = "direct"
 # before handing back to implement.
 [stages.reassess]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "devstral:24b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }] }
 description = "Step back after no progress: diagnose the dead end and re-plan"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
 max_iterations = 8
@@ -588,7 +588,7 @@ transform = "direct"
 
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and resolve errors encountered during implementation"
 available_tools = ["read_file", "bash", "context_append"]
 max_iterations = 10

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.0.1"
+version = "0.0.2"
 description = "Broad multi-topic survey - cast a wide net, compare approaches, dive on the interesting threads, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -15,7 +15,7 @@ bash       = "ask"
 # ─── Stage 1: Survey ──────────────────────────────────────────────────────────
 [stages.survey]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
 max_iterations = 25
@@ -54,7 +54,7 @@ transform = "direct"
 # Three edges: more breadth (survey), dive on a thread (deep_dive), or write it up.
 [stages.compare]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Compare and contrast approaches across the landscape"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
 max_iterations = 15
@@ -98,7 +98,7 @@ transform = "direct"
 # ─── Stage 3: Deep dive ───────────────────────────────────────────────────────
 [stages.deep_dive]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Focused deep read on one interesting thread flagged during comparison"
 available_tools = ["web_search", "web_fetch", "read_file", "context_append"]
 max_iterations = 12
@@ -129,7 +129,7 @@ transform = "direct"
 # ─── Stage 4: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a landscape overview with recommendations"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -153,7 +153,7 @@ non-obvious claims.
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch during the survey"
 available_tools = ["read_file", "bash"]
 max_iterations = 8

--- a/crates/leviath-cli/agents/writing-assistant/agent.leviath
+++ b/crates/leviath-cli/agents/writing-assistant/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "writing-assistant"
-version = "0.0.1"
+version = "0.0.2"
 description = "Research-backed writing - topic to polished draft, with a web-research stage, an interactive outline checkpoint, a draft⇄edit loop, and a final proofread pass"
 entry_stage = "research"
 
@@ -15,7 +15,7 @@ bash       = "ask"
 # ─── Stage 1: Research ────────────────────────────────────────────────────────
 [stages.research]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research the topic and gather supporting material"
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
 max_iterations = 20
@@ -52,7 +52,7 @@ transform = "direct"
 # ─── Stage 2: Outline (human-in-the-loop) ─────────────────────────────────────
 [stages.outline]
 mode = "interactive_points"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Create and refine an outline with user input"
 available_tools = ["ask_user_text", "read_file"]
 max_iterations = 15
@@ -118,7 +118,7 @@ abort_options = ["Abort - cancel this piece"]
 # ─── Stage 3: Draft ───────────────────────────────────────────────────────────
 [stages.draft]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Write the full draft"
 available_tools = ["write_file", "read_file"]
 max_iterations = 25
@@ -146,7 +146,7 @@ transform = "direct"
 # ─── Stage 4: Edit (structural) ───────────────────────────────────────────────
 [stages.edit]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "ollama", model = "qwen3.6:27b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.6:27b" }] }
 description = "Structural edit for clarity, accuracy, and flow"
 available_tools = ["read_file", "write_file", "context_append"]
 max_iterations = 15
@@ -197,7 +197,7 @@ transform = "direct"
 # it turns up a substantive problem.
 [stages.proofread]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Final line-level proofread and fact-check"
 available_tools = ["read_file", "write_file", "web_fetch"]
 max_iterations = 10
@@ -230,7 +230,7 @@ transform = "direct"
 # ─── Stage 6: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed research fetch or file write"
 available_tools = ["read_file", "bash"]
 max_iterations = 8

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -222,6 +222,59 @@ mod tests {
         }
     }
 
+    /// Every provider `lev setup` can configure. Claude Code is a transport
+    /// rather than a provider a stage names, so it is not in this list.
+    const SETUP_PROVIDERS: &[&str] = &["anthropic", "openai", "google", "openrouter", "ollama"];
+
+    #[test]
+    fn every_bundled_stage_offers_every_provider_setup_can_configure() {
+        // Getting Started promises that one provider is all you need. That is
+        // only true if each stage lists them all: a stage naming a subset fails
+        // at spawn on a machine holding a key for a provider it left out.
+        //
+        // Discovered from BUNDLED_AGENTS rather than enumerated, so a new
+        // blueprint is covered the day it lands.
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent has a manifest");
+            let blueprint =
+                leviath_core::manifest::parse_manifest(manifest).expect("manifest parses");
+
+            for stage in &blueprint.stages {
+                let stage_name = &stage.name;
+                let listed: Vec<&str> = stage
+                    .model
+                    .models
+                    .iter()
+                    .map(|entry| entry.provider.as_str())
+                    .collect();
+                for provider in SETUP_PROVIDERS {
+                    assert!(
+                        listed.contains(provider),
+                        "{}/{} omits provider {}",
+                        agent.name,
+                        stage_name,
+                        provider
+                    );
+                }
+                // Ollama needs no API key, so it registers on every machine. Any
+                // position but last makes it beat a provider the user actually
+                // configured, and the run then dies on its first inference.
+                assert_eq!(
+                    listed.last().copied(),
+                    Some("ollama"),
+                    "{}/{} must list ollama last",
+                    agent.name,
+                    stage_name
+                );
+            }
+        }
+    }
+
     /// The lint env for a bundled agent: the built-ins, the sub-agent tools,
     /// and the agent's own `tools/<name>.rhai`, each of which defines `<name>`.
     ///

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -226,6 +226,151 @@ mod tests {
     /// rather than a provider a stage names, so it is not in this list.
     const SETUP_PROVIDERS: &[&str] = &["anthropic", "openai", "google", "openrouter", "ollama"];
 
+    /// The published JSON Schema for `agent.leviath`.
+    ///
+    /// Compiled into the test so it cannot drift from the file that ships:
+    /// this is the same text served at
+    /// `https://leviath.dev/docs/<channel>/blueprint.schema.json`.
+    const BLUEPRINT_SCHEMA: &str = include_str!("../../../docs/schema/blueprint.schema.json");
+
+    /// Every way `value` fails `validator`, as readable lines.
+    ///
+    /// Shared by the positive and negative tests so the formatting closure runs
+    /// against real errors. Called only from the passing path of each, because
+    /// a call inside an `assert!` message is a region only failure reaches.
+    fn schema_problems(
+        validator: &jsonschema::Validator,
+        value: &serde_json::Value,
+    ) -> Vec<String> {
+        validator
+            .iter_errors(value)
+            .map(|e| format!("{}: {e}", e.instance_path()))
+            .collect()
+    }
+
+    /// Convert parsed TOML to JSON so a JSON Schema can be applied to it.
+    fn toml_to_json(value: &toml::Value) -> serde_json::Value {
+        match value {
+            toml::Value::String(s) => serde_json::Value::String(s.clone()),
+            toml::Value::Integer(i) => serde_json::Value::from(*i),
+            toml::Value::Float(f) => serde_json::Value::from(*f),
+            toml::Value::Boolean(b) => serde_json::Value::Bool(*b),
+            // A TOML datetime has no JSON counterpart; the blueprint format has
+            // no datetime-valued key, so rendering it as its own text is enough
+            // for the schema to reject it wherever it appears.
+            toml::Value::Datetime(d) => serde_json::Value::String(d.to_string()),
+            toml::Value::Array(items) => {
+                serde_json::Value::Array(items.iter().map(toml_to_json).collect())
+            }
+            toml::Value::Table(table) => serde_json::Value::Object(
+                table
+                    .iter()
+                    .map(|(k, v)| (k.clone(), toml_to_json(v)))
+                    .collect(),
+            ),
+        }
+    }
+
+    #[test]
+    fn toml_converts_to_json_for_every_value_kind() {
+        // Every arm, because a kind converted wrongly would be validated
+        // against the wrong JSON type and the schema would pass or fail for the
+        // wrong reason. `temperature` is a real float-valued blueprint key, so
+        // that arm is not hypothetical.
+        let source = concat!(
+            "s = \"text\"\n",
+            "i = 7\n",
+            "f = 0.5\n",
+            "b = true\n",
+            "d = 1979-05-27T07:32:00Z\n",
+            "a = [1, \"two\"]\n",
+            "[t]\n",
+            "nested = 1\n"
+        );
+        let parsed: toml::Value = toml::from_str(source).expect("valid TOML");
+        let json = toml_to_json(&parsed);
+        assert_eq!(json["s"], serde_json::json!("text"));
+        assert_eq!(json["i"], serde_json::json!(7));
+        assert_eq!(json["f"], serde_json::json!(0.5));
+        assert_eq!(json["b"], serde_json::json!(true));
+        // No JSON counterpart for a datetime, so it becomes its own text.
+        assert!(json["d"].is_string());
+        assert_eq!(json["a"], serde_json::json!([1, "two"]));
+        assert_eq!(json["t"]["nested"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn every_bundled_blueprint_validates_against_the_published_schema() {
+        // The schema is the only machine-readable description of this format,
+        // and an agent authoring a blueprint will write against it. Nothing but
+        // this test keeps it honest: the parser is a hand-rolled toml::Value
+        // walker, so there is no derive to generate it from.
+        let schema: serde_json::Value =
+            serde_json::from_str(BLUEPRINT_SCHEMA).expect("the schema is valid JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent has a manifest");
+            let parsed: toml::Value = toml::from_str(manifest).expect("the manifest is valid TOML");
+            let json = toml_to_json(&parsed);
+
+            assert_eq!(
+                schema_problems(&validator, &json),
+                Vec::<String>::new(),
+                "{} does not match blueprint.schema.json",
+                agent.name
+            );
+        }
+    }
+
+    #[test]
+    fn the_blueprint_schema_rejects_what_the_parser_rejects() {
+        // A schema that accepts everything would pass the test above over any
+        // input at all. These are the mistakes it exists to catch before a run
+        // is ever spawned.
+        let schema: serde_json::Value =
+            serde_json::from_str(BLUEPRINT_SCHEMA).expect("the schema is valid JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+        // Goes through `schema_problems` rather than `is_valid`, so the same
+        // error-formatting path the positive test uses is actually exercised
+        // by something that produces errors.
+        let rejects = |manifest: &str| {
+            let parsed: toml::Value = toml::from_str(manifest).expect("valid TOML");
+            !schema_problems(&validator, &toml_to_json(&parsed)).is_empty()
+        };
+
+        assert!(
+            rejects("[stages.main]\nmode = \"autonomous\"\n"),
+            "no [agent]"
+        );
+        assert!(
+            rejects("[agent]\nname = \"a\"\n\n[context.regions]\nx = { kind = \"nonsense\" }\n"),
+            "unknown region kind"
+        );
+        assert!(
+            rejects(
+                "[agent]\nname = \"a\"\n\n[stages.main.transitions.other]\ncondition = \"whenever\"\n"
+            ),
+            "unknown transition condition"
+        );
+        assert!(
+            rejects("[agent]\nname = \"a\"\n\n[stages.main]\nmax_iteratoins = 5\n"),
+            "a typo'd stage key"
+        );
+        assert!(
+            rejects("[agent]\nname = \"a\"\n\n[tool_permissions]\nshell = \"maybe\"\n"),
+            "an invalid tool policy"
+        );
+        // And the minimum the parser accepts still passes, so the rules above
+        // are not rejecting everything.
+        assert!(!rejects("[agent]\nname = \"a\"\n"), "a minimal manifest");
+    }
+
     #[test]
     fn every_bundled_stage_offers_every_provider_setup_can_configure() {
         // Getting Started promises that one provider is all you need. That is

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -68,6 +68,23 @@ pub struct RespondArgs {
     /// With `--approve`, allow the tool for the rest of the session.
     #[arg(long)]
     pub session: bool,
+    /// Report open interactions (or the outcome of answering one) as JSON.
+    /// This is how an unattended caller finds the questions it has to answer.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One open interaction in `lev respond --json`.
+///
+/// The whole request rather than the four fields the prose listing has room
+/// for: `tool_arguments` and `body` are exactly what a caller deciding whether
+/// to approve needs, and neither appears in the human listing.
+#[derive(serde::Serialize)]
+struct OpenInteraction<'a> {
+    /// The agent holding the question, for a caller polling several runs.
+    agent_id: &'a str,
+    #[serde(flatten)]
+    request: &'a InteractionRequest,
 }
 
 /// Send `request` and report the boolean outcome: `ok` prints `applied_msg`, a
@@ -252,9 +269,22 @@ fn build_response(request_id: &str, args: &RespondArgs) -> InteractionResponse {
 }
 
 /// List the interactions the daemon is currently holding.
-async fn list_interactions(client: &ControlClient) -> anyhow::Result<()> {
+async fn list_interactions(client: &ControlClient, json: bool) -> anyhow::Result<()> {
     match client.request(&ControlRequest::ListInteractions).await {
         Ok(ControlResponse::Interactions { interactions }) => {
+            if json {
+                let open: Vec<OpenInteraction<'_>> = interactions
+                    .iter()
+                    .map(|(agent_id, request)| OpenInteraction { agent_id, request })
+                    .collect();
+                // Nothing open is an empty array, not a sentence: a caller
+                // polling this branches on length, not on prose.
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&open).expect("an interaction listing serializes")
+                );
+                return Ok(());
+            }
             if interactions.is_empty() {
                 println!("no open interactions");
             } else {
@@ -273,14 +303,24 @@ async fn list_interactions(client: &ControlClient) -> anyhow::Result<()> {
 /// `request_id` is given.
 pub async fn respond(client: &ControlClient, args: &RespondArgs) -> anyhow::Result<()> {
     match &args.request_id {
-        None => list_interactions(client).await,
+        None => list_interactions(client, args.json).await,
         Some(request_id) => {
+            // A failed answer stays an error (non-zero exit plus the message on
+            // stderr), so `--json` only changes the success line.
+            let applied = match args.json {
+                // Serialized, not interpolated: a request id carrying a quote
+                // would otherwise emit JSON that does not parse.
+                true => {
+                    serde_json::json!({ "answered": true, "request_id": request_id }).to_string()
+                }
+                false => "answered".to_string(),
+            };
             send_bool(
                 client,
                 ControlRequest::AnswerInteraction {
                     response: build_response(request_id, args),
                 },
-                "answered",
+                &applied,
                 "no such open interaction",
             )
             .await
@@ -655,6 +695,7 @@ mod tests {
             approve: false,
             deny: false,
             session: false,
+            json: false,
         }
     }
 
@@ -705,6 +746,7 @@ mod tests {
             &RespondArgs {
                 approve: true,
                 session: true,
+                json: false,
                 ..respond_args()
             },
         );
@@ -771,6 +813,92 @@ mod tests {
         })
         .await;
         assert!(r.unwrap_err().to_string().contains("no such open"));
+    }
+
+    // ─── --json ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn open_interaction_serializes_the_agent_id_alongside_the_request() {
+        // `#[serde(flatten)]` is what puts `id` and `prompt` at the top level
+        // next to `agent_id`. Losing it would nest the request under a key no
+        // caller expects.
+        let mut request = InteractionRequest::multiple_choice(
+            "q1",
+            "Pick",
+            vec!["a".to_string(), "b".to_string()],
+            "plan",
+        );
+        request.tool_name = Some("bash".to_string());
+        let open = OpenInteraction {
+            agent_id: "agent-x",
+            request: &request,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&open).unwrap()).unwrap();
+        assert_eq!(value["agent_id"], serde_json::json!("agent-x"));
+        assert_eq!(value["id"], serde_json::json!("q1"));
+        assert_eq!(value["stage_name"], serde_json::json!("plan"));
+        assert_eq!(value["options"], serde_json::json!(["a", "b"]));
+        assert_eq!(value["tool_name"], serde_json::json!("bash"));
+    }
+
+    #[tokio::test]
+    async fn respond_lists_open_interactions_as_json() {
+        let req = InteractionRequest::free_text("q1", "What now?", "plan", true);
+        let line = serde_json::to_string(&ControlResponse::Interactions {
+            interactions: vec![("agent-a".to_string(), req)],
+        })
+        .unwrap();
+        let r = with_daemon(line, |c| async move {
+            respond(
+                &c,
+                &RespondArgs {
+                    request_id: None,
+                    json: true,
+                    ..respond_args()
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn respond_lists_nothing_open_as_json() {
+        let line = serde_json::to_string(&ControlResponse::Interactions {
+            interactions: Vec::new(),
+        })
+        .unwrap();
+        let r = with_daemon(line, |c| async move {
+            respond(
+                &c,
+                &RespondArgs {
+                    request_id: None,
+                    json: true,
+                    ..respond_args()
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn respond_answers_an_interaction_as_json() {
+        let r = with_daemon(r#"{"result":"ok","ok":true}"#, |c| async move {
+            respond(
+                &c,
+                &RespondArgs {
+                    json: true,
+                    ..respond_args()
+                },
+            )
+            .await
+        })
+        .await;
+        assert!(r.is_ok());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -13,9 +13,15 @@ pub struct ListArgs {
     /// Filter by type (agents, blueprints, all)
     #[arg(short, long, default_value = "all")]
     pub filter: String,
+
+    /// Report the catalog as JSON instead of prose, with each agent's source
+    /// named rather than implied by a heading.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// Info parsed from an agent manifest for display.
+#[derive(serde::Serialize)]
 struct AgentInfo {
     name: String,
     version: String,
@@ -25,6 +31,33 @@ struct AgentInfo {
     /// the listing is where someone looks before running an agent they just
     /// installed or copied over from another machine.
     read_paths: Option<String>,
+}
+
+/// One agent in `lev list --json`, with the source the prose report puts in a
+/// heading and the path `lev run` would resolve.
+#[derive(serde::Serialize)]
+struct ListedAgent {
+    #[serde(flatten)]
+    info: AgentInfo,
+    /// `installed`, `configured`, or `local`.
+    source: &'static str,
+    path: String,
+}
+
+/// What `lev list --json` prints.
+#[derive(serde::Serialize)]
+struct ListReport {
+    /// Every agent that can be run by name or path right now.
+    agents: Vec<ListedAgent>,
+    /// The catalog embedded in this binary, which `lev setup` installs from.
+    /// Not runnable until installed, which is why it is a separate key.
+    bundled: Vec<BundledEntry>,
+}
+
+#[derive(serde::Serialize)]
+struct BundledEntry {
+    name: String,
+    version: String,
 }
 
 fn read_agent_info(manifest_path: &Path, config: &Config, cwd: &Path) -> Option<AgentInfo> {
@@ -103,7 +136,7 @@ fn print_agent(info: &AgentInfo) {
     }
 }
 
-pub async fn execute(_args: ListArgs) -> anyhow::Result<()> {
+pub async fn execute(args: ListArgs) -> anyhow::Result<()> {
     // Propagate, don't default: a config that exists but doesn't parse would
     // silently list from the default `agent_paths`, hiding the user's own
     // agent directories with no hint why (a missing file loads as defaults).
@@ -114,7 +147,67 @@ pub async fn execute(_args: ListArgs) -> anyhow::Result<()> {
         .ok()
         .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
-    print_agent_listing(&agents_dir, &cwd, exe_dir.as_deref(), &config)
+    match args.json {
+        true => json_agent_listing(&agents_dir, &cwd, &config),
+        false => print_agent_listing(&agents_dir, &cwd, exe_dir.as_deref(), &config),
+    }
+}
+
+/// `lev list --json`: the same three runnable sources the prose report walks,
+/// each agent tagged with where it came from and the path `lev run` resolves.
+///
+/// The on-disk `<exe_dir>/agents` scan the prose report folds into its bundled
+/// line is left out: those entries are not installed, and merging them into a
+/// name-and-version list loses which of the two a name came from.
+fn json_agent_listing(agents_dir: &Path, cwd: &Path, config: &Config) -> anyhow::Result<()> {
+    let report = build_list_report(agents_dir, cwd, config);
+    // Owned strings with no map keys to reject, so this cannot fail.
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("an agent listing serializes")
+    );
+    Ok(())
+}
+
+/// The report [`json_agent_listing`] prints. Split out so its contents are
+/// assertable without capturing stdout.
+fn build_list_report(agents_dir: &Path, cwd: &Path, config: &Config) -> ListReport {
+    let installed = scan_directory_for_agents(agents_dir, config, cwd);
+    let local = read_agent_info(&cwd.join("agent.leviath"), config, cwd);
+    let configured: Vec<(PathBuf, AgentInfo)> = config
+        .agent_paths
+        .iter()
+        .flat_map(|dir| scan_directory_for_agents(dir, config, cwd))
+        .collect();
+
+    let from = |entries: Vec<(PathBuf, AgentInfo)>, source| {
+        entries.into_iter().map(move |(path, info)| ListedAgent {
+            info,
+            source,
+            path: path.display().to_string(),
+        })
+    };
+    let mut agents: Vec<ListedAgent> = from(installed, "installed")
+        .chain(from(configured, "configured"))
+        .collect();
+    if let Some(info) = local {
+        agents.push(ListedAgent {
+            info,
+            source: "local",
+            path: cwd.join("agent.leviath").display().to_string(),
+        });
+    }
+
+    ListReport {
+        agents,
+        bundled: crate::bundled::BUNDLED_AGENTS
+            .iter()
+            .map(|a| BundledEntry {
+                name: a.name.to_string(),
+                version: a.version.to_string(),
+            })
+            .collect(),
+    }
 }
 
 /// Core `lev list` logic, parameterized by every real-environment source it
@@ -464,6 +557,7 @@ allow = ["/data/runs"]
     fn list_args_default_filter() {
         let args = ListArgs {
             filter: "all".to_string(),
+            json: false,
         };
         assert_eq!(args.filter, "all");
     }
@@ -580,6 +674,7 @@ system = { kind = "pinned", max_tokens = 1000 }
             // config) but must always succeed regardless of what it finds.
             let args = ListArgs {
                 filter: "all".to_string(),
+                json: false,
             };
             let result = execute(args).await;
             assert!(result.is_ok());
@@ -599,6 +694,7 @@ system = { kind = "pinned", max_tokens = 1000 }
             FORCE_AGENTS_DIR_ERROR.with(|f| f.set(true));
             let args = ListArgs {
                 filter: "all".to_string(),
+                json: false,
             };
             let result = execute(args).await;
             FORCE_AGENTS_DIR_ERROR.with(|f| f.set(false));
@@ -639,6 +735,7 @@ system = { kind = "pinned", max_tokens = 1000 }
 
             let args = ListArgs {
                 filter: "all".to_string(),
+                json: false,
             };
             let result = execute(args).await;
 
@@ -660,6 +757,7 @@ system = { kind = "pinned", max_tokens = 1000 }
             crate::commands::force_cwd_error(true);
             let args = ListArgs {
                 filter: "all".to_string(),
+                json: false,
             };
             let result = execute(args).await;
             crate::commands::force_cwd_error(false);
@@ -681,6 +779,7 @@ system = { kind = "pinned", max_tokens = 1000 }
                 std::fs::write(fake_dir.join("config.toml"), "not = valid = toml").unwrap();
                 let args = ListArgs {
                     filter: "all".to_string(),
+                    json: false,
                 };
                 let err = execute(args).await.expect_err("broken config must error");
                 assert!(err.to_string().contains("parse"), "{err}");
@@ -690,6 +789,78 @@ system = { kind = "pinned", max_tokens = 1000 }
     }
 
     // ─── print_agent_listing (fully injectable) ─────────────────────────
+
+    // ─── --json ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn json_listing_tags_each_agent_with_where_it_came_from() {
+        let agents_dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let configured = tempfile::tempdir().unwrap();
+
+        let installed = agents_dir.path().join("from-install");
+        fs::create_dir_all(&installed).unwrap();
+        write_manifest(&installed, "installed-agent");
+        write_manifest(cwd.path(), "local-agent");
+        let extra = configured.path().join("from-config");
+        fs::create_dir_all(&extra).unwrap();
+        write_manifest(&extra, "configured-agent");
+
+        let config = Config {
+            agent_paths: vec![configured.path().to_path_buf()],
+            ..Config::default()
+        };
+        let report = build_list_report(agents_dir.path(), cwd.path(), &config);
+
+        let sourced: Vec<(&str, &str)> = report
+            .agents
+            .iter()
+            .map(|a| (a.info.name.as_str(), a.source))
+            .collect();
+        assert!(sourced.contains(&("installed-agent", "installed")));
+        assert!(sourced.contains(&("configured-agent", "configured")));
+        assert!(sourced.contains(&("local-agent", "local")));
+    }
+
+    #[test]
+    fn json_listing_reports_the_bundled_catalog_separately_from_runnable_agents() {
+        // Bundled agents are not runnable until installed, so they must not
+        // appear in `agents` on a machine with nothing installed.
+        let agents_dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+
+        let report = build_list_report(agents_dir.path(), cwd.path(), &Config::default());
+        assert!(report.agents.is_empty());
+        assert_eq!(report.bundled.len(), crate::bundled::BUNDLED_AGENTS.len());
+    }
+
+    #[test]
+    fn json_listing_flattens_the_agent_fields_next_to_its_source() {
+        // `#[serde(flatten)]` is easy to lose in a refactor, and losing it would
+        // nest every agent under an `info` key that no caller expects.
+        let agents_dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_manifest(cwd.path(), "flat-agent");
+
+        let report = build_list_report(agents_dir.path(), cwd.path(), &Config::default());
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(value["agents"][0]["name"], serde_json::json!("flat-agent"));
+        assert_eq!(value["agents"][0]["source"], serde_json::json!("local"));
+        assert!(value["agents"][0]["path"].is_string());
+    }
+
+    #[tokio::test]
+    async fn execute_with_json_runs_without_error() {
+        crate::config::with_isolated_config_path_async("list-json-ok", |_fake_dir| async move {
+            let args = ListArgs {
+                filter: "all".to_string(),
+                json: true,
+            };
+            assert!(execute(args).await.is_ok());
+        })
+        .await;
+    }
 
     #[test]
     fn print_agent_listing_nothing_installed() {

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -33,6 +33,26 @@ pub struct ListArgs {
     /// Include models from providers this install has no credential for
     #[arg(short = 'a', long)]
     pub all: bool,
+    /// Report the table as JSON, one object per model.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One model in `lev models list --json`.
+///
+/// Carries the full capability set rather than the six columns the table has
+/// room for, and turns the table's `*` marker into a field, since a caller
+/// choosing a model needs to know a capability came from config rather than
+/// from the provider.
+#[derive(serde::Serialize)]
+struct ModelRow {
+    id: String,
+    provider: String,
+    display_name: Option<String>,
+    capabilities: ModelCapabilities,
+    /// True when `[model_capabilities]` in config.toml replaced what Leviath
+    /// knows about this model.
+    capabilities_overridden: bool,
 }
 
 #[derive(Args)]
@@ -521,6 +541,27 @@ async fn list_with_registry(
         }
     }
 
+    // JSON before the emptiness guard: an empty catalog is an empty array, not
+    // an error, and a caller polling this should not have to parse a nudge.
+    if args.json {
+        let rows: Vec<ModelRow> = entries
+            .into_iter()
+            .map(|e| ModelRow {
+                capabilities_overridden: overridden.contains(&e.id),
+                id: e.id,
+                provider: e.provider,
+                display_name: e.display_name,
+                capabilities: e.capabilities,
+            })
+            .collect();
+        // Owned scalars with no map keys to reject, so this cannot fail.
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&rows).expect("a model listing serializes")
+        );
+        return Ok(());
+    }
+
     if entries.is_empty() {
         // Reachable two ways now: a `--provider` filter that matches nothing,
         // or no configured provider at all (a fresh install). Both want the
@@ -986,6 +1027,7 @@ mod tests {
                         provider: None,
                         remote: false,
                         all: false,
+                        json: false,
                     }),
                 };
                 // Should succeed: prints the builtin table
@@ -1006,6 +1048,7 @@ mod tests {
                         provider: Some("anthropic".to_string()),
                         remote: false,
                         all: false,
+                        json: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1025,6 +1068,7 @@ mod tests {
                         provider: Some("nonexistent_provider".to_string()),
                         remote: false,
                         all: false,
+                        json: false,
                     }),
                 };
                 // Should succeed but print "No models found."
@@ -1134,6 +1178,7 @@ mod tests {
                         provider: Some("openrouter".to_string()),
                         remote: false,
                         all: false,
+                        json: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1155,6 +1200,7 @@ mod tests {
                         provider: Some("openai".to_string()),
                         remote: false,
                         all: false,
+                        json: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1319,12 +1365,70 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &build_provider_registry_from_config).await;
                 assert!(result.is_ok());
             },
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn list_json_with_no_configured_provider_is_an_empty_array() {
+        // The prose report prints a nudge here. JSON must not: a caller reading
+        // this branches on the array's length, and a sentence would not parse.
+        crate::config::with_isolated_config_path_async(
+            "models-list_json_empty",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("no-such-provider".to_string()),
+                    all: false,
+                    json: true,
+                };
+                let result = list_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn list_json_with_all_succeeds() {
+        crate::config::with_isolated_config_path_async(
+            "models-list_json_all",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: None,
+                    all: true,
+                    json: true,
+                };
+                let result = list_with_registry(args, &build_provider_registry_from_config).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    #[test]
+    fn model_row_serializes_capabilities_and_the_override_flag() {
+        // The table shows an override as a `*` prefix on the provider column.
+        // JSON has to say so in a field, or a caller cannot tell a capability
+        // Leviath knows from one config asserted.
+        let row = ModelRow {
+            id: "m".to_string(),
+            provider: "p".to_string(),
+            display_name: Some("M".to_string()),
+            capabilities: ModelCapabilities::default(),
+            capabilities_overridden: true,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&row).unwrap()).unwrap();
+        assert_eq!(value["id"], serde_json::json!("m"));
+        assert_eq!(value["capabilities_overridden"], serde_json::json!(true));
+        assert!(value["capabilities"]["supports_tools"].is_boolean());
     }
 
     #[tokio::test]
@@ -1336,6 +1440,7 @@ mod tests {
                     remote: false,
                     provider: Some("anthropic".to_string()),
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &build_provider_registry_from_config).await;
                 assert!(result.is_ok());
@@ -1353,6 +1458,7 @@ mod tests {
                     remote: false,
                     provider: Some("no-such-provider".to_string()),
                     all: false,
+                    json: false,
                 };
                 // Should print "No models found." and still succeed, not error.
                 let result = list_with_registry(args, &build_provider_registry_from_config).await;
@@ -1506,6 +1612,7 @@ mod tests {
                     remote: true,
                     provider: Some("mock".to_string()),
                     all: false,
+                    json: false,
                 };
                 let new_model = ModelInfo {
                     id: "mock-brand-new-model".to_string(),
@@ -1534,6 +1641,7 @@ mod tests {
                     remote: true,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let new_model = ModelInfo {
                     id: "mock-brand-new-model".to_string(),
@@ -1559,6 +1667,7 @@ mod tests {
                     remote: true,
                     provider: Some("mock".to_string()),
                     all: false,
+                    json: false,
                 };
                 let overriding_model = ModelInfo {
                     id: known_id,
@@ -1588,6 +1697,7 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 // A registry with exactly one provider that the builtin table
                 // also knows: its rows survive, everything else is filtered.
@@ -1617,6 +1727,7 @@ mod tests {
                     remote: true,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let result =
                     list_with_registry(args, &mock_registry("anthropic", remote, false)).await;
@@ -1637,6 +1748,7 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: true,
+                    json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
                 assert!(result.is_ok());
@@ -1664,6 +1776,7 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let result =
                     list_with_registry(args, &mock_registry("anthropic", vec![], false)).await;
@@ -1682,6 +1795,7 @@ mod tests {
                     remote: true,
                     provider: Some("mock".to_string()),
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], true)).await;
                 assert!(result.is_ok());
@@ -1702,6 +1816,7 @@ mod tests {
                     remote: true,
                     provider: Some("mock-other".to_string()),
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
                 assert!(result.is_ok());
@@ -1825,6 +1940,7 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
                 assert!(result.is_ok());
@@ -1914,6 +2030,7 @@ mod tests {
                     remote: false,
                     provider: None,
                     all: false,
+                    json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
                 assert!(result.is_err());
@@ -1980,6 +2097,7 @@ mod tests {
             provider: None,
             remote: false,
             all: false,
+            json: false,
         }));
     }
 

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -61,6 +61,11 @@ pub struct RunArgs {
     #[arg(long, value_name = "DIR")]
     pub workdir: Option<std::path::PathBuf>,
 
+    /// Print the spawned run as JSON instead of a sentence, for a caller that
+    /// has to parse the run id back out and poll `lev ps --json`.
+    #[arg(long)]
+    pub json: bool,
+
     /// Dynamic per-region seed flags (`--<region> <text|@file>`), collected by an
     /// argv pre-scan in the binary since region names are blueprint-defined.
     /// clap skips this field; it is populated after parsing.
@@ -78,6 +83,10 @@ const KNOWN_RUN_FLAGS: &[&str] = &[
     "max-depth",
     "no-seed-commands",
     "workdir",
+    // Every flag `run` owns must be listed here. One that is missing is not a
+    // parse error: the pre-scan silently reads it as a `--<region>` seed and
+    // swallows the token after it.
+    "json",
     "verbose",
     "help",
     "version",
@@ -171,6 +180,23 @@ mod tests {
 
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn every_flag_run_declares_is_a_known_run_flag() {
+        // A flag clap owns but this list omits is not a parse error. The
+        // pre-scan reads it as a `--<region>` seed, eats the token after it, and
+        // the run starts with a region nobody asked for. Ask clap for the list
+        // rather than repeating it, so a new flag is covered when it is added.
+        let command = <RunArgs as clap::Args>::augment_args(clap::Command::new("run"));
+        for arg in command.get_arguments() {
+            if let Some(long) = arg.get_long() {
+                assert!(
+                    KNOWN_RUN_FLAGS.contains(&long),
+                    "`--{long}` is missing from KNOWN_RUN_FLAGS",
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -37,7 +37,14 @@ pub struct RunArgs {
     pub model: Option<String>,
 
     /// Run unattended: approve every tool call, and answer the agent's own
-    /// prompts (ask_user_*, plan approvals) instead of waiting for a person.
+    /// prompts (ask_user_*, interaction points) instead of waiting for a person.
+    ///
+    /// One exception, and it is the one that looks like a hang: an interaction
+    /// point declaring `unattended = "ask"` still holds for a person. The
+    /// bundled software-engineer's plan approval does, deliberately, because
+    /// everything after it writes code. Such a run parks in `Waiting` until
+    /// `[limits] interaction_timeout_secs` (default 3600) releases it. Lower
+    /// that to bound the wait.
     #[arg(long)]
     pub yolo: bool,
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -121,6 +121,73 @@ fn api_router() -> Router<AppState> {
         .route("/ws/agents/{id}", get(websocket::ws_agent))
 }
 
+/// Every `(path, method)` this file registers, read out of its own source.
+///
+/// Axum's `Router` offers no way to enumerate what it holds, so the only place
+/// the route table can be read back is the text that declares it. Used by the
+/// test that holds `docs/schema/openapi.json` to the real router, so a route
+/// added without a spec entry fails the build rather than shipping undocumented.
+/// The same technique `xtask/src/docs.rs` uses on the docs.
+#[cfg(test)]
+fn declared_routes() -> Vec<(String, String)> {
+    const SOURCE: &str = include_str!("mod.rs");
+    // Only the half above the test module. The tests below declare routes of
+    // their own as fixtures for the reader, and those are not served by
+    // anything. Reading the whole file counted them as production routes.
+    let production = SOURCE.split("\nmod tests {").next().unwrap_or(SOURCE);
+    routes_in(production)
+}
+
+/// The route reader itself, over arbitrary source text.
+///
+/// Split from [`declared_routes`] so its parsing can be tested against input a
+/// test writes, rather than only against this file, which a test cannot vary.
+#[cfg(test)]
+fn routes_in(source: &str) -> Vec<(String, String)> {
+    let mut routes = Vec::new();
+    // Split rather than index: the workspace denies `clippy::string_slice`,
+    // and a byte range into UTF-8 text is exactly the hazard that lint is for.
+    for chunk in source.split(".route(").skip(1) {
+        // Balance parentheses to take just this call's arguments. The handler
+        // chain (`get(..).post(..)`) contains its own, and the chunk runs on
+        // past the call's end.
+        let mut depth = 1usize;
+        let mut body = String::new();
+        for ch in chunk.chars() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            body.push(ch);
+        }
+        let Some(path) = body
+            .split_once('"')
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(path, _)| path)
+        else {
+            continue;
+        };
+        // This function's own source contains the text it splits on, so one
+        // chunk is always the split call itself. Requiring a route-shaped path
+        // drops it rather than inventing a route from the code around it.
+        if !path.starts_with('/') {
+            continue;
+        }
+        for method in ["get", "post", "put", "delete", "patch"] {
+            if body.contains(&format!("{method}(")) {
+                routes.push((path.to_string(), method.to_uppercase()));
+            }
+        }
+    }
+    routes
+}
+
 /// Core of [`execute`], with an optional shutdown signal so tests can stop
 /// the server gracefully and cover the `Ok(())` return path.
 ///
@@ -302,6 +369,99 @@ mod tests {
 
     use crate::runstate::RunMeta;
     use crate::test_support::with_tracing;
+
+    /// The published OpenAPI spec for this API.
+    const OPENAPI: &str = include_str!("../../../../../docs/schema/openapi.json");
+
+    /// Every `(path, METHOD)` the spec documents.
+    fn documented_routes() -> Vec<(String, String)> {
+        let spec: serde_json::Value = serde_json::from_str(OPENAPI).expect("the spec is JSON");
+        let paths = spec["paths"].as_object().expect("the spec has paths");
+        let mut routes = Vec::new();
+        for (path, item) in paths {
+            let operations = item.as_object().expect("a path item is an object");
+            for method in ["get", "post", "put", "delete", "patch"] {
+                if operations.contains_key(method) {
+                    routes.push((path.clone(), method.to_uppercase()));
+                }
+            }
+        }
+        routes
+    }
+
+    /// A set of `(path, METHOD)` pairs.
+    type Routes = Vec<(String, String)>;
+
+    /// The two ways the spec can be wrong: a route served but not documented,
+    /// and one documented but no longer served.
+    fn spec_drift() -> (Routes, Routes) {
+        let declared = declared_routes();
+        let documented = documented_routes();
+        let missing = declared
+            .iter()
+            .filter(|r| !documented.contains(r))
+            .cloned()
+            .collect();
+        let extra = documented
+            .iter()
+            .filter(|r| !declared.contains(r))
+            .cloned()
+            .collect();
+        (missing, extra)
+    }
+
+    #[test]
+    fn the_openapi_spec_documents_exactly_the_routes_this_router_serves() {
+        // Hand-written, because there is no derive to generate it from. Without
+        // this the spec would be a snapshot of whatever the API looked like the
+        // day it was written, and an agent reading it would call routes that
+        // moved.
+        //
+        // Bare `assert!` over a bool, with no message: anything in an assert's
+        // format arguments is a region only the failing path reaches, which the
+        // 100% coverage gate then reports as uncovered. That costs the failure
+        // its detail, so when one of these trips, call `spec_drift()` and print
+        // it: `missing` is served but undocumented, `extra` is the reverse.
+        let (missing, extra) = spec_drift();
+        assert!(missing.is_empty());
+        assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn the_route_reader_finds_the_routes_that_are_actually_there() {
+        // Guards the guard. This reads its own source text, so a change to how
+        // routes are written could quietly make it find nothing, and a test
+        // comparing two empty lists passes.
+        let declared = declared_routes();
+        assert!(declared.len() > 25);
+        assert!(declared.contains(&("/api/agents".to_string(), "POST".to_string())));
+        assert!(declared.contains(&("/api/agents/{id}".to_string(), "DELETE".to_string())));
+        assert!(declared.contains(&("/ws".to_string(), "GET".to_string())));
+    }
+
+    #[test]
+    fn the_route_reader_ignores_text_that_is_not_a_route() {
+        // The reader splits on a literal its own source contains, so it always
+        // sees at least one chunk that is not a route call. Anything without a
+        // route-shaped path has to be dropped rather than guessed at.
+        let source = concat!(
+            "let x = source.split(\".route(\").skip(1);\n",
+            ".route(\"not a path\", get(h))\n",
+            ".route(\"/real\", get(h).post(h))\n"
+        );
+        assert_eq!(
+            routes_in(source),
+            vec![
+                ("/real".to_string(), "GET".to_string()),
+                ("/real".to_string(), "POST".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_route_reader_reads_nothing_out_of_source_with_no_routes() {
+        assert_eq!(routes_in("fn main() {}"), Vec::new());
+    }
 
     /// Extracted so the `assert!` failure-message region (only executed
     /// when the assertion fails) is covered by this function's own

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -191,6 +191,47 @@ fn apply_flags(config: &mut Config, args: &SetupArgs) {
     if let Some(ref e) = args.claude_code_effort {
         config.providers.claude_code_effort = Some(e.clone());
     }
+    retarget_default_provider(config);
+}
+
+/// The providers this config holds a credential for, best first.
+///
+/// Ollama sits last on purpose. It needs no key, so a config that merely
+/// mentions it is not a statement of preference, and putting it first would
+/// make it the default on a machine that never installed it.
+fn configured_providers(config: &Config) -> Vec<&'static str> {
+    [
+        ("anthropic", config.providers.anthropic_api_key.is_some()),
+        ("openai", config.providers.openai_api_key.is_some()),
+        ("google", config.providers.google_api_key.is_some()),
+        ("openrouter", config.openrouter_api_key.is_some()),
+        ("claude-code", config.providers.claude_code_enabled),
+        ("ollama", config.ollama_base_url.is_some()),
+    ]
+    .into_iter()
+    .filter(|(_, configured)| *configured)
+    .map(|(id, _)| id)
+    .collect()
+}
+
+/// Point `default_provider` at a provider this config can actually reach.
+///
+/// It defaults to `anthropic` and nothing in non-interactive mode ever moved
+/// it, so `lev setup --non-interactive --openrouter-key ...` produced a config
+/// whose very next `lev doctor` said it "resolved to 'anthropic', which is not
+/// configured". The install was fine; the default was pointing at a provider
+/// the user had not asked for.
+///
+/// Only ever moves a default that is unreachable, so a deliberate choice
+/// already in the file survives.
+fn retarget_default_provider(config: &mut Config) {
+    let configured = configured_providers(config);
+    if configured.contains(&config.default_provider.as_str()) {
+        return;
+    }
+    if let Some(first) = configured.first() {
+        config.default_provider = (*first).to_string();
+    }
 }
 
 /// Build a wizard against `env`.
@@ -381,6 +422,103 @@ mod tests {
             env_lookup: Box::new(|_| None),
             opener: std::sync::Arc::new(|_| true),
         }
+    }
+
+    // ─── default_provider retargeting ───────────────────────────────────────
+
+    #[test]
+    fn a_single_non_anthropic_key_becomes_the_default_provider() {
+        // The bug this exists for: setup succeeded, then `lev doctor` said the
+        // install resolved to a provider the user had never configured.
+        let mut config = Config::default();
+        assert_eq!(config.default_provider, "anthropic");
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                openrouter_key: Some("sk-or-test".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(config.default_provider, "openrouter");
+    }
+
+    #[test]
+    fn a_reachable_default_provider_is_left_alone() {
+        let mut config = Config::default();
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                anthropic_key: Some("sk-ant-test".to_string()),
+                openrouter_key: Some("sk-or-test".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(config.default_provider, "anthropic");
+    }
+
+    #[test]
+    fn a_deliberate_default_provider_survives() {
+        let mut config = Config {
+            default_provider: "google".to_string(),
+            ..Config::default()
+        };
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                google_key: Some("AIza-test".to_string()),
+                openrouter_key: Some("sk-or-test".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(config.default_provider, "google");
+    }
+
+    #[test]
+    fn configuring_nothing_leaves_the_default_provider_untouched() {
+        // Nothing to retarget to, so moving it would only make it wrong
+        // differently.
+        let mut config = Config::default();
+        apply_flags(&mut config, &args());
+        assert_eq!(config.default_provider, "anthropic");
+    }
+
+    #[test]
+    fn ollama_is_the_last_provider_considered() {
+        // It needs no key, so it is the one most likely to be present by
+        // accident. Anything the user actually holds a credential for wins.
+        let mut config = Config::default();
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                ollama_url: Some("http://localhost:11434".to_string()),
+                google_key: Some("AIza-test".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(config.default_provider, "google");
+
+        let mut ollama_only = Config::default();
+        apply_flags(
+            &mut ollama_only,
+            &SetupArgs {
+                ollama_url: Some("http://localhost:11434".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(ollama_only.default_provider, "ollama");
+    }
+
+    #[test]
+    fn the_claude_code_transport_counts_as_a_configured_provider() {
+        let mut config = Config::default();
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                claude_code: Some(true),
+                ..args()
+            },
+        );
+        assert_eq!(config.default_provider, "claude-code");
     }
 
     // ─── the non-interactive path ───────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -1116,7 +1116,10 @@ mod tests {
 
         let screen = rendered(&w);
         assert!(screen.contains("up to date"));
-        assert!(screen.contains("install 0.0.1"));
+        // Read the expected version off the bundled agent rather than spelling
+        // it out, so bumping a blueprint does not break this test.
+        let not_installed = &crate::bundled::BUNDLED_AGENTS[1];
+        assert!(screen.contains(&format!("install {}", not_installed.version)));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -14,6 +14,95 @@ pub struct ValidateArgs {
     /// Fail on warnings too, not only errors. Notes never fail.
     #[arg(long)]
     pub(crate) deny_warnings: bool,
+
+    /// Report the blueprint and every finding as JSON instead of prose. The
+    /// exit status is unchanged, so a caller can branch on either.
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+/// The blueprint itself, for a caller that wants to know what it just validated.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BlueprintSummary {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    /// Null when the manifest names no `entry_stage`, in which case the first
+    /// stage is the entry.
+    pub entry_stage: Option<String>,
+    /// Stage names in blueprint order.
+    pub stages: Vec<String>,
+}
+
+/// What `lev validate --json` prints.
+///
+/// One shape for every outcome, so a caller parses once and branches on
+/// `valid`. A manifest that did not parse fills `error` and leaves `blueprint`
+/// null; one that did fills `blueprint` and leaves `error` null. `code` on each
+/// finding is a stable slug to branch on, where the prose line is written to be
+/// read.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ValidateReport {
+    /// True when nothing would have failed the command.
+    pub valid: bool,
+    /// Present when the manifest parsed and validated.
+    pub blueprint: Option<BlueprintSummary>,
+    /// Present when it did not.
+    pub error: Option<String>,
+    pub findings: Vec<LintFinding>,
+    pub errors: usize,
+    pub warnings: usize,
+    pub notes: usize,
+}
+
+impl ValidateReport {
+    /// The report for a manifest that got as far as linting.
+    fn linted(
+        blueprint: &leviath_core::Blueprint,
+        findings: Vec<LintFinding>,
+        deny_warnings: bool,
+    ) -> Self {
+        let count = |want: LintSeverity| findings.iter().filter(|f| f.severity == want).count();
+        let (errors, warnings) = (count(LintSeverity::Error), count(LintSeverity::Warning));
+        Self {
+            // Mirrors the exit-status rule exactly: notes never fail a build.
+            valid: errors == 0 && !(deny_warnings && warnings > 0),
+            blueprint: Some(BlueprintSummary {
+                name: blueprint.name.clone(),
+                version: blueprint.version.clone(),
+                description: blueprint.description.clone(),
+                entry_stage: blueprint.entry_stage.clone(),
+                stages: blueprint.stages.iter().map(|s| s.name.clone()).collect(),
+            }),
+            error: None,
+            errors,
+            warnings,
+            notes: count(LintSeverity::Note),
+            findings,
+        }
+    }
+
+    /// The report for a manifest that never parsed or never validated.
+    fn failed(error: String) -> Self {
+        Self {
+            valid: false,
+            blueprint: None,
+            error: Some(error),
+            findings: Vec::new(),
+            errors: 1,
+            warnings: 0,
+            notes: 0,
+        }
+    }
+
+    fn print(&self) {
+        // Owned scalars and vectors with no map keys to reject, so this cannot
+        // fail.
+        println!(
+            "{}",
+            serde_json::to_string_pretty(self).expect("a validate report serializes")
+        );
+    }
 }
 
 /// Resolve, read, parse, and validate the manifest at `path`. Distinguishes
@@ -187,12 +276,26 @@ fn execute_reporting_outcome(
     let checked = match check_manifest(&path) {
         Ok(c) => c,
         Err(ManifestCheckError::Io(e)) => return Err(e),
-        Err(ManifestCheckError::Parse(e)) => return Ok(ValidateOutcome::ParseError(e)),
-        Err(ManifestCheckError::Validation(e)) => return Ok(ValidateOutcome::ValidationError(e)),
+        Err(ManifestCheckError::Parse(e)) => {
+            if args.json {
+                ValidateReport::failed(format!("parse error: {e}")).print();
+            }
+            return Ok(ValidateOutcome::ParseError(e));
+        }
+        Err(ManifestCheckError::Validation(e)) => {
+            if args.json {
+                ValidateReport::failed(format!("validation failed: {e}")).print();
+            }
+            return Ok(ValidateOutcome::ValidationError(e));
+        }
     };
 
-    print_success(&checked.blueprint);
-    print_script_tool_report(&path);
+    // The human report is three separate printers. JSON is one document, so it
+    // is built after the lint and emitted once, and none of these run.
+    if !args.json {
+        print_success(&checked.blueprint);
+        print_script_tool_report(&path);
+    }
 
     let mut env = LintEnv::offline(&checked.agent_dir);
     if let Some(config) = config {
@@ -205,7 +308,14 @@ fn execute_reporting_outcome(
             .with_read_paths(&checked.blueprint, config, &workdir);
     }
     let findings = lint_manifest(&checked.content, &checked.blueprint, &env);
-    let (errors, warnings) = print_findings(&findings);
+    let (errors, warnings) = match args.json {
+        true => {
+            let report = ValidateReport::linted(&checked.blueprint, findings, args.deny_warnings);
+            report.print();
+            (report.errors, report.warnings)
+        }
+        false => print_findings(&findings),
+    };
 
     if errors > 0 || (args.deny_warnings && warnings > 0) {
         return Ok(ValidateOutcome::LintFailed { errors, warnings });
@@ -323,6 +433,7 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
         ValidateArgs {
             path: dir.to_str().unwrap().to_string(),
             deny_warnings: false,
+            json: false,
         }
     }
 
@@ -581,6 +692,7 @@ system = { kind = "pinned", max_tokens = 1000 }
             let args = ValidateArgs {
                 path: manifest_path.to_str().unwrap().to_string(),
                 deny_warnings: false,
+                json: false,
             };
             assert!(execute(args).await.is_ok());
         })
@@ -629,6 +741,154 @@ system = { kind = "pinned", max_tokens = 1000 }
                 warnings: 0
             }
             .is_success()
+        );
+    }
+
+    // ─── --json ──────────────────────────────────────────────────────────
+
+    fn json_args_for(dir: &std::path::Path) -> ValidateArgs {
+        ValidateArgs {
+            json: true,
+            ..args_for(dir)
+        }
+    }
+
+    /// A finding of a given severity. `LintFinding::new` is private to `lint`,
+    /// but the fields are public, so the report can be exercised from here
+    /// without widening that API for a test.
+    fn finding(severity: LintSeverity, code: &'static str) -> LintFinding {
+        LintFinding {
+            severity,
+            code,
+            stage: None,
+            message: format!("{code} message"),
+            fix: None,
+        }
+    }
+
+    #[test]
+    fn json_report_of_a_clean_manifest_is_valid_and_names_its_stages() {
+        let blueprint = parse(CLEAN_MANIFEST);
+        let report = ValidateReport::linted(&blueprint, Vec::new(), false);
+        assert!(report.valid);
+        assert_eq!(report.error, None);
+        let summary = report.blueprint.expect("a parsed manifest has a summary");
+        assert_eq!(summary.name, "ok-agent");
+        assert_eq!(summary.stages, vec!["main".to_string()]);
+        assert_eq!((report.errors, report.warnings, report.notes), (0, 0, 0));
+    }
+
+    #[test]
+    fn json_report_counts_each_severity_separately() {
+        let blueprint = parse(CLEAN_MANIFEST);
+        let findings = vec![
+            finding(LintSeverity::Error, "a"),
+            finding(LintSeverity::Warning, "b"),
+            finding(LintSeverity::Note, "c"),
+        ];
+        let report = ValidateReport::linted(&blueprint, findings, false);
+        assert_eq!((report.errors, report.warnings, report.notes), (1, 1, 1));
+        // An error is fatal whatever --deny-warnings says.
+        assert!(!report.valid);
+    }
+
+    #[test]
+    fn json_report_is_valid_with_a_warning_until_deny_warnings() {
+        let blueprint = parse(CLEAN_MANIFEST);
+        let warning = || vec![finding(LintSeverity::Warning, "b")];
+        assert!(ValidateReport::linted(&blueprint, warning(), false).valid);
+        assert!(!ValidateReport::linted(&blueprint, warning(), true).valid);
+    }
+
+    #[test]
+    fn json_report_of_a_note_stays_valid_under_deny_warnings() {
+        // Notes never fail a build. This is the rule most likely to drift, since
+        // the JSON `valid` flag restates it in a second place.
+        let blueprint = parse(CLEAN_MANIFEST);
+        let notes = vec![finding(LintSeverity::Note, "c")];
+        assert!(ValidateReport::linted(&blueprint, notes, true).valid);
+    }
+
+    #[test]
+    fn json_report_of_a_broken_manifest_carries_the_error_and_no_blueprint() {
+        let report = ValidateReport::failed("parse error: boom".to_string());
+        assert!(!report.valid);
+        assert!(report.blueprint.is_none());
+        assert_eq!(report.error.as_deref(), Some("parse error: boom"));
+    }
+
+    #[test]
+    fn json_report_serializes_every_key_a_caller_reads() {
+        let blueprint = parse(CLEAN_MANIFEST);
+        let report = ValidateReport::linted(
+            &blueprint,
+            vec![finding(LintSeverity::Error, "unknown-tool")],
+            false,
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(value["valid"], serde_json::json!(false));
+        assert_eq!(value["blueprint"]["name"], serde_json::json!("ok-agent"));
+        assert_eq!(value["error"], serde_json::Value::Null);
+        // `code` is the stable slug a caller branches on, and `severity` is
+        // lowercase rather than the padded table label.
+        assert_eq!(
+            value["findings"][0]["code"],
+            serde_json::json!("unknown-tool")
+        );
+        assert_eq!(value["findings"][0]["severity"], serde_json::json!("error"));
+    }
+
+    #[test]
+    fn json_mode_still_reports_a_parse_error_through_the_outcome() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "not valid toml [[[");
+        assert!(
+            execute_reporting_outcome(&json_args_for(dir.path()), None)
+                .unwrap()
+                .is_parse_error()
+        );
+    }
+
+    #[test]
+    fn json_mode_still_reports_a_validation_error_through_the_outcome() {
+        // A manifest that parses but names an entry stage that does not exist:
+        // the other half of the failure path, and a different report line.
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            r#"
+[agent]
+name = "bad-entry-agent"
+version = "0.1.0"
+description = "Entry stage does not exist"
+entry_stage = "does-not-exist"
+
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "Main"
+max_iterations = 5
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#,
+        );
+        assert!(
+            execute_reporting_outcome(&json_args_for(dir.path()), None)
+                .unwrap()
+                .is_validation_error()
+        );
+    }
+
+    #[test]
+    fn json_mode_still_succeeds_on_a_clean_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), CLEAN_MANIFEST);
+        assert!(
+            execute_reporting_outcome(&json_args_for(dir.path()), None)
+                .unwrap()
+                .is_success()
         );
     }
 
@@ -712,6 +972,7 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
         let args = ValidateArgs {
             path: dir.path().to_str().unwrap().to_string(),
             deny_warnings: true,
+            json: false,
         };
         assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
     }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -1472,6 +1472,81 @@ mod dotenv_tests {
 
 #[cfg(test)]
 mod tests {
+    /// The published JSON Schema for `config.toml`, and a config exercising
+    /// every section of it. Compiled in so neither can drift from what ships.
+    const CONFIG_SCHEMA: &str = include_str!("../../../docs/schema/config.schema.json");
+    const CONFIG_EXAMPLE: &str = include_str!("../../../docs/schema/config.example.toml");
+
+    /// Every way `value` fails `validator`. See the twin in `bundled.rs`.
+    fn schema_problems(
+        validator: &jsonschema::Validator,
+        value: &serde_json::Value,
+    ) -> Vec<String> {
+        validator
+            .iter_errors(value)
+            .map(|e| format!("{}: {e}", e.instance_path()))
+            .collect()
+    }
+
+    #[test]
+    fn the_example_config_satisfies_the_published_schema_and_deserializes() {
+        // Both halves matter. The schema alone could describe a shape `Config`
+        // rejects; `Config` alone could accept a shape the schema forbids.
+        // Holding one fixture to both is what keeps them describing the same
+        // format, since the schema is hand-written and nothing generates it.
+        let example: toml::Value = toml::from_str(CONFIG_EXAMPLE).expect("the example is TOML");
+        let schema: serde_json::Value =
+            serde_json::from_str(CONFIG_SCHEMA).expect("the schema is JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+
+        let json = serde_json::to_value(&example).expect("TOML converts to JSON");
+        assert_eq!(
+            schema_problems(&validator, &json),
+            Vec::<String>::new(),
+            "config.example.toml does not match config.schema.json"
+        );
+
+        let parsed: Config = toml::from_str(CONFIG_EXAMPLE).expect("the example deserializes");
+        // A couple of spot checks that the values landed where the schema says,
+        // rather than being silently dropped into nothing.
+        assert_eq!(parsed.default_provider, "anthropic");
+        assert_eq!(parsed.limits.interaction_timeout_secs, 3600);
+        assert_eq!(parsed.mcp_servers.len(), 2);
+    }
+
+    #[test]
+    fn the_config_schema_rejects_a_key_that_is_not_a_setting() {
+        // Without `additionalProperties: false` the schema would accept any
+        // typo, which is most of what an author wants it to catch.
+        let schema: serde_json::Value =
+            serde_json::from_str(CONFIG_SCHEMA).expect("the schema is JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+        // Through `schema_problems` rather than `is_valid`, so the formatting
+        // path the positive test relies on runs against real errors.
+        let rejects = |toml_text: &str| {
+            let value: toml::Value = toml::from_str(toml_text).expect("valid TOML");
+            let json = serde_json::to_value(&value).expect("converts");
+            !schema_problems(&validator, &json).is_empty()
+        };
+
+        assert!(
+            rejects("default_provdier = \"anthropic\"\n"),
+            "a typo'd key"
+        );
+        assert!(
+            rejects("[limits]\ninteraction_timeout_secs = \"an hour\"\n"),
+            "a string where a number belongs"
+        );
+        assert!(
+            rejects("[security]\ncredential_store = \"vault\"\n"),
+            "an unsupported credential store"
+        );
+        assert!(
+            !rejects("default_provider = \"openrouter\"\n"),
+            "a real key"
+        );
+    }
+
     /// Saving with a keychain that cannot be reached must fail rather than
     /// quietly writing the keys into the file. A user who asked for the keychain
     /// would otherwise end up with plaintext keys on disk and no sign of it.

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -228,13 +228,57 @@ fn spawn_warning_lines(
     lines
 }
 
+/// What `lev run --json` prints on a successful spawn.
+///
+/// `lev run` hands the agent to the daemon and returns, so the run id is the
+/// only handle a caller gets on the work it just started. Parsing it back out of
+/// `spawned <id>` meant a caller had to match on prose; this is the same
+/// information in a shape that does not change when the sentence does.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SpawnedRun {
+    /// The run id to poll with `lev ps --json` and stop with `lev cancel`.
+    pub run_id: String,
+    /// The manifest the run was resolved from.
+    pub blueprint_path: String,
+    /// The directory the agent's file tools are confined to.
+    pub workdir: String,
+    /// Whether the run was started unattended.
+    pub yolo: bool,
+}
+
+/// Render a spawn outcome for printing: JSON when `json`, else the sentence.
+///
+/// Split from [`send_spawn`] so both shapes are testable without a daemon.
+pub fn spawn_report(spawned: &SpawnedRun, json: bool) -> String {
+    match json {
+        // Four owned scalars with no map keys to reject, so this cannot fail.
+        true => serde_json::to_string_pretty(spawned).expect("a spawn report serializes"),
+        false => format!("spawned {}", spawned.run_id),
+    }
+}
+
 /// Send a resolved spawn request to the daemon and report the outcome, printing
 /// the new run id on success.
-pub async fn send_spawn(client: &ControlClient, spawn_args: SpawnArgs) -> anyhow::Result<()> {
+///
+/// Warnings go to stderr, so `--json` leaves stdout parseable on its own.
+pub async fn send_spawn(
+    client: &ControlClient,
+    spawn_args: SpawnArgs,
+    json: bool,
+) -> anyhow::Result<()> {
     warn_ungranted_read_paths(&spawn_args);
+    let blueprint_path = spawn_args.blueprint_path.clone();
+    let workdir = spawn_args.workdir.clone();
+    let yolo = spawn_args.yolo;
     match client.spawn(spawn_args).await {
         Ok(ControlResponse::Spawned { run_id }) => {
-            println!("spawned {run_id}");
+            let spawned = SpawnedRun {
+                run_id,
+                blueprint_path,
+                workdir,
+                yolo,
+            };
+            println!("{}", spawn_report(&spawned, json));
             Ok(())
         }
         Ok(ControlResponse::Error { message }) => bail!("spawn failed: {message}"),
@@ -670,9 +714,32 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
     async fn send(response_line: &'static str) -> anyhow::Result<()> {
         let dir = tempfile::tempdir().unwrap();
         let (id, server) = fake_daemon(dir.path(), response_line);
-        let result = send_spawn(&ControlClient::new(id), SpawnArgs::default()).await;
+        let result = send_spawn(&ControlClient::new(id), SpawnArgs::default(), false).await;
         server.await.unwrap();
         result
+    }
+
+    fn spawned() -> SpawnedRun {
+        SpawnedRun {
+            run_id: "run-abc".to_string(),
+            blueprint_path: "/agents/coder/agent.leviath".to_string(),
+            workdir: "/work".to_string(),
+            yolo: true,
+        }
+    }
+
+    #[test]
+    fn spawn_report_without_json_is_the_sentence() {
+        assert_eq!(spawn_report(&spawned(), false), "spawned run-abc");
+    }
+
+    #[test]
+    fn spawn_report_with_json_round_trips_every_field() {
+        // Parsing it back is the assertion that matters: a caller reads this to
+        // learn the id it has to poll, so the keys are the contract.
+        let parsed: SpawnedRun =
+            serde_json::from_str(&spawn_report(&spawned(), true)).expect("valid JSON");
+        assert_eq!(parsed, spawned());
     }
 
     // ─── the client-side [read_paths] warning ──────────────────────────
@@ -844,7 +911,7 @@ allow = ["/data/runs"]
         let dir = tempfile::tempdir().unwrap();
         // A control id with no daemon bound to it.
         let id = control_id(&dir.path().join("no-daemon"));
-        let err = send_spawn(&ControlClient::new(id), SpawnArgs::default())
+        let err = send_spawn(&ControlClient::new(id), SpawnArgs::default(), false)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("not reachable"));

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -339,6 +339,7 @@ mod tests {
             approve: false,
             deny: false,
             session: false,
+            json: false,
         };
         assert!(dispatch(Commands::Respond(args), &MockRisky).await.is_ok());
     }
@@ -450,6 +451,7 @@ mod tests {
         crate::config::with_isolated_config_path_async("dispatch-list", |_fake_dir| async move {
             let args = commands::list::ListArgs {
                 filter: "all".to_string(),
+                json: false,
             };
             let result = dispatch(Commands::List(args), &MockRisky).await;
             assert!(result.is_ok());
@@ -512,6 +514,7 @@ mod tests {
                     provider: None,
                     remote: false,
                     all: false,
+                    json: false,
                 }),
             };
             let result = dispatch(Commands::Models(args), &MockRisky).await;
@@ -535,6 +538,7 @@ mod tests {
                     .unwrap()
                     .to_string(),
                 deny_warnings: false,
+                json: false,
             };
             let result = dispatch(Commands::Validate(args), &MockRisky).await;
             assert!(result.is_err());

--- a/crates/leviath-cli/src/lint.rs
+++ b/crates/leviath-cli/src/lint.rs
@@ -32,13 +32,15 @@ use leviath_core::Blueprint;
 use leviath_core::blueprint::StageMode;
 use leviath_runtime::dynamic_interaction::BLOCKING_INTERACTION_TOOLS;
 use leviath_tools::canonical_tool_name;
+use serde::{Deserialize, Serialize};
 
 /// How much a finding matters. Only [`LintSeverity::Error`] fails
 /// `lev validate`; warnings are printed and the command still exits zero
 /// (unless `--deny-warnings` is passed); notes never fail anything.
 ///
 /// Declared worst-first so sorting by it groups the report.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum LintSeverity {
     /// The manifest says something that cannot be what the author meant - a
     /// tool name matching nothing, a permission for a tool the stage never
@@ -65,7 +67,10 @@ impl LintSeverity {
 }
 
 /// One thing worth telling the author about.
-#[derive(Debug, Clone)]
+///
+/// Serialize only: `code` is a `&'static str` pointing at a literal in this
+/// file, which no deserializer can produce.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LintFinding {
     pub severity: LintSeverity,
     /// Stable slug (`"unknown-tool"`), so a finding can be referenced in an

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -212,7 +212,7 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
     // verified a third of an hour ago. It also stops a run that was never going
     // to happen (a bad path, a typo'd region) from auto-starting a daemon.
     ensure_daemon_running().await?;
-    leviath_cli::daemon::client::send_spawn(&control_client()?, spawn_args).await
+    leviath_cli::daemon::client::send_spawn(&control_client()?, spawn_args, args.json).await
 }
 
 /// `lev doctor`: run the wiring checks, starting the daemon first so the fourth

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -67,6 +67,12 @@ pub struct SpawnArgs {
     /// tool call, waive the taint gate, and auto-answer the agent's own prompts
     /// (`ask_user_*`, blueprint interaction points) rather than parking on the
     /// interaction hub for a person who isn't there.
+    ///
+    /// An interaction point may opt out with `unattended = "ask"`, and then it
+    /// parks anyway: the point exists precisely because auto-approving it is
+    /// the wrong answer. Such a run waits for `[limits]
+    /// interaction_timeout_secs` (default 3600) rather than forever, but from
+    /// the outside an hour of `Waiting` is indistinguishable from a hang.
     #[serde(default)]
     pub yolo: bool,
     /// Refuse this run's `seed = { command = ... }` regions (the

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ look. You do not run a build here; you write Markdown, and it ships on the next 
    ```markdown
    ---
    title: My Feature
+   description: What a reader gets from this page, in one sentence.
    group: Concepts
    group_order: 2
    order: 9
@@ -46,6 +47,10 @@ look. You do not run a build here; you write Markdown, and it ships on the next 
      number for every page in a section. Current sections: `Get started` (1), `Concepts` (2),
      `Reference` (3), `Guides` (4), `Integrations` (5).
    - `order` is the page's position within its section.
+   - `description` is one sentence, under 160 characters. It is the line beside this page's link in
+     [`llms.txt`](https://leviath.dev/llms.txt), which is how a coding agent decides whether to fetch
+     the page at all. Say what the reader gets, not what the page is called. A description that
+     restates the title costs the agent a wasted round trip.
 
 3. Write the page. You can use:
    - Fenced code blocks with a language for highlighting (```bash, ```toml, ```rhai).

--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -3,7 +3,7 @@ title: Agent catalog
 description: The ten pre-built agents Leviath ships, what each one is for, and the command to run it.
 group: Get started
 group_order: 1
-order: 2
+order: 3
 ---
 
 # Agent catalog

--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -1,5 +1,6 @@
 ---
 title: Agent catalog
+description: The ten pre-built agents Leviath ships, what each one is for, and the command to run it.
 group: Get started
 group_order: 1
 order: 2

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -1,5 +1,6 @@
 ---
 title: Agent Client Protocol
+description: Serve an agent over the Agent Client Protocol on stdio, so an editor or orchestrator can drive it as a child process.
 group: Reference
 group_order: 3
 order: 11

--- a/docs/content/agent-quickstart.md
+++ b/docs/content/agent-quickstart.md
@@ -1,0 +1,220 @@
+---
+title: Quickstart for agents
+description: A runnable path from nothing to a running, observable agent, with the JSON output and failure signals a script needs.
+group: Get started
+group_order: 1
+order: 2
+---
+
+# Quickstart for agents
+
+This page is written to be executed rather than read. Every step is a command, what its output
+means, and what to do when it fails. It suits a person in a hurry too, but it exists because
+`lev run` hands work to a background daemon, and a caller that does not know that sees a command
+return instantly and concludes nothing happened.
+
+If you are reading the docs as a person, [Getting Started](/docs/getting-started) covers the same
+ground with more explanation.
+
+```mermaid
+flowchart LR
+  A["lev --version<br/>install if absent"] --> B["lev setup<br/>--non-interactive"]
+  B --> C["lev doctor --json<br/>first failure is the diagnosis"]
+  C --> D["lev validate --json<br/>before the first run"]
+  D --> E["lev run --json<br/>returns a run_id"]
+  E --> F["lev ps --json<br/>poll until terminal"]
+```
+
+## 1. Check for an existing install
+
+```bash
+lev --version
+```
+
+If that prints a version, skip to step 2. Otherwise install by platform. Pick the first row that
+applies and do not try the others.
+
+| Platform | Command |
+|---|---|
+| macOS or Linux | `curl -fsSL https://leviath.dev/install.sh \| sh` |
+| Windows | `powershell -ExecutionPolicy Bypass -c "irm https://leviath.dev/install.ps1 \| iex"` |
+| Any, with Rust already present | `cargo install leviath-cli` |
+
+The one-liners need no Rust toolchain. Set `LEVIATH_CHANNEL` to `beta` or `alpha` to install ahead
+of stable. See [Releases and channels](/docs/releases) for what those mean.
+
+## 2. Configure a provider
+
+```bash
+lev setup --non-interactive --anthropic-key "$ANTHROPIC_API_KEY" --install-agents
+```
+
+Two things about this command are easy to get wrong.
+
+**Without `--install-agents`, non-interactive setup installs no blueprints.** The interactive wizard
+asks; the scripted path does not, so `lev run coder` then fails with nothing to run.
+
+**If your key is not Anthropic, pass `--default-model` as well.** The flags are
+`--openai-key`, `--google-key`, `--openrouter-key`, and `--ollama-url`. Setup points
+`default_provider` at whichever one you configured, but it cannot guess which of that provider's
+models you want, and a stage stating no model preference needs one:
+
+```bash
+lev setup --non-interactive \
+  --openrouter-key "$OPENROUTER_API_KEY" \
+  --default-model "deepseek/deepseek-v4-flash" \
+  --install-agents
+```
+
+Ask [`lev models list --json --all`](/docs/cli) for the model ids a provider offers.
+
+## 3. Verify with `lev doctor`
+
+```bash
+lev doctor --json
+```
+
+Four checks run in order and stop at the first failure, because that failure is the diagnosis:
+
+| Check | What it proves | If it fails |
+|---|---|---|
+| `config` | config.toml parses and a provider registry builds | Fix the file, or rerun `lev setup` |
+| `resolve` | your defaults name a provider that is registered | Set `default_provider` and `default_model` |
+| `inference` | one real API call succeeds | The provider's own error text is in `detail` |
+| `daemon` | the daemon accepts and runs a throwaway agent | Your keys are fine; the daemon is not |
+
+The reply is `{"checks": [...], "passed": bool}`, and each check carries `name`, `status`, and
+`detail`. Branch on `passed`. The command also exits non-zero on failure, so it works as a gate in a
+script that does not parse JSON.
+
+`lev doctor` bills two inferences of at most 64 output tokens. `--no-daemon` stops after check three
+and bills one.
+
+## 4. Validate a blueprint before running it
+
+```bash
+lev validate <path> --json
+```
+
+Run this before the first `lev run` of any blueprint you did not write. It catches the settings whose
+absence quietly changes what a run does: a top-level `[model]` block, which parses and is then read
+by nothing, and a stage with no model, which silently takes the host default.
+
+The report is one shape whatever happens, so you parse once and branch on `valid`:
+
+```json
+{
+  "valid": true,
+  "blueprint": { "name": "reviewer", "version": "0.0.2", "entry_stage": "discover", "stages": ["discover", "scan"] },
+  "error": null,
+  "findings": [{ "severity": "note", "code": "command-seed", "stage": null, "message": "...", "fix": "..." }],
+  "errors": 0, "warnings": 0, "notes": 0
+}
+```
+
+A manifest that did not parse fills `error` and leaves `blueprint` null. Each finding's `code` is a
+stable slug to branch on; the `message` is written to be read. Notes never fail the command, and
+`--deny-warnings` makes warnings fail it too.
+
+## 5. Spawn a run
+
+```bash
+lev run <blueprint> --task "..." --json
+```
+
+This is the step that surprises callers. `lev run` does not run the agent in your process. It hands
+it to a background [daemon](/docs/daemon) and returns immediately, so the run survives your shell
+exiting. The reply is the only handle you get on it:
+
+```json
+{
+  "run_id": "software-engineer-1785800124-c8958e7267f4",
+  "blueprint_path": "/home/you/.leviath/agents/software-engineer/agent.leviath",
+  "workdir": "/home/you/project",
+  "yolo": false
+}
+```
+
+Keep `run_id`. Everything after this needs it. Warnings go to stderr, so stdout parses on its own.
+
+Useful flags: `--workdir <dir>` confines the agent's file tools, `--model provider/model` overrides
+the blueprint's choice for every stage, and `--task` also accepts a file path.
+
+## 6. Poll until it finishes
+
+```bash
+lev ps --json
+```
+
+`runs` holds what is live and `finished` what completed recently. Each entry carries `status`,
+`stage`, `iteration`, and `wait_reason`. Poll on an interval of seconds, not milliseconds: an
+inference call takes seconds, so a faster loop only burns CPU.
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `Active` | Working | Keep polling |
+| `Idle` | Alive, with nothing queued | Keep polling |
+| `Waiting` | Blocked on an answer | Read `wait_reason`, then see step 7 |
+| `Paused` | Held by `lev pause` | `lev resume <run_id>` |
+| `Complete` | Finished | Read its output; stop polling |
+| `Error` | Errored, with a `message` | `lev context <run_id> --json` has the history |
+| `Cancelled` | Stopped by `lev cancel` | Stop polling |
+
+`Complete`, `Error`, and `Cancelled` are terminal. The rest can still change.
+
+A finished run leaves `runs` and appears in `finished` for `[limits] finished_retention_secs`
+(300 by default). A run that is in neither is older than that, not lost. `lev ps --all` also lists
+on-disk runs the daemon is not hosting.
+
+## 7. Unattended runs
+
+Add `--yolo` to approve every tool call and answer the agent's own `ask_user_*` prompts instead of
+waiting for a person. Under `--yolo` those five tools are not advertised to the model at all, so it
+decides for itself rather than spending a round trip to be told nobody is there.
+
+One exception matters, and it is the one that looks like a hang. A blueprint
+[interaction point](/docs/interaction#interaction-points) may declare `unattended = "ask"`, and then
+it holds for a person even under `--yolo`. The shipped `software-engineer` does exactly that for its
+plan approval, deliberately, because everything after that gate writes code.
+
+Such a run reports `Waiting` with a `wait_reason` of `interaction_point` and does nothing until
+`[limits] interaction_timeout_secs` expires. That defaults to one hour, so the run is not stuck, but
+for an hour it is indistinguishable from a run that is. You have three ways out:
+
+- Lower `interaction_timeout_secs` in `config.toml` so the gate releases sooner. It is read once at
+  daemon start, so change it before `lev daemon restart`.
+- Answer the question yourself. `lev respond --json` lists every open interaction with the agent
+  holding it, and `lev respond <request_id> --choice <n>` answers one.
+- Run a blueprint with no such gate. `coder` does the same work with no plan checkpoint.
+
+## 8. Choose the right surface
+
+The CLI is one of four ways in. Pick by what is calling.
+
+| You are | Use | Why |
+|---|---|---|
+| A script or coding agent at a shell | The CLI with `--json` | Everything on this page |
+| An editor or orchestrator that spawns processes | [`lev agent-client`](/docs/agent-client-protocol) | Agent Client Protocol over stdio |
+| A service that speaks HTTP | [`lev serve`](/docs/api) | REST plus a WebSocket event stream |
+| A Rust program | [the `leviath` crate](/docs/embedding) | In-process, no daemon or socket |
+
+[Where Leviath fits](/docs/integrations) goes through the tradeoffs.
+
+## When something goes wrong
+
+| Symptom | First thing to run |
+|---|---|
+| Any command behaves oddly | `lev doctor --json` |
+| A run is `Waiting` and you do not know why | `lev respond --json` |
+| A run says `Active` but nothing changes | `lev ps --json` and watch `iteration` |
+| A run is missing from `lev ps` | `lev ps --all --json` |
+| A run failed and you want the history | `lev context <run_id> --json` |
+| A blueprint behaves unlike its manifest | `lev validate <path> --json --deny-warnings` |
+
+[Troubleshooting](/docs/troubleshooting) is organised by symptom and covers the rest.
+
+## Which commands speak JSON
+
+`--json` is on `run`, `ps`, `doctor`, `validate`, `list`, `models list`, `context`, `mcp list`, and
+`respond`. Everything else prints for a person. [CLI reference](/docs/cli) has every command and
+flag.

--- a/docs/content/agent-quickstart.md
+++ b/docs/content/agent-quickstart.md
@@ -119,7 +119,7 @@ stable slug to branch on; the `message` is written to be read. Notes never fail 
 ## 5. Spawn a run
 
 ```bash
-lev run <blueprint> --task "..." --json
+lev run <blueprint> --task "..." --json --yolo
 ```
 
 This is the step that surprises callers. `lev run` does not run the agent in your process. It hands
@@ -136,6 +136,11 @@ exiting. The reply is the only handle you get on it:
 ```
 
 Keep `run_id`. Everything after this needs it. Warnings go to stderr, so stdout parses on its own.
+
+`--yolo` is in that command deliberately. Without it, most blueprints stop on the first tool call
+whose permission is `ask` and wait for a person to approve it. Nobody answers, and an hour later
+`[limits] interaction_timeout_secs` expires and denies it. If you leave `--yolo` off, you are
+committing to answering prompts yourself, which step 7 covers.
 
 Useful flags: `--workdir <dir>` confines the agent's file tools, `--model provider/model` overrides
 the blueprint's choice for every stage, and `--task` also accepts a file path.
@@ -154,7 +159,7 @@ inference call takes seconds, so a faster loop only burns CPU.
 |---|---|---|
 | `Active` | Working | Keep polling |
 | `Idle` | Alive, with nothing queued | Keep polling |
-| `Waiting` | Blocked on an answer | Read `wait_reason`, then see step 7 |
+| `Waiting` | Blocked | Read `wait_reason`, below |
 | `Paused` | Held by `lev pause` | `lev resume <run_id>` |
 | `Complete` | Finished | Read its output; stop polling |
 | `Error` | Errored, with a `message` | `lev context <run_id> --json` has the history |
@@ -162,15 +167,46 @@ inference call takes seconds, so a faster loop only burns CPU.
 
 `Complete`, `Error`, and `Cancelled` are terminal. The rest can still change.
 
+`Waiting` is the one that needs care, because two very different things share it. `wait_reason` is
+an object with a `reason` key:
+
+| `wait_reason.reason` | Needs a person | What to do |
+|---|---|---|
+| `fan_out_workers` | No | Nothing. `outstanding` counts the workers still going |
+| `children` | No | Nothing. Sub-agents are running |
+| `tool_approval` | Yes | Approve it, or use `--yolo`. See step 7 |
+| `user_prompt` | Yes | The agent asked a question. See step 7 |
+| `interaction_point` | Yes | A blueprint checkpoint. See step 7 |
+| `taint_gate` | Yes | A clearance prompt. See step 7 |
+
+The first two resolve on their own and are healthy. The rest are stopped until somebody answers, and
+a caller that treats them as healthy waits out the timeout for nothing.
+
 A finished run leaves `runs` and appears in `finished` for `[limits] finished_retention_secs`
 (300 by default). A run that is in neither is older than that, not lost. `lev ps --all` also lists
 on-disk runs the daemon is not hosting.
 
-## 7. Unattended runs
+## 7. Unattended runs, and answering when you are not one
 
-Add `--yolo` to approve every tool call and answer the agent's own `ask_user_*` prompts instead of
+`--yolo` approves every tool call and answers the agent's own `ask_user_*` prompts instead of
 waiting for a person. Under `--yolo` those five tools are not advertised to the model at all, so it
-decides for itself rather than spending a round trip to be told nobody is there.
+decides for itself rather than spending a round trip to be told nobody is there. That clears
+`tool_approval`, `user_prompt`, and `taint_gate`.
+
+Without `--yolo`, you answer them. `lev respond --json` lists every open question with the run
+holding it, its kind, and its options:
+
+```bash
+lev respond --json
+lev respond <request_id> --approve            # a tool approval or a confirm
+lev respond <request_id> --approve --session  # and every later call to that tool
+lev respond <request_id> --deny
+lev respond <request_id> --choice 0           # a multiple-choice question
+lev respond <request_id> "some text"          # a free-text question
+```
+
+A prompt nobody answers is not held forever. `[limits] interaction_timeout_secs` expires it, and an
+expired tool approval is **denied**: a timeout is never read as consent.
 
 One exception matters, and it is the one that looks like a hang. A blueprint
 [interaction point](/docs/interaction#interaction-points) may declare `unattended = "ask"`, and then

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -1,5 +1,6 @@
 ---
 title: Agent blueprints
+description: The agent.leviath blueprint format: the TOML defining an agent's stages, models, tools, and context layout.
 group: Concepts
 group_order: 2
 order: 3

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -1,5 +1,6 @@
 ---
 title: HTTP API
+description: Every REST route and WebSocket stream `lev serve` exposes, with its auth model and payload shapes.
 group: Reference
 group_order: 3
 order: 2

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -1,5 +1,6 @@
 ---
 title: CLI reference
+description: Every `lev` command and flag, what each does, and when you need it.
 group: Reference
 group_order: 3
 order: 3

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -1,5 +1,6 @@
 ---
 title: Where Leviath sits
+description: Where Leviath sits among other agent tools, and which are worth running alongside it rather than instead of it.
 group: Get started
 group_order: 1
 order: 3

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -3,7 +3,7 @@ title: Where Leviath sits
 description: Where Leviath sits among other agent tools, and which are worth running alongside it rather than instead of it.
 group: Get started
 group_order: 1
-order: 3
+order: 4
 ---
 
 # Where Leviath sits

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: Every key in ~/.leviath/config.toml, with its type and default.
 group: Reference
 group_order: 3
 order: 1

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -1,5 +1,6 @@
 ---
 title: Structured context
+description: How structured context regions keep an agent coherent across hundreds of tool calls, where a flat message list drifts.
 group: Concepts
 group_order: 2
 order: 4

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -1,5 +1,6 @@
 ---
 title: The daemon
+description: The background daemon that owns every run, so agents survive a closed terminal and share one process.
 group: Concepts
 group_order: 2
 order: 1

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -1,5 +1,6 @@
 ---
 title: Dashboard
+description: The `lev dash` terminal UI for watching a fleet of runs, answering their questions, and steering them.
 group: Guides
 group_order: 4
 order: 1

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -1,5 +1,6 @@
 ---
 title: Embedding
+description: Run the Leviath runtime inside your own Rust process with the leviath crate, with no CLI, daemon, or config file.
 group: Reference
 group_order: 3
 order: 13

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -1,5 +1,6 @@
 ---
 title: ECS engine
+description: The ECS engine that keeps each agent as a row of data, so an agent that is waiting costs almost nothing.
 group: Concepts
 group_order: 2
 order: 2

--- a/docs/content/gas-city.md
+++ b/docs/content/gas-city.md
@@ -1,5 +1,6 @@
 ---
 title: Gas City
+description: Wiring Leviath into Gas City as the agent backend behind its orchestration.
 group: Integrations
 group_order: 5
 order: 2

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install Leviath, configure a provider, and run your first agent, in four steps.
 group: Get started
 group_order: 1
 order: 1

--- a/docs/content/glossary.md
+++ b/docs/content/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+description: Every term the Leviath docs use in a particular way, defined in one place.
 group: Guides
 group_order: 4
 order: 3

--- a/docs/content/integrations.md
+++ b/docs/content/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Where Leviath fits
+description: The four ways to drive Leviath from a tool you already use, and how to choose between them.
 group: Integrations
 group_order: 5
 order: 1

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -1,5 +1,6 @@
 ---
 title: Human-in-the-loop
+description: The three ways a person gets involved in a run: agent-raised questions, tool approvals, and blueprint interaction points.
 group: Concepts
 group_order: 2
 order: 7

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -177,6 +177,11 @@ before any code is written - and the prompt opens even under `--yolo`. The shipp
 [`interaction_timeout_secs`](/docs/configuration#limits), so an unanswered gate releases on its own
 terms instead of waiting for ever.
 
+Know what that looks like before you meet it. A `--yolo` run holding an `ask` gate reports
+`Waiting` in `lev ps`, with a wait reason of `interaction_point`, and does nothing until the timeout
+expires. The default timeout is one hour, so the run is not stuck, but for that hour it is
+indistinguishable from a run that is. `lev respond --json` lists the question it is holding.
+
 > [!WARNING]
 > The revise and edit loops are bounded: after 4 revision rounds at a single point (`MAX_REVISION_ROUNDS`),
 > the stage proceeds regardless, so a revise/edit loop can never run forever.

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -1,5 +1,6 @@
 ---
 title: MCP tool servers
+description: Connect Leviath to Model Context Protocol servers over stdio or HTTP, giving agents tools beyond the built-ins.
 group: Reference
 group_order: 3
 order: 5

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -1,5 +1,6 @@
 ---
 title: Observability
+description: Export traces, metrics, and logs over OpenTelemetry so your dashboards can answer which run is stuck.
 group: Reference
 group_order: 3
 order: 12

--- a/docs/content/packaging.md
+++ b/docs/content/packaging.md
@@ -1,5 +1,6 @@
 ---
 title: Packaging blueprints
+description: Bundle a blueprint into a .leviath-bundle, install one, and share it without a hosted registry.
 group: Guides
 group_order: 4
 order: 4

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -1,5 +1,6 @@
 ---
 title: Providers
+description: Configure Anthropic, OpenAI, Google, OpenRouter, or a local Ollama, and choose which model each stage uses.
 group: Reference
 group_order: 3
 order: 6

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -1,5 +1,6 @@
 ---
 title: Releases and channels
+description: How the alpha, beta, and stable channels work, and why stable ships the byte-for-byte alpha build.
 group: Guides
 group_order: 4
 order: 5

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -1,5 +1,6 @@
 ---
 title: Rhai providers
+description: Teach Leviath any HTTP model API with a Rhai script, without waiting for it to be added upstream.
 group: Reference
 group_order: 3
 order: 8

--- a/docs/content/rhai-regions.md
+++ b/docs/content/rhai-regions.md
@@ -1,5 +1,6 @@
 ---
 title: Rhai regions
+description: Write a context region's behaviour in Rhai when none of the built-in kinds does what you want.
 group: Reference
 group_order: 3
 order: 9

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -1,5 +1,6 @@
 ---
 title: Rhai tools & policy rules
+description: Declare new agent tools in Rhai, and write policy rules deciding whether a tool call may fire.
 group: Reference
 group_order: 3
 order: 10

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -1,5 +1,6 @@
 ---
 title: Rhai scripting
+description: Why Leviath embeds the Rhai scripting language, and what you can extend with it.
 group: Reference
 group_order: 3
 order: 7

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -1,5 +1,6 @@
 ---
 title: Security & sandboxing
+description: Sandboxed execution, tool permissions, and taint tracking, for running a blueprint you did not write.
 group: Concepts
 group_order: 2
 order: 8

--- a/docs/content/smithy.md
+++ b/docs/content/smithy.md
@@ -1,5 +1,6 @@
 ---
 title: Smithy
+description: How Leviath relates to Smithy, and why Smithy has no documented agent-backend seam today.
 group: Integrations
 group_order: 5
 order: 3

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -1,5 +1,6 @@
 ---
 title: Multi-stage workflows
+description: Split an agent into stages so each phase of a task gets its own model, tools, and context.
 group: Concepts
 group_order: 2
 order: 5

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -1,5 +1,6 @@
 ---
 title: Sub-agents & fan-out
+description: Start child agents and fan work out across them, so many small jobs run at once.
 group: Concepts
 group_order: 2
 order: 6

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -1,5 +1,6 @@
 ---
 title: Built-in tools
+description: The built-in tool catalog every agent can advertise, and how a stage decides which ones the model may call.
 group: Reference
 group_order: 3
 order: 4

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Common snags organised by symptom, starting with what `lev doctor` tells you.
 group: Guides
 group_order: 4
 order: 2

--- a/docs/content/work-queues.md
+++ b/docs/content/work-queues.md
@@ -1,5 +1,6 @@
 ---
 title: External work queues
+description: How an external work queue should ask whether a run is still going, without leaking slots or cancelling live work.
 group: Integrations
 group_order: 5
 order: 4

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -1,0 +1,480 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://leviath.dev/docs/stable/blueprint.schema.json",
+  "title": "Leviath agent blueprint (agent.leviath)",
+  "description": "The TOML manifest defining a Leviath agent: its stages, the model each one runs on, the tools it may call, and the shape of its context. Written against the parser in crates/leviath-core/src/manifest.rs, and checked against every bundled blueprint by a test in crates/leviath-cli/src/bundled.rs. See https://leviath.dev/docs/agents.",
+  "type": "object",
+  "required": ["agent"],
+  "additionalProperties": false,
+  "properties": {
+    "agent": { "$ref": "#/$defs/agent" },
+    "stages": {
+      "type": "object",
+      "description": "One entry per stage, keyed by stage name.",
+      "additionalProperties": { "$ref": "#/$defs/stage" }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "regions": {
+          "type": "object",
+          "description": "One entry per context region, keyed by region name.",
+          "additionalProperties": { "$ref": "#/$defs/region" }
+        },
+        "file_tracking": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "region": { "type": "string", "default": "files" },
+            "track_reads": { "type": "boolean", "default": true },
+            "track_writes": { "type": "boolean", "default": true },
+            "max_file_tokens": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "tool_permissions": { "$ref": "#/$defs/toolPermissions" },
+    "security": {
+      "type": "object",
+      "description": "Taint tracking for this blueprint. A machine-wide ceiling still applies.",
+      "properties": { "taint_tracking": { "type": "boolean" } }
+    },
+    "sandbox": { "$ref": "#/$defs/sandbox" },
+    "read_paths": {
+      "type": "object",
+      "description": "Paths outside the workdir this agent may read. Inert until the host grants them under [agent_read_paths] in config.toml.",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "An exact path (granting its subtree), `glob:<pattern>`, or `regex:<pattern>` (auto-anchored). `~/` expands; a relative path resolves against the workdir."
+          }
+        }
+      }
+    },
+    "compaction": {
+      "type": "object",
+      "description": "The model that summarizes a compacting region. Skipped without error when its provider is not registered, so a run on another provider loses compaction rather than failing.",
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string" },
+        "model": { "type": "string" },
+        "system_prompt": { "type": "string" },
+        "max_summary_tokens": { "type": "integer", "minimum": 1 },
+        "temperature": { "type": "number" }
+      }
+    },
+    "repetition_detection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "max_repeat_calls": { "type": "integer", "minimum": 1 },
+        "max_readonly_streak": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "transforms": {
+      "type": "array",
+      "description": "How context maps when one blueprint hands off to another.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "from_blueprint": { "type": "string" },
+          "to_blueprint": { "type": "string" },
+          "mappings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "from_region": { "type": "string" },
+                "to_region": { "type": "string" },
+                "transform": { "enum": ["direct", "summarize", "extract"] },
+                "fields": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "default": "unnamed" },
+        "version": { "type": "string", "default": "0.1.0" },
+        "description": { "type": "string", "default": "" },
+        "entry_stage": {
+          "type": "string",
+          "description": "The stage a run starts in. Defaults to the first stage declared."
+        },
+        "max_child_depth": { "type": "integer", "minimum": 0 },
+        "dynamic_tools": { "type": "boolean", "default": false },
+        "batch_tool_hint": { "type": "boolean" },
+        "shell_hint": { "type": "boolean" },
+        "nudge": { "$ref": "#/$defs/nudge" }
+      }
+    },
+
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "description": "How the stage runs. `interactive_points` holds at each declared interaction point.",
+          "enum": [
+            "autonomous",
+            "interactive",
+            "interactive_points",
+            "fan_out",
+            "fan_out_merge"
+          ]
+        },
+        "description": { "type": "string" },
+        "system_prompt": { "type": "string" },
+        "transition_prompt": { "type": "string" },
+        "available_tools": {
+          "type": "array",
+          "description": "The only tools the model is offered here. Anything absent is refused at dispatch.",
+          "items": { "type": "string" }
+        },
+        "required_tools": {
+          "type": "array",
+          "description": "Tools this stage cannot work without. Every entry must also appear in available_tools. Survives an unattended run, where the blocking interaction tools are otherwise withheld.",
+          "items": { "type": "string" }
+        },
+        "max_iterations": { "type": "integer", "minimum": 1 },
+        "max_revisits": { "type": "integer", "minimum": 0 },
+        "requires_children": { "type": "boolean", "default": false },
+        "allow_complete": { "type": "boolean", "default": false },
+        "allow_as_worker": { "type": "boolean", "default": false },
+        "accepts_messages": { "type": "boolean", "default": true },
+        "allow_blocking_tools": { "type": "boolean", "default": false },
+        "batch_tool_hint": { "type": "boolean" },
+        "shell_hint": { "type": "boolean" },
+        "model": { "$ref": "#/$defs/modelConfig" },
+        "nudge": { "$ref": "#/$defs/nudge" },
+        "sandbox": { "$ref": "#/$defs/sandbox" },
+        "security": { "type": "object" },
+        "tool_permissions": { "$ref": "#/$defs/toolPermissions" },
+        "tool_routing": {
+          "type": "object",
+          "description": "Where a tool result lands in context.",
+          "additionalProperties": false,
+          "properties": {
+            "default_region": { "type": "string" },
+            "persist": { "type": "boolean" },
+            "max_result_tokens": { "type": "integer", "minimum": 1 },
+            "overrides": {
+              "type": "object",
+              "description": "Tool name to region name.",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "regions": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/region" }
+            }
+          }
+        },
+        "transitions": {
+          "type": "object",
+          "description": "Outgoing edges, keyed by target stage name. An empty table marks a terminal stage.",
+          "additionalProperties": { "$ref": "#/$defs/transition" }
+        },
+        "interaction_points": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/interactionPoint" }
+        },
+        "on_worker_failure": { "enum": ["continue", "abort"] },
+        "max_workers": { "type": "integer", "minimum": 1 },
+        "worker_agent": { "type": "string" },
+        "worker_stage": { "type": "string" },
+        "worker_query": { "type": "string" },
+        "merge_stage": { "type": "string" },
+        "split_prompt": { "type": "string" }
+      }
+    },
+
+    "modelConfig": {
+      "type": "object",
+      "description": "Which model this stage runs on. `models` is an ordered fallback list: the first entry whose provider is registered wins.",
+      "additionalProperties": false,
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/modelEntry" }
+        },
+        "provider": {
+          "type": "string",
+          "description": "Back-compat shorthand for a single-entry `models` list."
+        },
+        "model": {
+          "type": "string",
+          "description": "Back-compat shorthand, paired with `provider`."
+        },
+        "fallbacks": {
+          "type": "array",
+          "description": "Back-compat: folded onto the end of `models`.",
+          "items": { "$ref": "#/$defs/modelEntry" }
+        },
+        "allow_user_default": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the host's default model may be used when nothing listed is registered."
+        },
+        "request_timeout_secs": { "type": "integer", "minimum": 1 },
+        "parameters": {
+          "type": "object",
+          "description": "Passed to the provider verbatim, so the accepted keys are the provider's.",
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "modelEntry": {
+      "type": "object",
+      "required": ["provider", "model"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "A registered provider name. The built-ins are anthropic, openai, google, openrouter, ollama, and claude-code; a Rhai provider resolves by its script name."
+        },
+        "model": {
+          "type": "string",
+          "description": "Passed to the provider verbatim and never validated locally, so a typo surfaces on the first live call."
+        }
+      }
+    },
+
+    "region": {
+      "type": "object",
+      "description": "One region of the context window. Budgets are ceilings, not allocations, and may sum past 100%.",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "description": "Omitted means `temporary`. An unrecognised value is a hard parse error.",
+          "enum": [
+            "temporary",
+            "pinned",
+            "sliding_window",
+            "compacting",
+            "compact_history",
+            "clearable",
+            "hashmap",
+            "hash_map",
+            "custom"
+          ]
+        },
+        "budget": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?%$",
+          "description": "A percentage of the window, as a string such as \"35%\"."
+        },
+        "max_tokens": { "type": "integer", "minimum": 1, "default": 5000 },
+        "min_tokens": { "type": "integer", "minimum": 0 },
+        "required": { "type": "boolean", "default": false },
+        "required_message": {
+          "type": "string",
+          "description": "Shown when a required region is empty. `{region}` interpolates."
+        },
+        "seed": { "$ref": "#/$defs/regionSeed" },
+        "max_items": { "type": "integer", "minimum": 1, "default": 10 },
+        "strategy": { "enum": ["per_item", "bulk", "compact"] },
+        "overflow": { "type": "integer", "minimum": 0 },
+        "compact_count": { "type": "integer", "minimum": 1 },
+        "compact_at": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?%$" },
+        "threshold_tokens": { "type": "integer", "minimum": 1 },
+        "source_region": { "type": "string" },
+        "max_entries": { "type": "integer", "minimum": 1 },
+        "script": {
+          "type": "string",
+          "description": "For `kind = \"custom\"`: the Rhai script under context_hooks/."
+        },
+        "persistent": { "type": "boolean" }
+      }
+    },
+
+    "regionSeed": {
+      "description": "What fills the region at spawn. The table form is checked key by key in the order below, so the first one present wins.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A caller-input key, such as \"task\", filled from --task or a --<region> flag."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "glob": {
+              "type": "string",
+              "description": "Concatenated contents of the workdir files matching this pattern."
+            },
+            "files": {
+              "type": "array",
+              "description": "Concatenated contents of these workdir-relative paths.",
+              "items": { "type": "string" }
+            },
+            "literal": {
+              "type": "string",
+              "description": "Verbatim text baked into the blueprint."
+            },
+            "rhai": {
+              "type": "string",
+              "description": "A Rhai script in the workdir whose returned String fills the region."
+            },
+            "command": {
+              "type": "string",
+              "description": "A shell command run at spawn. The only seed that executes anything, and it runs before the first inference and so before any approval prompt. Gated by [security] allow_seed_commands and --no-seed-commands."
+            },
+            "caller": {
+              "type": "string",
+              "description": "The caller-input key to fill from, the table form of the plain string."
+            }
+          }
+        }
+      ]
+    },
+
+    "transition": {
+      "type": "object",
+      "description": "One outgoing edge. A `hint` with no `condition` implies `llm_choice`.",
+      "additionalProperties": false,
+      "properties": {
+        "hint": {
+          "type": "string",
+          "description": "Told to the model when it is choosing where to go next."
+        },
+        "condition": {
+          "description": "An unrecognised value is a hard parse error.",
+          "enum": ["always", "llm_choice", "error", "max_iterations", "stuck"]
+        },
+        "transform": {
+          "description": "What happens to context on this edge. `custom` reads transform_config. Anything else is a hard parse error rather than a silent downgrade to `direct`.",
+          "enum": ["direct", "clear", "compact", "summarize", "custom"]
+        },
+        "transform_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "carry": { "type": "array", "items": { "type": "string" } },
+            "compact": { "type": "array", "items": { "type": "string" } },
+            "clear": { "type": "array", "items": { "type": "string" } },
+            "compact_prompt": { "type": "string" }
+          }
+        },
+        "gate": {
+          "type": "object",
+          "description": "A condition the stage must satisfy before this edge may be taken.",
+          "additionalProperties": false,
+          "properties": {
+            "require_modifications": { "type": "boolean" },
+            "message": { "type": "string" },
+            "region": { "type": "string" },
+            "tools": { "type": "array", "items": { "type": "string" } },
+            "max_attempts": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "stuck_after_iterations": { "type": "integer" },
+        "stuck_after_minutes": { "type": "integer" },
+        "stuck_after_same_file_edits": { "type": "integer" },
+        "stuck_after_tool_calls": { "type": "integer" }
+      }
+    },
+
+    "interactionPoint": {
+      "type": "object",
+      "description": "A checkpoint the runtime raises at the stage boundary, every time, rather than one the model chooses to raise.",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "prompt": { "type": "string" },
+        "required": { "type": "boolean", "default": true },
+        "unattended": {
+          "description": "What a --yolo run does here. `auto_approve` (the default) resolves it without asking. `ask` holds for a person even unattended, and the run then waits for [limits] interaction_timeout_secs.",
+          "enum": ["ask", "auto_approve"]
+        },
+        "style": { "enum": ["free_text", "multiple_choice", "confirm"] },
+        "options": { "type": "array", "items": { "type": "string" } },
+        "choices": {
+          "type": "array",
+          "description": "Alias for `options`.",
+          "items": { "type": "string" }
+        },
+        "directives": {
+          "type": "object",
+          "description": "Option text to the instruction added when it is picked.",
+          "additionalProperties": { "type": "string" }
+        },
+        "followups": {
+          "type": "object",
+          "description": "Alias for `directives`.",
+          "additionalProperties": { "type": "string" }
+        },
+        "abort_options": {
+          "type": "array",
+          "description": "Options that end the run immediately, with no further inference.",
+          "items": { "type": "string" }
+        },
+        "edit_options": {
+          "type": "array",
+          "description": "Options that open the document for the user to edit directly.",
+          "items": { "type": "string" }
+        },
+        "document_region": {
+          "type": "string",
+          "description": "The pinned region holding what this point is about. Replaced with the current text each time the point is presented."
+        }
+      }
+    },
+
+    "toolPermissions": {
+      "type": "object",
+      "description": "Tool name to policy. May only tighten the machine-wide ceiling in config.toml, never loosen it. `ask` blocks until answered.",
+      "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+    },
+
+    "sandbox": {
+      "type": "object",
+      "description": "Where tools execute. An agent and a stage resolve to the stronger of the pair.",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "enum": ["none", "namespace", "container"] },
+        "image": { "type": "string" },
+        "engine": { "enum": ["docker", "podman", "nerdctl", "finch"] },
+        "network": { "type": "boolean" },
+        "mount": { "type": "array", "items": { "type": "string" } },
+        "mounts": { "type": "array", "items": { "type": "string" } },
+        "persist": { "type": "boolean" },
+        "on_unavailable": { "enum": ["error", "warn"] }
+      }
+    },
+
+    "nudge": {
+      "type": "object",
+      "description": "What to say to a stage that has gone quiet. Cascades stage over agent over config.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "max": { "type": "integer", "minimum": 0 },
+        "text": {
+          "type": "string",
+          "description": "`{stage}` and `{regions}` interpolate."
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -1,0 +1,136 @@
+# A config.toml exercising every section, as the fixture behind two checks:
+# it must satisfy config.schema.json, and it must deserialize into `Config`.
+# One of those alone would let the schema and the struct drift apart.
+#
+# Not a recommended configuration. Nothing here is required, and a real install
+# with one provider key needs almost none of it.
+
+default_provider = "anthropic"
+default_model = "claude-sonnet-5"
+agent_paths = ["~/work/agents"]
+openrouter_api_key = "sk-or-example"
+ollama_base_url = "http://localhost:11434"
+request_timeout_secs = 600
+taint_tracking = false
+batch_tool_hint = true
+shell_hint = true
+allow = ["read_file"]
+
+[providers]
+anthropic_api_key = "sk-ant-example"
+openai_api_key = "sk-example"
+google_api_key = "AIza-example"
+claude_code_enabled = false
+claude_code_binary = "/usr/local/bin/claude"
+claude_code_effort = "medium"
+fallback_order = ["anthropic/claude-sonnet-5", "openai/gpt-5.4-mini"]
+
+[limits]
+max_concurrent_inferences = 8
+max_concurrent_tools = 8
+default_max_iterations = 50
+exact_token_counting = false
+script_shell_timeout_secs = 60
+stall_timeout_secs = 60
+dead_cycles_before_relief = 10
+finished_retention_secs = 300
+wedge_timeout_secs = 0
+provider_failures_before_open = 3
+provider_circuit_cooldown_secs = 300
+interaction_timeout_secs = 3600
+
+[security]
+allow_seed_commands = true
+allow_local_network = false
+allow_env_vars = ["MY_BUILD_TOKEN"]
+allow_blueprint_read_paths = false
+read_paths = ["~/reference"]
+credential_store = "file"
+
+[webhook]
+max_retries = 3
+base_delay_ms = 500
+max_delay_ms = 30000
+timeout_secs = 10
+
+[observability]
+enabled = false
+exporter = "otlp"
+endpoint = "http://localhost:4318"
+service_name = "leviath"
+
+[nudge]
+enabled = true
+max = 3
+text = "You are in {stage} and have not written to {regions}."
+
+[title]
+enabled = true
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[sandbox]
+kind = "none"
+image = "debian:stable-slim"
+engine = "docker"
+network = false
+mounts = ["/opt/toolchain:ro"]
+persist = false
+on_unavailable = "error"
+
+[tool_permissions]
+read_file = "allow"
+write_file = "ask"
+shell = "ask"
+
+[agent_tool_permissions.coder]
+shell = "allow"
+
+[tool_script_permissions]
+http_get = "inherit"
+http_post = "deny"
+shell = "inherit"
+read_file = "inherit"
+write_file = "inherit"
+env_var = "deny"
+
+[agent_read_paths.reviewer]
+allow = ["~/reference", "glob:~/schemas/**/*.json"]
+
+[rate_limits.anthropic]
+requests_per_minute = 50
+tokens_per_minute = 100000
+
+[model_capabilities."my-local-llama"]
+supports_temperature = true
+supports_streaming = true
+supports_tools = false
+supports_system_prompt = true
+max_context_tokens = 32768
+max_output_tokens = 4096
+
+[model_providers.groq]
+script = "groq.rhai"
+api_key = "gsk-example"
+base_url = "https://api.groq.com/openai/v1"
+
+[model_providers.groq.rate_limit]
+requests_per_minute = 30
+tokens_per_minute = 60000
+
+[[mcp_servers]]
+name = "filesystem"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+
+[mcp_servers.env]
+NODE_ENV = "production"
+
+[[mcp_servers]]
+name = "remote"
+transport = "http"
+url = "https://mcp.example.com/v1"
+
+[mcp_servers.headers]
+Authorization = "Bearer ${MY_MCP_TOKEN}"

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://leviath.dev/docs/stable/config.schema.json",
+  "title": "Leviath machine configuration (config.toml)",
+  "description": "Machine-wide settings, at ~/.leviath/config.toml (or wherever LEVIATH_HOME or LEVIATH_CONFIG_PATH points). Everything is optional: an install with one provider key needs nothing else. Written against the serde structs in crates/leviath-cli/src/config.rs and checked against a golden config by a test there. See https://leviath.dev/docs/configuration.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "default_provider": {
+      "type": "string",
+      "default": "anthropic",
+      "description": "Which provider a stage falls back to when it states no preference of its own. `lev setup` points this at a provider you configured; leaving it on one you did not is what makes `lev doctor` report a resolve failure."
+    },
+    "default_model": {
+      "type": "string",
+      "description": "The model to pair with default_provider. Without it a stage naming no model falls through to a hard-coded last resort, which fails on a machine with no Anthropic key."
+    },
+    "agent_paths": {
+      "type": "array",
+      "description": "Extra directories to scan for blueprints. Read by `lev list` and the serve API, but not by `lev run <name>`, which resolves installed names and paths only.",
+      "items": { "type": "string" }
+    },
+    "openrouter_api_key": { "type": "string" },
+    "ollama_base_url": { "type": "string", "default": "http://localhost:11434" },
+    "request_timeout_secs": { "type": "integer", "minimum": 1 },
+    "taint_tracking": { "type": "boolean", "default": false },
+    "batch_tool_hint": { "type": "boolean", "default": true },
+    "shell_hint": { "type": "boolean", "default": true },
+    "allow": {
+      "type": "array",
+      "description": "Tools allowed outright, the config-file form of repeated --allow.",
+      "items": { "type": "string" }
+    },
+
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "anthropic_api_key": { "type": "string" },
+        "openai_api_key": { "type": "string" },
+        "google_api_key": { "type": "string" },
+        "claude_code_enabled": { "type": "boolean", "default": false },
+        "claude_code_binary": { "type": "string" },
+        "claude_code_effort": {
+          "enum": ["low", "medium", "high", "xhigh", "max"]
+        },
+        "fallback_order": {
+          "type": "array",
+          "description": "Host-wide failover chain, best first, as \"provider/model\" strings. Tried after the blueprint's own list.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "limits": {
+      "type": "object",
+      "description": "The daemon reads these once at startup, so a change needs `lev daemon restart`.",
+      "additionalProperties": false,
+      "properties": {
+        "max_concurrent_inferences": { "type": "integer", "minimum": 1, "default": 8 },
+        "max_concurrent_tools": { "type": "integer", "minimum": 1, "default": 8 },
+        "default_max_iterations": { "type": "integer", "minimum": 1, "default": 50 },
+        "exact_token_counting": { "type": "boolean", "default": false },
+        "script_shell_timeout_secs": { "type": "integer", "minimum": 0, "default": 60 },
+        "stall_timeout_secs": { "type": "integer", "minimum": 0, "default": 60 },
+        "dead_cycles_before_relief": { "type": "integer", "minimum": 0, "default": 10 },
+        "finished_retention_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 300,
+          "description": "How long a finished run stays in the `finished` list of `lev ps`."
+        },
+        "wedge_timeout_secs": { "type": "integer", "minimum": 0, "default": 0 },
+        "provider_failures_before_open": { "type": "integer", "minimum": 1, "default": 3 },
+        "provider_circuit_cooldown_secs": { "type": "integer", "minimum": 0, "default": 300 },
+        "interaction_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 3600,
+          "description": "How long a prompt waits for a person before resolving as cancelled. `0` waits forever. This is what releases an interaction point that holds under --yolo, so the default means such a run sits for an hour looking dead."
+        }
+      }
+    },
+
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow_seed_commands": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether a blueprint's `seed = { command = ... }` regions may run. They execute at spawn, before any approval prompt."
+        },
+        "allow_local_network": { "type": "boolean", "default": false },
+        "allow_env_vars": {
+          "type": "array",
+          "description": "Credential-looking variables a Rhai script may read. Matched exactly and case-insensitively; \"*\" means a variable literally named `*`, not everything.",
+          "items": { "type": "string" }
+        },
+        "allow_blueprint_read_paths": { "type": "boolean", "default": false },
+        "read_paths": { "type": "array", "items": { "type": "string" } },
+        "credential_store": { "enum": ["file", "keychain"], "default": "file" }
+      }
+    },
+
+    "webhook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_retries": { "type": "integer", "minimum": 0, "default": 3 },
+        "base_delay_ms": { "type": "integer", "minimum": 0, "default": 500 },
+        "max_delay_ms": { "type": "integer", "minimum": 0, "default": 30000 },
+        "timeout_secs": { "type": "integer", "minimum": 1, "default": 10 }
+      }
+    },
+
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "exporter": { "enum": ["otlp", "stdout", "none"] },
+        "endpoint": {
+          "type": "string",
+          "description": "OTLP over HTTP/protobuf only. The gRPC port 4317 will not work."
+        },
+        "service_name": { "type": "string" }
+      }
+    },
+
+    "nudge": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "max": { "type": "integer", "minimum": 0 },
+        "text": { "type": "string" }
+      }
+    },
+
+    "title": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "provider": { "type": "string" },
+        "model": { "type": "string" }
+      }
+    },
+
+    "sandbox": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "enum": ["none", "namespace", "container"] },
+        "image": { "type": "string" },
+        "engine": { "enum": ["docker", "podman", "nerdctl", "finch"] },
+        "network": { "type": "boolean" },
+        "mounts": { "type": "array", "items": { "type": "string" } },
+        "persist": { "type": "boolean" },
+        "on_unavailable": { "enum": ["error", "warn"] }
+      }
+    },
+
+    "tool_permissions": {
+      "type": "object",
+      "description": "Tool name to policy, machine-wide. A blueprint may tighten this, never loosen it.",
+      "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+    },
+
+    "agent_tool_permissions": {
+      "type": "object",
+      "description": "Per-agent overrides, keyed by agent name. The escape hatch above the machine-wide ceiling.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+      }
+    },
+
+    "tool_script_permissions": {
+      "type": "object",
+      "description": "What a Rhai tool script may do. `inherit` defers to the equivalent built-in tool's policy.",
+      "additionalProperties": false,
+      "properties": {
+        "http_get": { "$ref": "#/$defs/scriptPermission" },
+        "http_post": { "$ref": "#/$defs/scriptPermission" },
+        "shell": { "$ref": "#/$defs/scriptPermission" },
+        "read_file": { "$ref": "#/$defs/scriptPermission" },
+        "write_file": { "$ref": "#/$defs/scriptPermission" },
+        "env_var": { "$ref": "#/$defs/scriptPermission" }
+      }
+    },
+
+    "agent_read_paths": {
+      "type": "object",
+      "description": "Read grants outside the workdir, keyed by agent name. A blueprint's [read_paths] is inert until granted here.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allow": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+
+    "rate_limits": {
+      "type": "object",
+      "description": "Keyed by built-in provider name.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "requests_per_minute": { "type": "integer", "minimum": 1 },
+          "tokens_per_minute": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+
+    "model_capabilities": {
+      "type": "object",
+      "description": "Keyed by model id. Overrides what Leviath believes about a model.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "supports_temperature": { "type": "boolean" },
+          "supports_streaming": { "type": "boolean" },
+          "supports_tools": { "type": "boolean" },
+          "supports_system_prompt": { "type": "boolean" },
+          "max_context_tokens": { "type": "integer", "minimum": 1 },
+          "max_output_tokens": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+
+    "model_providers": {
+      "type": "object",
+      "description": "Overrides for Rhai script providers, keyed by the name an agent references. Any key not listed here is forwarded verbatim to the script's initialize().",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "script": { "type": "string" },
+          "api_key": { "type": "string" },
+          "base_url": { "type": "string" },
+          "rate_limit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "requests_per_minute": { "type": "integer", "minimum": 1 },
+              "tokens_per_minute": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+
+    "mcp_servers": {
+      "type": "array",
+      "description": "MCP tool servers to connect to. `${VAR}` interpolates in headers and env.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "transport": {
+            "enum": ["stdio", "http"],
+            "description": "Inferred from whichever of command or url is present when omitted."
+          },
+          "url": { "type": "string" },
+          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "scriptPermission": { "enum": ["allow", "deny", "inherit"] }
+  }
+}

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1,0 +1,525 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Leviath HTTP API",
+    "version": "0.1.2",
+    "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
+    "license": { "name": "MIT" }
+  },
+  "servers": [{ "url": "http://127.0.0.1:3000", "description": "The default `lev serve` bind." }],
+  "security": [{ "bearerAuth": [] }],
+  "tags": [
+    { "name": "blueprints" },
+    { "name": "agents" },
+    { "name": "interactions" },
+    { "name": "mcp" },
+    { "name": "config" },
+    { "name": "diagnostics" },
+    { "name": "events" }
+  ],
+  "paths": {
+    "/api/blueprints": {
+      "get": {
+        "tags": ["blueprints"],
+        "summary": "List installed blueprints",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "post": {
+        "tags": ["blueprints"],
+        "summary": "Install a blueprint from a manifest string",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "manifest"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "manifest": { "type": "string", "description": "The agent.leviath text." }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/blueprints/validate": {
+      "post": {
+        "tags": ["blueprints"],
+        "summary": "Validate a manifest without installing it",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["manifest"],
+                "properties": { "manifest": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The verdict. Note an invalid manifest is still a 200 with `valid: false`.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ValidateResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/blueprints/{name}": {
+      "parameters": [{ "$ref": "#/components/parameters/Name" }],
+      "get": {
+        "tags": ["blueprints"],
+        "summary": "Fetch one blueprint",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "put": {
+        "tags": ["blueprints"],
+        "summary": "Replace a blueprint's manifest",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "delete": {
+        "tags": ["blueprints"],
+        "summary": "Uninstall a blueprint",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents": {
+      "get": {
+        "tags": ["agents"],
+        "summary": "List runs",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Filter to one status."
+          }
+        ],
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "post": {
+        "tags": ["agents"],
+        "summary": "Spawn a run",
+        "description": "Returns as soon as the daemon accepts the run. Poll GET /api/agents/{id} or subscribe to /ws for what happens next.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/SpawnAgentReq" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The new run's identifiers.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/SpawnAgentResp" } }
+            }
+          },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/api/agents/tree": {
+      "get": {
+        "tags": ["agents"],
+        "summary": "The full sub-agent tree",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "One run's metadata, with secrets redacted",
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "404": { "$ref": "#/components/responses/Error" }
+        }
+      },
+      "delete": {
+        "tags": ["agents"],
+        "summary": "Cancel a run",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/children": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "This run's direct children",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/context": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "The run's current context window",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/context/history": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "How the context window changed over the run",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/files": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "Read one file inside the run's workdir",
+        "description": "Confined to the run's working directory, and capped at 1 MiB.",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workdir-relative path."
+          }
+        ],
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "403": { "$ref": "#/components/responses/Error" },
+          "404": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/api/agents/{id}/logs": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "The run's logs",
+        "parameters": [
+          {
+            "name": "tail",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1 },
+            "description": "Return only the last N lines."
+          }
+        ],
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/result": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "The run's output and token usage",
+        "responses": {
+          "200": {
+            "description": "The result so far. Check `status` before trusting `output`.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/AgentResultResp" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/agents/{id}/tree-status": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["agents"],
+        "summary": "Token roll-ups across this run and its descendants",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/pause": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "post": {
+        "tags": ["agents"],
+        "summary": "Pause a run after its in-flight step",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/resume": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "post": {
+        "tags": ["agents"],
+        "summary": "Un-pause a run",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/message": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "post": {
+        "tags": ["agents"],
+        "summary": "Inject a message into a running agent's context",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["content"],
+                "properties": { "content": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/agents/{id}/interaction": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["interactions"],
+        "summary": "The question this run is waiting on, if any",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "post": {
+        "tags": ["interactions"],
+        "summary": "Answer the pending question",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/mcp/servers": {
+      "get": {
+        "tags": ["mcp"],
+        "summary": "Configured MCP servers",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "post": {
+        "tags": ["mcp"],
+        "summary": "Add an MCP server",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because adding a stdio server is arbitrary code execution by construction.",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/mcp/servers/{name}": {
+      "parameters": [{ "$ref": "#/components/parameters/Name" }],
+      "delete": {
+        "tags": ["mcp"],
+        "summary": "Remove an MCP server",
+        "description": "Admin only. See POST /api/mcp/servers.",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/mcp/servers/{name}/status": {
+      "parameters": [{ "$ref": "#/components/parameters/Name" }],
+      "get": {
+        "tags": ["mcp"],
+        "summary": "Whether this server is authenticated",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/mcp/servers/{name}/login": {
+      "parameters": [{ "$ref": "#/components/parameters/Name" }],
+      "post": {
+        "tags": ["mcp"],
+        "summary": "Begin the OAuth flow for this server",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/mcp/servers/{name}/test": {
+      "parameters": [{ "$ref": "#/components/parameters/Name" }],
+      "post": {
+        "tags": ["mcp"],
+        "summary": "Connect and list this server's tools",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/doctor": {
+      "get": {
+        "tags": ["diagnostics"],
+        "summary": "The `lev doctor` checks, as data",
+        "description": "A failing check is reported inside a 200 with `ok: false`, not as an HTTP error: the request succeeded, the install is what did not.",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/fs/dirs": {
+      "get": {
+        "tags": ["diagnostics"],
+        "summary": "One directory level, for a folder picker",
+        "parameters": [
+          { "name": "path", "in": "query", "schema": { "type": "string" } },
+          {
+            "name": "hidden",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "description": "Include dot-directories."
+          }
+        ],
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/config": {
+      "get": {
+        "tags": ["config"],
+        "summary": "The active configuration, with credentials redacted",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      },
+      "put": {
+        "tags": ["config"],
+        "summary": "Replace the configuration",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed.",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/api/config/validate": {
+      "post": {
+        "tags": ["config"],
+        "summary": "Validate one configuration key",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ValidateResponse" } }
+            },
+            "description": "Whether the key and value are usable."
+          }
+        }
+      }
+    },
+    "/api/models": {
+      "get": {
+        "tags": ["config"],
+        "summary": "Models this install can reach",
+        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+      }
+    },
+    "/ws": {
+      "get": {
+        "tags": ["events"],
+        "summary": "Event stream for every run",
+        "description": "A WebSocket upgrade, not a JSON response. Authenticate with `?token=` since a browser cannot set a header on the handshake. Each frame is a ServerEvent.",
+        "parameters": [
+          { "name": "token", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "101": { "description": "Switching protocols." } }
+      }
+    },
+    "/ws/agents/{id}": {
+      "parameters": [{ "$ref": "#/components/parameters/Id" }],
+      "get": {
+        "tags": ["events"],
+        "summary": "Event stream for one run",
+        "description": "As /ws, filtered to a single run.",
+        "parameters": [
+          { "name": "token", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "101": { "description": "Switching protocols." } }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "The token from `lev serve --token` or LEVIATH_API_TOKEN. The server refuses to start without one. WebSocket routes take it as `?token=` instead."
+      }
+    },
+    "parameters": {
+      "Id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string" },
+        "description": "A run id, as returned by `lev run --json` or POST /api/agents."
+      },
+      "Name": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string" }
+      }
+    },
+    "responses": {
+      "Ok": {
+        "description": "Success.",
+        "content": { "application/json": { "schema": { "type": "object" } } }
+      },
+      "Error": {
+        "description": "The request failed.",
+        "content": {
+          "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } }
+        }
+      }
+    },
+    "schemas": {
+      "SpawnAgentReq": {
+        "type": "object",
+        "required": ["blueprint", "task"],
+        "properties": {
+          "blueprint": {
+            "type": "string",
+            "description": "An installed blueprint name, or a path to one."
+          },
+          "task": { "type": "string" },
+          "model": {
+            "type": "string",
+            "description": "\"provider/model\", or a bare model id."
+          },
+          "max_depth": { "type": "integer", "minimum": 0 },
+          "yolo": {
+            "type": "boolean",
+            "default": false,
+            "description": "Run unattended. Refused when the server was started with --no-remote-yolo."
+          },
+          "allow": { "type": "array", "items": { "type": "string" } },
+          "no_seed_commands": { "type": "boolean", "default": false },
+          "workdir": {
+            "type": "string",
+            "description": "Confined to --workdir-root when the server sets one."
+          },
+          "regions": {
+            "type": "object",
+            "additionalProperties": { "type": "string" },
+            "description": "Seed content per named context region."
+          },
+          "metadata": { "type": "object", "additionalProperties": { "type": "string" } },
+          "callback_url": {
+            "type": "string",
+            "description": "POSTed on completion or error."
+          },
+          "callback_secret": {
+            "type": "string",
+            "description": "Shared secret for the HMAC-SHA256 signature on that callback."
+          }
+        }
+      },
+      "SpawnAgentResp": {
+        "type": "object",
+        "required": ["agent_id", "run_id"],
+        "properties": {
+          "agent_id": { "type": "string" },
+          "run_id": { "type": "string" }
+        }
+      },
+      "AgentResultResp": {
+        "type": "object",
+        "required": ["run_id", "status", "output", "prompt_tokens", "completion_tokens"],
+        "properties": {
+          "run_id": { "type": "string" },
+          "status": { "type": "string" },
+          "output": { "type": "string" },
+          "error": { "type": ["string", "null"] },
+          "prompt_tokens": { "type": "integer", "minimum": 0 },
+          "completion_tokens": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "ValidateResponse": {
+        "type": "object",
+        "required": ["valid"],
+        "properties": {
+          "valid": { "type": "boolean" },
+          "errors": { "type": ["array", "null"], "items": { "type": "string" } },
+          "warnings": { "type": ["array", "null"], "items": { "type": "string" } }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["error"],
+        "properties": { "error": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/xtask/src/docs.rs
+++ b/xtask/src/docs.rs
@@ -288,6 +288,37 @@ fn check_orders(pages: &[Page], problems: &mut Vec<String>) {
 }
 
 /// Read `docs/content/`, run every check, and report.
+/// The machine-readable artifacts published beside the pages.
+///
+/// `llms.txt` links these by name and the S3 sync uses `--delete`, so one that
+/// stops being emitted becomes a 404 the index still advertises.
+pub const SCHEMAS: &[&str] = &[
+    "blueprint.schema.json",
+    "config.schema.json",
+    "openapi.json",
+];
+
+/// Every published schema must exist and be parseable JSON.
+///
+/// Whether each one *describes the format correctly* is a different question,
+/// answered by tests in `leviath-cli` that validate real manifests and the real
+/// router against them. This only catches the file going missing or being
+/// truncated, which the release would otherwise ship without noticing.
+pub fn check_schemas(dir: &Path) -> Result<Vec<String>> {
+    let mut problems = Vec::new();
+    for name in SCHEMAS {
+        let path = dir.join(name);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            problems.push(format!("docs/schema/{name}: missing"));
+            continue;
+        };
+        if let Err(e) = serde_json::from_str::<serde_json::Value>(&text) {
+            problems.push(format!("docs/schema/{name}: not valid JSON ({e})"));
+        }
+    }
+    Ok(problems)
+}
+
 pub fn run(_mode: DocsMode) -> Result<()> {
     let dir = Path::new("docs/content");
     let mut pages = Vec::new();
@@ -305,9 +336,14 @@ pub fn run(_mode: DocsMode) -> Result<()> {
         pages.push(parse_page(slug, &std::fs::read_to_string(&path)?));
     }
 
-    let problems = check_all(&pages);
+    let mut problems = check_all(&pages);
+    problems.extend(check_schemas(Path::new("docs/schema"))?);
     if problems.is_empty() {
-        println!("docs: {} pages, no problems", pages.len());
+        println!(
+            "docs: {} pages, {} schemas, no problems",
+            pages.len(),
+            SCHEMAS.len()
+        );
         return Ok(());
     }
     for problem in &problems {

--- a/xtask/src/docs.rs
+++ b/xtask/src/docs.rs
@@ -41,6 +41,10 @@ pub struct Page {
     pub title: Option<String>,
     /// Frontmatter `group_order`, if present.
     pub group_order: Option<String>,
+    /// Frontmatter `description`, if present. One sentence, and the only thing
+    /// an agent reading `llms.txt` sees before it decides whether to fetch the
+    /// page, so a missing or padded one costs it a wasted round trip.
+    pub description: Option<String>,
     /// Anchors this page offers: heading slugs plus any `<a id="...">`.
     pub anchors: HashSet<String>,
     /// `/docs/<slug>` links found in the body, as `(slug, Option<anchor>)`.
@@ -148,6 +152,7 @@ fn record_frontmatter(page: &mut Page, line: &str) {
         "group" => page.group = Some(value),
         "group_order" => page.group_order = Some(value),
         "order" => page.order = Some(value),
+        "description" => page.description = Some(value),
         _ => {}
     }
 }
@@ -205,17 +210,37 @@ pub fn check_all(pages: &[Page]) -> Vec<String> {
     problems
 }
 
-/// Every page needs all four frontmatter keys.
+/// The ceiling on a `description`, in characters.
+///
+/// `llms.txt` renders one per page as a single line. Past roughly this length a
+/// description stops being a routing hint and becomes the page, which is the
+/// failure this bound exists to prevent.
+pub const MAX_DESCRIPTION_CHARS: usize = 160;
+
+/// Every page needs all five frontmatter keys, and `description` has to stay
+/// short enough to be a one-line routing hint.
 fn check_frontmatter(page: &Page, problems: &mut Vec<String>) {
     let missing = [
         ("title", page.title.is_none()),
         ("group", page.group.is_none()),
         ("group_order", page.group_order.is_none()),
         ("order", page.order.is_none()),
+        ("description", page.description.is_none()),
     ];
     for (key, absent) in missing {
         if absent {
             problems.push(format!("{}.md: frontmatter is missing `{key}`", page.slug));
+        }
+    }
+    // Counted in chars, not bytes: the workspace denies `clippy::string_slice`
+    // for the same reason, and a description may hold non-ASCII.
+    if let Some(description) = &page.description {
+        let length = description.chars().count();
+        if length > MAX_DESCRIPTION_CHARS {
+            problems.push(format!(
+                "{}.md: description is {length} chars, over the {MAX_DESCRIPTION_CHARS} limit",
+                page.slug
+            ));
         }
     }
 }

--- a/xtask/src/docs_tests.rs
+++ b/xtask/src/docs_tests.rs
@@ -7,8 +7,9 @@ use super::*;
 
 /// A well-formed page with an explicit `order`.
 fn page_with(slug: &str, order: usize, body: &str) -> Page {
-    let source =
-        format!("---\ntitle: T\ngroup: Concepts\ngroup_order: 2\norder: {order}\n---\n\n{body}\n");
+    let source = format!(
+        "---\ntitle: T\ndescription: D\ngroup: Concepts\ngroup_order: 2\norder: {order}\n---\n\n{body}\n"
+    );
     parse_page(slug, &source)
 }
 
@@ -73,9 +74,54 @@ fn heading_text_strips_inline_markup() {
 fn frontmatter_keys_are_read() {
     let p = page_with("api", 1, "# API");
     assert_eq!(p.title.as_deref(), Some("T"));
+    assert_eq!(p.description.as_deref(), Some("D"));
     assert_eq!(p.group.as_deref(), Some("Concepts"));
     assert_eq!(p.group_order.as_deref(), Some("2"));
     assert_eq!(p.order.as_deref(), Some("1"));
+}
+
+#[test]
+fn a_missing_description_is_reported() {
+    // The one frontmatter key an agent reads before deciding whether to fetch
+    // the page. Without it `llms.txt` is a bare link list again.
+    let src = "---\ntitle: T\ngroup: G\ngroup_order: 1\norder: 1\n---\n\n# Hi\n";
+    let problems = check_all(&[parse_page("x", src)]);
+    assert!(problems.iter().any(|p| p.contains("missing `description`")));
+}
+
+#[test]
+fn a_description_at_the_limit_is_accepted() {
+    let description = "d".repeat(MAX_DESCRIPTION_CHARS);
+    let src = format!(
+        "---\ntitle: T\ndescription: {description}\ngroup: G\ngroup_order: 1\norder: 1\n---\n\n# Hi\n"
+    );
+    let problems = check_all(&[parse_page("x", &src)]);
+    assert!(problems.is_empty(), "{problems:?}");
+}
+
+#[test]
+fn an_over_long_description_is_reported() {
+    let description = "d".repeat(MAX_DESCRIPTION_CHARS + 1);
+    let src = format!(
+        "---\ntitle: T\ndescription: {description}\ngroup: G\ngroup_order: 1\norder: 1\n---\n\n# Hi\n"
+    );
+    let problems = check_all(&[parse_page("x", &src)]);
+    assert!(
+        problems.iter().any(|p| p.contains("over the")),
+        "{problems:?}"
+    );
+}
+
+#[test]
+fn a_description_is_measured_in_chars_not_bytes() {
+    // Every char here is 4 bytes, so a byte-counting check would reject a
+    // description well inside the limit.
+    let description = "🌊".repeat(MAX_DESCRIPTION_CHARS);
+    let src = format!(
+        "---\ntitle: T\ndescription: {description}\ngroup: G\ngroup_order: 1\norder: 1\n---\n\n# Hi\n"
+    );
+    let problems = check_all(&[parse_page("x", &src)]);
+    assert!(problems.is_empty(), "{problems:?}");
 }
 
 #[test]
@@ -232,7 +278,8 @@ fn two_pages_claiming_one_order_are_reported() {
 #[test]
 fn pages_in_different_groups_may_share_an_order() {
     let a = page_with("a", 1, "text");
-    let src = "---\ntitle: T\ngroup: Guides\ngroup_order: 4\norder: 1\n---\n\ntext\n";
+    let src =
+        "---\ntitle: T\ndescription: D\ngroup: Guides\ngroup_order: 4\norder: 1\n---\n\ntext\n";
     assert!(check_all(&[a, parse_page("b", src)]).is_empty());
 }
 

--- a/xtask/src/docs_tests.rs
+++ b/xtask/src/docs_tests.rs
@@ -319,3 +319,44 @@ fn the_shipped_docs_pass_every_check() {
         problems.join("\n  ")
     );
 }
+
+// ── Published schemas ───────────────────────────────────────────────────────
+
+#[test]
+fn the_real_schemas_are_present_and_parse() {
+    // `run` resolves this relative to the repo root, but a test's working
+    // directory is the crate root, so anchor on the manifest directory.
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask/ has a parent");
+    assert_eq!(
+        check_schemas(&root.join("docs/schema")).unwrap(),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn a_missing_schema_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let problems = check_schemas(dir.path()).unwrap();
+    assert_eq!(problems.len(), SCHEMAS.len());
+    assert!(
+        problems.iter().all(|p| p.contains("missing")),
+        "{problems:?}"
+    );
+}
+
+#[test]
+fn a_truncated_schema_is_reported() {
+    // The failure this exists for: a half-written file still gets synced to S3
+    // and served under a name llms.txt advertises.
+    let dir = tempfile::tempdir().unwrap();
+    for name in SCHEMAS {
+        std::fs::write(dir.path().join(name), "{\"$schema\": ").unwrap();
+    }
+    let problems = check_schemas(dir.path()).unwrap();
+    assert!(
+        problems.iter().all(|p| p.contains("not valid JSON")),
+        "{problems:?}"
+    );
+}


### PR DESCRIPTION
## Why

An agent pointed at leviath.dev cannot currently install Leviath and get a run going on its own. This makes that work, and fixes the product bugs found while proving it.

The site was not starting from zero: `llms.txt`, `llms-full.txt`, and a raw `.md` twin of every page already shipped. The gaps were at the edges, which is where a cold agent walks in.

## What is in here

**Provider coverage (`fc60883`).** Getting Started promises one provider is all you need and names five. That was true for none of them: all 54 bundled stage model lists named only anthropic, openai, and ollama. Ollama registers with no API key, so a machine holding only a Google or OpenRouter key resolved every stage to a local Ollama that may never have been installed, spawned clean, and died on its first inference. Two `parallel-fixer` stages were narrower still and failed outright at spawn. Every stage now lists all five, keyed providers ahead of ollama, with an invariant test derived from `BUNDLED_AGENTS` rather than enumerating agents.

**`default_provider` (`31ee4c1`).** `lev setup --non-interactive --openrouter-key ...` wrote a config whose very next `lev doctor` reported `resolved to 'anthropic', which is not configured`. Setup never touched `default_provider`. Measured: both this and `--default-model` are needed, since `user_default_model` requires the default provider be registered before it offers the default model.

**`--json` (`7cb1a4e`).** On `run`, `list`, `models list`, `validate`, and `respond`. `lev run` is the one that unblocked the loop: it hands work to a daemon and returns, so the run id was the only handle a caller got and it was printed inside a sentence. Note `KNOWN_RUN_FLAGS` had to gain `"json"`, because a flag missing from that list is read by the argv pre-scan as a `--<region>` seed rather than being a parse error. A new test asks clap for the flag list so that cannot recur.

**Schemas (`e241715`).** `blueprint.schema.json`, `config.schema.json`, `openapi.json`, published beside the docs and linked from `llms.txt`. None can be generated: `parse_manifest` is a hand-rolled `toml::Value` walker and axum's `Router` cannot be enumerated. So each is held to the code by a test. The blueprint one caught two errors in itself immediately; the OpenAPI one caught its own reader counting test fixtures as production routes.

**Docs (`bb677c4`, `853ec75`, `127b41f`, `d65a331`).** Every page gains a one-sentence `description`, required and length-bounded by `cargo xtask docs`, which is what `llms.txt` puts beside each link. A new `agent-quickstart.md` is written to be executed rather than read.

## On `--yolo`

An external report concluded `lev run software-engineer --yolo` hangs forever. It does not. That gate declares `unattended = "ask"` deliberately, because everything after it writes code. Measured against a live daemon with the timeout at 30s: plan, implement, review, Complete. `writing-assistant` takes the default `auto_approve` and passes straight through with the timeout left at 3600. What was missing is that the default is an hour, and for that hour the run is indistinguishable from a dead one.

## Verification

Everything documented was run, not read off the source. The quickstart was executed verbatim, which found a hole in its own first draft: without `--yolo` a run parks on `tool_approval`, and an expired tool approval is denied rather than approved. Re-run after the fix: spawn to Complete in 90 seconds with the requested file written.

Also: 38 mermaid diagrams parsed under the site's own mermaid (harness checked against a deliberately broken diagram first), full workspace tests green, `cargo xtask coverage` at 100% on all 11 packages.

## Not in here

No version bump. Nothing reaches leviath.dev until a release, and that is deliberate for now.

The renderer half is [GEMISIS/leviath.dev#PLACEHOLDER](https://github.com/GEMISIS/leviath.dev) and should land alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETcgHbULnW1W8M2wG3XaBH
