### PR TITLE
refactor: delete dead MCP surface, gate the test-only runstate writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,12 @@ same list.
   file listing reports `modifying_tool_calls` and `modified_files_truncated` as
   separate facts, so a client never subtracts one from the other to guess how
   many files there were.
+- Removed: five public functions in `leviath-mcp` that nothing outside their own
+  tests called. `ToolExecutor::add_client` was `add_client_advertised` with an
+  empty advertised set, `ToolExecutor::execute_filtered` was `execute` behind a
+  name check the caller already does, and `ToolRegistry`'s `all_tools`,
+  `find_tool` and `server_tools` were superseded by the advertised-name map.
+  Callers of `add_client` want `add_client_advertised(name, client, &advertised)`.
 
 ## 0.2.0 - 2026-08-04
 

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -2306,7 +2306,11 @@ for line in sys.stdin:
         client.connect().await.expect("connect");
         client.list_tools().await.expect("list_tools");
         let mut executor = leviath_mcp::ToolExecutor::new();
-        executor.add_client("stub".to_string(), client);
+        let _ = executor.add_client_advertised(
+            "stub".to_string(),
+            client,
+            &std::collections::HashSet::new(),
+        );
         executor
     }
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -10,6 +10,21 @@
 //!
 //! The dashboard's activity log is persisted separately at:
 //! - `~/.leviath/dashboard.log` - never cleared, appended across sessions
+//!
+//! # Who writes, and which copy is authoritative
+//!
+//! There are two answers to "what runs exist", and that is deliberate. The ECS
+//! world is the live one: it knows wait reasons and tick-fresh progress for the
+//! runs the daemon is holding right now, and `host.rs`'s `list()` reads it.
+//! The runs directory is the durable one: it survives a crash or a daemon that
+//! is not running, and `list_runs` below reads it. Disk lags the world by at
+//! most one persistence tick, so the two disagreeing is expected rather than a
+//! bug, and every reconciliation of that gap goes through `looks_abandoned`.
+//!
+//! The runtime's `persistence_bridge` is the only thing that writes a live
+//! run's state. The writers in this module are `#[cfg(test)]` so that stays
+//! true by compilation rather than by convention: a test can lay down a run
+//! directory to read back, and production has no second path to the same files.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,6 +40,11 @@ pub use leviath_core::run_meta::{
 };
 
 /// Atomically write a context snapshot for the run.
+///
+/// Test-only. Production writes go through the runtime's `persistence_bridge`,
+/// which is the sole writer of a live run's on-disk state; this exists so a
+/// test can lay down a run directory to read back. See the module doc.
+#[cfg(test)]
 pub fn write_context_snapshot(run_id: &str, snap: &ContextSnapshot) -> anyhow::Result<()> {
     write_context_snapshot_to(&run_dir(run_id), snap)
 }
@@ -56,6 +76,7 @@ fn write_private_atomic(path: &std::path::Path, body: &str) -> anyhow::Result<()
     Ok(())
 }
 
+#[cfg(test)]
 fn write_context_snapshot_to(dir: &std::path::Path, snap: &ContextSnapshot) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(snap)
         .expect("infallible: ContextSnapshot always serializes to JSON");
@@ -455,6 +476,9 @@ pub fn final_output_path(dir: &std::path::Path) -> PathBuf {
 ///
 /// Raw content with no wrapper: serving it is a read, and `lev result --raw` is
 /// a copy. The descriptor in `meta.json` is what says it exists.
+///
+/// Test-only; see [`write_context_snapshot`].
+#[cfg(test)]
 pub fn write_final_output(dir: &std::path::Path, content: &str) -> anyhow::Result<()> {
     write_private_atomic(&final_output_path(dir), content)
 }
@@ -758,10 +782,14 @@ pub fn stage_dir(run_id: &str, stage_idx: usize) -> PathBuf {
 }
 
 /// Atomically write the stages index for a run.
+///
+/// Test-only; see [`write_context_snapshot`].
+#[cfg(test)]
 pub fn write_stages_index(run_id: &str, stages: &[StageRecord]) -> anyhow::Result<()> {
     write_stages_index_to(&run_dir(run_id), stages)
 }
 
+#[cfg(test)]
 fn write_stages_index_to(dir: &std::path::Path, stages: &[StageRecord]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(&stages)
         .expect("infallible: StageRecord slice always serializes to JSON");
@@ -779,12 +807,16 @@ pub fn read_stages_index(run_id: &str) -> Vec<StageRecord> {
 }
 
 /// Ensure the per-stage directory exists (called before first write).
+#[cfg(test)]
 fn ensure_stage_dir(run_id: &str, stage_idx: usize) {
     let dir = stage_dir(run_id, stage_idx);
     let _ = leviath_sys::create_private_dir_all(&dir);
 }
 
 /// Append a line of readable agent output to the per-stage output log.
+///
+/// Test-only; see [`write_context_snapshot`].
+#[cfg(test)]
 pub fn append_stage_output(run_id: &str, stage_idx: usize, text: &str) {
     use std::io::Write;
     ensure_stage_dir(run_id, stage_idx);
@@ -795,6 +827,9 @@ pub fn append_stage_output(run_id: &str, stage_idx: usize, text: &str) {
 }
 
 /// Append a line of operational/tool-activity log to the per-stage logs file.
+///
+/// Test-only; see [`write_context_snapshot`].
+#[cfg(test)]
 pub fn append_stage_log(run_id: &str, stage_idx: usize, text: &str) {
     use std::io::Write;
     ensure_stage_dir(run_id, stage_idx);
@@ -805,6 +840,9 @@ pub fn append_stage_log(run_id: &str, stage_idx: usize, text: &str) {
 }
 
 /// Atomically write a context snapshot for a specific stage.
+///
+/// Test-only; see [`write_context_snapshot`].
+#[cfg(test)]
 pub fn write_stage_context(
     run_id: &str,
     stage_idx: usize,

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -237,29 +237,6 @@ impl ToolDiscovery {
         Ok((tools, client))
     }
 
-    /// Return all discovered tools across all servers.
-    pub fn all_tools(&self) -> Vec<&ToolMetadata> {
-        self.servers
-            .values()
-            .flat_map(|tools| tools.iter())
-            .collect()
-    }
-
-    /// Find a tool by name, returning the server name and tool metadata.
-    pub fn find_tool(&self, name: &str) -> Option<(&str, &ToolMetadata)> {
-        for (server_name, tools) in &self.servers {
-            if let Some(tool) = tools.iter().find(|t| t.name == name) {
-                return Some((server_name.as_str(), tool));
-            }
-        }
-        None
-    }
-
-    /// Get tools for a specific server.
-    pub fn server_tools(&self, server_name: &str) -> Option<&[ToolMetadata]> {
-        self.servers.get(server_name).map(|v| v.as_slice())
-    }
-
     /// Get the number of servers registered.
     pub fn server_count(&self) -> usize {
         self.servers.len()
@@ -354,30 +331,10 @@ mod tests {
     }
 
     #[test]
-    fn new_all_tools_is_empty() {
-        let discovery = ToolDiscovery::new();
-        assert!(discovery.all_tools().is_empty());
-    }
-
-    #[test]
-    fn new_find_tool_returns_none() {
-        let discovery = ToolDiscovery::new();
-        assert!(discovery.find_tool("x").is_none());
-    }
-
-    #[test]
-    fn new_server_tools_returns_none() {
-        let discovery = ToolDiscovery::new();
-        assert!(discovery.server_tools("x").is_none());
-    }
-
-    #[test]
     fn default_same_as_new() {
         let d1 = ToolDiscovery::new();
         let d2 = ToolDiscovery::default();
         assert_eq!(d1.server_count(), d2.server_count());
-        assert!(d1.all_tools().is_empty());
-        assert!(d2.all_tools().is_empty());
     }
 
     // --- discover_from_client / discover_from_config ---
@@ -427,33 +384,6 @@ for line in sys.stdin:
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "echo");
         assert_eq!(discovery.server_count(), 1);
-        assert_eq!(discovery.all_tools().len(), 1);
-
-        let (server_name, tool) = discovery.find_tool("echo").expect("tool should be found");
-        assert_eq!(server_name, "server1");
-        assert_eq!(tool.name, "echo");
-
-        let server_tools = discovery
-            .server_tools("server1")
-            .expect("server tools should be present");
-        assert_eq!(server_tools.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn discover_from_client_missing_tool_returns_none() {
-        let mut client = MCPClient::spawn("python3", &["-c", STUB_INIT_AND_LIST], &HashMap::new())
-            .await
-            .expect("failed to spawn stub server");
-        client.connect().await.expect("connect should succeed");
-
-        let mut discovery = ToolDiscovery::new();
-        discovery
-            .discover_from_client("server1", &mut client)
-            .await
-            .expect("discovery should succeed");
-
-        assert!(discovery.find_tool("nonexistent").is_none());
-        assert!(discovery.server_tools("nonexistent").is_none());
     }
 
     #[tokio::test]
@@ -475,7 +405,6 @@ for line in sys.stdin:
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "echo");
         assert_eq!(discovery.server_count(), 1);
-        assert!(discovery.find_tool("echo").is_some());
 
         // The returned client is live and connected (capabilities were parsed).
         assert!(client.capabilities().is_some());

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -68,15 +68,6 @@ impl ToolExecutor {
         }
     }
 
-    /// Register an MCP client for a server, advertising its tools under names
-    /// safe for the LLM/provider.
-    ///
-    /// Equivalent to [`Self::add_client_advertised`] reserving nothing; kept for
-    /// callers that don't need the advertised metadata back.
-    pub fn add_client(&mut self, server_name: String, client: MCPClient) {
-        let _ = self.add_client_advertised(server_name, client, &HashSet::new());
-    }
-
     /// Register a client and return its tools under *advertised* names.
     ///
     /// Each advertised name is [`sanitize_tool_name`]d and made unique against
@@ -196,28 +187,6 @@ impl ToolExecutor {
         Ok(Self::map_result(tool_result))
     }
 
-    /// Execute a tool only if it is in the allowed list.
-    ///
-    /// Returns an error if the tool is not in the allowed_tools list.
-    pub async fn execute_filtered(
-        &mut self,
-        tool_name: &str,
-        arguments: Value,
-        allowed_tools: &[String],
-    ) -> anyhow::Result<ExecutionResult> {
-        if !allowed_tools.iter().any(|t| t == tool_name) {
-            return Ok(ExecutionResult {
-                success: false,
-                data: Value::Null,
-                text: format!(
-                    "Tool '{}' is not allowed in the current stage. Allowed tools: {:?}",
-                    tool_name, allowed_tools
-                ),
-            });
-        }
-        self.execute(tool_name, arguments).await
-    }
-
     /// Shutdown all connected MCP clients.
     ///
     /// `MCPClient::shutdown` always returns `Ok` by design (it swallows
@@ -292,20 +261,6 @@ mod tests {
     use super::*;
     use crate::client::EmbeddedResource;
     use crate::test_support::always_on_tracing_guard;
-
-    #[tokio::test]
-    async fn test_execute_filtered_rejects_disallowed_tool() {
-        let mut executor = ToolExecutor::new();
-        let allowed = vec!["read_file".to_string(), "write_file".to_string()];
-
-        let result = executor
-            .execute_filtered("delete_file", serde_json::json!({}), &allowed)
-            .await
-            .unwrap();
-
-        assert!(!result.success);
-        assert!(result.text.contains("not allowed"));
-    }
 
     #[test]
     fn test_tool_executor_creation() {
@@ -454,20 +409,6 @@ mod tests {
 
     // ─── execute_filtered: allowed tool ────────────────────────────────
 
-    #[tokio::test]
-    async fn test_execute_filtered_allowed_tool_but_no_server() {
-        let _guard = always_on_tracing_guard();
-        let mut executor = ToolExecutor::new();
-        let allowed = vec!["read_file".to_string()];
-
-        // Tool is allowed but no server has it
-        let result = executor
-            .execute_filtered("read_file", serde_json::json!({}), &allowed)
-            .await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No MCP server"));
-    }
-
     // ─── execute: no server ─────────────────────────────────────────────
 
     #[tokio::test]
@@ -559,7 +500,7 @@ for line in sys.stdin:
     async fn add_client_and_server_count_reflects_it() {
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
         assert_eq!(executor.server_count(), 1);
     }
 
@@ -570,7 +511,7 @@ for line in sys.stdin:
     async fn remove_client_takes_the_server_and_its_aliases() {
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
         assert_eq!(executor.server_count(), 1);
 
         assert!(executor.remove_client("nope").is_none());
@@ -587,7 +528,7 @@ for line in sys.stdin:
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
             .execute("echo", serde_json::json!({"text": "hi"}))
@@ -602,7 +543,7 @@ for line in sys.stdin:
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
             .execute_on("server1", "echo", serde_json::json!({}))
@@ -612,18 +553,21 @@ for line in sys.stdin:
         assert_eq!(result.text, "hello from tool");
     }
 
+    /// The end-to-end path against a live stub server. This used to go through
+    /// `execute_filtered`, which is gone; the call it actually exercised -
+    /// route by advertised name, dispatch, map the result - is `execute`, so
+    /// the coverage moves rather than disappearing with its wrapper.
     #[tokio::test]
-    async fn execute_filtered_allowed_tool_with_server_succeeds() {
+    async fn execute_routes_to_a_live_server_and_succeeds() {
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
-        let allowed = vec!["echo".to_string()];
         let result = executor
-            .execute_filtered("echo", serde_json::json!({}), &allowed)
+            .execute("echo", serde_json::json!({}))
             .await
-            .expect("execute_filtered should succeed");
+            .expect("execute should succeed");
         assert!(result.success);
     }
 
@@ -632,7 +576,7 @@ for line in sys.stdin:
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
         let client = spawn_ready_client().await;
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor.shutdown_all().await;
         assert!(result.is_ok());
@@ -712,7 +656,7 @@ for line in sys.stdin:
         client.list_tools().await.expect("list_tools");
 
         let mut executor = ToolExecutor::new();
-        executor.add_client("server1".to_string(), client);
+        let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
             .execute_on("server1", "echo", serde_json::json!({}))
@@ -1014,7 +958,7 @@ for line in sys.stdin:
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
         let client = spawn_named("plain").await;
-        executor.add_client("s".to_string(), client);
+        let _ = executor.add_client_advertised("s".to_string(), client, &HashSet::new());
         assert!(
             executor
                 .execute("plain", serde_json::json!({}))


### PR DESCRIPTION
Third of the Phase 2 structure cleanups. Two independent halves, one commit each.

### Five public functions with no non-test caller

`ToolExecutor::add_client` was `add_client_advertised` with an empty advertised set.
`ToolExecutor::execute_filtered` was `execute` behind a name check its only caller already
does. `ToolRegistry::all_tools`, `find_tool` and `server_tools` were superseded by the
advertised-name map and had no callers at all.

These are `pub` in a crate we publish, so it is a semver break - fine pre-1.0, and the
changelog names the replacement so nobody has to decode a compile error.

The one end-to-end test that ran through `execute_filtered` now runs through `execute`.
What it actually pinned - route by advertised name, dispatch to a live stub server, map the
result - lives there, so the coverage moves rather than leaving with the wrapper.

Deleting a function removes it from the coverage denominator, so the gate got easier here,
not harder.

### The single-writer rule, in the type system

The runs directory has exactly one production writer: the runtime's `persistence_bridge`.
I verified the nine write helpers in `leviath-cli`'s `runstate` are reachable only from
tests - every caller outside the module already sits in a `#[cfg(test)]` block, and
`persistence_bridge` lives in `leviath-runtime`, which does not depend on `leviath-cli` and
so cannot reach them even in principle.

`#[cfg(test)]` on all nine (six public, three private helpers that only they reach) turns
that convention into a compile-time guarantee and drops them from release builds. The Java
analogy is moving a helper from `src/main` to `src/test` without touching a call site.

The module doc gains the authority rule the two-source seam has always run on but never
wrote down: the ECS world is live truth, the runs directory is durable truth, disk lags by
at most one persistence tick, and every reconciliation of that gap goes through
`looks_abandoned`. That is the right amount of unification for this seam - a unified
abstraction over the two would be a distributed-consistency layer inside a single-machine
app.

### Verification

`cargo test -p leviath-mcp` 382 passing, `cargo test -p leviath-cli --all-features` 3013
passing, `cargo xtask coverage` clean on both packages, clippy clean with
`--all-features --all-targets`.

**Performance: none.** Nothing here runs; it is all deletion and compile-time gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
