### PR TITLE
feat(serve): paginated runs, server-side search, and run file listing for The Lair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,63 @@ same list.
   a run starting on an installed bundled blueprint that this build ships a
   different version of prints a one-line note before it spawns.
 
+- **Security:** `GET /api/agents/{id}/context/history` served every run's webhook
+  signing secret to any holder of the API token. The route returns points
+  replayed from the run journal, and the journal stores run metadata whole,
+  `callback_secret` included, because the daemon needs it to keep signing
+  webhooks for a run it reloads after a restart. The redaction covering
+  `/api/agents` and its siblings was never applied here. It now happens in the
+  shared reader, so every consumer of a run's history inherits it.
+- New: `GET /api/runs`, the run listing, paginated and searchable. It supersedes
+  the `GET` half of `/api/agents`, which returns every run ever recorded as one
+  unbounded array and is now deprecated. Paging is keyset rather than offset, so
+  a run created or deleted mid-walk cannot shift the window; `sort=started_at`
+  is the default because it is the only sort key that never changes, since
+  `updated_at` advances on the persistence heartbeat. `ids=` replaces what used
+  to be one request per run, and `fields=` trims each item.
+- New: server-side run search, through `q=` and `q_in=`. The default sources
+  read metadata already in memory and cost nothing. `context`, `logs` and
+  `journal` read from disk, so they are opt-in and bounded by a scan cap that
+  reports itself as `scan_truncated` with a null `total`. Matching runs carry
+  highlights saying why they matched, which is the part a browser cannot work
+  out for itself: it never holds a run's transcript.
+- New: `GET /api/agents/{id}/files` lists a run's files when given no `path`,
+  either from what the run recorded modifying or from the working directory
+  itself, one directory level per request so a workdir containing
+  `node_modules` cannot be enumerated in one response.
+- New: `GET /api/config` reports `api_version`, a `capabilities` list and the
+  server's numeric `limits`, so a client can light up features in one call
+  instead of probing routes and reading a 404 as "unsupported" - which is also
+  what a missing run looks like.
+- New: `GET /api/agents/{id}/logs` takes `stage=<index>|all` and
+  `stream=output|logs`.
+- Breaking: `GET /api/blueprints` returns a paginated envelope rather than a
+  bare array, and accepts `limit`, `cursor`, `q`, `sort` and `order`. Worth
+  saying plainly that pagination saves the server nothing here, since discovery
+  parses every manifest on every request regardless; `q` is the parameter with
+  real value.
+- Breaking: `GET /api/agents/{id}/context/history` is paginated. It previously
+  returned every recorded point, each carrying a full context window with
+  untruncated text, on a journal that grows for as long as the run does.
+- Changed: `GET /api/agents/{id}/files?path=<dir>` returns a listing instead of
+  a 400. Asking for a directory is the natural way to say "what is in here".
+- Fixed: the run-status filter rejected the spelling it hands out. `RunMeta`
+  serializes `waiting_input`, but the filter compared a lowercased `Display`,
+  i.e. `waitinginput`, so feeding back a status you had just read matched
+  nothing - on exactly the two statuses where the reason is least visible.
+- Fixed: `GET /api/agents/{id}/logs` returned an empty string for every run. It
+  read a run-level `output.log` that nothing has ever written; a run's output
+  lives under `stages/<idx>/`.
+- Fixed: which blueprint a name resolved to depended on `readdir` order.
+  Discovery neither sorted nor deduplicated, and blueprint lookup and agent
+  spawning both take the first match by name, so with one name reachable from
+  two configured roots, which agent actually ran could differ between two calls.
+- Fixed: `RunFlags.modified_file_count` counts modifying tool calls rather than
+  distinct files, so a run that edits one file three times records three. The
+  file listing reports `modifying_tool_calls` and `modified_files_truncated` as
+  separate facts, so a client never subtracts one from the other to guess how
+  many files there were.
+
 ## 0.2.0 - 2026-08-04
 
 - Windows no longer flashes console windows across the desktop. Every child

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -248,10 +248,13 @@ pub(super) async fn agent_context_history(
 
     // Which indices this page wants, given the direction and where the cursor
     // left off. Computed up front so the replay can skip everything else.
-    let after = cursor.as_ref().and_then(|c| match c.key {
-        super::cursor::CursorKey::Int(i) => usize::try_from(i).ok(),
-        super::cursor::CursorKey::Text(_) => None,
-    });
+    // This route only ever mints an integer key, so anything else means a
+    // cursor that did not come from here - and the `_` arm is what the common
+    // "no cursor at all" case takes too.
+    let after = match cursor.as_ref().map(|c| &c.key) {
+        Some(super::cursor::CursorKey::Int(i)) => usize::try_from(*i).ok(),
+        _ => None,
+    };
     let wanted: Vec<usize> = if ascending {
         let start = after.map(|i| i + 1).unwrap_or(0);
         (start..total).take(limit + 1).collect()
@@ -2037,6 +2040,157 @@ prompt = "Plan the work"
 
             let (status, _) = list_files(&run_id, "?source=workdir").await;
             assert_eq!(status, StatusCode::NOT_FOUND);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// A recorded path can be absolute, because a tool can be handed one, and
+    /// it can be shaped so it has no file name at all. Neither may panic or
+    /// silently vanish from the list.
+    #[tokio::test]
+    async fn a_modified_listing_handles_absolute_and_nameless_paths() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_odd_paths", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            let outside = tempfile::tempdir().unwrap();
+            std::fs::write(outside.path().join("elsewhere.txt"), "x").unwrap();
+            let run_id = unique_run_id("files-odd");
+
+            let mut meta = make_run(&run_id);
+            meta.workdir = workdir.path().to_string_lossy().into_owned();
+            meta.flags.modified_files = vec![
+                outside
+                    .path()
+                    .join("elsewhere.txt")
+                    .to_string_lossy()
+                    .into_owned(),
+                // `Path::file_name` is None for a path ending in `..`.
+                "nested/..".to_string(),
+            ];
+            create_run(&meta).unwrap();
+
+            let (status, listing) = list_files(&run_id, "").await;
+            assert_eq!(status, StatusCode::OK);
+            let entries = listing["entries"].as_array().unwrap();
+            assert_eq!(entries.len(), 2);
+            // The absolute one resolved, exists, and is flagged as outside the
+            // fence rather than quietly dropped.
+            assert_eq!(entries[0]["name"], "elsewhere.txt");
+            assert_eq!(entries[0]["exists"], true);
+            assert_eq!(entries[0]["outside_workdir"], true);
+            // With no file name to show, the recorded path stands in for it.
+            assert_eq!(entries[1]["name"], "nested/..");
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// A single directory really can hold six figures of entries, and the
+    /// response is built in memory.
+    #[tokio::test]
+    async fn a_workdir_listing_stops_at_the_entry_cap() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_cap", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            for i in 0..MAX_LISTING_ENTRIES + 5 {
+                std::fs::write(workdir.path().join(format!("f{i}.txt")), "x").unwrap();
+            }
+            let run_id = unique_run_id("files-many");
+            create_run_in(&run_id, workdir.path());
+
+            let (status, listing) = list_files(&run_id, "?source=workdir").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(
+                listing["entries"].as_array().unwrap().len(),
+                MAX_LISTING_ENTRIES
+            );
+            assert_eq!(listing["truncated"], true);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// A symlinked child can point outside the workdir even when the directory
+    /// being listed is inside it, so containment is checked per entry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_workdir_listing_excludes_a_child_that_escapes_the_workdir() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_escape", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            let outside = tempfile::tempdir().unwrap();
+            std::fs::write(workdir.path().join("inside.txt"), "x").unwrap();
+            std::os::unix::fs::symlink(outside.path(), workdir.path().join("escape")).unwrap();
+            let run_id = unique_run_id("files-escape");
+            create_run_in(&run_id, workdir.path());
+
+            let (_, listing) = list_files(&run_id, "?source=workdir").await;
+            let names: Vec<&str> = listing["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e["name"].as_str().unwrap())
+                .collect();
+            assert_eq!(names, vec!["inside.txt"]);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// Windows twin of the above. Windows spells a directory link
+    /// `symlink_dir`; the fence behaves the same because `resolves_within`
+    /// canonicalizes before comparing.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn a_workdir_listing_excludes_a_child_that_escapes_the_workdir_windows() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_escape", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            let outside = tempfile::tempdir().unwrap();
+            std::fs::write(workdir.path().join("inside.txt"), "x").unwrap();
+            std::os::windows::fs::symlink_dir(outside.path(), workdir.path().join("escape"))
+                .unwrap();
+            let run_id = unique_run_id("files-escape");
+            create_run_in(&run_id, workdir.path());
+
+            let (_, listing) = list_files(&run_id, "?source=workdir").await;
+            let names: Vec<&str> = listing["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e["name"].as_str().unwrap())
+                .collect();
+            assert_eq!(names, vec!["inside.txt"]);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// A journal that records no context change has no timeline to show, which
+    /// is a 404 rather than an empty page - but only when the caller was not
+    /// already partway through a walk.
+    #[tokio::test]
+    async fn context_history_404s_when_a_journal_records_no_points() {
+        crate::runstate::with_isolated_runs_dir_async("ctx-hist-empty", |_d| async move {
+            let run_id = unique_run_id("ctx-empty");
+            create_run(&make_run(&run_id)).unwrap();
+            // A header and nothing else: a valid archive with zero points.
+            write_archive_with_points(&run_id, 0, None);
+
+            let app = Router::new()
+                .route(
+                    "/api/agents/{id}/context/history",
+                    get(agent_context_history),
+                )
+                .with_state(test_state());
+            let req = Request::builder()
+                .uri(format!("/api/agents/{run_id}/context/history"))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
 
             let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
         })

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -117,10 +117,7 @@ pub(super) async fn list_agents(Query(query): Query<ListAgentsQuery>) -> Json<Ve
 
     if let Some(ref status_filter) = query.status {
         let filters: Vec<&str> = status_filter.split(',').collect();
-        runs.retain(|r| {
-            let s = format!("{}", r.status).to_lowercase();
-            filters.iter().any(|f| f.to_lowercase() == s)
-        });
+        runs.retain(|r| filters.iter().any(|f| status_matches(&r.status, f)));
     }
 
     // `.redacted()`: `RunMeta` carries the webhook signing secret, and this
@@ -183,6 +180,14 @@ pub(super) async fn agent_context_history(
     Ok(Json(history))
 }
 
+/// `GET /api/agents/{id}/logs`: what a run has written, by stage.
+///
+/// This read `<run_dir>/output.log`, a path nothing in the codebase writes, so
+/// it returned an empty string for every run that has ever existed - a run's
+/// real output lives under `stages/<idx>/`. `?stage=` and `?stream=` select
+/// which log; both default to what a caller tailing a live run wants (the
+/// current stage's readable output). Response stays a bare string, so an
+/// existing client sees only that it finally has content.
 pub(super) async fn agent_logs(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<LogsQuery>,
@@ -197,9 +202,15 @@ pub(super) async fn agent_logs(
         ));
     }
 
+    let selector = query
+        .selector()
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+    let stream = query
+        .log_stream()
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+
     let max_bytes = query.tail.unwrap_or(32_768);
-    let log = runstate::tail_file(&run_dir.join("output.log"), max_bytes);
-    Ok(log)
+    Ok(runstate::tail_run_logs(&id, selector, stream, max_bytes))
 }
 
 /// How much of a file `GET /api/agents/{id}/files` returns: 1 MiB, enough for
@@ -309,14 +320,14 @@ pub(super) async fn agent_result(
         )
     })?;
 
-    // Read the last stage's output
-    let stages = runstate::read_stages_index(&id);
-    let output = if !stages.is_empty() {
-        let last_idx = stages.len() - 1;
-        runstate::tail_stage_output(&id, last_idx, 65_536)
-    } else {
-        runstate::tail_file(&runstate::run_dir(&id).join("output.log"), 65_536)
-    };
+    // The last stage's output, through the same reader `agent_logs` uses -
+    // including its fallback for a run with no stages recorded.
+    let output = runstate::tail_run_logs(
+        &id,
+        runstate::StageSelector::Current,
+        runstate::LogStream::Output,
+        65_536,
+    );
 
     Ok(Json(AgentResultResp {
         run_id: meta.run_id,
@@ -631,6 +642,39 @@ mod tests {
             "/tmp".to_string(),
             1,
         )
+    }
+
+    /// A `stages.json` entry, so a log test can say which stages exist.
+    fn stage_rec(index: usize, name: &str) -> leviath_core::run_meta::StageRecord {
+        leviath_core::run_meta::StageRecord {
+            name: name.to_string(),
+            index,
+            status: leviath_core::run_meta::StageRunStatus::Complete,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cached_tokens: 0,
+            started_at: None,
+            ended_at: None,
+        }
+    }
+
+    /// Call `GET /api/agents/{id}/logs{query}` and return the body as text.
+    /// The endpoint's whole bug was that its body was always empty, so a log
+    /// test that does not read the body proves nothing.
+    async fn logs_body(run_id: &str, query: &str) -> String {
+        let app = Router::new()
+            .route("/api/agents/{id}/logs", get(agent_logs))
+            .with_state(test_state());
+        let req = Request::builder()
+            .uri(format!("/api/agents/{run_id}/logs{query}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&bytes).into_owned()
     }
 
     fn test_state_with_agent_paths(paths: Vec<PathBuf>, control: ControlClient) -> AppState {
@@ -1229,27 +1273,35 @@ prompt = "Plan the work"
     // ─── agent_logs ───────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn agent_logs_existing_run_returns_ok() {
+    async fn agent_logs_reads_the_current_stage_not_the_dead_run_level_file() {
         crate::runstate::with_isolated_runs_dir_async(
-            "agent_logs_existing_run_returns_ok",
+            "agent_logs_reads_current_stage",
             |_d| async move {
                 let run_id = unique_run_id("logs-ok");
                 let meta = make_run(&run_id);
                 create_run(&meta).unwrap();
 
-                // Write something to output.log
-                let log_path = runstate::run_dir(&run_id).join("output.log");
-                std::fs::write(&log_path, "hello log\n").unwrap();
+                // Two stages, so "current" has to mean the last one and not
+                // just "the only one that exists".
+                runstate::write_stages_index(
+                    &run_id,
+                    &[stage_rec(0, "plan"), stage_rec(1, "code")],
+                )
+                .unwrap();
+                runstate::append_stage_output(&run_id, 0, "from the planning stage");
+                runstate::append_stage_output(&run_id, 1, "from the coding stage");
+                // The path the handler used to read. Nothing writes it in
+                // production; planting it here proves the handler stopped.
+                std::fs::write(
+                    runstate::run_dir(&run_id).join("output.log"),
+                    "the dead run-level file",
+                )
+                .unwrap();
 
-                let app = Router::new()
-                    .route("/api/agents/{id}/logs", get(agent_logs))
-                    .with_state(test_state());
-                let req = Request::builder()
-                    .uri(format!("/api/agents/{}/logs", run_id))
-                    .body(Body::empty())
-                    .unwrap();
-                let resp = app.oneshot(req).await.unwrap();
-                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                let body = logs_body(&run_id, "").await;
+                assert!(body.contains("from the coding stage"));
+                assert!(!body.contains("from the planning stage"));
+                assert!(!body.contains("the dead run-level file"));
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },
@@ -1258,26 +1310,116 @@ prompt = "Plan the work"
     }
 
     #[tokio::test]
-    async fn agent_logs_with_tail_param() {
+    async fn agent_logs_selects_a_stage_a_stream_and_every_stage() {
         crate::runstate::with_isolated_runs_dir_async(
-            "agent_logs_with_tail_param",
+            "agent_logs_selects_stage_and_stream",
+            |_d| async move {
+                let run_id = unique_run_id("logs-select");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
+                runstate::write_stages_index(
+                    &run_id,
+                    &[stage_rec(0, "plan"), stage_rec(1, "code")],
+                )
+                .unwrap();
+                runstate::append_stage_output(&run_id, 0, "plan output");
+                runstate::append_stage_output(&run_id, 1, "code output");
+                runstate::append_stage_log(&run_id, 1, "[tool] write_file: ok");
+
+                // An explicit index reaches back past the current stage.
+                let stage0 = logs_body(&run_id, "?stage=0").await;
+                assert!(stage0.contains("plan output"));
+                assert!(!stage0.contains("code output"));
+
+                // The two streams stay separate.
+                let operational = logs_body(&run_id, "?stream=logs").await;
+                assert!(operational.contains("[tool] write_file: ok"));
+                assert!(!operational.contains("code output"));
+
+                // `all` joins every stage, oldest first, and labels them.
+                let all = logs_body(&run_id, "?stage=all").await;
+                assert!(all.contains("plan output"));
+                assert!(all.contains("code output"));
+                assert!(all.contains("stage 0: plan"));
+                assert!(all.find("plan output") < all.find("code output"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_logs_tail_bounds_the_bytes_returned() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_logs_tail_bounds_bytes",
             |_d| async move {
                 let run_id = unique_run_id("logs-tail");
                 let meta = make_run(&run_id);
                 create_run(&meta).unwrap();
+                runstate::write_stages_index(&run_id, &[stage_rec(0, "only")]).unwrap();
+                for i in 0..200 {
+                    runstate::append_stage_output(&run_id, 0, &format!("line {i}"));
+                }
 
-                let log_path = runstate::run_dir(&run_id).join("output.log");
-                std::fs::write(&log_path, "line1\nline2\nline3\n").unwrap();
+                let full = logs_body(&run_id, "?tail=100000").await;
+                assert!(full.contains("line 0"));
 
-                let app = Router::new()
-                    .route("/api/agents/{id}/logs", get(agent_logs))
-                    .with_state(test_state());
-                let req = Request::builder()
-                    .uri(format!("/api/agents/{}/logs?tail=100", run_id))
-                    .body(Body::empty())
-                    .unwrap();
-                let resp = app.oneshot(req).await.unwrap();
-                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+                // `tail` is a byte budget, so a small one drops the head.
+                let tailed = logs_body(&run_id, "?tail=200").await;
+                assert!(tailed.len() <= 200);
+                assert!(tailed.contains("line 199"));
+                assert!(!tailed.contains("line 0\n"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_logs_falls_back_to_the_run_level_file_when_no_stages_exist() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_logs_no_stages_fallback",
+            |_d| async move {
+                let run_id = unique_run_id("logs-fallback");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
+                // No stages.json at all - a run whose stage dirs were pruned.
+                std::fs::write(
+                    runstate::run_dir(&run_id).join("output.log"),
+                    "legacy output",
+                )
+                .unwrap();
+
+                assert!(logs_body(&run_id, "").await.contains("legacy output"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_logs_rejects_an_unparseable_stage_or_stream() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "agent_logs_rejects_bad_params",
+            |_d| async move {
+                let run_id = unique_run_id("logs-bad");
+                let meta = make_run(&run_id);
+                create_run(&meta).unwrap();
+
+                for query in ["?stage=middle", "?stream=everything"] {
+                    let app = Router::new()
+                        .route("/api/agents/{id}/logs", get(agent_logs))
+                        .with_state(test_state());
+                    let req = Request::builder()
+                        .uri(format!("/api/agents/{run_id}/logs{query}"))
+                        .body(Body::empty())
+                        .unwrap();
+                    let resp = app.oneshot(req).await.unwrap();
+                    assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+                }
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -231,12 +231,21 @@ pub(super) const MAX_FILE_READ_BYTES: u64 = 1024 * 1024;
 pub(super) async fn agent_file(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<FileQuery>,
-) -> Result<Json<FileContentResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<FileOrListing>, (StatusCode, Json<ErrorResponse>)> {
     let meta = runstate::read_meta(&id)
         .map_err(|_| err(StatusCode::NOT_FOUND, format!("Agent run '{id}' not found")))?;
 
+    let source = query
+        .file_source()
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+
+    // No path means "what is there", which is a listing rather than a read.
+    let Some(ref requested_path) = query.path else {
+        return list_run_files(&meta, source, None, query.hidden).map(Json);
+    };
+
     let workdir = PathBuf::from(&meta.workdir);
-    let requested = PathBuf::from(&query.path);
+    let requested = PathBuf::from(requested_path);
     let resolved = match requested.is_absolute() {
         true => requested,
         false => workdir.join(&requested),
@@ -244,25 +253,23 @@ pub(super) async fn agent_file(
     if !leviath_core::resolves_within(&resolved, &workdir) {
         return Err(err(
             StatusCode::FORBIDDEN,
-            format!(
-                "path '{}' is outside the run's working directory",
-                query.path
-            ),
+            format!("path '{requested_path}' is outside the run's working directory"),
         ));
     }
 
     let size = match std::fs::metadata(&resolved) {
+        // A directory used to be a 400. It is the natural way to ask "what is
+        // in here", and the folder picker already answers that shape, so it
+        // lists instead. Nothing can have depended on the old error.
         Ok(m) if m.is_dir() => {
-            return Err(err(
-                StatusCode::BAD_REQUEST,
-                format!("'{}' is a directory, not a file", query.path),
-            ));
+            return list_run_files(&meta, FileSource::Workdir, Some(&resolved), query.hidden)
+                .map(Json);
         }
         Ok(m) => m.len(),
         Err(_) => {
             return Err(err(
                 StatusCode::NOT_FOUND,
-                format!("file '{}' not found", query.path),
+                format!("file '{requested_path}' not found"),
             ));
         }
     };
@@ -274,7 +281,7 @@ pub(super) async fn agent_file(
     {
         return Err(err(
             StatusCode::NOT_FOUND,
-            format!("could not read '{}': {e}", query.path),
+            format!("could not read '{requested_path}': {e}"),
         ));
     }
     let truncated = size > MAX_FILE_READ_BYTES;
@@ -295,17 +302,169 @@ pub(super) async fn agent_file(
         Err(_) => {
             return Err(err(
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                format!("'{}' is not a text file", query.path),
+                format!("'{requested_path}' is not a text file"),
             ));
         }
     };
 
-    Ok(Json(FileContentResp {
+    Ok(Json(FileOrListing::File(FileContentResp {
         path: resolved.to_string_lossy().into_owned(),
         size,
         content,
         truncated,
-    }))
+    })))
+}
+
+/// Most entries one directory listing returns.
+///
+/// A single `node_modules/.pnpm` really does hold six figures of entries, and
+/// the response is built in memory.
+pub(super) const MAX_LISTING_ENTRIES: usize = 1000;
+
+/// List what a run touched, or what is in its working directory.
+///
+/// Two genuinely different questions, and neither substitutes for the other:
+///
+/// - [`FileSource::Modified`] is the run's own record of what it changed. Free -
+///   it is already in `meta.json` - but capped at record time, so it is a claim
+///   about the run rather than about the disk.
+/// - [`FileSource::Workdir`] is what is actually there now, read **one directory
+///   level per request**. That bound is the answer to "a repo with
+///   node_modules": the client walks the tree itself, exactly as the existing
+///   folder picker does, instead of one request trying to enumerate everything.
+fn list_run_files(
+    meta: &RunMeta,
+    source: FileSource,
+    dir: Option<&std::path::Path>,
+    hidden: bool,
+) -> Result<FileOrListing, (StatusCode, Json<ErrorResponse>)> {
+    let workdir = PathBuf::from(&meta.workdir);
+    let listing = match source {
+        FileSource::Modified => modified_listing(meta, &workdir),
+        FileSource::Workdir => workdir_listing(meta, &workdir, dir, hidden)?,
+    };
+    Ok(FileOrListing::Listing(Box::new(listing)))
+}
+
+/// The paths the run recorded modifying, stat-ed against the workdir.
+fn modified_listing(meta: &RunMeta, workdir: &std::path::Path) -> RunFileListing {
+    let entries = meta
+        .flags
+        .modified_files
+        .iter()
+        .map(|rel| {
+            let resolved = if std::path::Path::new(rel).is_absolute() {
+                PathBuf::from(rel)
+            } else {
+                workdir.join(rel)
+            };
+            let stat = std::fs::metadata(&resolved).ok();
+            RunFileEntry {
+                name: std::path::Path::new(rel)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| rel.clone()),
+                path: rel.clone(),
+                is_dir: stat.as_ref().is_some_and(|m| m.is_dir()),
+                size: stat.as_ref().map(|m| m.len()),
+                // A recorded path can name a file since deleted, or - for a
+                // tool given an absolute path - one outside the workdir.
+                // Reported rather than filtered away, so the list stays a
+                // faithful account of what the run did.
+                exists: stat.is_some(),
+                outside_workdir: !leviath_core::resolves_within(&resolved, workdir),
+            }
+        })
+        .collect();
+
+    RunFileListing {
+        kind: "listing",
+        source: "modified",
+        path: meta.workdir.clone(),
+        parent: None,
+        workdir: meta.workdir.clone(),
+        entries,
+        truncated: false,
+        // Both of the ways this list misleads, made visible in the response
+        // rather than left in the documentation. See the field docs.
+        modified_files_truncated: meta.flags.modified_files.len()
+            >= leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
+        modifying_tool_calls: meta.flags.modified_file_count,
+    }
+}
+
+/// One directory level of the run's working directory.
+fn workdir_listing(
+    meta: &RunMeta,
+    workdir: &std::path::Path,
+    dir: Option<&std::path::Path>,
+    hidden: bool,
+) -> Result<RunFileListing, (StatusCode, Json<ErrorResponse>)> {
+    let target = dir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workdir.to_path_buf());
+    if !target.is_dir() {
+        // Distinguished from an ordinary 404 because a lost workspace is a
+        // known run outcome (`flags.workspace_lost`), and an empty listing
+        // would read as "this run touched nothing".
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!(
+                "the run's working directory '{}' no longer exists",
+                target.display()
+            ),
+        ));
+    }
+
+    let mut entries: Vec<RunFileEntry> = Vec::new();
+    let mut truncated = false;
+    for child in std::fs::read_dir(&target).into_iter().flatten().flatten() {
+        if entries.len() >= MAX_LISTING_ENTRIES {
+            truncated = true;
+            break;
+        }
+        let name = child.file_name().to_string_lossy().into_owned();
+        if !hidden && name.starts_with('.') {
+            continue;
+        }
+        let path = child.path();
+        // Per entry, not just for the directory asked for: a symlinked child
+        // can point outside the fence. The folder picker already does this.
+        if !leviath_core::resolves_within(&path, workdir) {
+            continue;
+        }
+        let stat = child.metadata().ok();
+        entries.push(RunFileEntry {
+            path: path
+                .strip_prefix(workdir)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned(),
+            name,
+            is_dir: stat.as_ref().is_some_and(|m| m.is_dir()),
+            size: stat.as_ref().map(|m| m.len()),
+            exists: true,
+            outside_workdir: false,
+        });
+    }
+    // Directories first, then by name - the grouping a file tree wants, done
+    // once here rather than in every client.
+    entries.sort_by(|a, b| b.is_dir.cmp(&a.is_dir).then_with(|| a.name.cmp(&b.name)));
+
+    Ok(RunFileListing {
+        kind: "listing",
+        source: "workdir",
+        path: target.to_string_lossy().into_owned(),
+        parent: (target != workdir)
+            .then(|| target.parent().map(|p| p.to_string_lossy().into_owned()))
+            .flatten(),
+        workdir: meta.workdir.clone(),
+        entries,
+        truncated,
+        modified_files_truncated: meta.flags.modified_files.len()
+            >= leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
+        modifying_tool_calls: meta.flags.modified_file_count,
+    })
 }
 
 pub(super) async fn agent_result(
@@ -1477,6 +1636,179 @@ prompt = "Plan the work"
             .to_string()
     }
 
+    /// `GET /api/agents/{id}/files` with no `path`, plus any extra query.
+    async fn list_files(id: &str, extra: &str) -> (StatusCode, serde_json::Value) {
+        let uri = format!("/api/agents/{id}/files{extra}");
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = files_app().oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null),
+        )
+    }
+
+    /// The original Lair blocker: the console had a "+N more" badge and no
+    /// endpoint that could list the names behind it.
+    #[tokio::test]
+    async fn listing_defaults_to_what_the_run_recorded_modifying() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_modified", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            std::fs::write(workdir.path().join("kept.rs"), "x").unwrap();
+            let run_id = unique_run_id("files-mod");
+
+            let mut meta = make_run(&run_id);
+            meta.workdir = workdir.path().to_string_lossy().into_owned();
+            meta.flags.modified_files = vec!["kept.rs".to_string(), "deleted.rs".to_string()];
+            // Three calls, two distinct files: the two numbers disagree, which
+            // is exactly why a client must not subtract them.
+            meta.flags.modified_file_count = 3;
+            create_run(&meta).unwrap();
+
+            let (status, listing) = list_files(&run_id, "").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(listing["source"], "modified");
+            assert_eq!(listing["entries"].as_array().unwrap().len(), 2);
+            // A path the run recorded but which is now gone is reported as
+            // such rather than quietly dropped.
+            assert_eq!(listing["entries"][0]["exists"], true);
+            assert_eq!(listing["entries"][1]["name"], "deleted.rs");
+            assert_eq!(listing["entries"][1]["exists"], false);
+            // Named for what it counts, and not equal to the file count.
+            assert_eq!(listing["modifying_tool_calls"], 3);
+            assert_eq!(listing["modified_files_truncated"], false);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// Past the record-time cap the remaining names were never stored, so the
+    /// only honest thing the API can do is say the list is a prefix.
+    #[tokio::test]
+    async fn a_run_at_the_tracking_cap_reports_its_list_as_truncated() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_capped", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            let run_id = unique_run_id("files-cap");
+            let mut meta = make_run(&run_id);
+            meta.workdir = workdir.path().to_string_lossy().into_owned();
+            meta.flags.modified_files = (0..leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES)
+                .map(|i| format!("f{i}.rs"))
+                .collect();
+            meta.flags.modified_file_count = 5_000;
+            create_run(&meta).unwrap();
+
+            let (_, listing) = list_files(&run_id, "").await;
+            assert_eq!(listing["modified_files_truncated"], true);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// One directory level per request is the answer to "a repo with
+    /// node_modules": the client walks the tree rather than one response
+    /// trying to enumerate it.
+    #[tokio::test]
+    async fn a_workdir_listing_is_one_level_deep_and_descends_by_path() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_workdir", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            std::fs::write(workdir.path().join("top.txt"), "x").unwrap();
+            std::fs::write(workdir.path().join(".hidden"), "x").unwrap();
+            std::fs::create_dir(workdir.path().join("nested")).unwrap();
+            std::fs::write(workdir.path().join("nested/deep.txt"), "x").unwrap();
+            let run_id = unique_run_id("files-wd");
+            create_run_in(&run_id, workdir.path());
+
+            let (status, listing) = list_files(&run_id, "?source=workdir").await;
+            assert_eq!(status, StatusCode::OK);
+            let names: Vec<&str> = listing["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|e| e["name"].as_str().unwrap())
+                .collect();
+            // Directories first, then by name. The nested file is not here -
+            // one level only.
+            assert_eq!(names, vec!["nested", "top.txt"]);
+            assert!(listing["parent"].is_null(), "at the workdir root");
+
+            // Hidden entries are opt-in, mirroring the folder picker.
+            let (_, with_hidden) = list_files(&run_id, "?source=workdir&hidden=true").await;
+            assert_eq!(with_hidden["entries"].as_array().unwrap().len(), 3);
+
+            // Descending is the same route with a path.
+            let (_, deeper) = list_files(&run_id, "?source=workdir&path=nested").await;
+            assert_eq!(deeper["entries"][0]["name"], "deep.txt");
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// A lost workspace is a known run outcome, and an empty listing would
+    /// read as "this run touched nothing".
+    #[tokio::test]
+    async fn a_workdir_listing_404s_when_the_workspace_is_gone() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_gone", |_d| async move {
+            let run_id = unique_run_id("files-gone");
+            let mut meta = make_run(&run_id);
+            meta.workdir = "/definitely/not/here".to_string();
+            create_run(&meta).unwrap();
+
+            let (status, _) = list_files(&run_id, "?source=workdir").await;
+            assert_eq!(status, StatusCode::NOT_FOUND);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn an_unknown_file_source_is_refused() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_bad_source", |_d| async move {
+            let run_id = unique_run_id("files-bad");
+            create_run(&make_run(&run_id)).unwrap();
+
+            let (status, body) = list_files(&run_id, "?source=everything").await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert!(body["error"].as_str().unwrap().contains("everything"));
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// Reading a file must still serialize byte-for-byte as it did before the
+    /// listing shape was added, or every existing client breaks.
+    #[tokio::test]
+    async fn reading_a_file_still_returns_the_original_shape() {
+        crate::runstate::with_isolated_runs_dir_async("agent_files_compat", |_d| async move {
+            let workdir = tempfile::tempdir().unwrap();
+            std::fs::write(workdir.path().join("report.md"), "hello").unwrap();
+            let run_id = unique_run_id("files-compat");
+            create_run_in(&run_id, workdir.path());
+
+            let (status, body) = get_file(&run_id, "report.md").await;
+            assert_eq!(status, StatusCode::OK);
+            let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            let keys: Vec<&str> = value
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(keys, vec!["content", "path", "size", "truncated"]);
+            assert_eq!(value["content"], "hello");
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
     #[tokio::test]
     async fn agent_file_unknown_run_returns_404() {
         let (status, body) = get_file("nonexistent-run-xyz-files", "report.md").await;
@@ -1627,18 +1959,27 @@ prompt = "Plan the work"
     }
 
     #[tokio::test]
-    async fn agent_file_directory_returns_400() {
+    /// A directory used to be a 400. Asking for one is the natural way to say
+    /// "what is in here", so it lists instead - the behavior change this route
+    /// deliberately makes.
+    async fn agent_file_directory_lists_instead_of_erroring() {
         crate::runstate::with_isolated_runs_dir_async(
-            "agent_file_directory_returns_400",
+            "agent_file_directory_lists",
             |_d| async move {
                 let workdir = tempfile::tempdir().unwrap();
                 std::fs::create_dir(workdir.path().join("sub")).unwrap();
+                std::fs::write(workdir.path().join("sub/inner.txt"), "hi").unwrap();
                 let run_id = unique_run_id("file-dir");
                 create_run_in(&run_id, workdir.path());
 
                 let (status, body) = get_file(&run_id, "sub").await;
-                assert_eq!(status, StatusCode::BAD_REQUEST);
-                assert_eq!(error_of(&body), "'sub' is a directory, not a file");
+                assert_eq!(status, StatusCode::OK);
+                let listing: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(listing["kind"], "listing");
+                assert_eq!(listing["source"], "workdir");
+                assert_eq!(listing["entries"][0]["name"], "inner.txt");
+                // "Up one level" from a subdirectory is the workdir.
+                assert!(listing["parent"].is_string());
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -165,19 +165,152 @@ pub(super) async fn agent_context(
         })
 }
 
+/// Default number of history points returned when the client does not ask.
+pub(super) const HISTORY_DEFAULT_LIMIT: usize = 50;
+/// Largest history page. Lower than the run listing's cap because each item
+/// carries a whole context window rather than one struct of scalars.
+pub(super) const HISTORY_MAX_LIMIT: usize = 100;
+
+/// `GET /api/agents/{id}/context/history`: the run's context window over time.
+///
+/// This returned **every** recorded point, each carrying a full
+/// `ContextSnapshot` with untruncated region text - comfortably the largest
+/// response in the API, with no window and no cap, on a journal that grows for
+/// as long as the run does.
+///
+/// Now paged, through the same envelope the run listing uses. The cursor is the
+/// point index: the journal is append-only, so an index is stable once written
+/// and new points only ever arrive at the end - the strongest keyset of any
+/// route here. `order=asc` stays the default, which is both chronological and
+/// what the previous unpaged response gave.
+///
+/// The replay itself goes through `visit_points`, so points outside the window
+/// are folded but never materialized. Materializing means deep-copying an
+/// entire context window per point, and this endpoint's whole problem was doing
+/// that for the full history on every request.
 pub(super) async fn agent_context_history(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<Vec<leviath_core::run_archive::RunPoint>>, (StatusCode, Json<ErrorResponse>)> {
-    let history = runstate::context_history(&id);
-    if history.is_empty() {
-        return Err((
+    Query(query): Query<HistoryQuery>,
+) -> Result<Json<Page<leviath_core::run_archive::RunPoint>>, (StatusCode, Json<ErrorResponse>)> {
+    use std::ops::ControlFlow;
+
+    let ascending = match query.order.as_deref() {
+        None | Some("asc") => true,
+        Some("desc") => false,
+        Some(other) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("Unknown order '{other}': expected asc or desc"),
+            ));
+        }
+    };
+    let limit = match query.limit {
+        None => HISTORY_DEFAULT_LIMIT,
+        Some(0) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "`limit` must be at least 1; omit it for the default".to_string(),
+            ));
+        }
+        Some(n) => n.min(HISTORY_MAX_LIMIT),
+    };
+
+    let digest = super::cursor::filter_digest(&[&id]);
+    let order_name = if ascending { "asc" } else { "desc" };
+    let cursor = match query.cursor.as_deref() {
+        None => None,
+        Some(raw) => Some(
+            super::cursor::decode(raw, "index", order_name, &digest)
+                .map_err(|e| err(StatusCode::BAD_REQUEST, e.message()))?,
+        ),
+    };
+
+    let Some(records) = runstate::read_run_archive(&id) else {
+        return Err(err(
             StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: format!("No context history for run '{}'", id),
-            }),
+            format!("No context history for run '{id}'"),
+        ));
+    };
+
+    // One pass to count, so `total` is honest and a descending window knows
+    // where to start. Counting folds the deltas but materializes nothing.
+    let mut total = 0usize;
+    leviath_core::run_archive::visit_points(&records, &mut |_| {
+        total += 1;
+        ControlFlow::Continue(())
+    });
+    if total == 0 && query.cursor.is_none() {
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!("No context history for run '{id}'"),
         ));
     }
-    Ok(Json(history))
+
+    // Which indices this page wants, given the direction and where the cursor
+    // left off. Computed up front so the replay can skip everything else.
+    let after = cursor.as_ref().and_then(|c| match c.key {
+        super::cursor::CursorKey::Int(i) => usize::try_from(i).ok(),
+        super::cursor::CursorKey::Text(_) => None,
+    });
+    let wanted: Vec<usize> = if ascending {
+        let start = after.map(|i| i + 1).unwrap_or(0);
+        (start..total).take(limit + 1).collect()
+    } else {
+        let start = after
+            .map(|i| i.saturating_sub(1))
+            .unwrap_or_else(|| total.saturating_sub(1));
+        (0..=start).rev().take(limit + 1).collect()
+    };
+    let stop_at = wanted.iter().copied().max();
+
+    let mut collected: Vec<(usize, leviath_core::run_archive::RunPoint)> = Vec::new();
+    leviath_core::run_archive::visit_points(&records, &mut |point| {
+        if wanted.contains(&point.index) {
+            collected.push((
+                point.index,
+                leviath_core::run_archive::RunPoint {
+                    // Redacted for the same reason `runstate::context_history`
+                    // redacts: the journal stores RunMeta whole, secret and all.
+                    meta: point.meta.redacted(),
+                    context: point.context.clone(),
+                    at: point.at,
+                },
+            ));
+        }
+        match stop_at {
+            Some(last) if point.index >= last => ControlFlow::Break(()),
+            _ => ControlFlow::Continue(()),
+        }
+    });
+
+    if !ascending {
+        collected.sort_by_key(|(index, _)| std::cmp::Reverse(*index));
+    }
+
+    let has_more = collected.len() > limit;
+    collected.truncate(limit);
+    let next_cursor = has_more
+        .then(|| collected.last())
+        .flatten()
+        .map(|(index, _)| {
+            super::cursor::encode(
+                "index",
+                order_name,
+                &digest,
+                super::cursor::CursorKey::Int(*index as i64),
+                "",
+            )
+        });
+
+    let items = collected.into_iter().map(|(_, point)| point).collect();
+    Ok(Json(Page::new(items, next_cursor, Some(total), now_secs())))
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 /// `GET /api/agents/{id}/logs`: what a run has written, by stage.
@@ -1335,7 +1468,16 @@ prompt = "Plan the work"
 
     /// Write a minimal `run.lvr` (Header + one ContextCheckpoint) for `run_id`.
     fn write_archive_fixture(run_id: &str) {
+        write_archive_with_points(run_id, 1, None);
+    }
+
+    /// A journal with `points` context checkpoints, so history paging has
+    /// something to page over. `secret` plants a webhook key in the header, for
+    /// the redaction test.
+    fn write_archive_with_points(run_id: &str, points: usize, secret: Option<&str>) {
         use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+        let mut meta = make_run(run_id);
+        meta.callback_secret = secret.map(str::to_string);
         let mut buf = Vec::new();
         run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
         run_archive::write_record(
@@ -1347,24 +1489,51 @@ prompt = "Plan the work"
                     world_id: "w".to_string(),
                     created_at: 0,
                 },
-                meta: Box::new(make_run(run_id)),
+                meta: Box::new(meta),
             },
         )
         .unwrap();
-        run_archive::write_record(
-            &mut buf,
-            &RunRecord::ContextCheckpoint {
-                snapshot: runstate::ContextSnapshot {
-                    stage_name: "plan".to_string(),
-                    total_tokens: 7,
-                    max_tokens: 100,
-                    regions: vec![],
+        for i in 0..points {
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::ContextCheckpoint {
+                    snapshot: runstate::ContextSnapshot {
+                        // Named by index so a test can tell which point it got.
+                        stage_name: if points == 1 {
+                            "plan".to_string()
+                        } else {
+                            format!("stage-{i}")
+                        },
+                        total_tokens: 7,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: 1 + i as i64,
                 },
-                at: 1,
-            },
-        )
-        .unwrap();
+            )
+            .unwrap();
+        }
         std::fs::write(runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+    }
+
+    /// Call the history route and return the decoded page.
+    async fn history_page(run_id: &str, extra: &str) -> serde_json::Value {
+        let app = Router::new()
+            .route(
+                "/api/agents/{id}/context/history",
+                get(agent_context_history),
+            )
+            .with_state(test_state());
+        let req = Request::builder()
+            .uri(format!("/api/agents/{run_id}/context/history{extra}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
     }
 
     #[tokio::test]
@@ -1376,6 +1545,116 @@ prompt = "Plan the work"
                 create_run(&make_run(&run_id)).unwrap();
                 write_archive_fixture(&run_id);
 
+                let page = history_page(&run_id, "").await;
+                assert_eq!(page["items"].as_array().unwrap().len(), 1);
+                assert_eq!(page["items"][0]["context"]["stage_name"], "plan");
+                assert_eq!(page["total"], 1);
+                assert!(page["next_cursor"].is_null());
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+            },
+        )
+        .await;
+    }
+
+    /// This route returned every recorded point, each carrying a full context
+    /// window, on a journal that grows for as long as the run does.
+    #[tokio::test]
+    async fn context_history_pages_through_every_point_exactly_once() {
+        crate::runstate::with_isolated_runs_dir_async("ctx-hist-pages", |_d| async move {
+            let run_id = unique_run_id("ctx-page");
+            create_run(&make_run(&run_id)).unwrap();
+            write_archive_with_points(&run_id, 7, None);
+
+            let mut seen: Vec<String> = Vec::new();
+            let mut cursor: Option<String> = None;
+            for _ in 0..10 {
+                let extra = match cursor {
+                    None => "?limit=3".to_string(),
+                    Some(ref c) => format!("?limit=3&cursor={c}"),
+                };
+                let page = history_page(&run_id, &extra).await;
+                assert_eq!(page["total"], 7);
+                for item in page["items"].as_array().unwrap() {
+                    seen.push(item["context"]["stage_name"].as_str().unwrap().to_string());
+                }
+                match page["next_cursor"].as_str() {
+                    Some(c) => cursor = Some(c.to_string()),
+                    None => break,
+                }
+            }
+
+            // Chronological by default, complete, and nothing repeated.
+            assert_eq!(
+                seen,
+                (0..7).map(|i| format!("stage-{i}")).collect::<Vec<_>>()
+            );
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// Descending is what a UI tailing a run wants: the latest window without
+    /// paging through the whole history to reach it.
+    #[tokio::test]
+    async fn context_history_can_start_from_the_most_recent_point() {
+        crate::runstate::with_isolated_runs_dir_async("ctx-hist-desc", |_d| async move {
+            let run_id = unique_run_id("ctx-desc");
+            create_run(&make_run(&run_id)).unwrap();
+            write_archive_with_points(&run_id, 5, None);
+
+            let page = history_page(&run_id, "?order=desc&limit=2").await;
+            let names: Vec<&str> = page["items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|i| i["context"]["stage_name"].as_str().unwrap())
+                .collect();
+            assert_eq!(names, vec!["stage-4", "stage-3"]);
+
+            // And it continues downwards.
+            let cursor = page["next_cursor"].as_str().unwrap();
+            let next = history_page(&run_id, &format!("?order=desc&limit=2&cursor={cursor}")).await;
+            let names: Vec<&str> = next["items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|i| i["context"]["stage_name"].as_str().unwrap())
+                .collect();
+            assert_eq!(names, vec!["stage-2", "stage-1"]);
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    /// The journal stores `RunMeta` whole, so every point carries the webhook
+    /// signing key unless this route strips it. It did not, which is how the
+    /// key was reachable by any token holder.
+    #[tokio::test]
+    async fn context_history_never_serves_the_webhook_secret() {
+        crate::runstate::with_isolated_runs_dir_async("ctx-hist-secret", |_d| async move {
+            let run_id = unique_run_id("ctx-secret");
+            create_run(&make_run(&run_id)).unwrap();
+            write_archive_with_points(&run_id, 2, Some("super-secret-signing-key"));
+
+            let page = history_page(&run_id, "").await;
+            assert!(!page.to_string().contains("super-secret-signing-key"));
+
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn context_history_rejects_a_bad_order_or_limit() {
+        crate::runstate::with_isolated_runs_dir_async("ctx-hist-bad", |_d| async move {
+            let run_id = unique_run_id("ctx-bad");
+            create_run(&make_run(&run_id)).unwrap();
+            write_archive_fixture(&run_id);
+
+            for extra in ["?order=sideways", "?limit=0", "?cursor=zzz"] {
                 let app = Router::new()
                     .route(
                         "/api/agents/{id}/context/history",
@@ -1383,22 +1662,19 @@ prompt = "Plan the work"
                     )
                     .with_state(test_state());
                 let req = Request::builder()
-                    .uri(format!("/api/agents/{}/context/history", run_id))
+                    .uri(format!("/api/agents/{run_id}/context/history{extra}"))
                     .body(Body::empty())
                     .unwrap();
                 let resp = app.oneshot(req).await.unwrap();
-                assert_eq!(resp.status(), axum::http::StatusCode::OK);
-                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-                    .await
-                    .unwrap();
-                let got: Vec<leviath_core::run_archive::RunPoint> =
-                    serde_json::from_slice(&body).unwrap();
-                assert_eq!(got.len(), 1);
-                assert_eq!(got[0].context.stage_name, "plan");
+                assert_eq!(
+                    resp.status(),
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "expected {extra} to be rejected"
+                );
+            }
 
-                let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
-            },
-        )
+            let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
         .await;
     }
 

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -59,10 +59,10 @@ fn blueprint_dir(name: &str) -> Result<PathBuf, (StatusCode, Json<ErrorResponse>
 /// existing `.find()` already meant to pick - the installed catalog first - and
 /// this only makes that choice deterministic rather than changing it.
 ///
-/// **Then sort by `(name, path)`.** `name` is the client-facing identity; `path`
-/// is a tie-break that cannot itself be ambiguous, so the order is total. A list
-/// that is merely "whatever the filesystem said" cannot be paginated: a cursor
-/// over an unstable order skips and repeats entries.
+/// **Then sort by name**, which needs no tie-break precisely because the dedup
+/// above ran first: after it, no two entries share a name, so name alone is a
+/// total order. A list that is merely "whatever the filesystem said" cannot be
+/// paginated - a cursor over an unstable order skips and repeats entries.
 fn canonicalize(found: Vec<BlueprintInfo>) -> Vec<BlueprintInfo> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut kept: Vec<BlueprintInfo> = Vec::with_capacity(found.len());
@@ -77,7 +77,7 @@ fn canonicalize(found: Vec<BlueprintInfo>) -> Vec<BlueprintInfo> {
             );
         }
     }
-    kept.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
+    kept.sort_by(|a, b| a.name.cmp(&b.name));
     kept
 }
 
@@ -219,9 +219,11 @@ pub(super) async fn list_blueprints(
 
     // `discover_blueprints` already sorts by (name, path); re-sort only when
     // something other than that default was asked for.
+    // Sorting by version needs the name to break ties; sorting by name needs
+    // nothing, because `canonicalize` already made names unique.
     let key = |bp: &BlueprintInfo| match sort_name {
         "version" => (bp.version.clone(), bp.name.clone()),
-        _ => (bp.name.clone(), bp.path.clone()),
+        _ => (bp.name.clone(), String::new()),
     };
     found.sort_by(|a, b| {
         if descending {
@@ -606,6 +608,18 @@ prompt = "do it"
         let (_, nothing) = page(&dir, "?q=nothing-like-this-at-all").await;
         assert!(names(&nothing).is_empty());
         assert_eq!(nothing["total"], 0);
+    }
+
+    /// Versions collide freely, so this is the sort where the name tie-break
+    /// actually does work.
+    #[tokio::test]
+    async fn the_catalog_can_be_sorted_by_version() {
+        let dir = catalog(&[("alpha", "a"), ("bravo", "b")]);
+        let (status, body) = page(&dir, "?sort=version&limit=200").await;
+        assert_eq!(status, StatusCode::OK);
+        // Both fixtures declare 1.0.0, so the shared version leaves the name
+        // to order them.
+        assert_eq!(fixture_names(&body), vec![fx("alpha"), fx("bravo")]);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -43,7 +43,48 @@ fn blueprint_dir(name: &str) -> Result<PathBuf, (StatusCode, Json<ErrorResponse>
     Ok(agents_dir().join(name))
 }
 
+/// Collapse a raw discovery scan into the canonical catalog: one blueprint per
+/// name, in a stable order.
+///
+/// Split out of [`discover_blueprints`] because it is the part with the rules,
+/// and it can be tested over a hand-built `Vec` instead of a directory tree.
+///
+/// **Dedup by name, first wins.** `get_blueprint` and `spawn_agent` both resolve
+/// a blueprint with `.find(|b| b.name == name)` over this list, so a name
+/// reachable from two roots (the installed agents dir and a `config.agent_paths`
+/// entry, say) made *which agent actually ran* depend on `read_dir` order, which
+/// is a filesystem detail that can differ between two calls on one machine. The
+/// dedup happens in scan order, before the sort, so the winner is the one the
+/// existing `.find()` already meant to pick - the installed catalog first - and
+/// this only makes that choice deterministic rather than changing it.
+///
+/// **Then sort by `(name, path)`.** `name` is the client-facing identity; `path`
+/// is a tie-break that cannot itself be ambiguous, so the order is total. A list
+/// that is merely "whatever the filesystem said" cannot be paginated: a cursor
+/// over an unstable order skips and repeats entries.
+fn canonicalize(found: Vec<BlueprintInfo>) -> Vec<BlueprintInfo> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut kept: Vec<BlueprintInfo> = Vec::with_capacity(found.len());
+    for info in found {
+        if seen.insert(info.name.clone()) {
+            kept.push(info);
+        } else {
+            tracing::debug!(
+                name = %info.name,
+                shadowed = %info.path,
+                "duplicate blueprint name; keeping the earlier one"
+            );
+        }
+    }
+    kept.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
+    kept
+}
+
 /// Scan for blueprints from installed agents dir and configured agent_paths.
+///
+/// The result is deduplicated by name and name-sorted - see [`canonicalize`].
+/// Every consumer goes through here (`list_blueprints`, `get_blueprint`,
+/// `spawn_agent`), so they all share one answer to "which blueprint is `x`".
 pub(super) fn discover_blueprints(config: &crate::config::Config) -> Vec<BlueprintInfo> {
     let mut results = Vec::new();
     let agents = agents_dir();
@@ -60,19 +101,27 @@ pub(super) fn discover_blueprints(config: &crate::config::Config) -> Vec<Bluepri
         if manifest.exists() {
             results.extend(read_blueprint_info(&manifest, &dir));
         }
-        // Check subdirs
-        for entry in std::fs::read_dir(&dir).into_iter().flatten().flatten() {
-            let p = entry.path();
-            if p.is_dir() {
-                let m = p.join("agent.leviath");
-                if m.exists() {
-                    results.extend(read_blueprint_info(&m, &p));
-                }
+        // Check subdirs. Sorted, because `canonicalize` resolves a duplicate
+        // name by taking the first one scanned - and two subdirectories of the
+        // *same* root can declare the same name, so without this the winner
+        // would still come down to `read_dir` order.
+        let mut subdirs: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|p| p.is_dir())
+            .collect();
+        subdirs.sort();
+        for p in subdirs {
+            let m = p.join("agent.leviath");
+            if m.exists() {
+                results.extend(read_blueprint_info(&m, &p));
             }
         }
     }
 
-    results
+    canonicalize(results)
 }
 
 pub(super) fn read_blueprint_info(manifest_path: &Path, dir: &Path) -> Option<BlueprintInfo> {
@@ -252,6 +301,58 @@ fn validate_manifest_text(manifest: &str) -> ValidateResponse {
         valid: errors.is_empty(),
         errors: (!errors.is_empty()).then(|| errors.iter().map(render).collect()),
         warnings: (!warnings.is_empty()).then(|| warnings.iter().map(render).collect()),
+    }
+}
+
+#[cfg(test)]
+mod canonicalize_tests {
+    use super::*;
+
+    fn info(name: &str, path: &str) -> BlueprintInfo {
+        BlueprintInfo {
+            name: name.to_string(),
+            version: "1".to_string(),
+            description: String::new(),
+            path: path.to_string(),
+            stages: vec![],
+        }
+    }
+
+    /// The scan order decides the winner, so the *earlier* root keeps the name
+    /// even though its path sorts later. Getting this backwards would silently
+    /// change which agent a spawn runs.
+    #[test]
+    fn duplicate_names_keep_the_first_scanned_not_the_first_sorted() {
+        let out = canonicalize(vec![
+            info("coder", "/zzz/installed"),
+            info("coder", "/aaa/custom"),
+        ]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "/zzz/installed");
+    }
+
+    #[test]
+    fn output_is_name_sorted_with_path_as_the_tie_break() {
+        let out = canonicalize(vec![
+            info("zebra", "/b"),
+            info("alpha", "/z"),
+            info("alpha2", "/a"),
+        ]);
+        let names: Vec<&str> = out.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "alpha2", "zebra"]);
+    }
+
+    /// Distinct names from the same root all survive - the dedup keys on name,
+    /// not on the directory a blueprint was found in.
+    #[test]
+    fn distinct_names_are_all_kept() {
+        let out = canonicalize(vec![info("a", "/1"), info("b", "/2"), info("c", "/3")]);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn an_empty_scan_canonicalizes_to_an_empty_catalog() {
+        assert!(canonicalize(vec![]).is_empty());
     }
 }
 

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use axum::extract::Path as AxumPath;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Json;
@@ -136,8 +137,141 @@ pub(super) fn read_blueprint_info(manifest_path: &Path, dir: &Path) -> Option<Bl
     })
 }
 
-pub(super) async fn list_blueprints(State(state): State<AppState>) -> Json<Vec<BlueprintInfo>> {
-    Json(discover_blueprints(&state.config))
+/// Default page size. Comfortably more blueprints than anyone installs, so the
+/// common case is one request.
+const DEFAULT_LIMIT: usize = 50;
+/// Largest page served.
+const MAX_LIMIT: usize = 200;
+
+/// `GET /api/blueprints`: the installed agent catalog, paginated and filterable.
+///
+/// **Breaking change**, taken deliberately in the same release as the rest of
+/// this work: the response is now the envelope every paginated route here
+/// returns, rather than a bare array. Announced through the `capabilities` list
+/// on `GET /api/config` so a client can tell before it asks.
+///
+/// Worth being plain about the tradeoff: **pagination buys nothing here.**
+/// `discover_blueprints` scans every configured directory and TOML-parses every
+/// manifest on every request regardless of page size, so a page of ten costs
+/// what the whole list costs. The saving is wire bytes on a handful of small
+/// objects. The envelope is worth taking for one consistent shape across the
+/// API, and `q` is the part with real value - but the catalog is bounded by
+/// what a person installs, and this is not what makes it scale.
+pub(super) async fn list_blueprints(
+    State(state): State<AppState>,
+    Query(query): Query<BlueprintsQuery>,
+) -> Result<Json<Page<BlueprintInfo>>, (StatusCode, Json<ErrorResponse>)> {
+    let descending = match query.order.as_deref() {
+        None | Some("asc") => false,
+        Some("desc") => true,
+        Some(other) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("Unknown order '{other}': expected asc or desc"),
+            ));
+        }
+    };
+    let sort_name = match query.sort.as_deref() {
+        None | Some("name") => "name",
+        Some("version") => "version",
+        Some(other) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("Unknown sort '{other}': expected name or version"),
+            ));
+        }
+    };
+    let limit = match query.limit {
+        None => DEFAULT_LIMIT,
+        Some(0) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "`limit` must be at least 1; omit it for the default".to_string(),
+            ));
+        }
+        Some(n) => n.min(MAX_LIMIT),
+    };
+
+    let digest = super::cursor::filter_digest(&[query.q.as_deref().unwrap_or("")]);
+    let order_name = if descending { "desc" } else { "asc" };
+    let cursor = match query.cursor.as_deref() {
+        None => None,
+        Some(raw) => Some(
+            super::cursor::decode(raw, sort_name, order_name, &digest)
+                .map_err(|e| err(StatusCode::BAD_REQUEST, e.message()))?,
+        ),
+    };
+
+    let mut found = discover_blueprints(&state.config);
+
+    // `q` shares the search primitive but not the framework: three in-memory
+    // string fields do not need sources, phases or highlights.
+    if let Some(needle) = query.q.as_deref().filter(|s| !s.is_empty()) {
+        found.retain(|bp| {
+            super::search::find_ignore_ascii_case(&bp.name, needle).is_some()
+                || super::search::find_ignore_ascii_case(&bp.description, needle).is_some()
+                || bp
+                    .stages
+                    .iter()
+                    .any(|stage| super::search::find_ignore_ascii_case(stage, needle).is_some())
+        });
+    }
+
+    // `discover_blueprints` already sorts by (name, path); re-sort only when
+    // something other than that default was asked for.
+    let key = |bp: &BlueprintInfo| match sort_name {
+        "version" => (bp.version.clone(), bp.name.clone()),
+        _ => (bp.name.clone(), bp.path.clone()),
+    };
+    found.sort_by(|a, b| {
+        if descending {
+            key(b).cmp(&key(a))
+        } else {
+            key(a).cmp(&key(b))
+        }
+    });
+
+    let total = found.len();
+    let mut remaining: Vec<BlueprintInfo> = match cursor {
+        None => found,
+        Some(ref cursor) => found
+            .into_iter()
+            .filter(|bp| {
+                cursor.precedes(
+                    &super::cursor::CursorKey::Text(key(bp).0),
+                    &key(bp).1,
+                    descending,
+                )
+            })
+            .collect(),
+    };
+
+    let has_more = remaining.len() > limit;
+    remaining.truncate(limit);
+    let next_cursor = has_more.then(|| remaining.last()).flatten().map(|last| {
+        let (primary, tiebreak) = key(last);
+        super::cursor::encode(
+            sort_name,
+            order_name,
+            &digest,
+            super::cursor::CursorKey::Text(primary),
+            &tiebreak,
+        )
+    });
+
+    Ok(Json(Page::new(
+        remaining,
+        next_cursor,
+        Some(total),
+        now_secs(),
+    )))
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 pub(super) async fn get_blueprint(
@@ -305,6 +439,217 @@ fn validate_manifest_text(manifest: &str) -> ValidateResponse {
 }
 
 #[cfg(test)]
+mod listing_tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    use crate::config::Config;
+
+    fn manifest(name: &str, description: &str) -> String {
+        format!(
+            r#"
+[agent]
+name = "{name}"
+version = "1.0.0"
+description = "{description}"
+
+[stages.zzstage-work]
+prompt = "do it"
+"#
+        )
+    }
+
+    /// A catalog directory holding the named blueprints, each name prefixed so
+    /// it cannot be confused with an installed one.
+    fn catalog(entries: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, description) in entries {
+            let name = format!("{FIXTURE_PREFIX}{name}");
+            let sub = dir.path().join(&name);
+            std::fs::create_dir_all(&sub).unwrap();
+            std::fs::write(sub.join("agent.leviath"), manifest(&name, description)).unwrap();
+        }
+        dir
+    }
+
+    /// A fixture's full name.
+    fn fx(name: &str) -> String {
+        format!("{FIXTURE_PREFIX}{name}")
+    }
+
+    /// Fixture names all start with this, so assertions can pick them out of a
+    /// catalog that also contains whatever the developer running the tests has
+    /// installed.
+    ///
+    /// `discover_blueprints` always scans the installed agents dir on top of
+    /// `agent_paths`, and redirecting `LEVIATH_HOME` to hide it would mutate
+    /// process-global env and break every concurrently-running test that
+    /// resolves an agents path. So these assert invariants over the discovered
+    /// catalog instead of pinning its exact contents - which is the house rule
+    /// for agent tests anyway.
+    const FIXTURE_PREFIX: &str = "zzfixture-";
+
+    async fn page(dir: &tempfile::TempDir, extra: &str) -> (StatusCode, serde_json::Value) {
+        let (tx, _) = broadcast::channel(64);
+        let state = AppState {
+            config: Arc::new(Config {
+                agent_paths: vec![dir.path().to_path_buf()],
+                ..Default::default()
+            }),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Arc::new(crate::commands::serve::types::ServeLimits::default()),
+        };
+        let app = Router::new()
+            .route("/api/blueprints", get(list_blueprints))
+            .with_state(state);
+        let req = Request::builder()
+            .uri(format!("/api/blueprints{extra}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null),
+        )
+    }
+
+    /// Just this test's fixtures, in the order the page returned them.
+    fn fixture_names(page: &serde_json::Value) -> Vec<String> {
+        names(page)
+            .into_iter()
+            .filter(|n| n.starts_with(FIXTURE_PREFIX))
+            .collect()
+    }
+
+    fn names(page: &serde_json::Value) -> Vec<String> {
+        page["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn the_catalog_pages_through_every_blueprint_exactly_once() {
+        let dir = catalog(&[
+            ("alpha", "first"),
+            ("bravo", "second"),
+            ("charlie", "third"),
+            ("delta", "fourth"),
+        ]);
+
+        let mut seen: Vec<String> = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..10 {
+            let extra = match cursor {
+                None => "?limit=2".to_string(),
+                Some(ref c) => format!("?limit=2&cursor={c}"),
+            };
+            let (status, body) = page(&dir, &extra).await;
+            assert_eq!(status, StatusCode::OK);
+            seen.extend(names(&body));
+            match body["next_cursor"].as_str() {
+                Some(c) => cursor = Some(c.to_string()),
+                None => break,
+            }
+        }
+        // Every fixture, once, in order - regardless of what else the catalog
+        // holds, and regardless of which page each landed on.
+        let got: Vec<String> = seen
+            .iter()
+            .filter(|n| n.starts_with(FIXTURE_PREFIX))
+            .cloned()
+            .collect();
+        assert_eq!(
+            got,
+            vec![fx("alpha"), fx("bravo"), fx("charlie"), fx("delta")]
+        );
+        let mut unique = seen.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), seen.len(), "a blueprint was returned twice");
+    }
+
+    /// The part of this change with real value: the catalog is small, so
+    /// filtering is what a person actually wants from it.
+    #[tokio::test]
+    async fn q_matches_name_description_and_stage_names() {
+        let dir = catalog(&[
+            ("researcher", "digs through papers"),
+            ("coder", "writes zzrust"),
+        ]);
+
+        // The prefix makes the needle unique to this test's fixtures.
+        let (_, by_name) = page(&dir, "?q=ZZFIXTURE-RESEARCH").await;
+        assert_eq!(names(&by_name), vec![fx("researcher")]);
+
+        let (_, by_description) = page(&dir, "?q=writes+zzrust").await;
+        assert_eq!(names(&by_description), vec![fx("coder")]);
+
+        // Both fixtures declare a stage named after the prefix.
+        let (_, by_stage) = page(&dir, "?q=zzstage").await;
+        assert_eq!(fixture_names(&by_stage).len(), 2);
+
+        let (_, nothing) = page(&dir, "?q=nothing-like-this-at-all").await;
+        assert!(names(&nothing).is_empty());
+        assert_eq!(nothing["total"], 0);
+    }
+
+    #[tokio::test]
+    async fn the_catalog_can_be_ordered_backwards() {
+        let dir = catalog(&[("alpha", "a"), ("bravo", "b")]);
+        let (_, body) = page(&dir, "?order=desc&limit=200").await;
+        assert_eq!(fixture_names(&body), vec![fx("bravo"), fx("alpha")]);
+    }
+
+    #[tokio::test]
+    async fn a_bad_sort_order_or_limit_is_refused() {
+        let dir = catalog(&[("alpha", "a")]);
+        for extra in [
+            "?sort=whenever",
+            "?order=sideways",
+            "?limit=0",
+            "?cursor=zz",
+        ] {
+            let (status, _) = page(&dir, extra).await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "expected {extra} to be rejected"
+            );
+        }
+    }
+
+    /// A cursor names a position in one filtered list; changing the filter
+    /// under it cannot produce a meaningful continuation.
+    #[tokio::test]
+    async fn a_cursor_is_bound_to_the_query_that_minted_it() {
+        let dir = catalog(&[("alpha", "a"), ("bravo", "b"), ("charlie", "c")]);
+        let (_, first) = page(&dir, "?limit=1").await;
+        let cursor = first["next_cursor"].as_str().unwrap().to_string();
+
+        let (ok, _) = page(&dir, &format!("?limit=1&cursor={cursor}")).await;
+        assert_eq!(ok, StatusCode::OK);
+
+        let (changed, _) = page(&dir, &format!("?limit=1&q=alpha&cursor={cursor}")).await;
+        assert_eq!(changed, StatusCode::BAD_REQUEST);
+    }
+}
+
+#[cfg(test)]
 mod canonicalize_tests {
     use super::*;
 
@@ -414,9 +759,12 @@ prompt = "Plan the work"
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
-        let blueprints: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
-        // No blueprints in the empty temp dir (ignoring ~/.leviath/agents)
-        let _ = blueprints;
+        // The envelope, not a bare array - the breaking change this release
+        // takes deliberately.
+        let page: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(page["items"].is_array());
+        assert!(page["total"].is_number());
+        assert!(page["next_cursor"].is_null());
     }
 
     #[tokio::test]
@@ -439,7 +787,8 @@ prompt = "Plan the work"
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
-        let blueprints: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        let page: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let blueprints = page["items"].as_array().unwrap().clone();
         assert_test_bp_listed(&blueprints);
     }
 

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -19,6 +19,9 @@ fn redact(c: &Config) -> RedactedConfig {
         ollama_base_url: c.ollama_base_url.clone(),
         agent_paths: c.agent_paths.clone(),
         mcp_server_count: c.mcp_servers.len(),
+        api_version: API_VERSION.to_string(),
+        capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
+        limits: ApiLimits::current(),
     }
 }
 
@@ -207,6 +210,55 @@ mod tests {
         assert!(config.ollama_base_url.is_none());
     }
 
+    /// The console used to feature-detect by calling a route and reading a 404
+    /// as "unsupported" - which is also what a missing run looks like, and
+    /// costs one round trip per feature.
+    #[tokio::test]
+    async fn get_config_advertises_the_api_version_capabilities_and_limits() {
+        let app = Router::new()
+            .route("/api/config", get(get_config))
+            .with_state(test_state());
+        let req = Request::builder()
+            .uri("/api/config")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let config: RedactedConfig = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(config.api_version, API_VERSION);
+        for expected in [
+            "runs.envelope",
+            "runs.search",
+            "runs.files.listing",
+            "blueprints.envelope",
+            "context.history.page",
+        ] {
+            assert!(
+                config.capabilities.iter().any(|c| c == expected),
+                "missing capability {expected}"
+            );
+        }
+
+        // The numbers are what make this useful rather than decorative: a
+        // client that knows a feature exists still has to know its caps, and
+        // every one it guesses would be hardcoded and eventually wrong.
+        assert_eq!(
+            config.limits.max_limit,
+            crate::commands::serve::runs::MAX_LIMIT
+        );
+        assert_eq!(
+            config.limits.max_file_bytes,
+            crate::commands::serve::agents::MAX_FILE_READ_BYTES
+        );
+        assert_eq!(
+            config.limits.max_tracked_modified_files,
+            leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES
+        );
+    }
+
     #[tokio::test]
     async fn get_config_with_keys_shows_has_key_true() {
         let app = Router::new()
@@ -341,6 +393,9 @@ mod tests {
             ollama_base_url: None,
             agent_paths: vec![],
             mcp_server_count: 2,
+            api_version: API_VERSION.to_string(),
+            capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
+            limits: ApiLimits::current(),
         };
         let json = serde_json::to_string(&config).unwrap();
         // Must NOT contain actual key values
@@ -361,6 +416,9 @@ mod tests {
             ollama_base_url: Some("http://localhost:11434".to_string()),
             agent_paths: vec![],
             mcp_server_count: 0,
+            api_version: API_VERSION.to_string(),
+            capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
+            limits: ApiLimits::current(),
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"ollama_base_url\":\"http://localhost:11434\""));

--- a/crates/leviath-cli/src/commands/serve/cursor.rs
+++ b/crates/leviath-cli/src/commands/serve/cursor.rs
@@ -1,0 +1,196 @@
+//! The opaque pagination cursor every paginated route shares.
+//!
+//! **Keyset, not offset.** The collections being paged are live: runs are
+//! created while a client walks the list, and finished ones can be deleted. An
+//! offset into a shifting list silently skips and repeats items, and does it
+//! most often at the head, which is exactly where a console looks. A cursor that
+//! names *where you got to* rather than *how far in* cannot be shifted by an
+//! insert or a delete elsewhere in the list.
+//!
+//! The key is a `(sort value, id)` pair. The id is the tie-break, and it has to
+//! be there: sort values collide freely (two runs can start in the same second),
+//! and a keyset walk over a non-total order loses whichever colliding item it
+//! happened to resume past.
+//!
+//! Encoded as hex of a JSON payload. Hex rather than base64 because it is
+//! URL-safe with no percent-encoding and both `hex` and `serde_json` are already
+//! dependencies; base64 would buy ~30% shorter cursors and one more supply-chain
+//! edge. It is opaque to clients - nothing may parse it - but a maintainer can
+//! read one out of a bug report with `xxd`, which a compressed binary format
+//! would not allow.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The sort value a cursor resumes from.
+///
+/// Externally tagged rather than `#[serde(untagged)]`: untagged tries each arm
+/// in order and takes the first that parses, so a text key that happens to look
+/// numeric would silently decode as an integer, and the fallthrough arm would be
+/// unreachable in a way no test could distinguish.
+/// Ordered so a keyset comparison is one tuple compare. A given route uses one
+/// variant throughout, so the cross-variant ordering the derive produces is
+/// never exercised against real data - it exists to make the derive total.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(super) enum CursorKey {
+    /// A unix-seconds timestamp, for run listings.
+    Int(i64),
+    /// A name, for the blueprint catalog.
+    Text(String),
+}
+
+/// Everything needed to resume a walk, and to prove the walk is the same one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct Cursor {
+    /// Payload version, so the encoding can change without a client - which
+    /// must never parse this - noticing.
+    pub(super) v: u8,
+    /// The `sort` this cursor was minted for.
+    pub(super) sort: String,
+    /// The `order` this cursor was minted for.
+    pub(super) order: String,
+    /// First 8 hex chars of a digest over the filter params, see [`filter_digest`].
+    pub(super) digest: String,
+    /// The sort value of the last item on the previous page.
+    pub(super) key: CursorKey,
+    /// The id of the last item on the previous page - the tie-break.
+    pub(super) id: String,
+}
+
+/// The current payload version.
+const CURSOR_VERSION: u8 = 1;
+
+/// Why a cursor could not be used.
+///
+/// A `PartialEq` enum rather than a bare string so tests can assert on the
+/// specific failure with `assert_eq!`. `assert!(matches!(..))` would leave the
+/// unmatched arms as regions no test enters, which the 100% coverage gate then
+/// reports - and the workaround for that is usually to weaken the assertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CursorError {
+    /// Not valid hex - the client mangled it, or invented one.
+    NotHex,
+    /// Hex decoded, but the bytes are not the expected JSON payload.
+    NotJson,
+    /// Minted by a different (probably newer) version of this server.
+    UnknownVersion(u8),
+    /// Presented against a different `sort` than it was minted for.
+    SortMismatch { minted: String, requested: String },
+    /// Presented against a different `order` than it was minted for.
+    OrderMismatch { minted: String, requested: String },
+    /// Presented against a different filter set than it was minted for.
+    FilterMismatch,
+}
+
+impl CursorError {
+    /// A message naming what the client got wrong, for the 400 body.
+    pub(super) fn message(&self) -> String {
+        match self {
+            CursorError::NotHex | CursorError::NotJson => {
+                "Invalid cursor: pass back the `next_cursor` from the previous page unmodified"
+                    .to_string()
+            }
+            CursorError::UnknownVersion(v) => {
+                format!("Invalid cursor: unsupported cursor version {v}")
+            }
+            CursorError::SortMismatch { minted, requested } => format!(
+                "Cursor was minted for sort={minted} but the request asks for sort={requested}; \
+                 restart the walk from the first page"
+            ),
+            CursorError::OrderMismatch { minted, requested } => format!(
+                "Cursor was minted for order={minted} but the request asks for order={requested}; \
+                 restart the walk from the first page"
+            ),
+            CursorError::FilterMismatch => "Cursor was minted for a different set of filters; \
+                 restart the walk from the first page"
+                .to_string(),
+        }
+    }
+}
+
+/// Fold the filter params into a short digest a cursor can carry.
+///
+/// Changing a filter mid-walk cannot produce a meaningful continuation - the
+/// cursor names a position in a list that no longer exists. Binding the filters
+/// into the cursor turns that into a 400 the client can act on, instead of a
+/// page of quietly wrong results. Callers pass the params in a fixed order, so
+/// the digest is stable for a given filter set.
+pub(super) fn filter_digest(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update(part.as_bytes());
+        // A separator, so `["ab", "c"]` and `["a", "bc"]` do not collide.
+        hasher.update([0u8]);
+    }
+    hex::encode(hasher.finalize())
+        .chars()
+        .take(8)
+        .collect::<String>()
+}
+
+/// Mint a cursor pointing just past `(key, id)`.
+pub(super) fn encode(sort: &str, order: &str, digest: &str, key: CursorKey, id: &str) -> String {
+    let cursor = Cursor {
+        v: CURSOR_VERSION,
+        sort: sort.to_string(),
+        order: order.to_string(),
+        digest: digest.to_string(),
+        key,
+        id: id.to_string(),
+    };
+    // Serializing a struct of owned primitives cannot fail; the fallback keeps
+    // the signature infallible rather than making every caller handle a case
+    // that has no way to happen.
+    hex::encode(serde_json::to_vec(&cursor).unwrap_or_default())
+}
+
+/// Read a cursor back, checking it belongs to the walk being asked for.
+pub(super) fn decode(
+    raw: &str,
+    sort: &str,
+    order: &str,
+    digest: &str,
+) -> Result<Cursor, CursorError> {
+    let bytes = hex::decode(raw).map_err(|_| CursorError::NotHex)?;
+    let cursor: Cursor = serde_json::from_slice(&bytes).map_err(|_| CursorError::NotJson)?;
+    if cursor.v != CURSOR_VERSION {
+        return Err(CursorError::UnknownVersion(cursor.v));
+    }
+    if cursor.sort != sort {
+        return Err(CursorError::SortMismatch {
+            minted: cursor.sort,
+            requested: sort.to_string(),
+        });
+    }
+    if cursor.order != order {
+        return Err(CursorError::OrderMismatch {
+            minted: cursor.order,
+            requested: order.to_string(),
+        });
+    }
+    if cursor.digest != digest {
+        return Err(CursorError::FilterMismatch);
+    }
+    Ok(cursor)
+}
+
+impl Cursor {
+    /// Does `(key, id)` fall strictly after this cursor's position, walking in
+    /// `descending` order?
+    ///
+    /// The tie-break follows the primary direction, so this is one tuple
+    /// comparison rather than a special case per direction.
+    pub(super) fn precedes(&self, key: &CursorKey, id: &str, descending: bool) -> bool {
+        let here = (&self.key, self.id.as_str());
+        let there = (key, id);
+        if descending {
+            there < here
+        } else {
+            there > here
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cursor_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/cursor_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/cursor_tests.rs
@@ -1,0 +1,173 @@
+//! Tests for the pagination cursor codec.
+
+use super::*;
+
+const DIGEST: &str = "abcd1234";
+
+fn int_cursor() -> String {
+    encode(
+        "started_at",
+        "desc",
+        DIGEST,
+        CursorKey::Int(1_700_000_000),
+        "run-a",
+    )
+}
+
+#[test]
+fn a_cursor_round_trips_through_hex_and_json() {
+    let raw = int_cursor();
+    let back = decode(&raw, "started_at", "desc", DIGEST).expect("round trip");
+    assert_eq!(back.key, CursorKey::Int(1_700_000_000));
+    assert_eq!(back.id, "run-a");
+    assert_eq!(back.sort, "started_at");
+    assert_eq!(back.order, "desc");
+    assert_eq!(back.v, CURSOR_VERSION);
+}
+
+/// The blueprint catalog sorts by name, so the text variant has to survive the
+/// trip as text - this is what `#[serde(untagged)]` would have got wrong.
+#[test]
+fn a_text_key_stays_text_even_when_it_looks_numeric() {
+    let raw = encode(
+        "name",
+        "asc",
+        DIGEST,
+        CursorKey::Text("12345".to_string()),
+        "/p",
+    );
+    let back = decode(&raw, "name", "asc", DIGEST).expect("round trip");
+    assert_eq!(back.key, CursorKey::Text("12345".to_string()));
+}
+
+#[test]
+fn a_cursor_is_opaque_hex_carrying_none_of_its_payload_in_the_clear() {
+    let raw = int_cursor();
+    assert!(raw.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(!raw.contains("run-a"));
+}
+
+#[test]
+fn non_hex_is_rejected() {
+    assert_eq!(
+        decode("not a cursor!", "started_at", "desc", DIGEST),
+        Err(CursorError::NotHex)
+    );
+}
+
+#[test]
+fn hex_that_is_not_the_payload_is_rejected() {
+    let raw = hex::encode(b"{\"something\":\"else\"}");
+    assert_eq!(
+        decode(&raw, "started_at", "desc", DIGEST),
+        Err(CursorError::NotJson)
+    );
+}
+
+#[test]
+fn a_payload_from_another_version_is_rejected() {
+    let mut cursor: Cursor = serde_json::from_slice(&hex::decode(int_cursor()).unwrap()).unwrap();
+    cursor.v = 99;
+    let raw = hex::encode(serde_json::to_vec(&cursor).unwrap());
+    assert_eq!(
+        decode(&raw, "started_at", "desc", DIGEST),
+        Err(CursorError::UnknownVersion(99))
+    );
+}
+
+/// Changing the walk mid-flight cannot produce a meaningful continuation, so
+/// each of these is a 400 rather than a page of quietly wrong results.
+#[test]
+fn a_cursor_presented_against_a_different_walk_is_rejected() {
+    let raw = int_cursor();
+    assert_eq!(
+        decode(&raw, "updated_at", "desc", DIGEST),
+        Err(CursorError::SortMismatch {
+            minted: "started_at".to_string(),
+            requested: "updated_at".to_string(),
+        })
+    );
+    assert_eq!(
+        decode(&raw, "started_at", "asc", DIGEST),
+        Err(CursorError::OrderMismatch {
+            minted: "desc".to_string(),
+            requested: "asc".to_string(),
+        })
+    );
+    assert_eq!(
+        decode(&raw, "started_at", "desc", "99999999"),
+        Err(CursorError::FilterMismatch)
+    );
+}
+
+#[test]
+fn every_error_explains_itself_without_repeating_the_others() {
+    let messages = [
+        CursorError::NotHex.message(),
+        CursorError::NotJson.message(),
+        CursorError::UnknownVersion(7).message(),
+        CursorError::SortMismatch {
+            minted: "a".to_string(),
+            requested: "b".to_string(),
+        }
+        .message(),
+        CursorError::OrderMismatch {
+            minted: "desc".to_string(),
+            requested: "asc".to_string(),
+        }
+        .message(),
+        CursorError::FilterMismatch.message(),
+    ];
+    for message in &messages {
+        assert!(!message.is_empty());
+    }
+    assert!(messages[2].contains('7'));
+    assert!(messages[3].contains("sort=a"));
+    assert!(messages[4].contains("order=desc"));
+}
+
+#[test]
+fn the_filter_digest_is_stable_and_separates_its_parts() {
+    assert_eq!(
+        filter_digest(&["running", "q"]),
+        filter_digest(&["running", "q"])
+    );
+    assert_ne!(filter_digest(&["running"]), filter_digest(&["error"]));
+    // Without a separator these two would hash identically.
+    assert_ne!(filter_digest(&["ab", "c"]), filter_digest(&["a", "bc"]));
+    assert_eq!(filter_digest(&[]).len(), 8);
+}
+
+#[test]
+fn precedes_walks_descending_past_the_cursor_position() {
+    let cursor = decode(&int_cursor(), "started_at", "desc", DIGEST).unwrap();
+    // Older sorts after, in descending order.
+    assert!(cursor.precedes(&CursorKey::Int(1_699_999_999), "run-z", true));
+    // Newer sorts before - already returned on an earlier page.
+    assert!(!cursor.precedes(&CursorKey::Int(1_700_000_001), "run-a", true));
+    // The cursor's own item is never re-emitted.
+    assert!(!cursor.precedes(&CursorKey::Int(1_700_000_000), "run-a", true));
+}
+
+/// Two items sharing a sort value is the ordinary case, not the exotic one -
+/// runs start in the same second all the time. Without the id tie-break the
+/// walk would drop whichever one it resumed past.
+#[test]
+fn precedes_breaks_a_tie_on_the_id_in_the_primary_direction() {
+    let cursor = decode(&int_cursor(), "started_at", "desc", DIGEST).unwrap();
+    let same = CursorKey::Int(1_700_000_000);
+    // Descending: ids after "run-a" were already emitted, before it were not.
+    assert!(!cursor.precedes(&same, "run-b", true));
+    assert!(cursor.precedes(&same, "run-A", true));
+}
+
+#[test]
+fn precedes_reverses_for_an_ascending_walk() {
+    let raw = encode("started_at", "asc", DIGEST, CursorKey::Int(100), "run-m");
+    let cursor = decode(&raw, "started_at", "asc", DIGEST).unwrap();
+    assert!(cursor.precedes(&CursorKey::Int(101), "run-a", false));
+    assert!(!cursor.precedes(&CursorKey::Int(99), "run-z", false));
+    assert!(!cursor.precedes(&CursorKey::Int(100), "run-m", false));
+    // Tie-break also flips.
+    assert!(cursor.precedes(&CursorKey::Int(100), "run-n", false));
+}

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -7,11 +7,14 @@ mod agents;
 mod auth;
 mod blueprints;
 mod config;
+mod cursor;
 mod doctor;
 mod fs;
 mod interactions;
 mod mcp;
 mod polling;
+mod runs;
+mod search;
 #[cfg(test)]
 mod testutil;
 mod tree;
@@ -73,6 +76,9 @@ fn api_router() -> Router<AppState> {
                 .put(blueprints::update_blueprint)
                 .delete(blueprints::delete_blueprint),
         )
+        // Runs - the paginated, searchable listing. Supersedes the GET half of
+        // /api/agents, which stays as it is for existing clients.
+        .route("/api/runs", get(runs::list_runs))
         // Agents
         .route(
             "/api/agents",

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -625,17 +625,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_agent_files_route_is_mounted() {
-        // Without its required `path` query the handler's Query extractor
-        // rejects with 400 - an unmounted route would 404 at the router, so
-        // the 400 is what proves the route exists in the shared table. (The
-        // handler's own behavior is covered in agents.rs.)
+        // Both a mounted and an unmounted route answer this with a 404 - the
+        // run does not exist either way - so the status alone proves nothing.
+        // What separates them is the body: the handler explains itself, and
+        // the router's own catch-all has nothing to say. (The handler's real
+        // behavior is covered in agents.rs.)
+        //
+        // `path` used to be required, and the resulting 400 was the proof.
+        // That stopped discriminating when it became optional so a bare call
+        // could list.
         let app = test_app();
         let req = Request::builder()
             .uri("/api/agents/some-run/files")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error = serde_json::from_slice::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v["error"].as_str().map(str::to_string))
+            .unwrap_or_default();
+        assert!(error.contains("some-run"));
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -379,6 +379,22 @@ mod tests {
     /// The published OpenAPI spec for this API.
     const OPENAPI: &str = include_str!("../../../../../docs/schema/openapi.json");
 
+    /// `GET /api/config` reports an `api_version`, and it has to mean
+    /// something. A version a client can read that disagrees with the document
+    /// describing that version is worse than publishing no version at all - the
+    /// client trusts it, and it is silently wrong.
+    ///
+    /// The same spirit as the route-drift test below: the spec is only a
+    /// contract while something holds the code to it.
+    #[test]
+    fn the_api_version_matches_the_spec_it_names() {
+        let spec: serde_json::Value = serde_json::from_str(OPENAPI).expect("the spec is JSON");
+        let documented = spec["info"]["version"]
+            .as_str()
+            .expect("the spec declares a version");
+        assert_eq!(documented, types::API_VERSION);
+    }
+
     /// Every `(path, METHOD)` the spec documents.
     fn documented_routes() -> Vec<(String, String)> {
         let spec: serde_json::Value = serde_json::from_str(OPENAPI).expect("the spec is JSON");

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -631,38 +631,114 @@ fn logs_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
     }
 }
 
-/// Which tool call the match is in, from the run journal.
+/// Where in the run's history the match is: a tool call, or the context as it
+/// stood at some earlier point.
 ///
-/// Streams the records and looks only at tool batches. Deliberately never at
-/// `Header`/`Progress`/`Checkpoint` metadata: those carry a whole `RunMeta`,
-/// including the webhook signing secret, and a snippet cut from those bytes
-/// would put it in the response.
+/// Both halves matter. Live-testing this against real journals turned up runs
+/// that matched on `q_in=journal` and came back with **no highlight at all** -
+/// a result with no explanation, which is precisely what search-on-the-server
+/// was supposed to fix. The text was in the journal's context records, and only
+/// tool batches were being looked at.
+///
+/// Reads entry *content* and tool calls, and deliberately never the `meta` field
+/// of `Header`/`Progress`/`Checkpoint`. Those carry a whole `RunMeta` including
+/// the webhook signing secret, and a snippet cut from those bytes would put it
+/// in the response. That exclusion is structural - the code never reaches for
+/// the field - rather than a filter applied afterwards.
+///
+/// One residual case is left, and documented rather than papered over: the phase
+/// one filter scans the journal's raw bytes, which *do* include those repeated
+/// metadata blocks. A query matching only there (a workdir path, say) yields a
+/// run with no highlight. The same text is searchable, with a highlight, through
+/// `q_in=meta`.
 fn journal_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
+    use leviath_core::run_archive::{RegionDelta, RunRecord};
+
     let Some(records) = runstate::read_run_archive(&meta.run_id) else {
         return;
     };
+
+    /// Look through a region's entries, naming the region if one matches.
+    fn scan_entries(
+        region_name: &str,
+        entries: &[leviath_core::run_meta::RegionEntrySnapshot],
+        q: &str,
+        out: &mut Vec<Highlight>,
+    ) -> bool {
+        for entry in entries {
+            if let Some(at) = search::find_ignore_ascii_case(&entry.content, q) {
+                out.push(Highlight {
+                    field: format!("journal.context.{region_name}"),
+                    snippet: search::snippet(&entry.content, at),
+                    stage: None,
+                });
+                return true;
+            }
+        }
+        false
+    }
+
     for record in &records {
         if out.len() >= MAX_HIGHLIGHTS {
             return;
         }
-        let leviath_core::run_archive::RunRecord::ToolBatch {
-            calls, stage_index, ..
-        } = record
-        else {
-            continue;
-        };
-        for call in calls {
-            let haystacks = [&call.arguments, call.result.as_ref().unwrap_or(&call.name)];
-            for text in haystacks {
-                if let Some(at) = search::find_ignore_ascii_case(text, q) {
-                    out.push(Highlight {
-                        field: format!("journal.tool.{}", call.name),
-                        snippet: search::snippet(text, at),
-                        stage: Some(*stage_index),
-                    });
-                    return;
+        match record {
+            RunRecord::ToolBatch {
+                calls, stage_index, ..
+            } => {
+                for call in calls {
+                    let haystacks = [&call.arguments, call.result.as_ref().unwrap_or(&call.name)];
+                    for text in haystacks {
+                        if let Some(at) = search::find_ignore_ascii_case(text, q) {
+                            out.push(Highlight {
+                                field: format!("journal.tool.{}", call.name),
+                                snippet: search::snippet(text, at),
+                                stage: Some(*stage_index),
+                            });
+                            return;
+                        }
+                    }
                 }
             }
+            RunRecord::ContextCheckpoint { snapshot, .. } => {
+                for region in &snapshot.regions {
+                    if scan_entries(&region.name, &region.entries, q, out) {
+                        return;
+                    }
+                }
+            }
+            RunRecord::ContextDiff { delta, .. } | RunRecord::Progress { delta, .. } => {
+                for region in &delta.regions {
+                    let matched = match region {
+                        RegionDelta::Set(snapshot) => {
+                            scan_entries(&snapshot.name, &snapshot.entries, q, out)
+                        }
+                        RegionDelta::Append { name, entries, .. } => {
+                            scan_entries(name, entries, q, out)
+                        }
+                        // Carry no text of their own.
+                        RegionDelta::Clear { .. } | RegionDelta::Remove { .. } => false,
+                    };
+                    if matched {
+                        return;
+                    }
+                }
+            }
+            RunRecord::Checkpoint { context, .. } => {
+                for region in &context.regions {
+                    if scan_entries(&region.name, &region.entries, q, out) {
+                        return;
+                    }
+                }
+            }
+            // Carry no searchable content of their own - only the metadata this
+            // function must not cut a snippet from.
+            RunRecord::Header { .. }
+            | RunRecord::OwnershipChanged { .. }
+            | RunRecord::StatusChanged { .. }
+            | RunRecord::Inference { .. }
+            | RunRecord::ToolCallDone { .. }
+            | RunRecord::Message { .. } => {}
         }
     }
 }

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -338,10 +338,15 @@ fn known_meta_fields() -> HashSet<String> {
         String::new(),
         0,
     );
-    match serde_json::to_value(probe) {
-        Ok(serde_json::Value::Object(map)) => map.keys().cloned().collect(),
-        _ => HashSet::new(),
-    }
+    // `RunMeta` is a struct, so this is always an object; `as_object` keeps
+    // that assumption in one place instead of adding a match arm nothing can
+    // reach.
+    serde_json::to_value(probe)
+        .ok()
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .map(|map| map.keys().cloned().collect())
+        .unwrap_or_default()
 }
 
 /// `GET /api/runs`
@@ -389,11 +394,9 @@ pub(super) async fn list_runs(
     sort_runs(&mut runs, &resolved);
 
     let (runs, scan_truncated) = apply_search(runs, &resolved);
-    let total = if scan_truncated {
-        None
-    } else {
-        Some(runs.len())
-    };
+    // Null when the scan was cut short: a count taken from a partial scan is
+    // worse than no count, because a UI renders it as fact.
+    let total = (!scan_truncated).then_some(runs.len());
 
     let (page_runs, next_cursor) = paginate(runs, &resolved);
     let items = page_runs
@@ -527,12 +530,12 @@ fn meta_fields(meta: &RunMeta) -> Vec<(String, String)> {
     }
     // `callback_url` and `callback_secret` are deliberately absent. The secret
     // never leaves the process, and neither is something a user searches for.
-    let mut keys: Vec<&String> = meta.metadata.keys().collect();
-    keys.sort();
-    for key in keys {
-        if let Some(value) = meta.metadata.get(key) {
-            out.push((format!("metadata.{key}"), value.clone()));
-        }
+    // Sorted so the highlight a search reports for a metadata match does not
+    // depend on hash order.
+    let mut entries: Vec<(&String, &String)> = meta.metadata.iter().collect();
+    entries.sort();
+    for (key, value) in entries {
+        out.push((format!("metadata.{key}"), value.clone()));
     }
     out
 }
@@ -573,9 +576,9 @@ fn highlights_for(meta: &RunMeta, q: &str, sources: &[Source]) -> Vec<Highlight>
                     });
                 }
             }
-            Source::Context => context_highlight(meta, q, &mut out),
-            Source::Logs => logs_highlights(meta, q, &mut out),
-            Source::Journal => journal_highlights(meta, q, &mut out),
+            Source::Context => out.extend(context_highlight(meta, q)),
+            Source::Logs => out.extend(logs_highlights(meta, q)),
+            Source::Journal => out.extend(journal_highlights(meta, q)),
         }
     }
     out.truncate(MAX_HIGHLIGHTS);
@@ -587,48 +590,47 @@ fn highlights_for(meta: &RunMeta, q: &str, sources: &[Source]) -> Vec<Highlight>
 /// Parses `context.json` once. Never replays the journal: that deep-copies a
 /// whole context window per recorded point, which is the cost this design
 /// exists to avoid.
-fn context_highlight(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
-    let Some(snapshot) = runstate::read_context_snapshot(&meta.run_id) else {
-        return;
-    };
-    for region in &snapshot.regions {
-        for entry in &region.entries {
-            if let Some(at) = search::find_ignore_ascii_case(&entry.content, q) {
-                out.push(Highlight {
-                    field: format!("context.{}", region.name),
-                    snippet: search::snippet(&entry.content, at),
-                    stage: None,
-                });
-                return;
-            }
-        }
-    }
+fn context_highlight(meta: &RunMeta, q: &str) -> Option<Highlight> {
+    let snapshot = runstate::read_context_snapshot(&meta.run_id)?;
+    snapshot.regions.iter().find_map(|region| {
+        region.entries.iter().find_map(|entry| {
+            search::find_ignore_ascii_case(&entry.content, q).map(|at| Highlight {
+                field: format!("context.{}", region.name),
+                snippet: search::snippet(&entry.content, at),
+                stage: None,
+            })
+        })
+    })
 }
 
 /// Which stage's log the match is in - so a client can then fetch that stage.
-fn logs_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
-    for idx in stage_indices(&meta.run_id) {
-        if out.len() >= MAX_HIGHLIGHTS {
-            return;
-        }
-        let output = runstate::tail_stage_output(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
-        if let Some(at) = search::find_ignore_ascii_case(&output, q) {
-            out.push(Highlight {
-                field: "logs.output".to_string(),
-                snippet: search::snippet(&output, at),
-                stage: Some(idx),
-            });
-            continue;
-        }
-        let operational = runstate::tail_stage_log(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
-        if let Some(at) = search::find_ignore_ascii_case(&operational, q) {
-            out.push(Highlight {
+///
+/// One highlight per stage at most, and the two streams are tried in the order
+/// a person reads them: the assistant's own output first, the operational log
+/// second. Expressed as a `find_map` rather than a loop with early returns
+/// because the caller already caps the total, so there is nothing here that
+/// needs to bail out partway.
+fn logs_highlights(meta: &RunMeta, q: &str) -> Vec<Highlight> {
+    stage_indices(&meta.run_id)
+        .into_iter()
+        .filter_map(|idx| {
+            let output = runstate::tail_stage_output(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
+            if let Some(at) = search::find_ignore_ascii_case(&output, q) {
+                return Some(Highlight {
+                    field: "logs.output".to_string(),
+                    snippet: search::snippet(&output, at),
+                    stage: Some(idx),
+                });
+            }
+            let operational = runstate::tail_stage_log(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
+            search::find_ignore_ascii_case(&operational, q).map(|at| Highlight {
                 field: "logs.operational".to_string(),
                 snippet: search::snippet(&operational, at),
                 stage: Some(idx),
-            });
-        }
-    }
+            })
+        })
+        .take(MAX_HIGHLIGHTS)
+        .collect()
 }
 
 /// Where in the run's history the match is: a tool call, or the context as it
@@ -651,86 +653,56 @@ fn logs_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
 /// metadata blocks. A query matching only there (a workdir path, say) yields a
 /// run with no highlight. The same text is searchable, with a highlight, through
 /// `q_in=meta`.
-fn journal_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
+fn journal_highlights(meta: &RunMeta, q: &str) -> Option<Highlight> {
     use leviath_core::run_archive::{RegionDelta, RunRecord};
 
-    let Some(records) = runstate::read_run_archive(&meta.run_id) else {
-        return;
-    };
-
-    /// Look through a region's entries, naming the region if one matches.
-    fn scan_entries(
+    /// The first entry in a region whose content matches, named by region.
+    fn in_entries(
         region_name: &str,
         entries: &[leviath_core::run_meta::RegionEntrySnapshot],
         q: &str,
-        out: &mut Vec<Highlight>,
-    ) -> bool {
-        for entry in entries {
-            if let Some(at) = search::find_ignore_ascii_case(&entry.content, q) {
-                out.push(Highlight {
-                    field: format!("journal.context.{region_name}"),
-                    snippet: search::snippet(&entry.content, at),
-                    stage: None,
-                });
-                return true;
-            }
-        }
-        false
+    ) -> Option<Highlight> {
+        entries.iter().find_map(|entry| {
+            search::find_ignore_ascii_case(&entry.content, q).map(|at| Highlight {
+                field: format!("journal.context.{region_name}"),
+                snippet: search::snippet(&entry.content, at),
+                stage: None,
+            })
+        })
     }
 
-    for record in &records {
-        if out.len() >= MAX_HIGHLIGHTS {
-            return;
-        }
+    /// The first match in one record, or `None` if it carries no matching text.
+    fn in_record(record: &RunRecord, q: &str) -> Option<Highlight> {
         match record {
             RunRecord::ToolBatch {
                 calls, stage_index, ..
-            } => {
-                for call in calls {
-                    let haystacks = [&call.arguments, call.result.as_ref().unwrap_or(&call.name)];
-                    for text in haystacks {
-                        if let Some(at) = search::find_ignore_ascii_case(text, q) {
-                            out.push(Highlight {
-                                field: format!("journal.tool.{}", call.name),
-                                snippet: search::snippet(text, at),
-                                stage: Some(*stage_index),
-                            });
-                            return;
-                        }
-                    }
-                }
-            }
-            RunRecord::ContextCheckpoint { snapshot, .. } => {
-                for region in &snapshot.regions {
-                    if scan_entries(&region.name, &region.entries, q, out) {
-                        return;
-                    }
-                }
-            }
+            } => calls.iter().find_map(|call| {
+                [&call.arguments, call.result.as_ref().unwrap_or(&call.name)]
+                    .into_iter()
+                    .find_map(|text| {
+                        search::find_ignore_ascii_case(text, q).map(|at| Highlight {
+                            field: format!("journal.tool.{}", call.name),
+                            snippet: search::snippet(text, at),
+                            stage: Some(*stage_index),
+                        })
+                    })
+            }),
+            RunRecord::ContextCheckpoint { snapshot, .. } => snapshot
+                .regions
+                .iter()
+                .find_map(|region| in_entries(&region.name, &region.entries, q)),
             RunRecord::ContextDiff { delta, .. } | RunRecord::Progress { delta, .. } => {
-                for region in &delta.regions {
-                    let matched = match region {
-                        RegionDelta::Set(snapshot) => {
-                            scan_entries(&snapshot.name, &snapshot.entries, q, out)
-                        }
-                        RegionDelta::Append { name, entries, .. } => {
-                            scan_entries(name, entries, q, out)
-                        }
-                        // Carry no text of their own.
-                        RegionDelta::Clear { .. } | RegionDelta::Remove { .. } => false,
-                    };
-                    if matched {
-                        return;
-                    }
-                }
+                delta.regions.iter().find_map(|region| match region {
+                    RegionDelta::Set(snapshot) => in_entries(&snapshot.name, &snapshot.entries, q),
+                    RegionDelta::Append { name, entries, .. } => in_entries(name, entries, q),
+                    // Carry no text of their own.
+                    RegionDelta::Clear { .. } | RegionDelta::Remove { .. } => None,
+                })
             }
-            RunRecord::Checkpoint { context, .. } => {
-                for region in &context.regions {
-                    if scan_entries(&region.name, &region.entries, q, out) {
-                        return;
-                    }
-                }
-            }
+            RunRecord::Checkpoint { context, .. } => context
+                .regions
+                .iter()
+                .find_map(|region| in_entries(&region.name, &region.entries, q)),
             // Carry no searchable content of their own - only the metadata this
             // function must not cut a snippet from.
             RunRecord::Header { .. }
@@ -738,9 +710,12 @@ fn journal_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
             | RunRecord::StatusChanged { .. }
             | RunRecord::Inference { .. }
             | RunRecord::ToolCallDone { .. }
-            | RunRecord::Message { .. } => {}
+            | RunRecord::Message { .. } => None,
         }
     }
+
+    let records = runstate::read_run_archive(&meta.run_id)?;
+    records.iter().find_map(|record| in_record(record, q))
 }
 
 /// Take this page's runs and mint the cursor for the next one.

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -1,0 +1,723 @@
+//! `GET /api/runs` - the paginated, searchable run listing.
+//!
+//! Supersedes `GET /api/agents`, which returns every run ever recorded as one
+//! unbounded array and accepts only a status filter. That route stays exactly as
+//! it is, deprecated: it is the legacy spelling (the console says "runs"
+//! everywhere), and it gets a replacement at a new path rather than a changed
+//! response shape, so nothing that calls it today breaks.
+//!
+//! What this adds over that: keyset pagination, sorting, server-side search with
+//! highlights, batch fetch by id, and field projection.
+//!
+//! **What it does not fix.** Every listing here still walks the runs directory
+//! and parses every `meta.json`, because that is the only index there is.
+//! Pagination bounds what crosses the wire and what the browser holds; it does
+//! not bound the server's work, and runs are never pruned. The guard that does
+//! bound the damage is [`MAX_SEARCH_SCAN`], on the filesystem-reading half of
+//! search.
+
+use std::collections::HashSet;
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::Json;
+
+use super::cursor::{self, Cursor, CursorKey};
+use super::search;
+use super::types::*;
+use crate::runstate::{self, RunMeta};
+
+/// Page size when the client does not ask.
+const DEFAULT_LIMIT: usize = 50;
+/// Largest page size served. A larger `limit` is clamped rather than refused: a
+/// client asking for 1000 wants as much as it can get, and the real value is
+/// discoverable from `GET /api/config`.
+const MAX_LIMIT: usize = 200;
+/// Most ids one batch fetch may name.
+const MAX_IDS: usize = 200;
+/// How many runs a filesystem-reading search will examine before giving up.
+///
+/// `q_in=logs` over an unbounded, never-pruned run set is a self-inflicted
+/// denial of service: every request would read two files per stage per run, for
+/// every run that has ever existed. Stopping after a bounded prefix - taken in
+/// the requested sort order, so it is the newest runs - answers the common case
+/// and says so via `scan_truncated`, which is better than refusing the query or
+/// than quietly taking longer every month.
+const MAX_SEARCH_SCAN: usize = 500;
+/// How much of each stage log a search reads, from the end.
+const SEARCH_LOG_TAIL_BYTES: u64 = 256 * 1024;
+/// Most highlights attached to one item. A log with ten thousand matches must
+/// not become the response body.
+const MAX_HIGHLIGHTS: usize = 5;
+
+/// Which field a run is ordered by.
+///
+/// The shared `At` suffix is the point, not an accident: these are the three
+/// timestamps on a run, and each variant is named for the `RunMeta` field it
+/// reads and the query value that selects it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "named after the fields they read"
+)]
+enum SortKey {
+    StartedAt,
+    UpdatedAt,
+    LastProgressAt,
+}
+
+impl SortKey {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "started_at" => Some(SortKey::StartedAt),
+            "updated_at" => Some(SortKey::UpdatedAt),
+            "last_progress_at" => Some(SortKey::LastProgressAt),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            SortKey::StartedAt => "started_at",
+            SortKey::UpdatedAt => "updated_at",
+            SortKey::LastProgressAt => "last_progress_at",
+        }
+    }
+
+    /// This run's value for the key.
+    ///
+    /// `last_progress_at` is `Option`, and absent means "written by a daemon
+    /// older than the field, or before the first snapshot landed". The run
+    /// demonstrably started, so `started_at` is the honest floor - and it keeps
+    /// the key non-null, which the cursor needs.
+    fn value(self, meta: &RunMeta) -> i64 {
+        match self {
+            SortKey::StartedAt => meta.started_at,
+            SortKey::UpdatedAt => meta.updated_at,
+            SortKey::LastProgressAt => meta.last_progress_at.unwrap_or(meta.started_at),
+        }
+    }
+}
+
+/// Where search looks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Source {
+    /// Fields already parsed into `RunMeta`. No IO.
+    Meta,
+    /// The tracked modified-file paths. No IO.
+    Files,
+    /// The run's current context window, as raw unparsed bytes.
+    Context,
+    /// The tail of each stage's logs, as raw bytes.
+    Logs,
+    /// The run journal, as raw bytes.
+    Journal,
+}
+
+impl Source {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "meta" => Some(Source::Meta),
+            "files" => Some(Source::Files),
+            "context" => Some(Source::Context),
+            "logs" => Some(Source::Logs),
+            "journal" => Some(Source::Journal),
+            _ => None,
+        }
+    }
+
+    /// Does answering this source require reading files?
+    ///
+    /// Only these count against [`MAX_SEARCH_SCAN`] - the in-memory sources are
+    /// free and must not consume the budget.
+    fn reads_filesystem(self) -> bool {
+        matches!(self, Source::Context | Source::Logs | Source::Journal)
+    }
+}
+
+/// Query parameters of `GET /api/runs`.
+#[derive(serde::Deserialize, Default)]
+pub(super) struct RunsQuery {
+    pub(super) limit: Option<usize>,
+    pub(super) cursor: Option<String>,
+    pub(super) status: Option<String>,
+    pub(super) sort: Option<String>,
+    pub(super) order: Option<String>,
+    pub(super) q: Option<String>,
+    pub(super) q_in: Option<String>,
+    pub(super) fields: Option<String>,
+    pub(super) ids: Option<String>,
+    pub(super) since: Option<i64>,
+}
+
+/// A validated query. Every 400 this route can produce is decided here, so the
+/// handler below is a straight-line composition and the error paths are all
+/// reachable from a plain unit test.
+struct Resolved {
+    limit: usize,
+    cursor: Option<Cursor>,
+    statuses: Vec<String>,
+    sort: SortKey,
+    descending: bool,
+    q: Option<String>,
+    sources: Vec<Source>,
+    fields: Option<HashSet<String>>,
+    ids: Option<Vec<String>>,
+    since: Option<i64>,
+    digest: String,
+}
+
+impl Resolved {
+    /// Does any requested source read files?
+    fn searches_filesystem(&self) -> bool {
+        self.q.is_some() && self.sources.iter().any(|s| s.reads_filesystem())
+    }
+}
+
+type ApiError = (StatusCode, Json<ErrorResponse>);
+
+fn bad_request(message: String) -> ApiError {
+    err(StatusCode::BAD_REQUEST, message)
+}
+
+/// Split a comma list, dropping empties so `a,,b` and a trailing comma are not
+/// errors a client has to think about.
+fn comma_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
+    // `ids` is a batch fetch, not a filter: it names exactly what it wants, so
+    // paging, ordering and filtering have nothing to act on. Rejecting the
+    // combination is deliberate - a silently ignored parameter produces the
+    // kind of bug report that takes a day to read.
+    let ids = query.ids.as_deref().map(comma_list);
+    if let Some(ref ids) = ids {
+        let conflicts = [
+            ("cursor", query.cursor.is_some()),
+            ("q", query.q.is_some()),
+            ("status", query.status.is_some()),
+            ("since", query.since.is_some()),
+        ];
+        if let Some((name, _)) = conflicts.iter().find(|(_, present)| *present) {
+            return Err(bad_request(format!(
+                "`ids` names exactly which runs to return, so it cannot be combined with `{name}`"
+            )));
+        }
+        if ids.len() > MAX_IDS {
+            return Err(bad_request(format!(
+                "`ids` names {} runs; at most {MAX_IDS} may be fetched at once",
+                ids.len()
+            )));
+        }
+    }
+
+    let limit = match query.limit {
+        None => DEFAULT_LIMIT,
+        Some(0) => {
+            return Err(bad_request(
+                "`limit` must be at least 1; omit it for the default".to_string(),
+            ));
+        }
+        Some(n) => n.min(MAX_LIMIT),
+    };
+
+    let sort_raw = query.sort.as_deref().unwrap_or("started_at");
+    let sort = SortKey::parse(sort_raw).ok_or_else(|| {
+        bad_request(format!(
+            "Unknown sort '{sort_raw}': expected started_at, updated_at or last_progress_at"
+        ))
+    })?;
+
+    let order_raw = query.order.as_deref().unwrap_or("desc");
+    let descending = match order_raw {
+        "desc" => true,
+        "asc" => false,
+        other => {
+            return Err(bad_request(format!(
+                "Unknown order '{other}': expected desc or asc"
+            )));
+        }
+    };
+
+    let q = query
+        .q
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let sources_raw = query.q_in.as_deref().unwrap_or("meta,files");
+    let mut sources = Vec::new();
+    for name in comma_list(sources_raw) {
+        let source = Source::parse(&name).ok_or_else(|| {
+            bad_request(format!(
+                "Unknown q_in '{name}': expected meta, files, context, logs or journal"
+            ))
+        })?;
+        if !sources.contains(&source) {
+            sources.push(source);
+        }
+    }
+
+    let fields = match query.fields.as_deref() {
+        None => None,
+        Some(raw) => {
+            let requested = comma_list(raw);
+            let known = known_meta_fields();
+            let unknown: Vec<&String> = requested
+                .iter()
+                .filter(|name| !known.contains(name.as_str()))
+                .collect();
+            if let Some(first) = unknown.first() {
+                // Naming the nested case separately, because `flags.count` is
+                // the natural thing to try and "unknown field" would be a
+                // misleading answer to it.
+                if first.contains('.') {
+                    return Err(bad_request(format!(
+                        "`fields` selects top-level fields only, so '{first}' is not available"
+                    )));
+                }
+                return Err(bad_request(format!("Unknown field '{first}' in `fields`")));
+            }
+            let mut set: HashSet<String> = requested.into_iter().collect();
+            // Identity is never optional: a projected item nothing can be keyed
+            // by is useless to every client.
+            set.insert("run_id".to_string());
+            Some(set)
+        }
+    };
+
+    let statuses = query.status.as_deref().map(comma_list).unwrap_or_default();
+
+    // The filters, in a fixed order, so the same filter set always digests the
+    // same way.
+    let digest = cursor::filter_digest(&[
+        &statuses.join(","),
+        q.as_deref().unwrap_or(""),
+        sources_raw,
+        &query.since.map(|s| s.to_string()).unwrap_or_default(),
+    ]);
+
+    let cursor = match query.cursor.as_deref() {
+        None => None,
+        Some(raw) => Some(
+            cursor::decode(raw, sort.as_str(), order_raw, &digest)
+                .map_err(|e| bad_request(e.message()))?,
+        ),
+    };
+
+    Ok(Resolved {
+        limit,
+        cursor,
+        statuses,
+        sort,
+        descending,
+        q,
+        sources,
+        fields,
+        ids,
+        since: query.since,
+        digest,
+    })
+}
+
+/// The top-level keys of a serialized `RunMeta`, for validating `fields`.
+///
+/// Derived from an actual serialization rather than a hand-written list, so the
+/// allowlist cannot drift away from the struct when a field is added.
+fn known_meta_fields() -> HashSet<String> {
+    let probe = RunMeta::new(
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        None,
+        String::new(),
+        0,
+    );
+    match serde_json::to_value(probe) {
+        Ok(serde_json::Value::Object(map)) => map.keys().cloned().collect(),
+        _ => HashSet::new(),
+    }
+}
+
+/// `GET /api/runs`
+pub(super) async fn list_runs(
+    Query(query): Query<RunsQuery>,
+) -> Result<Json<Page<RunItem>>, ApiError> {
+    let resolved = resolve(&query)?;
+    let server_time = now_secs();
+
+    // A batch fetch reads exactly the named runs, rather than scanning the
+    // whole directory and filtering it down to them.
+    if let Some(ref ids) = resolved.ids {
+        let mut items = Vec::new();
+        let mut missing = Vec::new();
+        for id in ids {
+            match runstate::read_meta(id) {
+                Ok(meta) => items.push(build_item(&meta, &resolved, None)),
+                Err(_) => missing.push(id.clone()),
+            }
+        }
+        let total = items.len();
+        let mut page = Page::new(items, None, Some(total), server_time);
+        page.missing = missing;
+        return Ok(Json(page));
+    }
+
+    let mut runs = runstate::list_runs();
+    if !resolved.statuses.is_empty() {
+        runs.retain(|meta| {
+            resolved
+                .statuses
+                .iter()
+                .any(|filter| status_matches(&meta.status, filter))
+        });
+    }
+    if let Some(since) = resolved.since {
+        // Inclusive: at seconds granularity an exclusive comparison drops
+        // updates that land in the same second as the previous watermark, and a
+        // re-delivered item is recoverable where a lost one is not.
+        runs.retain(|meta| resolved.sort.value(meta) >= since);
+    }
+
+    // Sort before searching, so the scan budget is spent on the runs the client
+    // asked to see first.
+    sort_runs(&mut runs, &resolved);
+
+    let (runs, scan_truncated) = apply_search(runs, &resolved);
+    let total = if scan_truncated {
+        None
+    } else {
+        Some(runs.len())
+    };
+
+    let (page_runs, next_cursor) = paginate(runs, &resolved);
+    let items = page_runs
+        .iter()
+        .map(|meta| {
+            let highlights = resolved
+                .q
+                .as_deref()
+                .map(|q| highlights_for(meta, q, &resolved.sources))
+                .unwrap_or_default();
+            build_item(meta, &resolved, Some(highlights))
+        })
+        .collect();
+
+    let mut page = Page::new(items, next_cursor, total, server_time);
+    page.scan_truncated = scan_truncated;
+    Ok(Json(page))
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Order by `(sort value, run_id)`, with the tie-break following the primary
+/// direction.
+///
+/// The tie-break is not decoration: two runs can start in the same second, and
+/// a keyset walk over a non-total order drops whichever colliding run it
+/// resumed past. Run ids are unique, so this makes the order total.
+fn sort_runs(runs: &mut [RunMeta], resolved: &Resolved) {
+    runs.sort_by(|a, b| {
+        let ka = (resolved.sort.value(a), a.run_id.as_str());
+        let kb = (resolved.sort.value(b), b.run_id.as_str());
+        if resolved.descending {
+            kb.cmp(&ka)
+        } else {
+            ka.cmp(&kb)
+        }
+    });
+}
+
+/// Phase one of search: keep the runs that could match, bounding how many of
+/// them are allowed to cost a file read.
+fn apply_search(runs: Vec<RunMeta>, resolved: &Resolved) -> (Vec<RunMeta>, bool) {
+    let Some(ref q) = resolved.q else {
+        return (runs, false);
+    };
+    let budgeted = resolved.searches_filesystem();
+    let mut kept = Vec::new();
+    let mut scanned = 0usize;
+    let mut truncated = false;
+    for meta in runs {
+        if budgeted {
+            if scanned >= MAX_SEARCH_SCAN {
+                truncated = true;
+                break;
+            }
+            scanned += 1;
+        }
+        if matches_query(&meta, q, &resolved.sources) {
+            kept.push(meta);
+        }
+    }
+    (kept, truncated)
+}
+
+/// Does this run match, according to the requested sources? Sources are OR-ed.
+///
+/// Nothing here parses. The cheap sources read already-parsed metadata; the
+/// deep ones substring-scan raw file bytes. Parsing is phase two's job, and it
+/// only happens for the items actually being returned.
+fn matches_query(meta: &RunMeta, q: &str, sources: &[Source]) -> bool {
+    sources.iter().any(|source| match source {
+        Source::Meta => meta_fields(meta)
+            .iter()
+            .any(|(_, text)| search::find_ignore_ascii_case(text, q).is_some()),
+        Source::Files => meta
+            .flags
+            .modified_files
+            .iter()
+            .any(|path| search::find_ignore_ascii_case(path, q).is_some()),
+        Source::Context => scan_file(&runstate::run_dir(&meta.run_id).join("context.json"), q),
+        Source::Journal => scan_file(&runstate::run_dir(&meta.run_id).join("run.lvr"), q),
+        Source::Logs => stage_indices(&meta.run_id).iter().any(|idx| {
+            let output = runstate::tail_stage_output(&meta.run_id, *idx, SEARCH_LOG_TAIL_BYTES);
+            let operational = runstate::tail_stage_log(&meta.run_id, *idx, SEARCH_LOG_TAIL_BYTES);
+            search::find_ignore_ascii_case(&output, q).is_some()
+                || search::find_ignore_ascii_case(&operational, q).is_some()
+        }),
+    })
+}
+
+/// The stage indices a run recorded, from `stages.json` - the index of record,
+/// rather than a `read_dir` of the directory its bytes happened to land in.
+fn stage_indices(run_id: &str) -> Vec<usize> {
+    runstate::read_stages_index(run_id)
+        .iter()
+        .map(|stage| stage.index)
+        .collect()
+}
+
+/// Substring-scan a whole file's bytes without parsing it.
+fn scan_file(path: &std::path::Path, q: &str) -> bool {
+    match std::fs::read(path) {
+        Ok(bytes) => search::contains_ignore_ascii_case(&bytes, q.as_bytes()).is_some(),
+        Err(_) => false,
+    }
+}
+
+/// The searchable `(name, text)` pairs already present in a `RunMeta`.
+fn meta_fields(meta: &RunMeta) -> Vec<(String, String)> {
+    let mut out = vec![
+        ("run_id".to_string(), meta.run_id.clone()),
+        ("agent_name".to_string(), meta.agent_name.clone()),
+        ("agent_path".to_string(), meta.agent_path.clone()),
+        ("task".to_string(), meta.task.clone()),
+        ("workdir".to_string(), meta.workdir.clone()),
+        ("current_stage".to_string(), meta.current_stage.clone()),
+    ];
+    if let Some(ref title) = meta.title {
+        out.push(("title".to_string(), title.clone()));
+    }
+    if let Some(ref model) = meta.model {
+        out.push(("model".to_string(), model.clone()));
+    }
+    if let Some(ref error) = meta.error {
+        out.push(("error".to_string(), error.clone()));
+    }
+    // `callback_url` and `callback_secret` are deliberately absent. The secret
+    // never leaves the process, and neither is something a user searches for.
+    let mut keys: Vec<&String> = meta.metadata.keys().collect();
+    keys.sort();
+    for key in keys {
+        if let Some(value) = meta.metadata.get(key) {
+            out.push((format!("metadata.{key}"), value.clone()));
+        }
+    }
+    out
+}
+
+/// Phase two: why this run matched, for the items actually being returned.
+fn highlights_for(meta: &RunMeta, q: &str, sources: &[Source]) -> Vec<Highlight> {
+    let mut out = Vec::new();
+    for source in sources {
+        if out.len() >= MAX_HIGHLIGHTS {
+            break;
+        }
+        match source {
+            Source::Meta => {
+                for (field, text) in meta_fields(meta) {
+                    if out.len() >= MAX_HIGHLIGHTS {
+                        break;
+                    }
+                    if let Some(at) = search::find_ignore_ascii_case(&text, q) {
+                        out.push(Highlight {
+                            field,
+                            snippet: search::snippet(&text, at),
+                            stage: None,
+                        });
+                    }
+                }
+            }
+            Source::Files => {
+                if let Some(path) = meta
+                    .flags
+                    .modified_files
+                    .iter()
+                    .find(|p| search::find_ignore_ascii_case(p, q).is_some())
+                {
+                    out.push(Highlight {
+                        field: "modified_files".to_string(),
+                        snippet: path.clone(),
+                        stage: None,
+                    });
+                }
+            }
+            Source::Context => context_highlight(meta, q, &mut out),
+            Source::Logs => logs_highlights(meta, q, &mut out),
+            Source::Journal => journal_highlights(meta, q, &mut out),
+        }
+    }
+    out.truncate(MAX_HIGHLIGHTS);
+    out
+}
+
+/// Where in the run's context window the match is, named by region.
+///
+/// Parses `context.json` once. Never replays the journal: that deep-copies a
+/// whole context window per recorded point, which is the cost this design
+/// exists to avoid.
+fn context_highlight(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
+    let Some(snapshot) = runstate::read_context_snapshot(&meta.run_id) else {
+        return;
+    };
+    for region in &snapshot.regions {
+        for entry in &region.entries {
+            if let Some(at) = search::find_ignore_ascii_case(&entry.content, q) {
+                out.push(Highlight {
+                    field: format!("context.{}", region.name),
+                    snippet: search::snippet(&entry.content, at),
+                    stage: None,
+                });
+                return;
+            }
+        }
+    }
+}
+
+/// Which stage's log the match is in - so a client can then fetch that stage.
+fn logs_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
+    for idx in stage_indices(&meta.run_id) {
+        if out.len() >= MAX_HIGHLIGHTS {
+            return;
+        }
+        let output = runstate::tail_stage_output(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
+        if let Some(at) = search::find_ignore_ascii_case(&output, q) {
+            out.push(Highlight {
+                field: "logs.output".to_string(),
+                snippet: search::snippet(&output, at),
+                stage: Some(idx),
+            });
+            continue;
+        }
+        let operational = runstate::tail_stage_log(&meta.run_id, idx, SEARCH_LOG_TAIL_BYTES);
+        if let Some(at) = search::find_ignore_ascii_case(&operational, q) {
+            out.push(Highlight {
+                field: "logs.operational".to_string(),
+                snippet: search::snippet(&operational, at),
+                stage: Some(idx),
+            });
+        }
+    }
+}
+
+/// Which tool call the match is in, from the run journal.
+///
+/// Streams the records and looks only at tool batches. Deliberately never at
+/// `Header`/`Progress`/`Checkpoint` metadata: those carry a whole `RunMeta`,
+/// including the webhook signing secret, and a snippet cut from those bytes
+/// would put it in the response.
+fn journal_highlights(meta: &RunMeta, q: &str, out: &mut Vec<Highlight>) {
+    let Some(records) = runstate::read_run_archive(&meta.run_id) else {
+        return;
+    };
+    for record in &records {
+        if out.len() >= MAX_HIGHLIGHTS {
+            return;
+        }
+        let leviath_core::run_archive::RunRecord::ToolBatch {
+            calls, stage_index, ..
+        } = record
+        else {
+            continue;
+        };
+        for call in calls {
+            let haystacks = [&call.arguments, call.result.as_ref().unwrap_or(&call.name)];
+            for text in haystacks {
+                if let Some(at) = search::find_ignore_ascii_case(text, q) {
+                    out.push(Highlight {
+                        field: format!("journal.tool.{}", call.name),
+                        snippet: search::snippet(text, at),
+                        stage: Some(*stage_index),
+                    });
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Take this page's runs and mint the cursor for the next one.
+///
+/// Takes `limit + 1` and keeps `limit`, so a cursor is only ever emitted when a
+/// further item is known to exist. Emitting one speculatively would make a
+/// client's "loop until null" run one empty request longer, every time.
+fn paginate(runs: Vec<RunMeta>, resolved: &Resolved) -> (Vec<RunMeta>, Option<String>) {
+    let mut after_cursor: Vec<RunMeta> = match resolved.cursor {
+        None => runs,
+        Some(ref cursor) => runs
+            .into_iter()
+            .filter(|meta| {
+                cursor.precedes(
+                    &CursorKey::Int(resolved.sort.value(meta)),
+                    &meta.run_id,
+                    resolved.descending,
+                )
+            })
+            .collect(),
+    };
+
+    let has_more = after_cursor.len() > resolved.limit;
+    after_cursor.truncate(resolved.limit);
+    let next = has_more.then(|| after_cursor.last()).flatten().map(|last| {
+        cursor::encode(
+            resolved.sort.as_str(),
+            if resolved.descending { "desc" } else { "asc" },
+            &resolved.digest,
+            CursorKey::Int(resolved.sort.value(last)),
+            &last.run_id,
+        )
+    });
+    (after_cursor, next)
+}
+
+/// Build one response item, redacting and then projecting.
+///
+/// `redacted()` is applied here, at the single place a `RunMeta` becomes JSON on
+/// this route, rather than at each call site - it is what strips the webhook
+/// signing secret, and a redaction that has to be remembered per handler is the
+/// one that gets forgotten.
+fn build_item(meta: &RunMeta, resolved: &Resolved, highlights: Option<Vec<Highlight>>) -> RunItem {
+    let mut value = serde_json::to_value(meta.redacted()).unwrap_or(serde_json::Value::Null);
+    if let (Some(fields), serde_json::Value::Object(map)) = (&resolved.fields, &mut value) {
+        map.retain(|key, _| fields.contains(key));
+    }
+    RunItem {
+        meta: value,
+        highlights: highlights.unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+#[path = "runs_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -32,9 +32,9 @@ const DEFAULT_LIMIT: usize = 50;
 /// Largest page size served. A larger `limit` is clamped rather than refused: a
 /// client asking for 1000 wants as much as it can get, and the real value is
 /// discoverable from `GET /api/config`.
-const MAX_LIMIT: usize = 200;
+pub(super) const MAX_LIMIT: usize = 200;
 /// Most ids one batch fetch may name.
-const MAX_IDS: usize = 200;
+pub(super) const MAX_IDS: usize = 200;
 /// How many runs a filesystem-reading search will examine before giving up.
 ///
 /// `q_in=logs` over an unbounded, never-pruned run set is a self-inflicted
@@ -43,9 +43,9 @@ const MAX_IDS: usize = 200;
 /// the requested sort order, so it is the newest runs - answers the common case
 /// and says so via `scan_truncated`, which is better than refusing the query or
 /// than quietly taking longer every month.
-const MAX_SEARCH_SCAN: usize = 500;
+pub(super) const MAX_SEARCH_SCAN: usize = 500;
 /// How much of each stage log a search reads, from the end.
-const SEARCH_LOG_TAIL_BYTES: u64 = 256 * 1024;
+pub(super) const SEARCH_LOG_TAIL_BYTES: u64 = 256 * 1024;
 /// Most highlights attached to one item. A log with ten thousand matches must
 /// not become the response body.
 const MAX_HIGHLIGHTS: usize = 5;

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -624,6 +624,109 @@ async fn a_deep_search_finds_text_only_present_in_a_stage_log_and_says_where() {
     .await;
 }
 
+/// Write a journal for `run_id` whose context carries `content`, and whose
+/// metadata carries a webhook secret.
+fn plant_journal(run_id: &str, content: &str, secret: Option<&str>) {
+    use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+    use leviath_core::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot};
+
+    let mut meta = meta_at(run_id, 1);
+    meta.callback_secret = secret.map(str::to_string);
+
+    let mut buf = Vec::new();
+    run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+    run_archive::write_record(
+        &mut buf,
+        &RunRecord::Header {
+            identity: RunIdentity {
+                run_id: run_id.to_string(),
+                machine_id: "m".to_string(),
+                world_id: "w".to_string(),
+                created_at: 0,
+            },
+            meta: Box::new(meta),
+        },
+    )
+    .unwrap();
+    run_archive::write_record(
+        &mut buf,
+        &RunRecord::ContextCheckpoint {
+            snapshot: ContextSnapshot {
+                stage_name: "work".to_string(),
+                total_tokens: 1,
+                max_tokens: 100,
+                regions: vec![RegionSnapshot {
+                    name: "system".to_string(),
+                    kind: "pinned".to_string(),
+                    current_tokens: 1,
+                    max_tokens: 100,
+                    entries: vec![RegionEntrySnapshot {
+                        content: content.to_string(),
+                        tokens: 1,
+                        kind: leviath_core::region::EntryKind::Text,
+                        metadata: None,
+                        key: None,
+                        taint: leviath_core::taint::TaintLevel::default(),
+                    }],
+                }],
+            },
+            at: 2,
+        },
+    )
+    .unwrap();
+    std::fs::write(crate::runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+}
+
+/// Regression test for a gap found by running this against real journals: runs
+/// matched on `q_in=journal` and came back with no highlight at all, because
+/// only tool batches were being inspected while the text lived in the journal's
+/// context records. A result with no explanation is the thing server-side
+/// search exists to avoid.
+#[tokio::test]
+async fn a_journal_match_in_a_context_record_still_explains_itself() {
+    crate::runstate::with_isolated_runs_dir_async("runs-journal-context", |_d| async move {
+        create_run(&meta_at("run-j", 1)).unwrap();
+        plant_journal("run-j", "the codex entry mentions xylophone here", None);
+
+        let page = page_of(&[("q", "xylophone"), ("q_in", "journal")]).await;
+        assert_eq!(page.items.len(), 1);
+        let highlights = &page.items[0].highlights;
+        assert!(
+            !highlights.is_empty(),
+            "a match with no highlight is the bug"
+        );
+        assert_eq!(highlights[0].field, "journal.context.system");
+        assert!(highlights[0].snippet.contains("xylophone"));
+    })
+    .await;
+}
+
+/// The journal stores `RunMeta` whole, secret included, so the highlighter must
+/// never cut a snippet from those bytes. Phase one scans the raw file and so
+/// *can* match there - the run may come back - but nothing it returns may echo
+/// the secret.
+#[tokio::test]
+async fn searching_the_journal_never_echoes_the_webhook_secret() {
+    crate::runstate::with_isolated_runs_dir_async("runs-journal-secret", |_d| async move {
+        create_run(&meta_at("run-s", 1)).unwrap();
+        plant_journal(
+            "run-s",
+            "ordinary content",
+            Some("super-secret-signing-key"),
+        );
+
+        for source in ["journal", "meta", "context"] {
+            let page = page_of(&[("q", "super-secret-signing-key"), ("q_in", source)]).await;
+            let rendered = serde_json::to_string(&page.items).unwrap();
+            assert!(
+                !rendered.contains("super-secret-signing-key"),
+                "q_in={source} echoed the signing key"
+            );
+        }
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn a_bad_request_is_reported_rather_than_served() {
     crate::runstate::with_isolated_runs_dir_async("runs-handler-bad", |_d| async move {

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -727,6 +727,444 @@ async fn searching_the_journal_never_echoes_the_webhook_secret() {
     .await;
 }
 
+/// A journal exercising every record kind the highlighter reads: a tool call,
+/// an appended region, a replaced region, and a full checkpoint.
+fn plant_rich_journal(run_id: &str) {
+    use leviath_core::run_archive::{
+        self, ContextDelta, RegionDelta, RunIdentity, RunRecord, ToolCallRecord,
+    };
+    use leviath_core::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot};
+
+    fn entry(content: &str) -> RegionEntrySnapshot {
+        RegionEntrySnapshot {
+            content: content.to_string(),
+            tokens: 1,
+            kind: leviath_core::region::EntryKind::Text,
+            metadata: None,
+            key: None,
+            taint: leviath_core::taint::TaintLevel::default(),
+        }
+    }
+    fn region(name: &str, content: &str) -> RegionSnapshot {
+        RegionSnapshot {
+            name: name.to_string(),
+            kind: "pinned".to_string(),
+            current_tokens: 1,
+            max_tokens: 100,
+            entries: vec![entry(content)],
+        }
+    }
+    fn snapshot(regions: Vec<RegionSnapshot>) -> ContextSnapshot {
+        ContextSnapshot {
+            stage_name: "work".to_string(),
+            total_tokens: 1,
+            max_tokens: 100,
+            regions,
+        }
+    }
+    fn delta(regions: Vec<RegionDelta>) -> ContextDelta {
+        ContextDelta {
+            stage_name: "work".to_string(),
+            total_tokens: 1,
+            max_tokens: 100,
+            regions,
+        }
+    }
+
+    let mut buf = Vec::new();
+    run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+    let write = |buf: &mut Vec<u8>, record: &RunRecord| {
+        run_archive::write_record(buf, record).unwrap();
+    };
+    write(
+        &mut buf,
+        &RunRecord::Header {
+            identity: RunIdentity {
+                run_id: run_id.to_string(),
+                machine_id: "m".to_string(),
+                world_id: "w".to_string(),
+                created_at: 0,
+            },
+            meta: Box::new(meta_at(run_id, 1)),
+        },
+    );
+    write(
+        &mut buf,
+        &RunRecord::ToolBatch {
+            calls: vec![ToolCallRecord {
+                id: "c1".to_string(),
+                name: "write_file".to_string(),
+                arguments: r#"{"path":"toolneedle.rs"}"#.to_string(),
+                result: Some("wrote resultneedle".to_string()),
+                thought_signature: None,
+            }],
+            at: 2,
+            stage_index: 3,
+            iteration: 0,
+            response: String::new(),
+        },
+    );
+    write(
+        &mut buf,
+        &RunRecord::ContextCheckpoint {
+            snapshot: snapshot(vec![region("system", "checkpointneedle here")]),
+            at: 3,
+        },
+    );
+    write(
+        &mut buf,
+        &RunRecord::Progress {
+            meta: Box::new(meta_at(run_id, 1)),
+            delta: delta(vec![RegionDelta::Append {
+                name: "conversation".to_string(),
+                entries: vec![entry("appendneedle here")],
+                current_tokens: 2,
+            }]),
+            at: 4,
+        },
+    );
+    write(
+        &mut buf,
+        &RunRecord::ContextDiff {
+            delta: delta(vec![RegionDelta::Set(region("scratch", "setneedle here"))]),
+            at: 5,
+        },
+    );
+    // Arms that carry no text of their own, so the highlighter must skip them
+    // rather than treat them as a miss.
+    write(
+        &mut buf,
+        &RunRecord::ContextDiff {
+            delta: delta(vec![
+                RegionDelta::Clear {
+                    name: "conversation".to_string(),
+                },
+                RegionDelta::Remove {
+                    name: "scratch".to_string(),
+                },
+            ]),
+            at: 6,
+        },
+    );
+    write(
+        &mut buf,
+        &RunRecord::Checkpoint {
+            meta: Box::new(meta_at(run_id, 1)),
+            context: snapshot(vec![region("final", "checkneedle here")]),
+            at: 7,
+        },
+    );
+    std::fs::write(crate::runstate::run_dir(run_id).join("run.lvr"), &buf).unwrap();
+}
+
+/// Each record kind that carries text has to be reachable, or a match in it is
+/// a result the user cannot account for.
+#[tokio::test]
+async fn journal_highlights_name_the_record_the_match_came_from() {
+    crate::runstate::with_isolated_runs_dir_async("runs-journal-kinds", |_d| async move {
+        create_run(&meta_at("run-rich", 1)).unwrap();
+        plant_rich_journal("run-rich");
+
+        // A tool call reports the tool and its stage, so a client can jump
+        // straight to that stage's log.
+        for (needle, field, stage) in [
+            ("toolneedle", "journal.tool.write_file", Some(3)),
+            ("resultneedle", "journal.tool.write_file", Some(3)),
+        ] {
+            let page = page_of(&[("q", needle), ("q_in", "journal")]).await;
+            assert_eq!(page.items.len(), 1, "{needle} should match");
+            assert_eq!(page.items[0].highlights[0].field, field);
+            assert_eq!(page.items[0].highlights[0].stage, stage);
+        }
+
+        // Context text is named by the region it lived in, whether it arrived
+        // as a checkpoint, an append, a replacement, or a full checkpoint.
+        for (needle, field) in [
+            ("checkpointneedle", "journal.context.system"),
+            ("appendneedle", "journal.context.conversation"),
+            ("setneedle", "journal.context.scratch"),
+            ("checkneedle", "journal.context.final"),
+        ] {
+            let page = page_of(&[("q", needle), ("q_in", "journal")]).await;
+            assert_eq!(page.items.len(), 1, "{needle} should match");
+            let highlight = &page.items[0].highlights[0];
+            assert_eq!(highlight.field, field);
+            assert!(highlight.snippet.contains(needle));
+        }
+    })
+    .await;
+}
+
+/// The operational stream carries tool activity and errors, which is often
+/// exactly what someone is looking for.
+#[tokio::test]
+async fn a_log_search_can_match_the_operational_stream() {
+    crate::runstate::with_isolated_runs_dir_async("runs-logs-operational", |_d| async move {
+        create_run(&meta_at("run-ops", 1)).unwrap();
+        crate::runstate::write_stages_index(
+            "run-ops",
+            &[leviath_core::run_meta::StageRecord {
+                name: "work".to_string(),
+                index: 0,
+                status: leviath_core::run_meta::StageRunStatus::Complete,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cached_tokens: 0,
+                started_at: None,
+                ended_at: None,
+            }],
+        )
+        .unwrap();
+        crate::runstate::append_stage_output("run-ops", 0, "ordinary assistant text");
+        crate::runstate::append_stage_log("run-ops", 0, "[error] opsneedle exploded");
+
+        let page = page_of(&[("q", "opsneedle"), ("q_in", "logs")]).await;
+        assert_eq!(page.items.len(), 1);
+        let highlight = &page.items[0].highlights[0];
+        assert_eq!(highlight.field, "logs.operational");
+        assert_eq!(highlight.stage, Some(0));
+        assert!(highlight.snippet.contains("opsneedle"));
+    })
+    .await;
+}
+
+/// One run matching in many places must not crowd out the rest of the page.
+#[tokio::test]
+async fn journal_highlights_stop_at_the_cap() {
+    crate::runstate::with_isolated_runs_dir_async("runs-journal-cap", |_d| async move {
+        create_run(&meta_at("run-cap", 1)).unwrap();
+        plant_rich_journal("run-cap");
+
+        // "needle" appears in every planted record.
+        let page = page_of(&[("q", "needle"), ("q_in", "journal")]).await;
+        assert_eq!(page.items.len(), 1);
+        assert!(page.items[0].highlights.len() <= MAX_HIGHLIGHTS);
+    })
+    .await;
+}
+
+/// A match in the run's current context window, named by the region it is in.
+#[tokio::test]
+async fn a_context_search_names_the_region_that_matched() {
+    crate::runstate::with_isolated_runs_dir_async("runs-context-region", |_d| async move {
+        create_run(&meta_at("run-ctx", 1)).unwrap();
+        crate::runstate::write_context_snapshot(
+            "run-ctx",
+            &leviath_core::run_meta::ContextSnapshot {
+                stage_name: "work".to_string(),
+                total_tokens: 1,
+                max_tokens: 100,
+                regions: vec![leviath_core::run_meta::RegionSnapshot {
+                    name: "working_memory".to_string(),
+                    kind: "pinned".to_string(),
+                    current_tokens: 1,
+                    max_tokens: 100,
+                    entries: vec![leviath_core::run_meta::RegionEntrySnapshot {
+                        content: "the plan mentions ctxneedle somewhere".to_string(),
+                        tokens: 1,
+                        kind: leviath_core::region::EntryKind::Text,
+                        metadata: None,
+                        key: None,
+                        taint: leviath_core::taint::TaintLevel::default(),
+                    }],
+                }],
+            },
+        )
+        .unwrap();
+
+        let page = page_of(&[("q", "ctxneedle"), ("q_in", "context")]).await;
+        assert_eq!(page.items.len(), 1);
+        let highlight = &page.items[0].highlights[0];
+        assert_eq!(highlight.field, "context.working_memory");
+        assert!(highlight.snippet.contains("ctxneedle"));
+    })
+    .await;
+}
+
+/// Once a run has filled its highlight budget from one source, the remaining
+/// sources must stop rather than keep reading files for output that would be
+/// discarded. Also covers each deep source finding nothing to read at all.
+#[tokio::test]
+async fn deep_sources_stop_once_the_highlight_budget_is_full() {
+    crate::runstate::with_isolated_runs_dir_async("runs-budget-full", |_d| async move {
+        let mut meta = meta_at("run-full", 1);
+        // Enough metadata matches to fill the budget before any file is read.
+        meta.title = Some("aaa".to_string());
+        meta.error = Some("aaa".to_string());
+        meta.model = Some("aaa".to_string());
+        for i in 0..10 {
+            meta.metadata.insert(format!("k{i}"), "aaa".to_string());
+        }
+        create_run(&meta).unwrap();
+        // Deliberately no context.json, no stages and no journal, so each deep
+        // source also exercises its "nothing here" path.
+        crate::runstate::write_stages_index(
+            "run-full",
+            &[leviath_core::run_meta::StageRecord {
+                name: "work".to_string(),
+                index: 0,
+                status: leviath_core::run_meta::StageRunStatus::Complete,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cached_tokens: 0,
+                started_at: None,
+                ended_at: None,
+            }],
+        )
+        .unwrap();
+
+        let page = page_of(&[("q", "aaa"), ("q_in", "meta,context,logs,journal")]).await;
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].highlights.len(), MAX_HIGHLIGHTS);
+    })
+    .await;
+}
+
+/// The descending walk is covered above; ascending mints its own cursors, and
+/// a cursor minted for the wrong direction is unusable.
+#[tokio::test]
+async fn an_ascending_page_mints_a_usable_cursor() {
+    crate::runstate::with_isolated_runs_dir_async("runs-asc-cursor", |_d| async move {
+        for i in 0..4 {
+            create_run(&meta_at(&format!("run-{i}"), 100 + i)).unwrap();
+        }
+
+        let first = page_of(&[("limit", "2"), ("order", "asc")]).await;
+        assert_eq!(
+            item_ids(&first),
+            vec!["run-0".to_string(), "run-1".to_string()]
+        );
+        let cursor = first.next_cursor.expect("more pages");
+
+        let second = page_of(&[("limit", "2"), ("order", "asc"), ("cursor", &cursor)]).await;
+        assert_eq!(
+            item_ids(&second),
+            vec!["run-2".to_string(), "run-3".to_string()]
+        );
+        assert!(second.next_cursor.is_none());
+    })
+    .await;
+}
+
+/// Every sort key has to survive a cursor round trip, since the cursor records
+/// which key it was minted for and refuses to be used against another.
+#[tokio::test]
+async fn each_sort_key_pages_with_its_own_cursor() {
+    crate::runstate::with_isolated_runs_dir_async("runs-sort-keys", |_d| async move {
+        for i in 0..4 {
+            let mut meta = meta_at(&format!("run-{i}"), 100 + i);
+            meta.updated_at = 200 + i;
+            meta.last_progress_at = Some(300 + i);
+            create_run(&meta).unwrap();
+        }
+
+        for sort in ["started_at", "updated_at", "last_progress_at"] {
+            let first = page_of(&[("limit", "2"), ("sort", sort)]).await;
+            assert_eq!(first.items.len(), 2, "{sort} first page");
+            let first_ids = item_ids(&first);
+            let cursor = first
+                .next_cursor
+                .clone()
+                .unwrap_or_else(|| panic!("{sort} should have a second page"));
+            let second = page_of(&[("limit", "2"), ("sort", sort), ("cursor", &cursor)]).await;
+            assert_eq!(second.items.len(), 2, "{sort} second page");
+            // No overlap between the two pages.
+            for id in item_ids(&second) {
+                assert!(!first_ids.contains(&id), "{sort} repeated {id}");
+            }
+        }
+    })
+    .await;
+}
+
+/// A source that is asked about but finds nothing must simply contribute no
+/// highlight, rather than suppressing the ones that did match.
+#[tokio::test]
+async fn a_source_with_nothing_to_say_does_not_suppress_the_others() {
+    crate::runstate::with_isolated_runs_dir_async("runs-quiet-source", |_d| async move {
+        let mut meta = meta_at("run-quiet", 1);
+        meta.title = Some("quietneedle in the title".to_string());
+        meta.flags.modified_files = vec!["unrelated.rs".to_string()];
+        create_run(&meta).unwrap();
+
+        // Matches only via meta, but every other source is asked too - and
+        // none of them has a file to read.
+        let page = page_of(&[
+            ("q", "quietneedle"),
+            ("q_in", "meta,files,context,logs,journal"),
+        ])
+        .await;
+        assert_eq!(page.items.len(), 1);
+        let highlights = &page.items[0].highlights;
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].field, "title");
+    })
+    .await;
+}
+
+/// A run whose files exist but do not match, so the deep sources are read and
+/// come back empty rather than being skipped.
+#[tokio::test]
+async fn deep_sources_that_read_files_and_find_nothing_are_quiet() {
+    crate::runstate::with_isolated_runs_dir_async("runs-quiet-deep", |_d| async move {
+        let mut meta = meta_at("run-deepquiet", 1);
+        meta.title = Some("deepquietneedle".to_string());
+        create_run(&meta).unwrap();
+
+        // All three deep sources have something to read, none of it matching.
+        crate::runstate::write_context_snapshot(
+            "run-deepquiet",
+            &leviath_core::run_meta::ContextSnapshot {
+                stage_name: "work".to_string(),
+                total_tokens: 1,
+                max_tokens: 100,
+                regions: vec![leviath_core::run_meta::RegionSnapshot {
+                    name: "system".to_string(),
+                    kind: "pinned".to_string(),
+                    current_tokens: 1,
+                    max_tokens: 100,
+                    entries: vec![leviath_core::run_meta::RegionEntrySnapshot {
+                        content: "nothing of interest".to_string(),
+                        tokens: 1,
+                        kind: leviath_core::region::EntryKind::Text,
+                        metadata: None,
+                        key: None,
+                        taint: leviath_core::taint::TaintLevel::default(),
+                    }],
+                }],
+            },
+        )
+        .unwrap();
+        crate::runstate::write_stages_index(
+            "run-deepquiet",
+            &[leviath_core::run_meta::StageRecord {
+                name: "work".to_string(),
+                index: 0,
+                status: leviath_core::run_meta::StageRunStatus::Complete,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cached_tokens: 0,
+                started_at: None,
+                ended_at: None,
+            }],
+        )
+        .unwrap();
+        crate::runstate::append_stage_output("run-deepquiet", 0, "ordinary output");
+        crate::runstate::append_stage_log("run-deepquiet", 0, "[tool] ordinary");
+        plant_rich_journal("run-deepquiet");
+
+        let page = page_of(&[
+            ("q", "deepquietneedle"),
+            ("q_in", "meta,context,logs,journal"),
+        ])
+        .await;
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].highlights.len(), 1);
+        assert_eq!(page.items[0].highlights[0].field, "title");
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn a_bad_request_is_reported_rather_than_served() {
     crate::runstate::with_isolated_runs_dir_async("runs-handler-bad", |_d| async move {

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -1,0 +1,636 @@
+//! Tests for the paginated, searchable run listing.
+//!
+//! The pure halves - query resolution, ordering, paging, projection - are
+//! exercised directly over in-memory `RunMeta` values, so every 400 and every
+//! ordering rule is a plain unit test with no HTTP and no temp directory. Only
+//! the tests that genuinely need files on disk take the isolated-runs-dir path.
+
+use super::*;
+use crate::runstate::{RunStatus, create_run};
+
+// ─── fixtures ───────────────────────────────────────────────────────────────
+
+fn meta_at(id: &str, started_at: i64) -> RunMeta {
+    let mut meta = RunMeta::new(
+        id.to_string(),
+        "test-agent".to_string(),
+        "/agents/test".to_string(),
+        "do the thing".to_string(),
+        None,
+        "/work".to_string(),
+        1,
+    );
+    meta.started_at = started_at;
+    meta.updated_at = started_at;
+    meta
+}
+
+/// Build a `RunsQuery` the way a real request would, through axum's own
+/// extractor, so these tests cannot pass on a struct shape the wire never
+/// produces.
+fn query(pairs: &[(&str, &str)]) -> RunsQuery {
+    let encoded = pairs
+        .iter()
+        .map(|(k, v)| format!("{k}={}", urlencode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    let uri: axum::http::Uri = format!("http://test/api/runs?{encoded}")
+        .parse()
+        .expect("uri parses");
+    Query::<RunsQuery>::try_from_uri(&uri)
+        .expect("query parses")
+        .0
+}
+
+fn urlencode(raw: &str) -> String {
+    raw.chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | ',' => c.to_string(),
+            other => other
+                .to_string()
+                .bytes()
+                .map(|b| format!("%{b:02X}"))
+                .collect(),
+        })
+        .collect()
+}
+
+fn resolve_ok(pairs: &[(&str, &str)]) -> Resolved {
+    match resolve(&query(pairs)) {
+        Ok(resolved) => resolved,
+        Err((_, body)) => panic!("expected resolve to succeed: {}", body.0.error),
+    }
+}
+
+fn resolve_err(pairs: &[(&str, &str)]) -> String {
+    match resolve(&query(pairs)) {
+        Ok(_) => String::new(),
+        Err((status, body)) => {
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            body.0.error.clone()
+        }
+    }
+}
+
+fn ids(runs: &[RunMeta]) -> Vec<&str> {
+    runs.iter().map(|m| m.run_id.as_str()).collect()
+}
+
+// ─── query resolution ───────────────────────────────────────────────────────
+
+#[test]
+fn defaults_are_a_descending_started_at_page_of_fifty_over_the_cheap_sources() {
+    let r = resolve_ok(&[]);
+    assert_eq!(r.limit, DEFAULT_LIMIT);
+    assert_eq!(r.sort, SortKey::StartedAt);
+    assert!(r.descending);
+    assert!(r.q.is_none());
+    assert_eq!(r.sources, vec![Source::Meta, Source::Files]);
+    assert!(r.fields.is_none());
+    assert!(!r.searches_filesystem());
+}
+
+/// A client asking for more than the cap wants as much as it can get, so the
+/// value is clamped rather than the request refused.
+#[test]
+fn an_oversized_limit_is_clamped_and_a_zero_limit_is_refused() {
+    assert_eq!(resolve_ok(&[("limit", "100000")]).limit, MAX_LIMIT);
+    assert_eq!(resolve_ok(&[("limit", "5")]).limit, 5);
+    assert!(resolve_err(&[("limit", "0")]).contains("at least 1"));
+}
+
+#[test]
+fn an_unknown_sort_order_or_source_is_refused_by_name() {
+    assert!(resolve_err(&[("sort", "whenever")]).contains("whenever"));
+    assert!(resolve_err(&[("order", "sideways")]).contains("sideways"));
+    assert!(resolve_err(&[("q_in", "everything")]).contains("everything"));
+}
+
+#[test]
+fn every_sort_key_and_order_resolves() {
+    assert_eq!(
+        resolve_ok(&[("sort", "updated_at")]).sort,
+        SortKey::UpdatedAt
+    );
+    assert_eq!(
+        resolve_ok(&[("sort", "last_progress_at")]).sort,
+        SortKey::LastProgressAt
+    );
+    assert!(!resolve_ok(&[("order", "asc")]).descending);
+}
+
+#[test]
+fn duplicate_and_empty_search_sources_are_tolerated() {
+    let r = resolve_ok(&[("q_in", "meta,,meta,files,")]);
+    assert_eq!(r.sources, vec![Source::Meta, Source::Files]);
+}
+
+#[test]
+fn a_filesystem_source_is_only_budgeted_when_there_is_a_query() {
+    assert!(!resolve_ok(&[("q_in", "logs")]).searches_filesystem());
+    assert!(resolve_ok(&[("q", "x"), ("q_in", "logs")]).searches_filesystem());
+    assert!(!resolve_ok(&[("q", "x"), ("q_in", "meta")]).searches_filesystem());
+}
+
+/// An identity-less item is useless to every client, so `run_id` is not
+/// something a projection can drop.
+#[test]
+fn fields_always_keeps_run_id_and_rejects_what_it_cannot_serve() {
+    let r = resolve_ok(&[("fields", "status,title")]);
+    let fields = r.fields.expect("fields set");
+    assert!(fields.contains("run_id"));
+    assert!(fields.contains("status"));
+
+    assert!(resolve_err(&[("fields", "nonsense")]).contains("nonsense"));
+    // The nested case gets its own message: "unknown field" would be a
+    // misleading answer to a reasonable thing to try.
+    assert!(resolve_err(&[("fields", "flags.modified_file_count")]).contains("top-level"));
+}
+
+/// A silently ignored parameter is the API smell that produces the worst bug
+/// reports, so each conflicting combination is refused by name.
+#[test]
+fn ids_cannot_be_combined_with_the_parameters_it_would_override() {
+    for conflicting in ["cursor", "q", "status", "since"] {
+        let message = resolve_err(&[("ids", "a,b"), (conflicting, "1")]);
+        assert!(
+            message.contains(conflicting),
+            "expected {conflicting} to be named, got {message}"
+        );
+    }
+    assert_eq!(
+        resolve_ok(&[("ids", "a,b")]).ids,
+        Some(vec!["a".to_string(), "b".to_string()])
+    );
+}
+
+#[test]
+fn too_many_ids_are_refused() {
+    let many = (0..MAX_IDS + 1)
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(resolve_err(&[("ids", &many)]).contains("at most"));
+}
+
+#[test]
+fn an_empty_query_string_is_treated_as_no_search() {
+    assert!(resolve_ok(&[("q", "")]).q.is_none());
+}
+
+// ─── cursor binding ─────────────────────────────────────────────────────────
+
+/// A cursor names a position in a particular list. Presented against a
+/// different sort, order or filter set it cannot mean anything, so it is a 400
+/// rather than a page of quietly wrong results.
+#[test]
+fn a_cursor_is_bound_to_the_walk_it_was_minted_for() {
+    let base = resolve_ok(&[("status", "running")]);
+    let raw = cursor::encode(
+        base.sort.as_str(),
+        "desc",
+        &base.digest,
+        CursorKey::Int(10),
+        "run-a",
+    );
+
+    assert!(resolve(&query(&[("status", "running"), ("cursor", &raw)])).is_ok());
+
+    assert!(resolve_err(&[("status", "error"), ("cursor", &raw)]).contains("filters"));
+    assert!(
+        resolve_err(&[
+            ("status", "running"),
+            ("cursor", &raw),
+            ("sort", "updated_at")
+        ])
+        .contains("sort=")
+    );
+    assert!(
+        resolve_err(&[("status", "running"), ("cursor", &raw), ("order", "asc")])
+            .contains("order=")
+    );
+}
+
+#[test]
+fn a_malformed_cursor_is_refused() {
+    assert!(!resolve_err(&[("cursor", "zzzz")]).is_empty());
+}
+
+// ─── ordering and paging ────────────────────────────────────────────────────
+
+#[test]
+fn runs_sort_by_the_chosen_key_in_the_chosen_direction() {
+    let mut runs = vec![meta_at("b", 200), meta_at("a", 100), meta_at("c", 300)];
+    sort_runs(&mut runs, &resolve_ok(&[]));
+    assert_eq!(ids(&runs), vec!["c", "b", "a"]);
+
+    sort_runs(&mut runs, &resolve_ok(&[("order", "asc")]));
+    assert_eq!(ids(&runs), vec!["a", "b", "c"]);
+}
+
+/// Two runs starting in the same second is ordinary, not exotic. Without the
+/// id tie-break the order is not total, and a keyset walk drops whichever
+/// colliding run it happened to resume past.
+#[test]
+fn runs_sharing_a_sort_value_are_broken_apart_by_id() {
+    let mut runs = vec![meta_at("b", 100), meta_at("c", 100), meta_at("a", 100)];
+    sort_runs(&mut runs, &resolve_ok(&[]));
+    assert_eq!(ids(&runs), vec!["c", "b", "a"], "descending id tie-break");
+
+    sort_runs(&mut runs, &resolve_ok(&[("order", "asc")]));
+    assert_eq!(ids(&runs), vec!["a", "b", "c"], "ascending id tie-break");
+}
+
+/// Absent `last_progress_at` means "older daemon, or before the first
+/// snapshot" - the run did start, so `started_at` is the honest floor, and it
+/// keeps the sort key non-null for the cursor.
+#[test]
+fn a_missing_last_progress_at_falls_back_to_started_at() {
+    let mut meta = meta_at("a", 500);
+    meta.last_progress_at = None;
+    assert_eq!(SortKey::LastProgressAt.value(&meta), 500);
+    meta.last_progress_at = Some(900);
+    assert_eq!(SortKey::LastProgressAt.value(&meta), 900);
+    assert_eq!(SortKey::UpdatedAt.value(&meta), 500);
+}
+
+/// Walking the whole list a page at a time must visit every run exactly once.
+/// That is the property keyset paging exists for, so it is asserted as a
+/// property rather than on one hand-picked page.
+#[test]
+fn paging_all_the_way_through_visits_every_run_exactly_once() {
+    let all: Vec<RunMeta> = (0..25)
+        .map(|i| meta_at(&format!("run-{i:02}"), i))
+        .collect();
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor_raw: Option<String> = None;
+    for _ in 0..20 {
+        let resolved = match cursor_raw {
+            None => resolve_ok(&[("limit", "4")]),
+            Some(ref c) => resolve_ok(&[("limit", "4"), ("cursor", c)]),
+        };
+
+        let mut runs = all.clone();
+        sort_runs(&mut runs, &resolved);
+        let (page, next) = paginate(runs, &resolved);
+
+        assert!(page.len() <= 4);
+        seen.extend(page.iter().map(|m| m.run_id.clone()));
+        match next {
+            Some(c) => cursor_raw = Some(c),
+            None => break,
+        }
+    }
+
+    let mut unique = seen.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), seen.len(), "a run was returned twice");
+    assert_eq!(seen.len(), all.len(), "a run was skipped");
+}
+
+/// Emitting a cursor speculatively would make every client's "loop until null"
+/// run one extra empty request, every single time.
+#[test]
+fn no_cursor_is_emitted_on_the_last_page() {
+    let all: Vec<RunMeta> = (0..3).map(|i| meta_at(&format!("r{i}"), i)).collect();
+    let (page, next) = paginate(all, &resolve_ok(&[("limit", "3")]));
+    assert_eq!(page.len(), 3);
+    assert!(next.is_none(), "exactly-full page must not promise more");
+}
+
+#[test]
+fn an_empty_list_pages_to_nothing() {
+    let (page, next) = paginate(Vec::new(), &resolve_ok(&[]));
+    assert!(page.is_empty());
+    assert!(next.is_none());
+}
+
+/// Keyset paging's whole point: an insert elsewhere in the list must not shift
+/// the window, the way an offset would.
+#[test]
+fn a_run_arriving_at_the_head_does_not_shift_the_next_page() {
+    let all: Vec<RunMeta> = (0..6)
+        .map(|i| meta_at(&format!("run-{i}"), i * 10))
+        .collect();
+    let resolved = resolve_ok(&[("limit", "2")]);
+    let mut sorted = all.clone();
+    sort_runs(&mut sorted, &resolved);
+    let (first_page, next) = paginate(sorted, &resolved);
+    assert_eq!(ids(&first_page), vec!["run-5", "run-4"]);
+
+    // A brand new run arrives at the head between the two requests.
+    let mut with_new = all.clone();
+    with_new.push(meta_at("run-9", 999));
+    let raw = next.expect("more pages");
+    let resolved2 = resolve_ok(&[("limit", "2"), ("cursor", &raw)]);
+    let mut sorted2 = with_new;
+    sort_runs(&mut sorted2, &resolved2);
+    let (second_page, _) = paginate(sorted2, &resolved2);
+
+    // The new run sorts before the cursor so the walk skips it, and crucially
+    // nothing either side of it is dropped or repeated.
+    assert_eq!(ids(&second_page), vec!["run-3", "run-2"]);
+}
+
+// ─── projection ─────────────────────────────────────────────────────────────
+
+#[test]
+fn without_fields_an_item_carries_the_whole_redacted_meta() {
+    let item = build_item(&meta_at("a", 1), &resolve_ok(&[]), None);
+    let map = item.meta.as_object().expect("object");
+    assert!(map.contains_key("run_id"));
+    assert!(map.contains_key("task"));
+    assert!(map.contains_key("status"));
+}
+
+#[test]
+fn fields_narrows_the_item_but_never_drops_the_id() {
+    let item = build_item(&meta_at("a", 1), &resolve_ok(&[("fields", "status")]), None);
+    let map = item.meta.as_object().expect("object");
+    assert!(map.contains_key("run_id"));
+    assert!(map.contains_key("status"));
+    assert!(!map.contains_key("task"));
+}
+
+/// `redacted()` is what strips the webhook signing key, and it is applied at
+/// the one place a `RunMeta` becomes JSON on this route.
+#[test]
+fn an_item_never_carries_the_webhook_secret() {
+    let mut meta = meta_at("a", 1);
+    meta.callback_url = Some("https://example.invalid/hook".to_string());
+    meta.callback_secret = Some("super-secret-signing-key".to_string());
+
+    for resolved in [resolve_ok(&[]), resolve_ok(&[("fields", "status")])] {
+        let item = build_item(&meta, &resolved, None);
+        let rendered = serde_json::to_string(&item).unwrap();
+        assert!(!rendered.contains("super-secret-signing-key"));
+    }
+}
+
+#[test]
+fn highlights_are_omitted_from_the_wire_when_there_are_none() {
+    let item = build_item(&meta_at("a", 1), &resolve_ok(&[]), Some(Vec::new()));
+    assert!(!serde_json::to_string(&item).unwrap().contains("highlights"));
+}
+
+// ─── search: in-memory sources ──────────────────────────────────────────────
+
+#[test]
+fn the_meta_source_matches_the_fields_a_user_would_search_for() {
+    let mut meta = meta_at("run-abc", 1);
+    meta.title = Some("Refactor the retry backoff".to_string());
+    meta.error = Some("connection reset".to_string());
+    meta.metadata
+        .insert("ticket".to_string(), "ENG-4212".to_string());
+
+    let sources = [Source::Meta];
+    for needle in [
+        "refactor",
+        "BACKOFF",
+        "connection",
+        "ENG-4212",
+        "run-abc",
+        "do the thing",
+    ] {
+        assert!(
+            matches_query(&meta, needle, &sources),
+            "expected {needle} to match"
+        );
+    }
+    assert!(!matches_query(&meta, "nothing-like-this", &sources));
+}
+
+/// The signing secret must not be reachable through search either - otherwise
+/// it could be confirmed a character at a time.
+#[test]
+fn the_meta_source_does_not_search_the_webhook_secret() {
+    let mut meta = meta_at("a", 1);
+    meta.callback_secret = Some("super-secret-signing-key".to_string());
+    assert!(!matches_query(&meta, "super-secret", &[Source::Meta]));
+}
+
+#[test]
+fn the_files_source_matches_tracked_paths_only_when_asked_for() {
+    let mut meta = meta_at("a", 1);
+    meta.flags.modified_files = vec!["src/retry.rs".to_string()];
+    assert!(matches_query(&meta, "retry.rs", &[Source::Files]));
+    assert!(!matches_query(&meta, "retry.rs", &[Source::Meta]));
+}
+
+#[test]
+fn sources_are_ored_together() {
+    let mut meta = meta_at("a", 1);
+    meta.flags.modified_files = vec!["src/retry.rs".to_string()];
+    assert!(matches_query(
+        &meta,
+        "retry.rs",
+        &[Source::Meta, Source::Files]
+    ));
+}
+
+#[test]
+fn highlights_name_the_field_that_matched_and_quote_it() {
+    let mut meta = meta_at("a", 1);
+    meta.title = Some("Refactor the retry backoff".to_string());
+    let out = highlights_for(&meta, "backoff", &[Source::Meta]);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].field, "title");
+    assert!(out[0].snippet.contains("backoff"));
+    assert!(out[0].stage.is_none());
+}
+
+#[test]
+fn highlights_are_capped_so_one_run_cannot_dominate_a_page() {
+    let mut meta = meta_at("aaa", 1);
+    meta.title = Some("aaa".to_string());
+    meta.error = Some("aaa".to_string());
+    meta.model = Some("aaa".to_string());
+    for i in 0..20 {
+        meta.metadata.insert(format!("k{i}"), "aaa".to_string());
+    }
+    assert_eq!(
+        highlights_for(&meta, "aaa", &[Source::Meta]).len(),
+        MAX_HIGHLIGHTS
+    );
+}
+
+#[test]
+fn a_files_highlight_reports_the_matching_path() {
+    let mut meta = meta_at("a", 1);
+    meta.flags.modified_files = vec!["docs/readme.md".to_string(), "src/retry.rs".to_string()];
+    let out = highlights_for(&meta, "retry", &[Source::Files]);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].field, "modified_files");
+    assert_eq!(out[0].snippet, "src/retry.rs");
+}
+
+// ─── search: the scan budget ────────────────────────────────────────────────
+
+/// The guard that keeps `q_in=logs` from becoming a self-inflicted denial of
+/// service against a run set nothing prunes.
+#[test]
+fn a_filesystem_search_stops_after_the_scan_budget_and_says_so() {
+    let runs: Vec<RunMeta> = (0..MAX_SEARCH_SCAN + 10)
+        .map(|i| meta_at(&format!("run-{i:05}"), i as i64))
+        .collect();
+    let (kept, truncated) = apply_search(runs, &resolve_ok(&[("q", "x"), ("q_in", "logs")]));
+    assert!(
+        truncated,
+        "the budget must be reported, not silently applied"
+    );
+    assert!(kept.len() <= MAX_SEARCH_SCAN);
+}
+
+/// The in-memory sources cost nothing, so they must not consume the budget -
+/// otherwise a plain title search would stop working past 500 runs.
+#[test]
+fn an_in_memory_search_is_not_budgeted_however_many_runs_there_are() {
+    let runs: Vec<RunMeta> = (0..MAX_SEARCH_SCAN + 10)
+        .map(|i| meta_at(&format!("run-{i:05}"), i as i64))
+        .collect();
+    let (kept, truncated) = apply_search(
+        runs,
+        &resolve_ok(&[("q", "do the thing"), ("q_in", "meta")]),
+    );
+    assert!(!truncated);
+    assert_eq!(kept.len(), MAX_SEARCH_SCAN + 10);
+}
+
+#[test]
+fn without_a_query_search_keeps_everything_untouched() {
+    let runs: Vec<RunMeta> = (0..3).map(|i| meta_at(&format!("r{i}"), i)).collect();
+    let (kept, truncated) = apply_search(runs, &resolve_ok(&[]));
+    assert_eq!(kept.len(), 3);
+    assert!(!truncated);
+}
+
+// ─── the handler, over real files ───────────────────────────────────────────
+
+async fn page_of(pairs: &[(&str, &str)]) -> Page<RunItem> {
+    list_runs(Query(query(pairs))).await.expect("page").0
+}
+
+fn item_ids(page: &Page<RunItem>) -> Vec<String> {
+    page.items
+        .iter()
+        .map(|i| i.meta["run_id"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn the_handler_pages_and_reports_a_total_and_a_server_time() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-pages", |_d| async move {
+        for i in 0..5 {
+            create_run(&meta_at(&format!("run-{i}"), 100 + i)).unwrap();
+        }
+
+        let page = page_of(&[("limit", "2")]).await;
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.total, Some(5));
+        assert!(page.server_time > 0);
+        assert!(page.next_cursor.is_some());
+        assert!(!page.scan_truncated);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn the_handler_filters_by_the_status_spelling_it_serves() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-status", |_d| async move {
+        let mut waiting = meta_at("run-waiting", 1);
+        waiting.status = RunStatus::WaitingInput;
+        create_run(&waiting).unwrap();
+        create_run(&meta_at("run-plain", 2)).unwrap();
+
+        // The serde spelling, which is what a client reads back off the wire.
+        let page = page_of(&[("status", "waiting_input")]).await;
+        assert_eq!(item_ids(&page), vec!["run-waiting".to_string()]);
+    })
+    .await;
+}
+
+/// The batch fetch that replaces N separate `GET /api/agents/{id}` calls.
+#[tokio::test]
+async fn ids_fetches_exactly_those_runs_and_reports_the_ones_that_are_gone() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-ids", |_d| async move {
+        create_run(&meta_at("run-a", 1)).unwrap();
+        create_run(&meta_at("run-b", 2)).unwrap();
+
+        let page = page_of(&[("ids", "run-b,run-a,run-vanished")]).await;
+        // In the order asked for, not in sort order.
+        assert_eq!(
+            item_ids(&page),
+            vec!["run-b".to_string(), "run-a".to_string()]
+        );
+        assert_eq!(page.missing, vec!["run-vanished".to_string()]);
+        assert!(page.next_cursor.is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn since_filters_on_the_sorted_field_inclusively() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-since", |_d| async move {
+        create_run(&meta_at("run-old", 100)).unwrap();
+        create_run(&meta_at("run-edge", 200)).unwrap();
+        create_run(&meta_at("run-new", 300)).unwrap();
+
+        // Inclusive, so the run exactly on the boundary is re-delivered rather
+        // than lost - the safe direction at seconds granularity.
+        assert_eq!(
+            item_ids(&page_of(&[("since", "200")]).await),
+            vec!["run-new".to_string(), "run-edge".to_string()]
+        );
+    })
+    .await;
+}
+
+/// The part that cannot be done in the browser: the console never holds a
+/// run's transcript, which is the whole reason search moved to the server.
+#[tokio::test]
+async fn a_deep_search_finds_text_only_present_in_a_stage_log_and_says_where() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-deep", |_d| async move {
+        create_run(&meta_at("run-deep", 1)).unwrap();
+        crate::runstate::write_stages_index(
+            "run-deep",
+            &[leviath_core::run_meta::StageRecord {
+                name: "review".to_string(),
+                index: 0,
+                status: leviath_core::run_meta::StageRunStatus::Complete,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cached_tokens: 0,
+                started_at: None,
+                ended_at: None,
+            }],
+        )
+        .unwrap();
+        crate::runstate::append_stage_output("run-deep", 0, "the mitochondria is the powerhouse");
+
+        // Invisible at the default depth: this text is in no metadata field.
+        assert!(page_of(&[("q", "mitochondria")]).await.items.is_empty());
+
+        // Opting in finds it, and the highlight names the stage so the client
+        // can go fetch that log next.
+        let page = page_of(&[("q", "mitochondria"), ("q_in", "logs")]).await;
+        assert_eq!(page.items.len(), 1);
+        let highlight = &page.items[0].highlights[0];
+        assert_eq!(highlight.field, "logs.output");
+        assert_eq!(highlight.stage, Some(0));
+        assert!(highlight.snippet.contains("mitochondria"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_bad_request_is_reported_rather_than_served() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-bad", |_d| async move {
+        let (status, _) = list_runs(Query(query(&[("sort", "nonsense")])))
+            .await
+            .expect_err("should be rejected");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}

--- a/crates/leviath-cli/src/commands/serve/search.rs
+++ b/crates/leviath-cli/src/commands/serve/search.rs
@@ -1,0 +1,66 @@
+//! Matching primitives for server-side search.
+//!
+//! Search over runs is deliberately two-phase, and these are the pieces phase
+//! one is built from.
+//!
+//! **Phase one is a candidate filter that never parses anything.** It answers
+//! "could this run match" over raw bytes: the already-parsed `RunMeta` for the
+//! cheap sources, and unparsed file contents for the deep ones. It must stay
+//! cheap because it runs over *every* candidate run, and the run set grows
+//! without bound - nothing prunes it.
+//!
+//! **Phase two builds the highlights**, and runs only over the items actually
+//! being returned. That is where parsing is affordable, because it is bounded by
+//! the page size rather than by how long the daemon has been installed.
+//!
+//! The measured reason this works without an index: a substring scan across
+//! every journal on a real machine - 84 archives, 22 MB - takes about 10 ms
+//! warm. What is *not* affordable is replaying those journals, which deep-copies
+//! a whole context window per recorded point.
+
+/// Find `needle` in `haystack`, ignoring ASCII case, returning the byte offset.
+///
+/// Returns the offset rather than a bool so phase two can reuse the position to
+/// cut a snippet instead of searching again.
+///
+/// Two deliberate limits, both of which belong in the API description rather
+/// than being discovered by a user:
+///
+/// - **ASCII case only.** No Unicode case folding, so `Straße` does not match
+///   `STRASSE`. Doing this properly means allocating a case-folded copy of every
+///   haystack, and the haystacks here are megabyte-scale files.
+/// - It works on raw bytes, so when the haystack is JSON (a context snapshot or
+///   a run journal) the needle is matched against the *escaped* text. A query
+///   containing a quote, a backslash, a newline, or a character serde escapes
+///   may not match even though the underlying text contains it.
+///
+/// An empty needle matches at 0, which is the same convention `str::find` uses.
+pub(super) fn contains_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle))
+}
+
+/// [`contains_ignore_ascii_case`] over `&str`, for the in-memory metadata
+/// sources where the haystack is already text.
+pub(super) fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
+    contains_ignore_ascii_case(haystack.as_bytes(), needle.as_bytes())
+}
+
+/// How much text to show either side of a match.
+pub(super) const SNIPPET_RADIUS: usize = 80;
+
+/// Build the snippet for a match at `at` in `text`.
+pub(super) fn snippet(text: &str, at: usize) -> String {
+    leviath_core::text::snippet_around(text, at, SNIPPET_RADIUS)
+}
+
+#[cfg(test)]
+#[path = "search_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/search_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/search_tests.rs
@@ -1,0 +1,87 @@
+//! Tests for the search matching primitives.
+
+use super::*;
+
+#[test]
+fn a_match_reports_the_offset_it_was_found_at() {
+    assert_eq!(
+        contains_ignore_ascii_case(b"hello world", b"world"),
+        Some(6)
+    );
+    assert_eq!(
+        contains_ignore_ascii_case(b"hello world", b"hello"),
+        Some(0)
+    );
+}
+
+#[test]
+fn case_is_ignored_on_both_sides() {
+    assert_eq!(
+        contains_ignore_ascii_case(b"Hello World", b"WORLD"),
+        Some(6)
+    );
+    assert_eq!(contains_ignore_ascii_case(b"HELLO", b"hello"), Some(0));
+}
+
+#[test]
+fn a_needle_that_is_absent_or_too_long_finds_nothing() {
+    assert_eq!(contains_ignore_ascii_case(b"hello", b"goodbye"), None);
+    // Longer than the haystack: the early return, not a windows() panic.
+    assert_eq!(contains_ignore_ascii_case(b"hi", b"hello there"), None);
+    assert_eq!(contains_ignore_ascii_case(b"", b"x"), None);
+}
+
+/// Matches `str::find`, so a caller that passes an empty query gets "everything
+/// matches" rather than "nothing does".
+#[test]
+fn an_empty_needle_matches_at_the_start() {
+    assert_eq!(contains_ignore_ascii_case(b"anything", b""), Some(0));
+    assert_eq!(contains_ignore_ascii_case(b"", b""), Some(0));
+}
+
+/// The documented limit. Pinned by a test so it is a decision rather than a
+/// surprise: if someone adds folding later, this test is where they say so.
+#[test]
+fn non_ascii_case_is_not_folded() {
+    assert_eq!(find_ignore_ascii_case("straße", "STRASSE"), None);
+    assert_eq!(find_ignore_ascii_case("ÉCOLE", "école"), None);
+    // ASCII either side of the multi-byte character still matches.
+    assert_eq!(find_ignore_ascii_case("café LATTE", "latte"), Some(6));
+}
+
+#[test]
+fn the_str_wrapper_finds_the_same_offsets() {
+    assert_eq!(find_ignore_ascii_case("hello world", "WORLD"), Some(6));
+    assert_eq!(find_ignore_ascii_case("hello", "nope"), None);
+}
+
+/// Scanning raw JSON means the needle meets escaped text. This is the limit the
+/// API description has to carry, so it is pinned here too.
+#[test]
+fn a_needle_spanning_a_json_escape_does_not_match_the_escaped_form() {
+    let raw_json = br#"{"content":"line one\nline two"}"#;
+    // The logical text contains "one\nline" but the bytes contain a backslash-n.
+    assert_eq!(contains_ignore_ascii_case(raw_json, b"one\nline"), None);
+    // The escaped form is what is actually there.
+    assert!(contains_ignore_ascii_case(raw_json, br"one\nline").is_some());
+    // Text either side of the escape matches normally, which is why the
+    // filter is still useful.
+    assert!(contains_ignore_ascii_case(raw_json, b"line two").is_some());
+}
+
+#[test]
+fn a_snippet_is_cut_around_the_match() {
+    let text = format!("{}NEEDLE{}", "a".repeat(200), "b".repeat(200));
+    let at = text.find("NEEDLE").unwrap();
+    let out = snippet(&text, at);
+    assert!(out.contains("NEEDLE"));
+    assert!(out.starts_with('…'));
+    assert!(out.ends_with('…'));
+    // Bounded by the radius either side, plus the match and the two ellipses.
+    assert!(out.chars().count() <= SNIPPET_RADIUS * 2 + "NEEDLE".len() + 2);
+}
+
+#[test]
+fn a_short_text_snippets_whole_and_unmarked() {
+    assert_eq!(snippet("short text", 0), "short text");
+}

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -352,6 +352,20 @@ pub(super) struct BlueprintInfo {
     pub(super) stages: Vec<String>,
 }
 
+/// Query for `GET /api/blueprints`.
+#[derive(Deserialize, Default)]
+pub(super) struct BlueprintsQuery {
+    pub(super) limit: Option<usize>,
+    pub(super) cursor: Option<String>,
+    /// Case-insensitive substring over name, description and stage names.
+    pub(super) q: Option<String>,
+    /// `name` (default) or `version`.
+    pub(super) sort: Option<String>,
+    /// `asc` (default) or `desc`. Ascending by name is the catalog order a
+    /// person reads.
+    pub(super) order: Option<String>,
+}
+
 #[derive(Deserialize)]
 pub(super) struct CreateBlueprintReq {
     pub(super) name: String,
@@ -509,6 +523,19 @@ impl LogsQuery {
             )),
         }
     }
+}
+
+/// Query for `GET /api/agents/{id}/context/history`.
+#[derive(Deserialize, Default)]
+pub(super) struct HistoryQuery {
+    /// How many points to return. Capped lower than the run listing's, because
+    /// each item carries a whole context window.
+    pub(super) limit: Option<usize>,
+    /// Continuation token from the previous page's `next_cursor`.
+    pub(super) cursor: Option<String>,
+    /// `asc` (default, chronological - and what the unpaged response gave) or
+    /// `desc` to start from the most recent point.
+    pub(super) order: Option<String>,
 }
 
 /// Query for `GET /api/agents/{id}/files`.
@@ -750,6 +777,86 @@ pub(super) struct RedactedConfig {
     pub(super) ollama_base_url: Option<String>,
     pub(super) agent_paths: Vec<PathBuf>,
     pub(super) mcp_server_count: usize,
+    /// The API contract this server implements, matching `info.version` in
+    /// `docs/schema/openapi.json`. A test holds the two together.
+    pub(super) api_version: String,
+    /// What this server can do, so a client can light up features in one call.
+    ///
+    /// Before this, the console feature-detected by calling a route and reading
+    /// a 404 as "unsupported" - fragile, because a 404 also means "no such run",
+    /// and one round trip per feature.
+    pub(super) capabilities: Vec<String>,
+    pub(super) limits: ApiLimits,
+}
+
+/// The API contract version. Held equal to the OpenAPI spec's `info.version` by
+/// a test, because a version that can silently disagree with the document it
+/// names is worse than no version at all.
+pub(super) const API_VERSION: &str = "0.3.0";
+
+/// Every capability a client may check for.
+pub(super) const API_CAPABILITIES: &[&str] = &[
+    "runs.envelope",
+    "runs.cursor",
+    "runs.search",
+    "runs.search.context",
+    "runs.search.logs",
+    "runs.search.journal",
+    "runs.fields",
+    "runs.ids",
+    "runs.since",
+    "runs.files.listing",
+    "runs.files.workdir",
+    "logs.stage",
+    "logs.stream",
+    "context.history.page",
+    "blueprints.envelope",
+    "blueprints.query",
+];
+
+/// The server's numeric limits.
+///
+/// This is what makes capability discovery useful rather than decorative: a
+/// client that knows the feature exists still has to guess the page cap, the
+/// file-size cap and the tracked-file cap, and every one of those guesses would
+/// be hardcoded and eventually wrong.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ApiLimits {
+    /// Largest `limit` on `GET /api/runs`; larger values are clamped.
+    pub(super) max_limit: usize,
+    /// Most ids one `ids=` batch may name.
+    pub(super) max_ids: usize,
+    /// Largest file body `?path=` returns.
+    pub(super) max_file_bytes: u64,
+    /// Most entries one directory listing returns.
+    pub(super) max_listing_entries: usize,
+    /// How many runs a filesystem-reading search examines before reporting
+    /// `scan_truncated`.
+    pub(super) max_search_scan: usize,
+    /// How much of each stage log a search reads, from the end.
+    pub(super) search_log_tail_bytes: u64,
+    /// Largest `limit` on the context-history route.
+    pub(super) max_history_limit: usize,
+    /// How many distinct modified paths a run records before
+    /// `modified_files_truncated` is set.
+    pub(super) max_tracked_modified_files: usize,
+}
+
+impl ApiLimits {
+    /// Read from the constants the handlers actually use, so the two cannot
+    /// drift into disagreeing.
+    pub(super) fn current() -> Self {
+        Self {
+            max_limit: super::runs::MAX_LIMIT,
+            max_ids: super::runs::MAX_IDS,
+            max_file_bytes: super::agents::MAX_FILE_READ_BYTES,
+            max_listing_entries: super::agents::MAX_LISTING_ENTRIES,
+            max_search_scan: super::runs::MAX_SEARCH_SCAN,
+            search_log_tail_bytes: super::runs::SEARCH_LOG_TAIL_BYTES,
+            max_history_limit: super::agents::HISTORY_MAX_LIMIT,
+            max_tracked_modified_files: leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
+        }
+    }
 }
 
 /// Body of `PUT /api/config` (admin-only). Every field is optional; a present
@@ -991,6 +1098,9 @@ mod tests {
             ollama_base_url: None,
             agent_paths: vec![],
             mcp_server_count: 0,
+            api_version: API_VERSION.to_string(),
+            capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
+            limits: ApiLimits::current(),
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RedactedConfig = serde_json::from_str(&json).unwrap();

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -511,12 +511,107 @@ impl LogsQuery {
     }
 }
 
-/// Query for `GET /api/agents/{id}/files`: the file to read. Relative paths
-/// resolve against the run's workdir; absolute paths are accepted but must
-/// still land inside it.
-#[derive(Deserialize)]
+/// Query for `GET /api/agents/{id}/files`.
+///
+/// With `path`, reads that file. Without, lists - the same idiom `GET
+/// /api/fs/dirs` uses for the folder picker.
+#[derive(Deserialize, Default)]
 pub(super) struct FileQuery {
+    /// The file to read. Relative paths resolve against the run's workdir;
+    /// absolute paths are accepted but must still land inside it. Absent means
+    /// "list", and a directory lists rather than erroring.
+    pub(super) path: Option<String>,
+    /// `modified` (default) or `workdir`. See [`FileSource`].
+    pub(super) source: Option<String>,
+    /// Include dot-prefixed entries when listing a directory. Off by default,
+    /// mirroring `DirsQuery`.
+    #[serde(default)]
+    pub(super) hidden: bool,
+}
+
+/// Which question a listing answers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FileSource {
+    /// What the run recorded modifying. Free, but a claim about the run rather
+    /// than about the disk, and capped at record time.
+    Modified,
+    /// What is in the run's working directory now, one level at a time.
+    Workdir,
+}
+
+impl FileQuery {
+    /// Resolve `source`, or report the bad value.
+    pub(super) fn file_source(&self) -> Result<FileSource, String> {
+        match self.source.as_deref() {
+            None | Some("modified") => Ok(FileSource::Modified),
+            Some("workdir") => Ok(FileSource::Workdir),
+            Some(other) => Err(format!(
+                "Invalid source '{other}': expected 'modified' or 'workdir'"
+            )),
+        }
+    }
+}
+
+/// Response of `GET /api/agents/{id}/files`: either one file's contents, or a
+/// listing.
+///
+/// Untagged, with the listing carrying a literal `kind` field, so a client
+/// discriminates on a value rather than by trying parses until one fits.
+/// `FileContentResp` is unchanged and still serializes exactly as before, so
+/// existing readers of `?path=<file>` see no difference at all.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(super) enum FileOrListing {
+    File(FileContentResp),
+    /// Boxed because it is much the larger variant, and every file read would
+    /// otherwise pay for its size.
+    Listing(Box<RunFileListing>),
+}
+
+/// Response of `GET /api/agents/{id}/files` with no file named.
+#[derive(Debug, Serialize)]
+pub(super) struct RunFileListing {
+    /// Always `"listing"`. What a client checks to tell the two shapes apart.
+    pub(super) kind: &'static str,
+    /// Which question this answers: `modified` or `workdir`.
+    pub(super) source: &'static str,
+    /// The directory listed, or the workdir for a `modified` listing.
     pub(super) path: String,
+    /// Where "up one level" goes, or `null` at the workdir root.
+    pub(super) parent: Option<String>,
+    /// The run's working directory, which paths are relative to.
+    pub(super) workdir: String,
+    pub(super) entries: Vec<RunFileEntry>,
+    /// Whether `entries` stops short of the directory's real contents.
+    pub(super) truncated: bool,
+    /// Whether the run hit the tracked-modified-files cap, so its recorded list
+    /// is a prefix and the remaining names were never stored anywhere.
+    ///
+    /// Exposed because the alternative - a client subtracting
+    /// `modifying_tool_calls` from `entries.len()` - is wrong, and was the
+    /// original "+N more" bug. Use `source=workdir` for ground truth about what
+    /// is actually on disk.
+    pub(super) modified_files_truncated: bool,
+    /// Successful **modifying tool calls**, which is not a file count: a run
+    /// that edits one file three times records three. Named for what it counts.
+    pub(super) modifying_tool_calls: usize,
+}
+
+/// One entry in a [`RunFileListing`].
+#[derive(Debug, Serialize)]
+pub(super) struct RunFileEntry {
+    pub(super) name: String,
+    /// Relative to the run's workdir where possible, so a client can pass it
+    /// straight back as `?path=`.
+    pub(super) path: String,
+    pub(super) is_dir: bool,
+    /// `null` when the entry could not be stat-ed.
+    pub(super) size: Option<u64>,
+    /// False for a recorded path that has since been deleted.
+    pub(super) exists: bool,
+    /// True for a recorded path that resolves outside the workdir - possible
+    /// when a tool was handed an absolute path. Reported rather than hidden.
+    pub(super) outside_workdir: bool,
 }
 
 /// Response of `GET /api/agents/{id}/files`: one file the run wrote, as text.

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -337,6 +337,29 @@ pub(super) struct ListAgentsQuery {
     pub(super) status: Option<String>,
 }
 
+/// Does `filter` name this run's status?
+///
+/// `RunStatus` reaches a client two different ways: `Json<RunMeta>` serializes
+/// it through serde, which is `snake_case` (`waiting_input`), while the status
+/// filter compared it through `Display`, which is PascalCase, lowercased
+/// (`waitinginput`). So a client that took a status out of one response and fed
+/// it back as a filter got nothing, on exactly the two multi-word variants where
+/// it is least obvious why.
+///
+/// Normalizing both sides - lowercase, and drop `_` and `-` - accepts every
+/// spelling of the same status, including the two that already worked. That
+/// makes this strictly wider than the old comparison, so nothing a client does
+/// today can start failing.
+pub(super) fn status_matches(status: &crate::runstate::RunStatus, filter: &str) -> bool {
+    fn normalize(s: &str) -> String {
+        s.chars()
+            .filter(|c| *c != '_' && *c != '-')
+            .flat_map(char::to_lowercase)
+            .collect()
+    }
+    normalize(&format!("{status}")) == normalize(filter)
+}
+
 #[derive(Serialize)]
 pub(super) struct AgentResultResp {
     pub(super) run_id: String,
@@ -347,9 +370,49 @@ pub(super) struct AgentResultResp {
     pub(super) completion_tokens: usize,
 }
 
-#[derive(Deserialize)]
+/// Query for `GET /api/agents/{id}/logs`.
+#[derive(Deserialize, Default)]
 pub(super) struct LogsQuery {
+    /// How many **bytes** from the end to return (default 32 KiB). Bytes, not
+    /// lines - the OpenAPI description said lines and was wrong.
     pub(super) tail: Option<u64>,
+    /// Which stage: a numeric index, or `all` for every stage joined oldest
+    /// first. Absent means the stage the run is on now.
+    pub(super) stage: Option<String>,
+    /// `output` (default) for the assistant's readable output, or `logs` for
+    /// the operational stream (`[tool]`, `[Tokens: …]`, `[error]`).
+    ///
+    /// Kept as two separate streams rather than interleaved: they have
+    /// different audiences and no shared clock in the files, so merging them
+    /// would be presenting a guess at ordering as a fact.
+    pub(super) stream: Option<String>,
+}
+
+impl LogsQuery {
+    /// Resolve `stage` into a [`StageSelector`], or report the bad value.
+    pub(super) fn selector(&self) -> Result<crate::runstate::StageSelector, String> {
+        use crate::runstate::StageSelector;
+        match self.stage.as_deref() {
+            None => Ok(StageSelector::Current),
+            Some("all") => Ok(StageSelector::All),
+            Some(other) => other
+                .parse::<usize>()
+                .map(StageSelector::Index)
+                .map_err(|_| format!("Invalid stage '{other}': expected a stage index or 'all'")),
+        }
+    }
+
+    /// Resolve `stream`, or report the bad value.
+    pub(super) fn log_stream(&self) -> Result<crate::runstate::LogStream, String> {
+        use crate::runstate::LogStream;
+        match self.stream.as_deref() {
+            None | Some("output") => Ok(LogStream::Output),
+            Some("logs") => Ok(LogStream::Operational),
+            Some(other) => Err(format!(
+                "Invalid stream '{other}': expected 'output' or 'logs'"
+            )),
+        }
+    }
 }
 
 /// Query for `GET /api/agents/{id}/files`: the file to read. Relative paths
@@ -535,6 +598,55 @@ pub(super) struct ModelEntry {
     pub(super) max_context_tokens: usize,
     pub(super) max_output_tokens: usize,
     pub(super) supports_tools: bool,
+}
+
+#[cfg(test)]
+mod status_matches_tests {
+    use super::*;
+    use crate::runstate::RunStatus;
+
+    /// The bug this function exists for: `WaitingInput` serializes as
+    /// `waiting_input`, so that is the spelling a client has in hand - and the
+    /// old `Display`-lowercased comparison rejected exactly that.
+    #[test]
+    fn the_serde_spelling_a_client_reads_back_is_accepted() {
+        assert!(status_matches(&RunStatus::WaitingInput, "waiting_input"));
+        assert!(status_matches(
+            &RunStatus::CompleteInteractive,
+            "complete_interactive"
+        ));
+    }
+
+    /// The spellings that worked before must keep working - this widens the
+    /// filter, it does not move it.
+    #[test]
+    fn the_display_spelling_that_already_worked_still_does() {
+        assert!(status_matches(&RunStatus::WaitingInput, "waitinginput"));
+        assert!(status_matches(&RunStatus::Running, "running"));
+        assert!(status_matches(&RunStatus::Running, "Running"));
+    }
+
+    #[test]
+    fn hyphens_and_mixed_case_are_accepted_too() {
+        assert!(status_matches(&RunStatus::WaitingInput, "Waiting-Input"));
+        assert!(status_matches(
+            &RunStatus::CompleteInteractive,
+            "COMPLETE-INTERACTIVE"
+        ));
+    }
+
+    /// Normalizing must not collapse genuinely different statuses into each
+    /// other, or a filter would quietly return the wrong runs.
+    #[test]
+    fn a_different_status_still_does_not_match() {
+        assert!(!status_matches(&RunStatus::Running, "complete"));
+        assert!(!status_matches(
+            &RunStatus::Complete,
+            "complete_interactive"
+        ));
+        assert!(!status_matches(&RunStatus::CompleteInteractive, "complete"));
+        assert!(!status_matches(&RunStatus::Running, ""));
+    }
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -245,6 +245,102 @@ pub(super) fn err(
     (code, axum::response::Json(ErrorResponse { error: message }))
 }
 
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+/// One page of a collection: the shape every paginated route returns.
+///
+/// One envelope rather than one per route, so a client writes the paging loop
+/// once. The house rule for which routes get it: **collections that grow
+/// without bound are paginated; bounded catalogs stay bare arrays.** Runs
+/// accumulate forever and are never pruned, so they are paged; `/api/models`
+/// and `/api/mcp/servers` are sized by what the user configured, and
+/// `/api/agents/tree` is a tree, where `next_cursor` would not mean anything.
+#[derive(Debug, Serialize)]
+pub(super) struct Page<T> {
+    /// This page's items, in the requested order.
+    pub(super) items: Vec<T>,
+    /// Pass back as `cursor` for the next page. `null` means this was the last
+    /// one - clients loop until null rather than counting against `total`,
+    /// because `total` can move underneath a walk.
+    ///
+    /// Only ever emitted when a further item is known to exist: the handler
+    /// takes `limit + 1` and keeps `limit`.
+    pub(super) next_cursor: Option<String>,
+    /// How many items matched this query, at the moment of this request.
+    ///
+    /// `null` when the answer would be a guess - see `scan_truncated`. A count
+    /// derived from a partial scan is worse than no count, because a UI renders
+    /// it as fact and a user paginates against it.
+    pub(super) total: Option<usize>,
+    /// Unix **seconds** at which this page was built, on the server's clock.
+    ///
+    /// The watermark for a client's next `since=`: round-tripping the server's
+    /// own timestamp keeps a polling client from missing or re-fetching work
+    /// because its clock disagrees.
+    pub(super) server_time: i64,
+    /// Set when a filesystem-scanning filter gave up before examining every
+    /// candidate, so this page is a prefix of the truth rather than all of it.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub(super) scan_truncated: bool,
+    /// Ids from an `ids=` batch fetch that no longer exist. Absent otherwise.
+    ///
+    /// A missing id is reported rather than 404ing the whole request: a batch
+    /// refresh of ten runs should not fail because one was deleted.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) missing: Vec<String>,
+}
+
+impl<T> Page<T> {
+    /// A page with nothing unusual about it: no truncation, no missing ids.
+    pub(super) fn new(
+        items: Vec<T>,
+        next_cursor: Option<String>,
+        total: Option<usize>,
+        server_time: i64,
+    ) -> Self {
+        Self {
+            items,
+            next_cursor,
+            total,
+            server_time,
+            scan_truncated: false,
+            missing: Vec::new(),
+        }
+    }
+}
+
+/// One run in a `GET /api/runs` page.
+#[derive(Debug, Serialize)]
+pub(super) struct RunItem {
+    /// The run's metadata, redacted, and narrowed to the requested `fields`.
+    ///
+    /// A `serde_json::Value` rather than a second `RunSummary` struct: field
+    /// projection is a runtime choice, and serializing through `RunMeta`'s own
+    /// serde means there is no parallel shape that can drift away from it.
+    pub(super) meta: serde_json::Value,
+    /// Why this run matched, when the request carried a `q`. Empty otherwise.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) highlights: Vec<Highlight>,
+}
+
+/// Where a search matched, and enough text to show a user why.
+///
+/// The part of search that cannot be done in the browser: the console never has
+/// a run's transcript, so without this a deep match is an unexplained result.
+#[derive(Debug, Serialize)]
+pub(super) struct Highlight {
+    /// What matched: a `RunMeta` field name, `metadata.<key>`,
+    /// `modified_files`, `context.<region>`, `logs.output`, `logs.operational`,
+    /// or `journal.tool.<tool_name>`.
+    pub(super) field: String,
+    /// The matching text with a little either side, elided at any cut end.
+    pub(super) snippet: String,
+    /// Which stage the match came from, for the sources that have one. A client
+    /// can pass it straight to `GET /api/agents/{id}/logs?stage=`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) stage: Option<usize>,
+}
+
 // ─── Blueprint types ────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -641,6 +641,87 @@ pub fn tail_stage_log(run_id: &str, stage_idx: usize, max_bytes: u64) -> String 
     tail_file(&stage_dir(run_id, stage_idx).join("logs.log"), max_bytes)
 }
 
+/// Which stage's logs to read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageSelector {
+    /// The stage the run is on now - the last entry in `stages.json`. What a
+    /// caller tailing a live run wants, and what `agent_result` already picked.
+    Current,
+    /// One specific stage by index.
+    Index(usize),
+    /// Every stage, oldest first, with a separator between them.
+    All,
+}
+
+/// Which of a stage's two logs to read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogStream {
+    /// `output.log` - the assistant's readable output.
+    Output,
+    /// `logs.log` - operational lines: `[tool] …`, `[Tokens: …]`, `[error] …`.
+    Operational,
+}
+
+/// Read a run's logs, choosing the stage and the stream.
+///
+/// Exists because there were two answers in the codebase to "where is a run's
+/// output", and one of them was wrong: `GET /api/agents/{id}/logs` read
+/// `<run_dir>/output.log`, which nothing has ever written, so it returned an
+/// empty string for every run there has ever been. The real logs are per-stage,
+/// under `stages/<idx>/`. Routing both that handler and `agent_result` through
+/// here leaves one answer.
+///
+/// Stages come from `stages.json` rather than a `read_dir` of `stages/`, because
+/// that index is the record of which stages exist and in what order - the
+/// directory is just where their bytes landed.
+///
+/// `max_bytes` applies to what is returned, so for [`StageSelector::All`] it
+/// bounds the joined text rather than each stage separately: "the last N bytes
+/// of what you asked for" holds whatever the selector was.
+pub fn tail_run_logs(
+    run_id: &str,
+    selector: StageSelector,
+    stream: LogStream,
+    max_bytes: u64,
+) -> String {
+    let read = |idx: usize| match stream {
+        LogStream::Output => tail_stage_output(run_id, idx, max_bytes),
+        LogStream::Operational => tail_stage_log(run_id, idx, max_bytes),
+    };
+    let stages = read_stages_index(run_id);
+    match selector {
+        StageSelector::Index(idx) => read(idx),
+        StageSelector::Current => match stages.len().checked_sub(1) {
+            Some(last) => read(last),
+            // No stages recorded yet. Fall back to the legacy run-level file:
+            // nothing writes it today, but a run whose stage dirs were pruned
+            // still reads honestly instead of claiming it produced nothing.
+            None => tail_file(&run_dir(run_id).join("output.log"), max_bytes),
+        },
+        StageSelector::All => {
+            let joined = stages
+                .iter()
+                .map(|stage| {
+                    format!(
+                        "===== stage {}: {} =====\n{}",
+                        stage.index,
+                        stage.name,
+                        read(stage.index)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            // Re-bound the join: each part was capped individually, so their
+            // concatenation can exceed the cap the caller asked for.
+            let start = leviath_core::text::floor_char_boundary(
+                &joined,
+                joined.len().saturating_sub(max_bytes as usize),
+            );
+            joined.split_at(start).1.to_string()
+        }
+    }
+}
+
 /// Build the isolated base directory for a run-state test and create its
 /// `runs/` subdir. Returned so the caller's closure can plant fixtures under it.
 ///

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1533,13 +1533,12 @@ mod tests {
             .unwrap();
             std::fs::write(run_dir(run_id).join("run.lvr"), &buf).unwrap();
 
-            // The secret really is in the journal, so redaction has work to do.
-            let records = read_run_archive(run_id).expect("archive read");
-            let archived_secret = records.iter().find_map(|r| match r {
-                RunRecord::Header { meta, .. } => meta.callback_secret.clone(),
-                _ => None,
-            });
-            assert_eq!(archived_secret.as_deref(), Some("super-secret-signing-key"));
+            // The secret really is on disk, so redaction has work to do. Read
+            // the raw bytes rather than matching over parsed records: a match
+            // that stops at the Header leaves its other arm unreachable, and
+            // this says the thing that actually matters anyway.
+            let raw = std::fs::read(run_dir(run_id).join("run.lvr")).unwrap();
+            assert!(String::from_utf8_lossy(&raw).contains("super-secret-signing-key"));
 
             // What the reader hands out has it stripped, and keeps the rest.
             let history = context_history(run_id);

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -75,10 +75,29 @@ pub fn read_run_archive(run_id: &str) -> Option<Vec<leviath_core::run_archive::R
 
 /// A run's context-window history: the full window (+ metadata) at each recorded
 /// point over time, oldest first. Empty when there's no readable archive.
+///
+/// Every point's `meta` is [`RunMeta::redacted`]. The journal stores `RunMeta`
+/// whole - including `callback_secret`, which the daemon needs to keep signing
+/// webhooks for a run it reloads - so a replayed point carries the secret unless
+/// it is stripped here. `GET /api/agents/{id}/context/history` serialized these
+/// points directly, which handed the webhook signing key to any holder of the
+/// API token: the same disclosure `redacted()` was introduced for on
+/// `/api/agents`, re-opened through the archive.
+///
+/// Redacted in this shared reader rather than in that one handler so the next
+/// consumer of a run's history inherits the fix instead of having to remember
+/// it. No caller needs the secret: the CLI printer, the dashboard, and the API
+/// all only display these points.
 pub fn context_history(run_id: &str) -> Vec<leviath_core::run_archive::RunPoint> {
     read_run_archive(run_id)
         .map(|records| leviath_core::run_archive::replay_points(&records))
         .unwrap_or_default()
+        .into_iter()
+        .map(|point| leviath_core::run_archive::RunPoint {
+            meta: point.meta.redacted(),
+            ..point
+        })
+        .collect()
 }
 
 fn now_secs() -> i64 {
@@ -1373,6 +1392,82 @@ mod tests {
             assert_eq!(records.len(), 2);
             let history = context_history(run_id);
             assert_eq!(history.len(), 1);
+            assert_eq!(history[0].context.stage_name, "plan");
+        });
+    }
+
+    /// The journal keeps `callback_secret` (the daemon re-signs webhooks for a
+    /// run it reloads), so a replayed point carries it unless the reader strips
+    /// it. `GET /api/agents/{id}/context/history` serves these points straight
+    /// out, which handed the webhook signing key to any API token holder.
+    ///
+    /// Asserts against the *archive* as well as the history, so the test still
+    /// means something if the journal ever stops storing the secret: were that
+    /// to happen, the first assertion fails rather than the second silently
+    /// passing on a field that is no longer there to leak.
+    #[test]
+    fn context_history_redacts_the_webhook_secret_the_journal_keeps() {
+        with_isolated_runs_dir("context-history-redacts-secret", |_d| {
+            use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+            let run_id = "archive-secret-unit";
+            std::fs::create_dir_all(run_dir(run_id)).unwrap();
+            let mut buf = Vec::new();
+            run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+            let mut meta = RunMeta::new(
+                run_id.to_string(),
+                "a".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            meta.callback_url = Some("https://example.invalid/hook".to_string());
+            meta.callback_secret = Some("super-secret-signing-key".to_string());
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::Header {
+                    identity: RunIdentity {
+                        run_id: run_id.to_string(),
+                        machine_id: "m".to_string(),
+                        world_id: "w".to_string(),
+                        created_at: 0,
+                    },
+                    meta: Box::new(meta),
+                },
+            )
+            .unwrap();
+            run_archive::write_record(
+                &mut buf,
+                &RunRecord::ContextCheckpoint {
+                    snapshot: ContextSnapshot {
+                        stage_name: "plan".to_string(),
+                        total_tokens: 3,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: 1,
+                },
+            )
+            .unwrap();
+            std::fs::write(run_dir(run_id).join("run.lvr"), &buf).unwrap();
+
+            // The secret really is in the journal, so redaction has work to do.
+            let records = read_run_archive(run_id).expect("archive read");
+            let archived_secret = records.iter().find_map(|r| match r {
+                RunRecord::Header { meta, .. } => meta.callback_secret.clone(),
+                _ => None,
+            });
+            assert_eq!(archived_secret.as_deref(), Some("super-secret-signing-key"));
+
+            // What the reader hands out has it stripped, and keeps the rest.
+            let history = context_history(run_id);
+            assert_eq!(history.len(), 1);
+            assert_eq!(history[0].meta.callback_secret, None);
+            assert_eq!(
+                history[0].meta.callback_url.as_deref(),
+                Some("https://example.invalid/hook")
+            );
             assert_eq!(history[0].context.stage_name, "plan");
         });
     }

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -39,6 +39,7 @@
 //! [`fold`] reconstructs the current state from the whole journal.
 
 use std::io::{self, Read, Write};
+use std::ops::ControlFlow;
 
 use serde::{Deserialize, Serialize};
 
@@ -654,16 +655,45 @@ pub struct RunPoint {
     pub at: i64,
 }
 
-/// Replay a run journal into the sequence of context-window snapshots over time,
-/// one [`RunPoint`] per record that changes the context (a checkpoint, diff, or
-/// progress step). This is what the context-history views (TUI/CLI/API) consume
-/// to show the window "at each stage and point". Returns an empty vec if the
-/// records don't start with a [`RunRecord::Header`].
-pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
+/// One replayed point, lent to a [`visit_points`] visitor rather than handed
+/// over. Borrowing is the whole purpose: see that function.
+#[derive(Debug)]
+pub struct PointRef<'a> {
+    /// Position in the timeline, counting only records that produce a point.
+    /// Stable for a given journal prefix, because the journal is append-only -
+    /// which is what makes it usable as a pagination cursor.
+    pub index: usize,
+    /// Unix seconds this point was recorded.
+    pub at: i64,
+    /// The run metadata in effect at this point.
+    pub meta: &'a RunMeta,
+    /// The full context window at this point.
+    pub context: &'a ContextSnapshot,
+}
+
+/// Replay a run journal, calling `visit` once per record that changes the
+/// context (a checkpoint, diff, or progress step), in order. Stops early if the
+/// visitor returns [`ControlFlow::Break`]. Does nothing if the records don't
+/// start with a [`RunRecord::Header`].
+///
+/// The point of lending each point instead of collecting them: replaying a run
+/// means carrying one running window and mutating it, so materializing the
+/// timeline costs a **full deep copy of the context window per point** - and a
+/// window holds every region's entry text. On a megabyte-scale journal that is
+/// hundreds of whole-window clones, which is why anything that wants a slice of
+/// the timeline, or just an answer to "does any point contain this text",
+/// should come through here rather than [`replay_points`].
+///
+/// `&mut dyn FnMut` rather than a generic parameter, deliberately: this is
+/// called from a handful of places with unrelated closure types, and one
+/// monomorphization keeps both the compiled size and the coverage instantiation
+/// count at one - the same reasoning `execute_with_shutdown` documents in the
+/// serve module.
+pub fn visit_points(records: &[RunRecord], visit: &mut dyn FnMut(PointRef<'_>) -> ControlFlow<()>) {
     let mut iter = records.iter();
     let mut meta = match iter.next() {
         Some(RunRecord::Header { meta, .. }) => (**meta).clone(),
-        _ => return Vec::new(),
+        _ => return,
     };
     let mut context = ContextSnapshot {
         stage_name: String::new(),
@@ -671,26 +701,24 @@ pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
         max_tokens: 0,
         regions: Vec::new(),
     };
-    let mut points = Vec::new();
+    let mut index = 0usize;
     for record in iter {
-        match record {
-            RunRecord::Header { meta: m, .. } => meta = (**m).clone(),
-            RunRecord::StatusChanged { status, .. } => meta.status = status.clone(),
+        let at = match record {
+            RunRecord::Header { meta: m, .. } => {
+                meta = (**m).clone();
+                continue;
+            }
+            RunRecord::StatusChanged { status, .. } => {
+                meta.status = status.clone();
+                continue;
+            }
             RunRecord::ContextCheckpoint { snapshot, at } => {
                 context = snapshot.clone();
-                points.push(RunPoint {
-                    meta: meta.clone(),
-                    context: context.clone(),
-                    at: *at,
-                });
+                *at
             }
             RunRecord::ContextDiff { delta, at } => {
                 apply_delta(&mut context, delta);
-                points.push(RunPoint {
-                    meta: meta.clone(),
-                    context: context.clone(),
-                    at: *at,
-                });
+                *at
             }
             RunRecord::Checkpoint {
                 meta: m,
@@ -699,29 +727,52 @@ pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
             } => {
                 meta = (**m).clone();
                 context = c.clone();
-                points.push(RunPoint {
-                    meta: meta.clone(),
-                    context: context.clone(),
-                    at: *at,
-                });
+                *at
             }
             RunRecord::Progress { meta: m, delta, at } => {
                 meta = (**m).clone();
                 apply_delta(&mut context, delta);
-                points.push(RunPoint {
-                    meta: meta.clone(),
-                    context: context.clone(),
-                    at: *at,
-                });
+                *at
             }
             // Non-context records don't add a timeline point.
             RunRecord::OwnershipChanged { .. }
             | RunRecord::Inference { .. }
             | RunRecord::ToolBatch { .. }
             | RunRecord::ToolCallDone { .. }
-            | RunRecord::Message { .. } => {}
+            | RunRecord::Message { .. } => continue,
+        };
+        let flow = visit(PointRef {
+            index,
+            at,
+            meta: &meta,
+            context: &context,
+        });
+        index += 1;
+        if flow.is_break() {
+            return;
         }
     }
+}
+
+/// Replay a run journal into the sequence of context-window snapshots over time,
+/// one [`RunPoint`] per record that changes the context (a checkpoint, diff, or
+/// progress step). This is what the context-history views (TUI/CLI/API) consume
+/// to show the window "at each stage and point". Returns an empty vec if the
+/// records don't start with a [`RunRecord::Header`].
+///
+/// Materializes every point, so it deep-copies the whole context window once per
+/// point. Prefer [`visit_points`] when only part of the timeline is wanted, or
+/// when the answer is a predicate rather than the points themselves.
+pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
+    let mut points = Vec::new();
+    visit_points(records, &mut |point| {
+        points.push(RunPoint {
+            meta: point.meta.clone(),
+            context: point.context.clone(),
+            at: point.at,
+        });
+        ControlFlow::Continue(())
+    });
     points
 }
 
@@ -1551,6 +1602,135 @@ mod tests {
     }
 
     // ── replay_points (context-window history) ──
+
+    /// Three context changes, so a windowing caller has something to page over.
+    fn three_point_records() -> Vec<RunRecord> {
+        let mut running = meta();
+        running.status = RunStatus::Running;
+        vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![region("conv", vec![entry("first", 1)])]),
+                at: 10,
+            },
+            RunRecord::ContextDiff {
+                delta: ContextDelta {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 2,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("second", 1)],
+                        current_tokens: 2,
+                    }],
+                },
+                at: 20,
+            },
+            RunRecord::Progress {
+                meta: Box::new(running),
+                delta: ContextDelta {
+                    stage_name: "code".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 10_000,
+                    regions: vec![RegionDelta::Append {
+                        name: "conv".to_string(),
+                        entries: vec![entry("third", 1)],
+                        current_tokens: 3,
+                    }],
+                },
+                at: 30,
+            },
+        ]
+    }
+
+    #[test]
+    fn visit_points_indexes_points_in_order_and_carries_the_running_window() {
+        let records = three_point_records();
+        let mut seen: Vec<(usize, i64, usize)> = Vec::new();
+        visit_points(&records, &mut |point| {
+            seen.push((
+                point.index,
+                point.at,
+                point.context.regions[0].entries.len(),
+            ));
+            ControlFlow::Continue(())
+        });
+        // Index counts points, not records - the Header produces none.
+        assert_eq!(seen, vec![(0, 10, 1), (1, 20, 2), (2, 30, 3)]);
+    }
+
+    /// The reason this function exists: a caller wanting one window, or an
+    /// answer to "does any point match", must be able to stop.
+    #[test]
+    fn visit_points_stops_at_the_first_break() {
+        let records = three_point_records();
+        let mut visits = 0;
+        visit_points(&records, &mut |point| {
+            visits += 1;
+            if point.index == 1 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+        assert_eq!(
+            visits, 2,
+            "stopped at the breaking point, did not run the third"
+        );
+    }
+
+    #[test]
+    fn visit_points_without_a_header_visits_nothing() {
+        let mut visits = 0;
+        visit_points(&[], &mut |_| {
+            visits += 1;
+            ControlFlow::Continue(())
+        });
+        visit_points(
+            &[RunRecord::ContextCheckpoint {
+                snapshot: snapshot("plan", vec![]),
+                at: 1,
+            }],
+            &mut |_| {
+                visits += 1;
+                ControlFlow::Continue(())
+            },
+        );
+        assert_eq!(visits, 0);
+    }
+
+    /// `replay_points` is now a thin collector over `visit_points`, so this
+    /// pins the two together: if the reimplementation ever drifts, the borrowed
+    /// walk and the materialized one stop agreeing here first.
+    #[test]
+    fn visit_points_and_replay_points_agree() {
+        for records in [
+            three_point_records(),
+            vec![header()],
+            vec![],
+            vec![RunRecord::Message {
+                message: MessageRecord {
+                    role: "user".to_string(),
+                    content: "x".to_string(),
+                },
+                at: 1,
+            }],
+        ] {
+            let collected: Vec<RunPoint> = {
+                let mut out = Vec::new();
+                visit_points(&records, &mut |point| {
+                    out.push(RunPoint {
+                        meta: point.meta.clone(),
+                        context: point.context.clone(),
+                        at: point.at,
+                    });
+                    ControlFlow::Continue(())
+                });
+                out
+            };
+            assert_eq!(collected, replay_points(&records));
+        }
+    }
 
     #[test]
     fn replay_points_requires_a_header() {

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -1682,21 +1682,28 @@ mod tests {
     #[test]
     fn visit_points_without_a_header_visits_nothing() {
         let mut visits = 0;
-        visit_points(&[], &mut |_| {
-            visits += 1;
-            ControlFlow::Continue(())
-        });
-        visit_points(
-            &[RunRecord::ContextCheckpoint {
-                snapshot: snapshot("plan", vec![]),
-                at: 1,
-            }],
-            &mut |_| {
+        {
+            let mut count = |_: PointRef<'_>| {
                 visits += 1;
                 ControlFlow::Continue(())
-            },
-        );
-        assert_eq!(visits, 0);
+            };
+
+            // A well-formed journal first, with the *same* visitor. Without
+            // this the test would pass against a visitor that can never run at
+            // all, which is exactly the reassurance it is not meant to give.
+            visit_points(&three_point_records(), &mut count);
+            // Neither of these starts with a Header, so neither is a replayable
+            // journal and neither may produce a point.
+            visit_points(&[], &mut count);
+            visit_points(
+                &[RunRecord::ContextCheckpoint {
+                    snapshot: snapshot("plan", vec![]),
+                    at: 1,
+                }],
+                &mut count,
+            );
+        }
+        assert_eq!(visits, 3, "only the well-formed journal produced points");
     }
 
     /// `replay_points` is now a thin collector over `visit_points`, so this

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -40,6 +40,49 @@ pub fn truncate_at_boundary(s: &str, max: usize) -> &str {
     &s[..floor_char_boundary(s, max)]
 }
 
+/// Smallest byte index `>= min` that is a char boundary in `s`.
+///
+/// The mirror of [`floor_char_boundary`], for cutting the *end* of a window.
+/// The walk-forward always terminates: `s.len()` is a boundary in every string.
+pub fn ceil_char_boundary(s: &str, min: usize) -> usize {
+    let mut start = min.min(s.len());
+    while !s.is_char_boundary(start) {
+        start += 1;
+    }
+    start
+}
+
+/// A window of `s` around the byte offset `at`, reaching `radius` bytes either
+/// side, with `…` marking each end that was cut.
+///
+/// For showing *why* something matched: a search hit deep in a megabyte of
+/// transcript is only useful with the text around it, and neither existing
+/// helper gives that - [`truncate_at_boundary`] only takes a prefix.
+///
+/// Both ends are moved outward to char boundaries rather than inward, so the
+/// window never loses a character that was inside the requested radius, and the
+/// match itself cannot be clipped by a boundary walk. `at` past the end clamps,
+/// so a stale offset yields a short window instead of a panic.
+#[expect(
+    clippy::string_slice,
+    reason = "both indices come from the boundary helpers above, so the range is a char boundary \
+              by construction"
+)]
+pub fn snippet_around(s: &str, at: usize, radius: usize) -> String {
+    let at = at.min(s.len());
+    let start = floor_char_boundary(s, at.saturating_sub(radius));
+    let end = ceil_char_boundary(s, (at + radius).min(s.len()));
+    let mut out = String::new();
+    if start > 0 {
+        out.push('…');
+    }
+    out.push_str(&s[start..end]);
+    if end < s.len() {
+        out.push('…');
+    }
+    out
+}
+
 /// The workspace's one generic token estimate: bytes divided by four,
 /// rounded up.
 ///
@@ -71,6 +114,71 @@ pub fn interpolate(template: &str, vars: &[(&str, &str)]) -> String {
         out = out.replace(&format!("{{{name}}}"), value);
     }
     out
+}
+
+#[cfg(test)]
+mod snippet_tests {
+    use super::*;
+
+    const HAY: &str = "the quick brown fox jumps over the lazy dog";
+
+    #[test]
+    fn a_window_in_the_middle_is_elided_at_both_ends() {
+        let at = HAY.find("fox").unwrap();
+        let out = snippet_around(HAY, at, 6);
+        assert!(out.starts_with('…'));
+        assert!(out.ends_with('…'));
+        assert!(out.contains("fox"));
+    }
+
+    #[test]
+    fn a_window_at_the_edges_is_not_elided_there() {
+        assert!(!snippet_around(HAY, 0, 5).starts_with('…'));
+        assert!(!snippet_around(HAY, HAY.len(), 5).ends_with('…'));
+    }
+
+    #[test]
+    fn a_radius_covering_everything_returns_the_whole_string_unmarked() {
+        assert_eq!(snippet_around(HAY, 10, 1000), HAY);
+    }
+
+    /// The reason this lives here rather than at a call site: a byte offset
+    /// landing inside a multi-byte character used to abort the daemon.
+    #[test]
+    fn multi_byte_characters_are_never_split() {
+        let hay = "aaa🇯🇵🎉bbb needle ccc🚀ddd";
+        let at = hay.find("needle").unwrap();
+        // Every radius walks the ends over the emoji in both directions.
+        for radius in 0..hay.len() + 4 {
+            let out = snippet_around(hay, at, radius);
+            assert!(out.chars().all(|c| c != '\u{FFFD}'));
+            if radius >= "needle".len() {
+                assert!(out.contains("needle"));
+            }
+        }
+    }
+
+    #[test]
+    fn an_offset_past_the_end_clamps_instead_of_panicking() {
+        let out = snippet_around(HAY, HAY.len() + 500, 4);
+        assert!(out.starts_with('…'));
+        assert!(!out.ends_with('…'));
+    }
+
+    #[test]
+    fn an_empty_haystack_yields_an_empty_snippet() {
+        assert_eq!(snippet_around("", 0, 10), "");
+        assert_eq!(snippet_around("", 7, 10), "");
+    }
+
+    #[test]
+    fn ceil_char_boundary_walks_forward_and_clamps() {
+        let s = "a🎉b";
+        assert_eq!(ceil_char_boundary(s, 0), 0);
+        // Bytes 2..4 are inside the emoji; the next boundary is 5.
+        assert_eq!(ceil_char_boundary(s, 2), 5);
+        assert_eq!(ceil_char_boundary(s, 900), s.len());
+    }
 }
 
 #[cfg(test)]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -64,15 +64,18 @@ Base path `/api`; all JSON unless noted.
 
 | Method · Path | Purpose |
 |---|---|
-| `GET /api/agents` · `POST /api/agents` | List runs · spawn an agent. Reads the persisted records, so unlike `lev ps` it keeps finished runs |
+| `GET /api/runs` | List runs: paginated, sortable, searchable. See [below](#listing-and-searching-runs) |
+| `GET /api/agents` · `POST /api/agents` | List runs *(deprecated, use `/api/runs`)* · spawn an agent. Reads the persisted records, so unlike `lev ps` it keeps finished runs |
 | `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
-| `GET /api/agents/{id}/result` · `/logs` · `/context` · `/context/history` | Run output, logs, context |
-| `GET /api/agents/{id}/files?path=` | Read one file the run wrote. The resolved path must land inside the run's working directory, so this reads what the run itself was allowed to write. Capped at 1 MiB |
+| `GET /api/agents/{id}/result` · `/context` | Run output and current context window |
+| `GET /api/agents/{id}/logs?stage=&stream=&tail=` | A run's logs. `stage` takes an index or `all`, defaulting to the current stage; `stream` is `output` (the assistant's text) or `logs` (tool calls, token counts, errors); `tail` is a byte budget |
+| `GET /api/agents/{id}/context/history` | How the context window changed over the run, paginated |
+| `GET /api/agents/{id}/files` | List a run's files, or read one with `?path=`. See [below](#a-runs-files) |
 | `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
 | `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
 | `POST /api/agents/{id}/message` | Steer a running agent |
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
-| `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation |
+| `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q` |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
@@ -86,6 +89,88 @@ Base path `/api`; all JSON unless noted.
 > a run against `last_progress_at`. `pid` is always 0 and means nothing: the daemon hosts every run
 > in one shared world, so there is no process per run. If you are tracking slots from outside, read
 > [reconciling an external work queue](/docs/work-queues) first.
+
+## Listing and searching runs
+
+`GET /api/runs` returns a page, not the whole list:
+
+```json
+{ "items": [{ "meta": { "run_id": "…" }, "highlights": [] }],
+  "next_cursor": "7b2276…", "total": 340, "server_time": 1785869070 }
+```
+
+Pass `next_cursor` back as `cursor` and loop until it comes back null. Do not count pages against
+`total`. It is what matched at the moment of that one request, and runs are being created and
+finished underneath you.
+
+Paging is keyset rather than offset, because an offset into a list that is changing skips and
+repeats items, and does it most often at the head. **`sort=started_at` is the default because it is
+the only sort key that never changes.** `updated_at` moves on the daemon's 30-second heartbeat, so
+every live run shifts under a walk; a run whose sort value changes mid-walk can be missed or
+repeated. To poll for what changed, use `since=` with no cursor rather than deep-paginating.
+
+`since=` filters whichever field `sort` names, and is inclusive. Pass the previous response's
+`server_time` and you may see one item twice, which is the safe direction when the granularity is
+whole seconds.
+
+Two parameters exist so a console does not have to make N requests: `ids=a,b,c` fetches exactly
+those runs, and `fields=run_id,status,title` trims each one. Ids that no longer exist come back in
+`missing` rather than failing the request.
+
+### Search
+
+`q=` is a case-insensitive substring. It is not a regular expression, there are no boolean
+operators or phrase quoting, and case folding is ASCII-only.
+
+`q_in=` chooses where to look, defaulting to `meta,files`:
+
+| Source | Looks at | Cost |
+|---|---|---|
+| `meta` | title, task, agent name, workdir, run id, error, metadata values | free |
+| `files` | the paths the run recorded modifying | free |
+| `context` | the run's current context window | one file read per run |
+| `logs` | the tail of each stage's logs | two reads per stage per run |
+| `journal` | the whole run journal: tool calls and context history | one file read per run |
+
+The last three read from disk, which is why they are opt-in. Surface them as a "search inside
+runs" toggle rather than making every keystroke pay for them. They also stop after a bounded number
+of runs, newest first; when that happens the response says `scan_truncated: true` and sets `total`
+to null, because a count taken from a partial scan would be rendered as fact.
+
+Matching items carry `highlights` saying *why* they matched: the field, a snippet, and the stage
+where there is one, which you can pass straight to `/logs?stage=`. This is the part that cannot be
+done in the browser, because the console never holds a run's transcript.
+
+One honest limit: the deep sources match the raw JSON on disk, so a query containing a quote,
+a backslash or a newline may not match text that does contain it.
+
+## A run's files
+
+`GET /api/agents/{id}/files` answers two different questions, and neither substitutes for the other.
+
+`source=modified` (the default) is the run's own record of what it changed. It is free, but it is a
+claim about the run rather than about the disk, and it is capped when recorded, so check
+`modified_files_truncated`.
+
+`source=workdir` reads the filesystem, **one directory level per request**; pass a directory as
+`path` to descend. That bound is deliberate: a workdir containing `node_modules` cannot be
+enumerated in one response, so walk it the way a file tree does.
+
+> [!WARNING]
+> `modifying_tool_calls` counts modifying tool *calls*, not files. A run that edits one file three
+> times records three. Do not subtract it from the entry count to get "how many more files";
+> that number is meaningless. Use `modified_files_truncated`, or `source=workdir` for ground truth.
+
+With `?path=<file>` the response is the file's contents, unchanged from earlier versions. A listing
+carries `"kind": "listing"`, so check that field rather than guessing from the shape.
+
+## Feature detection
+
+`GET /api/config` reports `api_version`, a `capabilities` list, and the server's `limits`. Check
+those instead of calling a route and treating a 404 as "unsupported": a 404 also means "no such
+run", and it costs a round trip per feature. The limits matter as much as the capability names: they
+are where the page cap, file cap and listing cap actually live, so a client never has to hardcode
+one.
 
 ## Live updates over WebSocket
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -255,15 +255,27 @@
       "parameters": [{ "$ref": "#/components/parameters/Id" }],
       "get": {
         "tags": ["agents"],
-        "summary": "Read one file inside the run's workdir",
-        "description": "Confined to the run's working directory, and capped at 1 MiB.",
+        "summary": "Read a file inside the run's workdir, or list files",
+        "description": "With `path`, reads that file: confined to the run's working directory and capped at 1 MiB. Without `path`, lists instead, and the response carries `kind: \"listing\"` so the two shapes can be told apart. Reading a file returns exactly the shape it always has.\n\n`source=modified` lists what the run recorded changing - free, but capped when it was recorded, so check `modified_files_truncated`. `source=workdir` reads the filesystem, **one directory level per request**; pass a directory as `path` to descend. Note `modifying_tool_calls` counts modifying tool calls and not distinct files, so subtracting it from the entry count does not give \"how many more files\".",
         "parameters": [
           {
             "name": "path",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": { "type": "string" },
-            "description": "Workdir-relative path."
+            "description": "Workdir-relative path. A file is read; a directory is listed; absent lists the run's files."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["modified", "workdir"], "default": "modified" },
+            "description": "`modified` lists what the run recorded changing; `workdir` reads one directory level of the filesystem."
+          },
+          {
+            "name": "hidden",
+            "in": "query",
+            "schema": { "type": "boolean", "default": false },
+            "description": "Include dot-prefixed entries when listing a directory."
           }
         ],
         "responses": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.1.2",
+    "version": "0.3.0",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": { "name": "MIT" }
   },
@@ -23,7 +23,43 @@
       "get": {
         "tags": ["blueprints"],
         "summary": "List installed blueprints",
-        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+        "description": "**Breaking change in 0.3.0**: returns the same paginated envelope as /api/runs rather than a bare array. Check `blueprints.envelope` in the `capabilities` list on GET /api/config.\n\nNote that pagination saves the server nothing here - discovery parses every manifest on every request regardless of page size, and the catalog is bounded by what a person installs. `q` is the parameter with real value.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200, "default": 50 },
+            "description": "Page size. Larger values are clamped rather than refused."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Continuation token from a previous page's next_cursor. Opaque; bound to the query that minted it."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Case-insensitive substring over name, description and stage names."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["name", "version"], "default": "name" },
+            "description": "Ordering key."
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["asc", "desc"], "default": "asc" },
+            "description": "Sort direction. Ascending by name is the order a person reads a catalog in."
+          }
+        ],
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
       },
       "post": {
         "tags": ["blueprints"],
@@ -248,7 +284,32 @@
       "get": {
         "tags": ["agents"],
         "summary": "How the context window changed over the run",
-        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+        "description": "**Breaking change in 0.3.0**: paginated, returning the shared envelope rather than every recorded point as one array. Each point carries a full context window with untruncated region text, on a journal that grows for as long as the run does, so the unpaged form was comfortably the largest response in the API.\n\nThe cursor is the point index. The journal is append-only, so an index is stable once written and new points only ever arrive at the end.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 },
+            "description": "Points per page. Capped lower than the run listing because each item carries a whole context window."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Continuation token from the previous page's next_cursor."
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["asc", "desc"], "default": "asc" },
+            "description": "`asc` is chronological, and matches what the unpaged response gave. `desc` starts from the most recent point, which is what a view tailing a live run wants."
+          }
+        ],
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "400": { "$ref": "#/components/responses/Error" },
+          "404": { "$ref": "#/components/responses/Error" }
+        }
       }
     },
     "/api/agents/{id}/files": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -9,6 +9,7 @@
   "servers": [{ "url": "http://127.0.0.1:3000", "description": "The default `lev serve` bind." }],
   "security": [{ "bearerAuth": [] }],
   "tags": [
+    { "name": "runs" },
     { "name": "blueprints" },
     { "name": "agents" },
     { "name": "interactions" },
@@ -89,10 +90,89 @@
         "responses": { "200": { "$ref": "#/components/responses/Ok" } }
       }
     },
+    "/api/runs": {
+      "get": {
+        "tags": ["runs"],
+        "summary": "List runs, paginated and searchable",
+        "description": "Supersedes the GET half of /api/agents, which returns every run ever recorded as one unbounded array.\n\nPagination is keyset, not offset: runs are created and deleted while a client walks the list, and an offset into a shifting list silently skips and repeats items. Pass `next_cursor` back verbatim and loop until it is null.\n\n`sort=started_at` is the only immutable sort key, and it is the default. `updated_at` also advances on the daemon's 30-second persistence heartbeat, so every live run moves under a walk, and a run whose sort value changes mid-walk may be skipped or repeated. Use started_at for a stable walk, and `since=` with no cursor to poll for what changed.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200, "default": 50 },
+            "description": "Page size. Larger values are clamped rather than refused; the live cap is in GET /api/config."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Continuation token from a previous page's next_cursor. Opaque - do not parse or construct it. Presenting one against a different sort, order or filter set is a 400, not a quietly different result."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Comma-separated statuses to keep. Matched loosely: waiting_input, waitinginput and Waiting-Input are all accepted."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["started_at", "updated_at", "last_progress_at"],
+              "default": "started_at"
+            },
+            "description": "Ordering key. last_progress_at falls back to started_at where it is absent."
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["desc", "asc"], "default": "desc" },
+            "description": "Sort direction."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Case-insensitive substring to search for. Not a regex; no boolean operators or phrase quoting, and ASCII case folding only."
+          },
+          {
+            "name": "q_in",
+            "in": "query",
+            "schema": { "type": "string", "default": "meta,files" },
+            "description": "Comma-separated search sources: meta, files, context, logs, journal. The last three read files, so they are opt-in and subject to a scan cap - see scan_truncated in the response. They also match the raw JSON on disk, so a query containing a quote, backslash or newline may not match text that does contain it."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Comma-separated top-level RunMeta fields to return. run_id is always included. Nested paths are not supported."
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Comma-separated run ids to fetch directly, bypassing the scan. Cannot be combined with cursor, q, status or since. Ids that no longer exist come back in `missing` rather than failing the request."
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "schema": { "type": "integer" },
+            "description": "Keep only runs whose sort field is at or after this unix-seconds value. Inclusive, so a client polling with the previous response's server_time re-receives same-second items rather than losing them."
+          }
+        ],
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
     "/api/agents": {
       "get": {
         "tags": ["agents"],
         "summary": "List runs",
+        "description": "Deprecated: use GET /api/runs, which paginates and supports search. This route returns every run ever recorded as one array, and is kept unchanged for existing clients.",
+        "deprecated": true,
         "parameters": [
           {
             "name": "status",
@@ -198,15 +278,31 @@
       "get": {
         "tags": ["agents"],
         "summary": "The run's logs",
+        "description": "A run's logs, by stage. Output is recorded per stage under stages/<idx>/, and the two streams are kept separate rather than interleaved because they share no ordering.",
         "parameters": [
           {
             "name": "tail",
             "in": "query",
-            "schema": { "type": "integer", "minimum": 1 },
-            "description": "Return only the last N lines."
+            "schema": { "type": "integer", "minimum": 1, "default": 32768 },
+            "description": "Return only the last N bytes (not lines)."
+          },
+          {
+            "name": "stage",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Stage index to read, or `all` to join every stage oldest first. Defaults to the stage the run is on now."
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["output", "logs"], "default": "output" },
+            "description": "`output` for the assistant's readable output, `logs` for the operational stream: tool calls, token counts and errors."
           }
         ],
-        "responses": { "200": { "$ref": "#/components/responses/Ok" } }
+        "responses": {
+          "200": { "$ref": "#/components/responses/Ok" },
+          "400": { "$ref": "#/components/responses/Error" }
+        }
       }
     },
     "/api/agents/{id}/result": {


### PR DESCRIPTION
Three features The Lair is blocked on, plus a live secret disclosure and four bugs found on the way.

## The security fix, first

`GET /api/agents/{id}/context/history` served every run's **webhook signing secret** to any holder of the API token. The route returns points replayed from the run journal, and the journal stores `RunMeta` whole — `callback_secret` included, because the daemon needs it to keep signing webhooks for a run it reloads after a restart. The redaction that covers `/api/agents` and its siblings was never applied here; `RunMeta::redacted`'s own doc names the three routes that were fixed for exactly this, and this one was missed.

One journal on my machine held a live non-null secret. The fix goes in the shared reader, so the CLI printer, the dashboard, and any future consumer inherit it rather than each having to remember.

## What the Lair asked for

**`GET /api/runs`** — paginated, sortable, searchable. Paging is keyset rather than offset, because an offset into a list that is changing skips and repeats items, worst at the head, which is exactly where a console looks. The cursor carries `(sort value, run id)`; the id is load-bearing, not decorative, since two runs start in the same second all the time and a keyset walk over a non-total order drops whichever colliding run it resumed past. It also carries the sort, order and a digest of the filter set, and disagreeing with any of them is a 400 — a cursor names a position in a particular list, and a page of quietly wrong results is far worse to debug than a refusal.

`sort=started_at` is the default because it is the only immutable sort key. `updated_at` advances on the daemon's 30-second persistence heartbeat, so every live run moves under a walk; that is documented as best-effort rather than papered over.

**Search** is two-phase. Phase one never parses — it filters over already-parsed metadata and, for the opt-in deep sources, raw file bytes. Phase two parses, and only for the items actually returned, so the expensive half is bounded by page size rather than by how long the daemon has been installed. Measured on real data: a substring scan across every journal here (84 archives, 22 MB) is ~10 ms warm, so this needs no index.

`MAX_SEARCH_SCAN` is the guardrail that matters. `q_in=logs` over a run set nothing prunes is a self-inflicted denial of service; the scan stops after a bounded prefix, newest first, and reports `scan_truncated` with a null `total` — a count from a partial scan is worse than no count, because a UI renders it as fact.

**File listing** on `GET /api/agents/{id}/files` with no `path`. Two sources, because they answer different questions: `source=modified` is the run's own record (free, but a claim about the run, capped when recorded), and `source=workdir` reads the filesystem **one directory level per request**. That bound is the answer to "a repo with `node_modules`" — verified live against a workdir with 1200 files in one directory; the cap holds at 1000 and says `truncated`.

## Also in scope, at the author's request

- `GET /api/blueprints` returns the shared envelope with `q`. Stated plainly in the code and changelog: pagination buys nothing here, since discovery parses every manifest on every request regardless. `q` is the parameter with real value.
- `GET /api/agents/{id}/context/history` is paginated. It returned every recorded point, each carrying a full context window with untruncated text, on a journal that grows for as long as the run does — comfortably the largest response in the API.
- `GET /api/config` reports `api_version`, `capabilities` and `limits`. The limits are what make it useful rather than decorative: knowing a feature exists still leaves a client guessing the page cap and the file cap, and every guess would be hardcoded and eventually wrong. They are read from the constants the handlers use, and a test holds `API_VERSION` to the spec's `info.version`.

## Bugs found on the way, all live before this PR

- **`GET /api/agents/{id}/logs` returned `""` for every run.** It read a run-level `output.log` that nothing has ever written. Across the 97 run directories on my machine there are **zero** of those against 179 stage-level ones. The two tests covering it wrote to the dead path and asserted only the status code, so they passed regardless of the body.
- **Blueprint name resolution depended on `readdir` order.** Discovery neither sorted nor deduplicated, and blueprint lookup and agent spawning both take the first match by name — so with one name reachable from two configured roots, *which agent actually ran* could differ between two calls.
- **The status filter rejected the spelling it returns.** `RunMeta` serializes `waiting_input`; the filter compared a lowercased `Display`, i.e. `waitinginput`.
- **`modified_file_count` counts modifying tool calls, not files.** A run editing one file three times records three, so the console's `count - files.len()` "+N more" was wrong. Rather than add a persisted distinct-count — which cannot be maintained past the record-time cap without the unbounded `meta.json` growth that cap prevents — the response names the two facts separately (`modifying_tool_calls`, `modified_files_truncated`), so a client never subtracts. Exact under the cap, an honest "200+" above it, with `source=workdir` for ground truth.

## Two notes on how this was verified

**Live testing caught what tests did not.** A `q_in=journal` search matched runs and returned *no highlight at all* — passing every unit test while failing at the one thing server-side search exists for. The text lived in the journal's context records and only tool batches were being read. Fixed in `fa1f8a3`, with a regression test verified to fail against the old behavior.

**Reaching 100% turned up code worth deleting rather than testing around.** A blueprint tie-break on path was unreachable because the dedup above it already makes names unique; `known_meta_fields` had a non-object arm a struct's serialization cannot take; the three highlighters carried manual early-return branches whose budget checks the caller had already made, and are now `find_map` expressions. One of my own tests was the documented closure-over-empty-collection trap: the no-header case for `visit_points` asserted with a visitor that had never run.

## Verification

- All 11 packages at 100% coverage, clippy clean, docs linter clean, full suite green — re-run after rebasing onto the tool-auth commits.
- Twelve end-to-end checks against a real `lev serve` with real run data: full pagination walks with no duplicates or skips, every 400 guard, deep search finding transcript-only text, the file-listing cap, history redaction, and `/api/agents` still returning a bare array.

## Compatibility

Two deliberate breaking changes, both announced through the new `capabilities` list: `/api/blueprints` and `/api/agents/{id}/context/history` now return envelopes. `GET /api/agents` is untouched and deprecated. Reading a file via `?path=` is unchanged down to its serialized field set, pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVuNjUYNnyV251BvJKG92g
