### PR TITLE
refactor(manifest): finish the parse_manifest section extraction (927 lines to 180)

### DIFF
--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -751,34 +751,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     blueprint.dynamic_tools = dynamic_tools;
 
     if let Some(compaction_table) = parsed.get("compaction").and_then(|v| v.as_table()) {
-        let mut cc = CompactionConfig::default();
-
-        if let Some(provider) = compaction_table.get("provider").and_then(|v| v.as_str()) {
-            cc.provider = provider.to_string();
-        }
-        if let Some(model) = compaction_table.get("model").and_then(|v| v.as_str()) {
-            cc.model = model.to_string();
-        }
-        if let Some(sp) = compaction_table
-            .get("system_prompt")
-            .and_then(|v| v.as_str())
-        {
-            cc.system_prompt = Some(sp.to_string());
-        }
-        if let Some(mst) = compaction_table
-            .get("max_summary_tokens")
-            .and_then(|v| v.as_integer())
-        {
-            cc.max_summary_tokens = mst as usize;
-        }
-        if let Some(temp) = compaction_table
-            .get("temperature")
-            .and_then(|v| v.as_float())
-        {
-            cc.temperature = temp as f32;
-        }
-
-        blueprint.compaction_config = Some(cc);
+        blueprint.compaction_config = Some(parse_compaction_config(compaction_table));
     }
 
     // Parse agent-level security config: [security]
@@ -819,19 +792,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // syntax-checked here so a broken one fails `lev validate`/`lev add`/spawn
     // loudly, instead of degrading the agent at its first out-of-workdir read.
     if let Some(rp_table) = parsed.get("read_paths").and_then(|v| v.as_table()) {
-        let mut allow = Vec::new();
-        if let Some(entries) = rp_table.get("allow").and_then(|v| v.as_array()) {
-            for entry in entries {
-                let Some(raw) = entry.as_str() else {
-                    return Err(Error::Other(format!(
-                        "[read_paths] allow entries must be strings, got: {entry}"
-                    )));
-                };
-                crate::read_paths::validate_entry_syntax(raw).map_err(Error::Other)?;
-                allow.push(raw.to_string());
-            }
-        }
-        blueprint.read_paths = Some(crate::blueprint::ReadPathsConfig { allow });
+        blueprint.read_paths = Some(parse_read_paths(rp_table)?);
     }
 
     // [safe_commands]: what this agent would like to run unprompted. Inert
@@ -839,37 +800,14 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // still a hard error, because a list that silently loses members reads as a
     // grant that was made.
     if let Some(sc_table) = parsed.get("safe_commands").and_then(|v| v.as_table()) {
-        let strings = |field: &str| -> Result<Vec<String>> {
-            let Some(entries) = sc_table.get(field).and_then(|v| v.as_array()) else {
-                return Ok(Vec::new());
-            };
-            entries
-                .iter()
-                .map(|entry| {
-                    entry.as_str().map(str::to_string).ok_or_else(|| {
-                        Error::Other(format!(
-                            "[safe_commands] {field} entries must be strings, got: {entry}"
-                        ))
-                    })
-                })
-                .collect()
-        };
-        blueprint.safe_commands = Some(crate::blueprint::SafeCommandsConfig {
-            tools: strings("tools")?,
-            shell: strings("shell")?,
-        });
+        blueprint.safe_commands = Some(parse_safe_commands(sc_table)?);
     }
 
     // Parse agent-level tool permissions: [tool_permissions]
     if let Some(tp_table) = parsed.get("tool_permissions").and_then(|v| v.as_table()) {
-        for (tool_name, policy_val) in tp_table {
-            if let Some(policy_str) = policy_val.as_str() {
-                blueprint.metadata.insert(
-                    format!("tool_perm:{}", tool_name),
-                    serde_json::Value::String(policy_str.to_string()),
-                );
-            }
-        }
+        blueprint
+            .metadata
+            .extend(tool_permission_metadata(tp_table));
     }
 
     // Parse file tracking config: [context.file_tracking]
@@ -878,30 +816,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
             .get("file_tracking")
             .and_then(|v| v.as_table())
     {
-        let region = ft_table
-            .get("region")
-            .and_then(|v| v.as_str())
-            .unwrap_or("files")
-            .to_string();
-        let track_reads = ft_table
-            .get("track_reads")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let track_writes = ft_table
-            .get("track_writes")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let max_file_tokens = ft_table
-            .get("max_file_tokens")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize);
-
-        blueprint.file_tracking = Some(crate::FileTrackingConfig {
-            region,
-            track_reads,
-            track_writes,
-            max_file_tokens,
-        });
+        blueprint.file_tracking = Some(parse_file_tracking(ft_table));
     }
 
     // Parse repetition-detection config: [repetition_detection]
@@ -909,38 +824,159 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         .get("repetition_detection")
         .and_then(|v| v.as_table())
     {
-        blueprint.repetition_detection = Some(crate::RepetitionDetectionConfig {
-            max_repeat_calls: rd_table
-                .get("max_repeat_calls")
-                .and_then(|v| v.as_integer())
-                .map(|v| v as usize),
-            max_readonly_streak: rd_table
-                .get("max_readonly_streak")
-                .and_then(|v| v.as_integer())
-                .map(|v| v as usize),
-            enabled: rd_table.get("enabled").and_then(|v| v.as_bool()),
-        });
+        blueprint.repetition_detection = Some(parse_repetition_detection(rd_table));
     }
 
     // Parse cross-blueprint context transforms: [[transforms]]. Each maps a
     // parent (`from_blueprint`) region onto a child (`to_blueprint`) region when
     // a sub-agent is spawned, optionally transforming the content en route.
     if let Some(transforms_arr) = parsed.get("transforms").and_then(|v| v.as_array()) {
-        for t in transforms_arr {
-            let mappings = t
-                .get("mappings")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().map(parse_region_mapping).collect())
-                .unwrap_or_default();
-            blueprint.transforms.push(ContextTransform {
-                from_blueprint: str_field(t, "from_blueprint"),
-                to_blueprint: str_field(t, "to_blueprint"),
-                mappings,
-            });
-        }
+        blueprint
+            .transforms
+            .extend(transforms_arr.iter().map(parse_context_transform));
     }
 
     Ok(blueprint)
+}
+
+/// Parse `[compaction]` over the defaults, leaving any field the manifest does
+/// not mention at its default rather than at zero.
+fn parse_compaction_config(table: &toml::value::Table) -> CompactionConfig {
+    let mut cc = CompactionConfig::default();
+
+    if let Some(provider) = table.get("provider").and_then(|v| v.as_str()) {
+        cc.provider = provider.to_string();
+    }
+    if let Some(model) = table.get("model").and_then(|v| v.as_str()) {
+        cc.model = model.to_string();
+    }
+    if let Some(sp) = table.get("system_prompt").and_then(|v| v.as_str()) {
+        cc.system_prompt = Some(sp.to_string());
+    }
+    if let Some(mst) = table.get("max_summary_tokens").and_then(|v| v.as_integer()) {
+        cc.max_summary_tokens = mst as usize;
+    }
+    if let Some(temp) = table.get("temperature").and_then(|v| v.as_float()) {
+        cc.temperature = temp as f32;
+    }
+
+    cc
+}
+
+/// Parse `[read_paths]`. Entries are syntax-checked here so a broken one fails
+/// `lev validate`/`lev add`/spawn loudly, instead of degrading the agent at its
+/// first out-of-workdir read.
+fn parse_read_paths(table: &toml::value::Table) -> Result<crate::blueprint::ReadPathsConfig> {
+    let mut allow = Vec::new();
+    if let Some(entries) = table.get("allow").and_then(|v| v.as_array()) {
+        for entry in entries {
+            let Some(raw) = entry.as_str() else {
+                return Err(Error::Other(format!(
+                    "[read_paths] allow entries must be strings, got: {entry}"
+                )));
+            };
+            crate::read_paths::validate_entry_syntax(raw).map_err(Error::Other)?;
+            allow.push(raw.to_string());
+        }
+    }
+    Ok(crate::blueprint::ReadPathsConfig { allow })
+}
+
+/// Parse `[safe_commands]`: what this agent would like to run unprompted.
+///
+/// Inert until the user opts in, so parsing is permissive - but a non-string
+/// entry is still a hard error, because a list that silently loses members
+/// reads as a grant that was made.
+fn parse_safe_commands(table: &toml::value::Table) -> Result<crate::blueprint::SafeCommandsConfig> {
+    let strings = |field: &str| -> Result<Vec<String>> {
+        let Some(entries) = table.get(field).and_then(|v| v.as_array()) else {
+            return Ok(Vec::new());
+        };
+        entries
+            .iter()
+            .map(|entry| {
+                entry.as_str().map(str::to_string).ok_or_else(|| {
+                    Error::Other(format!(
+                        "[safe_commands] {field} entries must be strings, got: {entry}"
+                    ))
+                })
+            })
+            .collect()
+    };
+    Ok(crate::blueprint::SafeCommandsConfig {
+        tools: strings("tools")?,
+        shell: strings("shell")?,
+    })
+}
+
+/// Flatten `[tool_permissions]` into the `tool_perm:<tool>` metadata keys the
+/// permission layer reads. A non-string policy is dropped rather than rejected:
+/// the value's meaning is validated where it is resolved.
+fn tool_permission_metadata(
+    table: &toml::value::Table,
+) -> impl Iterator<Item = (String, serde_json::Value)> + use<'_> {
+    table.iter().filter_map(|(tool_name, policy_val)| {
+        policy_val.as_str().map(|policy| {
+            (
+                format!("tool_perm:{}", tool_name),
+                serde_json::Value::String(policy.to_string()),
+            )
+        })
+    })
+}
+
+/// Parse `[context.file_tracking]`. Tracking both directions into a `files`
+/// region is the default because that is what the shipped layouts assume.
+fn parse_file_tracking(table: &toml::value::Table) -> crate::FileTrackingConfig {
+    crate::FileTrackingConfig {
+        region: table
+            .get("region")
+            .and_then(|v| v.as_str())
+            .unwrap_or("files")
+            .to_string(),
+        track_reads: table
+            .get("track_reads")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        track_writes: table
+            .get("track_writes")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        max_file_tokens: table
+            .get("max_file_tokens")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize),
+    }
+}
+
+/// Parse `[repetition_detection]`. Every field stays `None` when absent so the
+/// global config's value survives; there are no local defaults to apply here.
+fn parse_repetition_detection(table: &toml::value::Table) -> crate::RepetitionDetectionConfig {
+    crate::RepetitionDetectionConfig {
+        max_repeat_calls: table
+            .get("max_repeat_calls")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize),
+        max_readonly_streak: table
+            .get("max_readonly_streak")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as usize),
+        enabled: table.get("enabled").and_then(|v| v.as_bool()),
+    }
+}
+
+/// Parse one `[[transforms]]` entry: a parent region mapped onto a child region
+/// when a sub-agent is spawned, optionally transformed en route.
+fn parse_context_transform(t: &toml::Value) -> ContextTransform {
+    ContextTransform {
+        from_blueprint: str_field(t, "from_blueprint"),
+        to_blueprint: str_field(t, "to_blueprint"),
+        mappings: t
+            .get("mappings")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().map(parse_region_mapping).collect())
+            .unwrap_or_default(),
+    }
 }
 
 /// A required-shaped string field, defaulting to empty when absent (the value's

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -57,651 +57,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     let mut stages = Vec::new();
     if let Some(stages_table) = parsed.get("stages").and_then(|v| v.as_table()) {
         for (stage_name, stage_value) in stages_table {
-            let model_table = stage_value.get("model").and_then(|v| v.as_table());
-            let model_config = if let Some(mt) = model_table {
-                let mut models = Vec::new();
-
-                // New format: [[stages.<name>.model.models]] list
-                if let Some(models_arr) = mt.get("models").and_then(|v| v.as_array()) {
-                    for entry in models_arr {
-                        if let Some(entry_table) = entry.as_table() {
-                            models.push(ModelEntry::new(
-                                entry_table
-                                    .get("provider")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("anthropic")
-                                    .to_string(),
-                                entry_table
-                                    .get("model")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("claude-sonnet-4-6")
-                                    .to_string(),
-                            ));
-                        }
-                    }
-                }
-
-                // Backward compat: old single-model format (provider + model at
-                // top level) or old fallbacks list - treat both as models entries.
-                if models.is_empty() {
-                    if let Some(provider) = mt.get("provider").and_then(|v| v.as_str()) {
-                        let model_name = mt
-                            .get("model")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("claude-sonnet-4-6");
-                        models.push(ModelEntry::new(
-                            provider.to_string(),
-                            model_name.to_string(),
-                        ));
-                    }
-
-                    // Old fallbacks become additional models entries
-                    if let Some(fallbacks_arr) = mt.get("fallbacks").and_then(|v| v.as_array()) {
-                        for fb in fallbacks_arr {
-                            if let Some(fb_table) = fb.as_table() {
-                                models.push(ModelEntry::new(
-                                    fb_table
-                                        .get("provider")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("anthropic")
-                                        .to_string(),
-                                    fb_table
-                                        .get("model")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("claude-sonnet-4-6")
-                                        .to_string(),
-                                ));
-                            }
-                        }
-                    }
-                }
-
-                // If still empty, use defaults
-                if models.is_empty() {
-                    models.push(ModelEntry::new(
-                        "anthropic".to_string(),
-                        "claude-sonnet-4-6".to_string(),
-                    ));
-                }
-
-                let allow_user_default = mt
-                    .get("allow_user_default")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(true);
-
-                // Parse parameters
-                let mut parameters = std::collections::HashMap::new();
-                if let Some(params) = mt.get("parameters").and_then(|v| v.as_table()) {
-                    for (k, v) in params {
-                        // Converting a parsed `toml::Value` to JSON is infallible:
-                        // serde_json maps non-finite floats to null rather than
-                        // erroring, and every other toml scalar/collection maps
-                        // cleanly.
-                        let json_val = serde_json::to_value(v)
-                            .expect("infallible: toml::Value always converts to serde_json::Value");
-                        parameters.insert(k.clone(), json_val);
-                    }
-                }
-
-                let request_timeout_secs =
-                    mt.get("request_timeout_secs").and_then(|v| v.as_integer());
-                let request_timeout_secs = request_timeout_secs
-                    .filter(|&secs| secs >= 0)
-                    .map(|secs| secs as u64);
-
-                ModelConfig {
-                    models,
-                    allow_user_default,
-                    parameters,
-                    request_timeout_secs,
-                }
-            } else {
-                ModelConfig::new("anthropic".to_string(), "claude-sonnet-4-6".to_string())
-            };
-
-            let mut stage = Stage::new(stage_name.clone(), model_config);
-
-            if let Some(mode_str) = stage_value.get("mode").and_then(|v| v.as_str()) {
-                stage = match mode_str {
-                    "interactive" => stage.with_mode(StageMode::Interactive),
-                    "interactive_points" => {
-                        let mut points = Vec::new();
-                        if let Some(pts_arr) = stage_value
-                            .get("interaction_points")
-                            .and_then(|v| v.as_array())
-                        {
-                            for pt in pts_arr {
-                                let pt_name = pt
-                                    .get("name")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let pt_prompt = pt
-                                    .get("prompt")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let pt_required =
-                                    pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
-                                // What the point does when nobody is watching.
-                                // Absent means auto-approve, the behaviour every
-                                // `--yolo` run has had; `"ask"` opts a genuine
-                                // human checkpoint out of that. A misspelling
-                                // here would silently un-gate the checkpoint, so
-                                // it is an error rather than a fallback.
-                                let pt_unattended = match pt
-                                    .get("unattended")
-                                    .and_then(|v| v.as_str())
-                                {
-                                    None | Some("auto_approve") => {
-                                        crate::blueprint::UnattendedPolicy::AutoApprove
-                                    }
-                                    Some("ask") => crate::blueprint::UnattendedPolicy::Ask,
-                                    Some(other) => {
-                                        return Err(Error::Other(format!(
-                                            "stage '{stage_name}': interaction point '{pt_name}' \
-                                             has unattended = \"{other}\" - expected \"ask\" or \
-                                             \"auto_approve\""
-                                        )));
-                                    }
-                                };
-                                let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
-                                    Some("multiple_choice") => {
-                                        crate::blueprint::InteractionStyle::MultipleChoice
-                                    }
-                                    Some("confirm") => crate::blueprint::InteractionStyle::Confirm,
-                                    _ => crate::blueprint::InteractionStyle::FreeText,
-                                };
-                                // Accept either "options" or "choices" key
-                                let pt_options: Vec<String> = pt
-                                    .get("options")
-                                    .or_else(|| pt.get("choices"))
-                                    .and_then(|v| v.as_array())
-                                    .map(|arr| {
-                                        arr.iter()
-                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                // Per-option directives, keyed by option label:
-                                // [stages.<name>.interaction_points.directives]
-                                // "Revise - I'll describe changes" = "Call ask_user_text ..."
-                                // `followups` is accepted as a backward-compat alias.
-                                let pt_directives: std::collections::HashMap<String, String> = pt
-                                    .get("directives")
-                                    .or_else(|| pt.get("followups"))
-                                    .and_then(|v| v.as_table())
-                                    .map(|tbl| {
-                                        tbl.iter()
-                                            .filter_map(|(k, v)| {
-                                                v.as_str().map(|s| (k.clone(), s.to_string()))
-                                            })
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                // Options that immediately abort the run:
-                                // abort_options = ["Abort - cancel this run"]
-                                let pt_abort_options: Vec<String> = pt
-                                    .get("abort_options")
-                                    .and_then(|v| v.as_array())
-                                    .map(|arr| {
-                                        arr.iter()
-                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                // Options that open the last output for direct editing:
-                                // edit_options = ["Add detail - expand a section"]
-                                let pt_edit_options: Vec<String> = pt
-                                    .get("edit_options")
-                                    .and_then(|v| v.as_array())
-                                    .map(|arr| {
-                                        arr.iter()
-                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                            .collect()
-                                    })
-                                    .unwrap_or_default();
-                                // Pinned region that holds the authoritative
-                                // document: document_region = "plan"
-                                let pt_document_region: Option<String> = pt
-                                    .get("document_region")
-                                    .and_then(|v| v.as_str())
-                                    .map(|s| s.to_string());
-                                points.push(crate::blueprint::InteractionPoint {
-                                    name: pt_name,
-                                    prompt: pt_prompt,
-                                    required: pt_required,
-                                    unattended: pt_unattended,
-                                    style: pt_style,
-                                    options: pt_options,
-                                    directives: pt_directives,
-                                    abort_options: pt_abort_options,
-                                    edit_options: pt_edit_options,
-                                    document_region: pt_document_region,
-                                });
-                            }
-                        }
-                        stage.with_mode(StageMode::InteractivePoints { points })
-                    }
-                    "fan_out" => {
-                        let str_field = |key: &str| {
-                            stage_value
-                                .get(key)
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string())
-                        };
-                        let on_worker_failure = match stage_value
-                            .get("on_worker_failure")
-                            .and_then(|v| v.as_str())
-                        {
-                            Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
-                            // "continue" / missing / unknown all mean continue.
-                            _ => crate::blueprint::WorkerFailurePolicy::Continue,
-                        };
-                        let config = crate::blueprint::FanOutConfig {
-                            worker_agent: str_field("worker_agent"),
-                            worker_stage: str_field("worker_stage"),
-                            worker_query: str_field("worker_query"),
-                            merge_stage: str_field("merge_stage"),
-                            max_workers: stage_value
-                                .get("max_workers")
-                                .and_then(|v| v.as_integer())
-                                .map(|n| n as usize)
-                                .unwrap_or(4),
-                            on_worker_failure,
-                            split_prompt: str_field("split_prompt").unwrap_or_default(),
-                            results_region: str_field("results_region"),
-                            max_items: stage_value
-                                .get("max_items")
-                                .and_then(|v| v.as_integer())
-                                .filter(|n| *n > 0)
-                                .map(|n| n as usize),
-                        };
-                        stage.with_mode(StageMode::FanOut { config })
-                    }
-                    "output" => stage.with_mode(StageMode::Output),
-                    "autonomous" => stage.with_mode(StageMode::Autonomous),
-                    // A misspelled mode used to become an autonomous stage in
-                    // silence, so `mode = "outupt"` produced a stage that ran
-                    // normally and never asked for the output it was written to
-                    // produce. Region kinds have always rejected an unknown
-                    // `kind` for the same reason; this brings stage modes into
-                    // line. Any manifest this refuses was already not doing what
-                    // it said.
-                    unknown => {
-                        return Err(Error::Other(format!(
-                            "stage '{stage_name}': unknown mode \"{unknown}\" (valid modes: \
-                             autonomous, interactive, interactive_points, fan_out, output)"
-                        )));
-                    }
-                };
-            }
-
-            if let Some(max_iter) = stage_value
-                .get("max_iterations")
-                .and_then(|v| v.as_integer())
-            {
-                stage.max_iterations = Some(max_iter as usize);
-            }
-
-            if let Some(tools_arr) = stage_value
-                .get("available_tools")
-                .and_then(|v| v.as_array())
-            {
-                stage.available_tools = tools_arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect();
-            }
-
-            // Human tools this stage keeps even when the run is unattended.
-            // Validated against `available_tools` by `Stage::validate`.
-            if let Some(tools_arr) = stage_value.get("required_tools").and_then(|v| v.as_array()) {
-                stage.required_tools = tools_arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect();
-            }
-
-            if let Some(sp) = stage_value.get("system_prompt").and_then(|v| v.as_str()) {
-                stage.config.insert(
-                    "system_prompt".to_string(),
-                    serde_json::Value::String(sp.trim().to_string()),
-                );
-            }
-
-            // Warn on a common authoring mistake: a `system_prompt` written
-            // *after* the `[stages.X.model]` sub-table lands under
-            // `stages.X.model` (TOML nesting rules) and is silently ignored, so
-            // the stage runs with no instructions. Point the author at the fix.
-            let model_has_system_prompt = stage_value
-                .get("model")
-                .and_then(|v| v.as_table())
-                .map(|t| t.contains_key("system_prompt"))
-                .unwrap_or(false);
-            if model_has_system_prompt {
-                tracing::warn!(
-                    "stage '{stage_name}': `system_prompt` is nested under \
-                     [stages.{stage_name}.model] and will be IGNORED - move the \
-                     `system_prompt = \"\"\"...\"\"\"` line ABOVE the \
-                     [stages.{stage_name}.model] table so it belongs to the stage"
-                );
-            }
-
-            // Parse tool_routing configuration
-            if let Some(routing_table) = stage_value.get("tool_routing").and_then(|v| v.as_table())
-            {
-                let mut routing = crate::blueprint::ToolResultRouting::default();
-
-                if let Some(dr) = routing_table.get("default_region").and_then(|v| v.as_str()) {
-                    routing.default_region = dr.to_string();
-                }
-                if let Some(p) = routing_table.get("persist").and_then(|v| v.as_bool()) {
-                    routing.persist = p;
-                }
-                if let Some(mt) = routing_table
-                    .get("max_result_tokens")
-                    .and_then(|v| v.as_integer())
-                {
-                    routing.max_result_tokens = Some(mt as usize);
-                }
-                if let Some(overrides_table) =
-                    routing_table.get("overrides").and_then(|v| v.as_table())
-                {
-                    for (tool_name, region_val) in overrides_table {
-                        if let Some(region_name) = region_val.as_str() {
-                            routing
-                                .tool_overrides
-                                .insert(tool_name.clone(), region_name.to_string());
-                        }
-                    }
-                }
-
-                stage.tool_result_routing = Some(routing);
-            }
-
-            // Parse requires_children flag
-            if let Some(rc) = stage_value
-                .get("requires_children")
-                .and_then(|v| v.as_bool())
-            {
-                stage.requires_children = rc;
-            }
-
-            // Parse allow_complete flag: lets the LLM end the run at this
-            // stage (e.g. an approving review) instead of being forced down
-            // its only/first transition edge.
-            if let Some(ac) = stage_value.get("allow_complete").and_then(|v| v.as_bool()) {
-                stage.allow_complete = ac;
-            }
-
-            // Parse allow_as_worker flag: opts this stage in to being used as a
-            // fan-out `worker_stage` target.
-            if let Some(aw) = stage_value.get("allow_as_worker").and_then(|v| v.as_bool()) {
-                stage.allow_as_worker = aw;
-            }
-
-            // Whether the stage must hand back a final output. `mode = "output"`
-            // means it by definition; any other stage opts in by hand (a fan-out
-            // worker whose merge stage depends on its summary, say).
-            if let Some(ro) = stage_value.get("require_output").and_then(|v| v.as_bool()) {
-                stage.require_output = ro;
-            }
-
-            // `mode = "output"` is sugar for three settings, applied here rather
-            // than in the mode arm above because `available_tools` and
-            // `allow_complete` are read after it and would otherwise clobber
-            // them. Writing them onto the Stage - instead of special-casing the
-            // mode at dispatch - means `lev validate`, the tool filter, and the
-            // lint all read one honest list.
-            if stage.mode == StageMode::Output {
-                stage.require_output = true;
-                if !stage
-                    .available_tools
-                    .iter()
-                    .any(|t| t == crate::blueprint::SUBMIT_OUTPUT_TOOL)
-                {
-                    stage
-                        .available_tools
-                        .push(crate::blueprint::SUBMIT_OUTPUT_TOOL.to_string());
-                }
-                // An output stage is normally the last thing a run does, so it
-                // may end the run. An author who routes onward can say
-                // `allow_complete = false` and be believed.
-                if stage_value.get("allow_complete").is_none() {
-                    stage.allow_complete = true;
-                }
-            }
-
-            // Parse allow_blocking_tools flag: says this autonomous stage means
-            // to offer `ask_user_*` / `present_for_review`, so `lev validate`
-            // stops warning about it.
-            if let Some(ab) = stage_value
-                .get("allow_blocking_tools")
-                .and_then(|v| v.as_bool())
-            {
-                stage.allow_blocking_tools = ab;
-            }
-
-            // Parse per-stage security override: [stages.<name>.security]
-            if let Some(sec_table) = stage_value.get("security").and_then(|v| v.as_table()) {
-                stage.security = Some(parse_security_config(sec_table));
-            }
-
-            // Parse per-stage batch_tool_hint override: opt an individual stage
-            // in/out of the batch-tool-calls system-prompt hint (e.g. `false` for
-            // a sequential validate stage). Absent ⇒ inherit agent/global.
-            if let Some(bth) = stage_value.get("batch_tool_hint").and_then(|v| v.as_bool()) {
-                stage.batch_tool_hint = Some(bth);
-            }
-
-            // Parse per-stage shell_hint override: opt an individual stage
-            // in/out of the platform shell hint. Absent ⇒ inherit agent/global.
-            if let Some(sh) = stage_value.get("shell_hint").and_then(|v| v.as_bool()) {
-                stage.shell_hint = Some(sh);
-            }
-
-            // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
-            // each field inherits agent/global.
-            if let Some(nudge_table) = stage_value.get("nudge").and_then(|v| v.as_table()) {
-                stage.nudge = Some(parse_nudge_config(nudge_table));
-            }
-
-            // Parse per-stage sandbox override: [stages.<name>.sandbox]
-            if let Some(sandbox_table) = stage_value.get("sandbox").and_then(|v| v.as_table()) {
-                stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
-            }
-
-            // Parse the stage's declared output shape: [stages.<name>.output].
-            // Narrows [agent.output]; whoever starts the run overrides both.
-            if let Some(output_table) = stage_value.get("output").and_then(|v| v.as_table()) {
-                stage.output = Some(parse_output_spec(output_table));
-            }
-
-            // Parse accepts_messages flag: whether mid-run user messages are
-            // injected into context between inference calls. Defaults to true
-            // (via the Stage constructor); set false for stages that shouldn't
-            // be interrupted (e.g. a final report generation stage).
-            if let Some(am) = stage_value
-                .get("accepts_messages")
-                .and_then(|v| v.as_bool())
-            {
-                stage.accepts_messages = am;
-            }
-
-            // Parse per-stage tool permissions: [stages.<name>.tool_permissions]
-            if let Some(tp_table) = stage_value
-                .get("tool_permissions")
-                .and_then(|v| v.as_table())
-            {
-                for (tool_name, policy_val) in tp_table {
-                    if let Some(policy_str) = policy_val.as_str() {
-                        stage
-                            .tool_permissions
-                            .insert(tool_name.clone(), policy_str.to_string());
-                    }
-                }
-            }
-
-            // Parse per-stage context layout: [stages.<name>.context.regions].
-            // Different stages can carry different region sets - the runtime swaps
-            // to a stage's layout on entry (apply_stage_context → apply_layout),
-            // preserving overlapping regions' content by name. Absent ⇒ the stage
-            // inherits the global [context.regions] layout. NOTE (TOML nesting):
-            // like [stages.<name>.model], this must be its own `[...]` section;
-            // don't place `context = ...` inline keys after other sub-tables.
-            if let Some(regions_table) = stage_value
-                .get("context")
-                .and_then(|v| v.get("regions"))
-                .and_then(|v| v.as_table())
-            {
-                let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
-                stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
-            }
-
-            // Parse max_revisits
-            if let Some(mr) = stage_value.get("max_revisits").and_then(|v| v.as_integer()) {
-                stage.max_revisits = Some(mr as usize);
-            }
-
-            // Parse transition_prompt
-            if let Some(tp) = stage_value
-                .get("transition_prompt")
-                .and_then(|v| v.as_str())
-            {
-                stage.transition_prompt = Some(tp.trim().to_string());
-            }
-
-            // Parse transitions: [stages.<name>.transitions.<target>]
-            if let Some(transitions_table) =
-                stage_value.get("transitions").and_then(|v| v.as_table())
-            {
-                let mut transitions = std::collections::HashMap::new();
-                for (target_name, edge_value) in transitions_table {
-                    let hint = edge_value
-                        .get("hint")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
-
-                    let condition = match edge_value.get("condition").and_then(|v| v.as_str()) {
-                        Some("error") => TransitionCondition::Error,
-                        Some("max_iterations") => TransitionCondition::MaxIterations,
-                        Some("llm_choice") => TransitionCondition::LlmChoice,
-                        Some("stuck") => TransitionCondition::Stuck,
-                        Some("always") | None => TransitionCondition::Always,
-                        // Reject unknown conditions rather than silently building a
-                        // `Custom(..)` edge the runtime never evaluates (a dead edge).
-                        Some(other) => {
-                            return Err(Error::Other(format!(
-                                "transition to '{target_name}' has unknown condition \
-                                 '{other}' (valid: always, error, max_iterations, \
-                                 llm_choice, stuck)"
-                            )));
-                        }
-                    };
-
-                    // Stuck thresholds live on the edge they arm, so a stage can
-                    // be armed on iterations while another is armed on wall clock.
-                    // Both halves are required together: a bare `condition =
-                    // "stuck"` edge could never fire, and thresholds under any
-                    // other condition would be silently ignored.
-                    let stuck = parse_stuck_config(edge_value);
-                    let is_stuck = condition == TransitionCondition::Stuck;
-                    if is_stuck && stuck.is_none() {
-                        return Err(Error::Other(format!(
-                            "transition to '{target_name}' has condition 'stuck' but no \
-                             threshold (set at least one of stuck_after_iterations, \
-                             stuck_after_minutes, stuck_after_same_file_edits, \
-                             stuck_after_tool_calls)"
-                        )));
-                    }
-                    if !is_stuck && stuck.is_some() {
-                        return Err(Error::Other(format!(
-                            "transition to '{target_name}' sets stuck_after_* thresholds \
-                             but its condition is not 'stuck' - they would never be read"
-                        )));
-                    }
-
-                    let transform = match edge_value.get("transform").and_then(|v| v.as_str()) {
-                        Some("clear") => EdgeTransform::Clear,
-                        Some("compact") | Some("summarize") => {
-                            EdgeTransform::Compact { prompt: None }
-                        }
-                        Some("custom") => {
-                            // Parse transform_config sub-table
-                            let tc = edge_value.get("transform_config");
-                            let carry = tc
-                                .and_then(|v| v.get("carry"))
-                                .and_then(|v| v.as_array())
-                                .map(|arr| {
-                                    arr.iter()
-                                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-                            let compact = tc
-                                .and_then(|v| v.get("compact"))
-                                .and_then(|v| v.as_array())
-                                .map(|arr| {
-                                    arr.iter()
-                                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-                            let clear = tc
-                                .and_then(|v| v.get("clear"))
-                                .and_then(|v| v.as_array())
-                                .map(|arr| {
-                                    arr.iter()
-                                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-                            let compact_prompt = tc
-                                .and_then(|v| v.get("compact_prompt"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-                            EdgeTransform::Custom {
-                                carry,
-                                compact,
-                                clear,
-                                compact_prompt,
-                            }
-                        }
-                        Some("direct") | None => EdgeTransform::Direct,
-                        // Reject unknown transforms rather than silently downgrading
-                        // to a plain `Direct` copy (a typo would pass unnoticed).
-                        Some(other) => {
-                            return Err(Error::Other(format!(
-                                "transition to '{target_name}' has unknown transform \
-                                 '{other}' (valid: direct, clear, compact, summarize, custom)"
-                            )));
-                        }
-                    };
-
-                    // Parse the edge gate: `gate = { require_modifications = true, ... }`
-                    // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
-                    let gate = edge_value
-                        .get("gate")
-                        .and_then(|v| v.as_table())
-                        .map(parse_transition_gate);
-
-                    transitions.insert(
-                        target_name.clone(),
-                        TransitionEdge {
-                            target: target_name.clone(),
-                            condition,
-                            hint,
-                            transform,
-                            gate,
-                            stuck,
-                        },
-                    );
-                }
-                stage.transitions = Some(transitions);
-            }
-
-            stages.push(stage);
+            stages.push(parse_stage(stage_name, stage_value)?);
         }
     }
 
@@ -837,6 +193,647 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     }
 
     Ok(blueprint)
+}
+
+/// Parse one `[stages.<name>]` table into a [`Stage`].
+///
+/// Reads nothing outside its own table, so the manifest's stage order is the
+/// only thing the caller contributes.
+fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
+    let model_table = stage_value.get("model").and_then(|v| v.as_table());
+    let model_config = if let Some(mt) = model_table {
+        let mut models = Vec::new();
+
+        // New format: [[stages.<name>.model.models]] list
+        if let Some(models_arr) = mt.get("models").and_then(|v| v.as_array()) {
+            for entry in models_arr {
+                if let Some(entry_table) = entry.as_table() {
+                    models.push(ModelEntry::new(
+                        entry_table
+                            .get("provider")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("anthropic")
+                            .to_string(),
+                        entry_table
+                            .get("model")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("claude-sonnet-4-6")
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
+        // Backward compat: old single-model format (provider + model at
+        // top level) or old fallbacks list - treat both as models entries.
+        if models.is_empty() {
+            if let Some(provider) = mt.get("provider").and_then(|v| v.as_str()) {
+                let model_name = mt
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("claude-sonnet-4-6");
+                models.push(ModelEntry::new(
+                    provider.to_string(),
+                    model_name.to_string(),
+                ));
+            }
+
+            // Old fallbacks become additional models entries
+            if let Some(fallbacks_arr) = mt.get("fallbacks").and_then(|v| v.as_array()) {
+                for fb in fallbacks_arr {
+                    if let Some(fb_table) = fb.as_table() {
+                        models.push(ModelEntry::new(
+                            fb_table
+                                .get("provider")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("anthropic")
+                                .to_string(),
+                            fb_table
+                                .get("model")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("claude-sonnet-4-6")
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // If still empty, use defaults
+        if models.is_empty() {
+            models.push(ModelEntry::new(
+                "anthropic".to_string(),
+                "claude-sonnet-4-6".to_string(),
+            ));
+        }
+
+        let allow_user_default = mt
+            .get("allow_user_default")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        // Parse parameters
+        let mut parameters = std::collections::HashMap::new();
+        if let Some(params) = mt.get("parameters").and_then(|v| v.as_table()) {
+            for (k, v) in params {
+                // Converting a parsed `toml::Value` to JSON is infallible:
+                // serde_json maps non-finite floats to null rather than
+                // erroring, and every other toml scalar/collection maps
+                // cleanly.
+                let json_val = serde_json::to_value(v)
+                    .expect("infallible: toml::Value always converts to serde_json::Value");
+                parameters.insert(k.clone(), json_val);
+            }
+        }
+
+        let request_timeout_secs = mt.get("request_timeout_secs").and_then(|v| v.as_integer());
+        let request_timeout_secs = request_timeout_secs
+            .filter(|&secs| secs >= 0)
+            .map(|secs| secs as u64);
+
+        ModelConfig {
+            models,
+            allow_user_default,
+            parameters,
+            request_timeout_secs,
+        }
+    } else {
+        ModelConfig::new("anthropic".to_string(), "claude-sonnet-4-6".to_string())
+    };
+
+    let mut stage = Stage::new(stage_name.to_string(), model_config);
+
+    if let Some(mode_str) = stage_value.get("mode").and_then(|v| v.as_str()) {
+        stage = match mode_str {
+            "interactive" => stage.with_mode(StageMode::Interactive),
+            "interactive_points" => {
+                let mut points = Vec::new();
+                if let Some(pts_arr) = stage_value
+                    .get("interaction_points")
+                    .and_then(|v| v.as_array())
+                {
+                    for pt in pts_arr {
+                        let pt_name = pt
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let pt_prompt = pt
+                            .get("prompt")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let pt_required =
+                            pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
+                        // What the point does when nobody is watching.
+                        // Absent means auto-approve, the behaviour every
+                        // `--yolo` run has had; `"ask"` opts a genuine
+                        // human checkpoint out of that. A misspelling
+                        // here would silently un-gate the checkpoint, so
+                        // it is an error rather than a fallback.
+                        let pt_unattended = match pt.get("unattended").and_then(|v| v.as_str()) {
+                            None | Some("auto_approve") => {
+                                crate::blueprint::UnattendedPolicy::AutoApprove
+                            }
+                            Some("ask") => crate::blueprint::UnattendedPolicy::Ask,
+                            Some(other) => {
+                                return Err(Error::Other(format!(
+                                    "stage '{stage_name}': interaction point '{pt_name}' \
+                                     has unattended = \"{other}\" - expected \"ask\" or \
+                                     \"auto_approve\""
+                                )));
+                            }
+                        };
+                        let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
+                            Some("multiple_choice") => {
+                                crate::blueprint::InteractionStyle::MultipleChoice
+                            }
+                            Some("confirm") => crate::blueprint::InteractionStyle::Confirm,
+                            _ => crate::blueprint::InteractionStyle::FreeText,
+                        };
+                        // Accept either "options" or "choices" key
+                        let pt_options: Vec<String> = pt
+                            .get("options")
+                            .or_else(|| pt.get("choices"))
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        // Per-option directives, keyed by option label:
+                        // [stages.<name>.interaction_points.directives]
+                        // "Revise - I'll describe changes" = "Call ask_user_text ..."
+                        // `followups` is accepted as a backward-compat alias.
+                        let pt_directives: std::collections::HashMap<String, String> = pt
+                            .get("directives")
+                            .or_else(|| pt.get("followups"))
+                            .and_then(|v| v.as_table())
+                            .map(|tbl| {
+                                tbl.iter()
+                                    .filter_map(|(k, v)| {
+                                        v.as_str().map(|s| (k.clone(), s.to_string()))
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        // Options that immediately abort the run:
+                        // abort_options = ["Abort - cancel this run"]
+                        let pt_abort_options: Vec<String> = pt
+                            .get("abort_options")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        // Options that open the last output for direct editing:
+                        // edit_options = ["Add detail - expand a section"]
+                        let pt_edit_options: Vec<String> = pt
+                            .get("edit_options")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        // Pinned region that holds the authoritative
+                        // document: document_region = "plan"
+                        let pt_document_region: Option<String> = pt
+                            .get("document_region")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        points.push(crate::blueprint::InteractionPoint {
+                            name: pt_name,
+                            prompt: pt_prompt,
+                            required: pt_required,
+                            unattended: pt_unattended,
+                            style: pt_style,
+                            options: pt_options,
+                            directives: pt_directives,
+                            abort_options: pt_abort_options,
+                            edit_options: pt_edit_options,
+                            document_region: pt_document_region,
+                        });
+                    }
+                }
+                stage.with_mode(StageMode::InteractivePoints { points })
+            }
+            "fan_out" => {
+                let str_field = |key: &str| {
+                    stage_value
+                        .get(key)
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                };
+                let on_worker_failure = match stage_value
+                    .get("on_worker_failure")
+                    .and_then(|v| v.as_str())
+                {
+                    Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
+                    // "continue" / missing / unknown all mean continue.
+                    _ => crate::blueprint::WorkerFailurePolicy::Continue,
+                };
+                let config = crate::blueprint::FanOutConfig {
+                    worker_agent: str_field("worker_agent"),
+                    worker_stage: str_field("worker_stage"),
+                    worker_query: str_field("worker_query"),
+                    merge_stage: str_field("merge_stage"),
+                    max_workers: stage_value
+                        .get("max_workers")
+                        .and_then(|v| v.as_integer())
+                        .map(|n| n as usize)
+                        .unwrap_or(4),
+                    on_worker_failure,
+                    split_prompt: str_field("split_prompt").unwrap_or_default(),
+                    results_region: str_field("results_region"),
+                    max_items: stage_value
+                        .get("max_items")
+                        .and_then(|v| v.as_integer())
+                        .filter(|n| *n > 0)
+                        .map(|n| n as usize),
+                };
+                stage.with_mode(StageMode::FanOut { config })
+            }
+            "output" => stage.with_mode(StageMode::Output),
+            "autonomous" => stage.with_mode(StageMode::Autonomous),
+            // A misspelled mode used to become an autonomous stage in
+            // silence, so `mode = "outupt"` produced a stage that ran
+            // normally and never asked for the output it was written to
+            // produce. Region kinds have always rejected an unknown
+            // `kind` for the same reason; this brings stage modes into
+            // line. Any manifest this refuses was already not doing what
+            // it said.
+            unknown => {
+                return Err(Error::Other(format!(
+                    "stage '{stage_name}': unknown mode \"{unknown}\" (valid modes: \
+                     autonomous, interactive, interactive_points, fan_out, output)"
+                )));
+            }
+        };
+    }
+
+    if let Some(max_iter) = stage_value
+        .get("max_iterations")
+        .and_then(|v| v.as_integer())
+    {
+        stage.max_iterations = Some(max_iter as usize);
+    }
+
+    if let Some(tools_arr) = stage_value
+        .get("available_tools")
+        .and_then(|v| v.as_array())
+    {
+        stage.available_tools = tools_arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+    }
+
+    // Human tools this stage keeps even when the run is unattended.
+    // Validated against `available_tools` by `Stage::validate`.
+    if let Some(tools_arr) = stage_value.get("required_tools").and_then(|v| v.as_array()) {
+        stage.required_tools = tools_arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+    }
+
+    if let Some(sp) = stage_value.get("system_prompt").and_then(|v| v.as_str()) {
+        stage.config.insert(
+            "system_prompt".to_string(),
+            serde_json::Value::String(sp.trim().to_string()),
+        );
+    }
+
+    // Warn on a common authoring mistake: a `system_prompt` written
+    // *after* the `[stages.X.model]` sub-table lands under
+    // `stages.X.model` (TOML nesting rules) and is silently ignored, so
+    // the stage runs with no instructions. Point the author at the fix.
+    let model_has_system_prompt = stage_value
+        .get("model")
+        .and_then(|v| v.as_table())
+        .map(|t| t.contains_key("system_prompt"))
+        .unwrap_or(false);
+    if model_has_system_prompt {
+        tracing::warn!(
+            "stage '{stage_name}': `system_prompt` is nested under \
+             [stages.{stage_name}.model] and will be IGNORED - move the \
+             `system_prompt = \"\"\"...\"\"\"` line ABOVE the \
+             [stages.{stage_name}.model] table so it belongs to the stage"
+        );
+    }
+
+    // Parse tool_routing configuration
+    if let Some(routing_table) = stage_value.get("tool_routing").and_then(|v| v.as_table()) {
+        let mut routing = crate::blueprint::ToolResultRouting::default();
+
+        if let Some(dr) = routing_table.get("default_region").and_then(|v| v.as_str()) {
+            routing.default_region = dr.to_string();
+        }
+        if let Some(p) = routing_table.get("persist").and_then(|v| v.as_bool()) {
+            routing.persist = p;
+        }
+        if let Some(mt) = routing_table
+            .get("max_result_tokens")
+            .and_then(|v| v.as_integer())
+        {
+            routing.max_result_tokens = Some(mt as usize);
+        }
+        if let Some(overrides_table) = routing_table.get("overrides").and_then(|v| v.as_table()) {
+            for (tool_name, region_val) in overrides_table {
+                if let Some(region_name) = region_val.as_str() {
+                    routing
+                        .tool_overrides
+                        .insert(tool_name.clone(), region_name.to_string());
+                }
+            }
+        }
+
+        stage.tool_result_routing = Some(routing);
+    }
+
+    // Parse requires_children flag
+    if let Some(rc) = stage_value
+        .get("requires_children")
+        .and_then(|v| v.as_bool())
+    {
+        stage.requires_children = rc;
+    }
+
+    // Parse allow_complete flag: lets the LLM end the run at this
+    // stage (e.g. an approving review) instead of being forced down
+    // its only/first transition edge.
+    if let Some(ac) = stage_value.get("allow_complete").and_then(|v| v.as_bool()) {
+        stage.allow_complete = ac;
+    }
+
+    // Parse allow_as_worker flag: opts this stage in to being used as a
+    // fan-out `worker_stage` target.
+    if let Some(aw) = stage_value.get("allow_as_worker").and_then(|v| v.as_bool()) {
+        stage.allow_as_worker = aw;
+    }
+
+    // Whether the stage must hand back a final output. `mode = "output"`
+    // means it by definition; any other stage opts in by hand (a fan-out
+    // worker whose merge stage depends on its summary, say).
+    if let Some(ro) = stage_value.get("require_output").and_then(|v| v.as_bool()) {
+        stage.require_output = ro;
+    }
+
+    // `mode = "output"` is sugar for three settings, applied here rather
+    // than in the mode arm above because `available_tools` and
+    // `allow_complete` are read after it and would otherwise clobber
+    // them. Writing them onto the Stage - instead of special-casing the
+    // mode at dispatch - means `lev validate`, the tool filter, and the
+    // lint all read one honest list.
+    if stage.mode == StageMode::Output {
+        stage.require_output = true;
+        if !stage
+            .available_tools
+            .iter()
+            .any(|t| t == crate::blueprint::SUBMIT_OUTPUT_TOOL)
+        {
+            stage
+                .available_tools
+                .push(crate::blueprint::SUBMIT_OUTPUT_TOOL.to_string());
+        }
+        // An output stage is normally the last thing a run does, so it
+        // may end the run. An author who routes onward can say
+        // `allow_complete = false` and be believed.
+        if stage_value.get("allow_complete").is_none() {
+            stage.allow_complete = true;
+        }
+    }
+
+    // Parse allow_blocking_tools flag: says this autonomous stage means
+    // to offer `ask_user_*` / `present_for_review`, so `lev validate`
+    // stops warning about it.
+    if let Some(ab) = stage_value
+        .get("allow_blocking_tools")
+        .and_then(|v| v.as_bool())
+    {
+        stage.allow_blocking_tools = ab;
+    }
+
+    // Parse per-stage security override: [stages.<name>.security]
+    if let Some(sec_table) = stage_value.get("security").and_then(|v| v.as_table()) {
+        stage.security = Some(parse_security_config(sec_table));
+    }
+
+    // Parse per-stage batch_tool_hint override: opt an individual stage
+    // in/out of the batch-tool-calls system-prompt hint (e.g. `false` for
+    // a sequential validate stage). Absent ⇒ inherit agent/global.
+    if let Some(bth) = stage_value.get("batch_tool_hint").and_then(|v| v.as_bool()) {
+        stage.batch_tool_hint = Some(bth);
+    }
+
+    // Parse per-stage shell_hint override: opt an individual stage
+    // in/out of the platform shell hint. Absent ⇒ inherit agent/global.
+    if let Some(sh) = stage_value.get("shell_hint").and_then(|v| v.as_bool()) {
+        stage.shell_hint = Some(sh);
+    }
+
+    // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
+    // each field inherits agent/global.
+    if let Some(nudge_table) = stage_value.get("nudge").and_then(|v| v.as_table()) {
+        stage.nudge = Some(parse_nudge_config(nudge_table));
+    }
+
+    // Parse per-stage sandbox override: [stages.<name>.sandbox]
+    if let Some(sandbox_table) = stage_value.get("sandbox").and_then(|v| v.as_table()) {
+        stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
+    }
+
+    // Parse the stage's declared output shape: [stages.<name>.output].
+    // Narrows [agent.output]; whoever starts the run overrides both.
+    if let Some(output_table) = stage_value.get("output").and_then(|v| v.as_table()) {
+        stage.output = Some(parse_output_spec(output_table));
+    }
+
+    // Parse accepts_messages flag: whether mid-run user messages are
+    // injected into context between inference calls. Defaults to true
+    // (via the Stage constructor); set false for stages that shouldn't
+    // be interrupted (e.g. a final report generation stage).
+    if let Some(am) = stage_value
+        .get("accepts_messages")
+        .and_then(|v| v.as_bool())
+    {
+        stage.accepts_messages = am;
+    }
+
+    // Parse per-stage tool permissions: [stages.<name>.tool_permissions]
+    if let Some(tp_table) = stage_value
+        .get("tool_permissions")
+        .and_then(|v| v.as_table())
+    {
+        for (tool_name, policy_val) in tp_table {
+            if let Some(policy_str) = policy_val.as_str() {
+                stage
+                    .tool_permissions
+                    .insert(tool_name.clone(), policy_str.to_string());
+            }
+        }
+    }
+
+    // Parse per-stage context layout: [stages.<name>.context.regions].
+    // Different stages can carry different region sets - the runtime swaps
+    // to a stage's layout on entry (apply_stage_context → apply_layout),
+    // preserving overlapping regions' content by name. Absent ⇒ the stage
+    // inherits the global [context.regions] layout. NOTE (TOML nesting):
+    // like [stages.<name>.model], this must be its own `[...]` section;
+    // don't place `context = ...` inline keys after other sub-tables.
+    if let Some(regions_table) = stage_value
+        .get("context")
+        .and_then(|v| v.get("regions"))
+        .and_then(|v| v.as_table())
+    {
+        let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
+        stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
+    }
+
+    // Parse max_revisits
+    if let Some(mr) = stage_value.get("max_revisits").and_then(|v| v.as_integer()) {
+        stage.max_revisits = Some(mr as usize);
+    }
+
+    // Parse transition_prompt
+    if let Some(tp) = stage_value
+        .get("transition_prompt")
+        .and_then(|v| v.as_str())
+    {
+        stage.transition_prompt = Some(tp.trim().to_string());
+    }
+
+    // Parse transitions: [stages.<name>.transitions.<target>]
+    if let Some(transitions_table) = stage_value.get("transitions").and_then(|v| v.as_table()) {
+        let mut transitions = std::collections::HashMap::new();
+        for (target_name, edge_value) in transitions_table {
+            let hint = edge_value
+                .get("hint")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let condition = match edge_value.get("condition").and_then(|v| v.as_str()) {
+                Some("error") => TransitionCondition::Error,
+                Some("max_iterations") => TransitionCondition::MaxIterations,
+                Some("llm_choice") => TransitionCondition::LlmChoice,
+                Some("stuck") => TransitionCondition::Stuck,
+                Some("always") | None => TransitionCondition::Always,
+                // Reject unknown conditions rather than silently building a
+                // `Custom(..)` edge the runtime never evaluates (a dead edge).
+                Some(other) => {
+                    return Err(Error::Other(format!(
+                        "transition to '{target_name}' has unknown condition \
+                         '{other}' (valid: always, error, max_iterations, \
+                         llm_choice, stuck)"
+                    )));
+                }
+            };
+
+            // Stuck thresholds live on the edge they arm, so a stage can
+            // be armed on iterations while another is armed on wall clock.
+            // Both halves are required together: a bare `condition =
+            // "stuck"` edge could never fire, and thresholds under any
+            // other condition would be silently ignored.
+            let stuck = parse_stuck_config(edge_value);
+            let is_stuck = condition == TransitionCondition::Stuck;
+            if is_stuck && stuck.is_none() {
+                return Err(Error::Other(format!(
+                    "transition to '{target_name}' has condition 'stuck' but no \
+                     threshold (set at least one of stuck_after_iterations, \
+                     stuck_after_minutes, stuck_after_same_file_edits, \
+                     stuck_after_tool_calls)"
+                )));
+            }
+            if !is_stuck && stuck.is_some() {
+                return Err(Error::Other(format!(
+                    "transition to '{target_name}' sets stuck_after_* thresholds \
+                     but its condition is not 'stuck' - they would never be read"
+                )));
+            }
+
+            let transform = match edge_value.get("transform").and_then(|v| v.as_str()) {
+                Some("clear") => EdgeTransform::Clear,
+                Some("compact") | Some("summarize") => EdgeTransform::Compact { prompt: None },
+                Some("custom") => {
+                    // Parse transform_config sub-table
+                    let tc = edge_value.get("transform_config");
+                    let carry = tc
+                        .and_then(|v| v.get("carry"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let compact = tc
+                        .and_then(|v| v.get("compact"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let clear = tc
+                        .and_then(|v| v.get("clear"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let compact_prompt = tc
+                        .and_then(|v| v.get("compact_prompt"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    EdgeTransform::Custom {
+                        carry,
+                        compact,
+                        clear,
+                        compact_prompt,
+                    }
+                }
+                Some("direct") | None => EdgeTransform::Direct,
+                // Reject unknown transforms rather than silently downgrading
+                // to a plain `Direct` copy (a typo would pass unnoticed).
+                Some(other) => {
+                    return Err(Error::Other(format!(
+                        "transition to '{target_name}' has unknown transform \
+                         '{other}' (valid: direct, clear, compact, summarize, custom)"
+                    )));
+                }
+            };
+
+            // Parse the edge gate: `gate = { require_modifications = true, ... }`
+            // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
+            let gate = edge_value
+                .get("gate")
+                .and_then(|v| v.as_table())
+                .map(parse_transition_gate);
+
+            transitions.insert(
+                target_name.clone(),
+                TransitionEdge {
+                    target: target_name.clone(),
+                    condition,
+                    hint,
+                    transform,
+                    gate,
+                    stuck,
+                },
+            );
+        }
+        stage.transitions = Some(transitions);
+    }
+
+    Ok(stage)
 }
 
 /// Parse `[compaction]` over the defaults, leaving any field the manifest does

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -195,13 +195,11 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     Ok(blueprint)
 }
 
-/// Parse one `[stages.<name>]` table into a [`Stage`].
-///
-/// Reads nothing outside its own table, so the manifest's stage order is the
-/// only thing the caller contributes.
-fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
+/// Parse `[stages.<name>.model]`, or the shipped default when the stage does
+/// not name one.
+fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
     let model_table = stage_value.get("model").and_then(|v| v.as_table());
-    let model_config = if let Some(mt) = model_table {
+    if let Some(mt) = model_table {
         let mut models = Vec::new();
 
         // New format: [[stages.<name>.model.models]] list
@@ -299,182 +297,326 @@ fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
         }
     } else {
         ModelConfig::new("anthropic".to_string(), "claude-sonnet-4-6".to_string())
+    }
+}
+
+/// Apply `[stages.<name>] mode`, along with the sub-tables a given mode reads
+/// (`interaction_points` for `interactive_points`, the fan-out block for
+/// `fan_out`). A stage that names no mode keeps the constructor's default.
+fn apply_stage_mode(stage: Stage, stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
+    let Some(mode_str) = stage_value.get("mode").and_then(|v| v.as_str()) else {
+        return Ok(stage);
     };
-
-    let mut stage = Stage::new(stage_name.to_string(), model_config);
-
-    if let Some(mode_str) = stage_value.get("mode").and_then(|v| v.as_str()) {
-        stage = match mode_str {
-            "interactive" => stage.with_mode(StageMode::Interactive),
-            "interactive_points" => {
-                let mut points = Vec::new();
-                if let Some(pts_arr) = stage_value
-                    .get("interaction_points")
-                    .and_then(|v| v.as_array())
-                {
-                    for pt in pts_arr {
-                        let pt_name = pt
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let pt_prompt = pt
-                            .get("prompt")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let pt_required =
-                            pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
-                        // What the point does when nobody is watching.
-                        // Absent means auto-approve, the behaviour every
-                        // `--yolo` run has had; `"ask"` opts a genuine
-                        // human checkpoint out of that. A misspelling
-                        // here would silently un-gate the checkpoint, so
-                        // it is an error rather than a fallback.
-                        let pt_unattended = match pt.get("unattended").and_then(|v| v.as_str()) {
-                            None | Some("auto_approve") => {
-                                crate::blueprint::UnattendedPolicy::AutoApprove
-                            }
-                            Some("ask") => crate::blueprint::UnattendedPolicy::Ask,
-                            Some(other) => {
-                                return Err(Error::Other(format!(
-                                    "stage '{stage_name}': interaction point '{pt_name}' \
-                                     has unattended = \"{other}\" - expected \"ask\" or \
-                                     \"auto_approve\""
-                                )));
-                            }
-                        };
-                        let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
-                            Some("multiple_choice") => {
-                                crate::blueprint::InteractionStyle::MultipleChoice
-                            }
-                            Some("confirm") => crate::blueprint::InteractionStyle::Confirm,
-                            _ => crate::blueprint::InteractionStyle::FreeText,
-                        };
-                        // Accept either "options" or "choices" key
-                        let pt_options: Vec<String> = pt
-                            .get("options")
-                            .or_else(|| pt.get("choices"))
-                            .and_then(|v| v.as_array())
-                            .map(|arr| {
-                                arr.iter()
-                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        // Per-option directives, keyed by option label:
-                        // [stages.<name>.interaction_points.directives]
-                        // "Revise - I'll describe changes" = "Call ask_user_text ..."
-                        // `followups` is accepted as a backward-compat alias.
-                        let pt_directives: std::collections::HashMap<String, String> = pt
-                            .get("directives")
-                            .or_else(|| pt.get("followups"))
-                            .and_then(|v| v.as_table())
-                            .map(|tbl| {
-                                tbl.iter()
-                                    .filter_map(|(k, v)| {
-                                        v.as_str().map(|s| (k.clone(), s.to_string()))
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        // Options that immediately abort the run:
-                        // abort_options = ["Abort - cancel this run"]
-                        let pt_abort_options: Vec<String> = pt
-                            .get("abort_options")
-                            .and_then(|v| v.as_array())
-                            .map(|arr| {
-                                arr.iter()
-                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        // Options that open the last output for direct editing:
-                        // edit_options = ["Add detail - expand a section"]
-                        let pt_edit_options: Vec<String> = pt
-                            .get("edit_options")
-                            .and_then(|v| v.as_array())
-                            .map(|arr| {
-                                arr.iter()
-                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        // Pinned region that holds the authoritative
-                        // document: document_region = "plan"
-                        let pt_document_region: Option<String> = pt
-                            .get("document_region")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        points.push(crate::blueprint::InteractionPoint {
-                            name: pt_name,
-                            prompt: pt_prompt,
-                            required: pt_required,
-                            unattended: pt_unattended,
-                            style: pt_style,
-                            options: pt_options,
-                            directives: pt_directives,
-                            abort_options: pt_abort_options,
-                            edit_options: pt_edit_options,
-                            document_region: pt_document_region,
-                        });
-                    }
-                }
-                stage.with_mode(StageMode::InteractivePoints { points })
-            }
-            "fan_out" => {
-                let str_field = |key: &str| {
-                    stage_value
-                        .get(key)
+    Ok(match mode_str {
+        "interactive" => stage.with_mode(StageMode::Interactive),
+        "interactive_points" => {
+            let mut points = Vec::new();
+            if let Some(pts_arr) = stage_value
+                .get("interaction_points")
+                .and_then(|v| v.as_array())
+            {
+                for pt in pts_arr {
+                    let pt_name = pt
+                        .get("name")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                };
-                let on_worker_failure = match stage_value
-                    .get("on_worker_failure")
-                    .and_then(|v| v.as_str())
-                {
-                    Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
-                    // "continue" / missing / unknown all mean continue.
-                    _ => crate::blueprint::WorkerFailurePolicy::Continue,
-                };
-                let config = crate::blueprint::FanOutConfig {
-                    worker_agent: str_field("worker_agent"),
-                    worker_stage: str_field("worker_stage"),
-                    worker_query: str_field("worker_query"),
-                    merge_stage: str_field("merge_stage"),
-                    max_workers: stage_value
-                        .get("max_workers")
-                        .and_then(|v| v.as_integer())
-                        .map(|n| n as usize)
-                        .unwrap_or(4),
-                    on_worker_failure,
-                    split_prompt: str_field("split_prompt").unwrap_or_default(),
-                    results_region: str_field("results_region"),
-                    max_items: stage_value
-                        .get("max_items")
-                        .and_then(|v| v.as_integer())
-                        .filter(|n| *n > 0)
-                        .map(|n| n as usize),
-                };
-                stage.with_mode(StageMode::FanOut { config })
+                        .unwrap_or("")
+                        .to_string();
+                    let pt_prompt = pt
+                        .get("prompt")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let pt_required = pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
+                    // What the point does when nobody is watching.
+                    // Absent means auto-approve, the behaviour every
+                    // `--yolo` run has had; `"ask"` opts a genuine
+                    // human checkpoint out of that. A misspelling
+                    // here would silently un-gate the checkpoint, so
+                    // it is an error rather than a fallback.
+                    let pt_unattended = match pt.get("unattended").and_then(|v| v.as_str()) {
+                        None | Some("auto_approve") => {
+                            crate::blueprint::UnattendedPolicy::AutoApprove
+                        }
+                        Some("ask") => crate::blueprint::UnattendedPolicy::Ask,
+                        Some(other) => {
+                            return Err(Error::Other(format!(
+                                "stage '{stage_name}': interaction point '{pt_name}' \
+                                 has unattended = \"{other}\" - expected \"ask\" or \
+                                 \"auto_approve\""
+                            )));
+                        }
+                    };
+                    let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
+                        Some("multiple_choice") => {
+                            crate::blueprint::InteractionStyle::MultipleChoice
+                        }
+                        Some("confirm") => crate::blueprint::InteractionStyle::Confirm,
+                        _ => crate::blueprint::InteractionStyle::FreeText,
+                    };
+                    // Accept either "options" or "choices" key
+                    let pt_options: Vec<String> = pt
+                        .get("options")
+                        .or_else(|| pt.get("choices"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    // Per-option directives, keyed by option label:
+                    // [stages.<name>.interaction_points.directives]
+                    // "Revise - I'll describe changes" = "Call ask_user_text ..."
+                    // `followups` is accepted as a backward-compat alias.
+                    let pt_directives: std::collections::HashMap<String, String> = pt
+                        .get("directives")
+                        .or_else(|| pt.get("followups"))
+                        .and_then(|v| v.as_table())
+                        .map(|tbl| {
+                            tbl.iter()
+                                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    // Options that immediately abort the run:
+                    // abort_options = ["Abort - cancel this run"]
+                    let pt_abort_options: Vec<String> = pt
+                        .get("abort_options")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    // Options that open the last output for direct editing:
+                    // edit_options = ["Add detail - expand a section"]
+                    let pt_edit_options: Vec<String> = pt
+                        .get("edit_options")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    // Pinned region that holds the authoritative
+                    // document: document_region = "plan"
+                    let pt_document_region: Option<String> = pt
+                        .get("document_region")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    points.push(crate::blueprint::InteractionPoint {
+                        name: pt_name,
+                        prompt: pt_prompt,
+                        required: pt_required,
+                        unattended: pt_unattended,
+                        style: pt_style,
+                        options: pt_options,
+                        directives: pt_directives,
+                        abort_options: pt_abort_options,
+                        edit_options: pt_edit_options,
+                        document_region: pt_document_region,
+                    });
+                }
             }
-            "output" => stage.with_mode(StageMode::Output),
-            "autonomous" => stage.with_mode(StageMode::Autonomous),
-            // A misspelled mode used to become an autonomous stage in
-            // silence, so `mode = "outupt"` produced a stage that ran
-            // normally and never asked for the output it was written to
-            // produce. Region kinds have always rejected an unknown
-            // `kind` for the same reason; this brings stage modes into
-            // line. Any manifest this refuses was already not doing what
-            // it said.
-            unknown => {
+            stage.with_mode(StageMode::InteractivePoints { points })
+        }
+        "fan_out" => {
+            let str_field = |key: &str| {
+                stage_value
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            };
+            let on_worker_failure = match stage_value
+                .get("on_worker_failure")
+                .and_then(|v| v.as_str())
+            {
+                Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
+                // "continue" / missing / unknown all mean continue.
+                _ => crate::blueprint::WorkerFailurePolicy::Continue,
+            };
+            let config = crate::blueprint::FanOutConfig {
+                worker_agent: str_field("worker_agent"),
+                worker_stage: str_field("worker_stage"),
+                worker_query: str_field("worker_query"),
+                merge_stage: str_field("merge_stage"),
+                max_workers: stage_value
+                    .get("max_workers")
+                    .and_then(|v| v.as_integer())
+                    .map(|n| n as usize)
+                    .unwrap_or(4),
+                on_worker_failure,
+                split_prompt: str_field("split_prompt").unwrap_or_default(),
+                results_region: str_field("results_region"),
+                max_items: stage_value
+                    .get("max_items")
+                    .and_then(|v| v.as_integer())
+                    .filter(|n| *n > 0)
+                    .map(|n| n as usize),
+            };
+            stage.with_mode(StageMode::FanOut { config })
+        }
+        "output" => stage.with_mode(StageMode::Output),
+        "autonomous" => stage.with_mode(StageMode::Autonomous),
+        // A misspelled mode used to become an autonomous stage in
+        // silence, so `mode = "outupt"` produced a stage that ran
+        // normally and never asked for the output it was written to
+        // produce. Region kinds have always rejected an unknown
+        // `kind` for the same reason; this brings stage modes into
+        // line. Any manifest this refuses was already not doing what
+        // it said.
+        unknown => {
+            return Err(Error::Other(format!(
+                "stage '{stage_name}': unknown mode \"{unknown}\" (valid modes: \
+                 autonomous, interactive, interactive_points, fan_out, output)"
+            )));
+        }
+    })
+}
+
+/// Parse `[stages.<name>.transitions.<target>]` into the stage's edge map.
+///
+/// Unknown conditions and transforms are rejected here rather than degraded,
+/// because both failure modes build an edge the runtime never takes and a
+/// dead edge is invisible until the run wedges.
+fn parse_transitions(
+    transitions_table: &toml::value::Table,
+) -> Result<std::collections::HashMap<String, TransitionEdge>> {
+    let mut transitions = std::collections::HashMap::new();
+    for (target_name, edge_value) in transitions_table {
+        let hint = edge_value
+            .get("hint")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let condition = match edge_value.get("condition").and_then(|v| v.as_str()) {
+            Some("error") => TransitionCondition::Error,
+            Some("max_iterations") => TransitionCondition::MaxIterations,
+            Some("llm_choice") => TransitionCondition::LlmChoice,
+            Some("stuck") => TransitionCondition::Stuck,
+            Some("always") | None => TransitionCondition::Always,
+            // Reject unknown conditions rather than silently building a
+            // `Custom(..)` edge the runtime never evaluates (a dead edge).
+            Some(other) => {
                 return Err(Error::Other(format!(
-                    "stage '{stage_name}': unknown mode \"{unknown}\" (valid modes: \
-                     autonomous, interactive, interactive_points, fan_out, output)"
+                    "transition to '{target_name}' has unknown condition \
+                     '{other}' (valid: always, error, max_iterations, \
+                     llm_choice, stuck)"
                 )));
             }
         };
+
+        // Stuck thresholds live on the edge they arm, so a stage can
+        // be armed on iterations while another is armed on wall clock.
+        // Both halves are required together: a bare `condition =
+        // "stuck"` edge could never fire, and thresholds under any
+        // other condition would be silently ignored.
+        let stuck = parse_stuck_config(edge_value);
+        let is_stuck = condition == TransitionCondition::Stuck;
+        if is_stuck && stuck.is_none() {
+            return Err(Error::Other(format!(
+                "transition to '{target_name}' has condition 'stuck' but no \
+                 threshold (set at least one of stuck_after_iterations, \
+                 stuck_after_minutes, stuck_after_same_file_edits, \
+                 stuck_after_tool_calls)"
+            )));
+        }
+        if !is_stuck && stuck.is_some() {
+            return Err(Error::Other(format!(
+                "transition to '{target_name}' sets stuck_after_* thresholds \
+                 but its condition is not 'stuck' - they would never be read"
+            )));
+        }
+
+        let transform = match edge_value.get("transform").and_then(|v| v.as_str()) {
+            Some("clear") => EdgeTransform::Clear,
+            Some("compact") | Some("summarize") => EdgeTransform::Compact { prompt: None },
+            Some("custom") => {
+                // Parse transform_config sub-table
+                let tc = edge_value.get("transform_config");
+                let carry = tc
+                    .and_then(|v| v.get("carry"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let compact = tc
+                    .and_then(|v| v.get("compact"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let clear = tc
+                    .and_then(|v| v.get("clear"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let compact_prompt = tc
+                    .and_then(|v| v.get("compact_prompt"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                EdgeTransform::Custom {
+                    carry,
+                    compact,
+                    clear,
+                    compact_prompt,
+                }
+            }
+            Some("direct") | None => EdgeTransform::Direct,
+            // Reject unknown transforms rather than silently downgrading
+            // to a plain `Direct` copy (a typo would pass unnoticed).
+            Some(other) => {
+                return Err(Error::Other(format!(
+                    "transition to '{target_name}' has unknown transform \
+                     '{other}' (valid: direct, clear, compact, summarize, custom)"
+                )));
+            }
+        };
+
+        // Parse the edge gate: `gate = { require_modifications = true, ... }`
+        // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
+        let gate = edge_value
+            .get("gate")
+            .and_then(|v| v.as_table())
+            .map(parse_transition_gate);
+
+        transitions.insert(
+            target_name.clone(),
+            TransitionEdge {
+                target: target_name.clone(),
+                condition,
+                hint,
+                transform,
+                gate,
+                stuck,
+            },
+        );
     }
+    Ok(transitions)
+}
+
+/// Parse one `[stages.<name>]` table into a [`Stage`].
+///
+/// Reads nothing outside its own table, so the manifest's stage order is the
+/// only thing the caller contributes.
+fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
+    let model_config = parse_stage_model(stage_value);
+
+    let mut stage = Stage::new(stage_name.to_string(), model_config);
+
+    stage = apply_stage_mode(stage, stage_name, stage_value)?;
 
     if let Some(max_iter) = stage_value
         .get("max_iterations")
@@ -710,127 +852,7 @@ fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
 
     // Parse transitions: [stages.<name>.transitions.<target>]
     if let Some(transitions_table) = stage_value.get("transitions").and_then(|v| v.as_table()) {
-        let mut transitions = std::collections::HashMap::new();
-        for (target_name, edge_value) in transitions_table {
-            let hint = edge_value
-                .get("hint")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            let condition = match edge_value.get("condition").and_then(|v| v.as_str()) {
-                Some("error") => TransitionCondition::Error,
-                Some("max_iterations") => TransitionCondition::MaxIterations,
-                Some("llm_choice") => TransitionCondition::LlmChoice,
-                Some("stuck") => TransitionCondition::Stuck,
-                Some("always") | None => TransitionCondition::Always,
-                // Reject unknown conditions rather than silently building a
-                // `Custom(..)` edge the runtime never evaluates (a dead edge).
-                Some(other) => {
-                    return Err(Error::Other(format!(
-                        "transition to '{target_name}' has unknown condition \
-                         '{other}' (valid: always, error, max_iterations, \
-                         llm_choice, stuck)"
-                    )));
-                }
-            };
-
-            // Stuck thresholds live on the edge they arm, so a stage can
-            // be armed on iterations while another is armed on wall clock.
-            // Both halves are required together: a bare `condition =
-            // "stuck"` edge could never fire, and thresholds under any
-            // other condition would be silently ignored.
-            let stuck = parse_stuck_config(edge_value);
-            let is_stuck = condition == TransitionCondition::Stuck;
-            if is_stuck && stuck.is_none() {
-                return Err(Error::Other(format!(
-                    "transition to '{target_name}' has condition 'stuck' but no \
-                     threshold (set at least one of stuck_after_iterations, \
-                     stuck_after_minutes, stuck_after_same_file_edits, \
-                     stuck_after_tool_calls)"
-                )));
-            }
-            if !is_stuck && stuck.is_some() {
-                return Err(Error::Other(format!(
-                    "transition to '{target_name}' sets stuck_after_* thresholds \
-                     but its condition is not 'stuck' - they would never be read"
-                )));
-            }
-
-            let transform = match edge_value.get("transform").and_then(|v| v.as_str()) {
-                Some("clear") => EdgeTransform::Clear,
-                Some("compact") | Some("summarize") => EdgeTransform::Compact { prompt: None },
-                Some("custom") => {
-                    // Parse transform_config sub-table
-                    let tc = edge_value.get("transform_config");
-                    let carry = tc
-                        .and_then(|v| v.get("carry"))
-                        .and_then(|v| v.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    let compact = tc
-                        .and_then(|v| v.get("compact"))
-                        .and_then(|v| v.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    let clear = tc
-                        .and_then(|v| v.get("clear"))
-                        .and_then(|v| v.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    let compact_prompt = tc
-                        .and_then(|v| v.get("compact_prompt"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
-                    EdgeTransform::Custom {
-                        carry,
-                        compact,
-                        clear,
-                        compact_prompt,
-                    }
-                }
-                Some("direct") | None => EdgeTransform::Direct,
-                // Reject unknown transforms rather than silently downgrading
-                // to a plain `Direct` copy (a typo would pass unnoticed).
-                Some(other) => {
-                    return Err(Error::Other(format!(
-                        "transition to '{target_name}' has unknown transform \
-                         '{other}' (valid: direct, clear, compact, summarize, custom)"
-                    )));
-                }
-            };
-
-            // Parse the edge gate: `gate = { require_modifications = true, ... }`
-            // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
-            let gate = edge_value
-                .get("gate")
-                .and_then(|v| v.as_table())
-                .map(parse_transition_gate);
-
-            transitions.insert(
-                target_name.clone(),
-                TransitionEdge {
-                    target: target_name.clone(),
-                    condition,
-                    hint,
-                    transform,
-                    gate,
-                    stuck,
-                },
-            );
-        }
-        stage.transitions = Some(transitions);
+        stage.transitions = Some(parse_transitions(transitions_table)?);
     }
 
     Ok(stage)


### PR DESCRIPTION
Fourth of the Phase 2 structure cleanups. Independent of #264 (different crate).

`parse_manifest` was one 927-line function linearly parsing about twenty independent TOML
sections. The convention for fixing that already existed in the same file - eleven
`parse_*` helpers, one per section - it just was never finished.

**927 lines to 180.** Three commits, extracting bottom-up so each move left everything
above it untouched, with a compile and a test run between each.

| Commit | What moved | After |
|---|---|---|
| 1 | The seven agent-level sections that still had inline bodies: compaction, read_paths, safe_commands, tool_permissions, file_tracking, repetition_detection, transforms | 821 |
| 2 | The whole `[stages]` loop body into `parse_stage(stage_name, stage_value)` | 180 |
| 3 | `parse_stage`'s own three seams: `parse_stage_model`, `apply_stage_mode`, `parse_transitions` | `parse_stage` 640 → 246 |

The trap in extracting a linear parser is shared mutable state and evaluation order - a
section reading something an earlier section defaulted. I checked before the big move:
the stage loop body references nothing in the enclosing scope but `stage_name` and
`stage_value`, so it lifts whole with no state threaded through. The only edit inside it
is `stage_name.clone()` becoming `stage_name.to_string()`, since the parameter is a `&str`
rather than the map's `&String`.

`parse_stage`'s remaining 246 lines are a flat list of independent "read this key, set
that field" blocks, largest of them 29 lines. Splitting that further would trade a
readable list for a table of contents pointing at one-liners, so it stays.

### Verification

753 `leviath-core` tests unchanged and passing at every step. `cargo xtask coverage
--package leviath-core` clean on the first run - the check that actually matters here,
since extracting a function adds it to the coverage denominator and each new one has to be
reached through its caller on a path the existing tests already drove. Clippy and
`cargo xtask docs --check` clean.

**Performance: none.** Pure moves, and `parse_manifest` runs once per blueprint load, not
on any per-tick path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
