### PR TITLE
perf: halve the daemon's live memory, drop it after runs finish, and stop dead-ended graphs from reporting success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "leviath-testkit",
  "leviath-tools",
  "libc",
+ "mimalloc",
  "opentelemetry_sdk",
  "pulldown-cmark",
  "rand 0.10.2",
@@ -2593,6 +2594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2719,15 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -27,6 +27,10 @@ path = "src/main.rs"
 debug-http = ["leviath-providers/debug-http"]
 
 [dependencies]
+# The binary's global allocator (see main.rs). Kept out of the workspace dep
+# table on purpose: only the composition-root binary should pick an allocator,
+# never a library crate.
+mimalloc = "0.1"
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }

--- a/crates/leviath-cli/agents/daily-briefer/agent.leviath
+++ b/crates/leviath-cli/agents/daily-briefer/agent.leviath
@@ -45,6 +45,13 @@ bash       = "raw_data"
 hint = "Sources checked - rank what was found"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.collect.transitions.brief]
+hint = "Prioritization keeps looping - write the brief from what is collected"
+transform = "compact"
+
 [stages.collect.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -132,6 +139,13 @@ the runtime captured - read it first, note which source is unavailable, and
 record that gap so the briefing can flag it. Then return to prioritize with
 whatever was successfully collected.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.brief]
+hint = "Recovery is not converging - brief on what was gathered"
+transform = "compact"
 
 [stages.error_recovery.transitions.prioritize]
 hint = "Recovered - triage what we have"

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -49,6 +49,13 @@ than a narrow one.
 hint = "The schema is decided"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.scope.transitions.build]
+hint = "No further splitting is useful - build from what is already gathered"
+transform = "compact"
+
 [stages.scope.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -218,6 +225,13 @@ workaround in `caveats`.
 A source that will not load is not a reason to stop: record the gap and hand
 back so the dataset can be finished from what is reachable.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.present]
+hint = "Recovery is not converging - present the analysis built so far"
+transform = "compact"
 
 [stages.error_recovery.transitions.split]
 hint = "Recovered - split and gather again"

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -51,6 +51,13 @@ list_dir   = "sources"
 hint = "Enough primary sources gathered for meaningful analysis"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.gather.transitions.synthesize]
+hint = "Analysis is out of revisits - synthesize from the material in hand"
+transform = "compact"
+
 [stages.gather.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -137,6 +144,13 @@ read_file  = "sources"
 hint = "Cited sources read - resume analysis"
 transform = "compact"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.follow_citations.transitions.synthesize]
+hint = "Analysis is out of revisits - synthesize from the material in hand"
+transform = "compact"
+
 [stages.follow_citations.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -179,6 +193,13 @@ A call failed mid-research. The `error_report` region holds the error text the
 runtime captured - read it first. Record which source is unavailable and why (as
 a gap), and hand back to analyze to continue with the material you do have.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.synthesize]
+hint = "Recovery is not converging - synthesize what was gathered"
+transform = "compact"
 
 [stages.error_recovery.transitions.analyze]
 hint = "Recovered - continue analysis"

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -41,6 +41,13 @@ bash      = "logs"
 hint = "Log format identified, ready to analyze"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.ingest.transitions.report]
+hint = "Analysis is out of revisits - report what ingestion established"
+transform = "compact"
+
 [stages.ingest.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -133,6 +140,13 @@ transform = "direct"
 hint = "Script results ready - return to analysis"
 transform = "compact"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.script.transitions.report]
+hint = "Analysis is out of revisits - report the findings so far"
+transform = "compact"
+
 [stages.script.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -178,6 +192,13 @@ text the runtime captured - read it first, diagnose it (a malformed log line, a
 script bug, a missing file), note a workaround, then return to analyze to
 continue with the data available.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.report]
+hint = "Recovery is not converging - report the findings so far"
+transform = "compact"
 
 [stages.error_recovery.transitions.analyze]
 hint = "Recovered - resume analysis"

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -48,6 +48,13 @@ default_region = "raw_findings"
 hint = "Enough gathered for a first pass of analysis"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.gather.transitions.summarize]
+hint = "Analysis is out of revisits - summarize from the material in hand"
+transform = "compact"
+
 [stages.gather.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -138,6 +145,13 @@ Something failed during research (a source fetch, a parse, etc.). The
 work out what went wrong, and note a workaround. Then hand back to analyze to
 continue with whatever material is available.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.summarize]
+hint = "Recovery is not converging - summarize what was found"
+transform = "compact"
 
 [stages.error_recovery.transitions.analyze]
 hint = "Recovered - continue analysis"

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -87,6 +87,13 @@ list_dir  = "findings"
 hint = "First pass complete - scrutinize the flagged areas"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.scan.transitions.report]
+hint = "Deep review is out of revisits - report the scan findings"
+transform = "compact"
+
 [stages.scan.transitions.error_handler]
 condition = "error"
 transform = "direct"
@@ -179,6 +186,13 @@ An error occurred during review. The `error_report` region holds the error text
 the runtime captured - read it first, note a workaround (e.g. skip an unreadable
 file and record why), then return to deep_review to continue with the rest.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_handler.transitions.report]
+hint = "Recovery is not converging - report what was reviewed"
+transform = "compact"
 
 [stages.error_handler.transitions.deep_review]
 hint = "Recovered - resume the deep review"

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -46,6 +46,13 @@ list_dir   = "landscape"
 hint = "Landscape mapped - ready to compare approaches"
 transform = "direct"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.survey.transitions.summarize]
+hint = "Comparison is out of revisits - write the overview from the survey"
+transform = "compact"
+
 [stages.survey.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -122,6 +129,13 @@ read_file  = "landscape"
 hint = "Thread explored - resume comparing"
 transform = "compact"
 
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.deep_dive.transitions.summarize]
+hint = "Comparison is out of revisits - write the overview with this depth"
+transform = "compact"
+
 [stages.deep_dive.transitions.error_recovery]
 condition = "error"
 transform = "direct"
@@ -163,6 +177,13 @@ A call failed during the survey. The `error_report` region holds the error text
 the runtime captured - read it first, note the gap it leaves, and return to
 compare to continue with the coverage you have.
 """
+
+# Un-exhaustible escape (lint: dead-end-possible): when every looping
+# target has spent its max_revisits budget, the run can still move forward
+# to the deliverable instead of dead-ending.
+[stages.error_recovery.transitions.summarize]
+hint = "Recovery is not converging - write the overview from what exists"
+transform = "compact"
 
 [stages.error_recovery.transitions.compare]
 hint = "Recovered - continue comparing"

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -358,7 +358,7 @@ async fn inference_check(provider: &dyn Provider, model: &str) -> Check {
     };
 
     let started = Instant::now();
-    match provider.infer(request).await {
+    match provider.infer(&request).await {
         Ok(response) => {
             let usage = response.tokens_used;
             let echo = match response.content.contains(PROBE_EXPECTED) {

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -59,7 +59,7 @@ impl StubProvider {
 impl Provider for StubProvider {
     async fn infer(
         &self,
-        _request: InferenceRequest,
+        _request: &InferenceRequest,
     ) -> leviath_providers::Result<InferenceResponse> {
         match &self.reply {
             Ok(content) => Ok(InferenceResponse {

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1544,7 +1544,7 @@ mod tests {
     impl leviath_providers::Provider for MockProvider {
         async fn infer(
             &self,
-            _request: leviath_providers::InferenceRequest,
+            _request: &leviath_providers::InferenceRequest,
         ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
         {
             Err(leviath_providers::ProviderError::Other(
@@ -2016,7 +2016,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        let result = provider.infer(request).await;
+        let result = provider.infer(&request).await;
         assert!(result.is_err());
     }
 

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -249,20 +249,25 @@ pub(super) async fn agent_context_history(
         ),
     };
 
-    let Some(records) = runstate::read_run_archive(&id) else {
+    // One streamed pass to count, so `total` is honest and a descending window
+    // knows where to start. Counting folds the deltas but materializes nothing
+    // - and streaming means the journal is never parsed whole into memory:
+    // `read_run_archive` materialized every record (tens of MB for a mature
+    // run, 2-4x that as parsed structs) per request, which was this API's
+    // single largest transient allocation and the reason a page refresh
+    // stair-stepped the server's RSS.
+    let mut total = 0usize;
+    if runstate::visit_run_archive(&id, &mut |_| {
+        total += 1;
+        ControlFlow::Continue(())
+    })
+    .is_none()
+    {
         return Err(err(
             StatusCode::NOT_FOUND,
             format!("No context history for run '{id}'"),
         ));
-    };
-
-    // One pass to count, so `total` is honest and a descending window knows
-    // where to start. Counting folds the deltas but materializes nothing.
-    let mut total = 0usize;
-    leviath_core::run_archive::visit_points(&records, &mut |_| {
-        total += 1;
-        ControlFlow::Continue(())
-    });
+    }
     if total == 0 && query.cursor.is_none() {
         return Err(err(
             StatusCode::NOT_FOUND,
@@ -291,7 +296,7 @@ pub(super) async fn agent_context_history(
     let stop_at = wanted.iter().copied().max();
 
     let mut collected: Vec<(usize, leviath_core::run_archive::RunPoint)> = Vec::new();
-    leviath_core::run_archive::visit_points(&records, &mut |point| {
+    runstate::visit_run_archive(&id, &mut |point| {
         if wanted.contains(&point.index) {
             collected.push((
                 point.index,
@@ -369,9 +374,16 @@ pub(super) async fn agent_logs(
         .log_stream()
         .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
 
-    let max_bytes = query.tail.unwrap_or(32_768);
+    // Clamped like every other limit in this API: `tail` is client-controlled
+    // and `stage=all` multiplies it by the stage count, so an unclamped value
+    // was an arbitrary-size allocation on request.
+    let max_bytes = query.tail.unwrap_or(32_768).min(LOGS_MAX_TAIL_BYTES);
     Ok(runstate::tail_run_logs(&id, selector, stream, max_bytes))
 }
+
+/// Largest per-stage byte window `GET /api/agents/{id}/logs?tail=` honors:
+/// 1 MiB, matching the file endpoint's cap.
+pub(super) const LOGS_MAX_TAIL_BYTES: u64 = 1024 * 1024;
 
 /// How much of a file `GET /api/agents/{id}/files` returns: 1 MiB, enough for
 /// any report a browser would render, small enough to hand out in one JSON body.

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -298,14 +298,23 @@ pub(super) async fn test_server(
 }
 
 /// Connect to `server` and return its tool names.
+///
+/// The client is shut down on EVERY path, not just success: `MCPClient` has no
+/// `Drop` and a stdio transport's child process does not die with the handle,
+/// so the early-return `?`s here each orphaned a spawned MCP server process
+/// per failed test request.
 async fn connect_and_list(
     server: &MCPServerConfig,
     auth_header: Option<(String, String)>,
 ) -> anyhow::Result<Vec<String>> {
     let mut client = MCPClient::from_config_with_auth(server, auth_header, &[]).await?;
-    client.connect().await?;
-    let tools = client.list_tools().await?;
+    let listed = async {
+        client.connect().await?;
+        client.list_tools().await
+    }
+    .await;
     let _ = client.shutdown().await;
+    let tools = listed?;
     Ok(tools.into_iter().map(|t| t.name).collect())
 }
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -238,7 +238,9 @@ async fn execute_with_shutdown(
         tracing::warn!("{}", warning);
     }
 
-    let (event_tx, _) = broadcast::channel::<ServerEvent>(1024);
+    // Sized like the daemon's WorldEvent ring (see WorldHost): the ring never
+    // shrinks, so its capacity is a permanent memory floor once filled.
+    let (event_tx, _) = broadcast::channel::<ServerEvent>(256);
 
     let state = AppState {
         config: Arc::new(cfg),

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -723,8 +723,18 @@ fn journal_highlights(meta: &RunMeta, q: &str) -> Option<Highlight> {
         }
     }
 
-    let records = runstate::read_run_archive(&meta.run_id)?;
-    records.iter().find_map(|record| in_record(record, q))
+    // Streamed, stopping at the first matching record: parsing the whole
+    // journal per returned item multiplied the history endpoint's biggest
+    // allocation by the page size.
+    let mut found = None;
+    runstate::visit_run_records(&meta.run_id, &mut |record| match in_record(record, q) {
+        Some(hit) => {
+            found = Some(hit);
+            std::ops::ControlFlow::Break(())
+        }
+        None => std::ops::ControlFlow::Continue(()),
+    })?;
+    found
 }
 
 /// Take this page's runs and mint the cursor for the next one.

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -98,12 +98,8 @@ async fn handle_ws_with(
                         // ServerEvent always serializes; a failure is a bug.
                         let json = serde_json::to_string(&ev)
                             .expect("ServerEvent serialization must not fail");
-                        let sent = tokio::time::timeout(
-                            send_timeout,
-                            socket.send(Message::Text(json.into())),
-                        )
-                        .await;
-                        if !matches!(sent, Ok(Ok(()))) {
+                        if !send_within(&mut socket, send_timeout, Message::Text(json.into())).await
+                        {
                             break; // dead or wedged peer either way
                         }
                     }
@@ -114,23 +110,32 @@ async fn handle_ws_with(
                 }
             }
             _ = ping.tick() => {
-                if awaiting_pong {
-                    // The previous ping was never answered: the peer is gone
-                    // without a Close (sleep, kill, dropped NAT mapping).
+                // An unanswered previous ping, and a ping that cannot be
+                // sent, both mean the peer is gone without a Close (sleep,
+                // kill, dropped NAT mapping).
+                if awaiting_pong
+                    || !send_within(
+                        &mut socket,
+                        send_timeout,
+                        Message::Ping(Vec::new().into()),
+                    )
+                    .await
+                {
                     break;
                 }
                 awaiting_pong = true;
-                let pinged = tokio::time::timeout(
-                    send_timeout,
-                    socket.send(Message::Ping(Vec::new().into())),
-                )
-                .await;
-                if !matches!(pinged, Ok(Ok(()))) {
-                    break;
-                }
             }
         }
     }
+}
+
+/// Send one frame, bounded by `timeout`. `false` means the peer is dead or
+/// wedged (the send errored, or its flush never completed in time).
+async fn send_within(socket: &mut WebSocket, timeout: std::time::Duration, msg: Message) -> bool {
+    matches!(
+        tokio::time::timeout(timeout, socket.send(msg)).await,
+        Ok(Ok(()))
+    )
 }
 
 #[cfg(test)]
@@ -296,6 +301,19 @@ mod tests {
             .route("/ws", get(ws_global))
             .route("/ws/agents/{id}", get(ws_agent))
             .with_state(state);
+        spawn_router_with_shutdown(app).await
+    }
+
+    /// Serve `app` on a loopback port with graceful shutdown - the one server
+    /// block every WS test server shares, so exercising its shutdown once
+    /// covers them all.
+    async fn spawn_router_with_shutdown(
+        app: Router,
+    ) -> (
+        std::net::SocketAddr,
+        tokio::sync::oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -329,7 +347,10 @@ mod tests {
     }
 
     /// A server whose WS route uses injected ping/send deadlines, so the
-    /// dead-peer branches can be driven in tens of milliseconds.
+    /// dead-peer branches can be driven in tens of milliseconds. Shares the
+    /// graceful-shutdown server plumbing with `spawn_test_server_with_shutdown`
+    /// (whose shutdown path a dedicated test exercises); the shutdown sender
+    /// is leaked exactly like `spawn_test_server` leaks its own.
     async fn spawn_ping_test_server(
         state: AppState,
         ping_every: std::time::Duration,
@@ -348,27 +369,36 @@ mod tests {
                 ),
             )
             .with_state(state);
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
+        let (addr, shutdown_tx, _handle) = spawn_router_with_shutdown(app).await;
+        std::mem::forget(shutdown_tx);
         addr
+    }
+
+    fn assert_receiver_count_reached(reached: bool, expected: usize, actual: usize) {
+        assert!(
+            reached,
+            "receiver count never reached {expected} (still {actual})"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "receiver count never reached")]
+    fn assert_receiver_count_reached_panics_when_it_never_did() {
+        assert_receiver_count_reached(false, 1, 0);
     }
 
     /// Wait until the broadcast subscriber count reaches `expected` (the
     /// handler task subscribing or dropping its receiver), or panic.
     async fn wait_for_receiver_count(tx: &broadcast::Sender<ServerEvent>, expected: usize) {
+        let mut reached = false;
         for _ in 0..100 {
             if tx.receiver_count() == expected {
-                return;
+                reached = true;
+                break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
-        panic!(
-            "receiver count never reached {expected} (still {})",
-            tx.receiver_count()
-        );
+        assert_receiver_count_reached(reached, expected, tx.receiver_count());
     }
 
     /// A peer that never answers pings is declared dead after one unanswered
@@ -407,16 +437,16 @@ mod tests {
         let mut client = WsTestClient::connect(addr, "/ws").await;
         wait_for_receiver_count(&tx, 1).await;
 
-        // Answer pings for ~5 intervals.
+        // Answer pings for ~5 intervals. Nothing else is broadcast on this
+        // channel, so every inbound frame is a ping.
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(400);
         while std::time::Instant::now() < deadline {
             let (opcode, payload) =
                 tokio::time::timeout(std::time::Duration::from_secs(5), client.recv_frame())
                     .await
                     .expect("expected a ping before the deadline");
-            if opcode == 0x9 {
-                client.send_frame(0xA, &payload).await; // masked pong
-            }
+            assert_eq!(opcode, 0x9, "only pings flow on an idle channel");
+            client.send_frame(0xA, &payload).await; // masked pong
         }
         assert_eq!(
             tx.receiver_count(),

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -7,6 +7,24 @@ use tokio::sync::broadcast;
 
 use super::types::*;
 
+/// How often the server pings an idle-or-not connection. A peer that has not
+/// ponged by the NEXT ping is declared dead. Browsers answer pings
+/// automatically, so a live client never trips this.
+const WS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// How long one outbound frame may take to send+flush before the peer is
+/// declared dead. A peer that stopped reading without closing (a backgrounded
+/// tab, a sleeping laptop, a NAT that dropped the mapping) leaves `send()`
+/// pending forever otherwise - the task then never polls `recv()` either, so
+/// it holds its broadcast receiver and ~256 KB of frame buffers until TCP
+/// keepalive fires hours later.
+const WS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Cap tungstenite's outbound frame buffering per connection. Without it a
+/// wedged peer's connection buffers frames without bound while waiting for
+/// the send timeout to notice.
+const WS_MAX_WRITE_BUFFER: usize = 256 * 1024;
+
 pub(super) async fn ws_global(
     State(state): State<AppState>,
     ws: WebSocketUpgrade,
@@ -16,7 +34,8 @@ pub(super) async fn ws_global(
     // channel becomes Closed and rx.recv() returns Err(Closed) immediately,
     // making that match arm reachable in tests.
     let rx = state.event_tx.subscribe();
-    ws.on_upgrade(move |socket| handle_ws(socket, rx, None))
+    ws.max_write_buffer_size(WS_MAX_WRITE_BUFFER)
+        .on_upgrade(move |socket| handle_ws(socket, rx, None))
 }
 
 pub(super) async fn ws_agent(
@@ -25,17 +44,47 @@ pub(super) async fn ws_agent(
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
     let rx = state.event_tx.subscribe();
-    ws.on_upgrade(move |socket| handle_ws(socket, rx, Some(id)))
+    ws.max_write_buffer_size(WS_MAX_WRITE_BUFFER)
+        .on_upgrade(move |socket| handle_ws(socket, rx, Some(id)))
 }
 
 async fn handle_ws(
+    socket: WebSocket,
+    rx: broadcast::Receiver<ServerEvent>,
+    filter_run_id: Option<String>,
+) {
+    handle_ws_with(socket, rx, filter_run_id, WS_PING_INTERVAL, WS_SEND_TIMEOUT).await
+}
+
+/// Core of the WS relay, with the ping cadence and send deadline injected so
+/// tests can drive the dead-peer branches without real multi-second waits.
+///
+/// The `select!` is deliberately **unbiased**: the old `biased;` variant
+/// polled the event branch first every iteration, so under a busy run the
+/// inbound half (`socket.recv()` - the only place Close frames and pongs are
+/// seen) could be starved indefinitely.
+async fn handle_ws_with(
     mut socket: WebSocket,
     mut rx: broadcast::Receiver<ServerEvent>,
     filter_run_id: Option<String>,
+    ping_every: std::time::Duration,
+    send_timeout: std::time::Duration,
 ) {
+    // First ping only after a full interval - a fresh connection is known
+    // live, and pinging in the handshake's shadow confuses simple clients.
+    let mut ping = tokio::time::interval_at(tokio::time::Instant::now() + ping_every, ping_every);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut awaiting_pong = false;
     loop {
         tokio::select! {
-            biased;
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Pong(_))) => awaiting_pong = false,
+                    Some(Err(_)) => break,
+                    _ => {} // Ignore other client messages
+                }
+            }
             event = rx.recv() => {
                 match event {
                     Ok(ev) => {
@@ -49,8 +98,13 @@ async fn handle_ws(
                         // ServerEvent always serializes; a failure is a bug.
                         let json = serde_json::to_string(&ev)
                             .expect("ServerEvent serialization must not fail");
-                        if socket.send(Message::Text(json.into())).await.is_err() {
-                            break;
+                        let sent = tokio::time::timeout(
+                            send_timeout,
+                            socket.send(Message::Text(json.into())),
+                        )
+                        .await;
+                        if !matches!(sent, Ok(Ok(()))) {
+                            break; // dead or wedged peer either way
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -59,10 +113,20 @@ async fn handle_ws(
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
-            msg = socket.recv() => {
-                match msg {
-                    Some(Ok(Message::Close(_))) | None => break,
-                    _ => {} // Ignore other client messages
+            _ = ping.tick() => {
+                if awaiting_pong {
+                    // The previous ping was never answered: the peer is gone
+                    // without a Close (sleep, kill, dropped NAT mapping).
+                    break;
+                }
+                awaiting_pong = true;
+                let pinged = tokio::time::timeout(
+                    send_timeout,
+                    socket.send(Message::Ping(Vec::new().into())),
+                )
+                .await;
+                if !matches!(pinged, Ok(Ok(()))) {
+                    break;
                 }
             }
         }
@@ -262,6 +326,138 @@ mod tests {
     #[should_panic(expected = "expected a text frame")]
     fn assert_text_frame_panics_on_non_text_opcode() {
         assert_text_frame(0x2);
+    }
+
+    /// A server whose WS route uses injected ping/send deadlines, so the
+    /// dead-peer branches can be driven in tens of milliseconds.
+    async fn spawn_ping_test_server(
+        state: AppState,
+        ping_every: std::time::Duration,
+        send_timeout: std::time::Duration,
+    ) -> std::net::SocketAddr {
+        let app = Router::new()
+            .route(
+                "/ws",
+                get(
+                    move |State(state): State<AppState>, ws: WebSocketUpgrade| async move {
+                        let rx = state.event_tx.subscribe();
+                        ws.on_upgrade(move |socket| {
+                            handle_ws_with(socket, rx, None, ping_every, send_timeout)
+                        })
+                    },
+                ),
+            )
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        addr
+    }
+
+    /// Wait until the broadcast subscriber count reaches `expected` (the
+    /// handler task subscribing or dropping its receiver), or panic.
+    async fn wait_for_receiver_count(tx: &broadcast::Sender<ServerEvent>, expected: usize) {
+        for _ in 0..100 {
+            if tx.receiver_count() == expected {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!(
+            "receiver count never reached {expected} (still {})",
+            tx.receiver_count()
+        );
+    }
+
+    /// A peer that never answers pings is declared dead after one unanswered
+    /// interval: the handler drops its receiver instead of holding it (plus
+    /// its frame buffers) until TCP keepalive fires hours later.
+    #[tokio::test]
+    async fn ws_closes_a_client_that_never_pongs() {
+        let state = test_state();
+        let tx = state.event_tx.clone();
+        let addr = spawn_ping_test_server(
+            state,
+            std::time::Duration::from_millis(80),
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        // The raw test client ignores pings entirely.
+        let _client = WsTestClient::connect(addr, "/ws").await;
+        wait_for_receiver_count(&tx, 1).await;
+        // First interval sends the ping; the second finds it unanswered.
+        wait_for_receiver_count(&tx, 0).await;
+    }
+
+    /// A peer that answers pings stays connected across many intervals.
+    #[tokio::test]
+    async fn ws_stays_alive_when_client_pongs() {
+        let state = test_state();
+        let tx = state.event_tx.clone();
+        let addr = spawn_ping_test_server(
+            state,
+            std::time::Duration::from_millis(60),
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        let mut client = WsTestClient::connect(addr, "/ws").await;
+        wait_for_receiver_count(&tx, 1).await;
+
+        // Answer pings for ~5 intervals.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(400);
+        while std::time::Instant::now() < deadline {
+            let (opcode, payload) =
+                tokio::time::timeout(std::time::Duration::from_secs(5), client.recv_frame())
+                    .await
+                    .expect("expected a ping before the deadline");
+            if opcode == 0x9 {
+                client.send_frame(0xA, &payload).await; // masked pong
+            }
+        }
+        assert_eq!(
+            tx.receiver_count(),
+            1,
+            "a ponging client must not be disconnected"
+        );
+        client.send_close().await;
+        wait_for_receiver_count(&tx, 0).await;
+    }
+
+    /// A peer that stopped reading without closing wedges `send()`; the send
+    /// deadline breaks the connection instead of parking the task forever.
+    #[tokio::test]
+    async fn ws_send_timeout_disconnects_a_wedged_peer() {
+        let state = test_state();
+        let tx = state.event_tx.clone();
+        let addr = spawn_ping_test_server(
+            state,
+            std::time::Duration::from_secs(3600), // pings out of the picture
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+
+        // Connect and then never read: the kernel buffers fill and the
+        // server's flush pends.
+        let _client = WsTestClient::connect(addr, "/ws").await;
+        wait_for_receiver_count(&tx, 1).await;
+
+        let big_line = "x".repeat(256 * 1024);
+        for _ in 0..64 {
+            if tx.receiver_count() == 0 {
+                break; // already disconnected
+            }
+            let _ = tx.send(ServerEvent::Log {
+                agent_id: "a".to_string(),
+                run_id: "run-1".to_string(),
+                line: big_line.clone(),
+            });
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        wait_for_receiver_count(&tx, 0).await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -353,7 +353,7 @@ async fn run_test_case(
     };
 
     let response = provider
-        .infer(request)
+        .infer(&request)
         .await
         .map_err(|e| anyhow::anyhow!("Inference failed: {}", e))?;
 
@@ -1168,7 +1168,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     impl Provider for MockProvider {
         async fn infer(
             &self,
-            _request: InferenceRequest,
+            _request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             Ok(InferenceResponse {
                 content: self.content.clone(),
@@ -1209,7 +1209,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     impl Provider for NoTemperatureProvider {
         async fn infer(
             &self,
-            _request: InferenceRequest,
+            _request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             Ok(InferenceResponse {
                 content: "cold hello".to_string(),
@@ -1252,7 +1252,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     impl Provider for ErrorProvider {
         async fn infer(
             &self,
-            _request: InferenceRequest,
+            _request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             Err(leviath_providers::ProviderError::ApiError(
                 "simulated inference error".to_string(),
@@ -1319,9 +1319,9 @@ max_tokens = 5000
     impl Provider for RecordingProvider {
         async fn infer(
             &self,
-            request: InferenceRequest,
+            request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
-            *self.seen.lock().unwrap() = Some(request);
+            *self.seen.lock().unwrap() = Some(request.clone());
             Ok(InferenceResponse {
                 content: "recorded".to_string(),
                 tool_calls: vec![],

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -337,7 +337,7 @@ mod tests {
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
             &self,
-            _r: leviath_providers::InferenceRequest,
+            _r: &leviath_providers::InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("test".to_string()))
         }
@@ -656,7 +656,7 @@ mod tests {
         use leviath_providers::Provider;
         let p = FakeProvider;
         assert!(
-            p.infer(leviath_providers::InferenceRequest {
+            p.infer(&leviath_providers::InferenceRequest {
                 system: vec![],
                 messages: vec![],
                 model: "m".to_string(),

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -527,7 +527,7 @@ mod tests {
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
             &self,
-            _r: leviath_providers::InferenceRequest,
+            _r: &leviath_providers::InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("t".to_string()))
         }
@@ -1924,7 +1924,7 @@ mod tests {
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(
-            p.infer(leviath_providers::InferenceRequest {
+            p.infer(&leviath_providers::InferenceRequest {
                 system: vec![],
                 messages: vec![],
                 model: "m".to_string(),

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -550,7 +550,7 @@ mod tests {
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
             &self,
-            _r: leviath_providers::InferenceRequest,
+            _r: &leviath_providers::InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other("test".to_string()))
         }
@@ -1228,7 +1228,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(
-            p.infer(leviath_providers::InferenceRequest {
+            p.infer(&leviath_providers::InferenceRequest {
                 system: vec![],
                 messages: vec![],
                 model: "m".to_string(),

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -1538,7 +1538,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
             &self,
-            _r: leviath_providers::InferenceRequest,
+            _r: &leviath_providers::InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other(
                 "test provider".to_string(),
@@ -2948,7 +2948,7 @@ system = { kind = "pinned", max_tokens = 1000 }
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
         assert!(
-            p.infer(leviath_providers::InferenceRequest {
+            p.infer(&leviath_providers::InferenceRequest {
                 system: vec![],
                 messages: vec![],
                 model: "m".to_string(),

--- a/crates/leviath-cli/src/lint.rs
+++ b/crates/leviath-cli/src/lint.rs
@@ -268,6 +268,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
     findings.extend(lint_held_checkpoints(blueprint));
     findings.extend(lint_graph(blueprint));
     findings.extend(lint_output_reachable(blueprint));
+    findings.extend(lint_dead_end_possible(blueprint));
 
     let agent_permissions = blueprint.agent_tool_permissions();
 
@@ -594,6 +595,65 @@ fn lint_output_stage(stage: &leviath_core::Stage) -> Vec<LintFinding> {
 /// to a stage's custom `transition_prompt` - so a stage can offer an exit its own
 /// prompt never mentions. A run that takes it ends with no answer and looks
 /// exactly like success.
+/// Stages whose every normal exit can run out of `max_revisits` budget.
+///
+/// A stage transitions along its `Always`/`LlmChoice` edges; an edge whose
+/// target has `max_revisits` stops being followable once the budget is spent.
+/// When EVERY normal edge is like that, a long enough run strands the stage
+/// with nowhere to go - which the engine now reports as a dead-end *error*
+/// (it used to read as `complete`, from the middle of the graph, with the
+/// output stage still pending). Observed live: a wide-researcher bounced
+/// deep_dive → compare until compare's budget ran out, then "completed" with
+/// nothing produced.
+///
+/// The fix is one un-exhaustible way forward: an edge to a stage without
+/// `max_revisits` (an output/terminal stage usually), or a
+/// `condition = "max_iterations"` escape.
+fn lint_dead_end_possible(blueprint: &Blueprint) -> Vec<LintFinding> {
+    let mut findings = Vec::new();
+    for stage in &blueprint.stages {
+        let Some(transitions) = &stage.transitions else {
+            continue;
+        };
+        let normal: Vec<&leviath_core::blueprint::TransitionEdge> = transitions
+            .values()
+            .filter(|e| {
+                matches!(
+                    e.condition,
+                    leviath_core::blueprint::TransitionCondition::Always
+                        | leviath_core::blueprint::TransitionCondition::LlmChoice
+                )
+            })
+            .collect();
+        if normal.is_empty() {
+            continue; // terminal (or conditioned-only) stage: nothing to strand
+        }
+        let all_exhaustible = normal.iter().all(|e| {
+            blueprint
+                .find_stage(&e.target)
+                .is_none_or(|t| t.max_revisits.is_some())
+        });
+        if all_exhaustible {
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Warning,
+                    "dead-end-possible",
+                    "can strand the run: every normal transition's target has a max_revisits \
+                     budget, and once they are all spent the run errors as dead-ended"
+                        .to_string(),
+                )
+                .in_stage(&stage.name)
+                .with_fix(
+                    "add one un-exhaustible way forward - an edge to a stage without \
+                     max_revisits (the output stage, usually), or a condition = \
+                     \"max_iterations\" escape",
+                ),
+            );
+        }
+    }
+    findings
+}
+
 fn lint_output_reachable(blueprint: &Blueprint) -> Vec<LintFinding> {
     let outputs: Vec<&leviath_core::Stage> = blueprint
         .stages

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1142,7 +1142,7 @@ a = "true"
 }
 
 #[test]
-fn a_cycle_with_max_revisits_is_fine() {
+fn a_capped_cycle_no_longer_trips_the_cycle_lint_but_can_dead_end() {
     let toml = manifest(
         r#"
 [stages.a]
@@ -1163,7 +1163,13 @@ max_revisits = 3
 a = "true"
 "#,
     );
-    assert!(lint(&toml, &LintEnv::default()).is_empty());
+    // Capping both ends satisfies the cycle lint - but now EVERY exit of each
+    // stage is exhaustible, so once both budgets are spent the run dead-ends
+    // (an error at runtime). The dead-end lint says so for both stages.
+    assert_eq!(
+        codes(&lint(&toml, &LintEnv::default())),
+        ["dead-end-possible", "dead-end-possible"]
+    );
 }
 
 /// A self-loop is not a two-stage cycle, and a terminal stage has an empty
@@ -1263,7 +1269,12 @@ fn the_graph_walk_steps_over_names_that_are_not_stages() {
         vec![dangling],
         ContextLayout::new(Vec::new(), 1000),
     );
-    assert!(lint_manifest("", &bp, &LintEnv::default()).is_empty());
+    // The cycle walk has nothing to say, but an edge nothing can ever follow
+    // is a guaranteed strand, which the dead-end lint reports.
+    assert_eq!(
+        codes(&lint_manifest("", &bp, &LintEnv::default())),
+        ["dead-end-possible"]
+    );
 }
 
 // ─── Finding rendering ────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -24,6 +24,17 @@ use leviath_cli::commands;
 use leviath_cli::commands::dashboard::{CrosstermEventSource, DashboardArgs, TerminalSetup};
 use leviath_cli::dispatch::{Commands, RiskyExecutors, apply_region_flags, dispatch};
 
+/// mimalloc instead of the platform allocator. The daemon's workload is a
+/// stream of large, variably-sized, short-lived allocations (assembled
+/// inference requests, context snapshots, tool results) interleaved with
+/// long-lived small ones; the system allocator strands the freed spans behind
+/// the live objects and RSS never comes back down (measured: a 22 MB live
+/// footprint under 293 MB of retained RSS after a five-agent burst). mimalloc
+/// returns freed pages to the OS aggressively, so RSS tracks what the process
+/// actually holds.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Leviath CLI - Agent framework with structured context windows
 #[derive(Parser)]
 #[command(name = "lev")]

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1662,25 +1662,83 @@ mod tests {
     #[test]
     fn streaming_visitors_return_none_when_the_archive_is_missing() {
         with_isolated_runs_dir("streaming-visitors-missing", |_d| {
-            assert!(
-                visit_run_archive("no-such-run", &mut |_| std::ops::ControlFlow::Continue(()))
-                    .is_none()
-            );
-            assert!(
-                visit_run_records("no-such-run", &mut |_| std::ops::ControlFlow::Continue(()))
-                    .is_none()
-            );
+            // One visitor closure of each kind, shared across every call in
+            // this test - the last pair of calls (on a real archive) executes
+            // them, so a missing/invalid archive is proven by the counters
+            // staying put, not by never-run closures.
+            let points_seen = std::cell::Cell::new(0usize);
+            let mut on_point = |_: leviath_core::run_archive::PointRef<'_>| {
+                points_seen.set(points_seen.get() + 1);
+                std::ops::ControlFlow::Continue(())
+            };
+            let records_seen = std::cell::Cell::new(0usize);
+            let mut on_record = |_: &leviath_core::run_archive::RunRecord| {
+                records_seen.set(records_seen.get() + 1);
+                std::ops::ControlFlow::Continue(())
+            };
+
+            assert!(visit_run_archive("no-such-run", &mut on_point).is_none());
+            assert!(visit_run_records("no-such-run", &mut on_record).is_none());
             // A file that is not an archive fails the preamble check.
             let run_id = "bad-preamble";
             std::fs::create_dir_all(run_dir(run_id)).unwrap();
             std::fs::write(run_dir(run_id).join("run.lvr"), b"junk").unwrap();
-            assert!(
-                visit_run_archive(run_id, &mut |_| std::ops::ControlFlow::Continue(())).is_none()
-            );
-            assert!(
-                visit_run_records(run_id, &mut |_| std::ops::ControlFlow::Continue(())).is_none()
-            );
+            assert!(visit_run_archive(run_id, &mut on_point).is_none());
+            assert!(visit_run_records(run_id, &mut on_record).is_none());
+            assert_eq!((points_seen.get(), records_seen.get()), (0, 0));
+
+            // The same closures over a real archive do run.
+            let real = "streaming-visitors-real";
+            std::fs::create_dir_all(run_dir(real)).unwrap();
+            write_minimal_archive(real);
+            assert!(visit_run_archive(real, &mut on_point).is_some());
+            assert!(visit_run_records(real, &mut on_record).is_some());
+            assert_eq!(points_seen.get(), 1);
+            assert_eq!(records_seen.get(), 2);
         });
+    }
+
+    /// Write a two-record archive (Header + one ContextCheckpoint) for `run_id`.
+    fn write_minimal_archive(run_id: &str) {
+        use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+        let mut buf = Vec::new();
+        run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
+        let meta = RunMeta::new(
+            run_id.to_string(),
+            "a".to_string(),
+            "/p".to_string(),
+            "t".to_string(),
+            None,
+            "/w".to_string(),
+            1,
+        );
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::Header {
+                identity: RunIdentity {
+                    run_id: run_id.to_string(),
+                    machine_id: "m".to_string(),
+                    world_id: "w".to_string(),
+                    created_at: 0,
+                },
+                meta: Box::new(meta),
+            },
+        )
+        .unwrap();
+        run_archive::write_record(
+            &mut buf,
+            &RunRecord::ContextCheckpoint {
+                snapshot: ContextSnapshot {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 100,
+                    regions: vec![],
+                },
+                at: 1,
+            },
+        )
+        .unwrap();
+        std::fs::write(run_dir(run_id).join("run.lvr"), &buf).unwrap();
     }
 
     /// The journal keeps `callback_secret` (the daemon re-signs webhooks for a

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -70,12 +70,54 @@ pub fn read_context_snapshot(run_id: &str) -> Option<ContextSnapshot> {
 
 /// Read + parse a run's portable archive (`<run_dir>/run.lvr`), returning its
 /// records, or `None` if the archive is missing or unreadable.
+///
+/// Materializes the whole journal. For anything that only walks the timeline
+/// (the history API, journal search highlights), prefer [`visit_run_archive`]:
+/// a mature run's journal is tens of MB, and parsing it whole per request was
+/// the API's single largest transient allocation.
 pub fn read_run_archive(run_id: &str) -> Option<Vec<leviath_core::run_archive::RunRecord>> {
     let path = run_dir(run_id).join("run.lvr");
     let bytes = std::fs::read(&path).ok()?;
     leviath_core::run_archive::read_archive(&mut bytes.as_slice())
         .ok()
         .map(|(_version, records)| records)
+}
+
+/// Stream a run's raw journal records through `visit`, one at a time, without
+/// materializing the archive. Same lenient tail handling as
+/// [`visit_run_archive`]. For consumers that inspect records rather than
+/// replayed points (journal search).
+pub fn visit_run_records(
+    run_id: &str,
+    visit: &mut dyn FnMut(&leviath_core::run_archive::RunRecord) -> std::ops::ControlFlow<()>,
+) -> Option<()> {
+    let path = run_dir(run_id).join("run.lvr");
+    let file = std::fs::File::open(&path).ok()?;
+    let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
+    leviath_core::run_archive::read_archive_start(&mut reader).ok()?;
+    while let Ok(Some(record)) = leviath_core::run_archive::read_record(&mut reader) {
+        if visit(&record).is_break() {
+            break;
+        }
+    }
+    Some(())
+}
+
+/// Stream a run's archive through a [`visit_points`] visitor without ever
+/// materializing the journal: one buffered pass over `run.lvr`, one record and
+/// one running window in memory. Returns `None` if the archive is missing or
+/// its preamble is invalid; a torn tail (a live run mid-append) just ends the
+/// walk with the points already visited.
+///
+/// [`visit_points`]: leviath_core::run_archive::visit_points
+pub fn visit_run_archive(
+    run_id: &str,
+    visit: &mut dyn FnMut(leviath_core::run_archive::PointRef<'_>) -> std::ops::ControlFlow<()>,
+) -> Option<()> {
+    let path = run_dir(run_id).join("run.lvr");
+    let file = std::fs::File::open(&path).ok()?;
+    let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
+    leviath_core::run_archive::visit_archive_points(&mut reader, visit).ok()
 }
 
 /// A run's context-window history: the full window (+ metadata) at each recorded
@@ -1587,6 +1629,57 @@ mod tests {
             let history = context_history(run_id);
             assert_eq!(history.len(), 1);
             assert_eq!(history[0].context.stage_name, "plan");
+
+            // The streaming visitors see the same journal without ever
+            // materializing it.
+            let mut streamed_points = Vec::new();
+            visit_run_archive(run_id, &mut |p| {
+                streamed_points.push((p.index, p.context.stage_name.to_string()));
+                std::ops::ControlFlow::Continue(())
+            })
+            .expect("streamed replay");
+            assert_eq!(streamed_points, vec![(0, "plan".to_string())]);
+
+            let mut streamed_records = 0usize;
+            visit_run_records(run_id, &mut |_| {
+                streamed_records += 1;
+                std::ops::ControlFlow::Continue(())
+            })
+            .expect("streamed records");
+            assert_eq!(streamed_records, 2);
+
+            // And a visitor can stop early.
+            let mut first_only = 0usize;
+            visit_run_records(run_id, &mut |_| {
+                first_only += 1;
+                std::ops::ControlFlow::Break(())
+            })
+            .expect("streamed records with break");
+            assert_eq!(first_only, 1);
+        });
+    }
+
+    #[test]
+    fn streaming_visitors_return_none_when_the_archive_is_missing() {
+        with_isolated_runs_dir("streaming-visitors-missing", |_d| {
+            assert!(
+                visit_run_archive("no-such-run", &mut |_| std::ops::ControlFlow::Continue(()))
+                    .is_none()
+            );
+            assert!(
+                visit_run_records("no-such-run", &mut |_| std::ops::ControlFlow::Continue(()))
+                    .is_none()
+            );
+            // A file that is not an archive fails the preamble check.
+            let run_id = "bad-preamble";
+            std::fs::create_dir_all(run_dir(run_id)).unwrap();
+            std::fs::write(run_dir(run_id).join("run.lvr"), b"junk").unwrap();
+            assert!(
+                visit_run_archive(run_id, &mut |_| std::ops::ControlFlow::Continue(())).is_none()
+            );
+            assert!(
+                visit_run_records(run_id, &mut |_| std::ops::ControlFlow::Continue(())).is_none()
+            );
         });
     }
 

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -458,15 +458,14 @@ impl Blueprint {
                         return true;
                     }
                 }
-                // If all targets are exhaustible (already visited + have max_revisits),
-                // the stage will eventually have zero available edges → terminal
-                transitions.keys().all(|target| {
-                    self.stages
-                        .iter()
-                        .find(|s| s.name == *target)
-                        .map(|s| s.max_revisits.is_some())
-                        .unwrap_or(false)
-                })
+                // No target reaches a terminal stage. This used to fall back to
+                // "all targets are exhaustible, so the stage will eventually
+                // have zero available edges" and call THAT a terminal path -
+                // but running out of edges mid-graph is now a run *error*
+                // (StageResolution::DeadEnd in the runtime), not a completion,
+                // so certifying it here validated blueprints that could never
+                // finish successfully.
+                false
             }
         }
     }
@@ -2079,9 +2078,15 @@ mod tests {
         );
         stage.transitions = Some(transitions);
         let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
-        // Should pass: self-loop has max_revisits, and the self-loop target
-        // will eventually exhaust, leaving zero edges → terminal
-        assert!(bp.validate().is_ok());
+        // Must FAIL now: this used to pass on the theory that the self-loop
+        // exhausts its max_revisits and "leaving zero edges" counts as
+        // terminal - but running out of edges mid-graph is a run error
+        // (StageResolution::DeadEnd), so a blueprint whose only ending is
+        // exhaustion can never finish successfully.
+        let err = bp
+            .validate()
+            .expect_err("an exhaustion-only graph is invalid");
+        assert!(err.to_string().contains("no terminal path"), "{err}");
     }
 
     #[test]

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -1149,15 +1149,21 @@ mod tests {
         buf
     }
 
-    /// Collect `(index, at, total_tokens)` per visited point.
-    fn collect_streamed(bytes: &[u8]) -> Vec<(usize, i64, usize)> {
+    /// Collect `(index, at, total_tokens)` per visited point, or the stream
+    /// error. One closure shared by every streamed test, including the
+    /// bad-preamble one whose visitor never runs.
+    fn try_collect_streamed(bytes: &[u8]) -> io::Result<Vec<(usize, i64, usize)>> {
         let mut seen = Vec::new();
         visit_archive_points(&mut &bytes[..], &mut |p| {
             seen.push((p.index, p.at, p.context.total_tokens));
             ControlFlow::Continue(())
-        })
-        .unwrap();
-        seen
+        })?;
+        Ok(seen)
+    }
+
+    /// Collect `(index, at, total_tokens)` per visited point.
+    fn collect_streamed(bytes: &[u8]) -> Vec<(usize, i64, usize)> {
+        try_collect_streamed(bytes).unwrap()
     }
 
     #[test]
@@ -1195,9 +1201,7 @@ mod tests {
 
     #[test]
     fn visit_archive_points_rejects_a_bad_preamble() {
-        let mut bogus: &[u8] = b"not an archive at all";
-        let result = visit_archive_points(&mut bogus, &mut |_| ControlFlow::Continue(()));
-        assert!(result.is_err());
+        assert!(try_collect_streamed(b"not an archive at all").is_err());
     }
 
     #[test]

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -822,33 +822,99 @@ pub struct PointRef<'a> {
 /// serve module.
 pub fn visit_points(records: &[RunRecord], visit: &mut dyn FnMut(PointRef<'_>) -> ControlFlow<()>) {
     let mut iter = records.iter();
-    let mut meta = match iter.next() {
-        Some(RunRecord::Header { meta, .. }) => (**meta).clone(),
-        _ => return,
+    let Some(mut folder) = (match iter.next() {
+        Some(first) => PointFolder::start(first),
+        None => None,
+    }) else {
+        return;
     };
-    let mut context = ContextSnapshot {
-        stage_name: String::new(),
-        total_tokens: 0,
-        max_tokens: 0,
-        regions: Vec::new(),
-    };
-    let mut index = 0usize;
     for record in iter {
+        if folder.push(record, visit).is_break() {
+            return;
+        }
+    }
+}
+
+/// Streaming [`visit_points`] over a framed archive: validate the preamble,
+/// then read one record at a time and fold it into the running window - so a
+/// multi-megabyte `run.lvr` is walked holding one record and one window in
+/// memory, instead of the whole parsed journal (`read_archive` materializes
+/// every record first, typically 2-4x the file's bytes as structs).
+///
+/// Errors only on a bad preamble. Like [`read_archive_lenient`], a torn or
+/// unreadable frame ends the walk with the points already visited: the tail of
+/// a live run's journal can legitimately be mid-append.
+pub fn visit_archive_points(
+    r: &mut dyn Read,
+    visit: &mut dyn FnMut(PointRef<'_>) -> ControlFlow<()>,
+) -> io::Result<()> {
+    read_archive_start(r)?;
+    let mut folder = match read_record(r) {
+        Ok(Some(first)) => match PointFolder::start(&first) {
+            Some(folder) => folder,
+            None => return Ok(()),
+        },
+        _ => return Ok(()),
+    };
+    while let Ok(Some(record)) = read_record(r) {
+        if folder.push(&record, visit).is_break() {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+/// The running state of a point replay: the metadata and window in effect,
+/// folded record by record. Shared by [`visit_points`] (in-memory records) and
+/// [`visit_archive_points`] (streamed records) so the two can never disagree
+/// about what a record means.
+struct PointFolder {
+    meta: RunMeta,
+    context: ContextSnapshot,
+    index: usize,
+}
+
+impl PointFolder {
+    /// Start a replay from the first record, which must be the Header -
+    /// anything else means this isn't a run journal, and the replay visits
+    /// nothing (`None`).
+    fn start(first: &RunRecord) -> Option<Self> {
+        match first {
+            RunRecord::Header { meta, .. } => Some(Self {
+                meta: (**meta).clone(),
+                context: ContextSnapshot {
+                    stage_name: String::new(),
+                    total_tokens: 0,
+                    max_tokens: 0,
+                    regions: Vec::new(),
+                },
+                index: 0,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Fold one record; when it produces a timeline point, lend it to `visit`.
+    fn push(
+        &mut self,
+        record: &RunRecord,
+        visit: &mut dyn FnMut(PointRef<'_>) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
         let at = match record {
             RunRecord::Header { meta: m, .. } => {
-                meta = (**m).clone();
-                continue;
+                self.meta = (**m).clone();
+                return ControlFlow::Continue(());
             }
             RunRecord::StatusChanged { status, .. } => {
-                meta.status = status.clone();
-                continue;
+                self.meta.status = status.clone();
+                return ControlFlow::Continue(());
             }
             RunRecord::ContextCheckpoint { snapshot, at } => {
-                context = snapshot.clone();
+                self.context = snapshot.clone();
                 *at
             }
             RunRecord::ContextDiff { delta, at } => {
-                apply_delta(&mut context, delta);
+                apply_delta(&mut self.context, delta);
                 *at
             }
             RunRecord::Checkpoint {
@@ -856,13 +922,13 @@ pub fn visit_points(records: &[RunRecord], visit: &mut dyn FnMut(PointRef<'_>) -
                 context: c,
                 at,
             } => {
-                meta = (**m).clone();
-                context = c.clone();
+                self.meta = (**m).clone();
+                self.context = c.clone();
                 *at
             }
             RunRecord::Progress { meta: m, delta, at } => {
-                meta = (**m).clone();
-                apply_delta(&mut context, delta);
+                self.meta = (**m).clone();
+                apply_delta(&mut self.context, delta);
                 *at
             }
             // Non-context records don't add a timeline point.
@@ -870,18 +936,16 @@ pub fn visit_points(records: &[RunRecord], visit: &mut dyn FnMut(PointRef<'_>) -
             | RunRecord::Inference { .. }
             | RunRecord::ToolBatch { .. }
             | RunRecord::ToolCallDone { .. }
-            | RunRecord::Message { .. } => continue,
+            | RunRecord::Message { .. } => return ControlFlow::Continue(()),
         };
         let flow = visit(PointRef {
-            index,
+            index: self.index,
             at,
-            meta: &meta,
-            context: &context,
+            meta: &self.meta,
+            context: &self.context,
         });
-        index += 1;
-        if flow.is_break() {
-            return;
-        }
+        self.index += 1;
+        flow
     }
 }
 
@@ -1071,6 +1135,119 @@ mod tests {
         let delta = diff_context(&a, &b);
         assert_eq!(region_delta_kind(&delta.regions[0]), "set");
         assert_diff_roundtrip(&a, &b);
+    }
+
+    // ── streaming point replay ──
+
+    /// Frame `records` exactly as `run.lvr` stores them.
+    fn framed(records: &[RunRecord]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        for record in records {
+            write_record(&mut buf, record).unwrap();
+        }
+        buf
+    }
+
+    /// Collect `(index, at, total_tokens)` per visited point.
+    fn collect_streamed(bytes: &[u8]) -> Vec<(usize, i64, usize)> {
+        let mut seen = Vec::new();
+        visit_archive_points(&mut &bytes[..], &mut |p| {
+            seen.push((p.index, p.at, p.context.total_tokens));
+            ControlFlow::Continue(())
+        })
+        .unwrap();
+        seen
+    }
+
+    #[test]
+    fn visit_archive_points_matches_visit_points() {
+        let records = vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 10,
+            },
+            RunRecord::StatusChanged {
+                status: RunStatus::Running,
+                at: 11,
+            },
+            RunRecord::Progress {
+                meta: Box::new(meta()),
+                delta: diff_context(
+                    &snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]),
+                    &snapshot(
+                        "s1",
+                        vec![region("conv", vec![entry("hi", 1), entry("more", 2)])],
+                    ),
+                ),
+                at: 12,
+            },
+        ];
+        let mut in_memory = Vec::new();
+        visit_points(&records, &mut |p| {
+            in_memory.push((p.index, p.at, p.context.total_tokens));
+            ControlFlow::Continue(())
+        });
+        assert_eq!(collect_streamed(&framed(&records)), in_memory);
+        assert_eq!(in_memory.len(), 2, "checkpoint + progress = two points");
+    }
+
+    #[test]
+    fn visit_archive_points_rejects_a_bad_preamble() {
+        let mut bogus: &[u8] = b"not an archive at all";
+        let result = visit_archive_points(&mut bogus, &mut |_| ControlFlow::Continue(()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn visit_archive_points_is_lenient_about_a_torn_tail() {
+        let records = vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]),
+                at: 10,
+            },
+        ];
+        let mut bytes = framed(&records);
+        // A torn frame: a length prefix promising more than exists.
+        bytes.extend_from_slice(&1000u64.to_be_bytes());
+        bytes.extend_from_slice(b"partial");
+        assert_eq!(collect_streamed(&bytes).len(), 1, "points before the tear");
+    }
+
+    #[test]
+    fn visit_archive_points_visits_nothing_without_a_header() {
+        let records = vec![RunRecord::ContextCheckpoint {
+            snapshot: snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]),
+            at: 10,
+        }];
+        assert!(collect_streamed(&framed(&records)).is_empty());
+        // And an archive with no records at all visits nothing.
+        assert!(collect_streamed(&framed(&[])).is_empty());
+    }
+
+    #[test]
+    fn visit_archive_points_stops_on_break() {
+        let records = vec![
+            header(),
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("s1", vec![region("conv", vec![entry("a", 1)])]),
+                at: 10,
+            },
+            RunRecord::ContextCheckpoint {
+                snapshot: snapshot("s1", vec![region("conv", vec![entry("b", 2)])]),
+                at: 11,
+            },
+        ];
+        let bytes = framed(&records);
+        let mut seen = 0;
+        visit_archive_points(&mut &bytes[..], &mut |_| {
+            seen += 1;
+            ControlFlow::Break(())
+        })
+        .unwrap();
+        assert_eq!(seen, 1);
     }
 
     // ── digest-based diffing ──

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -342,6 +342,137 @@ pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDe
     }
 }
 
+// ─── digest-based diffing ───────────────────────────────────────────────────
+//
+// `diff_context` needs the previous snapshot only to answer two questions per
+// region: "did anything change?" and "did it change by appending at the tail?".
+// A per-entry fingerprint answers both, so the writer can retain this digest
+// instead of a full copy of every live run's context window (which doubled the
+// per-run resident cost of the persistence lane).
+
+/// Fingerprint of one region: everything `diff_context` compares except the
+/// entry contents themselves, which are folded into per-entry hashes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegionDigest {
+    /// The region name.
+    pub name: String,
+    /// The region's stringified kind.
+    pub kind: String,
+    /// The region's token count at digest time.
+    pub current_tokens: usize,
+    /// The region's token budget at digest time.
+    pub max_tokens: usize,
+    /// One hash per entry, in order.
+    pub entries: Vec<u64>,
+}
+
+/// Fingerprint of a whole context window, cheap to retain per live run.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ContextDigest {
+    /// Per-region fingerprints, in snapshot order.
+    pub regions: Vec<RegionDigest>,
+}
+
+/// Hash one region entry. Every field participates: two entries that differ
+/// anywhere must digest differently, or a real change would be recorded as
+/// "unchanged" and the folded archive would silently drift from the run.
+fn entry_digest(entry: &RegionEntrySnapshot) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    entry.content.hash(&mut hasher);
+    entry.tokens.hash(&mut hasher);
+    entry.key.hash(&mut hasher);
+    // kind / metadata / taint are small enums and values without a Hash impl;
+    // their serialized form is tiny next to `content` and hashes faithfully.
+    serde_json::to_string(&entry.kind)
+        .expect("EntryKind always serializes")
+        .hash(&mut hasher);
+    serde_json::to_string(&entry.metadata)
+        .expect("entry metadata always serializes")
+        .hash(&mut hasher);
+    serde_json::to_string(&entry.taint)
+        .expect("taint always serializes")
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Compute the retained fingerprint of `snapshot`.
+pub fn digest_context(snapshot: &ContextSnapshot) -> ContextDigest {
+    ContextDigest {
+        regions: snapshot
+            .regions
+            .iter()
+            .map(|r| RegionDigest {
+                name: r.name.clone(),
+                kind: r.kind.clone(),
+                current_tokens: r.current_tokens,
+                max_tokens: r.max_tokens,
+                entries: r.entries.iter().map(entry_digest).collect(),
+            })
+            .collect(),
+    }
+}
+
+/// Whether `prev`'s entry hashes are a prefix of `next`'s entries.
+fn is_prefix_digest(prev: &[u64], next: &[RegionEntrySnapshot]) -> bool {
+    prev.len() <= next.len()
+        && prev
+            .iter()
+            .zip(next)
+            .all(|(hash, entry)| *hash == entry_digest(entry))
+}
+
+/// [`diff_context`] against a retained [`ContextDigest`] instead of a full
+/// previous snapshot. Produces the same delta shapes for the same changes:
+/// unchanged regions emit nothing, tail growth becomes `Append`, everything
+/// else `Set`/`Clear`/`Remove`.
+pub fn diff_context_digest(prev: &ContextDigest, next: &ContextSnapshot) -> ContextDelta {
+    let mut regions = Vec::new();
+    for nr in &next.regions {
+        match prev.regions.iter().find(|r| r.name == nr.name) {
+            None => regions.push(RegionDelta::Set(nr.clone())),
+            Some(pr) => {
+                let unchanged = pr.kind == nr.kind
+                    && pr.max_tokens == nr.max_tokens
+                    && pr.current_tokens == nr.current_tokens
+                    && pr.entries.len() == nr.entries.len()
+                    && is_prefix_digest(&pr.entries, &nr.entries);
+                if unchanged {
+                    // emit nothing
+                } else if nr.entries.is_empty() && !pr.entries.is_empty() {
+                    regions.push(RegionDelta::Clear {
+                        name: nr.name.clone(),
+                    });
+                } else if pr.kind == nr.kind
+                    && pr.max_tokens == nr.max_tokens
+                    && is_prefix_digest(&pr.entries, &nr.entries)
+                {
+                    regions.push(RegionDelta::Append {
+                        name: nr.name.clone(),
+                        entries: nr.entries[pr.entries.len()..].to_vec(),
+                        current_tokens: nr.current_tokens,
+                    });
+                } else {
+                    regions.push(RegionDelta::Set(nr.clone()));
+                }
+            }
+        }
+    }
+    for pr in &prev.regions {
+        if !next.regions.iter().any(|r| r.name == pr.name) {
+            regions.push(RegionDelta::Remove {
+                name: pr.name.clone(),
+            });
+        }
+    }
+    ContextDelta {
+        stage_name: next.stage_name.clone(),
+        total_tokens: next.total_tokens,
+        max_tokens: next.max_tokens,
+        regions,
+    }
+}
+
 /// Apply a [`ContextDelta`] to `base` in place. Lenient: a delta referencing a
 /// region that isn't present is skipped rather than erroring, so folding never
 /// fails on a malformed diff.
@@ -940,6 +1071,128 @@ mod tests {
         let delta = diff_context(&a, &b);
         assert_eq!(region_delta_kind(&delta.regions[0]), "set");
         assert_diff_roundtrip(&a, &b);
+    }
+
+    // ── digest-based diffing ──
+    //
+    // `diff_context_digest(digest(a), b)` must produce the same delta as
+    // `diff_context(a, b)` for every shape: the persistence lane retains only
+    // the digest, and any divergence would silently corrupt the archive.
+
+    fn assert_digest_matches_full_diff(a: &ContextSnapshot, b: &ContextSnapshot) {
+        let via_digest = diff_context_digest(&digest_context(a), b);
+        assert_eq!(via_digest, diff_context(a, b));
+        // And the digest-produced delta still round-trips.
+        let mut base = a.clone();
+        apply_delta(&mut base, &via_digest);
+        assert_eq!(&base, b);
+    }
+
+    #[test]
+    fn digest_diff_append_only_growth_is_compact() {
+        let a = snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]);
+        let b = snapshot(
+            "s1",
+            vec![region("conv", vec![entry("hi", 1), entry("there", 2)])],
+        );
+        let delta = diff_context_digest(&digest_context(&a), &b);
+        assert_eq!(region_delta_kind(&delta.regions[0]), "append");
+        assert_digest_matches_full_diff(&a, &b);
+    }
+
+    #[test]
+    fn digest_diff_new_cleared_removed_and_rewritten_regions() {
+        let a = snapshot(
+            "s1",
+            vec![
+                region("conv", vec![entry("hi", 1)]),
+                region("gone", vec![entry("bye", 1)]),
+                region("wiped", vec![entry("w", 1)]),
+                region("rewritten", vec![entry("old", 1)]),
+            ],
+        );
+        let b = snapshot(
+            "s1",
+            vec![
+                region("conv", vec![entry("hi", 1)]),
+                region("wiped", vec![]),
+                region("rewritten", vec![entry("new", 1)]),
+                region("fresh", vec![entry("f", 2)]),
+            ],
+        );
+        let delta = diff_context_digest(&digest_context(&a), &b);
+        let kinds: Vec<_> = delta.regions.iter().map(region_delta_kind).collect();
+        assert_eq!(kinds, vec!["clear", "set", "set", "remove"]);
+        assert_digest_matches_full_diff(&a, &b);
+    }
+
+    #[test]
+    fn digest_diff_unchanged_region_emits_nothing() {
+        let a = snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]);
+        let delta = diff_context_digest(&digest_context(&a), &a.clone());
+        assert!(delta.regions.is_empty());
+        assert_digest_matches_full_diff(&a, &a.clone());
+    }
+
+    #[test]
+    fn digest_diff_kind_change_is_set_not_append() {
+        let a = snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]);
+        let mut grown = region("conv", vec![entry("hi", 1), entry("more", 1)]);
+        grown.kind = "sliding".to_string();
+        let b = snapshot("s1", vec![grown]);
+        let delta = diff_context_digest(&digest_context(&a), &b);
+        assert_eq!(region_delta_kind(&delta.regions[0]), "set");
+        assert_digest_matches_full_diff(&a, &b);
+    }
+
+    /// A token-count change with identical entries is still an (empty) Append
+    /// carrying the new count, exactly as the full diff records it.
+    #[test]
+    fn digest_diff_token_recount_is_an_empty_append() {
+        let a = snapshot("s1", vec![region("conv", vec![entry("hi", 1)])]);
+        let mut recounted = region("conv", vec![entry("hi", 1)]);
+        recounted.current_tokens = 42;
+        let b = snapshot("s1", vec![recounted]);
+        let delta = diff_context_digest(&digest_context(&a), &b);
+        assert_eq!(region_delta_kind(&delta.regions[0]), "append");
+        assert_digest_matches_full_diff(&a, &b);
+    }
+
+    /// Every field of an entry participates in its digest: a change anywhere
+    /// must change the hash, or a real edit would fold as "unchanged".
+    #[test]
+    fn entry_digest_covers_every_field() {
+        let base = entry("text", 1);
+        let variants = [
+            entry("other", 1),
+            entry("text", 2),
+            RegionEntrySnapshot {
+                key: Some("k".to_string()),
+                ..entry("text", 1)
+            },
+            RegionEntrySnapshot {
+                metadata: Some(serde_json::json!({"a": 1})),
+                ..entry("text", 1)
+            },
+            RegionEntrySnapshot {
+                kind: crate::region::EntryKind::ToolResult {
+                    tool_call_id: "c1".to_string(),
+                    tool_name: "shell".to_string(),
+                    is_error: false,
+                },
+                ..entry("text", 1)
+            },
+        ];
+        let base_hash = entry_digest(&base);
+        for variant in &variants {
+            assert_ne!(
+                entry_digest(variant),
+                base_hash,
+                "field change must change the digest: {variant:?}"
+            );
+        }
+        // And digesting the same entry twice is stable.
+        assert_eq!(entry_digest(&base), entry_digest(&entry("text", 1)));
     }
 
     #[test]

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -540,14 +540,14 @@ impl AnthropicProvider {
 
 #[async_trait]
 impl Provider for AnthropicProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         tracing::debug!(model = %request.model, "Calling Anthropic API");
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.acquire().await?;
         }
 
-        let body = self.build_request_body(&request);
+        let body = self.build_request_body(request);
         maybe_dump_request(&body);
         let url = format!("{}/messages", self.base_url);
 
@@ -614,7 +614,7 @@ impl Provider for AnthropicProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         tracing::debug!(model = %request.model, "Calling Anthropic API (streaming)");
 
@@ -622,7 +622,7 @@ impl Provider for AnthropicProvider {
             limiter.acquire().await?;
         }
 
-        let mut body = self.build_request_body(&request);
+        let mut body = self.build_request_body(request);
         body["stream"] = serde_json::Value::Bool(true);
         maybe_dump_request(&body);
         let url = format!("{}/messages", self.base_url);
@@ -2317,7 +2317,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        let result = provider.infer(request).await;
+        let result = provider.infer(&request).await;
         assert!(result.is_err());
         assert!(
             result
@@ -2351,7 +2351,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        assert!(provider.infer_stream(request).await.is_err());
+        assert!(provider.infer_stream(&request).await.is_err());
     }
 
     #[tokio::test]
@@ -2535,7 +2535,7 @@ mod tests {
         }"#;
         let url = spawn_mock_server(200, "OK", body).await;
         let provider = provider_with_url(url);
-        let resp = provider.infer(simple_request()).await.unwrap();
+        let resp = provider.infer(&simple_request()).await.unwrap();
         assert_eq!(resp.content, "hello there");
         assert_eq!(resp.tokens_used.prompt_tokens, 10);
         assert_eq!(resp.tokens_used.completion_tokens, 5);
@@ -2545,7 +2545,7 @@ mod tests {
     async fn infer_rate_limited_returns_rate_limit_error() {
         let url = spawn_mock_server(429, "Too Many Requests", b"{}").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert_eq!(
             std::mem::discriminant(&err),
             std::mem::discriminant(&ProviderError::RateLimitExceeded)
@@ -2558,7 +2558,7 @@ mod tests {
             spawn_mock_server_with_headers(429, "Too Many Requests", "retry-after: 5\r\n", b"{}")
                 .await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert_eq!(
             std::mem::discriminant(&err),
             std::mem::discriminant(&ProviderError::RateLimitExceeded)
@@ -2570,7 +2570,7 @@ mod tests {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
         let provider = provider_with_url(url);
         let msg = provider
-            .infer(simple_request())
+            .infer(&simple_request())
             .await
             .unwrap_err()
             .to_string();
@@ -2593,7 +2593,7 @@ mod tests {
         let url = spawn_mock_server_truncated_error_body(500, "Internal Server Error").await;
         let provider = provider_with_url(url);
         let msg = provider
-            .infer(simple_request())
+            .infer(&simple_request())
             .await
             .unwrap_err()
             .to_string();
@@ -2604,7 +2604,7 @@ mod tests {
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().starts_with("Invalid response:"));
     }
 
@@ -2612,7 +2612,7 @@ mod tests {
     async fn infer_stream_rate_limited_returns_error() {
         let url = spawn_mock_server(429, "Too Many Requests", b"{}").await;
         let provider = provider_with_url(url);
-        assert!(provider.infer_stream(simple_request()).await.is_err());
+        assert!(provider.infer_stream(&simple_request()).await.is_err());
     }
 
     #[tokio::test]
@@ -2621,14 +2621,14 @@ mod tests {
             spawn_mock_server_with_headers(429, "Too Many Requests", "retry-after: 5\r\n", b"{}")
                 .await;
         let provider = provider_with_url(url);
-        assert!(provider.infer_stream(simple_request()).await.is_err());
+        assert!(provider.infer_stream(&simple_request()).await.is_err());
     }
 
     #[tokio::test]
     async fn infer_stream_non_success_status_returns_api_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
         let provider = provider_with_url(url);
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("503"));
     }
@@ -2637,7 +2637,7 @@ mod tests {
     async fn infer_stream_non_success_status_body_read_error_falls_back_to_unknown_error() {
         let url = spawn_mock_server_truncated_error_body(503, "Service Unavailable").await;
         let provider = provider_with_url(url);
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("503"));
     }
@@ -2650,7 +2650,7 @@ mod tests {
         let sse_body = b"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n";
         let url = spawn_mock_server(200, "OK", sse_body).await;
         let provider = provider_with_url(url);
-        let mut stream = provider.infer_stream(simple_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&simple_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
@@ -2809,7 +2809,7 @@ mod tests {
         });
 
         let provider = provider_with_url(format!("http://{}", addr));
-        let mut stream = provider.infer_stream(simple_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&simple_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let result = stream.next().await;
         assert!(result.is_some());

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -174,13 +174,13 @@ impl ClaudeCodeProvider {
     /// failure branches without a real 5-minute wait or a full disk.
     async fn infer_with_timeout(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
         temp_dir: &std::path::Path,
         timeout_duration: std::time::Duration,
     ) -> Result<InferenceResponse> {
         // The system prompt goes via a file (it routinely exceeds Linux's 128 KB
         // cap on a single argv entry), and the transcript via stdin (same reason).
-        let prompt_file = stage_prompt_file(temp_dir, &Self::build_system_prompt(&request))
+        let prompt_file = stage_prompt_file(temp_dir, &Self::build_system_prompt(request))
             .map_err(prompt_file_error)?;
 
         let mut cmd = tokio::process::Command::new(&self.binary_path);
@@ -432,7 +432,7 @@ async fn retry_etxtbsy<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io
 
 #[async_trait]
 impl Provider for ClaudeCodeProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         // Honor a per-stage `request_timeout_secs`; fall back to the shared
         // default so this provider is bounded the same way as the HTTP ones.
         let timeout = std::time::Duration::from_secs(
@@ -990,7 +990,7 @@ mod tests {
             "echo {\"result\": \"hello from stub\", \"usage\": {\"input_tokens\": 3, \"output_tokens\": 2}}",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let resp = provider.infer(make_request()).await.unwrap();
+        let resp = provider.infer(&make_request()).await.unwrap();
         assert_eq!(resp.content, "hello from stub");
         let _ = std::fs::remove_file(&script);
     }
@@ -1045,7 +1045,7 @@ mod tests {
         assert!(argv.contains("--system-prompt-file"));
         assert!(argv.contains("--effort medium"));
         // And the provider itself still completes against the same stub.
-        assert_eq!(provider.infer(make_request()).await.unwrap().content, "ok");
+        assert_eq!(provider.infer(&make_request()).await.unwrap().content, "ok");
         let _ = std::fs::remove_file(&script);
     }
 
@@ -1059,7 +1059,7 @@ mod tests {
             "set /p P=\r\necho {\"result\": \"saw:%P%\"}",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let resp = provider.infer(make_request()).await.unwrap();
+        let resp = provider.infer(&make_request()).await.unwrap();
         assert!(resp.content.contains("User: hi"), "got {:?}", resp.content);
         let _ = std::fs::remove_file(&script);
     }
@@ -1078,7 +1078,7 @@ mod tests {
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
         let err = provider
             .infer_with_timeout(
-                make_request(),
+                &make_request(),
                 &std::env::temp_dir(),
                 std::time::Duration::from_millis(100),
             )
@@ -1101,7 +1101,7 @@ mod tests {
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
         let mut request = make_request();
         request.request_timeout_secs = Some(1);
-        let err = provider.infer(request).await.unwrap_err();
+        let err = provider.infer(&request).await.unwrap_err();
         assert!(err.to_string().contains("timed out"), "{err}");
         let _ = std::fs::remove_file(&script);
     }
@@ -1114,7 +1114,7 @@ mod tests {
         let provider = ClaudeCodeProvider::new();
         let missing = std::env::temp_dir().join("lev-cc-infer-no-dir-7z8y9");
         let err = provider
-            .infer_with_timeout(make_request(), &missing, std::time::Duration::from_secs(5))
+            .infer_with_timeout(&make_request(), &missing, std::time::Duration::from_secs(5))
             .await
             .unwrap_err();
         assert!(
@@ -1142,7 +1142,7 @@ mod tests {
         let mut req = make_request();
         // >1 MiB so the write cannot be swallowed whole by the pipe buffer.
         req.messages[0].content = "x".repeat(2 * 1024 * 1024).into();
-        let err = provider.infer(req).await.unwrap_err();
+        let err = provider.infer(&req).await.unwrap_err();
         assert!(
             err.to_string().contains("boom"),
             "the child's stderr must survive an undrained stdin; got: {err}"
@@ -1158,7 +1158,7 @@ mod tests {
             "echo {\"is_error\": true, \"result\": \"bad request\"}",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let err = provider.infer(make_request()).await.unwrap_err();
+        let err = provider.infer(&make_request()).await.unwrap_err();
         assert!(err.to_string().contains("bad request"));
         let _ = std::fs::remove_file(&script);
     }
@@ -1171,7 +1171,7 @@ mod tests {
             "echo boom 1>&2\r\nexit /b 1",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let err = provider.infer(make_request()).await.unwrap_err();
+        let err = provider.infer(&make_request()).await.unwrap_err();
         assert!(err.to_string().contains("boom"));
         let _ = std::fs::remove_file(&script);
     }
@@ -1184,7 +1184,7 @@ mod tests {
             "echo not json at all",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let err = provider.infer(make_request()).await.unwrap_err();
+        let err = provider.infer(&make_request()).await.unwrap_err();
         assert!(err.to_string().starts_with("Invalid response:"), "{err}");
         assert!(!err.is_transient());
         let _ = std::fs::remove_file(&script);
@@ -1242,7 +1242,7 @@ mod tests {
         let provider = ClaudeCodeProvider::with_binary_path(
             "/nonexistent/definitely/not/a/real/binary".to_string(),
         );
-        let err = provider.infer(make_request()).await.unwrap_err();
+        let err = provider.infer(&make_request()).await.unwrap_err();
         assert!(err.to_string().contains("Is Claude Code installed?"));
         assert!(
             !err.is_transient(),
@@ -1269,7 +1269,7 @@ mod tests {
             description: "read a file".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         }];
-        let resp = provider.infer(req).await.unwrap();
+        let resp = provider.infer(&req).await.unwrap();
         assert_eq!(resp.content, "On it.");
         assert_eq!(resp.tool_calls.len(), 1);
         assert_eq!(resp.tool_calls[0].name, "read_file");
@@ -1298,7 +1298,7 @@ mod tests {
             drop(holder);
         });
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let resp = provider.infer(make_request()).await.unwrap();
+        let resp = provider.infer(&make_request()).await.unwrap();
         assert_eq!(resp.content, "hello from stub");
         release.await.unwrap();
         let _ = std::fs::remove_file(&script);
@@ -1317,7 +1317,7 @@ mod tests {
             "echo {\"result\": \"streamed\"}",
         );
         let provider = ClaudeCodeProvider::with_binary_path(script.to_str().unwrap().to_string());
-        let mut stream = provider.infer_stream(make_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&make_request()).await.unwrap();
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "streamed");
         assert!(stream.next().await.is_none());

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -187,14 +187,14 @@ impl GeminiProvider {
 
 #[async_trait]
 impl Provider for GeminiProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         tracing::debug!(model = %request.model, "Calling Gemini API");
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.acquire().await?;
         }
 
-        let body = build_openai_request_body(&request);
+        let body = build_openai_request_body(request);
         let url = format!("{}/chat/completions", self.base_url);
 
         let response = send_chat_request(
@@ -227,7 +227,7 @@ impl Provider for GeminiProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         tracing::debug!(model = %request.model, "Calling Gemini API (streaming)");
 
@@ -235,7 +235,7 @@ impl Provider for GeminiProvider {
             limiter.acquire().await?;
         }
 
-        let mut body = build_openai_request_body(&request);
+        let mut body = build_openai_request_body(request);
         body["stream"] = serde_json::Value::Bool(true);
         body["stream_options"] = serde_json::json!({ "include_usage": true });
         let url = format!("{}/chat/completions", self.base_url);
@@ -815,7 +815,7 @@ mod tests {
         let body = br#"{"choices":[{"message":{"content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
         let url = spawn_mock_server(200, "OK", body).await;
         let provider = provider_with_url(url);
-        let resp = provider.infer(simple_request()).await.unwrap();
+        let resp = provider.infer(&simple_request()).await.unwrap();
         assert_eq!(resp.content, "hi there");
     }
 
@@ -823,7 +823,7 @@ mod tests {
     async fn infer_non_success_status_returns_error() {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("API error:"));
     }
 
@@ -831,7 +831,7 @@ mod tests {
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
 
@@ -839,7 +839,7 @@ mod tests {
     async fn infer_stream_non_success_status_returns_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
         let provider = provider_with_url(url);
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("API error:"));
     }
@@ -853,7 +853,7 @@ mod tests {
             b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
         let url = spawn_mock_server(200, "OK", sse_body).await;
         let provider = provider_with_url(url);
-        let mut stream = provider.infer_stream(simple_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&simple_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
@@ -920,14 +920,14 @@ mod tests {
     #[tokio::test]
     async fn infer_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Request failed:"));
     }
 
     #[tokio::test]
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(
             result
                 .err()

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -275,10 +275,10 @@ impl Default for OllamaProvider {
 
 #[async_trait]
 impl Provider for OllamaProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         tracing::debug!(model = %request.model, "Calling Ollama API");
 
-        let mut body = self.build_request_body(&request);
+        let mut body = self.build_request_body(request);
         body["stream"] = serde_json::Value::Bool(false);
         let url = format!("{}/api/chat", self.base_url);
 
@@ -330,11 +330,11 @@ impl Provider for OllamaProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         tracing::debug!(model = %request.model, "Calling Ollama API (streaming)");
 
-        let mut body = self.build_request_body(&request);
+        let mut body = self.build_request_body(request);
         body["stream"] = serde_json::Value::Bool(true);
         let url = format!("{}/api/chat", self.base_url);
 
@@ -1379,7 +1379,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        let result = provider.infer(request).await;
+        let result = provider.infer(&request).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("Request failed:"));
@@ -1402,7 +1402,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        let result = provider.infer_stream(request).await;
+        let result = provider.infer_stream(&request).await;
         assert!(
             result
                 .err()
@@ -1927,7 +1927,7 @@ mod tests {
     async fn infer_non_success_status_returns_api_error() {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
         let provider = OllamaProvider::with_base_url(url);
-        let err = provider.infer(mock_request()).await.unwrap_err();
+        let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("API error:"));
     }
 
@@ -1937,7 +1937,7 @@ mod tests {
         // error for it. The status is what matters and must survive.
         let url = spawn_mock_server_truncated_error_body(500, "Internal Server Error").await;
         let provider = OllamaProvider::with_base_url(url);
-        let err = provider.infer(mock_request()).await.unwrap_err();
+        let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("500"), "{err}");
     }
 
@@ -1945,7 +1945,7 @@ mod tests {
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
         let provider = OllamaProvider::with_base_url(url);
-        let err = provider.infer(mock_request()).await.unwrap_err();
+        let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
 
@@ -1953,7 +1953,7 @@ mod tests {
     async fn infer_stream_non_success_status_returns_api_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
         let provider = OllamaProvider::with_base_url(url);
-        let result = provider.infer_stream(mock_request()).await;
+        let result = provider.infer_stream(&mock_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("API error:"));
     }
@@ -1962,7 +1962,7 @@ mod tests {
     async fn infer_stream_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(503, "Service Unavailable").await;
         let provider = OllamaProvider::with_base_url(url);
-        let result = provider.infer_stream(mock_request()).await;
+        let result = provider.infer_stream(&mock_request()).await;
         let err = result
             .err()
             .expect("a truncated error body is still an error");
@@ -1975,7 +1975,7 @@ mod tests {
             b"{\"message\":{\"content\":\"hi\"},\"done\":true,\"eval_count\":1,\"prompt_eval_count\":1}\n";
         let url = spawn_mock_server(200, "OK", ndjson_body).await;
         let provider = OllamaProvider::with_base_url(url);
-        let mut stream = provider.infer_stream(mock_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&mock_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
@@ -2003,7 +2003,7 @@ mod tests {
             let _ = socket.shutdown().await;
         });
         let provider = OllamaProvider::with_base_url(format!("http://{}", addr));
-        let mut stream = provider.infer_stream(mock_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&mock_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let mut saw_error = false;
         while let Some(item) = stream.next().await {

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -126,14 +126,14 @@ impl OpenAIProvider {
 
 #[async_trait]
 impl Provider for OpenAIProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         tracing::debug!(model = %request.model, "Calling OpenAI API");
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.acquire().await?;
         }
 
-        let body = build_openai_request_body(&request);
+        let body = build_openai_request_body(request);
         let url = format!("{}/chat/completions", self.base_url);
 
         let response = send_chat_request(
@@ -166,7 +166,7 @@ impl Provider for OpenAIProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         tracing::debug!(model = %request.model, "Calling OpenAI API (streaming)");
 
@@ -174,7 +174,7 @@ impl Provider for OpenAIProvider {
             limiter.acquire().await?;
         }
 
-        let mut body = build_openai_request_body(&request);
+        let mut body = build_openai_request_body(request);
         body["stream"] = serde_json::Value::Bool(true);
         body["stream_options"] = serde_json::json!({ "include_usage": true });
         let url = format!("{}/chat/completions", self.base_url);
@@ -658,7 +658,7 @@ mod tests {
         let body = br#"{"choices":[{"message":{"content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
         let url = spawn_mock_server(200, "OK", body).await;
         let provider = provider_with_url(url);
-        let resp = provider.infer(simple_request()).await.unwrap();
+        let resp = provider.infer(&simple_request()).await.unwrap();
         assert_eq!(resp.content, "hi there");
     }
 
@@ -666,7 +666,7 @@ mod tests {
     async fn infer_non_success_status_returns_error() {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("API error:"));
     }
 
@@ -674,7 +674,7 @@ mod tests {
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
 
@@ -682,7 +682,7 @@ mod tests {
     async fn infer_stream_non_success_status_returns_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
         let provider = provider_with_url(url);
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("API error:"));
     }
@@ -696,7 +696,7 @@ mod tests {
             b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
         let url = spawn_mock_server(200, "OK", sse_body).await;
         let provider = provider_with_url(url);
-        let mut stream = provider.infer_stream(simple_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&simple_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
@@ -763,14 +763,14 @@ mod tests {
     #[tokio::test]
     async fn infer_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Request failed:"));
     }
 
     #[tokio::test]
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(
             result
                 .err()

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -161,14 +161,14 @@ impl OpenRouterProvider {
 
 #[async_trait]
 impl Provider for OpenRouterProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         tracing::debug!(model = %request.model, "Calling OpenRouter API");
 
         if let Some(limiter) = &self.rate_limiter {
             limiter.acquire().await?;
         }
 
-        let body = self.build_request_body(&request);
+        let body = self.build_request_body(request);
         let url = format!("{}/chat/completions", self.base_url);
 
         let response = send_chat_request(
@@ -206,7 +206,7 @@ impl Provider for OpenRouterProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         tracing::debug!(model = %request.model, "Calling OpenRouter API (streaming)");
 
@@ -214,7 +214,7 @@ impl Provider for OpenRouterProvider {
             limiter.acquire().await?;
         }
 
-        let mut body = self.build_request_body(&request);
+        let mut body = self.build_request_body(request);
         body["stream"] = serde_json::Value::Bool(true);
         let url = format!("{}/chat/completions", self.base_url);
 
@@ -1018,7 +1018,7 @@ mod tests {
         let body = br#"{"choices":[{"message":{"content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
         let url = spawn_mock_server(200, "OK", body).await;
         let provider = provider_with_url(url);
-        let resp = provider.infer(simple_request()).await.unwrap();
+        let resp = provider.infer(&simple_request()).await.unwrap();
         assert_eq!(resp.content, "hi there");
     }
 
@@ -1027,14 +1027,14 @@ mod tests {
     #[tokio::test]
     async fn infer_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Request failed:"));
     }
 
     #[tokio::test]
     async fn infer_stream_connection_refused_returns_error() {
         let provider = provider_with_url("http://127.0.0.1:19997".to_string());
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(
             result
                 .err()
@@ -1063,7 +1063,7 @@ mod tests {
     async fn infer_non_success_status_returns_api_error() {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("API error:"));
     }
 
@@ -1071,7 +1071,7 @@ mod tests {
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
         let provider = provider_with_url(url);
-        let err = provider.infer(simple_request()).await.unwrap_err();
+        let err = provider.infer(&simple_request()).await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
     async fn infer_stream_non_success_status_returns_api_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
         let provider = provider_with_url(url);
-        let result = provider.infer_stream(simple_request()).await;
+        let result = provider.infer_stream(&simple_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("API error:"));
     }
@@ -1093,7 +1093,7 @@ mod tests {
             b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
         let url = spawn_mock_server(200, "OK", sse_body).await;
         let provider = provider_with_url(url);
-        let mut stream = provider.infer_stream(simple_request()).await.unwrap();
+        let mut stream = provider.infer_stream(&simple_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -656,7 +656,7 @@ pub fn build_http_client(timeout_secs: Option<u64>) -> reqwest::Client {
 #[async_trait]
 pub trait Provider: Send + Sync {
     /// Execute inference with the given request.
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse>;
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse>;
 
     /// Execute streaming inference with the given request.
     ///
@@ -664,7 +664,7 @@ pub trait Provider: Send + Sync {
     /// Default implementation collects the full response from `infer()`.
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         let response = self.infer(request).await?;
         let chunk = StreamChunk {
@@ -1262,7 +1262,7 @@ mod tests {
 
     #[async_trait]
     impl Provider for MinimalProvider {
-        async fn infer(&self, _request: InferenceRequest) -> Result<InferenceResponse> {
+        async fn infer(&self, _request: &InferenceRequest) -> Result<InferenceResponse> {
             Ok(InferenceResponse {
                 content: "hello".to_string(),
                 tool_calls: vec![ToolCall {
@@ -1314,7 +1314,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        let mut stream = provider.infer_stream(request).await.unwrap();
+        let mut stream = provider.infer_stream(&request).await.unwrap();
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hello");
         assert_eq!(chunk.tool_calls.len(), 1);

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -311,12 +311,12 @@ fn collapse_chunk(response: InferenceResponse) -> StreamChunk {
 
 #[async_trait]
 impl Provider for RhaiProvider {
-    async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
         if let Some(rl) = &self.rate_limiter {
             rl.acquire().await?;
         }
-        let timeout = self.effective_timeout(&request);
-        let request_dyn = request_to_dynamic(&request);
+        let timeout = self.effective_timeout(request);
+        let request_dyn = request_to_dynamic(request);
         let state_dyn = (*self.state).clone();
         let ast = self.ast.clone();
 
@@ -341,7 +341,7 @@ impl Provider for RhaiProvider {
 
     async fn infer_stream(
         &self,
-        request: InferenceRequest,
+        request: &InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         if !self.has_stream {
             // No native `stream` fn: collapse a full inference into one chunk.
@@ -352,8 +352,8 @@ impl Provider for RhaiProvider {
         if let Some(rl) = &self.rate_limiter {
             rl.acquire().await?;
         }
-        let timeout = self.effective_timeout(&request);
-        let request_dyn = request_to_dynamic(&request);
+        let timeout = self.effective_timeout(request);
+        let request_dyn = request_to_dynamic(request);
         let state_dyn = (*self.state).clone();
         let ast = self.ast.clone();
 

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -161,7 +161,7 @@ fn from_source_initialize_receives_config() {
         no_env_allowlist(),
     )
     .unwrap();
-    let out = tokio_block(p.infer(request("ignored")));
+    let out = tokio_block(p.infer(&request("ignored")));
     assert_eq!(out.unwrap().content, "cfg-model");
 }
 
@@ -223,7 +223,7 @@ async fn infer_no_http() {
     );
     let exec = FakeExecutor::new();
     let p = build(&src, exec.clone()).unwrap();
-    let r = p.infer(request("m")).await.unwrap();
+    let r = p.infer(&request("m")).await.unwrap();
     assert_eq!(r.content, "hello");
     assert_eq!(r.tokens_used.total_tokens, 5);
     assert_eq!(r.finish_reason, FinishReason::Complete);
@@ -240,7 +240,7 @@ async fn infer_single_http_post() {
     );
     let exec = FakeExecutor::with_responses(vec![Ok("{\"text\":\"hi\",\"n\":7}".to_string())]);
     let p = build(&src, exec.clone()).unwrap();
-    let r = p.infer(request("gpt-x")).await.unwrap();
+    let r = p.infer(&request("gpt-x")).await.unwrap();
     assert_eq!(r.content, "hi");
     assert_eq!(r.tokens_used.total_tokens, 7);
     // The broker performed exactly one request with our header + body.
@@ -265,7 +265,7 @@ async fn infer_uses_two_arg_http_overloads() {
         Ok("{\"y\":\"2\"}".to_string()),
     ]);
     let p = build(&src, exec.clone()).unwrap();
-    let r = p.infer(request("m")).await.unwrap();
+    let r = p.infer(&request("m")).await.unwrap();
     assert_eq!(r.content, "12");
     let calls = exec.calls.lock().unwrap();
     assert_eq!(calls[0].headers.get("H").unwrap(), "v");
@@ -282,7 +282,7 @@ async fn infer_rate_limited_without_limiter() {
     let exec =
         FakeExecutor::with_responses(vec![Err(HostHttpError::RateLimited { retry_after: None })]);
     let p = build(&src, exec).unwrap();
-    let err = p.infer(request("m")).await.err().unwrap();
+    let err = p.infer(&request("m")).await.err().unwrap();
     assert!(matches!(err, ProviderError::RateLimitExceeded));
 }
 
@@ -299,7 +299,7 @@ async fn infer_multiple_http_calls() {
         Ok("{\"v\":\"y\"}".to_string()),
     ]);
     let p = build(&src, exec.clone()).unwrap();
-    let r = p.infer(request("m")).await.unwrap();
+    let r = p.infer(&request("m")).await.unwrap();
     assert_eq!(r.content, "xy");
     assert_eq!(exec.call_count(), 2);
 }
@@ -310,7 +310,7 @@ async fn infer_script_throw_maps_transient() {
         "{NOOP_INIT}fn inference(s, r) {{ throw #{{ message: \"upstream down\", transient: true }}; }}"
     );
     let p = build(&src, FakeExecutor::new()).unwrap();
-    let err = p.infer(request("m")).await.err().unwrap();
+    let err = p.infer(&request("m")).await.err().unwrap();
     assert!(err.is_transient());
     assert!(matches!(err, ProviderError::RequestFailed(m) if m == "upstream down"));
 }
@@ -331,7 +331,7 @@ async fn infer_http_429_maps_to_rate_limit() {
             tokens_per_minute: 100_000,
         }),
     );
-    let err = p.infer(request("m")).await.err().unwrap();
+    let err = p.infer(&request("m")).await.err().unwrap();
     assert!(matches!(err, ProviderError::RateLimitExceeded));
 }
 
@@ -351,7 +351,7 @@ async fn infer_http_api_error_propagates() {
             tokens_per_minute: 100_000,
         }),
     );
-    let err = p.infer(request("m")).await.err().unwrap();
+    let err = p.infer(&request("m")).await.err().unwrap();
     assert!(matches!(err, ProviderError::ApiError(_)));
 }
 
@@ -372,7 +372,7 @@ async fn infer_records_tokens_and_resets_backoff() {
             tokens_per_minute: 100_000,
         }),
     );
-    let r = p.infer(request("m")).await.unwrap();
+    let r = p.infer(&request("m")).await.unwrap();
     assert_eq!(r.tokens_used.total_tokens, 11);
 }
 
@@ -380,7 +380,7 @@ async fn infer_records_tokens_and_resets_backoff() {
 async fn infer_rejects_non_map_return() {
     let src = format!("{NOOP_INIT}fn inference(s, r) {{ [1, 2, 3] }}");
     let p = build(&src, FakeExecutor::new()).unwrap();
-    let err = p.infer(request("m")).await.err().unwrap();
+    let err = p.infer(&request("m")).await.err().unwrap();
     assert!(matches!(err, ProviderError::InvalidResponse(_)));
 }
 
@@ -514,7 +514,7 @@ async fn collect_stream(
     p: &RhaiProvider,
     req: InferenceRequest,
 ) -> Vec<Result<crate::provider::StreamChunk>> {
-    let mut s = p.infer_stream(req).await.unwrap();
+    let mut s = p.infer_stream(&req).await.unwrap();
     let mut out = Vec::new();
     while let Some(item) = s.next().await {
         out.push(item);
@@ -601,7 +601,7 @@ async fn stream_fallback_propagates_infer_error() {
         "{NOOP_INIT}fn inference(s, r) {{ throw #{{ message: \"nope\", transient: false }}; }}"
     );
     let p = build(&src, FakeExecutor::new()).unwrap();
-    let err = p.infer_stream(request("m")).await.err().unwrap();
+    let err = p.infer_stream(&request("m")).await.err().unwrap();
     assert!(matches!(err, ProviderError::Other(m) if m == "nope"));
 }
 
@@ -709,6 +709,6 @@ fn tokio_block_helper_used() {
     // freshly-built current-thread runtime).
     let src = format!("{NOOP_INIT}fn inference(s, r) {{ #{{ content: \"z\" }} }}");
     let p = build(&src, FakeExecutor::new()).unwrap();
-    let out = tokio_block(p.infer(request("m"))).unwrap();
+    let out = tokio_block(p.infer(&request("m"))).unwrap();
     assert_eq!(out.content, "z");
 }

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -67,7 +67,7 @@ pub async fn run_compaction_job(
     let mut summaries = Vec::new();
     let mut result = Ok(());
     for (region, request) in requests {
-        match tokio::time::timeout(deadline, provider.infer(request)).await {
+        match tokio::time::timeout(deadline, provider.infer(&request)).await {
             Ok(Ok(response)) => summaries.push((region, response.content)),
             Ok(Err(e)) => {
                 result = Err(e);
@@ -122,7 +122,7 @@ mod tests {
     impl Provider for Script {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             match self.out.lock().unwrap().pop_front() {
                 Some(Ok(text)) => Ok(InferenceResponse {
@@ -163,7 +163,7 @@ mod tests {
     impl Provider for Hang {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             std::future::pending().await
         }

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -526,7 +526,7 @@ mod tests {
     impl Provider for FakeProvider {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             if self.fail {
                 return Err(ProviderError::Other("boom".to_string()));

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -384,26 +384,44 @@ async fn dispatch(req: ControlRequest, op_tx: &UnboundedSender<ControlOp>) -> Co
     }
 }
 
-/// Stream [`WorldEvent`]s to a subscribed client until it disconnects (a write
-/// fails) or the broadcast channel closes. Lagged events are skipped.
-async fn stream_events<W>(
+/// Stream [`WorldEvent`]s to a subscribed client until it disconnects or the
+/// broadcast channel closes. Lagged events are skipped.
+///
+/// The read half is watched alongside the writes: a subscriber that hangs up
+/// is otherwise only noticed when the *next* event's write fails, and an idle
+/// daemon may not produce one for hours - each such half-dead connection
+/// parked a task and a `broadcast::Receiver` here for the daemon's life
+/// (serve's polling loop re-subscribes every 500ms after a drop, and the ACP
+/// client subscribes once per prompt turn, so these accumulated fast).
+async fn stream_events<R, W>(
+    read: &mut tokio::io::Lines<BufReader<R>>,
     write: &mut W,
     mut rx: broadcast::Receiver<WorldEvent>,
 ) -> std::io::Result<()>
 where
+    R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
     loop {
-        match rx.recv().await {
-            Ok(event) => {
-                let mut line = serde_json::to_string(&event).expect("WorldEvent serializes");
-                line.push('\n');
-                if write.write_all(line.as_bytes()).await.is_err() {
-                    return Ok(()); // client hung up
+        tokio::select! {
+            event = rx.recv() => match event {
+                Ok(event) => {
+                    let mut line = serde_json::to_string(&event).expect("WorldEvent serializes");
+                    line.push('\n');
+                    if write.write_all(line.as_bytes()).await.is_err() {
+                        return Ok(()); // client hung up
+                    }
                 }
-            }
-            Err(broadcast::error::RecvError::Lagged(_)) => continue,
-            Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return Ok(()),
+            },
+            line = read.next_line() => match line {
+                // A subscriber has nothing left to say; any line it does send
+                // is ignored chatter, not a request.
+                Ok(Some(_)) => continue,
+                // EOF or a read error: the client is gone.
+                Ok(None) | Err(_) => return Ok(()),
+            },
         }
     }
 }
@@ -472,7 +490,7 @@ where
             Ok(ControlRequest::Subscribe) => {
                 let rx = events.subscribe();
                 drop(events);
-                return stream_events(&mut write_half, rx).await;
+                return stream_events(&mut lines, &mut write_half, rx).await;
             }
             // Already authenticated: a repeat is harmless, not an error.
             Ok(ControlRequest::Authenticate { .. }) => ControlResponse::Ok { ok: true },
@@ -1176,6 +1194,22 @@ mod tests {
         );
     }
 
+    /// A quiet inbound half for driving `stream_events` directly: the returned
+    /// guard keeps the peer's write side open so `next_line` stays pending.
+    fn quiet_read_half() -> (
+        tokio::io::Lines<BufReader<tokio::io::ReadHalf<tokio::io::DuplexStream>>>,
+        tokio::io::WriteHalf<tokio::io::DuplexStream>,
+    ) {
+        let (client, server) = tokio::io::duplex(4096);
+        let (server_read, _server_write) = tokio::io::split(server);
+        let (_client_read, client_write) = tokio::io::split(client);
+        // Leak the unused halves' drop by returning the write guard only; the
+        // client read half closing is invisible to the server's reader.
+        std::mem::forget(_server_write);
+        std::mem::forget(_client_read);
+        (BufReader::new(server_read).lines(), client_write)
+    }
+
     #[tokio::test]
     async fn stream_events_skips_lagged_writes_ok_and_stops_on_closed() {
         use tokio::io::AsyncReadExt;
@@ -1186,8 +1220,9 @@ mod tests {
         tx.send(completed("third")).unwrap();
         drop(tx); // no more senders → Closed once drained
 
+        let (mut lines, _keep_open) = quiet_read_half();
         let (mut w, mut r) = tokio::io::duplex(4096);
-        let server = tokio::spawn(async move { stream_events(&mut w, rx).await });
+        let server = tokio::spawn(async move { stream_events(&mut lines, &mut w, rx).await });
         let mut buf = String::new();
         r.read_to_string(&mut buf).await.unwrap();
         server.await.unwrap().unwrap();
@@ -1200,10 +1235,60 @@ mod tests {
     async fn stream_events_returns_when_the_client_hangs_up() {
         let (tx, rx) = broadcast::channel::<WorldEvent>(4);
         tx.send(completed("x")).unwrap();
+        let (mut lines, _keep_open) = quiet_read_half();
         let (mut w, r) = tokio::io::duplex(64);
         drop(r); // reader gone → the write fails, ending the stream
-        stream_events(&mut w, rx).await.unwrap();
+        stream_events(&mut lines, &mut w, rx).await.unwrap();
         drop(tx);
+    }
+
+    /// A subscriber that closes its half of the connection ends the stream
+    /// even when no event ever arrives - previously the daemon-side task (and
+    /// its broadcast receiver) lived until the next write failed, which on an
+    /// idle daemon is never.
+    #[tokio::test]
+    async fn stream_events_returns_on_client_eof_without_any_event() {
+        let (tx, rx) = broadcast::channel::<WorldEvent>(4);
+        let (client, server) = tokio::io::duplex(4096);
+        let (server_read, _server_write) = tokio::io::split(server);
+        let mut lines = BufReader::new(server_read).lines();
+        drop(client); // EOF on the read half, nothing was ever sent
+
+        let (mut w, _r) = tokio::io::duplex(4096);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stream_events(&mut lines, &mut w, rx),
+        )
+        .await
+        .expect("EOF must end the stream promptly")
+        .unwrap();
+        drop(tx);
+    }
+
+    /// A line the subscriber sends mid-stream is chatter, not a request: the
+    /// stream keeps delivering events after it.
+    #[tokio::test]
+    async fn stream_events_ignores_subscriber_chatter() {
+        use tokio::io::AsyncReadExt;
+        let (tx, rx) = broadcast::channel::<WorldEvent>(4);
+        let (client, server) = tokio::io::duplex(4096);
+        let (server_read, _server_write) = tokio::io::split(server);
+        let (_client_read, mut client_write) = tokio::io::split(client);
+        std::mem::forget(_server_write);
+        std::mem::forget(_client_read);
+        let mut lines = BufReader::new(server_read).lines();
+
+        client_write.write_all(b"hello?\n").await.unwrap();
+        let (mut w, mut r) = tokio::io::duplex(4096);
+        let server = tokio::spawn(async move { stream_events(&mut lines, &mut w, rx).await });
+        // Give the chatter a chance to be read, then deliver a real event.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tx.send(completed("after-chatter")).unwrap();
+        drop(tx);
+        let mut buf = String::new();
+        r.read_to_string(&mut buf).await.unwrap();
+        server.await.unwrap().unwrap();
+        assert!(buf.contains("after-chatter"));
     }
 
     /// `create` reports rather than panicking when its directory cannot be

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -442,7 +442,7 @@ mod tests {
     impl leviath_providers::Provider for StubProvider {
         async fn infer(
             &self,
-            _request: leviath_providers::InferenceRequest,
+            _request: &leviath_providers::InferenceRequest,
         ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
         {
             Err(leviath_providers::ProviderError::ApiError(
@@ -472,7 +472,7 @@ mod tests {
         assert_eq!(p.max_context_tokens("m"), 8192);
         let _ = p.capabilities("m");
         assert!(
-            p.infer(leviath_providers::InferenceRequest {
+            p.infer(&leviath_providers::InferenceRequest {
                 system: vec![],
                 messages: vec![],
                 model: "m".to_string(),

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Provider for Mock {
-        async fn infer(&self, _r: InferenceRequest) -> Result<InferenceResponse, ProviderError> {
+        async fn infer(&self, _r: &InferenceRequest) -> Result<InferenceResponse, ProviderError> {
             self.responses
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
@@ -568,7 +568,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Provider for Recorder {
-        async fn infer(&self, r: InferenceRequest) -> Result<InferenceResponse, ProviderError> {
+        async fn infer(&self, r: &InferenceRequest) -> Result<InferenceResponse, ProviderError> {
             self.seen
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
@@ -1408,7 +1408,7 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         let _ = recorder.capabilities("m");
         assert!(
             mock.infer(
-                serde_json::from_value(serde_json::json!({
+                &serde_json::from_value(serde_json::json!({
                     "messages": [],
                     "model": "m",
                     "max_tokens": 1,

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -281,12 +281,24 @@ pub fn fan_out_collect(world: &mut World) {
             .take::<FanOutWaiting>()
             .expect("a Waiting fan-out parent still holds FanOutWaiting");
 
-        // 1. Reap workers that have reached a terminal state.
+        // 1. Reap workers that have reached a terminal state. A consumed
+        // worker's result now lives in `w.summaries`/`w.failures`, so its heavy
+        // components are dead weight - mark it for `slim_merged_workers`, which
+        // drops them once the terminal snapshot has reached the persistence
+        // lane. The entity itself stays (the host only despawns it when the
+        // parent goes terminal), but without its context window: previously
+        // every finished fan-out worker kept a full window resident for the
+        // whole remainder of the parent's run.
         let mut still_active = Vec::with_capacity(w.active.len());
         for aw in std::mem::take(&mut w.active) {
             match worker_terminal_result(world, aw.entity) {
-                Some(Ok(content)) => w.summaries.push((aw.item_id, content)),
-                Some(Err(message)) => w.failures.push((aw.item_id, message)),
+                Some(result) => {
+                    match result {
+                        Ok(content) => w.summaries.push((aw.item_id, content)),
+                        Err(message) => w.failures.push((aw.item_id, message)),
+                    }
+                    world.entity_mut(aw.entity).insert(MergedWorker);
+                }
                 None => still_active.push(aw),
             }
         }
@@ -320,6 +332,49 @@ pub fn fan_out_collect(world: &mut World) {
         } else {
             world.entity_mut(parent).insert(w);
         }
+    }
+}
+
+/// A fan-out worker whose terminal result the parent has already consumed.
+/// Set by [`fan_out_collect`]; consumed by [`slim_merged_workers`].
+#[derive(Component)]
+pub struct MergedWorker;
+
+/// Drop a merged worker's heavy components once its terminal snapshot has
+/// reached the persistence lane.
+///
+/// Ordering makes this safe on both sides: the marker is only set after the
+/// parent consumed the worker's result (so the merge no longer reads the
+/// worker), and the watermark gate (`PersistWatermark::persisted_status`)
+/// holds the slim back until the terminal state is on its way to disk (so
+/// nothing readable is lost - the entity's remaining metadata still identifies
+/// the run, and its full final state is in the run dir).
+pub fn slim_merged_workers(
+    workers: Query<(Entity, &crate::pipeline::PersistWatermark), With<MergedWorker>>,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, watermark) in workers.iter() {
+        crate::tick_scope::enter(entity);
+        let terminal_persisted = matches!(
+            watermark.persisted_status(),
+            Some(
+                leviath_core::run_meta::RunStatus::Complete
+                    | leviath_core::run_meta::RunStatus::Error
+                    | leviath_core::run_meta::RunStatus::Cancelled
+            )
+        );
+        if !terminal_persisted {
+            continue; // the terminal snapshot has not been dispatched yet
+        }
+        commands.entity(entity).remove::<(
+            ContextWindow,
+            InferenceResult,
+            crate::pipeline::StageInferences,
+            crate::pipeline::StageSetups,
+            AgentBlueprint,
+            MergedWorker,
+        )>();
     }
 }
 
@@ -1030,6 +1085,56 @@ mod tests {
                 .current_tokens
                 > 0
         );
+    }
+
+    /// Run the slim system once over `world`.
+    fn run_slim(world: &mut World) {
+        let mut schedule = bevy_ecs::schedule::Schedule::default();
+        schedule.add_systems(slim_merged_workers);
+        schedule.run(world);
+    }
+
+    /// A merged worker keeps its heavy components until its terminal snapshot
+    /// has been dispatched, then sheds them - previously every finished
+    /// fan-out worker kept a full context window resident until the parent
+    /// went terminal.
+    #[test]
+    fn merged_workers_are_slimmed_once_their_terminal_state_is_persisted() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 2, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"}]"#,
+        );
+        fan_out_split(&mut world);
+        fan_out_collect(&mut world);
+        let worker = world.get::<SubAgentChildren>(e).unwrap().children[0];
+        // Give the worker a context window so there is something to shed.
+        world
+            .entity_mut(worker)
+            .insert((window(), crate::pipeline::PersistWatermark::default()));
+        complete_worker(&mut world, worker, "done");
+        fan_out_collect(&mut world);
+
+        // Consumed by the merge and marked - but its terminal snapshot has not
+        // been dispatched, so it keeps its state.
+        assert!(world.get::<MergedWorker>(worker).is_some());
+        run_slim(&mut world);
+        assert!(
+            world.get::<ContextWindow>(worker).is_some(),
+            "unpersisted terminal state stays resident"
+        );
+
+        // Stamp the watermark terminal, and the worker sheds its heavy parts.
+        let mut wm = crate::pipeline::PersistWatermark::default();
+        wm.stamp_status(leviath_core::run_meta::RunStatus::Complete);
+        world.entity_mut(worker).insert(wm);
+        run_slim(&mut world);
+        assert!(world.get::<ContextWindow>(worker).is_none());
+        assert!(world.get::<MergedWorker>(worker).is_none());
+        // The entity itself survives for the host's bookkeeping.
+        assert!(world.get::<AgentState>(worker).is_some());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -746,7 +746,11 @@ impl WorldHost {
     /// Wrap a world with a specific interaction hub - the daemon shares one hub
     /// between the tool service's per-agent backends and this host.
     pub fn with_interactions(mut world: PipelineWorld, interactions: InteractionHub) -> Self {
-        let (events, _) = broadcast::channel(1024);
+        // 256, not more: a tokio broadcast ring never shrinks, so every slot a
+        // busy period fills stays allocated (holding its event's strings) for
+        // the daemon's life. Consumers here are live relays, not replayers -
+        // one that falls a full ring behind gets a Lagged skip either way.
+        let (events, _) = broadcast::channel(256);
         // Let ECS systems (the persistence drain) push events - per-agent log
         // lines - into the same stream the control transport serves.
         world

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -1946,7 +1946,7 @@ mod tests {
     impl Provider for Script {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             self.responses
                 .lock()
@@ -2138,7 +2138,7 @@ mod tests {
     impl Provider for Hangs {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             if self.hang {
                 std::future::pending().await
@@ -2183,13 +2183,13 @@ mod tests {
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(20), p.infer(request()))
+            tokio::time::timeout(std::time::Duration::from_millis(20), p.infer(&request()))
                 .await
                 .is_err(),
             "hanging: the whole point is that the call never lands"
         );
         // ...and the answering arm, so the call has a reachable way out.
-        assert!(Hangs { hang: false }.infer(request()).await.is_err());
+        assert!(Hangs { hang: false }.infer(&request()).await.is_err());
     }
 
     /// A host whose only provider hangs, with model `m` capped at `limit`
@@ -4545,7 +4545,7 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        assert!(p.infer(req).await.is_err()); // exhausted
+        assert!(p.infer(&req).await.is_err()); // exhausted
 
         let exec = NoTools.exec_for(
             Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id"),

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -685,6 +685,13 @@ pub struct WorldHost {
     /// How long an unloaded run stays in [`Self::finished`]. `0` keeps none.
     /// See [`Self::set_finished_retention_secs`].
     finished_retention_secs: u64,
+    /// Paused runs the host has paged out of the world, by run id, each holding
+    /// its last listing row. A parked run's full state is on disk; `Resume`,
+    /// `Message` and `Cancel` all page it back through
+    /// [`Self::resolve_or_reload`], and [`Self::list`] keeps reporting it so an
+    /// operator's `lev ps` view does not change just because the daemon stopped
+    /// spending memory on a run nobody is driving.
+    parked: HashMap<String, RunListEntry>,
 }
 
 /// How often the serve loop re-drives the world on its own.
@@ -769,6 +776,7 @@ impl WorldHost {
             events,
             emitted: HashMap::new(),
             emitted_interactions: HashSet::new(),
+            parked: HashMap::new(),
             subagent_tx,
             subagent_rx,
             redrive: DEFAULT_REDRIVE_INTERVAL,
@@ -1079,6 +1087,7 @@ impl WorldHost {
         // daemon's reap hook has already had the world and is free to have taken
         // the components it reads.
         let mut to_reap: Vec<(String, Entity, RunListEntry)> = Vec::new();
+        let mut to_park: Vec<(String, Entity, RunListEntry)> = Vec::new();
         let now = chrono::Utc::now().timestamp();
         for (run_id, entity) in pairs {
             let Some(state) = self.world.world().get::<AgentState>(entity) else {
@@ -1211,13 +1220,25 @@ impl WorldHost {
                 let entry = self.entry_for(&run_id, entity, state);
                 to_reap.push((run_id.clone(), entity, entry));
             }
+            // Page a paused run out of the world once its paused state is on
+            // its way to disk. Unlike `Waiting` (see the NOTE below), `Paused`
+            // carries no live continuation - it is the one non-terminal state
+            // whose whole meaning is "nothing is driving this" - and Resume,
+            // Message and Cancel all page an unloaded run back in through
+            // `resolve_or_reload`, exactly as a daemon restart would. Scoped
+            // to standalone roots: a run with tree links or an open prompt
+            // keeps the restart-equivalence question open and stays resident.
+            if self.parkable(entity, &state.status) {
+                let entry = self.entry_for(&run_id, entity, state);
+                to_park.push((run_id.clone(), entity, entry));
+            }
             // NOTE: non-terminal `Waiting` agents are intentionally NOT unloaded.
             // Every `Waiting` state carries a live, unpersisted continuation - a
             // blocked `ask` future (`AwaitingInteraction`), running fan-out workers
             // (`FanOutWaiting`), or pending children (`WaitingForChildren`) - so
             // flushing one to disk and paging it back cannot resume it (in-flight
             // interactions aren't persisted; the blocked future is gone). Only
-            // terminal agents, whose full state is on disk, are safe to reap.
+            // terminal agents (fully on disk) are reaped, and paused ones parked.
 
             self.emitted.insert(run_id, cur);
         }
@@ -1228,6 +1249,7 @@ impl WorldHost {
         // is safe. The reaper is moved out for the loop to avoid borrowing `self`
         // twice, then restored.
         let mut reaper = self.reaper.take();
+        let reaped_any = !to_reap.is_empty();
         for (run_id, entity, entry) in to_reap {
             if let Some(reaper) = reaper.as_mut() {
                 reaper(&mut self.world, entity);
@@ -1239,8 +1261,35 @@ impl WorldHost {
             // still say how it ended, which is the whole of issue #205.
             self.record_finished(entry, now);
         }
+        // Park paused runs: same teardown as a reap (the reap hook drops the
+        // agent's tool state and sandbox, which a page-in rebuilds the way a
+        // daemon restart does), but the listing row moves to `parked` rather
+        // than `finished` - the run is not over, it is just not resident.
+        for (run_id, entity, entry) in to_park {
+            if let Some(reaper) = reaper.as_mut() {
+                reaper(&mut self.world, entity);
+            }
+            self.world.world_mut().despawn(entity);
+            self.by_run_id.remove(&run_id);
+            self.emitted.remove(&run_id);
+            self.parked.insert(run_id, entry);
+        }
         self.reaper = reaper;
         self.prune_finished(now);
+        // Reaped runs answer no further prompts: drop their request ids from
+        // the emitted-interaction set, which otherwise grows for the daemon's
+        // life (the set is keyed by request id, so prune by what is still
+        // pending - the same shape `cancel_tree` uses).
+        if reaped_any {
+            let still_open: std::collections::HashSet<String> = self
+                .interactions
+                .pending()
+                .into_iter()
+                .map(|(_, req)| req.id)
+                .collect();
+            self.emitted_interactions
+                .retain(|id| still_open.contains(id));
+        }
 
         for (agent_id, request) in self.interactions.pending() {
             if self.emitted_interactions.insert(request.id.clone()) {
@@ -1278,6 +1327,41 @@ impl WorldHost {
                 self.by_run_id.insert(run_id, entity);
             }
         }
+    }
+
+    /// Whether a paused agent is safe to page out of the world.
+    ///
+    /// Conservative on purpose - this is the restart-equivalence question, and
+    /// only shapes where the answer is a settled "yes" qualify:
+    /// - status is `Paused`, and the *persisted* status is too (the watermark
+    ///   proves the paused snapshot was dispatched, so disk can rebuild it);
+    /// - it is a standalone root: no parent that might address it by entity,
+    ///   no children whose links a page-in would have to rebuild;
+    /// - no open interaction and no fan-out in flight (a pause that landed
+    ///   mid-prompt or mid-split keeps its live machinery).
+    fn parkable(&self, entity: Entity, status: &AgentStatus) -> bool {
+        if !matches!(status, AgentStatus::Paused) {
+            return false;
+        }
+        // No reloader, no parking: a host that cannot page a run back in
+        // (an embedded world, a bare test host) must keep it resident, or
+        // "paused" silently becomes "gone".
+        if self.reloader.is_none() {
+            return false;
+        }
+        let world = self.world.world();
+        let paused_persisted = world
+            .get::<crate::pipeline::PersistWatermark>(entity)
+            .and_then(|w| w.persisted_status())
+            == Some(leviath_core::run_meta::RunStatus::Paused);
+        paused_persisted
+            && world.get::<crate::components::ParentRef>(entity).is_none()
+            && world.get::<SubAgentChildren>(entity).is_none()
+            && world.get::<crate::fanout::FanOutWaiting>(entity).is_none()
+            && world
+                .get::<crate::interaction_points::AwaitingInteractionPoint>(entity)
+                .is_none()
+            && world.get::<AwaitingInteraction>(entity).is_none()
     }
 
     /// Whether a terminal agent is safe to unload: it has no **live** parent that
@@ -1339,6 +1423,8 @@ impl WorldHost {
         }
         let entity = (self.reloader.as_mut()?)(&mut self.world, run_id)?;
         self.by_run_id.insert(run_id.to_string(), entity);
+        // Live again: its listing row comes off the entity, not the parked map.
+        self.parked.remove(run_id);
         Some(entity)
     }
 
@@ -1354,7 +1440,9 @@ impl WorldHost {
 
     /// Record the run-id → entity mapping for a freshly-spawned agent.
     pub fn register(&mut self, run_id: impl Into<String>, entity: Entity) {
-        self.by_run_id.insert(run_id.into(), entity);
+        let run_id = run_id.into();
+        self.parked.remove(&run_id);
+        self.by_run_id.insert(run_id, entity);
     }
 
     /// Resolve a run id to a **live** entity (one that still exists in the world).
@@ -1694,6 +1782,9 @@ impl WorldHost {
                 let state = world.get::<AgentState>(entity)?;
                 Some(self.entry_for(run_id, entity, state))
             })
+            // Parked (paused, paged-out) runs are still the daemon's runs; an
+            // operator must not lose sight of one just because it left memory.
+            .chain(self.parked.values().cloned())
             .collect()
     }
 
@@ -1770,6 +1861,7 @@ impl WorldHost {
                 let status = self
                     .live_entity(&run_id)
                     .and_then(|e| self.world.agent_status(e))
+                    .or_else(|| self.parked.get(&run_id).map(|e| e.status.clone()))
                     .or_else(|| {
                         self.finished
                             .iter()
@@ -2926,6 +3018,105 @@ mod tests {
             })
             .await,
             None
+        );
+    }
+
+    /// A paused standalone root whose paused snapshot has been dispatched is
+    /// paged out of the world: the entity is gone, but the listing and the
+    /// Status op still report it, and a Resume pages it back in.
+    #[tokio::test]
+    async fn a_persisted_paused_root_is_parked_and_pages_back_in() {
+        let mut host = host_with(vec![]);
+        // A reloader that restores the run the way `reload_run` does: paused,
+        // ready to be resumed.
+        host.set_reloader(Box::new(|world, run_id| {
+            let mut state = agent_state(run_id);
+            state.status = AgentStatus::Paused;
+            Some(world.spawn_agent((state,)))
+        }));
+        let e = spawn(&mut host, "run-a", "agent-a");
+        assert!(
+            ask(&mut host, |reply| ControlOp::Pause {
+                run_id: "run-a".to_string(),
+                reply
+            })
+            .await
+        );
+        // Stamp the watermark as though the paused snapshot was dispatched.
+        let mut wm = crate::pipeline::PersistWatermark::default();
+        wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
+        host.world_mut().world_mut().entity_mut(e).insert(wm);
+
+        host.emit_events();
+
+        // Paged out: the entity is despawned and the run id unmapped.
+        assert!(host.world.world().get::<AgentState>(e).is_none());
+        assert!(!host.by_run_id.contains_key("run-a"));
+        // But not lost: the listing still carries the paused row...
+        let listing = ask(&mut host, |reply| ControlOp::List { reply }).await;
+        let row = listing
+            .runs
+            .iter()
+            .find(|r| r.run_id == "run-a")
+            .expect("a parked run stays listed");
+        assert_eq!(row.status, AgentStatus::Paused);
+        // ...and Status answers from the parked map.
+        let status = ask(&mut host, |reply| ControlOp::Status {
+            run_id: "run-a".to_string(),
+            reply,
+        })
+        .await;
+        assert_eq!(status, Some(AgentStatus::Paused));
+
+        // Resume pages the run back in through the reloader and unparks it.
+        assert!(
+            ask(&mut host, |reply| ControlOp::Resume {
+                run_id: "run-a".to_string(),
+                reply
+            })
+            .await
+        );
+        assert!(host.parked.is_empty(), "resumed run left the parked map");
+        let e2 = host.by_run_id["run-a"];
+        assert_eq!(host.world.agent_status(e2), Some(AgentStatus::Active));
+    }
+
+    /// The park gate holds until the paused state is known to be on its way to
+    /// disk, and never fires for a run with tree links.
+    #[tokio::test]
+    async fn a_paused_run_stays_resident_until_persisted_and_when_linked() {
+        let mut host = host_with(vec![]);
+        host.set_reloader(paging_reloader());
+        let e = spawn(&mut host, "run-a", "agent-a");
+        assert!(
+            ask(&mut host, |reply| ControlOp::Pause {
+                run_id: "run-a".to_string(),
+                reply
+            })
+            .await
+        );
+
+        // Paused, but no watermark proof the paused snapshot was dispatched.
+        host.emit_events();
+        assert!(
+            host.world.world().get::<AgentState>(e).is_some(),
+            "an unpersisted pause stays resident"
+        );
+
+        // Persisted now, but carrying a child link: still resident.
+        let mut wm = crate::pipeline::PersistWatermark::default();
+        wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
+        host.world_mut().world_mut().entity_mut(e).insert((
+            wm,
+            SubAgentChildren {
+                children: vec![],
+                max_child_depth: 1,
+            },
+        ));
+        host.emit_events();
+        assert!(
+            host.world.world().get::<AgentState>(e).is_some(),
+            "a run with tree links keeps the restart question open"
         );
     }
 

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -3034,6 +3034,13 @@ mod tests {
             state.status = AgentStatus::Paused;
             Some(world.spawn_agent((state,)))
         }));
+        // Parking runs the same teardown hook a reap does (sandbox + tool
+        // state); record that it fired.
+        let reaped = Arc::new(Mutex::new(0usize));
+        let reaped_in_hook = reaped.clone();
+        host.set_reaper(Box::new(move |_world, _entity| {
+            *reaped_in_hook.lock().unwrap() += 1;
+        }));
         let e = spawn(&mut host, "run-a", "agent-a");
         assert!(
             ask(&mut host, |reply| ControlOp::Pause {
@@ -3049,9 +3056,11 @@ mod tests {
 
         host.emit_events();
 
-        // Paged out: the entity is despawned and the run id unmapped.
+        // Paged out: the entity is despawned, the run id unmapped, and the
+        // reap hook tore the agent's state down first.
         assert!(host.world.world().get::<AgentState>(e).is_none());
         assert!(!host.by_run_id.contains_key("run-a"));
+        assert_eq!(*reaped.lock().unwrap(), 1);
         // But not lost: the listing still carries the paused row...
         let listing = ask(&mut host, |reply| ControlOp::List { reply }).await;
         let row = listing
@@ -3118,6 +3127,19 @@ mod tests {
             host.world.world().get::<AgentState>(e).is_some(),
             "a run with tree links keeps the restart question open"
         );
+
+        // Links gone: it parks - and this host has no reap hook installed, so
+        // the park teardown's no-reaper path is exercised too.
+        host.world_mut()
+            .world_mut()
+            .entity_mut(e)
+            .remove::<SubAgentChildren>();
+        host.emit_events();
+        assert!(
+            host.world.world().get::<AgentState>(e).is_none(),
+            "unlinked and persisted: parked without a reaper"
+        );
+        assert!(host.parked.contains_key("run-a"));
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -163,10 +163,14 @@ pub async fn run_inference_job(
     // exponential backoff, holding the permit across the backoff; a permanent
     // error fails immediately. The whole thing is bounded by `job_timeout` so a
     // never-completing (stalled-stream) call cannot hold the pool slot forever.
+    //
+    // `infer` borrows the request, so every attempt reuses the one assembled
+    // copy. It used to be cloned per attempt, which doubled the live footprint
+    // of every in-flight request for the whole (possibly minutes-long) call.
     let attempts = async {
         let mut attempt = 1u32;
         loop {
-            match provider.infer(request.clone()).await {
+            match provider.infer(&request).await {
                 Ok(response) => break Ok(response),
                 Err(e) if e.is_transient() && attempt < retry.max_attempts => {
                     tokio::time::sleep(retry.base_delay * 2u32.pow(attempt - 1)).await;
@@ -255,7 +259,7 @@ mod tests {
     impl Provider for Fixed {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             match self {
                 Fixed::Ok(r) => Ok(r.clone()),
@@ -443,7 +447,7 @@ mod tests {
     impl Provider for Counter {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             Ok(response("ok"))
         }
@@ -625,7 +629,7 @@ mod tests {
     impl Provider for Scripted {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             *self.calls.lock().unwrap() += 1;
             // Pop before matching so the mutex guard is not held across the

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -11,6 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
+use leviath_core::run_archive;
 use leviath_core::run_meta::{ContextSnapshot, RunMeta, StageRecord};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -75,6 +76,20 @@ pub enum PersistMsg {
         /// (per-call results).
         ack: Option<tokio::sync::oneshot::Sender<()>>,
     },
+    /// Buffered per-stage output/log lines with nothing else to report. The
+    /// dispatch system sends this instead of a full [`PersistMsg::Snapshot`]
+    /// when lines were buffered but the run's watermark did not move - tool
+    /// activity between iterations used to force a whole-window snapshot
+    /// (context deep-clone, meta/context rewrite, archive record) per batch of
+    /// log lines, several times per iteration.
+    StageLines {
+        /// The run id (its directory name under the runs dir).
+        run_id: String,
+        /// Readable output lines to append to `stages/<idx>/output.log`.
+        output_appends: Vec<(usize, String)>,
+        /// Operational log lines to append to `stages/<idx>/logs.log`.
+        log_appends: Vec<(usize, String)>,
+    },
 }
 
 /// The single-lane persistence worker: writes each [`PersistJob`]'s files under
@@ -105,34 +120,75 @@ pub async fn persistence_worker(
     };
     let machine_id = load_or_create_machine_id(&runs_dir);
     let world_id = generate_id();
-    // The last context window archived per run, so the next write can be stored
-    // as a compact diff rather than a full snapshot.
-    let mut last_context: std::collections::HashMap<String, ContextSnapshot> =
+    // The fingerprint of the last context window archived per run, so the next
+    // write can be stored as a compact diff rather than a full snapshot. A
+    // digest, not the snapshot itself: retaining a full copy of every live
+    // run's context doubled the lane's resident cost.
+    let mut last_context: std::collections::HashMap<String, run_archive::ContextDigest> =
         std::collections::HashMap::new();
-    while let Some(msg) = jobs.recv().await {
-        match msg {
-            PersistMsg::Snapshot(job) => {
-                let prev = last_context.get(&job.run_id);
-                write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev).await;
-                // Drop a fully-terminal run's cached context (it won't be written
-                // again), so the map stays bounded by the set of *live* runs
-                // rather than every run the daemon has ever seen.
-                if is_terminal_run(&job.meta.status) {
-                    last_context.remove(&job.run_id);
-                } else {
-                    last_context.insert(job.run_id.clone(), job.context.clone());
-                }
+    while let Some(first) = jobs.recv().await {
+        // Drain whatever else is already queued and process it as one batch,
+        // keeping only the NEWEST snapshot per run: each snapshot carries the
+        // whole window, so writing a superseded one is pure disk and memory
+        // churn. On a slow disk this is what stops queued full-window
+        // snapshots from piling up unboundedly. Appends and stage lines keep
+        // their order and are never dropped.
+        let mut batch = vec![first];
+        while let Ok(msg) = jobs.try_recv() {
+            batch.push(msg);
+        }
+        let mut newest_snapshot: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for (i, msg) in batch.iter().enumerate() {
+            if let PersistMsg::Snapshot(job) = msg {
+                newest_snapshot.insert(job.run_id.clone(), i);
             }
-            PersistMsg::Append {
-                run_id,
-                record,
-                ack,
-            } => {
-                append_record(&runs_dir, &run_id, &record).await;
-                // Ack unconditionally - persistence is best-effort and the
-                // dispatch-side barrier must never stall on a failed append.
-                if let Some(ack) = ack {
-                    let _ = ack.send(());
+        }
+        for (i, msg) in batch.into_iter().enumerate() {
+            match msg {
+                PersistMsg::Snapshot(job) => {
+                    if newest_snapshot.get(job.run_id.as_str()) != Some(&i) {
+                        continue; // superseded by a newer snapshot in this batch
+                    }
+                    let prev = last_context.get(&job.run_id);
+                    write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev).await;
+                    // Drop a fully-terminal run's cached digest (it won't be
+                    // written again), so the map stays bounded by the set of
+                    // *live* runs rather than every run the daemon has ever
+                    // seen.
+                    if is_terminal_run(&job.meta.status) {
+                        last_context.remove(&job.run_id);
+                    } else {
+                        last_context.insert(
+                            job.run_id.clone(),
+                            run_archive::digest_context(&job.context),
+                        );
+                    }
+                }
+                PersistMsg::Append {
+                    run_id,
+                    record,
+                    ack,
+                } => {
+                    append_record(&runs_dir, &run_id, &record).await;
+                    // Ack unconditionally - persistence is best-effort and the
+                    // dispatch-side barrier must never stall on a failed append.
+                    if let Some(ack) = ack {
+                        let _ = ack.send(());
+                    }
+                }
+                PersistMsg::StageLines {
+                    run_id,
+                    output_appends,
+                    log_appends,
+                } => {
+                    let dir = runs_dir.join(&run_id);
+                    for (idx, line) in &output_appends {
+                        append_stage_line(&dir, *idx, "output.log", line, &run_id).await;
+                    }
+                    for (idx, line) in &log_appends {
+                        append_stage_line(&dir, *idx, "logs.log", line, &run_id).await;
+                    }
                 }
             }
         }
@@ -257,7 +313,7 @@ async fn write_snapshot(
     job: &PersistJob,
     machine_id: &str,
     world_id: &str,
-    prev_context: Option<&ContextSnapshot>,
+    prev_context: Option<&run_archive::ContextDigest>,
 ) {
     let dir = runs_dir.join(&job.run_id);
     if let Err(e) = create_private_dir(&dir).await {
@@ -266,17 +322,24 @@ async fn write_snapshot(
     }
     append_run_archive(&dir, job, machine_id, world_id, prev_context).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
-    write_bytes_atomic(&dir.join("meta.json"), meta_json.as_bytes(), &job.run_id).await;
-    let ctx_json =
-        serde_json::to_string_pretty(&job.context).expect("ContextSnapshot always serializes");
-    write_bytes_atomic(&dir.join("context.json"), ctx_json.as_bytes(), &job.run_id).await;
+    write_bytes_atomic(&dir.join("meta.json"), meta_json.into_bytes(), &job.run_id).await;
+    // Compact, not pretty: the context is the largest file the lane writes and
+    // every consumer parses it; pretty-printing only inflated the write (and
+    // its transient allocation) by half.
+    let ctx_json = serde_json::to_string(&job.context).expect("ContextSnapshot always serializes");
+    write_bytes_atomic(
+        &dir.join("context.json"),
+        ctx_json.into_bytes(),
+        &job.run_id,
+    )
+    .await;
 
     // The answer's bytes, beside the descriptor `meta.json` carries. Written
     // raw, so serving it is a read and `lev result --raw` is a copy.
     if let Some(content) = &job.final_output {
         write_bytes_atomic(
             &dir.join(leviath_core::FINAL_OUTPUT_FILE),
-            content.as_bytes(),
+            content.clone().into_bytes(),
             &job.run_id,
         )
         .await;
@@ -288,7 +351,7 @@ async fn write_snapshot(
             serde_json::to_string_pretty(&job.stages).expect("StageRecord slice always serializes");
         write_bytes_atomic(
             &dir.join("stages.json"),
-            stages_json.as_bytes(),
+            stages_json.into_bytes(),
             &job.run_id,
         )
         .await;
@@ -306,7 +369,7 @@ async fn write_snapshot(
         let _ = create_private_dir(&stage_dir).await;
         write_bytes_atomic(
             &stage_dir.join("taint_audit.json"),
-            json.as_bytes(),
+            json.clone().into_bytes(),
             &job.run_id,
         )
         .await;
@@ -315,7 +378,9 @@ async fn write_snapshot(
     // parent is no longer parked on a fan-out.
     let fanout_path = dir.join("fanout.json");
     match &job.fanout {
-        Some(json) => write_bytes_atomic(&fanout_path, json.as_bytes(), &job.run_id).await,
+        Some(json) => {
+            write_bytes_atomic(&fanout_path, json.clone().into_bytes(), &job.run_id).await
+        }
         None => {
             let _ = tokio::fs::remove_file(&fanout_path).await;
         }
@@ -324,7 +389,9 @@ async fn write_snapshot(
     // agent is no longer parked at a stage-boundary interaction point.
     let interactions_path = dir.join("interactions.json");
     match &job.interactions {
-        Some(json) => write_bytes_atomic(&interactions_path, json.as_bytes(), &job.run_id).await,
+        Some(json) => {
+            write_bytes_atomic(&interactions_path, json.clone().into_bytes(), &job.run_id).await
+        }
         None => {
             let _ = tokio::fs::remove_file(&interactions_path).await;
         }
@@ -349,9 +416,9 @@ async fn append_run_archive(
     job: &PersistJob,
     machine_id: &str,
     world_id: &str,
-    prev_context: Option<&ContextSnapshot>,
+    prev_context: Option<&run_archive::ContextDigest>,
 ) {
-    use leviath_core::run_archive::{self, RunIdentity, RunRecord};
+    use leviath_core::run_archive::{RunIdentity, RunRecord};
 
     let path = dir.join("run.lvr");
     let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
@@ -364,7 +431,7 @@ async fn append_run_archive(
         Some(prev) => {
             let progress = RunRecord::Progress {
                 meta: Box::new(job.meta.clone()),
-                delta: run_archive::diff_context(prev, &job.context),
+                delta: run_archive::diff_context_digest(prev, &job.context),
                 at,
             };
             run_archive::write_record(&mut buf, &progress).expect("writing to a Vec never fails");
@@ -438,7 +505,7 @@ async fn append_stage_line(run_dir: &Path, stage_idx: usize, file: &str, line: &
 
 /// Write `bytes` to `path` via a sibling temp file + rename (atomic on the same
 /// filesystem, so a reader never sees a half-written file). Best-effort.
-async fn write_bytes_atomic(path: &Path, bytes: &[u8], run_id: &str) {
+async fn write_bytes_atomic(path: &Path, bytes: Vec<u8>, run_id: &str) {
     let tmp = path.with_extension("json.tmp");
     // `write_private`, not a plain write: these files carry the run's task
     // prompt, its conversation, its tool output, and - in `meta.json` - the
@@ -451,7 +518,9 @@ async fn write_bytes_atomic(path: &Path, bytes: &[u8], run_id: &str) {
     // Blocking, so it goes to a blocking thread rather than stalling the
     // persistence lane. The alternative is a per-platform mode dance here, and
     // `leviath-sys` already owns that (including the Windows `icacls` path).
-    let (tmp_for_write, bytes) = (tmp.clone(), bytes.to_vec());
+    // Owned bytes in, so a multi-hundred-KB context serialization is written
+    // from the one buffer it was serialized into instead of being copied again.
+    let tmp_for_write = tmp.clone();
     let written =
         tokio::task::spawn_blocking(move || leviath_sys::write_private(&tmp_for_write, &bytes))
             .await;
@@ -761,7 +830,14 @@ mod tests {
         let first = job_with_context("run-1", 1);
         let second = job_with_context("run-1", 3); // grew by 2 entries
         write_snapshot(dir.path(), &first, "m", "w", None).await;
-        write_snapshot(dir.path(), &second, "m", "w", Some(&first.context)).await;
+        write_snapshot(
+            dir.path(),
+            &second,
+            "m",
+            "w",
+            Some(&run_archive::digest_context(&first.context)),
+        )
+        .await;
 
         let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
         let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
@@ -827,6 +903,83 @@ mod tests {
         assert!(!is_terminal_run(&RunStatus::CompleteInteractive));
     }
 
+    /// Snapshots queued behind a slow write are coalesced latest-wins per run:
+    /// three queued snapshots produce ONE write carrying the newest context,
+    /// not three full-window writes.
+    #[tokio::test]
+    async fn worker_coalesces_queued_snapshots_to_the_newest_per_run() {
+        use leviath_core::run_archive::{RunRecord, read_archive};
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context("run-1", 1))))
+            .unwrap();
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context("run-1", 2))))
+            .unwrap();
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context("run-1", 3))))
+            .unwrap();
+        // A different run's snapshot is not swallowed by run-1's coalescing.
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context("run-2", 1))))
+            .unwrap();
+        drop(tx);
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
+
+        let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
+        let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
+        let checkpoints: Vec<_> = records
+            .iter()
+            .filter_map(|r| match r {
+                RunRecord::ContextCheckpoint { snapshot, .. } => Some(snapshot),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(checkpoints.len(), 1, "one write for three queued snapshots");
+        assert_eq!(
+            checkpoints[0].regions[0].entries.len(),
+            3,
+            "and it carries the NEWEST context"
+        );
+        // Header + one ContextCheckpoint and nothing else: no superseded
+        // snapshot produced a Progress record.
+        assert_eq!(records.len(), 2);
+        assert!(dir.path().join("run-2").join("meta.json").exists());
+    }
+
+    /// `StageLines` appends output/log lines without rewriting `meta.json` or
+    /// `context.json` - the whole point of the lines-only fast path.
+    #[tokio::test]
+    async fn worker_appends_stage_lines_without_a_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        // Establish the run dir with one snapshot first (like the spawn tick).
+        tx.send(PersistMsg::Snapshot(Box::new(job("run-1"))))
+            .unwrap();
+        tx.send(PersistMsg::StageLines {
+            run_id: "run-1".to_string(),
+            output_appends: vec![(0, "an output line".to_string())],
+            log_appends: vec![(0, "[tool] shell: ls".to_string())],
+        })
+        .unwrap();
+        drop(tx);
+
+        let meta_before = {
+            // The worker hasn't run yet; nothing exists.
+            !dir.path().join("run-1").join("meta.json").exists()
+        };
+        assert!(meta_before);
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
+
+        let run = dir.path().join("run-1");
+        let out = std::fs::read_to_string(run.join("stages/0/output.log")).unwrap();
+        assert!(out.contains("an output line"));
+        let log = std::fs::read_to_string(run.join("stages/0/logs.log")).unwrap();
+        assert!(log.contains("[tool] shell: ls"));
+        // meta.json exists from the snapshot, and was not rewritten by the
+        // lines message (same content as the snapshot wrote).
+        let meta: RunMeta =
+            serde_json::from_str(&std::fs::read_to_string(run.join("meta.json")).unwrap()).unwrap();
+        assert_eq!(meta.run_id, "run-1");
+    }
+
     #[tokio::test]
     async fn worker_drops_terminal_runs_from_the_context_cache() {
         // A terminal job exercises the cache-cleanup branch; the run is still
@@ -881,7 +1034,14 @@ mod tests {
         write_snapshot(dir.path(), &fo_job, "m", "w", None).await;
         assert!(path.exists());
         // A later job without fan-out state removes the now-stale file.
-        write_snapshot(dir.path(), &job("run-1"), "m", "w", Some(&fo_job.context)).await;
+        write_snapshot(
+            dir.path(),
+            &job("run-1"),
+            "m",
+            "w",
+            Some(&run_archive::digest_context(&fo_job.context)),
+        )
+        .await;
         assert!(!path.exists());
     }
 

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -14,6 +14,26 @@ use super::*;
 /// timestamp mean something.
 pub(crate) const PERSIST_HEARTBEAT_SECS: i64 = 30;
 
+/// Longest log line the event broadcast carries; the on-disk stage logs keep
+/// the full line. 8 KB shows any tool banner or error whole while keeping the
+/// (never-shrinking) broadcast ring's worst-case floor at ring-size x this.
+pub(crate) const BROADCAST_LOG_LINE_MAX_BYTES: usize = 8 * 1024;
+
+/// Clone `line` for the event broadcast, truncated to
+/// [`BROADCAST_LOG_LINE_MAX_BYTES`] on a char boundary with a marker so a
+/// reader knows to fetch the stage log for the rest.
+fn truncate_log_line(line: &str) -> String {
+    if line.len() <= BROADCAST_LOG_LINE_MAX_BYTES {
+        return line.to_string();
+    }
+    let cut = leviath_core::text::floor_char_boundary(line, BROADCAST_LOG_LINE_MAX_BYTES);
+    format!(
+        "{} [truncated {} bytes]",
+        line.split_at(cut).0,
+        line.len() - cut
+    )
+}
+
 /// Debounce watermark: the (iteration, stage index, status) last persisted for an
 /// agent. A snapshot is written only when one of these changes, so the world
 /// writes on meaningful progress rather than every tick. `None` until the first
@@ -247,13 +267,18 @@ pub fn dispatch_persistence(
         // Stream each buffered line to WS subscribers as a `Log` event (in
         // addition to the disk append below). No-op in worlds without the sink
         // (test / `lev run`); a zero-subscriber `send` error is ignored.
+        //
+        // Truncated for the broadcast only - the full line still reaches the
+        // stage log on disk. The ring retains every slot's strings until the
+        // slot is overwritten, so an assistant's whole multi-KB turn broadcast
+        // per line made the ring a multi-MB permanent floor after any busy run.
         if let Some(sink) = &sink {
             for (_idx, line) in output_appends.iter().chain(log_appends.iter()) {
                 // `Res<T>` derefs to `T` in bevy_ecs 0.19; it is not a tuple struct.
                 let _ = sink.0.send(crate::host::WorldEvent::Log {
                     run_id: md.run_id.clone(),
                     agent_id: state.agent_id.clone(),
-                    line: line.clone(),
+                    line: truncate_log_line(line),
                 });
             }
         }

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -38,6 +38,12 @@ pub struct PersistWatermark {
     /// holds. Without it the heartbeat would rewrite a quarter-megabyte file
     /// every thirty seconds for the whole life of a long run, to no effect.
     last_output: Option<(i64, usize)>,
+    /// The taint audit already on disk, as `(stage index, event count)`.
+    ///
+    /// The audit file is only rewritten when the gate recorded a new event.
+    /// Without it every snapshot re-serialized the whole (append-only) log,
+    /// an O(events) allocation per tick that grew with the run.
+    last_taint: Option<(usize, usize)>,
 }
 
 impl PersistWatermark {
@@ -237,11 +243,6 @@ pub fn dispatch_persistence(
         if !watermark_changed && !has_appends && !due_for_heartbeat {
             continue; // nothing meaningful changed, nothing buffered, beat not due
         }
-        if watermark_changed {
-            watermark.last = Some(current);
-            watermark.last_progress_at = Some(now);
-        }
-        watermark.last_written_at = Some(now);
 
         // Stream each buffered line to WS subscribers as a `Log` event (in
         // addition to the disk append below). No-op in worlds without the sink
@@ -256,6 +257,26 @@ pub fn dispatch_persistence(
                 });
             }
         }
+
+        // Buffered lines with no real progress and no heartbeat due: journal
+        // just the lines. The full path below deep-clones the whole context
+        // window per snapshot, and tool activity buffers lines several times
+        // per iteration - snapshotting on each batch multiplied the lane's
+        // biggest allocation by the run's tool traffic for no new state.
+        if !watermark_changed && !due_for_heartbeat {
+            let _ = stage.0.send(PersistMsg::StageLines {
+                run_id: md.run_id.clone(),
+                output_appends,
+                log_appends,
+            });
+            continue;
+        }
+
+        if watermark_changed {
+            watermark.last = Some(current);
+            watermark.last_progress_at = Some(now);
+        }
+        watermark.last_written_at = Some(now);
 
         // Tree links, for a deterministic restart-time rebuild of the graph.
         let depth = parent_ref.map(|p| p.depth).unwrap_or(0);
@@ -280,15 +301,26 @@ pub fn dispatch_persistence(
         );
         let context = build_context_snapshot(window, &state.current_stage);
         let stages = ledger.as_deref().map(|l| l.0.clone()).unwrap_or_default();
-        // Persist the taint gate's audit log (per-stage) when it has events, so
-        // security decisions are inspectable after the fact.
-        let taint_audit = taint_gate.filter(|g| !g.audit_log().is_empty()).map(|g| {
-            (
-                cursor.index,
-                serde_json::to_string_pretty(g.audit_log())
-                    .expect("GateEvent slice always serializes"),
-            )
-        });
+        // Persist the taint gate's audit log (per-stage) when it gained events
+        // since the last write, so security decisions are inspectable after
+        // the fact. The log is append-only, so an unchanged (stage, count)
+        // means the file on disk is already current - re-serializing the whole
+        // log every heartbeat was an O(events) allocation that grew with the
+        // run.
+        let taint_audit = taint_gate
+            .filter(|g| !g.audit_log().is_empty())
+            .and_then(|g| {
+                let key = (cursor.index, g.audit_log().len());
+                if watermark.last_taint == Some(key) {
+                    return None;
+                }
+                watermark.last_taint = Some(key);
+                Some((
+                    cursor.index,
+                    serde_json::to_string(g.audit_log())
+                        .expect("GateEvent slice always serializes"),
+                ))
+            });
         // A parent parked mid fan-out: persist its waiting state so the
         // split/merge resumes after a restart (removed once it's no longer
         // waiting - see the writer).

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -73,12 +73,28 @@ impl PersistWatermark {
         self.last_progress_at
     }
 
+    /// The run status the last dispatched snapshot carried, if any - the proof
+    /// that a given status has reached the persistence lane. Unloading
+    /// decisions key on this: an entity may only be slimmed or paged out once
+    /// the state being dropped is known to be on its way to disk.
+    pub(crate) fn persisted_status(&self) -> Option<leviath_core::run_meta::RunStatus> {
+        self.last.as_ref().map(|(_, _, status)| status.clone())
+    }
+
     /// Move both stamps back to `at`, so a test can reach the heartbeat window
     /// without sleeping through it.
     #[cfg(test)]
     pub(crate) fn backdate(&mut self, at: i64) {
         self.last_written_at = Some(at);
         self.last_progress_at = Some(at);
+    }
+
+    /// Stamp the watermark as though a snapshot with `status` was dispatched,
+    /// so unload tests can drive [`Self::persisted_status`] without running the
+    /// full persistence schedule.
+    #[cfg(test)]
+    pub(crate) fn stamp_status(&mut self, status: leviath_core::run_meta::RunStatus) {
+        self.last = Some((0, 0, status));
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -410,7 +410,7 @@ mod tests {
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
             &self,
-            _r: leviath_providers::InferenceRequest,
+            _r: &leviath_providers::InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             Err(leviath_providers::ProviderError::Other(
                 "test provider".to_string(),
@@ -446,7 +446,7 @@ mod tests {
                 "extra": null,
             }))
             .unwrap();
-        assert!(p.infer(request).await.is_err());
+        assert!(p.infer(&request).await.is_err());
         assert_eq!(p.count_tokens("x", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         assert_eq!(p.name(), "fake");

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5195,7 +5195,7 @@ fn transition_allow_complete_single_edge_awaits_choice() {
 }
 
 #[test]
-fn transition_visit_exhausted_edge_is_terminal() {
+fn transition_visit_exhausted_edge_is_a_dead_end_error() {
     use leviath_core::blueprint::TransitionCondition;
     let bp = blueprint(vec![
         stage_named(
@@ -5213,11 +5213,54 @@ fn transition_visit_exhausted_edge_is_terminal() {
 
     run_transition(&mut world);
 
-    // Only edge exhausted ⇒ terminal.
-    assert_eq!(
-        world.get::<AgentState>(e).unwrap().status,
-        AgentStatus::Complete
-    );
+    // The stage declared a normal edge and every one of them is exhausted:
+    // the graph dead-ended mid-run, which is an ERROR, not a completion.
+    // This resolved to `Complete` before, which is how a run silently ended
+    // at stage 2 of 5 with the output stage still pending.
+    let status = world.get::<AgentState>(e).unwrap().status.clone();
+    let AgentStatus::Error { message } = status else {
+        panic!("a dead-ended graph must error, got {status:?}");
+    };
+    assert!(message.contains("dead-ended"), "{message}");
+    assert!(message.contains("'a'"), "{message}");
+}
+
+/// A dead end with an `error` edge in budget routes down it - exhaustion is
+/// now a failure mode `error_recovery` can actually catch.
+#[test]
+fn transition_dead_end_routes_down_the_error_edge_when_present() {
+    use leviath_core::blueprint::TransitionCondition;
+    let bp = blueprint(vec![
+        stage_named(
+            "a",
+            Some(vec![
+                edge("b", TransitionCondition::Always),
+                edge("rescue", TransitionCondition::Error),
+            ]),
+            false,
+            None,
+        ),
+        stage_named("b", None, false, Some(0)), // max_revisits 0
+        stage_named("rescue", None, false, None),
+    ]);
+    let mut visits = VisitCounts::default();
+    visits.0.insert("b".to_string(), 1); // b is out of budget
+    let mut world = World::new();
+    let e = spawn_transition_agent(&mut world, bp, vec![si("m0"), si("m1"), si("m2")], visits);
+
+    run_transition(&mut world);
+
+    let state = world.get::<AgentState>(e).unwrap();
+    assert_eq!(state.status, AgentStatus::Active, "recovering, not dead");
+    assert_eq!(state.current_stage, "rescue");
+    // And the recovery stage can read why it was entered.
+    let window = world.get::<ContextWindow>(e).unwrap();
+    let noted = window
+        .regions
+        .iter()
+        .flat_map(|r| r.content.iter())
+        .any(|entry| entry.content.contains("dead-ended"));
+    assert!(noted, "the dead-end reason is in the context");
 }
 
 #[test]
@@ -5251,7 +5294,7 @@ fn transition_non_choosable_edge_is_terminal() {
 }
 
 #[test]
-fn transition_unknown_target_edge_is_terminal() {
+fn transition_unknown_target_edge_is_a_dead_end_error() {
     use leviath_core::blueprint::TransitionCondition;
     let bp = blueprint(vec![stage_named(
         "a",
@@ -5264,11 +5307,13 @@ fn transition_unknown_target_edge_is_terminal() {
 
     run_transition(&mut world);
 
-    // Edge points at a nonexistent stage ⇒ filtered ⇒ terminal.
-    assert_eq!(
-        world.get::<AgentState>(e).unwrap().status,
-        AgentStatus::Complete
-    );
+    // The only declared edge points at a nonexistent stage: nothing can ever
+    // follow it, so completing here would be a silent lie.
+    let status = world.get::<AgentState>(e).unwrap().status.clone();
+    let AgentStatus::Error { message } = status else {
+        panic!("an unfollowable graph must error, got {status:?}");
+    };
+    assert!(message.contains("dead-ended"), "{message}");
 }
 
 // ── stage setup on entry ──

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -17,7 +17,7 @@ struct Cfg {
 impl Provider for Cfg {
     async fn infer(
         &self,
-        _r: InferenceRequest,
+        _r: &InferenceRequest,
     ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
         Ok(leviath_providers::InferenceResponse {
             content: "ok".to_string(),
@@ -593,7 +593,7 @@ struct Exploding;
 impl Provider for Exploding {
     async fn infer(
         &self,
-        _r: InferenceRequest,
+        _r: &InferenceRequest,
     ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
         panic!("provider adapter blew up")
     }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1654,15 +1654,67 @@ fn dispatch_persistence_flushes_buffered_io_without_a_watermark_change() {
     run_dispatch_persistence(&mut world);
     let _ = rx.try_recv().expect("first job");
 
-    // Watermark unchanged, but new buffered content ⇒ still flushed.
+    // Watermark unchanged and no heartbeat due, but new buffered content ⇒
+    // the lines are journaled WITHOUT a whole-window snapshot. Snapshotting
+    // per log-line batch deep-cloned the context several times per iteration.
     world
         .get_mut::<StageIoBuffer>(e)
         .unwrap()
         .logs
         .push((0, "late log".to_string()));
     run_dispatch_persistence(&mut world);
-    let job = snapshot_job(rx.try_recv().expect("append-triggered job"));
-    assert_eq!(job.log_appends, vec![(0, "late log".to_string())]);
+    match rx.try_recv().expect("append-triggered message") {
+        PersistMsg::StageLines {
+            run_id,
+            output_appends,
+            log_appends,
+        } => {
+            assert_eq!(run_id, "run-1");
+            assert!(output_appends.is_empty());
+            assert_eq!(log_appends, vec![(0, "late log".to_string())]);
+        }
+        PersistMsg::Snapshot(_) | PersistMsg::Append { .. } => {
+            panic!("buffered lines alone must not force a whole-window snapshot")
+        }
+    }
+    // The buffer was drained in place either way.
+    assert!(world.get::<StageIoBuffer>(e).unwrap().logs.is_empty());
+}
+
+/// Buffered lines when the heartbeat IS due ride the full snapshot rather
+/// than a lines-only message, so `updated_at` still advances.
+#[test]
+fn dispatch_persistence_appends_ride_the_snapshot_when_heartbeat_is_due() {
+    let (mut world, mut rx) = world_with_persistence();
+    let e = world
+        .spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            StageIoBuffer::default(),
+        ))
+        .id();
+
+    run_dispatch_persistence(&mut world);
+    let _ = rx.try_recv().expect("first job");
+
+    // Age the watermark past the heartbeat window, then buffer a line.
+    let stale = chrono::Utc::now().timestamp() - (PERSIST_HEARTBEAT_SECS + 1);
+    world
+        .get_mut::<PersistWatermark>(e)
+        .unwrap()
+        .backdate(stale);
+    world
+        .get_mut::<StageIoBuffer>(e)
+        .unwrap()
+        .logs
+        .push((0, "heartbeat log".to_string()));
+    run_dispatch_persistence(&mut world);
+    let job = snapshot_job(rx.try_recv().expect("heartbeat job"));
+    assert_eq!(job.log_appends, vec![(0, "heartbeat log".to_string())]);
 }
 
 #[test]
@@ -1762,6 +1814,50 @@ fn dispatch_persistence_persists_taint_audit_when_the_gate_has_events() {
     let (idx, json) = job.taint_audit.expect("taint audit persisted");
     assert_eq!(idx, 1);
     assert!(json.contains("shell"));
+}
+
+/// An unchanged audit log is not re-serialized on the next snapshot: the file
+/// on disk is already current, and rewriting it every heartbeat was an
+/// O(events) allocation that grew with the run.
+#[test]
+fn dispatch_persistence_taint_audit_is_not_rewritten_when_unchanged() {
+    let (mut world, mut prx) = world_with_persistence();
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            run_metadata(),
+            agent_state(),
+            infer_with(vec![tc("c_shell", "shell")]),
+            tainted_conv_window(),
+            ReadyForTools,
+            enabled_gate(),
+            StageCursor { index: 1 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+    run_dispatch_persistence(&mut world);
+    let first = snapshot_job(prx.try_recv().expect("first job"));
+    assert!(first.taint_audit.is_some(), "first write carries the audit");
+
+    // Force a heartbeat snapshot with no new gate events: the audit rides
+    // along exactly once.
+    let stale = chrono::Utc::now().timestamp() - (PERSIST_HEARTBEAT_SECS + 1);
+    world
+        .get_mut::<PersistWatermark>(e)
+        .unwrap()
+        .backdate(stale);
+    run_dispatch_persistence(&mut world);
+    let second = snapshot_job(prx.try_recv().expect("heartbeat job"));
+    assert!(
+        second.taint_audit.is_none(),
+        "an unchanged audit log is not re-serialized"
+    );
 }
 
 #[test]
@@ -2877,7 +2973,9 @@ fn append_msg(
             record,
             ack,
         } => (run_id, *record, ack),
-        PersistMsg::Snapshot(_) => panic!("expected an append on the lane"),
+        PersistMsg::Snapshot(_) | PersistMsg::StageLines { .. } => {
+            panic!("expected an append on the lane")
+        }
     }
 }
 
@@ -8372,7 +8470,9 @@ fn world_with_persistence() -> (World, mpsc::UnboundedReceiver<PersistMsg>) {
 fn snapshot_job(msg: PersistMsg) -> PersistJob {
     match msg {
         PersistMsg::Snapshot(job) => *job,
-        PersistMsg::Append { .. } => panic!("expected a snapshot on the lane"),
+        PersistMsg::Append { .. } | PersistMsg::StageLines { .. } => {
+            panic!("expected a snapshot on the lane")
+        }
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1761,6 +1761,40 @@ fn dispatch_persistence_broadcasts_buffered_lines_as_log_events() {
     assert!(sink_rx.try_recv().is_err(), "no extra events");
 }
 
+/// Broadcast log lines are truncated (the never-shrinking ring retains every
+/// slot's strings); the on-disk stage log keeps the full line.
+#[test]
+fn dispatch_persistence_truncates_long_broadcast_lines_but_not_disk_appends() {
+    use crate::host::{WorldEvent, WorldEventSink};
+    let (mut world, mut rx) = world_with_persistence();
+    let (sink_tx, mut sink_rx) = tokio::sync::broadcast::channel(16);
+    world.insert_resource(WorldEventSink(sink_tx));
+    let long_line = "y".repeat(BROADCAST_LOG_LINE_MAX_BYTES + 100);
+    let mut buf = StageIoBuffer::default();
+    buf.output.push((0, long_line.clone()));
+    world.spawn((
+        run_metadata(),
+        agent_state(),
+        conv_window(),
+        StageCursor { index: 0 },
+        TokenTotals::default(),
+        PersistWatermark::default(),
+        buf,
+    ));
+
+    run_dispatch_persistence(&mut world);
+
+    let event = sink_rx.try_recv().expect("log event");
+    let WorldEvent::Log { line, .. } = event else {
+        panic!("expected a Log event");
+    };
+    assert!(line.len() < long_line.len(), "broadcast copy is truncated");
+    assert!(line.ends_with("[truncated 100 bytes]"), "got: {line}");
+    // The disk append still carries the whole line.
+    let job = snapshot_job(rx.try_recv().expect("persist job"));
+    assert_eq!(job.output_appends, vec![(0, long_line)]);
+}
+
 #[test]
 fn dispatch_persistence_emits_no_log_events_without_a_sink() {
     use crate::host::WorldEventSink;

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -71,6 +71,12 @@ pub(crate) enum StageResolution {
     /// The stage errored and has no `error` edge - terminate the run as errored,
     /// preserving the error status the collect system already set.
     TerminalError,
+    /// The stage DECLARES normal outgoing transitions, but every one of them is
+    /// revisit-exhausted (or targets an unknown stage): the graph dead-ended in
+    /// the middle. Distinct from [`Self::Terminal`] because reporting this as
+    /// `Complete` is how a run silently ended at stage 2 of 5 with no output -
+    /// the resolver routes it down the stage's `error` edge, or fails the run.
+    DeadEnd,
     /// Advance to this stage index, applying the edge's context transform once
     /// the edge's gate (if any) is satisfied.
     Next(
@@ -481,7 +487,24 @@ pub(crate) fn resolve_transition_sync(
                 })
                 .collect();
             match choosable.len() {
-                0 => StageResolution::Terminal,
+                0 => {
+                    // No followable edge left. If the stage never declared a
+                    // normal (Always/LlmChoice) edge, this is a legitimate
+                    // terminal whose conditioned edges are alternates. If it
+                    // DID - and they were all filtered out above - the graph
+                    // dead-ended mid-run, which must not read as success.
+                    let declared_normal = transitions.values().any(|e| {
+                        matches!(
+                            e.condition,
+                            TransitionCondition::Always | TransitionCondition::LlmChoice
+                        )
+                    });
+                    if declared_normal {
+                        StageResolution::DeadEnd
+                    } else {
+                        StageResolution::Terminal
+                    }
+                }
                 1 if !stage.allow_complete => {
                     let idx = blueprint
                         .stages
@@ -1032,6 +1055,33 @@ pub fn resolve_transition(
             }
             None => resolve_transition_sync(&bp.0, stage, cursor.index, &visits.0),
         };
+        // A dead end resolves like a stage error: down the `error` edge when one
+        // has budget left (this is what finally makes `error_recovery` reachable
+        // for exhaustion, not just for provider failures), and otherwise the run
+        // FAILS. It used to resolve as `Terminal`, so a wide-researcher whose
+        // deep_dive ran `compare` out of revisits reported `complete` from the
+        // middle of its graph with the output stage still pending and nothing
+        // produced - success indistinguishable from the run that worked.
+        let resolution = match resolution {
+            StageResolution::DeadEnd => {
+                let message = format!(
+                    "stage '{}' dead-ended: every declared transition's target has spent \
+                     its max_revisits budget before an output or terminal stage was reached",
+                    stage.name
+                );
+                match find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error) {
+                    Some((i, t)) => {
+                        note_error(&mut window, &stage.name, &message);
+                        StageResolution::Next(i, t, None)
+                    }
+                    None => {
+                        state.status = AgentStatus::Error { message };
+                        StageResolution::TerminalError
+                    }
+                }
+            }
+            other => other,
+        };
         match resolution {
             StageResolution::Terminal => {
                 state.status = AgentStatus::Complete;
@@ -1040,8 +1090,11 @@ pub fn resolve_transition(
                     .remove::<ResolveTransition>()
                     .remove::<StageOutcome>();
             }
-            StageResolution::TerminalError => {
-                // Status was set to Error by the collect system; just stop.
+            // `DeadEnd` is in the pattern only for exhaustiveness: the
+            // conversion above always turns it into `Next` or `TerminalError`.
+            StageResolution::TerminalError | StageResolution::DeadEnd => {
+                // Status was set to Error by the collect system (or by the
+                // dead-end conversion above); just stop.
                 commands
                     .entity(entity)
                     .remove::<ResolveTransition>()

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -79,7 +79,7 @@ mod tests {
     impl Provider for StubProvider {
         async fn infer(
             &self,
-            _request: InferenceRequest,
+            _request: &InferenceRequest,
         ) -> Result<InferenceResponse, ProviderError> {
             Err(ProviderError::ApiError("stub".to_string()))
         }
@@ -170,6 +170,6 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         };
-        assert!(p.infer(request).await.is_err());
+        assert!(p.infer(&request).await.is_err());
     }
 }

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -219,7 +219,7 @@ mod tests {
     impl Provider for Scripted {
         async fn infer(
             &self,
-            _r: InferenceRequest,
+            _r: &InferenceRequest,
         ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
             match self.0 {
                 Ok(reply) => Ok(leviath_providers::InferenceResponse {
@@ -326,7 +326,7 @@ mod tests {
         impl Provider for Hang {
             async fn infer(
                 &self,
-                _r: InferenceRequest,
+                _r: &InferenceRequest,
             ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
                 std::future::pending().await
             }

--- a/crates/leviath-runtime/src/title_bridge.rs
+++ b/crates/leviath-runtime/src/title_bridge.rs
@@ -60,7 +60,7 @@ pub async fn run_title_job(
         permit,
     } = job;
 
-    let result = match tokio::time::timeout(deadline, provider.infer(request)).await {
+    let result = match tokio::time::timeout(deadline, provider.infer(&request)).await {
         Ok(outcome) => outcome.map(|r| r.content),
         Err(_) => Err(leviath_providers::ProviderError::Other(format!(
             "title generation exceeded the {}s deadline and was aborted to free the pool slot",

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1039,7 +1039,7 @@ mod tests {
     impl Provider for Script {
         async fn infer(
             &self,
-            _req: InferenceRequest,
+            _req: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             let next = self.responses.lock().unwrap().pop_front();
             next.ok_or_else(|| ProviderError::Other("script exhausted".to_string()))

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -394,6 +394,11 @@ impl PipelineWorld {
                 // same tick rather than waiting for the next one.
                 fail_wedged_runs,
                 dispatch_persistence,
+                // After persistence: a merged fan-out worker is only slimmed
+                // once its terminal snapshot has been dispatched to the lane,
+                // and running behind `dispatch_persistence` means the check
+                // reads this tick's watermark, not last tick's.
+                crate::fanout::slim_merged_workers,
             )
                 .chain()
                 .after(crate::interaction_points::collect_interaction_point),

--- a/perf-tools/leviath_monitor.py
+++ b/perf-tools/leviath_monitor.py
@@ -659,6 +659,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="stop automatically after this many samples (default: unlimited)",
     )
     parser.add_argument(
+        "--pid",
+        type=int,
+        default=None,
+        help="watch this exact pid instead of searching by name",
+    )
+    parser.add_argument(
         "--runs-dir",
         default=None,
         help=(
@@ -694,7 +700,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print("error: --max-samples must be greater than 0", file=sys.stderr)
         return 1
 
-    proc = find_leviath_process(args.name)
+    if args.pid is not None:
+        try:
+            proc = psutil.Process(args.pid)
+        except psutil.Error:
+            print(f"error: pid {args.pid} is not running", file=sys.stderr)
+            return 1
+    else:
+        proc = find_leviath_process(args.name)
     if proc is None:
         print(
             f"error: no running process matching {args.name!r} was found",

--- a/perf-tools/leviath_monitor.py
+++ b/perf-tools/leviath_monitor.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-"""Watch the ``leviath`` process and graph its CPU / memory use over time.
+"""Watch the ``leviath`` daemon and graph sessions, CPU, and memory over time.
 
 Start this script, go do whatever you want with leviath, then press Ctrl-C to
 stop it. On stop it writes a timestamped CSV of every sample it took plus a
-timestamped PNG graph (CPU percent on top, resident memory on the bottom).
-Because both output names carry a ``YYYYmmdd_HHMMSS`` stamp, repeated runs never
-clobber each other.
+timestamped PNG graph with three aligned panels:
+
+1. Active sessions - runs whose ``meta.json`` status is non-terminal
+   (``starting``, ``running``, ``waiting_input``, ``paused``), sampled from the
+   runs directory the daemon persists to.
+2. CPU percent.
+3. Memory - two lines. ``rss`` is what ``ps`` shows and includes freed pages
+   the allocator has not handed back to the OS, so it only ever ratchets up.
+   ``footprint`` is the process's live memory (macOS physical footprint, Linux
+   PSS, Windows USS) and is the number that actually tells you whether leviath
+   is holding onto memory. When the two diverge, the gap is allocator-retained
+   pages, not a leak.
+
+Every panel title carries the metric's average and peak, and a dashed line
+marks the average. Because both output names carry a ``YYYYmmdd_HHMMSS``
+stamp, repeated runs never clobber each other.
 
 Requires ``psutil`` and ``matplotlib``.
 
@@ -14,6 +27,7 @@ Usage:
     python3 leviath_monitor.py -i 0.5
     python3 leviath_monitor.py -n leviath-server -o ./monitor-runs
     python3 leviath_monitor.py --max-samples 60
+    python3 leviath_monitor.py --runs-dir /tmp/lev-home/.leviath/runs
 
 Exit codes:
     0 - clean stop (Ctrl-C, sample cap reached, or watched process exited);
@@ -25,12 +39,23 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
+import re
+import subprocess
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, List, NamedTuple, Optional, Sequence, Tuple
+from typing import (
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import psutil
 
@@ -47,7 +72,11 @@ __all__ = [
     "DEFAULT_PROCESS_NAME",
     "DEFAULT_INTERVAL",
     "CSV_HEADER",
+    "ACTIVE_STATUSES",
     "find_leviath_process",
+    "sample_live_memory_mb",
+    "default_runs_dir",
+    "ActiveRunCounter",
     "sample_process",
     "build_output_paths",
     "init_csv",
@@ -65,10 +94,30 @@ DEFAULT_PROCESS_NAME = "leviath"
 DEFAULT_INTERVAL = 1.0
 
 #: Column order of the emitted CSV.
-CSV_HEADER = ("elapsed_seconds", "timestamp", "cpu_percent", "memory_mb")
+CSV_HEADER = (
+    "elapsed_seconds",
+    "timestamp",
+    "cpu_percent",
+    "rss_mb",
+    "footprint_mb",
+    "active_runs",
+)
+
+#: ``meta.json`` statuses that count as a live session. Mirrors the
+#: non-terminal variants of ``RunStatus`` in ``crates/leviath-core``
+#: (``snake_case`` on disk).
+ACTIVE_STATUSES = frozenset({"starting", "running", "waiting_input", "paused"})
 
 #: Bytes per megabyte, used to convert psutil's RSS figure.
 _BYTES_PER_MB = 1024 * 1024
+
+#: Matches the value ``top -stats mem`` prints on macOS, e.g. ``22M``,
+#: ``1536K+``, ``1.2G-``. The trailing +/- is top's delta marker.
+_TOP_MEM_RE = re.compile(r"^(\d+(?:\.\d+)?)([BKMG])[+-]?$")
+
+#: Matches the summary line of ``/usr/bin/footprint``, e.g.
+#: ``lev [6994]: 64-bit    Footprint: 22 MB (16384 bytes per page)``.
+_FOOTPRINT_RE = re.compile(r"Footprint:\s+(\d+(?:\.\d+)?)\s*([BKMG])B?\b")
 
 
 class Sample(NamedTuple):
@@ -77,31 +126,42 @@ class Sample(NamedTuple):
     elapsed: float
     timestamp: str
     cpu_percent: float
-    memory_mb: float
+    rss_mb: float
+    footprint_mb: Optional[float]
+    active_runs: Optional[int]
 
 
 def find_leviath_process(
     pattern: str = DEFAULT_PROCESS_NAME,
 ) -> Optional[psutil.Process]:
-    """Return the first running process matching *pattern*, or ``None``.
+    """Return the best running process matching *pattern*, or ``None``.
 
     The match is a case-insensitive substring test against both the process
-    name and its full command line, so ``leviath`` finds ``leviath``,
-    ``leviath-server`` and ``python3 /opt/leviath/run.py`` alike.
+    name and its full command line. Among the matches, the daemon and serve
+    processes are preferred over incidental hits: an editor whose command line
+    merely contains a leviath path would otherwise win by being first in the
+    process table.
 
-    This monitor's own process is always skipped: its command line contains
-    "leviath_monitor.py", which would otherwise match the default pattern and
-    make the script graph itself instead of the process you care about.
+    Ranking, best first:
+
+    1. name matches and the cmdline mentions ``daemon`` or ``serve``
+    2. name matches
+    3. only the cmdline matches
+
+    This monitor's own process is always skipped, as is any process running
+    this script (its command line contains "leviath_monitor", which would
+    otherwise match the default pattern).
 
     Args:
         pattern: Substring to look for.
 
     Returns:
-        A :class:`psutil.Process` for the first match, or ``None`` if nothing
+        A :class:`psutil.Process` for the best match, or ``None`` if nothing
         matched.
     """
     needle = pattern.lower()
     own_pid = os.getpid()
+    best: Optional[Tuple[int, int, psutil.Process]] = None
     for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
             info = proc.info
@@ -110,20 +170,193 @@ def find_leviath_process(
             name = (info.get("name") or "").lower()
             cmdline = " ".join(info.get("cmdline") or []).lower()
         except psutil.Error:
-            # Process died or is not readable while we were iterating; skip it.
+            # Process died or is not readable while we were iterating.
             continue
-        if needle in name or needle in cmdline:
-            return proc
+        if "leviath_monitor" in cmdline:
+            continue
+        name_hit = needle in name or name in ("lev", "lev.exe")
+        cmdline_hit = needle in cmdline
+        if not name_hit and not cmdline_hit:
+            continue
+        if name_hit and ("daemon" in cmdline or "serve" in cmdline):
+            rank = 0
+        elif name_hit:
+            rank = 1
+        else:
+            rank = 2
+        key = (rank, info.get("pid") or 0)
+        if best is None or key < (best[0], best[1]):
+            best = (rank, info.get("pid") or 0, proc)
+    return best[2] if best else None
+
+
+_UNIT_TO_MB = {"B": 1 / _BYTES_PER_MB, "K": 1 / 1024, "M": 1.0, "G": 1024.0}
+
+
+def _live_memory_darwin(pid: int) -> Optional[float]:
+    """macOS: physical footprint, in MB.
+
+    Physical footprint is the figure ``vmmap`` and Activity Monitor report,
+    and unlike psutil's ``memory_full_info`` it needs no elevated privileges.
+    RSS on macOS keeps counting MADV_FREE'd pages, so it can sit hundreds of
+    MB above the memory the process actually holds.
+
+    ``/usr/bin/footprint`` answers in ~30ms; ``top`` is the fallback because
+    it is always present but costs over a second of system time per call (it
+    scans the whole process table even when pinned to one pid).
+    """
+    try:
+        out = subprocess.run(
+            ["/usr/bin/footprint", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+        match = _FOOTPRINT_RE.search(out)
+        if match:
+            return float(match.group(1)) * _UNIT_TO_MB[match.group(2)]
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        out = subprocess.run(
+            ["top", "-l", "1", "-s", "0", "-pid", str(pid), "-stats", "mem"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in reversed(out.splitlines()):
+        token = line.strip().split()[0] if line.strip() else ""
+        match = _TOP_MEM_RE.match(token)
+        if match:
+            return float(match.group(1)) * _UNIT_TO_MB[match.group(2)]
     return None
 
 
-def sample_process(proc: psutil.Process, start_time: float) -> Sample:
-    """Take one CPU/memory measurement of *proc*.
+def _live_memory_linux(pid: int) -> Optional[float]:
+    """Linux: PSS from ``smaps_rollup``, in MB. Unprivileged for own processes."""
+    try:
+        text = Path(f"/proc/{pid}/smaps_rollup").read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.startswith("Pss:"):
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return int(parts[1]) / 1024
+    return None
+
+
+def _live_memory_psutil(proc: psutil.Process) -> Optional[float]:
+    """Fallback: USS via psutil, in MB. Works unprivileged on Windows."""
+    try:
+        return proc.memory_full_info().uss / _BYTES_PER_MB
+    except (psutil.Error, AttributeError):
+        return None
+
+
+def sample_live_memory_mb(proc: psutil.Process) -> Optional[float]:
+    """Return the process's live memory in MB, or ``None`` if unmeasurable.
+
+    "Live" means the memory the process is actually holding right now: macOS
+    physical footprint, Linux PSS, Windows USS. Where the platform refuses to
+    say (e.g. psutil's USS needs root on macOS), the sample is ``None`` and the
+    CSV cell is left empty rather than repeating the misleading RSS number.
+    """
+    if sys.platform == "darwin":
+        return _live_memory_darwin(proc.pid)
+    if sys.platform.startswith("linux"):
+        value = _live_memory_linux(proc.pid)
+        if value is not None:
+            return value
+    return _live_memory_psutil(proc)
+
+
+def default_runs_dir() -> Path:
+    """Resolve the runs directory the same way ``lev`` itself does.
+
+    ``LEVIATH_RUNS_DIR`` wins outright; otherwise ``LEVIATH_HOME`` (or the OS
+    home) anchors ``.leviath/runs``. Keeping this in lockstep with
+    ``runstate::runs_dir`` in ``crates/leviath-cli`` means the session counts
+    follow an isolated test daemon automatically.
+    """
+    override = os.environ.get("LEVIATH_RUNS_DIR")
+    if override:
+        return Path(override)
+    home = os.environ.get("LEVIATH_HOME")
+    base = Path(home) if home else Path.home()
+    return base / ".leviath" / "runs"
+
+
+class ActiveRunCounter:
+    """Count non-terminal runs by scanning ``meta.json`` files.
+
+    Reads go to the same on-disk run state the daemon persists (its read
+    model), so no auth token or API round trip is needed and the count works
+    identically on every OS. Each ``meta.json`` is re-read only when its
+    mtime changes, so steady-state sampling is a directory listing plus a
+    handful of ``stat`` calls even with hundreds of historical runs on disk.
+    """
+
+    def __init__(self, runs_dir: Path):
+        self.runs_dir = runs_dir
+        self._cache: Dict[Path, Tuple[float, Optional[str]]] = {}
+
+    def count(self) -> Optional[int]:
+        """Return the number of active runs, or ``None`` if unreadable."""
+        try:
+            entries = list(self.runs_dir.iterdir())
+        except OSError:
+            return None
+        active = 0
+        seen = set()
+        for entry in entries:
+            meta_path = entry / "meta.json"
+            seen.add(meta_path)
+            try:
+                mtime = meta_path.stat().st_mtime
+            except OSError:
+                self._cache.pop(meta_path, None)
+                continue
+            cached = self._cache.get(meta_path)
+            if cached is not None and cached[0] == mtime:
+                status = cached[1]
+            else:
+                status = self._read_status(meta_path)
+                self._cache[meta_path] = (mtime, status)
+            if status in ACTIVE_STATUSES:
+                active += 1
+        # Forget runs whose directories were deleted.
+        for stale in [p for p in self._cache if p not in seen]:
+            del self._cache[stale]
+        return active
+
+    @staticmethod
+    def _read_status(meta_path: Path) -> Optional[str]:
+        """Read ``status`` out of one ``meta.json``, or ``None`` on any error."""
+        try:
+            with open(meta_path, encoding="utf-8") as handle:
+                meta = json.load(handle)
+        except (OSError, ValueError):
+            return None
+        status = meta.get("status")
+        return status if isinstance(status, str) else None
+
+
+def sample_process(
+    proc: psutil.Process,
+    start_time: float,
+    run_counter: Optional[ActiveRunCounter] = None,
+) -> Sample:
+    """Take one measurement of *proc*.
 
     Args:
         proc: The process to measure.
         start_time: ``time.time()`` value from when monitoring began, used to
             compute the elapsed-seconds x-axis value.
+        run_counter: Optional session counter; ``None`` records an empty
+            ``active_runs`` cell.
 
     Returns:
         A :class:`Sample`.
@@ -132,12 +365,16 @@ def sample_process(proc: psutil.Process, start_time: float) -> Sample:
         psutil.Error: If the process vanished or is no longer readable.
     """
     cpu_percent = float(proc.cpu_percent(interval=None))
-    memory_mb = proc.memory_info().rss / _BYTES_PER_MB
+    rss_mb = proc.memory_info().rss / _BYTES_PER_MB
+    footprint_mb = sample_live_memory_mb(proc)
+    active_runs = run_counter.count() if run_counter is not None else None
     return Sample(
         elapsed=time.time() - start_time,
         timestamp=datetime.now().isoformat(timespec="seconds"),
         cpu_percent=cpu_percent,
-        memory_mb=memory_mb,
+        rss_mb=rss_mb,
+        footprint_mb=footprint_mb,
+        active_runs=active_runs,
     )
 
 
@@ -170,6 +407,7 @@ def append_csv_row(csv_path: Path | str, sample: Sample) -> None:
 
     Rows are flushed as they are taken rather than dumped at the end, so the
     data survives even if the monitor is killed outright instead of Ctrl-C'd.
+    Unmeasurable values are left as empty cells.
     """
     with open(csv_path, "a", newline="", encoding="utf-8") as handle:
         csv.writer(handle).writerow(
@@ -177,9 +415,52 @@ def append_csv_row(csv_path: Path | str, sample: Sample) -> None:
                 f"{sample.elapsed:.3f}",
                 sample.timestamp,
                 f"{sample.cpu_percent:.2f}",
-                f"{sample.memory_mb:.3f}",
+                f"{sample.rss_mb:.3f}",
+                "" if sample.footprint_mb is None else f"{sample.footprint_mb:.3f}",
+                "" if sample.active_runs is None else str(sample.active_runs),
             ]
         )
+
+
+def _stats_label(name: str, values: Sequence[float], unit: str) -> str:
+    """Format ``name (avg X, peak Y unit)`` for a panel title."""
+    if not values:
+        return name
+    avg = sum(values) / len(values)
+    return f"{name} (avg {avg:.1f}, peak {max(values):.1f} {unit})"
+
+
+def _plot_series(
+    axes,
+    samples: Sequence[Sample],
+    pick: Callable[[Sample], Optional[float]],
+    color: str,
+    label: Optional[str] = None,
+    step: bool = False,
+) -> List[float]:
+    """Plot one metric, skipping ``None`` gaps, with a dashed average line.
+
+    Returns:
+        The plotted (non-``None``) values, for the caller's title stats.
+    """
+    points = [
+        (sample.elapsed, value)
+        for sample in samples
+        if (value := pick(sample)) is not None
+    ]
+    if not points:
+        return []
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    if step:
+        axes.step(xs, ys, where="post", color=color, linewidth=1.5, label=label)
+    else:
+        axes.plot(xs, ys, color=color, linewidth=1.5, label=label)
+    axes.fill_between(xs, ys, color=color, alpha=0.15, step="post" if step else None)
+    axes.axhline(
+        sum(ys) / len(ys), color=color, linewidth=1.0, linestyle="--", alpha=0.6
+    )
+    return ys
 
 
 def generate_graph(
@@ -187,7 +468,11 @@ def generate_graph(
     png_path: Path | str,
     label: str = DEFAULT_PROCESS_NAME,
 ) -> Path:
-    """Render *samples* to a two-panel PNG at *png_path*.
+    """Render *samples* to a three-panel PNG at *png_path*.
+
+    Panels share one x-axis: active sessions on top, CPU in the middle, and
+    memory (RSS vs live footprint) on the bottom, each titled with its average
+    and peak.
 
     Args:
         samples: Collected measurements; an empty sequence produces a
@@ -199,26 +484,45 @@ def generate_graph(
         The path that was written.
     """
     destination = Path(png_path)
-    figure, (cpu_axes, memory_axes) = plt.subplots(
-        2, 1, sharex=True, figsize=(10, 7)
+    figure, (runs_axes, cpu_axes, memory_axes) = plt.subplots(
+        3, 1, sharex=True, figsize=(10, 9)
     )
 
     if samples:
-        elapsed = [sample.elapsed for sample in samples]
-        cpu = [sample.cpu_percent for sample in samples]
-        memory = [sample.memory_mb for sample in samples]
+        runs = _plot_series(
+            runs_axes,
+            samples,
+            lambda s: None if s.active_runs is None else float(s.active_runs),
+            color="tab:green",
+            step=True,
+        )
+        if runs:
+            runs_axes.set_title(
+                _stats_label("Active sessions", runs, "runs"), fontsize=10
+            )
+        else:
+            runs_axes.set_title("Active sessions (no data)", fontsize=10)
 
-        cpu_axes.plot(elapsed, cpu, color="tab:red", linewidth=1.5)
-        cpu_axes.fill_between(elapsed, cpu, color="tab:red", alpha=0.15)
-        memory_axes.plot(elapsed, memory, color="tab:blue", linewidth=1.5)
-        memory_axes.fill_between(elapsed, memory, color="tab:blue", alpha=0.15)
+        cpu = _plot_series(cpu_axes, samples, lambda s: s.cpu_percent, "tab:red")
+        cpu_axes.set_title(_stats_label("CPU", cpu, "%"), fontsize=10)
 
-        peak_cpu = max(cpu)
-        peak_memory = max(memory)
-        cpu_axes.set_title(f"CPU (peak {peak_cpu:.1f}%)", fontsize=10)
-        memory_axes.set_title(f"Memory (peak {peak_memory:.1f} MB)", fontsize=10)
+        rss = _plot_series(
+            memory_axes, samples, lambda s: s.rss_mb, "tab:blue", label="rss"
+        )
+        footprint = _plot_series(
+            memory_axes,
+            samples,
+            lambda s: s.footprint_mb,
+            "tab:purple",
+            label="footprint (live)",
+        )
+        parts = [_stats_label("rss", rss, "MB")]
+        if footprint:
+            parts.append(_stats_label("footprint", footprint, "MB"))
+        memory_axes.set_title("Memory - " + ", ".join(parts), fontsize=10)
+        memory_axes.legend(loc="upper left", fontsize=8)
     else:
-        for axes in (cpu_axes, memory_axes):
+        for axes in (runs_axes, cpu_axes, memory_axes):
             axes.text(
                 0.5,
                 0.5,
@@ -230,10 +534,11 @@ def generate_graph(
                 color="gray",
             )
 
+    runs_axes.set_ylabel("Sessions")
     cpu_axes.set_ylabel("CPU %")
     memory_axes.set_ylabel("Memory (MB)")
     memory_axes.set_xlabel("Elapsed time (seconds)")
-    for axes in (cpu_axes, memory_axes):
+    for axes in (runs_axes, cpu_axes, memory_axes):
         axes.grid(True, alpha=0.3)
 
     figure.suptitle(
@@ -252,6 +557,7 @@ def watch_loop(
     max_samples: Optional[int] = None,
     sleep_fn: Callable[[float], None] = time.sleep,
     on_sample: Optional[Callable[[Sample], None]] = None,
+    run_counter: Optional[ActiveRunCounter] = None,
 ) -> List[Sample]:
     """Sample *proc* every *interval* seconds until told to stop.
 
@@ -271,6 +577,7 @@ def watch_loop(
             until interrupted.
         sleep_fn: Callable used to wait between samples.
         on_sample: Called with each sample; defaults to a one-line status print.
+        run_counter: Optional session counter shared across samples.
 
     Returns:
         Every sample collected, in order.
@@ -281,7 +588,7 @@ def watch_loop(
 
     while True:
         try:
-            sample = sample_process(proc, start_time)
+            sample = sample_process(proc, start_time, run_counter)
             append_csv_row(csv_path, sample)
             samples.append(sample)
             report(sample)
@@ -301,9 +608,16 @@ def watch_loop(
 
 def _print_sample(sample: Sample) -> None:
     """Print a single live status line for *sample*."""
+    footprint = (
+        "      n/a"
+        if sample.footprint_mb is None
+        else f"{sample.footprint_mb:9.1f}"
+    )
+    runs = "  ?" if sample.active_runs is None else f"{sample.active_runs:3d}"
     print(
         f"  [{sample.elapsed:7.1f}s] "
-        f"cpu {sample.cpu_percent:6.1f}%   mem {sample.memory_mb:9.1f} MB"
+        f"runs {runs}   cpu {sample.cpu_percent:6.1f}%   "
+        f"rss {sample.rss_mb:9.1f} MB   live {footprint} MB"
     )
 
 
@@ -312,8 +626,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="leviath_monitor.py",
         description=(
-            "Watch the leviath process and graph its CPU and memory use. "
-            "Press Ctrl-C to stop and write the outputs."
+            "Watch the leviath process and graph its sessions, CPU, and "
+            "memory use. Press Ctrl-C to stop and write the outputs."
         ),
     )
     parser.add_argument(
@@ -343,6 +657,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="stop automatically after this many samples (default: unlimited)",
+    )
+    parser.add_argument(
+        "--runs-dir",
+        default=None,
+        help=(
+            "runs directory to count active sessions from (default: "
+            "LEVIATH_RUNS_DIR, else LEVIATH_HOME/.leviath/runs, else "
+            "~/.leviath/runs)"
+        ),
+    )
+    parser.add_argument(
+        "--no-runs",
+        action="store_true",
+        help="skip session counting entirely",
     )
     return parser
 
@@ -392,6 +720,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     except psutil.Error:
         pass
 
+    run_counter: Optional[ActiveRunCounter] = None
+    if not args.no_runs:
+        runs_dir = Path(args.runs_dir) if args.runs_dir else default_runs_dir()
+        run_counter = ActiveRunCounter(runs_dir)
+        if not runs_dir.is_dir():
+            print(
+                f"note: runs dir {runs_dir} does not exist yet; session "
+                "counts will be empty until it does"
+            )
+
     csv_path, png_path = build_output_paths(args.output_dir, datetime.now())
     init_csv(csv_path)
 
@@ -405,6 +743,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.interval,
         csv_path,
         max_samples=args.max_samples,
+        run_counter=run_counter,
     )
 
     generate_graph(samples, png_path, label=name)

--- a/perf-tools/ws_churn_test.py
+++ b/perf-tools/ws_churn_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Hammer `lev serve` with abruptly-dropped WebSocket connections.
+
+Simulates a browser tab being refreshed mid-stream: open a batch of
+connections to ``/ws``, hold them for a second, then close them abruptly
+(SO_LINGER 0, so the peer sees a reset rather than a clean close). Between
+batches the daemon's RSS and live footprint are printed so a per-connection
+leak shows up as a staircase.
+
+A healthy server shows zero growth across batches; that was the measured
+behavior when this script was written (100 drops, +/- 0 MB).
+
+Usage:
+    python3 ws_churn_test.py --pid 6994 --token <control token>
+    python3 ws_churn_test.py --pid 6994 --token <t> --batches 10 --per-batch 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+
+def rss_kb(pid: int) -> int:
+    """Return the process RSS in KB via ``ps``."""
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)])
+    return int(out.strip())
+
+
+def open_ws(host: str, port: int, path: str, timeout: float = 5.0) -> socket.socket:
+    """Open a raw WebSocket (handshake only) and return the socket."""
+    sock = socket.create_connection((host, port), timeout=timeout)
+    key = base64.b64encode(os.urandom(16)).decode()
+    request = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n"
+    )
+    sock.sendall(request.encode())
+    sock.settimeout(2)
+    try:
+        sock.recv(4096)
+    except socket.timeout:
+        pass
+    return sock
+
+
+def abrupt_close(sock: socket.socket) -> None:
+    """Close with SO_LINGER 0 so the peer sees a reset, like a killed tab."""
+    try:
+        sock.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+        )
+    except OSError:
+        pass
+    sock.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pid", type=int, required=True, help="lev serve pid")
+    parser.add_argument("--token", required=True, help="serve auth token")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=3000)
+    parser.add_argument("--batches", type=int, default=5)
+    parser.add_argument("--per-batch", type=int, default=20)
+    args = parser.parse_args()
+
+    path = f"/ws?token={args.token}"
+    print(f"baseline rss: {rss_kb(args.pid) / 1024:.1f} MB")
+
+    for batch in range(args.batches):
+        socks = []
+        for _ in range(args.per_batch):
+            try:
+                socks.append(open_ws(args.host, args.port, path))
+            except OSError as error:
+                print(f"  connect error: {error}", file=sys.stderr)
+        time.sleep(1.0)
+        mid = rss_kb(args.pid)
+        for sock in socks:
+            abrupt_close(sock)
+        time.sleep(1.0)
+        after = rss_kb(args.pid)
+        print(
+            f"batch {batch + 1}: opened {len(socks)}, "
+            f"rss mid {mid / 1024:.1f} MB, after close {after / 1024:.1f} MB"
+        )
+
+    time.sleep(2)
+    print(f"final rss: {rss_kb(args.pid) / 1024:.1f} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Running five research/engineering agents concurrently took the daemon from a 16 MB baseline to a 679 MB peak with a matching 26% CPU spike, `ps` showed 300+ MB "retained" after every run finished, and one wide-researcher ended `complete` from the middle of its stage graph with no output. This PR is the measured fix for all three, plus the measurement tooling to prove it.

## What was actually wrong (verified live before any code changed)

- **"Memory never came back down" was mostly a measurement artifact.** `vmmap` on the idle daemon: 21.7 MB physical footprint under 292.8 MB `ps` RSS. Terminal runs were already reaped correctly; the gap was freed pages the system allocator never returns. The monitor graphed the wrong metric.
- **The real memory problem was the peak and the churn.** Each in-flight inference held ~5 copies of the full context (world window, assembled request, a fresh clone per retry attempt, the `serde_json::Value` body tree, the serialized bytes), and the persistence lane deep-cloned and serialized the whole window several times per iteration because any buffered log line forced a full snapshot. The measured 600-MB-in-4-seconds spike was these multiplied across 8 concurrent inferences of a 1M-token stage.
- **The serve APIs did not leak connections** (100 abrupt websocket drops: zero growth), but `context/history` parsed the entire `run.lvr` into memory per request, `logs?tail=` was unclamped, a dead-but-open websocket peer could wedge its task forever, and a control-socket subscriber's daemon-side task only died on the next write failure - on an idle daemon, never.
- **The silent no-output run was a dead-ended stage graph.** deep_dive's only normal exit ran out of `max_revisits`, and the engine mapped "zero followable edges" to `Complete`.

## The changes

1. **perf-tools** - the monitor samples true live memory (macOS physical footprint, Linux PSS, Windows USS) alongside RSS, counts active sessions from the runs dir, renders three aligned panels with avg+peak on each, and can pin an exact pid. `ws_churn_test.py` is the abrupt-disconnect harness.
2. **mimalloc** as the lev binary's global allocator, so RSS follows real usage back down.
3. **Providers borrow the request** (`infer(&InferenceRequest)`) - the per-attempt clone of the fully-assembled context is gone.
4. **Persistence lane**: lines-only journaling when nothing but logs changed, latest-wins coalescing of queued snapshots, a per-entry digest instead of a retained full context copy per live run, compact `context.json`, no re-copy in the atomic writer, taint audit serialized only when it gained events.
5. **Serve**: `context/history` and journal-search stream `run.lvr` frame-by-frame; `logs?tail=` clamped; websockets ping/pong with a send deadline and a capped write buffer; control-socket subscribers notice client EOF; both broadcast rings 1024→256 slots with log lines capped at 8 KB (disk keeps full lines); the MCP test endpoint no longer orphans a child process on error paths.
6. **Run lifecycle**: merged fan-out workers shed their context window once their terminal snapshot is persisted; paused standalone roots are paged out entirely (still listed, and Resume/Message/Cancel page them back in via the existing reloader); the emitted-interaction set is pruned on reap.
7. **Dead ends are errors**: a stage that declared normal edges and has none left routes down its `error` edge or fails the run with a named-stage message; validation rejects graphs whose only ending is exhaustion; a new `dead-end-possible` lint flags strandable stages; every bundled blueprint it flagged gained an un-exhaustible escape edge to its deliverable stage.

## Measured result

Same deterministic 24-run burst on both binaries (mock Rhai provider, ~77K-token contexts, 13 iterations each, unthrottled, 45s settle window after the last run):

| metric | before | after |
|---|---|---|
| live footprint avg / peak | 119.1 / 124.0 MB | **60.9 / 100.0 MB** |
| live footprint after all runs done | **124.0 MB (parked at peak forever)** | **53.0 MB (drops ~10s after the burst)** |
| RSS avg / peak | 132.7 / 137.9 MB | 109.3 / 113.7 MB |
| CPU avg / peak | 2.5% / 37.4% | **0.4% / 32.1%** |

Also verified live on the new binary: a run that dead-ends now errors with a message naming the stage (previously silent `complete`); a paused run pages out, stays visible in `lev ps`, and resumes to completion; 100 heavy `context/history` + unclamped-`tail` requests spike the serve process 5.6→46 MB transiently and it settles back to 23 MB; 100 abrupt websocket drops leave RSS flat.

## Deliberately deferred (follow-ups, not oversights)

- MCP pool connections still live for the daemon's life - refcounted disconnect touches the OAuth/transport flows and deserves its own PR.
- The tool-lane relief valve still widens permanently after a jam - shrinking the semaphore interacts with wedge detection (#191).
- `lev dash` still re-reads every run's context at 10 Hz - worst allocation churn left, TUI-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9P3DnrTCx7a5j9u84CyFr
