### PR TITLE
docs: fix stale file references and changelog-shaped comments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Keep the build context to sources: the target dir alone is gigabytes.
-# agents/ must stay complete - build.rs embeds every file of every bundled
-# blueprint, including their READMEs.
+# crates/leviath-cli/agents/ must stay complete - build.rs embeds every file of
+# every bundled blueprint, including their READMEs.
 target/
 coverage/
 .git/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,8 @@ strip = "symbols"
 # NOTE: `panic = "abort"` is deliberately NOT set, and should not be added.
 #
 # The daemon depends on unwinding. Rhai host functions are wrapped in
-# `catch_unwind` (`leviath_scripting::tool::guard_str`/`guard_dyn`) so that a
+# `catch_unwind` (`guard_str`/`guard_dyn`, private to
+# `crates/leviath-scripting/src/tool.rs`) so that a
 # panic inside a native function registered with the script engine becomes an
 # ordinary script error instead of taking the whole daemon down - that was issue
 # #109, where a byte-boundary panic inside `decode_entities` aborted the process

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -442,9 +442,8 @@ fn builtin_table() -> Vec<BuiltinEntry> {
 /// each call site's monomorphization of this function separately, and it
 /// has been observed to report the production instantiation as 0-hit even
 /// though it's genuinely exercised by `execute_list_command_runs_without_error`
-/// et al. - the same instantiation-merging undercount documented for
-/// `run_stage_loop` (see `run/worker.rs`'s `run_worker_inner` and
-/// `run/session.rs`'s `resolve_task_with`, which use the same fix). A
+/// et al. - the same instantiation-merging undercount `run/task.rs`'s
+/// `resolve_task_with` documents at length and fixes the same way. A
 /// `&dyn Fn` trait object is one concrete type regardless of what closure is
 /// passed, so every call site shares a single instrumented instantiation.
 async fn list_with_registry(
@@ -494,7 +493,7 @@ async fn list_with_registry(
             // `registry.get(provider_name)` is structurally guaranteed
             // `Some` here - `provider_name` comes from
             // `registry.provider_names()` just above, and both methods read
-            // the same underlying map (see `leviath-runtime/src/engine.rs`'s
+            // the same underlying map (see `leviath-runtime/src/providers.rs`'s
             // `ProviderRegistry`). There is no way to construct a registry
             // where a name from `provider_names()` isn't `get()`-able, so
             // `.expect()` documents that invariant instead of leaving a

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -224,8 +224,7 @@ mod tests {
     // `runstate::list_runs()` reads the real on-disk runs directory (there's
     // no test-isolated override in this crate's test suite), so these tests
     // use unique run-id prefixes and only assert on their own entries, then
-    // clean up afterward - the same convention already used by
-    // `commands/run/worker.rs` and `commands/run/mod.rs`'s tests.
+    // clean up afterward.
 
     struct RunCleanup<'a>(&'a [&'a str]);
     impl Drop for RunCleanup<'_> {

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -666,9 +666,10 @@ impl Provider for AnthropicProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        // Shared classification here too. This used to be `RequestFailed`,
-        // which `is_transient` treats as retryable, so a revoked key looked
-        // like a flaky network rather than something only the operator can fix.
+        // Shared classification here too. `is_transient` treats
+        // `RequestFailed` as retryable, so classifying by status is what keeps
+        // a revoked key from looking like a flaky network - the one is only
+        // fixable by the operator, the other by waiting.
         let response = crate::provider::check_http_response(response, None).await?;
 
         let body: serde_json::Value = response

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -356,8 +356,9 @@ impl Provider for OllamaProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        // Shared classification, as above: a non-2xx here used to be
-        // `RequestFailed`, which reads as a retryable network fault.
+        // Shared classification, as above. A bare `RequestFailed` here would
+        // read as a retryable network fault; the status is what says whether
+        // retrying can help.
         let response = crate::provider::check_http_response(response, None).await?;
 
         let body: serde_json::Value = response

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -562,7 +562,8 @@ impl Stream for OpenAiSseStream {
 /// it only discovered after committing to a 200: the upstream provider goes
 /// down mid-generation, or the account runs out of credits between chunks. That
 /// arrives as a `data:` line whose object is `{"error":{…}}` and no `choices`,
-/// which used to fall through the usage-only branch and simply end the stream -
+/// which is why it needs an arm of its own: matched only on `choices` it fits
+/// the usage-only shape, and falling through there ends the stream cleanly -
 /// a truncated answer with nothing anywhere saying why.
 #[expect(
     clippy::string_slice,

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -1240,8 +1240,9 @@ impl MessageInbox {
     }
 
     /// Add a message to the inbox. Messages deliver in the order they
-    /// arrived; there used to be a priority field here, but no path that
-    /// sends a message ever set it, so FIFO is what always happened.
+    /// arrived, and deliberately carry no priority: nothing that sends one
+    /// has a reason to reorder, and a priority field nobody sets is a field
+    /// every reader of the inbox has to rule out first.
     pub fn push(&mut self, msg: AgentMessage) {
         self.messages.push(msg);
     }

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -36,6 +36,8 @@ Spawn an agent into the daemon. `PATH` is an installed agent name, a blueprint d
 | `--allow <TOOL>` | Allow one tool outright. Repeatable |
 | `--max-depth <N>` | Override the blueprint's maximum sub-agent tree depth |
 | `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions for this run |
+| `--count <N>` | Start this many runs of the same agent and task, each under its own run id, from one invocation |
+| `--json` | Print the spawned run as JSON rather than a sentence, for a caller that parses the run id back out. With `--count` above 1 it is an array, one object per run |
 | `--output-format <LABEL>` | Ask for the final output in this shape. See [Final outputs](/docs/outputs) |
 | `--output-instructions <TEXT>` | Extra guidance about that shape |
 | `--output-schema <JSON\|@FILE>` | A JSON Schema the final output must satisfy |


### PR DESCRIPTION
Second of the Phase 3 hygiene PRs: doc and comment accuracy. Two commits, no behaviour
change anywhere.

### Four references to files that do not exist

A comment pointing at a path a reader cannot open costs more than no comment, because the
reader assumes the code moved and goes looking.

- `models.rs` cited `run/worker.rs`'s `run_worker_inner` and `run/session.rs`'s
  `resolve_task_with` as prior art for the `&dyn Fn` coverage fix. Neither file exists,
  neither does `run_worker_inner`, and neither does the `run_stage_loop` the sentence hangs
  off. `resolve_task_with` is real and documents the same llvm-cov behaviour at length, at
  `run/task.rs:75`, so the reference points there and the rest goes.
- `models.rs` placed `ProviderRegistry` in `leviath-runtime/src/engine.rs`; it is in
  `providers.rs`.
- `serve/tree.rs` cited `commands/run/worker.rs` and `commands/run/mod.rs` as users of the
  unique-run-id-prefix test convention. The first does not exist and the second does not
  use it, so the claim goes rather than moves.
- `.dockerignore` named a root `agents/`; the blueprints are at `crates/leviath-cli/agents/`.

Found by extracting every `` `*.rs` `` reference in the tree and checking each one
resolves, rather than by reading - which is how the fourth turned up. The one apparent
miss, `bundled_agents.rs`, is generated into `OUT_DIR` by `build.rs` and correctly absent
from the source tree.

Also adds `--count` and `--json` to the `lev run` flag table: they were the only two
`RunArgs` fields the table omitted, and both are already documented in the source, so this
is the docs catching up rather than a new claim.

### Comments that state the constraint instead of the changelog entry

Four comments explained the current code by contrast with a version nobody can read any
more. Each keeps its load-bearing "why" and drops the history - the two provider ones now
say that classifying by HTTP status is what separates a revoked key from a flaky network,
the SSE one says why an error object needs its own arm (matched only on `choices` it fits
the usage-only shape), and the inbox one says why there is deliberately no priority field
rather than that there once was.

**Three candidates stay as they are, and the reason is the interesting part.** `tools.rs`'s
two and `openai_compat.rs:1947` are doc comments on regression tests, where naming the bug
being pinned is the test's whole provenance: a reader who cannot see which failure a test
was written for cannot judge whether it still earns its place. `world.rs:956`'s bevy 0.15
note and the root manifest's `panic = "abort"` block are constraints on future edits, not
history, and the second is probably the most load-bearing comment in the repo.

The manifest's pointer to the `catch_unwind` guards named
`leviath_scripting::tool::guard_str` as if it were a path; both are private, so it names
the file instead.

### One audit finding was wrong, recorded rather than acted on

The audit reported zero `#[expect(clippy::string_slice)]` sites. There are **15**. They are
written across multiple lines, which is why a single-line grep missed them. Every one
carries a `reason`, which is exactly what the manifest paragraph prescribes, so that
paragraph stands unchanged - but "zero uses" and "15 correct uses" are different facts
about the codebase and the second is the true one.

`cargo xtask docs --check`: 36 pages, 3 schemas, no problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
