### PR TITLE
fix(windows): stop child processes flashing console windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ same list.
 
 ## Unreleased
 
+- Windows no longer flashes console windows across the desktop. Every child
+  process Leviath starts is a console application, and one started by a process
+  with no console of its own gets a fresh window on the interactive desktop.
+  With a `shell` call or two per agent iteration that is a strobe, and a fleet
+  of agents made it worse. Every spawn whose output is already piped or
+  discarded now asks for no window: the `shell` tool, a script tool's `shell()`,
+  seed commands, container lifecycle commands, MCP servers, the Claude Code
+  provider, the browser launcher, the dashboard's clipboard helper, and the
+  daemon itself. The editor `lev run` opens for you is deliberately left alone,
+  since it is the one child meant to be seen. Nothing about output capture
+  changes.
+- Which shell a command runs in is now decided by a function that takes the
+  platform as an argument rather than by a compile-time branch, so the Windows
+  answer is checked on every CI machine instead of only on the Windows one.
+  Behaviour is unchanged: `cmd.exe /C` on Windows, `$SHELL` then bash, zsh, sh
+  for the `shell` tool elsewhere, and always `/bin/sh -c` for script tools.
 - OpenRouter works end to end. Several separate faults added up to an install
   that was configured correctly and still did nothing useful:
   - `default_provider` is now honoured. It was only consulted after every

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -126,13 +126,16 @@ fn yank_to_clipboard_with(
 
     // Try native clipboard tools first - most reliable
     for (cmd, args) in clipboard_cmds {
-        if let Ok(mut child) = Command::new(cmd)
+        let mut command = Command::new(cmd);
+        command
             .args(*args)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        {
+            .stderr(Stdio::null());
+        // The dashboard is a full-screen TUI; a console window popping over it
+        // on every yank would be the worst place for one.
+        leviath_sys::hide_console_window(&mut command);
+        if let Ok(mut child) = command.spawn() {
             // `child.stdin` is guaranteed `Some` here because the child was
             // spawned with `.stdin(Stdio::piped())` above - an `if let`
             // guard would introduce an implicit "pattern didn't match" branch

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -262,10 +262,12 @@ fn unavailable(
 /// Real lifecycle-command runner: spawn synchronously, map a non-zero exit to
 /// its stderr.
 fn real_run(argv: &[String]) -> Result<(), String> {
-    let output = StdCommand::new(&argv[0])
-        .args(&argv[1..])
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut cmd = StdCommand::new(&argv[0]);
+    cmd.args(&argv[1..]);
+    // `docker run`/`docker rm` are bookkeeping the operator never watches, so
+    // they get no console window on Windows.
+    leviath_sys::hide_console_window(&mut cmd);
+    let output = cmd.output().map_err(|e| e.to_string())?;
     if output.status.success() {
         Ok(())
     } else {

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -692,6 +692,10 @@ impl ScriptIo for RealScriptIo {
         // tool, which does the same.
         cmd.kill_on_drop(true);
         leviath_tools::own_process_group(&mut cmd);
+        // No console window on Windows - a script tool's `shell()` is as chatty
+        // as the built-in one. Applied here, after the sandbox has had its say,
+        // so the sandboxed command is covered too.
+        leviath_tools::hide_console_window(&mut cmd);
         // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
         // command's output is still captured.
         cmd.stdout(std::process::Stdio::piped())
@@ -751,13 +755,18 @@ impl ScriptIo for RealScriptIo {
 /// once and run on every machine, so it gets the POSIX shell it can count on
 /// instead of whatever interactive shell the operator happens to prefer.
 pub(crate) fn default_shell() -> (&'static str, &'static str) {
-    #[cfg(windows)]
-    {
-        ("cmd.exe", "/C")
-    }
-    #[cfg(not(windows))]
-    {
-        ("/bin/sh", "-c")
+    default_shell_for(std::env::consts::OS)
+}
+
+/// [`default_shell`] with the platform as a parameter.
+///
+/// Pure over the OS string rather than `#[cfg(windows)]`-switched, following
+/// `leviath_sys::browser::open_command_for`, so the Windows answer is reachable
+/// under test on every platform instead of only on the Windows CI leg.
+pub(crate) fn default_shell_for(os: &str) -> (&'static str, &'static str) {
+    match os {
+        "windows" => ("cmd.exe", "/C"),
+        _ => ("/bin/sh", "-c"),
     }
 }
 
@@ -1814,6 +1823,18 @@ mod tests {
         let (shell, flag) = default_shell();
         assert!(!shell.is_empty());
         assert!(!flag.is_empty());
+    }
+
+    /// Both answers, from whichever platform is running the test. A script tool
+    /// gets `/bin/sh` everywhere it exists and `cmd.exe` where it does not -
+    /// never the operator's `$SHELL`, which is what makes a Rhai tool behave
+    /// the same on every machine.
+    #[test]
+    fn default_shell_for_answers_per_platform() {
+        assert_eq!(default_shell_for("windows"), ("cmd.exe", "/C"));
+        for posix in ["linux", "macos", "freebsd", "haiku"] {
+            assert_eq!(default_shell_for(posix), ("/bin/sh", "-c"), "{posix}");
+        }
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/seed_command.rs
+++ b/crates/leviath-cli/src/daemon/seed_command.rs
@@ -137,6 +137,9 @@ fn build_seed_command(
 /// orphaning it.
 fn run_seed_command(mut cmd: TokioCommand, timeout: Duration) -> Result<String, String> {
     cmd.kill_on_drop(true);
+    // One per seeded region at spawn, and `output()` pipes both streams, so
+    // there is no console for this to want on Windows.
+    leviath_tools::hide_console_window(&mut cmd);
     std::thread::spawn(move || {
         // A current-thread runtime with no ambient runtime present only fails on
         // OS resource exhaustion, at which point the spawn itself is doomed

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -154,6 +154,11 @@ impl StdioTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
+        // The server talks JSON-RPC over those pipes and has no use for a
+        // console. It matters most here: `command_candidates` resolves `npx` to
+        // `npx.cmd`, a batch file, which Windows always runs through `cmd.exe`.
+        leviath_sys::hide_console_window(cmd.as_std_mut());
+
         cmd.spawn()
     }
 

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -208,6 +208,9 @@ impl ClaudeCodeProvider {
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
+        // This runs once per inference call, so on Windows it would be a
+        // console window per turn of every agent.
+        leviath_sys::hide_console_window(cmd.as_std_mut());
 
         let mut child = retry_etxtbsy(|| cmd.spawn()).await.map_err(|e| {
             // Permanent: a missing or unusable binary will not fix itself, and

--- a/crates/leviath-sys/src/browser.rs
+++ b/crates/leviath-sys/src/browser.rs
@@ -55,7 +55,13 @@ pub fn open_url_via(spawn: fn(&mut Command) -> std::io::Result<()>, url: &str) -
 ///
 /// The browser launcher is detached: we neither wait for it nor read its
 /// pipes, since it may outlive this process.
+///
+/// The Windows launcher is `cmd /C start`, which would otherwise flash a
+/// console on its way to opening the browser. `start` hands the URL to the
+/// shell association and needs no console of its own, so suppressing the window
+/// costs nothing - the browser still opens.
 pub fn spawn_detached(cmd: &mut Command) -> std::io::Result<()> {
+    crate::process::hide_console_window(cmd);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/crates/leviath-sys/src/editor.rs
+++ b/crates/leviath-sys/src/editor.rs
@@ -131,6 +131,11 @@ pub fn launch_via(
         };
         let mut cmd = Command::new(program);
         cmd.args(args);
+        // Deliberately *not* `hide_console_window`, unlike every other spawn in
+        // this workspace: the editor is the one child that is meant to be seen.
+        // It inherits this process's stdio and draws in the user's terminal, so
+        // starting `vim` or `edit` without a console would leave it nowhere to
+        // draw and nothing to read from.
 
         match run(&mut cmd) {
             // Exited, even non-zero: the user closed the editor.

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -42,7 +42,7 @@ pub use editor::launch as launch_editor;
 pub use perms::{ensure_file_private, secure_dir_perms, secure_file_perms, write_private};
 #[cfg(unix)]
 pub use process::peer_uid;
-pub use process::{configure_detached, current_uid, kill_process_group};
+pub use process::{configure_detached, current_uid, hide_console_window, kill_process_group};
 pub use sandbox::{
     ContainerRunSpec, container_exec_argv, container_rm_argv, container_run_argv,
     detect_container_engine, namespace_argv, namespace_supported,

--- a/crates/leviath-sys/src/platform/fallback.rs
+++ b/crates/leviath-sys/src/platform/fallback.rs
@@ -25,6 +25,10 @@ pub(crate) fn ensure_private(_path: &Path, _mode: u32) -> io::Result<Option<u32>
 
 pub(crate) fn configure_detached(_cmd: &mut std::process::Command) {}
 
+/// No consoles to suppress on such a target; Windows is the only platform where
+/// a child process can be handed a window.
+pub(crate) fn hide_console_window(_cmd: &mut std::process::Command) {}
+
 /// No POSIX uid here; the value is only used to address a per-user
 /// launchd/systemd domain, neither of which exists on such a target.
 pub(crate) fn current_uid() -> u32 {

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -18,6 +18,11 @@ pub(crate) fn configure_detached(cmd: &mut Command) {
     cmd.process_group(0);
 }
 
+/// Nothing to hide: a Unix process has no console of its own to be given, so
+/// there is no window for a child to pop. Windows is the only platform where
+/// this does anything.
+pub(crate) fn hide_console_window(_cmd: &mut Command) {}
+
 /// Create (or truncate) `path` with `mode` already applied, then write
 /// `contents`.
 ///
@@ -216,5 +221,9 @@ mod tests {
         // takes effect on a later spawn(), which this test deliberately omits.
         let mut cmd = Command::new("true");
         configure_detached(&mut cmd);
+        // And the console-window shim is a no-op here rather than an error -
+        // callers apply it unconditionally and must not have to ask which
+        // platform they are on.
+        hide_console_window(&mut cmd);
     }
 }

--- a/crates/leviath-sys/src/platform/windows.rs
+++ b/crates/leviath-sys/src/platform/windows.rs
@@ -67,8 +67,34 @@ pub(crate) fn ensure_private(path: &Path, _mode: u32) -> io::Result<Option<u32>>
     Ok(None)
 }
 
-/// No process groups on Windows; the caller kills the direct child.
-pub(crate) fn configure_detached(_cmd: &mut std::process::Command) {}
+/// No process groups on Windows, but detaching still means something here: a
+/// child launched with no console of its own is the Windows equivalent of
+/// escaping the launching terminal, so it neither inherits Ctrl+C nor pops a
+/// window when the parent has no console to share. The caller kills the direct
+/// child.
+pub(crate) fn configure_detached(cmd: &mut std::process::Command) {
+    hide_console_window(cmd);
+}
+
+/// Start `cmd` without a console window.
+///
+/// Windows gives a console application a console. When the parent has one, the
+/// child shares it and nothing is drawn; when it does not - the daemon started
+/// from Explorer, a service, or a UI console - the OS allocates a fresh window
+/// and shows it on the interactive desktop. An agent calling the `shell` tool
+/// runs `cmd.exe` dozens of times per run, so that is a flood of flashing
+/// windows, and concurrent agents make it worse (issue #228).
+///
+/// `CREATE_NO_WINDOW` says "this is a console application, run it without a
+/// console window". It is right only for a child whose stdio is already piped
+/// or nulled, which is every caller here; a child meant to share the user's
+/// terminal (the editor) must not get it, or it opens with nowhere to draw.
+pub(crate) fn hide_console_window(cmd: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+    // <https://learn.microsoft.com/windows/win32/procthread/process-creation-flags>
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
 
 /// Windows has no POSIX uid; the value only addresses a per-user
 /// launchd/systemd domain, neither of which exists here.
@@ -86,9 +112,12 @@ pub(crate) fn kill_process_group(_pgid: u32) -> io::Result<()> {
 /// Remove every inherited permission from `path` and grant only its owner.
 fn restrict_to_owner(path: &Path) -> io::Result<()> {
     let user = resolve_user(std::env::var("USERNAME").ok())?;
-    let output = std::process::Command::new(icacls_program())
-        .args(icacls_args(path, &user))
-        .output()?;
+    let mut cmd = std::process::Command::new(icacls_program());
+    cmd.args(icacls_args(path, &user));
+    // Every secret write hardens its file, so this runs often enough to be
+    // noticed if each one flashed a console.
+    hide_console_window(&mut cmd);
+    let output = cmd.output()?;
     interpret_icacls(output.status.success(), &output.stderr, path)
 }
 
@@ -355,5 +384,22 @@ mod tests {
         configure_detached(&mut cmd);
         assert_eq!(current_uid(), 0);
         assert!(kill_process_group(1).is_ok());
+    }
+
+    /// The flag must hide the window without costing us the output - the whole
+    /// point is that a piped child behaves exactly as before, just unseen.
+    /// There is no way to observe "no window appeared" from a headless runner,
+    /// so what is asserted here is the half that *can* regress.
+    #[test]
+    fn a_hidden_child_still_has_its_output_captured() {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/C", "echo leviath"]);
+        hide_console_window(&mut cmd);
+        let output = cmd.output().expect("cmd.exe runs");
+        assert!(output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("leviath"),
+            "stdout is still captured with CREATE_NO_WINDOW set"
+        );
     }
 }

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -1,4 +1,4 @@
-//! Process control: detached spawning.
+//! Process control: detached spawning and console-window suppression.
 
 use std::process::Command;
 
@@ -9,6 +9,30 @@ use std::process::Command;
 /// platforms it is a no-op. Call this before `cmd.spawn()`.
 pub fn configure_detached(cmd: &mut Command) {
     crate::platform::configure_detached(cmd);
+}
+
+/// Configure `cmd` so the spawned child gets no console window.
+///
+/// On Windows a console application is given a console. A child of a process
+/// that has one shares it and draws nothing; a child of a process that has
+/// none, such as the daemon started from Explorer, from a service, or from a UI
+/// console, gets a brand new window on the interactive desktop. Agent tooling
+/// spawns `cmd.exe` many times per run, so without this the desktop fills with
+/// flashing consoles (issue #228). Elsewhere this is a no-op: no other platform
+/// hands a child a window.
+///
+/// Apply it to a child whose stdout/stderr are already piped or nulled, which
+/// is what every caller in this workspace does. Do **not** apply it to a child
+/// meant to share the user's terminal: the editor launched by `lev run` needs
+/// that console to draw in, and starting `vim` without one just breaks it.
+///
+/// One sharp edge worth knowing: `Command::creation_flags` *assigns* the flag
+/// word rather than OR-ing into it, so two callers setting different flags on
+/// one command would silently clobber each other. This function is deliberately
+/// the only writer of creation flags in the workspace. Add any future flag
+/// here, alongside `CREATE_NO_WINDOW`, rather than at a call site.
+pub fn hide_console_window(cmd: &mut Command) {
+    crate::platform::hide_console_window(cmd);
 }
 
 /// SIGKILL every process in the group led by `pgid` (a no-op on platforms
@@ -101,5 +125,15 @@ mod tests {
         // must not fork/exec or panic.
         let mut cmd = Command::new("true");
         configure_detached(&mut cmd);
+    }
+
+    #[test]
+    fn hide_console_window_public_wrapper_registers_without_spawning() {
+        // Same shape as the shim above: callers apply this unconditionally on
+        // every platform, so it must configure and return rather than fail
+        // where there is no window to suppress. Whether it took effect is only
+        // observable on Windows, and is asserted in that platform module.
+        let mut cmd = Command::new("true");
+        hide_console_window(&mut cmd);
     }
 }

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -407,34 +407,52 @@ impl BuiltinTools {
     /// - Windows: cmd.exe (always available)
     /// - Unix: $SHELL env var (user's preferred shell) → bash → zsh → sh
     pub(crate) fn detect_shell() -> (&'static str, &'static str) {
-        #[cfg(windows)]
-        {
-            ("cmd.exe", "/C")
-        }
-
-        #[cfg(not(windows))]
-        {
-            Self::detect_shell_impl(std::env::var("SHELL").ok(), &|s| {
-                std::path::Path::new(s).exists()
-            })
-        }
+        Self::detect_shell_for(
+            std::env::consts::OS,
+            std::env::var("SHELL").ok(),
+            &Self::shell_path_exists,
+        )
     }
 
-    /// Core shell-detection logic with injectable env and filesystem checks
-    /// for testing.
+    /// Whether `path` names something on disk.
+    ///
+    /// A named `fn` rather than the closure this used to be. On Windows
+    /// [`Self::detect_shell_for`] returns before probing anything, so a closure
+    /// written at the call site would be a region the Windows coverage leg
+    /// never executes; a `fn` can be handed to the seam directly by a test that
+    /// runs on every platform.
+    pub(crate) fn shell_path_exists(path: &str) -> bool {
+        std::path::Path::new(path).exists()
+    }
+
+    /// Core shell-detection logic with injectable OS, env, and filesystem
+    /// checks for testing.
+    ///
+    /// `os` is a parameter rather than a `#[cfg(windows)]` branch, following
+    /// `leviath_sys::browser::open_command_for` and
+    /// `leviath_runtime::pipeline::shell_guidance_for`: the Windows answer is
+    /// then reachable under test from any platform instead of only on the
+    /// Windows CI leg. Callers pass `std::env::consts::OS`.
+    ///
+    /// `$SHELL` is deliberately ignored on Windows even though Git for Windows
+    /// sets it - the value names an MSYS path (`/usr/bin/bash`) that
+    /// `CreateProcess` cannot run.
     ///
     /// `shell_exists` is a trait object (`&dyn Fn(&str) -> bool`) rather
     /// than `impl Fn(&str) -> bool` so every caller - production's real
-    /// `Path::exists` closure and each test's distinct closure - shares
+    /// `Path::exists` probe and each test's distinct closure - shares
     /// exactly ONE monomorphization of this function instead of one per
     /// closure type (this function was a confirmed generic-monomorphization
     /// coverage-attribution artifact: every source position had a covered
     /// instantiation, but the summary table still reported some as missed).
-    #[cfg(not(windows))]
-    pub(crate) fn detect_shell_impl(
+    pub(crate) fn detect_shell_for(
+        os: &str,
         env_shell: Option<String>,
         shell_exists: &dyn Fn(&str) -> bool,
     ) -> (&'static str, &'static str) {
+        if os == "windows" {
+            return ("cmd.exe", "/C");
+        }
         if let Some(shell) = env_shell
             && (shell.ends_with("/zsh") || shell.ends_with("/bash") || shell.ends_with("/sh"))
             && shell_exists(&shell)
@@ -502,6 +520,10 @@ impl BuiltinTools {
         // signalling the group on drop takes the whole tree down with it.
         cmd.kill_on_drop(true);
         own_process_group(&mut cmd);
+        // An agent runs this dozens of times per run, and on Windows each spawn
+        // would otherwise be given a console window. Applied here rather than in
+        // either branch above so it covers the sandboxed command too.
+        hide_console_window(&mut cmd);
         // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
         // command's output is still captured.
         cmd.stdout(std::process::Stdio::piped())

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1498,17 +1498,19 @@ mod tests {
 
     // ── detect_shell ──────────────────────────────────────────────────────
 
-    /// Windows' `detect_shell()` branch is a plain, unconditional constant
-    /// return (no env/filesystem dependence to inject) - the
-    /// platform-agnostic `detect_shell_returns_valid_shell` test below
-    /// already exercises it on Windows CI, but this asserts the exact
-    /// documented return value directly.
-    #[cfg(windows)]
+    /// The Windows answer, asserted from every platform now that the OS is a
+    /// parameter rather than a `#[cfg]`. `$SHELL` is ignored there even when it
+    /// is set (Git for Windows sets it to an MSYS path `CreateProcess` cannot
+    /// run), which is what the second call pins.
     #[test]
-    fn detect_shell_returns_cmd_exe() {
-        let (shell, flag) = BuiltinTools::detect_shell();
+    fn detect_shell_returns_cmd_exe_on_windows() {
+        let (shell, flag) = BuiltinTools::detect_shell_for("windows", None, &|_| true);
         assert_eq!(shell, "cmd.exe");
         assert_eq!(flag, "/C");
+
+        let (shell, _) =
+            BuiltinTools::detect_shell_for("windows", Some("/usr/bin/bash".to_string()), &|_| true);
+        assert_eq!(shell, "cmd.exe", "$SHELL is not consulted on Windows");
     }
 
     #[test]
@@ -1523,18 +1525,22 @@ mod tests {
         assert_eq!(flag, "-c");
     }
 
-    /// Forces `detect_shell()` to exercise the real `shell_exists` closure by
-    /// temporarily setting $SHELL to an unrecognized path, causing the candidate
-    /// loop (and the closure) to be reached. `temp_env::with_var` sets the var,
-    /// runs the closure, and restores it - serialized against every other
-    /// temp-env test process-wide, so no hand-rolled lock is needed.
-    #[cfg(not(windows))]
+    /// Drives the real filesystem probe (`shell_path_exists`) through the seam,
+    /// with an unrecognized `$SHELL` so the candidate loop is reached. Passing
+    /// `"linux"` rather than the host OS is what lets this run on the Windows
+    /// leg too - production's probe would otherwise be a function no Windows
+    /// test ever calls.
+    ///
+    /// The result is host-dependent: a Unix host finds one of the candidates,
+    /// a Windows host finds none and falls to the last resort. Both are correct,
+    /// so only the shape is asserted.
     #[test]
-    fn detect_shell_queries_real_filesystem_for_unrecognized_shell() {
-        let (shell, flag) =
-            temp_env::with_var("SHELL", Some("/opt/not-a-recognized-shell"), || {
-                BuiltinTools::detect_shell()
-            });
+    fn detect_shell_queries_the_real_filesystem_for_an_unrecognized_shell() {
+        let (shell, flag) = BuiltinTools::detect_shell_for(
+            "linux",
+            Some("/opt/not-a-recognized-shell".to_string()),
+            &BuiltinTools::shell_path_exists,
+        );
         assert_eq!(flag, "-c");
         assert!(
             [
@@ -1542,84 +1548,86 @@ mod tests {
                 "/usr/bin/bash",
                 "/bin/zsh",
                 "/usr/bin/zsh",
-                "/bin/sh"
+                "/bin/sh",
+                "sh",
             ]
-            .contains(&shell)
+            .contains(&shell),
+            "unexpected shell: {shell}"
         );
     }
 
-    // ── detect_shell_impl() - inject env and filesystem for full branch coverage ──
+    // ── detect_shell_for() - inject OS, env and filesystem for full branch coverage ──
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_returns_zsh_from_env() {
+    fn detect_shell_for_returns_zsh_from_env() {
         // `$SHELL` is trusted only when it exists on disk.
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/zsh".to_string()), &|s| {
+            BuiltinTools::detect_shell_for("linux", Some("/usr/local/bin/zsh".to_string()), &|s| {
                 s == "/usr/local/bin/zsh"
             });
         assert_eq!(shell, "/usr/local/bin/zsh");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_returns_bash_from_env() {
-        let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/local/bin/bash".to_string()), &|s| {
-                s == "/usr/local/bin/bash"
-            });
+    fn detect_shell_for_returns_bash_from_env() {
+        let (shell, flag) = BuiltinTools::detect_shell_for(
+            "macos",
+            Some("/usr/local/bin/bash".to_string()),
+            &|s| s == "/usr/local/bin/bash",
+        );
         assert_eq!(shell, "/usr/local/bin/bash");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_returns_sh_from_env() {
+    fn detect_shell_for_returns_sh_from_env() {
+        // An OS nobody special-cases still gets the POSIX treatment rather than
+        // falling into the Windows arm.
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/usr/bin/sh".to_string()), &|s| {
+            BuiltinTools::detect_shell_for("freebsd", Some("/usr/bin/sh".to_string()), &|s| {
                 s == "/usr/bin/sh"
             });
         assert_eq!(shell, "/usr/bin/sh");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_falls_back_when_env_shell_is_missing() {
+    fn detect_shell_for_falls_back_when_env_shell_is_missing() {
         // Regression for #79: `$SHELL` is a recognized shell name but does not
         // exist on disk (a stale or sandbox-missing `/bin/zsh`). It must NOT be
         // returned - fall through to an available fallback instead of failing
         // every shell call with "No such file or directory".
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/bin/zsh".to_string()), &|s| s == "/bin/sh");
+            BuiltinTools::detect_shell_for("linux", Some("/bin/zsh".to_string()), &|s| {
+                s == "/bin/sh"
+            });
         assert_eq!(shell, "/bin/sh");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_falls_through_when_env_unrecognized() {
+    fn detect_shell_for_falls_through_when_env_unrecognized() {
         // /opt/fish doesn't end with /zsh, /bash, or /sh → falls to candidate loop
         let (shell, flag) =
-            BuiltinTools::detect_shell_impl(Some("/opt/fish".to_string()), &|s| s == "/bin/bash");
+            BuiltinTools::detect_shell_for("linux", Some("/opt/fish".to_string()), &|s| {
+                s == "/bin/bash"
+            });
         assert_eq!(shell, "/bin/bash");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_skips_missing_candidates_and_finds_zsh() {
+    fn detect_shell_for_skips_missing_candidates_and_finds_zsh() {
         // bash paths return false; /bin/zsh exists - covers shell_exists false branch
-        let (shell, flag) = BuiltinTools::detect_shell_impl(None, &|s| s == "/bin/zsh");
+        let (shell, flag) = BuiltinTools::detect_shell_for("linux", None, &|s| s == "/bin/zsh");
         assert_eq!(shell, "/bin/zsh");
         assert_eq!(flag, "-c");
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn detect_shell_impl_returns_last_resort_when_nothing_exists() {
-        let (shell, flag) = BuiltinTools::detect_shell_impl(None, &|_| false);
+    fn detect_shell_for_returns_last_resort_when_nothing_exists() {
+        let (shell, flag) = BuiltinTools::detect_shell_for("linux", None, &|_| false);
         assert_eq!(shell, "sh");
         assert_eq!(flag, "-c");
     }

--- a/crates/leviath-tools/src/platform.rs
+++ b/crates/leviath-tools/src/platform.rs
@@ -14,6 +14,18 @@ pub fn own_process_group(cmd: &mut Command) {
     let _ = cmd;
 }
 
+/// Start `cmd` without a console window, so an agent's shell calls do not flash
+/// consoles across the desktop on Windows (issue #228).
+///
+/// The tokio twin of [`leviath_sys::hide_console_window`], which takes a
+/// `std::process::Command`; `as_std_mut` reaches the one tokio wraps, so the
+/// flag has a single implementation rather than a second copy of the `#[cfg]`.
+/// A no-op everywhere but Windows. Only for a child whose stdio is piped, which
+/// is every caller here.
+pub fn hide_console_window(cmd: &mut Command) {
+    leviath_sys::hide_console_window(cmd.as_std_mut());
+}
+
 /// SIGKILLs a shell's whole process group when dropped.
 ///
 /// `kill_on_drop` reaps the shell itself; this reaps what the shell started.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -150,6 +150,18 @@ blueprint's `[agent]` / `[stages.<name>]` block. A blueprint that spells out POS
 own prompt will still ask for them; that text has to change in the blueprint. See
 [which shell you get](/docs/tools#which-shell-you-get).
 
+## Console windows keep flashing on my Windows desktop
+
+Every child process Leviath starts is asked for no console window, so this
+should not happen on 0.1.3 or later. Before that, each `shell` call, each MCP
+server, and each provider that shells out could pop a `cmd.exe` window on the
+desktop, which a fleet of agents turned into a steady flicker.
+
+If you still see it, check what is spawning. `lev` itself run from a terminal
+shares that terminal and draws nothing extra. The one child that is still meant
+to be visible is your editor: `lev run` with no `--task` opens `$EDITOR` in the
+console on purpose, and that is not this bug.
+
 ## A run says `running` but never does anything
 
 Check its provider first, with `lev doctor`. If a stage's model list names only providers you


### PR DESCRIPTION
Closes #228.

## What was wrong

Every child process Leviath starts is a console application. Started from a process that already has a console it shares that one and draws nothing. Started from a process that has none, which is the daemon under Explorer, under a service, or under a UI console, Windows allocates a fresh console window and puts it on the interactive desktop.

An agent makes a shell call or two per iteration, so that is a strobe, and a fleet of concurrent agents made the desktop unusable. The reporter patched two call sites locally, rebuilt `lev`, and confirmed the flashing stopped.

## The fix

`CREATE_NO_WINDOW` is the flag for exactly this, and it costs nothing for a child whose output is already piped or discarded, which is every spawn touched here. It lands as `leviath_sys::hide_console_window`, dispatched through the existing `platform/{unix,windows,fallback}` triad so no call site grows a `#[cfg]` of its own, plus a tokio-flavoured wrapper in `leviath-tools` next to `own_process_group`.

The issue named two call sites. An audit of the workspace found six more that are equally agent-driven and equally piped, so all of them are covered:

| Site | Why |
|---|---|
| `leviath-tools` shell tool | The one the issue named. Single funnel, so the sandboxed command is covered too |
| daemon script host `shell()` | The other one it named |
| seed commands | One per seeded region at spawn |
| `docker`/`podman` lifecycle | Container create and remove |
| MCP servers | Worst case here: `npx` resolves to `npx.cmd`, a batch file, which always runs through `cmd.exe` |
| Claude Code provider | Once per inference call, so a window per turn of every agent |
| browser launcher | `cmd /C start "" <url>`; `start` needs no console of its own |
| dashboard clipboard | A window over a full-screen TUI |
| `icacls` | Runs on every secret write |

The Windows arm of `configure_detached` now sets it as well, which covers the daemon's own launch without touching `main.rs`: having no console is what detaching from the launching terminal means on that platform.

**The editor is deliberately excluded** and carries a comment saying so. It inherits our stdio and draws in the user's terminal, so a `vim` with no console is just a broken `vim`.

One sharp edge is documented on the helper: `Command::creation_flags` assigns rather than ORs, so this is deliberately the only writer of creation flags in the workspace.

## Also in here

Which shell a command runs in is now decided by a function taking the platform as an argument rather than by `#[cfg(windows)]`, following `browser::open_command_for` and `pipeline::shell_guidance_for`. Behaviour is identical: `cmd.exe /C` on Windows, `$SHELL` then bash/zsh/sh for the shell tool elsewhere, always `/bin/sh -c` for script tools.

The point is coverage. The Windows answer is now asserted on every CI machine instead of only the Windows one, and seven tests that had to be gated to non-Windows no longer are. The real filesystem probe became a named `fn` rather than a closure, because a closure written at the call site would be a region the Windows leg never executes.

## Verification

Done on macOS:

- `cargo build --all-targets` and `cargo clippy --all-targets --all-features -- -D warnings` clean
- full suite green, 32 test binaries, zero failures
- `cargo xtask coverage --package …` holds at 100% for all five touched packages
- the Windows-only code cross-checked with `rustc --target x86_64-pc-windows-msvc --emit=metadata`, since a full `cargo check` for that target dies in `aws-lc-sys` on macOS
- a live daemon run against an offline Rhai mock provider drove the shell tool through the changed path; output came back captured intact, workdir correct

**Still outstanding:** the symptom itself cannot be observed from macOS. Windows CI proves this compiles, links, and still captures output. It cannot prove no window appears. @a-programmers-programmer if you are able, a check against this branch on a real Windows desktop would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGqp26wEjCEtVg22PiR9Wz
