### PR TITLE
fix(alloc): purge freed memory at free time, in the binary itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2348,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "leviath-alloc"
+version = "0.2.0"
+dependencies = [
+ "libmimalloc-sys",
+ "temp-env",
+]
+
+[[package]]
 name = "leviath-cli"
 version = "0.2.0"
 dependencies = [
@@ -2361,6 +2375,7 @@ dependencies = [
  "jsonschema",
  "keyring-core",
  "leviath-agent-client",
+ "leviath-alloc",
  "leviath-core",
  "leviath-mcp",
  "leviath-package",
@@ -2600,6 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/leviath-scripting",
     "crates/leviath-package",
     "crates/leviath-cli",
+    "crates/leviath-alloc",
     "crates/leviath-tools",
     "crates/leviath-sys",
     "crates/leviath-telemetry",
@@ -35,7 +36,9 @@ categories = ["development-tools"]
 # Lints applied to every workspace member that opts in with `[lints] workspace = true`.
 # `unsafe_code = "forbid"` is a hard compile error that cannot be re-enabled by a
 # local `#[allow(unsafe_code)]` -- the OS-level unsafe leviath needs lives in audited
-# dependencies (nix, temp-env), so none is written in our own crates.
+# dependencies (nix, temp-env) plus ONE audited in-repo exception: leviath-alloc,
+# a single-call crate that deliberately does not opt into these lints (its lib.rs
+# carries the audit note). Nothing else writes unsafe.
 [workspace.lints.rust]
 unsafe_code = "forbid"
 

--- a/crates/leviath-alloc/Cargo.toml
+++ b/crates/leviath-alloc/Cargo.toml
@@ -1,0 +1,24 @@
+# The ONE workspace crate that does not opt into `[lints] workspace = true`:
+# it exists to hold a single audited `unsafe` FFI call into mimalloc that has
+# no safe wrapper anywhere on crates.io (see src/lib.rs for the full audit
+# note). Everything else in the workspace stays under `unsafe_code = "forbid"`.
+[package]
+name = "leviath-alloc"
+description = "Allocator tuning for the leviath binary: one audited mimalloc option call"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[features]
+# Off by default so builds without the mimalloc global allocator (the
+# `--no-default-features` A/B benchmarking configuration of leviath-cli)
+# compile no FFI at all and the entry point is a no-op.
+mimalloc = ["dep:libmimalloc-sys"]
+
+[dependencies]
+libmimalloc-sys = { version = "0.1", features = ["extended"], optional = true }
+
+[dev-dependencies]
+temp-env = { workspace = true }

--- a/crates/leviath-alloc/src/lib.rs
+++ b/crates/leviath-alloc/src/lib.rs
@@ -1,0 +1,105 @@
+//! Allocator tuning for the leviath binary.
+//!
+//! This crate holds exactly one capability: telling mimalloc to purge freed
+//! memory at free time instead of deferring it. It exists as a separate
+//! crate because the call is an `unsafe` C FFI invocation and the rest of
+//! the workspace compiles under `unsafe_code = "forbid"`; the policy is that
+//! OS-level unsafe lives in small audited places, and this crate is one.
+//!
+//! ## Why purge at free time
+//!
+//! mimalloc's default purge delay (10ms) is not a timer. It is a minimum age
+//! checked only when the owning thread next touches the allocator. A daemon
+//! worker thread that goes idle right after a burst therefore never returns
+//! its freed pages to the OS: the process sits tens to hundreds of MB above
+//! its idle baseline holding pages that contain nothing. Measured on the
+//! daemon: byte-for-byte flat across 10 idle minutes, then released by the
+//! next moment of allocator activity.
+//!
+//! With a delay of zero the `free` that empties a span performs the OS
+//! handoff itself, so nothing ever waits on future activity. The cost is a
+//! syscall per emptied span (paid at run-reap, off every latency path) and
+//! re-faulting pages when a later burst reallocates (milliseconds per burst
+//! ramp, measured indistinguishable end to end on the benchmark suite). The
+//! win is a daemon whose resident memory actually returns to its baseline
+//! when work finishes.
+//!
+//! A user who exports `MIMALLOC_PURGE_DELAY` themselves has made a choice,
+//! and [`use_purge_at_free_unless_overridden`] leaves it alone.
+//!
+//! ## Audit note (the single unsafe call)
+//!
+//! `mi_option_set(option, value)` writes a `long` into mimalloc's static
+//! options table. It allocates nothing, frees nothing, holds no lock, and is
+//! documented callable at any time; subsequent purge decisions read the
+//! stored value. The option index for `mi_option_purge_delay` is `15` in
+//! the mimalloc v2 header vendored by `libmimalloc-sys` 0.1.49, anchored on
+//! both sides by constants that crate does bind: `mi_option_eager_commit_delay
+//! = 14` and `mi_option_use_numa_nodes = 16` (the crate predates the
+//! `reset_delay` to `purge_delay` rename and simply does not name index 15).
+//! The test below asserts the round trip through `mi_option_get`, so a
+//! vendored-header reordering would fail loudly rather than silently tune
+//! the wrong knob.
+
+/// The environment variable mimalloc itself reads for this option; a user
+/// who set it keeps their value.
+pub const PURGE_DELAY_VAR: &str = "MIMALLOC_PURGE_DELAY";
+
+/// `mi_option_purge_delay` in the vendored mimalloc v2 option enum. See the
+/// module-level audit note for how this index is pinned.
+#[cfg(feature = "mimalloc")]
+const MI_OPTION_PURGE_DELAY: libmimalloc_sys::mi_option_t = 15;
+
+/// Configure mimalloc to purge freed memory at free time, unless the user
+/// chose their own delay via [`PURGE_DELAY_VAR`].
+///
+/// Returns whether the option was applied, so the decision is observable in
+/// tests. Call once, early in `main`; pages freed before the call simply
+/// purge on the pre-existing schedule.
+#[cfg(feature = "mimalloc")]
+pub fn use_purge_at_free_unless_overridden() -> bool {
+    if std::env::var_os(PURGE_DELAY_VAR).is_some() {
+        return false;
+    }
+    // SAFETY: writes a long into mimalloc's in-process options table; no
+    // memory is allocated, freed, or aliased. See the module audit note.
+    unsafe { libmimalloc_sys::mi_option_set(MI_OPTION_PURGE_DELAY, 0) };
+    true
+}
+
+/// Without the mimalloc feature there is nothing to tune: builds on the
+/// system allocator keep their platform defaults.
+#[cfg(not(feature = "mimalloc"))]
+pub fn use_purge_at_free_unless_overridden() -> bool {
+    false
+}
+
+#[cfg(all(test, feature = "mimalloc"))]
+mod tests {
+    use super::*;
+
+    /// The applied value must be readable back through mimalloc itself: this
+    /// is the guard against the option index drifting in a future vendored
+    /// header (the failure mode would be silently tuning the wrong knob).
+    #[test]
+    fn purge_at_free_is_applied_and_round_trips_through_mimalloc() {
+        temp_env::with_var_unset(PURGE_DELAY_VAR, || {
+            assert!(use_purge_at_free_unless_overridden());
+            // SAFETY: reads a long from the options table just written above.
+            let value = unsafe { libmimalloc_sys::mi_option_get(MI_OPTION_PURGE_DELAY) };
+            assert_eq!(value, 0);
+        });
+    }
+
+    /// An exported MIMALLOC_PURGE_DELAY is the user's decision, whatever the
+    /// value - even an explicit "0" is theirs to own, not ours to rewrite.
+    #[test]
+    fn a_user_exported_delay_is_left_alone() {
+        temp_env::with_var(PURGE_DELAY_VAR, Some("25"), || {
+            assert!(!use_purge_at_free_unless_overridden());
+        });
+        temp_env::with_var(PURGE_DELAY_VAR, Some("0"), || {
+            assert!(!use_purge_at_free_unless_overridden());
+        });
+    }
+}

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -30,13 +30,14 @@ debug-http = ["leviath-providers/debug-http"]
 # allocators can be benchmarked against each other on identical code
 # (`--no-default-features` builds on the system allocator), and so an
 # embedder-style build can opt out entirely.
-mimalloc-allocator = ["dep:mimalloc"]
+mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimalloc"]
 
 [dependencies]
 # The binary's global allocator (see main.rs). Kept out of the workspace dep
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.2.0", optional = true }
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -51,6 +51,14 @@ struct Cli {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Purge freed memory at free time (leviath-alloc has the full why): an
+    // idle daemon otherwise parks its burst memory as unflagged freed pages
+    // the OS keeps charging to it. Applied in-binary so every lev process
+    // behaves the same however it was started; a user-exported
+    // MIMALLOC_PURGE_DELAY always wins.
+    #[cfg(feature = "mimalloc-allocator")]
+    leviath_alloc::use_purge_at_free_unless_overridden();
+
     // An explicit runtime instead of `#[tokio::main]` for one number: script
     // providers execute every in-flight inference call on a blocking-pool
     // thread, and tokio's default cap of 512 silently gated


### PR DESCRIPTION
**Problem:** an idle daemon parks 20-900 MB above its baseline after bursts. mimalloc's purge delay is a minimum age checked only when the owning thread next touches the allocator, so workers that go idle after a burst never return their freed pages - measured byte-identical across 10 idle minutes, then released by the next moment of activity. Reachable heap at the floor: ~2 MB.

**Fix:** set `mi_option_purge_delay = 0` at the top of `main()` - the `free` that empties a span performs the OS handoff itself, so nothing waits on future activity. In the **binary**, not in spawn environments, so every lev process behaves identically however it was started (foreground, auto-spawned, supervised, benchmark harness). A user-exported `MIMALLOC_PURGE_DELAY` always wins.

**Tradeoff (measured):** a syscall per emptied span at run-reap (off every latency path) + page re-warming at the next burst's ramp (single-digit ms per burst). End-to-end drain times indistinguishable across the benchmark suite. In-flight agents untouched - only freed pages change hands.

**The unsafe:** one C FFI call with no safe wrapper on crates.io, so it gets the workspace's first in-repo audited-unsafe crate: `leviath-alloc` - three lines behind a safe function, audit note in lib.rs, workspace lints comment updated to name the exception. The option index (15, unbound by libmimalloc-sys) is anchored by its bound neighbors (14/16) and guarded by a test that round-trips the value through `mi_option_get`, so a vendored-header reorder fails loudly instead of tuning the wrong knob.

Coverage: all 12 packages at 100% locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9P3DnrTCx7a5j9u84CyFr