### PR TITLE
docs: the console-window fix lands in 0.2, not 0.1.3

### DIFF
--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -153,7 +153,7 @@ own prompt will still ask for them; that text has to change in the blueprint. Se
 ## Console windows keep flashing on my Windows desktop
 
 Every child process Leviath starts is asked for no console window, so this
-should not happen on 0.1.3 or later. Before that, each `shell` call, each MCP
+should not happen on 0.2 or later. Before that, each `shell` call, each MCP
 server, and each provider that shells out could pop a `cmd.exe` window on the
 desktop, which a fleet of agents turned into a steady flicker.
 


### PR DESCRIPTION
One-line correction. The troubleshooting entry added with #238 guessed at the next version number; it is 0.2.

No code change, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGqp26wEjCEtVg22PiR9Wz