### PR TITLE
test(dashboard): 103 render tests asserted nothing; now none do

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -613,6 +613,10 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         terminal.draw(|f| dash.draw(f)).unwrap();
+        // An empty dashboard still draws its chrome. Without this the test
+        // would pass just as happily against a `draw` that returned early.
+        let buf = crate::commands::dashboard::test_support::rendered_buffer(&terminal);
+        assert!(buf.contains("Agents"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -728,7 +728,7 @@ pub(in crate::commands::dashboard) fn wrapped_rows(lines: &[Line<'static>], widt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
@@ -794,6 +794,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     #[test]
@@ -808,6 +810,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("%"), "{buf}");
     }
 
     #[test]
@@ -823,6 +827,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     #[test]
@@ -838,6 +844,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     #[test]
@@ -880,6 +888,10 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        // The bar shows one initial per region, so three regions is the thing
+        // this case adds over the single-region ones above.
+        assert!(buf.contains("[P S H]"), "{buf}");
     }
 
     #[test]
@@ -895,6 +907,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Output"), "{buf}");
     }
 
     #[test]
@@ -963,6 +977,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Logs"), "{buf}");
     }
 
     #[test]
@@ -978,6 +994,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Context"), "{buf}");
     }
 
     #[test]
@@ -996,6 +1014,9 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Error"), "{buf}");
+        assert!(buf.contains("something broke"), "{buf}");
     }
 
     #[test]
@@ -1011,6 +1032,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("Error  "), "{buf}");
     }
 
     #[test]
@@ -1026,6 +1049,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Run was cancelled."), "{buf}");
     }
 
     #[test]
@@ -1042,6 +1067,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test"), "{buf}");
     }
 
     #[test]
@@ -1059,6 +1086,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("find"), "{buf}");
     }
 
     #[test]
@@ -1799,6 +1828,10 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        // Matches present: the title carries the position within them.
+        assert!(buf.contains("/token/"), "{buf}");
+        assert!(buf.contains("1/3"), "{buf}");
     }
 
     // ─── render_content_pane: scroll at bottom (detail_scroll = 0) ────────
@@ -1898,6 +1931,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("\u{2191}"), "{buf}");
     }
 
     // ─── build_output_lines: logs mode with prefixed lines ────────────────
@@ -1937,6 +1972,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Output"), "{buf}");
     }
 
     // ─── render_content_pane: Logs mode with tool count (run_state) ──────
@@ -1956,6 +1993,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Logs"), "{buf}");
     }
 
     // ─── render_context_bar: bar color variants ───────────────────────────
@@ -2028,6 +2067,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     // ─── render_context_bar: run_state agent uses stage context ──────────
@@ -2046,6 +2087,8 @@ mod tests {
                 dash.render_context_bar(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     /// Seed the cached history for `run_id` so browsing tests can render an
@@ -2218,6 +2261,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Context"), "{buf}");
     }
 
     // ─── render_content_pane: file path hint for context mode ─────────────
@@ -2235,6 +2280,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Context"), "{buf}");
     }
 
     // ─── render_content_pane: file path hint for Logs mode ───────────────
@@ -2252,6 +2299,8 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Logs"), "{buf}");
     }
 
     // ─── render_content_pane: search with no matches shows 0 matches ──────
@@ -2271,5 +2320,9 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        // The counterpart to the case above: no matches says so, rather than
+        // showing a position in an empty set.
+        assert!(buf.contains("0 matches"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -329,7 +329,7 @@ impl Dashboard {
 mod tests {
     use crate::commands::dashboard::graph::{GraphEdge, GraphTransitionInfo};
     use crate::commands::dashboard::history::{RunHistoryCache, derive_visits};
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use crate::commands::dashboard::types::*;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -560,6 +560,11 @@ mod tests {
         terminal
             .draw(|f| dash.draw_explorer_graph(f, f.area(), &agent, &[]))
             .unwrap();
+        // The guard is the point: with no explorer state there is nothing to
+        // lay out, so it must return before drawing rather than draw an empty
+        // graph frame.
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.trim().is_empty(), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -172,7 +172,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -221,6 +221,11 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
+        assert!(!buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("COMPLETE"), "{buf}");
+        assert!(!buf.contains("CANCEL"), "{buf}");
     }
 
     #[test]
@@ -235,6 +240,11 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("ACTIVE"), "{buf}");
+        assert!(!buf.contains("COMPLETE"), "{buf}");
+        assert!(!buf.contains("CANCEL"), "{buf}");
     }
 
     #[test]
@@ -249,6 +259,11 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("COMPLETE"), "{buf}");
+        assert!(!buf.contains("ACTIVE"), "{buf}");
+        assert!(!buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("CANCEL"), "{buf}");
     }
 
     #[test]
@@ -263,6 +278,11 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ERROR: boom"), "{buf}");
+        assert!(!buf.contains("ACTIVE"), "{buf}");
+        assert!(!buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("COMPLETE"), "{buf}");
     }
 
     #[test]
@@ -277,6 +297,11 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("CANCEL"), "{buf}");
+        assert!(!buf.contains("ACTIVE"), "{buf}");
+        assert!(!buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("COMPLETE"), "{buf}");
     }
 
     #[test]
@@ -292,6 +317,8 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test-agent"), "{buf}");
     }
 
     #[test]
@@ -307,6 +334,8 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -322,6 +351,8 @@ mod tests {
                 dash.render_header_breadcrumb(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
     }
 
     #[test]
@@ -336,6 +367,8 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test task"), "{buf}");
     }
 
     #[test]
@@ -361,6 +394,8 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test task"), "{buf}");
     }
 
     #[test]
@@ -376,6 +411,8 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("claude-sonnet-4"), "{buf}");
     }
 
     #[test]
@@ -391,6 +428,8 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test task"), "{buf}");
     }
 
     #[test]
@@ -407,6 +446,11 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("~/projects/test"), "{buf}");
+        // The point of the substitution: the real home path is gone, not just
+        // accompanied by a tilde somewhere on the line.
+        assert!(!buf.contains(&*home.to_string_lossy()), "{buf}");
     }
 
     #[test]
@@ -424,6 +468,8 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test task"), "{buf}");
     }
 
     #[test]
@@ -443,5 +489,7 @@ mod tests {
                 dash.render_info_strip(f, area, &agent, 120);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("test task"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -219,7 +219,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
@@ -289,6 +289,10 @@ mod tests {
                 dash.render_review_body(f, area, &lines, &pending);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Line 1"), "{buf}");
+        assert!(buf.contains("Line 2"), "{buf}");
+        assert!(buf.contains("Line 3"), "{buf}");
     }
 
     #[test]
@@ -307,6 +311,8 @@ mod tests {
                 dash.render_review_body(f, area, &lines, &pending);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("\u{2191}"), "no scrollbar drawn: {buf}");
     }
 
     /// Same display-row fix as the content pane: a review document whose
@@ -374,6 +380,8 @@ mod tests {
                 dash.render_review_body(f, area, &lines, &pending);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Review content"), "{buf}");
     }
 
     #[test]
@@ -392,6 +400,8 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Esc"), "{buf}");
     }
 
     #[test]
@@ -410,6 +420,8 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Esc"), "{buf}");
     }
 
     #[test]
@@ -430,6 +442,9 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Option A"), "{buf}");
+        assert!(buf.contains("Option B"), "{buf}");
     }
 
     #[test]
@@ -448,6 +463,9 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Yes"), "{buf}");
+        assert!(buf.contains("No"), "{buf}");
     }
 
     #[test]
@@ -466,6 +484,9 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("[i] respond"), "{buf}");
+        assert!(buf.contains("Choose wisely"), "{buf}");
     }
 
     #[test]
@@ -486,6 +507,8 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Edit Document"), "{buf}");
     }
 
     #[test]
@@ -510,6 +533,10 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Option A"), "{buf}");
+        assert!(buf.contains("Option B"), "{buf}");
+        assert!(buf.contains("Option C"), "{buf}");
     }
 
     #[test]
@@ -530,6 +557,9 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Yes"), "{buf}");
+        assert!(buf.contains("No"), "{buf}");
     }
 
     #[test]
@@ -549,5 +579,7 @@ mod tests {
                 dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Anything else?"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -273,7 +273,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use crate::commands::dashboard::types::{Toast, ToastLevel};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -317,6 +317,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("My Test"), "{buf}");
     }
 
     #[test]
@@ -330,6 +332,9 @@ mod tests {
             .push(make_test_agent("run-2", AgentDisplayStatus::Complete));
         dash.update_display_indices();
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #1"), "{buf}");
+        assert!(buf.contains("My Test #2"), "{buf}");
     }
 
     #[test]
@@ -342,6 +347,8 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -419,6 +426,8 @@ mod tests {
         dash.input_mode = true;
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
     }
 
     #[test]
@@ -446,6 +455,8 @@ mod tests {
         dash.selected_stage = 0;
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("write it"), "{buf}");
     }
 
     #[test]
@@ -473,6 +484,11 @@ mod tests {
         dash.selected_stage = 0;
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        // The pair to the Logs-mode case above: in Output mode the body is
+        // already in the output pane, so the review pane must not draw a
+        // second copy of it.
+        assert_eq!(buf.matches("write it").count(), 1, "{buf}");
     }
 
     #[test]
@@ -521,6 +537,8 @@ mod tests {
         dash.selected_stage = 0;
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
     }
 
     #[test]
@@ -548,6 +566,8 @@ mod tests {
         dash.detail_view = true;
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -587,6 +607,8 @@ mod tests {
         dash.selected_stage = 1; // wrong stage: selected_stage_can_respond() -> false
 
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
     }
 
     // ─── Regression: mid-run message input pane must actually render ──────
@@ -627,6 +649,8 @@ mod tests {
         let mut dash = make_test_dashboard();
         dash.show_help = true;
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Run list"), "{buf}");
     }
 
     #[test]
@@ -639,6 +663,8 @@ mod tests {
         dash.update_display_indices();
         dash.request_delete();
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Esc"), "{buf}");
     }
 
     #[test]
@@ -717,6 +743,8 @@ mod tests {
             level: ToastLevel::Info,
         });
         terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Hello"), "{buf}");
     }
 
     #[test]
@@ -730,6 +758,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -746,6 +776,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -775,6 +807,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("What should I do?"), "{buf}");
     }
 
     #[test]
@@ -793,6 +827,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("something broke"), "{buf}");
     }
 
     #[test]
@@ -810,6 +846,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("COMPLETE"), "{buf}");
     }
 
     #[test]
@@ -832,6 +870,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ctx"), "{buf}");
     }
 
     #[test]
@@ -861,6 +901,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
     }
 
     #[test]
@@ -910,6 +952,8 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("ACTIVE"), "{buf}");
     }
 
     #[test]
@@ -926,5 +970,7 @@ mod tests {
                 dash.draw_detail_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("CANCEL"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -135,7 +135,7 @@ impl Dashboard {
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use crate::commands::dashboard::types::*;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -183,6 +183,11 @@ mod tests {
                 dash.draw_toasts(f);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(
+            buf.trim().is_empty(),
+            "no toasts should draw nothing: {buf}"
+        );
     }
 
     #[test]
@@ -200,6 +205,8 @@ mod tests {
                 dash.draw_toasts(f);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Agent completed"), "{buf}");
     }
 
     #[test]
@@ -222,6 +229,9 @@ mod tests {
                 dash.draw_toasts(f);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Needs input"), "{buf}");
+        assert!(buf.contains("Agent failed"), "{buf}");
     }
 
     #[test]
@@ -234,6 +244,8 @@ mod tests {
                 dash.draw_help_overlay(f);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Run list"), "{buf}");
     }
 
     #[test]
@@ -246,6 +258,8 @@ mod tests {
                 dash.draw_help_overlay(f);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Run list"), "{buf}");
     }
 
     #[test]
@@ -280,16 +294,6 @@ mod tests {
     // rendering both the "Main list" and "Detail view"/"Input" sections
     // regardless of page would show the user keybindings for a page they
     // aren't on.
-
-    fn rendered_buffer(terminal: &Terminal<TestBackend>) -> String {
-        terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|c| c.symbol())
-            .collect()
-    }
 
     #[test]
     fn draw_help_overlay_main_list_omits_detail_view_section() {

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -223,7 +223,7 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::graph::{GraphEdge, GraphTransitionInfo};
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use crate::runstate::{StageRecord, StageRunStatus};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -292,6 +292,8 @@ mod tests {
                 dash.render_stage_tabs(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("main"), "{buf}");
     }
 
     #[test]
@@ -311,6 +313,9 @@ mod tests {
                 dash.render_stage_tabs(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("plan"), "{buf}");
+        assert!(buf.contains("implement"), "{buf}");
     }
 
     #[test]
@@ -334,6 +339,12 @@ mod tests {
                 dash.draw_linear_tabs(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("s1"), "{buf}");
+        assert!(buf.contains("s2"), "{buf}");
+        assert!(buf.contains("s3"), "{buf}");
+        assert!(buf.contains("s4"), "{buf}");
+        assert!(buf.contains("s5"), "{buf}");
     }
 
     #[test]
@@ -368,6 +379,9 @@ mod tests {
                 dash.render_stage_tabs(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("plan"), "{buf}");
+        assert!(buf.contains("implement"), "{buf}");
     }
 
     #[test]
@@ -388,6 +402,8 @@ mod tests {
                 dash.render_stage_tabs(f, area, &agent);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("main"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -577,6 +577,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("My Test"), "{buf}");
     }
 
     #[test]
@@ -594,6 +596,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("My Test"), "{buf}");
     }
 
     #[test]
@@ -614,6 +618,10 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #1"), "{buf}");
+        assert!(buf.contains("My Test #2"), "{buf}");
+        assert!(buf.contains("My Test #3"), "{buf}");
     }
 
     #[test]
@@ -630,6 +638,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #ecs"), "{buf}");
     }
 
     #[test]
@@ -648,6 +658,12 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #tok"), "{buf}");
+        // The name of the case: zero tokens render as a dash, so neither
+        // arrow glyph should be on the row at all.
+        assert!(!buf.contains("\u{2191}"), "{buf}");
+        assert!(!buf.contains("\u{2193}"), "{buf}");
     }
 
     #[test]
@@ -670,6 +686,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("fallback task text"), "{buf}");
     }
 
     #[test]
@@ -691,6 +709,9 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #stage"), "{buf}");
+        assert!(!buf.contains("main 1/"), "{buf}");
     }
 
     #[test]
@@ -707,6 +728,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #ctx"), "{buf}");
     }
 
     #[test]
@@ -724,6 +747,8 @@ mod tests {
                 dash.draw_agent_table(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("My Test #1"), "{buf}");
     }
 
     #[test]
@@ -738,6 +763,8 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("Agent started"), "{buf}");
     }
 
     #[test]
@@ -821,6 +848,9 @@ mod tests {
                 dash.draw_log_panel(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Agent started"), "{buf}");
+        assert!(buf.contains("Stage changed to implement"), "{buf}");
     }
 
     fn rendered_buffer(terminal: &Terminal<TestBackend>) -> String {
@@ -885,6 +915,9 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains("back to list"), "{buf}");
+        assert!(!buf.contains("Search: /"), "{buf}");
     }
 
     #[test]
@@ -899,6 +932,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("[Esc] back"), "{buf}");
     }
 
     #[test]
@@ -915,6 +950,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("send"), "{buf}");
     }
 
     #[test]
@@ -946,6 +983,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("select"), "{buf}");
     }
 
     #[test]
@@ -962,6 +1001,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Search: /"), "{buf}");
     }
 
     #[test]
@@ -978,6 +1019,10 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("/test/"), "{buf}");
+        assert!(buf.contains("clear search"), "{buf}");
+        assert!(!buf.contains("Search: /"), "{buf}");
     }
 
     #[test]
@@ -995,6 +1040,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("confirm"), "{buf}");
     }
 
     #[test]
@@ -1010,6 +1057,8 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Filter: /"), "{buf}");
     }
 
     #[test]
@@ -1028,6 +1077,10 @@ mod tests {
                 dash.draw_help_bar(f, area);
             })
             .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("/coder/"), "{buf}");
+        assert!(buf.contains("refine"), "{buf}");
+        assert!(!buf.contains("Filter: /"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/test_support.rs
+++ b/crates/leviath-cli/src/commands/dashboard/test_support.rs
@@ -15,3 +15,24 @@ pub(crate) fn make_test_dashboard() -> Dashboard {
     let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
     Dashboard::new(cmd_tx)
 }
+
+/// Every cell of a rendered frame, concatenated row by row.
+///
+/// The cheapest honest assertion a render test can make: that the thing the
+/// case exists to distinguish actually reached the screen. Deliberately not a
+/// full-frame snapshot, which would fail on any cosmetic layout change and
+/// teach the next person to regenerate it without reading.
+///
+/// Note there are no row separators, so a string long enough to wrap is split
+/// across the join. Assert on a fragment short enough to sit on one row.
+pub(crate) fn rendered_buffer(
+    terminal: &ratatui::Terminal<ratatui::backend::TestBackend>,
+) -> String {
+    terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|c| c.symbol())
+        .collect()
+}


### PR DESCRIPTION
**103 of the dashboard's 131 render tests built a `TestBackend`, called `terminal.draw(...)`,
and asserted nothing.** Now none do.

These are not the honest cost of the 100% gate. The gate only requires the render code to
execute; reading the buffer back afterwards is free. What the tests proved was "does not
panic" - which is real value, since ratatui panics on an out-of-bounds `Rect` - but nothing
about whether the variant each case exists to distinguish reached the screen.

I counted them with a brace-matching scan rather than by eye, and re-ran it after: 0 of 131.

### What writing them found

Four cases where the test and the renderer disagreed, which is the argument for doing this
rather than trusting the tests:

- **The agent table shows `title #<id-suffix>`, not the run id.** Nine tests I first wrote
  against `run-1` failed. They would have gone on passing forever against a table that
  stopped rendering identifiers entirely.
- **`draw_agent_table_run_state_zero_tokens_shows_dash` never checked for a dash.** It now
  asserts neither arrow glyph appears on the row, which is what the name means.
- **`render_content_pane_search_with_matches` and `..._no_matches`** differ in the title:
  `/token/  1/3` versus `🔍 /xyznotfound/  0 matches`. Each now pins its own, so the two
  cases can no longer both pass on the same output.
- **`draw_detail_view_output_body_suppresses_review_pane`** now asserts the body appears
  *exactly once*. The pairing with the Logs-mode case - where the separate review pane is
  what puts it on screen - is the actual claim, and a `!contains` could not express it.

### Negatives where the case is a distinction

`contains("ACTIVE")` alone would pass against a renderer that drew every status at once, so
the five status breadcrumbs each rule out the other four. An empty toast list must leave the
frame blank. A filtered-out agent must be *gone*. `draw_explorer_graph` with no explorer
state must draw nothing rather than an empty frame - that guard is the whole point of its
test, and "does not panic" could never tell the two apart.

### Deliberately not snapshots

Targeted substrings throughout. A full-frame snapshot fails on any cosmetic layout change
and teaches the next person to regenerate it without reading it, which is how a test quietly
stops being one.

`rendered_buffer` moves to `test_support` beside `make_test_dashboard`; three files had
their own copy.

### Verification

596 dashboard tests passing, `cargo xtask coverage --package leviath-cli` clean, clippy and
docs clean. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
