### PR TITLE
Update Version to 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # `labeled`/`unlabeled` are included so the `guard-main-rs` job re-runs when
-    # a maintainer applies/removes the `allow-main-rs-change` override label.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # Deliberately no `labeled`/`unlabeled`. Those used to be here so the guard
+    # jobs re-ran when a maintainer applied an override label, but a label event
+    # starts a whole second CI suite - the full three-OS matrix, ten minutes - to
+    # re-decide a five-second check. Worse, it does not even unblock the PR: the
+    # original suite's guard check run stays FAILURE on that commit forever, and
+    # the merge rollup counts each suite's copy of a check separately, so one
+    # stale failure keeps the PR red no matter how many later suites go green.
+    # The guards now read labels live (see `guard-main-rs`), so the fix is to
+    # rerun the failed job in its own suite - `gh run rerun <id> --failed`.
+    types: [opened, synchronize, reopened]
   # The merge queue runs required checks against a temporary `merge_group` ref.
   # Without this trigger those checks never run, so queued PRs block forever.
   merge_group:
@@ -352,16 +359,30 @@ jobs:
     name: Guard bin entrypoint (main.rs)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # Reading the labels needs more than the workflow-wide `contents: read`.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Require maintainer override to change main.rs
         env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Asked over the API rather than read from
+          # `github.event.pull_request.labels`, because a rerun replays the
+          # event payload it was given the first time. A maintainer who labels
+          # a PR after CI started would rerun this job, watch it report no
+          # labels at all, and have no way to clear the failure short of
+          # pushing a commit. The API answers for the PR as it is right now.
+          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
+          echo "Labels on this PR right now: ${LABELS:-(none)}"
+
           # Three dots, so this asks "what did the PR change" rather than "how
           # do these two trees differ". With two dots the diff also contains
           # everything main gained since the branch point, so any PR would fail
@@ -392,17 +413,28 @@ jobs:
     name: Guard release version bump
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # See `guard-main-rs`: the live label read needs its own scope.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Require maintainer override to bump the release version
         env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Read live rather than from the event payload, for the reason spelled
+          # out in `guard-main-rs`: a rerun replays the payload the run started
+          # with, so a label applied afterwards would be invisible.
+          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
+          echo "Labels on this PR right now: ${LABELS:-(none)}"
+
           # The merge base, not the base branch tip: comparing against the tip
           # would report a bump for every PR opened after someone else's release
           # landed on main.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-04
+
 - Windows no longer flashes console windows across the desktop. Every child
   process Leviath starts is a console application, and one started by a process
   with no console of its own gets a fresh window on the interactive desktop.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,18 @@ on any PR that moves the version — the same deliberate sign-off
 `allow-main-rs-change` asks for, with its own label so approving a release never
 doubles as approving an entrypoint change.
 
+If you label the PR after CI has already started, the guard job that ran without
+it stays red and keeps the PR blocked, because the merge rollup counts every
+suite's copy of a check rather than only the newest. Clear it by rerunning that
+job in the suite it failed in:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+The guards read the PR's labels live when they run, so the rerun sees the label
+you just applied. Adding the label does not start a run of its own.
+
 Merging fires the alpha release for the bump commit; beta promotes it the
 following Monday and stable the Thursday after. Channels with nothing new to
 publish skip in seconds. See

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "keyring",
  "keyring-core",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -60,17 +60,17 @@ string_slice = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.1.2" }
-leviath-core = { path = "crates/leviath-core", version = "0.1.2" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.1.2" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.1.2" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.1.2" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.1.2" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.1.2" }
-leviath-package = { path = "crates/leviath-package", version = "0.1.2" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.1.2" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.1.2" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.1.2" }
+leviath = { path = "crates/leviath", version = "0.2.0" }
+leviath-core = { path = "crates/leviath-core", version = "0.2.0" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.2.0" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.2.0" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.2.0" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.2.0" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.2.0" }
+leviath-package = { path = "crates/leviath-package", version = "0.2.0" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.2.0" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.2.0" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.2.0" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies


### PR DESCRIPTION
## What & why

<!-- What does this PR change, and what problem does it solve?
     Link the issue it addresses, if there is one: Fixes #NNN -->

## How it was tested

<!-- Beyond `cargo test`: if the change affects runtime behavior, describe the
     live run you did (`lev run ...`, `lev dash`, daemon restart, ...).
     CI-green alone is not evidence a behavior change works. -->

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [ ] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [ ] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
- [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
- [ ] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
- [ ] Version bumped only if this PR is meant to ship — use `cargo xtask version <X.Y.Z>`, and apply the `allow-version-bump` label (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))
