### PR TITLE
ci(alpha): grant the gate job the permissions ci.yml now asks for

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -135,6 +135,19 @@ jobs:
     name: Gate
     needs: check-version
     if: needs.check-version.outputs.skip != 'true'
+    # The ceiling for every job inside ci.yml, so it has to cover the widest
+    # scope any of them asks for - even one that will not run from here.
+    # Permissions are settled when the run is created, before a single `if:`
+    # has been evaluated, so `guard-main-rs` requesting `pull-requests: read`
+    # to read its override label off the API failed the WHOLE nightly at
+    # startup with "requesting 'pull-requests: read', but is only allowed
+    # 'pull-requests: none'" - no jobs, no logs, just a dead run. Grant it
+    # here, and note that anything ci.yml adds later has to be granted here
+    # too, because the failure lands on this workflow rather than on the PR
+    # that introduced it.
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 


### PR DESCRIPTION
The nightly alpha for `e50e9e9` died at startup — no jobs, no logs, just a dead run:

> The nested job `guard-main-rs` is requesting `pull-requests: read`, but is only allowed `pull-requests: none`.
> The nested job `guard-version-bump` is requesting `pull-requests: read`, but is only allowed `pull-requests: none`.

A called workflow cannot hold more permission than the job calling it. `gate` declared none of its own, so it inherited alpha.yml’s workflow-wide `contents: read`. When the two guards moved to reading their override label off the API (#e50e9e9) they picked up `pull-requests: read`, which raised the ceiling ci.yml needs above what `gate` was handing over.

The `if: github.event_name == 'pull_request'` on both guards is no defence here. Permissions are settled when the run is created, before any `if:` is evaluated — so a job that was never going to run took down the whole release.

## How it was tested

Diagnosed from the run itself (30883569823), not guessed: the API reports `startup_failure` with zero jobs, and the run page carries the validation error quoted above verbatim. The chain matches — alpha last succeeded on 2026-08-03 (`d26ad1ac`), and `ci.yml` is the only thing that changed in between. alpha.yml is the only caller of ci.yml; the three `publish-docs.yml` callers already grant that workflow’s `id-token: write` + `contents: read`, and beta/prod both ran green on 2026-08-03.

The real verification is the run after this merges: a `workflow_dispatch` of Alpha, which has to get past startup and ship 0.2.0.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [x] New code is fully covered — no Rust changed; this is workflow YAML only
- [x] Docs updated if user-facing behavior changed — no user-facing behavior changed
- [x] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible — not user-visible
- [x] Version bumped only if this PR is meant to ship — not bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)