### PR TITLE
fix(windows): lengthen EnsureDaemon readiness window to 15s

### DIFF
--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -323,16 +323,22 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
     if poll_until(|| is_daemon_running(&id)).await {
         return Ok(());
     }
-    anyhow::bail!("the leviath daemon did not start within 5s");
+    anyhow::bail!("the leviath daemon did not start within the readiness window");
 }
 
-/// Poll `done` until it returns true or ~5s elapses, sleeping 2ms at first
-/// and doubling to a 50ms ceiling. The daemon boots in ~20ms, so the old
-/// fixed 50ms tick spent more time waiting than the daemon spent starting -
-/// it was most of the measured 97ms cold `lev run`. Backoff keeps the
-/// slow-path cost (a daemon that genuinely takes seconds) unchanged.
+/// Poll `done` until it returns true or the readiness window elapses, sleeping
+/// 2ms at first and doubling to a 50ms ceiling. The daemon boots in ~20ms, so
+/// the old fixed 50ms tick spent more time waiting than the daemon spent
+/// starting - it was most of the measured 97ms cold `lev run`. Backoff keeps
+/// the slow-path cost (a daemon that genuinely takes seconds) unchanged.
+///
+/// Windows uses a longer window (15s): named-pipe bind plus job-object detach
+/// under concurrent EnsureDaemon (Gas City supervisor starting many sessions)
+/// regularly exceeded the original 5s cap and left pools with
+/// `runtime-missing` / pipe-busy failures.
 async fn poll_until(mut done: impl FnMut() -> bool) -> bool {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let secs: u64 = if cfg!(windows) { 15 } else { 5 };
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(secs);
     let mut delay = std::time::Duration::from_millis(2);
     while !done() {
         if tokio::time::Instant::now() >= deadline {


### PR DESCRIPTION
## Summary
On Windows, concurrent Gas City `EnsureDaemon` calls often lose the race with named-pipe bind + job-object detach. The readiness poll is still adaptive (2ms→50ms backoff), but the **deadline stays 5s on Unix** and becomes **15s on Windows**.

## Why
Observed under Life City / GC pool scale:
- `the leviath daemon did not start within 5s`
- sessions stuck `runtime-missing`
- control pipe `All pipe instances are busy (os error 231)`

## Change
- `poll_until`: `cfg!(windows) { 15 } else { 5 }`
- bail message: `readiness window` (not hard-coded 5s)

## Test plan
- [ ] `cargo test -p leviath-cli` (or CI)
- [ ] On Windows: stop daemon, `lev daemon start`, confirm ready well under 15s
- [ ] Optional stress: many concurrent `EnsureDaemon` / GC session starts no longer hit the old 5s bail