### PR TITLE
fix(windows): hide console on host_shell_command construction

### DIFF
--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -799,6 +799,10 @@ pub(crate) fn host_shell_command(
 ) -> TokioCommand {
     let mut c = TokioCommand::new(shell);
     c.arg(flag).arg(command).current_dir(workdir);
+    // Scripts call shell() often; apply CREATE_NO_WINDOW at construction so
+    // every caller (including seed commands) stays off the interactive desktop
+    // even if a later run_shell path forgets hide_console_window.
+    leviath_tools::hide_console_window(&mut c);
     c
 }
 


### PR DESCRIPTION
## Summary
Call `hide_console_window` inside `host_shell_command` so every construction path gets `CREATE_NO_WINDOW` on Windows, including seed commands that do not go through `RealScriptIo::run_shell`'s existing hide.

## Why
`RealScriptIo::run_shell` already hides consoles (issue #228 territory). Seed / host_shell construction paths can still flash windows if they spawn without that call. Applying hide at construction is defense-in-depth and keeps the flag next to command build.

## Change
- `host_shell_command`: `leviath_tools::hide_console_window(&mut c)` after args/workdir
- Unix: no-op

## Test plan
- [ ] CI / `cargo test -p leviath-cli`
- [ ] On Windows: script/seed shells do not flash console windows