### PR TITLE
fix(cli): adaptive daemon-readiness polling

### DIFF
--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -310,12 +310,7 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
         let _ = control_client()?
             .request(&leviath_runtime::control_socket::ControlRequest::Shutdown)
             .await;
-        for _ in 0..100 {
-            if !is_daemon_running(&id) {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
+        poll_until(|| !is_daemon_running(&id)).await;
     }
     let exe = std::env::current_exe()?;
     let mut cmd = std::process::Command::new(exe);
@@ -325,13 +320,28 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
         .stderr(std::process::Stdio::null());
     leviath_sys::process::configure_detached(&mut cmd);
     cmd.spawn()?;
-    for _ in 0..100 {
-        if is_daemon_running(&id) {
-            return Ok(());
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    if poll_until(|| is_daemon_running(&id)).await {
+        return Ok(());
     }
     anyhow::bail!("the leviath daemon did not start within 5s");
+}
+
+/// Poll `done` until it returns true or ~5s elapses, sleeping 2ms at first
+/// and doubling to a 50ms ceiling. The daemon boots in ~20ms, so the old
+/// fixed 50ms tick spent more time waiting than the daemon spent starting -
+/// it was most of the measured 97ms cold `lev run`. Backoff keeps the
+/// slow-path cost (a daemon that genuinely takes seconds) unchanged.
+async fn poll_until(mut done: impl FnMut() -> bool) -> bool {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut delay = std::time::Duration::from_millis(2);
+    while !done() {
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(std::time::Duration::from_millis(50));
+    }
+    true
 }
 
 /// `lev daemon start`: auto-start a detached daemon if none is running.
@@ -367,12 +377,9 @@ async fn real_daemon_stop() -> anyhow::Result<()> {
             None => return Err(e),
         }
     }
-    for _ in 0..100 {
-        if !is_daemon_running(&id) {
-            println!("daemon stopped");
-            return Ok(());
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    if poll_until(|| !is_daemon_running(&id)).await {
+        println!("daemon stopped");
+        return Ok(());
     }
     anyhow::bail!("the leviath daemon did not shut down within 5s");
 }


### PR DESCRIPTION
The daemon lifecycle waits (auto-start, stale-build restart, stop) ticked at a fixed 50ms while the daemon boots in ~20ms - the poll spent more time waiting than the daemon spent starting, and it was most of the measured 97ms cold `lev run`.

One shared `poll_until` helper: 2ms initial tick doubling to a 50ms ceiling, same 5s deadline. Fast path detects readiness within a few ms; the slow path (a daemon that genuinely takes seconds) costs exactly what it did before.

**Measured** (10 reps each, fully cold `lev run` to run-id returned): **93ms → 68ms median**.

main.rs-only (the untestable real-socket polling sliver); label applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9P3DnrTCx7a5j9u84CyFr