### PR TITLE
fix(daemon): provision 2048 blocking threads for script-provider pools

### DIFF
--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -540,6 +540,11 @@ pub struct LimitsConfig {
     /// Global fallback cap on concurrent inference requests for any model
     /// without its own per-model pool entry. Defaults to `Some(8)`; omit or set
     /// a large number to effectively unbound it.
+    ///
+    /// One physical bound sits behind this for *script* providers: each of
+    /// their in-flight calls occupies a blocking-pool thread, and the daemon's
+    /// runtime provisions 2048 of those. Pools above 2048 only run that wide
+    /// for HTTP providers, whose calls are fully async.
     #[serde(default = "default_max_concurrent_inferences")]
     pub max_concurrent_inferences: Option<usize>,
 

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -50,8 +50,22 @@ struct Cli {
     command: Commands,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // An explicit runtime instead of `#[tokio::main]` for one number: script
+    // providers execute every in-flight inference call on a blocking-pool
+    // thread, and tokio's default cap of 512 silently gated
+    // `[limits] max_concurrent_inferences` above that - a 1024-permit pool
+    // queued at the thread layer where nothing measured or reported it. 2048
+    // covers the largest supported pool; threads are spawned on demand and
+    // reaped when idle, so an idle daemon pays nothing for the headroom.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .max_blocking_threads(2048)
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     // Pre-scan argv for dynamic `--<region>` seed flags on `run` (region names
     // are blueprint-defined, so clap can't declare them), then parse the rest
     // and fold the extracted flags back in (both steps are tested lib seams).


### PR DESCRIPTION
Found sizing the benchmark pool sweep: script providers run each in-flight inference call on a tokio blocking-pool thread, and the runtime's default cap of **512** silently gated `[limits] max_concurrent_inferences` above that - a 1024-permit pool queued at the thread layer where nothing measured or reported the wait, so its benchmark numbers would have been indistinguishable from pool 512's.

The daemon's runtime is now built explicitly with `max_blocking_threads(2048)`, covering the largest supported pool with room to spare. Blocking threads spawn on demand and are reaped when idle - an idle daemon pays nothing for the headroom. The `max_concurrent_inferences` config doc now states the bound, and that HTTP providers (fully async) are not subject to it.

main.rs-only mechanical change (macro → explicit builder wrapping the same body); coverage-excluded, label applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9P3DnrTCx7a5j9u84CyFr