### PR TITLE
perf: MCP idle disconnect, tool-lane relief decay, dash parse cache; allocator decided by measurement

### DIFF
--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -24,13 +24,19 @@ name = "lev"
 path = "src/main.rs"
 
 [features]
+default = ["mimalloc-allocator"]
 debug-http = ["leviath-providers/debug-http"]
+# The lev binary's global allocator (see main.rs). A feature so the two
+# allocators can be benchmarked against each other on identical code
+# (`--no-default-features` builds on the system allocator), and so an
+# embedder-style build can opt out entirely.
+mimalloc-allocator = ["dep:mimalloc"]
 
 [dependencies]
 # The binary's global allocator (see main.rs). Kept out of the workspace dep
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
-mimalloc = "0.1"
+mimalloc = { version = "0.1", optional = true }
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -2370,7 +2370,7 @@ mod tests {
             key: None,
             taint: Default::default(),
         };
-        agent.context_snapshot = Some(crate::runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(crate::runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 20,
             max_tokens: 100,
@@ -2390,7 +2390,7 @@ mod tests {
                     entries: vec![entry("gamma")],
                 },
             ],
-        });
+        }));
         agent
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -45,7 +45,7 @@ impl Dashboard {
             .browsed_context_point()
             .map(|p| p.context.clone())
             .or_else(|| runstate::read_stage_context(&agent.id, self.selected_stage))
-            .or_else(|| agent.context_snapshot.clone());
+            .or_else(|| agent.context_snapshot.as_deref().cloned());
 
         // The card title shows the browsed history position - which point, of
         // how many, in which stage, recorded when - or a plain " ctx ".
@@ -478,7 +478,7 @@ impl Dashboard {
             .browsed_context_point()
             .map(|p| p.context.clone())
             .or_else(|| runstate::read_stage_context(&agent.id, self.selected_stage))
-            .or_else(|| agent.context_snapshot.clone());
+            .or_else(|| agent.context_snapshot.as_deref().cloned());
         if let Some(snap) = snap_opt {
             let mut lines: Vec<Line> = Vec::new();
 
@@ -787,7 +787,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-ctx", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -816,7 +816,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-high", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(7500, 8000)); // 93% = red
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(7500, 8000))); // 93% = red
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -831,7 +831,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-med", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(6000, 8000)); // 75% = yellow
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(6000, 8000))); // 75% = yellow
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -846,7 +846,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-multi", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 5000,
             max_tokens: 8000,
@@ -873,7 +873,7 @@ mod tests {
                     entries: vec![],
                 },
             ],
-        });
+        }));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -1312,7 +1312,7 @@ mod tests {
     fn build_context_lines_with_snapshot() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-bcl", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
@@ -1329,7 +1329,7 @@ mod tests {
     fn build_context_lines_with_graph_info() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-graph", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let mut edges = std::collections::HashMap::new();
         edges.insert(
             "main".to_string(),
@@ -1369,7 +1369,7 @@ mod tests {
         // sel_name must fall back to graph.stage_names.get(selected_stage).
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-graph-fallback", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let edges = std::collections::HashMap::new();
         agent.graph_info = Some(crate::commands::dashboard::graph::GraphTransitionInfo {
             edges,
@@ -1390,7 +1390,7 @@ mod tests {
     fn build_context_lines_graph_info_shows_visited_count() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-graph-visited", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         agent.graph_info = Some(crate::commands::dashboard::graph::GraphTransitionInfo {
             edges: std::collections::HashMap::new(),
             entry_stage: "main".to_string(),
@@ -1421,7 +1421,7 @@ mod tests {
     fn build_context_lines_graph_info_edge_with_non_always_condition() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-graph-cond", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let mut edges = std::collections::HashMap::new();
         edges.insert(
             "main".to_string(),
@@ -1469,7 +1469,7 @@ mod tests {
     fn build_context_lines_with_entries() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-entries", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
@@ -1487,7 +1487,7 @@ mod tests {
                     taint: Default::default(),
                 }],
             }],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
@@ -1501,7 +1501,7 @@ mod tests {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-old", AgentDisplayStatus::Active);
         // Has tokens but no entries = old run
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
@@ -1512,7 +1512,7 @@ mod tests {
                 max_tokens: 4000,
                 entries: vec![],
             }],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
@@ -1527,7 +1527,7 @@ mod tests {
     fn build_context_lines_with_graph_info_and_incoming_edges() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-incoming", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let mut edges = std::collections::HashMap::new();
         // "plan" has edge to "implement"
         edges.insert(
@@ -1571,7 +1571,7 @@ mod tests {
     fn build_context_lines_with_terminal_stage_no_edges() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-terminal", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let mut edges = std::collections::HashMap::new();
         // "implement" has no outgoing edges (terminal)
         edges.insert("plan".to_string(), vec![]);
@@ -1603,7 +1603,7 @@ mod tests {
         // Stage has no entry in edges map at all → shows "linear - no graph edges"
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-noedge", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         let edges = std::collections::HashMap::new(); // empty
         agent.graph_info = Some(crate::commands::dashboard::graph::GraphTransitionInfo {
             edges,
@@ -1634,7 +1634,7 @@ mod tests {
     fn build_context_lines_all_region_kinds() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-kinds", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 6000,
             max_tokens: 8000,
@@ -1689,7 +1689,7 @@ mod tests {
                     entries: vec![],
                 },
             ],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
@@ -1700,7 +1700,7 @@ mod tests {
     fn build_context_lines_high_usage_region() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-hiuse", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 7500,
             max_tokens: 8000,
@@ -1711,7 +1711,7 @@ mod tests {
                 max_tokens: 8000,
                 entries: vec![],
             }],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
@@ -1722,7 +1722,7 @@ mod tests {
     fn build_context_lines_medium_usage_region() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-meduse", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 5800,
             max_tokens: 8000,
@@ -1733,7 +1733,7 @@ mod tests {
                 max_tokens: 8000,
                 entries: vec![],
             }],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
@@ -1744,7 +1744,7 @@ mod tests {
     fn build_context_lines_zero_usage_region() {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-zerouse", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 0,
             max_tokens: 8000,
@@ -1755,7 +1755,7 @@ mod tests {
                 max_tokens: 8000,
                 entries: vec![],
             }],
-        });
+        }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
@@ -1774,7 +1774,7 @@ mod tests {
         dash.stage_content_mode = StageContentMode::Context;
         dash.search_query = "token".to_string();
         let mut agent = make_test_agent("run-sm2", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
@@ -1792,7 +1792,7 @@ mod tests {
                     taint: Default::default(),
                 }],
             }],
-        });
+        }));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 100, 20);
@@ -1880,7 +1880,7 @@ mod tests {
                 taint: Default::default(),
             })
             .collect();
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
@@ -1891,7 +1891,7 @@ mod tests {
                 max_tokens: 8000,
                 entries,
             }],
-        });
+        }));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 100, 20);
@@ -1966,7 +1966,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-regions", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
@@ -2021,7 +2021,7 @@ mod tests {
                     entries: vec![],
                 },
             ],
-        });
+        }));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -2039,7 +2039,7 @@ mod tests {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-rs-ctx", AgentDisplayStatus::Active);
         // is_run_state = true, context_snapshot as fallback
-        agent.context_snapshot = Some(make_context_snapshot(3000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(3000, 8000)));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 80, 5);
@@ -2122,7 +2122,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-follow", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(1000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(1000, 8000)));
         dash.agents.push(agent.clone());
         dash.update_display_indices();
         dash.stage_content_mode = StageContentMode::Context;
@@ -2264,7 +2264,7 @@ mod tests {
         dash.stage_content_mode = StageContentMode::Context;
         dash.search_query = "xyznotfound".to_string();
         let mut agent = make_test_agent("run-nm", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(make_context_snapshot(4000, 8000));
+        agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, 100, 20);

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -818,12 +818,12 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-cs", AgentDisplayStatus::Active);
-        agent.context_snapshot = Some(crate::runstate::ContextSnapshot {
+        agent.context_snapshot = Some(std::sync::Arc::new(crate::runstate::ContextSnapshot {
             stage_name: "main".to_string(),
             total_tokens: 4000,
             max_tokens: 8000,
             regions: vec![],
-        });
+        }));
         dash.agents.push(agent);
         dash.update_display_indices();
         terminal

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -75,6 +75,15 @@ pub(crate) struct Dashboard {
     pub(super) context_history_idx: Option<usize>,
     /// True after the first sync completes; suppresses startup toasts for pre-existing state.
     pub(super) initial_sync_done: bool,
+    // ── Poll caches ───────────────────────────────────────────────────────────
+    // The sync tick runs at 10Hz and used to re-read and re-parse every run's
+    // meta.json, stages.json, and whole context.json on every tick - ~100 MB/s
+    // of allocate-parse-free with 50 runs on disk, for files that change at
+    // most once per persist tick. These stat-gated caches reduce the steady
+    // state to stat calls.
+    pub(super) meta_cache: runstate::StatCache<runstate::RunMeta>,
+    pub(super) stages_cache: runstate::StatCache<Vec<leviath_core::run_meta::StageRecord>>,
+    pub(super) context_cache: runstate::StatCache<runstate::ContextSnapshot>,
     /// Monotonic tick counter for animations (spinner, toast timeouts)
     pub(super) tick_count: u64,
     /// Active toast notifications
@@ -238,6 +247,9 @@ impl Dashboard {
             stage_content_mode: StageContentMode::Output,
             context_history_idx: None,
             initial_sync_done: false,
+            meta_cache: runstate::StatCache::default(),
+            stages_cache: runstate::StatCache::default(),
+            context_cache: runstate::StatCache::default(),
             tick_count: 0,
             toasts: Vec::new(),
             show_help: false,
@@ -557,7 +569,7 @@ impl Dashboard {
         self.browsed_context_point()
             .map(|p| p.context.clone())
             .or_else(|| runstate::read_stage_context(&agent.id, self.selected_stage))
-            .or_else(|| agent.context_snapshot.clone())
+            .or_else(|| agent.context_snapshot.as_deref().cloned())
     }
 
     /// The Context view's interactive rows under the current fold state.
@@ -645,7 +657,20 @@ impl Dashboard {
 
     /// Sync agent list from on-disk run-state dir (background workers).
     pub(super) fn sync_from_run_state(&mut self) {
-        let runs = runstate::list_runs();
+        // Cached listing: metas re-parse only when their files change. Cloned
+        // out of the Arcs because the big match below reads fields by value;
+        // a meta is ~1KB, so the clone is noise next to the parses it avoids.
+        let runs: Vec<runstate::RunMeta> = runstate::list_runs_cached(&mut self.meta_cache)
+            .iter()
+            .map(|meta| (**meta).clone())
+            .collect();
+        // Prune the per-run caches down to runs that still exist.
+        let live_dirs: std::collections::HashSet<std::path::PathBuf> = runs
+            .iter()
+            .map(|run| runstate::run_dir(&run.run_id))
+            .collect();
+        self.stages_cache.retain_under(&live_dirs);
+        self.context_cache.retain_under(&live_dirs);
         for run in runs {
             // A live open prompt from the daemon's hub (populated each tick by
             // `sync_interactions`) is the authoritative signal that this agent is
@@ -688,8 +713,12 @@ impl Dashboard {
                 (None, None)
             };
 
-            // Read stages index
-            let stages = runstate::read_stages_index(&run.run_id);
+            // Read stages index + context snapshot through the poll caches,
+            // hoisted out of the per-agent branches below so the cache borrow
+            // does not overlap the `self.agents` borrow.
+            let stages = runstate::read_stages_index_cached(&run.run_id, &mut self.stages_cache);
+            let context_snapshot =
+                runstate::read_context_snapshot_cached(&run.run_id, &mut self.context_cache);
 
             if let Some(agent) = self.agents.iter_mut().find(|a| a.id == run.run_id) {
                 let prev_status_was_active = matches!(
@@ -770,7 +799,7 @@ impl Dashboard {
                 }
                 agent.status = status;
                 agent.workdir = run.workdir.clone();
-                agent.context_snapshot = runstate::read_context_snapshot(&run.run_id);
+                agent.context_snapshot = context_snapshot.clone();
                 agent.stages = stages;
                 agent.last_progress_at = run.last_progress_at;
 
@@ -853,7 +882,7 @@ impl Dashboard {
                     waiting_prompt,
                     pending_request,
                     last_answered_request_id: None,
-                    context_snapshot: runstate::read_context_snapshot(&run.run_id),
+                    context_snapshot,
                     stages,
                     workdir: run.workdir.clone(),
                     task: run.task.clone(),

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -226,7 +226,10 @@ pub struct DashboardAgent {
     /// re-showing the same prompt before the worker has consumed the response.
     pub last_answered_request_id: Option<String>,
     /// Live context window snapshot from context.json (background workers only)
-    pub context_snapshot: Option<runstate::ContextSnapshot>,
+    /// Shared, not owned: the live snapshot comes out of the sync tick's
+    /// stat-gated cache, and cloning a full context window per tick was the
+    /// churn that cache exists to remove.
+    pub context_snapshot: Option<std::sync::Arc<runstate::ContextSnapshot>>,
     /// Per-stage records from stages.json
     pub stages: Vec<StageRecord>,
     /// Working directory the agent ran in

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -493,6 +493,10 @@ fn default_dead_cycles_before_relief() -> u32 {
     leviath_runtime::host::DEFAULT_DEAD_CYCLES_BEFORE_RELIEF
 }
 
+fn default_mcp_idle_disconnect_secs() -> u64 {
+    crate::daemon::mcp_pool::DEFAULT_MCP_IDLE_DISCONNECT_SECS
+}
+
 fn default_finished_retention_secs() -> u64 {
     leviath_runtime::host::DEFAULT_FINISHED_RETENTION_SECS
 }
@@ -612,6 +616,17 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_finished_retention_secs")]
     pub finished_retention_secs: u64,
+    /// How long (seconds) a per-agent MCP server may sit with zero live runs
+    /// leasing it before the daemon disconnects it (ending a stdio server's
+    /// child process). Long enough that back-to-back runs of a blueprint reuse
+    /// the warm connection; the next run that declares the server reconnects
+    /// lazily. `0` keeps every server connected for the daemon's life, which
+    /// was the old behaviour. Global `[[mcp_servers]]` from config.toml are
+    /// never disconnected regardless.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_mcp_idle_disconnect_secs")]
+    pub mcp_idle_disconnect_secs: u64,
     /// How long (seconds) a run may sit in a state no part of the engine can
     /// reach before it is failed instead of left reported as running.
     ///
@@ -689,6 +704,7 @@ impl Default for LimitsConfig {
             stall_timeout_secs: default_stall_timeout_secs(),
             dead_cycles_before_relief: default_dead_cycles_before_relief(),
             finished_retention_secs: default_finished_retention_secs(),
+            mcp_idle_disconnect_secs: default_mcp_idle_disconnect_secs(),
             wedge_timeout_secs: default_wedge_timeout_secs(),
             provider_failures_before_open: default_provider_failures_before_open(),
             provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
@@ -3218,6 +3234,7 @@ enabled = false
             rate_limits: HashMap::new(),
             taint_tracking: false,
             limits: LimitsConfig {
+                mcp_idle_disconnect_secs: default_mcp_idle_disconnect_secs(),
                 max_concurrent_inferences: Some(4),
                 max_concurrent_tools: 3,
                 default_max_iterations: Some(99),

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -134,6 +134,10 @@ impl FanOutSpawner for DaemonFanOutSpawner {
         // the parent's - already warmed by the parent's preprocessor; the first
         // `worker_agent`/`worker_query` worker warms them here for its siblings).
         let mcp_defs = self.worker_mcp_defs(&args.blueprint_path);
+        // The worker holds its blueprint's per-agent servers open like any
+        // other run; the reap hook releases the lease when the worker ends.
+        self.mcp_pool
+            .lease_blueprint(&args.blueprint_path, &args.run_id);
 
         let config = self.config.current();
         let child = build_agent(

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -838,6 +838,79 @@ for line in sys.stdin:
         .await;
     }
 
+    /// Outside a runtime (a sync harness driving the reap hook directly), a
+    /// release is bookkeeping only: there is nowhere to spawn the grace
+    /// timer, and that must be a quiet no-op rather than a panic.
+    #[test]
+    fn release_run_without_a_runtime_is_bookkeeping_only() {
+        let pool = Arc::new(pool());
+        pool.release_run("no-runtime-run");
+    }
+
+    /// The scheduled path end to end: a real release on a live runtime spawns
+    /// the grace timer, and after the window the server is gone. With the
+    /// grace set to zero, releasing schedules nothing and the connection
+    /// stays.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn release_run_schedules_the_grace_disconnect() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("timedserver", &stub);
+            let timed = Arc::new(pool().with_idle_disconnect_secs(1));
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            assert_eq!(timed.ensure(&servers[0]).await.len(), 1);
+            timed.lease_blueprint(&bp, "run-a");
+            timed.release_run("run-a");
+            // Within the grace window the connection survives...
+            assert!(!timed.cached_defs_for(&servers).is_empty());
+            // ...and after it, the timer has torn it down.
+            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+            assert!(timed.cached_defs_for(&servers).is_empty());
+
+            // Grace zero: releasing disconnects nothing, ever.
+            let keeper = Arc::new(pool().with_idle_disconnect_secs(0));
+            assert_eq!(keeper.ensure(&servers[0]).await.len(), 1);
+            keeper.lease_blueprint(&bp, "run-b");
+            keeper.release_run("run-b");
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            assert!(!keeper.cached_defs_for(&servers).is_empty());
+        })
+        .await;
+    }
+
+    /// The defensive arms: a lease that never connected disconnects to a
+    /// no-op (no client in the executor), and a run entry pointing at a
+    /// server the table no longer holds is skipped rather than panicking.
+    #[tokio::test]
+    async fn disconnect_without_a_client_and_a_dangling_lease_are_noops() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("neverconnected", &stub);
+            let pool = Arc::new(pool());
+            // Leased but never `ensure`d: nothing in the executor to remove.
+            pool.lease_blueprint(&bp, "run-a");
+            let zeroed = pool.release_run_bookkeeping("run-a");
+            let (sig, name, generation) = zeroed[0].clone();
+            assert!(
+                !pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                "no client to remove is a no-op, not an error"
+            );
+
+            // A runs-map entry whose server row is gone (cannot happen through
+            // the public API, which mutates both under one lock) is skipped.
+            pool.lease_blueprint(&bp, "run-b");
+            pool.leases
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .servers
+                .clear();
+            assert!(pool.release_run_bookkeeping("run-b").is_empty());
+        })
+        .await;
+    }
+
     /// Global (seeded) servers belong to the daemon: they are never leased,
     /// and releasing runs never schedules them for disconnection. A missing
     /// manifest and an unknown run are no-ops.

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -36,6 +36,40 @@ pub struct McpPool {
     /// `[security] allow_env_vars`: which credential-shaped variables an MCP
     /// server's `${VAR}` headers may interpolate.
     allow_env_vars: Vec<String>,
+    /// Per-run leases on per-agent servers (see [`Self::lease_blueprint`]).
+    /// Same `std` mutex discipline as `connected`: held briefly, never across
+    /// an `.await`.
+    leases: StdMutex<LeaseTable>,
+    /// How long a per-agent server may sit with zero leasing runs before its
+    /// connection (and, for stdio servers, its child process) is torn down.
+    /// Zero disables disconnection - the pre-lease behavior, where every
+    /// server any blueprint ever declared stayed connected for the daemon's
+    /// life.
+    idle_disconnect: std::time::Duration,
+}
+
+/// Which runs hold which per-agent servers open.
+#[derive(Default)]
+struct LeaseTable {
+    /// Signature → the server's lease state.
+    servers: HashMap<String, ServerLease>,
+    /// Run id → the signatures it holds, so a reap releases them all.
+    runs: HashMap<String, Vec<String>>,
+    /// Signatures of the global config servers, seeded at startup: their
+    /// lifecycle belongs to the daemon, never to a run, so they are exempt
+    /// from idle disconnection.
+    global: HashSet<String>,
+}
+
+/// One per-agent server's lease state.
+struct ServerLease {
+    /// The server's name - the key the executor stores its client under.
+    name: String,
+    /// The runs currently holding it open.
+    holders: HashSet<String>,
+    /// Bumped on every lease and release, so a disconnect scheduled when the
+    /// count hit zero is a no-op if anything touched the server since.
+    generation: u64,
 }
 
 /// A stable dedup key for a server config: its full serialized form. Two
@@ -47,6 +81,13 @@ fn signature(config: &MCPServerConfig) -> String {
     serde_json::to_string(config).unwrap_or_default()
 }
 
+/// Default for how long a per-agent MCP server may sit with zero leasing runs
+/// before its connection is torn down. Long enough that back-to-back runs of
+/// the same blueprint reuse the warm connection (and never re-trigger an OAuth
+/// flow between them); short enough that a one-off run's servers do not hold
+/// child processes and buffers for the daemon's remaining life.
+pub const DEFAULT_MCP_IDLE_DISCONNECT_SECS: u64 = 60;
+
 impl McpPool {
     /// Build a pool over `shared`, reserving `reserved` names from advertisement.
     pub fn new(shared: Arc<Mutex<ToolExecutor>>, reserved: HashSet<String>) -> Self {
@@ -56,7 +97,16 @@ impl McpPool {
             connected: StdMutex::new(HashMap::new()),
             credential_store: leviath_core::CredentialStoreKind::default(),
             allow_env_vars: Vec::new(),
+            leases: StdMutex::new(LeaseTable::default()),
+            idle_disconnect: std::time::Duration::from_secs(DEFAULT_MCP_IDLE_DISCONNECT_SECS),
         }
+    }
+
+    /// How long a per-agent server may sit unleased before disconnection.
+    /// `0` disables it.
+    pub fn with_idle_disconnect_secs(mut self, secs: u64) -> Self {
+        self.idle_disconnect = std::time::Duration::from_secs(secs);
+        self
     }
 
     /// Allow these credential-shaped variables in MCP `${VAR}` headers.
@@ -84,6 +134,7 @@ impl McpPool {
             config_servers,
             leviath_core::CredentialStoreKind::default(),
             Vec::new(),
+            DEFAULT_MCP_IDLE_DISCONNECT_SECS,
         )
     }
 
@@ -99,6 +150,7 @@ impl McpPool {
         config_servers: &[MCPServerConfig],
         credential_store: leviath_core::CredentialStoreKind,
         allow_env_vars: Vec<String>,
+        idle_disconnect_secs: u64,
     ) -> Arc<Self> {
         let mut reserved: HashSet<String> =
             leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(std::env::temp_dir()))
@@ -109,7 +161,8 @@ impl McpPool {
         let pool = Arc::new(
             Self::new(shared_mcp, reserved)
                 .with_credential_store(credential_store)
-                .with_env_allowlist(allow_env_vars),
+                .with_env_allowlist(allow_env_vars)
+                .with_idle_disconnect_secs(idle_disconnect_secs),
         );
         for server in config_servers {
             pool.seed(server, Vec::new());
@@ -119,11 +172,138 @@ impl McpPool {
 
     /// Seed the cache with an already-connected server's defs (used at startup for
     /// the global config servers, connected once by `ToolRegistry::build`).
+    /// Seeded servers are global: their lifecycle belongs to the daemon, so
+    /// they are exempt from lease-driven idle disconnection.
     pub fn seed(&self, config: &MCPServerConfig, defs: Vec<Tool>) {
+        let sig = signature(config);
+        self.leases
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .global
+            .insert(sig.clone());
         self.connected
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-            .insert(signature(config), defs);
+            .insert(sig, defs);
+    }
+
+    /// Record `run_id` as holding every per-agent server `blueprint_path`
+    /// declares, so the connections stay up exactly as long as some run needs
+    /// them. Global (seeded) servers are skipped. A missing or unreadable
+    /// manifest leases nothing.
+    ///
+    /// Called from every path that brings a run into the world with a
+    /// blueprint: the spawner, the restart reloader, and the fan-out worker
+    /// spawner. The matching release is [`Self::release_run`], from the reap
+    /// hook.
+    pub fn lease_blueprint(&self, blueprint_path: &str, run_id: &str) {
+        let Ok(toml) = std::fs::read_to_string(blueprint_path) else {
+            return;
+        };
+        let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
+        for server in parse_blueprint_mcp_servers(&toml) {
+            let sig = signature(&server);
+            if table.global.contains(&sig) {
+                continue;
+            }
+            let entry = table
+                .servers
+                .entry(sig.clone())
+                .or_insert_with(|| ServerLease {
+                    name: server.name.clone(),
+                    holders: HashSet::new(),
+                    generation: 0,
+                });
+            entry.generation += 1;
+            if entry.holders.insert(run_id.to_string()) {
+                table.runs.entry(run_id.to_string()).or_default().push(sig);
+            }
+        }
+    }
+
+    /// Release every lease `run_id` holds. Servers whose holder count reaches
+    /// zero get an idle-disconnect scheduled (when a runtime is available and
+    /// `idle_disconnect` is non-zero); a new lease during the grace window
+    /// bumps the generation and turns the pending disconnect into a no-op.
+    pub fn release_run(self: &Arc<Self>, run_id: &str) {
+        let zeroed = self.release_run_bookkeeping(run_id);
+        if self.idle_disconnect.is_zero() {
+            return;
+        }
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return; // no runtime (a sync test): bookkeeping only
+        };
+        for (sig, name, generation) in zeroed {
+            let pool = Arc::clone(self);
+            handle.spawn(async move {
+                tokio::time::sleep(pool.idle_disconnect).await;
+                pool.disconnect_if_still_idle(&sig, &name, generation).await;
+            });
+        }
+    }
+
+    /// The synchronous half of [`Self::release_run`]: drop the run's leases and
+    /// return the `(signature, name, generation)` of every server that now has
+    /// zero holders.
+    fn release_run_bookkeeping(&self, run_id: &str) -> Vec<(String, String, u64)> {
+        let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
+        let Some(sigs) = table.runs.remove(run_id) else {
+            return Vec::new();
+        };
+        let mut zeroed = Vec::new();
+        for sig in sigs {
+            let Some(entry) = table.servers.get_mut(&sig) else {
+                continue;
+            };
+            entry.holders.remove(run_id);
+            entry.generation += 1;
+            if entry.holders.is_empty() {
+                zeroed.push((sig.clone(), entry.name.clone(), entry.generation));
+            }
+        }
+        zeroed
+    }
+
+    /// Tear a server down if nothing touched it since `generation`: forget its
+    /// cached defs (so the next spawn reconnects lazily), take its client out
+    /// of the shared executor, and shut it down - which is what actually ends
+    /// a stdio server's child process. Returns whether it disconnected.
+    pub async fn disconnect_if_still_idle(&self, sig: &str, name: &str, generation: u64) -> bool {
+        {
+            let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
+            let still_idle = table
+                .servers
+                .get(sig)
+                .is_some_and(|e| e.holders.is_empty() && e.generation == generation);
+            if !still_idle {
+                return false;
+            }
+            table.servers.remove(sig);
+        }
+        self.connected
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(sig);
+        let client = self.shared.lock().await.remove_client(name);
+        match client {
+            Some(mut client) => {
+                let _ = client.shutdown().await;
+                tracing::info!(server = %name, "disconnected idle per-agent MCP server");
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// The signatures currently holding leases, for tests and diagnostics.
+    #[cfg(test)]
+    fn leased_holders(&self, config: &MCPServerConfig) -> usize {
+        self.leases
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .servers
+            .get(&signature(config))
+            .map_or(0, |e| e.holders.len())
     }
 
     /// Ensure `config` is connected (idempotent by signature) and return its
@@ -587,6 +767,98 @@ for line in sys.stdin:
         let pool = pool();
         pool.warm_recovered(std::path::Path::new("/no/such/runs"))
             .await;
+    }
+
+    /// The lease lifecycle end to end: runs hold a server open, the last
+    /// release zeroes it, and the idle disconnect tears the connection down so
+    /// the next spawn reconnects lazily.
+    #[tokio::test]
+    async fn leases_hold_a_server_and_the_last_release_disconnects_it() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("leaseserver", &stub);
+            let pool = Arc::new(pool().with_idle_disconnect_secs(1));
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            let cfg = &servers[0];
+            // Connect for real, so there is a live client to tear down.
+            assert_eq!(pool.ensure(cfg).await.len(), 1);
+
+            pool.lease_blueprint(&bp, "run-a");
+            pool.lease_blueprint(&bp, "run-b");
+            // Leasing twice from the same run holds once.
+            pool.lease_blueprint(&bp, "run-b");
+            assert_eq!(pool.leased_holders(cfg), 2);
+
+            // Releasing one run leaves the server held (nothing zeroed, no
+            // timer scheduled).
+            pool.release_run("run-a");
+            assert_eq!(pool.leased_holders(cfg), 1);
+            assert!(!pool.cached_defs_for(&servers).is_empty());
+
+            // The last release zeroes it; drive the disconnect directly (the
+            // scheduled timer runs the same call after the grace window).
+            let zeroed = pool.release_run_bookkeeping("run-b");
+            assert_eq!(zeroed.len(), 1);
+            let (sig, name, generation) = zeroed[0].clone();
+            assert!(pool.disconnect_if_still_idle(&sig, &name, generation).await);
+            // Defs are forgotten, so the next spawn reconnects lazily...
+            assert!(pool.cached_defs_for(&servers).is_empty());
+            // ...and a replayed disconnect finds nothing to do.
+            assert!(!pool.disconnect_if_still_idle(&sig, &name, generation).await);
+        })
+        .await;
+    }
+
+    /// A lease taken during the grace window outdates the scheduled
+    /// disconnect: the generation moved, so the timer's callback is a no-op.
+    #[tokio::test]
+    async fn a_lease_during_the_grace_window_cancels_the_disconnect() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("graceserver", &stub);
+            let pool = Arc::new(pool().with_idle_disconnect_secs(1));
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            let cfg = &servers[0];
+            assert_eq!(pool.ensure(cfg).await.len(), 1);
+
+            pool.lease_blueprint(&bp, "run-a");
+            let zeroed = pool.release_run_bookkeeping("run-a");
+            let (sig, name, generation) = zeroed[0].clone();
+            // A new run leases before the timer would have fired.
+            pool.lease_blueprint(&bp, "run-b");
+            assert!(
+                !pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                "a stale generation must not tear down a re-leased server"
+            );
+            assert_eq!(pool.leased_holders(cfg), 1);
+            assert!(!pool.cached_defs_for(&servers).is_empty());
+        })
+        .await;
+    }
+
+    /// Global (seeded) servers belong to the daemon: they are never leased,
+    /// and releasing runs never schedules them for disconnection. A missing
+    /// manifest and an unknown run are no-ops.
+    #[tokio::test]
+    async fn seeded_servers_are_exempt_and_bad_inputs_are_noops() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("globalserver", &stub);
+            let pool = Arc::new(pool());
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            pool.seed(&servers[0], Vec::new());
+
+            pool.lease_blueprint(&bp, "run-a");
+            assert_eq!(pool.leased_holders(&servers[0]), 0, "global: no lease");
+            pool.release_run("run-a"); // nothing held → nothing zeroed
+            assert!(pool.release_run_bookkeeping("never-leased").is_empty());
+            pool.lease_blueprint("/no/such/agent.leviath", "run-b");
+            assert!(pool.release_run_bookkeeping("run-b").is_empty());
+        })
+        .await;
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -105,6 +105,7 @@ pub async fn setup_daemon_host(
         &config.mcp_servers,
         config.security.credential_store,
         config.security.allow_env_vars.clone(),
+        config.limits.mcp_idle_disconnect_secs,
     );
     mcp_pool.warm_recovered(&runs_dir).await;
     build_host(
@@ -123,8 +124,22 @@ pub async fn setup_daemon_host(
 /// tears down its sandbox via [`CliToolService::reap`]. Factored out (rather than
 /// an inline closure) so its body is exercised by a unit test - the daemon itself
 /// only ever fires the reaper from the private `serve()` loop.
-fn make_reaper(tool_service: Arc<CliToolService>) -> leviath_runtime::host::Reaper {
-    Box::new(move |_world, entity| tool_service.reap(entity))
+fn make_reaper(
+    tool_service: Arc<CliToolService>,
+    mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
+) -> leviath_runtime::host::Reaper {
+    Box::new(move |world, entity| {
+        // Release the run's MCP leases before the entity (and its metadata)
+        // goes away; servers nobody else holds get an idle-disconnect timer.
+        if let Some(md) = world
+            .world()
+            .get::<leviath_runtime::persistence::RunMetadata>(entity)
+        {
+            let run_id = md.run_id.clone();
+            mcp_pool.release_run(&run_id);
+        }
+        tool_service.reap(entity)
+    })
 }
 
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
@@ -297,11 +312,12 @@ pub fn build_host(
     let reload_hub = hub.clone();
     let reload_tx = subagent_tx.clone();
     let reload_runs = runs_dir.clone();
+    let reload_pool = mcp_pool.clone();
     host.set_reloader(Box::new(move |world, run_id| {
         // Pages a run back in with the current on-disk config, matching what a
         // real restart would restore it with.
         let reload_config = reload_reloader.current();
-        crate::daemon::recovery::reload_run(
+        let entity = crate::daemon::recovery::reload_run(
             world,
             reload_tools.as_ref(),
             &reload_config,
@@ -312,7 +328,15 @@ pub fn build_host(
             &reload_runs,
             now_secs(),
             &reload_tx,
-        )
+        );
+        // A paged-in run holds its blueprint's servers again, exactly like a
+        // fresh spawn (its reap released them when it was parked/unloaded).
+        if entity.is_some()
+            && let Ok(meta) = crate::runstate::read_meta(run_id)
+        {
+            reload_pool.lease_blueprint(&meta.agent_path, run_id);
+        }
+        entity
     }));
 
     // Last resort for a cancel the world can't service: force the run's on-disk
@@ -329,7 +353,7 @@ pub fn build_host(
     // its per-agent tool state (the latter also fixing a prior leak where tool
     // state was never released). Factored into `make_reaper` so the closure body
     // is unit-testable - the daemon only ever drives it from `serve()`.
-    host.set_reaper(make_reaper(tool_service.clone()));
+    host.set_reaper(make_reaper(tool_service.clone(), mcp_pool.clone()));
 
     // The shared MCP pool (created + recovery-warmed by the caller). Per-agent
     // `[[mcp_servers]]` connect lazily through it.
@@ -366,6 +390,9 @@ pub fn build_host(
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
         let defs = per_agent_mcp_defs(&spawn_pool, &mcp_tool_defs, &args.blueprint_path);
+        // Hold the blueprint's per-agent servers open for this run's life;
+        // the reap hook releases them (idle-disconnect follows).
+        spawn_pool.lease_blueprint(&args.blueprint_path, &args.run_id);
         // Fresh config per spawn: a `config.toml` edit (a new `[read_paths]`
         // grant, a permission change) takes effect on the next `lev run`
         // without a daemon restart.
@@ -536,7 +563,13 @@ mod tests {
             None,
             Handle::current(),
         );
-        let mut reaper = make_reaper(tool_service.clone());
+        let mut reaper = make_reaper(
+            tool_service.clone(),
+            crate::daemon::mcp_pool::McpPool::for_daemon(
+                Arc::new(tokio::sync::Mutex::new(leviath_mcp::ToolExecutor::new())),
+                &[],
+            ),
+        );
         // No registered state for this entity → a clean no-op (the reap-branch
         // logic itself is covered by CliToolService::reap's own unit test).
         let entity = bevy_ecs::entity::Entity::from_raw_u32(1)

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -329,13 +329,7 @@ pub fn build_host(
             now_secs(),
             &reload_tx,
         );
-        // A paged-in run holds its blueprint's servers again, exactly like a
-        // fresh spawn (its reap released them when it was parked/unloaded).
-        if entity.is_some()
-            && let Ok(meta) = crate::runstate::read_meta(run_id)
-        {
-            reload_pool.lease_blueprint(&meta.agent_path, run_id);
-        }
+        lease_reloaded(&reload_pool, run_id, entity.is_some());
         entity
     }));
 
@@ -464,6 +458,19 @@ fn write_placeholder_meta(runs_dir: &std::path::Path, args: &leviath_runtime::ho
     }
 }
 
+/// Re-lease a paged-in run's per-agent MCP servers, exactly like a fresh
+/// spawn (its reap released them when it was parked or unloaded). A declined
+/// reload, or a run whose metadata cannot be read back, leases nothing.
+/// Extracted from the reloader closure so its arms are unit-testable.
+fn lease_reloaded(pool: &crate::daemon::mcp_pool::McpPool, run_id: &str, reloaded: bool) {
+    if !reloaded {
+        return;
+    }
+    if let Ok(meta) = crate::runstate::read_meta(run_id) {
+        pool.lease_blueprint(&meta.agent_path, run_id);
+    }
+}
+
 /// The spawn-preprocessor body: connect the blueprint's declared `[[mcp_servers]]`
 /// into `pool` (lazy, deduped by signature). A missing/unreadable manifest is a
 /// no-op. Extracted from the closure so its body is unit-testable.
@@ -576,6 +583,30 @@ mod tests {
             .expect("a small literal index is always a valid entity id");
         reaper(&mut world, entity);
         assert!(tool_service.take(entity).is_none());
+
+        // An entity that carries run metadata also releases its MCP leases on
+        // reap (a run that never leased releases nothing - the pool's own
+        // tested no-op arm).
+        let with_meta = world.spawn_agent((leviath_runtime::persistence::RunMetadata {
+            run_id: "reaped-run".to_string(),
+            agent_name: "a".to_string(),
+            agent_path: "/p".to_string(),
+            task: "t".to_string(),
+            model: None,
+            workdir: "/w".to_string(),
+            num_stages: 1,
+            started_at: 0,
+            parent_run_id: None,
+            metadata: std::collections::HashMap::new(),
+            callback_url: None,
+            callback_secret: None,
+            title: None,
+            unattended: false,
+            read_paths: None,
+            output_request: None,
+        },));
+        reaper(&mut world, with_meta);
+        assert!(tool_service.take(with_meta).is_none());
     }
 
     struct FakeProvider;
@@ -936,6 +967,31 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             Default::default(),
         )
+    }
+
+    /// Every arm of the reloader's re-lease: a declined reload consults
+    /// nothing, a reload with no readable metadata leases nothing, and a
+    /// reload with metadata routes through the pool's lease.
+    #[test]
+    fn lease_reloaded_leases_only_on_a_successful_reload() {
+        crate::runstate::with_isolated_runs_dir("lease-reloaded", |_d| {
+            let pool = empty_pool();
+            lease_reloaded(&pool, "any-run", false);
+            lease_reloaded(&pool, "ghost-run", true);
+            let meta = leviath_core::run_meta::RunMeta::new(
+                "reloaded-run".to_string(),
+                "agent".to_string(),
+                "/no/such/agent.leviath".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            crate::runstate::create_run(&meta).unwrap();
+            // The manifest path is consulted; an unreadable one leases nothing,
+            // which is the pool's own (tested) arm.
+            lease_reloaded(&pool, "reloaded-run", true);
+        });
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -32,6 +32,7 @@ use leviath_cli::dispatch::{Commands, RiskyExecutors, apply_region_flags, dispat
 /// footprint under 293 MB of retained RSS after a five-agent burst). mimalloc
 /// returns freed pages to the OS aggressively, so RSS tracks what the process
 /// actually holds.
+#[cfg(feature = "mimalloc-allocator")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -12,6 +12,7 @@
 //! - `~/.leviath/dashboard.log` - never cleared, appended across sessions
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // The plain run-state data types (RunMeta, RunStatus, the snapshot structs, and
@@ -66,6 +67,72 @@ pub fn read_context_snapshot(run_id: &str) -> Option<ContextSnapshot> {
     let path = run_dir(run_id).join("context.json");
     let json = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&json).ok()
+}
+
+/// A parse cache keyed by a file's `(mtime, len)`: the file is re-read and
+/// re-parsed only when its stat changes.
+///
+/// For pollers reading run state on a tick. The dashboard synced at 10Hz by
+/// re-parsing every run's `meta.json`, `stages.json`, and whole
+/// `context.json`; with 50 runs on disk that was on the order of 100 MB/s of
+/// allocate-and-parse-and-free for files that change at most once per persist
+/// tick. A `stat` costs microseconds; this turns the steady-state tick into
+/// stats plus clones of shared `Arc`s.
+///
+/// `(mtime, len)` rather than mtime alone: the persistence lane's atomic
+/// rename gives every update a fresh temp inode and mtime, but coarse mtime
+/// granularity on some filesystems can miss two updates in the same instant -
+/// the length check catches most of those, and a same-length same-instant
+/// rewrite is indistinguishable anyway one tick later.
+pub struct StatCache<T> {
+    entries: std::collections::HashMap<PathBuf, (std::time::SystemTime, u64, Option<Arc<T>>)>,
+}
+
+impl<T> Default for StatCache<T> {
+    fn default() -> Self {
+        Self {
+            entries: std::collections::HashMap::new(),
+        }
+    }
+}
+
+impl<T> StatCache<T> {
+    /// The value parsed from `path`, re-reading only when the file's stat
+    /// changed since the last call. `None` when the file is missing,
+    /// unreadable, or `parse` rejects it - negative results are cached too, so
+    /// a persistently-bad file costs one stat per tick, not one parse.
+    pub fn get_with(
+        &mut self,
+        path: &Path,
+        parse: impl FnOnce(&str) -> Option<T>,
+    ) -> Option<Arc<T>> {
+        let Ok(meta) = std::fs::metadata(path) else {
+            self.entries.remove(path);
+            return None;
+        };
+        let stamp = (meta.modified().ok()?, meta.len());
+        if let Some((mtime, len, value)) = self.entries.get(path)
+            && (*mtime, *len) == stamp
+        {
+            return value.clone();
+        }
+        let value = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| parse(&text))
+            .map(Arc::new);
+        self.entries
+            .insert(path.to_path_buf(), (stamp.0, stamp.1, value.clone()));
+        value
+    }
+
+    /// Drop entries for files under runs that no longer exist, so a
+    /// long-lived poller's cache stays bounded by the live run set.
+    pub fn retain_under(&mut self, keep: &std::collections::HashSet<PathBuf>) {
+        self.entries.retain(|path, _| {
+            path.parent()
+                .is_some_and(|dir| keep.contains(&dir.to_path_buf()))
+        });
+    }
 }
 
 /// Read + parse a run's portable archive (`<run_dir>/run.lvr`), returning its
@@ -596,6 +663,52 @@ fn list_runs_in_dir(dir: PathBuf) -> Vec<RunMeta> {
 /// Silently skips any runs whose metadata cannot be read.
 pub fn list_runs() -> Vec<RunMeta> {
     list_runs_in_dir(runs_dir())
+}
+
+/// [`list_runs`] through a [`StatCache`], for pollers: each `meta.json` is
+/// re-parsed only when its stat changes, and cache entries for deleted runs
+/// are dropped. Same ordering and skip-unreadable behavior as `list_runs`.
+pub fn list_runs_cached(cache: &mut StatCache<RunMeta>) -> Vec<Arc<RunMeta>> {
+    let dir = runs_dir();
+    let mut runs = Vec::new();
+    let mut live_dirs = std::collections::HashSet::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            live_dirs.insert(entry.path());
+            let meta_path = entry.path().join("meta.json");
+            if let Some(meta) = cache.get_with(&meta_path, |json| {
+                serde_json::from_str::<RunMeta>(json).ok()
+            }) {
+                runs.push(meta);
+            }
+        }
+    }
+    cache.retain_under(&live_dirs);
+    runs.sort_by_key(|r| std::cmp::Reverse(r.started_at));
+    runs
+}
+
+/// [`read_stages_index`] through a [`StatCache`], for pollers.
+pub fn read_stages_index_cached(
+    run_id: &str,
+    cache: &mut StatCache<Vec<StageRecord>>,
+) -> Vec<StageRecord> {
+    let path = run_dir(run_id).join("stages.json");
+    cache
+        .get_with(&path, |json| serde_json::from_str(json).ok())
+        .map(|records| records.as_ref().clone())
+        .unwrap_or_default()
+}
+
+/// [`read_context_snapshot`] through a [`StatCache`], for pollers. The
+/// snapshot is shared, not cloned: a context window is the largest thing in a
+/// run dir, and handing out copies per tick is the churn this cache removes.
+pub fn read_context_snapshot_cached(
+    run_id: &str,
+    cache: &mut StatCache<ContextSnapshot>,
+) -> Option<Arc<ContextSnapshot>> {
+    let path = run_dir(run_id).join("context.json");
+    cache.get_with(&path, |json| serde_json::from_str(json).ok())
 }
 
 /// Read the last `max_bytes` of any file on disk, returning UTF-8 text.
@@ -1656,6 +1769,133 @@ mod tests {
             })
             .expect("streamed records with break");
             assert_eq!(first_only, 1);
+        });
+    }
+
+    /// The stat cache's contract: parse once, serve from cache while the stat
+    /// is unchanged, re-parse on change, cache negative results, and forget
+    /// files that disappear.
+    #[test]
+    fn stat_cache_parses_once_per_stat_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("value.json");
+        std::fs::write(&path, "41").unwrap();
+        let mut cache: StatCache<i64> = StatCache::default();
+        let mut parses = 0;
+        let get = |cache: &mut StatCache<i64>, path: &std::path::Path, parses: &mut usize| {
+            cache
+                .get_with(path, |text| {
+                    *parses += 1;
+                    text.trim().parse().ok()
+                })
+                .map(|v| *v)
+        };
+
+        assert_eq!(get(&mut cache, &path, &mut parses), Some(41));
+        assert_eq!(get(&mut cache, &path, &mut parses), Some(41));
+        assert_eq!(parses, 1, "the second read came from the cache");
+
+        // A same-length rewrite with a fresh mtime re-parses (the atomic-rename
+        // writer always produces a new inode+mtime; simulate with a bumped
+        // mtime via a rewrite of different content and length).
+        std::fs::write(&path, "1234").unwrap();
+        assert_eq!(get(&mut cache, &path, &mut parses), Some(1234));
+        assert_eq!(parses, 2);
+
+        // Unparseable content is cached as a miss - one parse attempt, then
+        // stat-only until the file changes again.
+        std::fs::write(&path, "not a number").unwrap();
+        assert_eq!(get(&mut cache, &path, &mut parses), None);
+        assert_eq!(get(&mut cache, &path, &mut parses), None);
+        assert_eq!(parses, 3, "the bad file was parsed once, not per tick");
+
+        // A deleted file is a miss and its entry is dropped.
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(get(&mut cache, &path, &mut parses), None);
+        assert_eq!(parses, 3);
+    }
+
+    #[test]
+    fn stat_cache_retain_under_drops_dead_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("live");
+        let dead = dir.path().join("dead");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::create_dir_all(&dead).unwrap();
+        std::fs::write(live.join("meta.json"), "1").unwrap();
+        std::fs::write(dead.join("meta.json"), "2").unwrap();
+        let mut cache: StatCache<i64> = StatCache::default();
+        cache.get_with(&live.join("meta.json"), |t| t.trim().parse().ok());
+        cache.get_with(&dead.join("meta.json"), |t| t.trim().parse().ok());
+        assert_eq!(cache.entries.len(), 2);
+
+        let keep: std::collections::HashSet<PathBuf> = [live.clone()].into_iter().collect();
+        cache.retain_under(&keep);
+        assert_eq!(cache.entries.len(), 1);
+        assert!(cache.entries.contains_key(&live.join("meta.json")));
+    }
+
+    /// The cached listing and per-run readers agree with their uncached
+    /// counterparts, and serve repeat calls without re-parsing.
+    #[test]
+    fn cached_run_readers_match_the_uncached_ones() {
+        with_isolated_runs_dir("cached-run-readers", |_d| {
+            let meta = RunMeta::new(
+                "cached-run".to_string(),
+                "agent".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                2,
+            );
+            create_run(&meta).unwrap();
+            write_stages_index(
+                "cached-run",
+                &[leviath_core::run_meta::StageRecord::new(
+                    "plan".to_string(),
+                    0,
+                )],
+            )
+            .unwrap();
+            write_context_snapshot(
+                "cached-run",
+                &ContextSnapshot {
+                    stage_name: "plan".to_string(),
+                    total_tokens: 3,
+                    max_tokens: 100,
+                    regions: vec![],
+                },
+            )
+            .unwrap();
+
+            let mut metas = StatCache::default();
+            let mut stages = StatCache::default();
+            let mut contexts = StatCache::default();
+
+            let listed = list_runs_cached(&mut metas);
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].run_id, list_runs()[0].run_id);
+
+            let cached_stages = read_stages_index_cached("cached-run", &mut stages);
+            let plain_stages = read_stages_index("cached-run");
+            assert_eq!(cached_stages.len(), plain_stages.len());
+            assert_eq!(cached_stages[0].name, plain_stages[0].name);
+            let cached_ctx =
+                read_context_snapshot_cached("cached-run", &mut contexts).expect("snapshot cached");
+            assert_eq!(
+                *cached_ctx,
+                read_context_snapshot("cached-run").expect("snapshot read")
+            );
+            // A repeat serves the SAME Arc - the whole point of the cache.
+            let again = read_context_snapshot_cached("cached-run", &mut contexts).unwrap();
+            assert!(Arc::ptr_eq(&cached_ctx, &again));
+
+            // A run whose dir disappears falls out of the cached listing.
+            std::fs::remove_dir_all(run_dir("cached-run")).unwrap();
+            assert!(list_runs_cached(&mut metas).is_empty());
+            assert!(read_stages_index_cached("cached-run", &mut stages).is_empty());
+            assert!(read_context_snapshot_cached("cached-run", &mut contexts).is_none());
         });
     }
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -110,7 +110,9 @@ impl<T> StatCache<T> {
             self.entries.remove(path);
             return None;
         };
-        let stamp = (meta.modified().ok()?, meta.len());
+        // A filesystem with no mtimes degrades to epoch (so length changes
+        // still refresh) rather than growing an unreachable error arm.
+        let stamp = (meta.modified().unwrap_or(std::time::UNIX_EPOCH), meta.len());
         if let Some((mtime, len, value)) = self.entries.get(path)
             && (*mtime, *len) == stamp
         {
@@ -1891,11 +1893,34 @@ mod tests {
             let again = read_context_snapshot_cached("cached-run", &mut contexts).unwrap();
             assert!(Arc::ptr_eq(&cached_ctx, &again));
 
+            // A second run makes the listing's ordering real: newest first,
+            // same as the uncached listing.
+            let mut second = RunMeta::new(
+                "cached-run-2".to_string(),
+                "agent".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            second.started_at += 100;
+            create_run(&second).unwrap();
+            let listed = list_runs_cached(&mut metas);
+            assert_eq!(listed.len(), 2);
+            assert_eq!(listed[0].run_id, "cached-run-2", "newest first");
+
             // A run whose dir disappears falls out of the cached listing.
             std::fs::remove_dir_all(run_dir("cached-run")).unwrap();
+            std::fs::remove_dir_all(run_dir("cached-run-2")).unwrap();
             assert!(list_runs_cached(&mut metas).is_empty());
             assert!(read_stages_index_cached("cached-run", &mut stages).is_empty());
             assert!(read_context_snapshot_cached("cached-run", &mut contexts).is_none());
+
+            // And a missing runs DIRECTORY altogether lists nothing (the
+            // read_dir-failed arm).
+            std::fs::remove_dir_all(runs_dir()).unwrap();
+            assert!(list_runs_cached(&mut metas).is_empty());
         });
     }
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1910,7 +1910,15 @@ mod tests {
             assert_eq!(listed.len(), 2);
             assert_eq!(listed[0].run_id, "cached-run-2", "newest first");
 
+            // A run dir with a garbled meta.json is skipped, not fatal - and
+            // skipped cheaply on every later tick (the negative result is
+            // cached until the file changes).
+            std::fs::create_dir_all(run_dir("garbled-run")).unwrap();
+            std::fs::write(run_dir("garbled-run").join("meta.json"), "not json {{").unwrap();
+            assert_eq!(list_runs_cached(&mut metas).len(), 2);
+
             // A run whose dir disappears falls out of the cached listing.
+            std::fs::remove_dir_all(run_dir("garbled-run")).unwrap();
             std::fs::remove_dir_all(run_dir("cached-run")).unwrap();
             std::fs::remove_dir_all(run_dir("cached-run-2")).unwrap();
             assert!(list_runs_cached(&mut metas).is_empty());

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -113,6 +113,20 @@ impl ToolExecutor {
         advertised
     }
 
+    /// Take a server's client back out of the executor, dropping the aliases
+    /// that routed to it. The caller owns the returned client and is expected
+    /// to shut it down - removal alone does not kill a stdio server's child
+    /// process. `None` if no such server is registered.
+    ///
+    /// The pool's idle-disconnect uses this: a per-agent server whose last
+    /// leasing run ended has no caller left, and before this the connection
+    /// (and its child process) lived until the daemon exited.
+    pub fn remove_client(&mut self, server_name: &str) -> Option<MCPClient> {
+        let client = self.clients.remove(server_name)?;
+        self.aliases.retain(|_, (server, _)| server != server_name);
+        Some(client)
+    }
+
     /// Compute a unique, provider-safe advertised name for `original`.
     ///
     /// Prefers the sanitized name; on a clash with `reserved` or an existing
@@ -547,6 +561,25 @@ for line in sys.stdin:
         let client = spawn_ready_client().await;
         executor.add_client("server1".to_string(), client);
         assert_eq!(executor.server_count(), 1);
+    }
+
+    /// Removing a server takes back its client and drops the aliases that
+    /// routed to it, so a later `execute` of its tools misses cleanly - and an
+    /// unknown name removes nothing.
+    #[tokio::test]
+    async fn remove_client_takes_the_server_and_its_aliases() {
+        let mut executor = ToolExecutor::new();
+        let client = spawn_ready_client().await;
+        executor.add_client("server1".to_string(), client);
+        assert_eq!(executor.server_count(), 1);
+
+        assert!(executor.remove_client("nope").is_none());
+        let mut taken = executor.remove_client("server1").expect("was registered");
+        assert_eq!(executor.server_count(), 0);
+        let result = executor.execute("echo", serde_json::json!({})).await;
+        assert!(result.is_err(), "the removed server's tools route nowhere");
+        // The caller owns the shutdown; this is what ends the child process.
+        taken.shutdown().await.expect("shutdown is best-effort Ok");
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/host.rs
+++ b/crates/leviath-runtime/src/host.rs
@@ -672,9 +672,12 @@ pub struct WorldHost {
     /// The progress fingerprint as of the previous re-drive, or `None` before
     /// the first one.
     last_progress: Option<u64>,
-    /// Extra tool-lane permits the relief valve has handed out over this
-    /// daemon's life.
+    /// Extra tool-lane permits the relief valve has handed out and not yet
+    /// reclaimed (see [`Self::decay_relief_if_healthy`]).
     relief_granted: usize,
+    /// Consecutive re-drives that found the lane healthy (no dead cycles, no
+    /// queue) while relief was outstanding - the decay countdown.
+    healthy_cycles: u32,
     /// Dead cycles the daemon tolerates before widening the tool lane. `0`
     /// disables relief. See [`Self::set_dead_cycles_before_relief`].
     dead_cycles_before_relief: u32,
@@ -693,6 +696,12 @@ pub struct WorldHost {
     /// spending memory on a run nobody is driving.
     parked: HashMap<String, RunListEntry>,
 }
+
+/// Consecutive healthy re-drives (no dead cycles, empty tool queue) before the
+/// relief-decay valve reclaims one granted permit. Each re-drive is seconds
+/// apart, so four of them is a comfortably-over margin - and each further
+/// healthy cycle reclaims one more, so a full lane's worth drains in minutes.
+const HEALTHY_CYCLES_BEFORE_DECAY: u32 = 4;
 
 /// How often the serve loop re-drives the world on its own.
 ///
@@ -783,6 +792,7 @@ impl WorldHost {
             dead_cycles: 0,
             last_progress: None,
             relief_granted: 0,
+            healthy_cycles: 0,
             dead_cycles_before_relief: DEFAULT_DEAD_CYCLES_BEFORE_RELIEF,
             finished: VecDeque::new(),
             finished_retention_secs: DEFAULT_FINISHED_RETENTION_SECS,
@@ -809,7 +819,43 @@ impl WorldHost {
         };
         self.log_lane_pressure(&snapshot);
         let relief = self.relieve_if_wedged(&snapshot);
+        self.decay_relief_if_healthy(&snapshot);
         self.observe_lanes(&snapshot, relief);
+    }
+
+    /// The relief valve's give-back half: once the lane has been demonstrably
+    /// healthy for [`HEALTHY_CYCLES_BEFORE_DECAY`] consecutive re-drives,
+    /// reclaim one granted permit per further healthy cycle until the lane is
+    /// back at its configured width.
+    ///
+    /// The guards are what keep this on the safe side of the wedge detection
+    /// that granted the relief in the first place (issue #191): nothing is
+    /// reclaimed while `dead_cycles` is non-zero (a wedge may be forming),
+    /// nothing is reclaimed while the extra capacity is in use (`narrow` only
+    /// takes *idle* permits), and the width can never drop below what the
+    /// config asked for, because only permits this valve granted are counted.
+    fn decay_relief_if_healthy(&mut self, snapshot: &LaneSnapshot) {
+        if self.relief_granted == 0 {
+            self.healthy_cycles = 0;
+            return;
+        }
+        let healthy = self.dead_cycles == 0 && snapshot.tools_queued == 0;
+        self.healthy_cycles = match healthy {
+            true => self.healthy_cycles.saturating_add(1),
+            false => 0,
+        };
+        if self.healthy_cycles < HEALTHY_CYCLES_BEFORE_DECAY {
+            return;
+        }
+        let narrowed = self.world.narrow_tool_lane(1);
+        if narrowed > 0 {
+            self.relief_granted -= narrowed;
+            tracing::info!(
+                narrowed,
+                relief_granted = self.relief_granted,
+                "the jam is over; reclaiming relief capacity from the tool lane"
+            );
+        }
     }
 
     /// Widen the tool lane if the daemon has been going nowhere long enough, and
@@ -2773,6 +2819,74 @@ mod tests {
             await_drained_queue(&mut host).await;
             assert_eq!(host.world_mut().lane_snapshot().tools_busy, 2);
             release_the_lane(&mut host, &[release]).await;
+        })
+        .await;
+    }
+
+    /// The give-back half: once the jam is over and the lane has been healthy
+    /// for the decay margin, the granted capacity is reclaimed - a historical
+    /// wedge no longer raises the daemon's concurrency ceiling (and with it,
+    /// its peak memory) for the rest of its life.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relief_decays_back_once_the_lane_is_healthy_again() {
+        leviath_testkit::with_tracing(|| async {
+            let mut host = host_with_full_pool(1);
+            host.set_dead_cycles_before_relief(2);
+            let release = wedge_the_tool_lane(&mut host).await;
+            host.observe_redrive(); // baseline
+            host.observe_redrive(); // 1
+            host.observe_redrive(); // 2 → relief
+            assert_eq!(host.relief_granted, 1);
+            assert_eq!(host.health().tools_workers, 2);
+
+            // Unjam and drain, so the relief permit sits idle.
+            await_drained_queue(&mut host).await;
+            release_the_lane(&mut host, &[release]).await;
+
+            // Healthy cycles accumulate; nothing comes back inside the margin.
+            for _ in 0..(HEALTHY_CYCLES_BEFORE_DECAY - 1) {
+                host.observe_redrive();
+            }
+            assert_eq!(host.relief_granted, 1, "still inside the decay margin");
+            host.observe_redrive(); // margin reached → one permit reclaimed
+            assert_eq!(host.relief_granted, 0, "the extra permit went back");
+            assert_eq!(host.health().tools_workers, 1);
+
+            // And with nothing granted, further healthy cycles change nothing.
+            host.observe_redrive();
+            assert_eq!(host.healthy_cycles, 0, "the countdown is parked");
+        })
+        .await;
+    }
+
+    /// Decay only ever takes *idle* permits: a lane whose relief capacity is
+    /// genuinely in use keeps it, however healthy the queue looks, and the
+    /// reclaim happens later once the work finishes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relief_decay_takes_only_idle_permits() {
+        leviath_testkit::with_tracing(|| async {
+            let mut host = host_with_full_pool(1);
+            host.set_dead_cycles_before_relief(1);
+            let release = wedge_the_tool_lane(&mut host).await;
+            host.observe_redrive();
+            host.observe_redrive(); // → relief
+            assert_eq!(host.relief_granted, 1);
+            await_drained_queue(&mut host).await;
+
+            // Both permits are now BUSY (the original wedge plus the queued
+            // batch that relief let in) and the queue is empty: healthy by the
+            // decay's measure, but there is nothing idle to take.
+            for _ in 0..(HEALTHY_CYCLES_BEFORE_DECAY + 2) {
+                host.observe_redrive();
+            }
+            assert_eq!(host.relief_granted, 1, "busy permits are never taken");
+            assert_eq!(host.health().tools_workers, 2);
+
+            // Once the work releases, the next healthy cycle reclaims it.
+            release_the_lane(&mut host, &[release]).await;
+            host.observe_redrive();
+            assert_eq!(host.relief_granted, 0);
+            assert_eq!(host.health().tools_workers, 1);
         })
         .await;
     }

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -173,6 +173,11 @@ impl ToolLaneStats {
         self.workers.fetch_add(extra, Ordering::Relaxed);
     }
 
+    /// Lower the cap by `taken`, to match permits forgotten from the semaphore.
+    fn narrowed(&self, taken: usize) {
+        self.workers.fetch_sub(taken, Ordering::Relaxed);
+    }
+
     /// Whether every unit of capacity is taken and batches are waiting behind
     /// them.
     #[must_use]
@@ -224,11 +229,14 @@ impl ToolLane {
         self.runtime.clone().spawn(serve_lane(lane, jobs))
     }
 
-    /// Add `extra` permits, widening the lane for good.
+    /// Add `extra` permits, widening the lane.
     ///
     /// The relief valve under a lane that has stopped draining: handing out more
     /// capacity lets the queued batches run without cancelling anything. Returns
-    /// how many were added.
+    /// how many were added. No longer "for good": once the jam is over,
+    /// [`Self::narrow`] hands the extra capacity back, so a single historical
+    /// wedge does not raise the daemon's peak concurrency (and with it, peak
+    /// memory) for the rest of its life.
     pub fn relieve(&self, extra: usize) -> usize {
         if extra == 0 {
             return 0;
@@ -236,6 +244,22 @@ impl ToolLane {
         self.permits.add_permits(extra);
         self.stats.widen(extra);
         extra
+    }
+
+    /// Take up to `upto` *idle* permits back out of the lane, returning how many
+    /// were reclaimed.
+    ///
+    /// `forget_permits` only removes permits that are currently available, so
+    /// this can never stall a batch that is running or block waiting for one to
+    /// finish - a busy lane just gives back fewer (possibly zero) permits, and
+    /// the caller tries again on a later healthy cycle.
+    pub fn narrow(&self, upto: usize) -> usize {
+        if upto == 0 {
+            return 0;
+        }
+        let taken = self.permits.forget_permits(upto);
+        self.stats.narrowed(taken);
+        taken
     }
 }
 
@@ -844,6 +868,51 @@ mod tests {
         release.notify_one();
         let held = h.next_outcome().await;
         assert_eq!(held.entity, entity(1));
+        h.drain().await;
+    }
+
+    /// `narrow` reclaims only *idle* permits: a busy lane gives back nothing,
+    /// an idle one gives back what was asked (bounded by availability), and
+    /// the cap tracks the permits in both directions.
+    #[tokio::test]
+    async fn narrow_reclaims_idle_permits_and_never_busy_ones() {
+        let mut h = Harness::new(1);
+        assert_eq!(h.lane.relieve(2), 2);
+        assert_eq!(h.stats.workers(), 3);
+
+        // All three permits idle: narrowing nothing is a no-op, narrowing one
+        // takes one.
+        assert_eq!(h.lane.narrow(0), 0, "narrowing nothing changes nothing");
+        assert_eq!(h.lane.narrow(1), 1);
+        assert_eq!(h.stats.workers(), 2);
+
+        // Occupy both remaining permits, then try to narrow: nothing is idle,
+        // so nothing is taken and the cap stays put.
+        let started_a = Arc::new(Notify::new());
+        let release_a = Arc::new(Notify::new());
+        h.submit(held_job(
+            1,
+            started_a.clone(),
+            release_a.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(started_a.notified()).await;
+        let started_b = Arc::new(Notify::new());
+        let release_b = Arc::new(Notify::new());
+        h.submit(held_job(
+            2,
+            started_b.clone(),
+            release_b.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(started_b.notified()).await;
+        assert_eq!(h.lane.narrow(1), 0, "a busy lane keeps its permits");
+        assert_eq!(h.stats.workers(), 2);
+
+        release_a.notify_one();
+        release_b.notify_one();
+        h.next_outcome().await;
+        h.next_outcome().await;
         h.drain().await;
     }
 

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -603,13 +603,20 @@ impl PipelineWorld {
         }
     }
 
-    /// Widen the tool lane by `extra` batches, permanently.
+    /// Widen the tool lane by `extra` batches.
     ///
     /// The relief valve: when the lane has stopped draining, handing out more
     /// capacity lets the queued batches through without cancelling anything.
     /// Returns how many were added.
     pub fn relieve_tool_lane(&self, extra: usize) -> usize {
         self.tool_lane.relieve(extra)
+    }
+
+    /// Reclaim up to `upto` idle permits from the tool lane (the relief valve's
+    /// give-back half). Returns how many were reclaimed; never touches a permit
+    /// a running batch holds.
+    pub fn narrow_tool_lane(&self, upto: usize) -> usize {
+        self.tool_lane.narrow(upto)
     }
 
     /// The status of an agent, if it still exists.


### PR DESCRIPTION
The three follow-ups deferred from #247, landed - plus the allocator question answered with data instead of a defaults argument.

## MCP pool: per-run leases with idle disconnect

Every spawn path (spawner, restart reloader, fan-out worker spawner) leases a blueprint's declared `[[mcp_servers]]` for the run's life; the reap hook releases them. A server with zero holders is disconnected after a grace window (`[limits] mcp_idle_disconnect_secs`, default 60, `0` = never): its client comes out of the executor and is shut down, which is what actually ends a stdio server's child process. A lease taken during the grace window bumps a generation counter and voids the pending disconnect; global config servers are exempt; reconnection is the existing lazy `ensure` path, so back-to-back runs of the same blueprint still share a warm connection.

## Tool-lane relief decay

The relief valve's give-back half. After four consecutive healthy re-drives (no dead cycles, empty queue), each further healthy cycle reclaims one granted permit via `Semaphore::forget_permits` - which only ever takes **idle** permits, so a busy lane keeps its capacity, nothing is reclaimed while a wedge may be forming, and the width can never drop below the configured base. A single historical jam no longer raises the daemon's peak concurrency (and with it, peak memory) for the rest of its life.

## lev dash: stat-gated parse cache

The 10 Hz sync tick re-parsed every run's `meta.json`, `stages.json`, and whole `context.json` every tick - on the order of 100 MB/s of allocate-parse-free with 50 runs on disk, for files that change at most once per persist tick. `runstate::StatCache` re-parses only when a file's `(mtime, len)` changes, context snapshots are shared `Arc`s instead of per-tick deep copies, and entries for deleted runs are pruned.

## The allocator, decided by measurement

The binary's allocator is now a feature (`mimalloc-allocator`, default on), so identical code was benchmarked on three allocators (24-run deterministic burst, macOS, 3-minute settle):

| | fresh idle | live peak | live settled |
|---|---|---|---|
| system malloc | **6.2 MB** | **69 MB** | 69 MB (decays only over hours/pressure) |
| mimalloc | 8.5 MB | 94 MB | **52 MB (within ~10s)** |
| jemalloc (1s decay baked) | 13 MB | 77 MB | 74 MB |

Two findings that frame it: `heap` analysis shows only **~2 MB actually reachable** after a burst - every settled floor above that is allocator accounting, not leviath data - and true idle (daemon up, nothing run) is **8.5 MB**. mimalloc stays the default: best post-burst release, best cross-platform story; jemalloc (worst on both ends here) was tried and dropped. The final binary's burst profile: live avg 51.6 MB / peak 99 / settled 48, CPU avg 0.2%, against the pre-#247 baseline's 117 / 122 / 122-forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9P3DnrTCx7a5j9u84CyFr
