### PR TITLE
chore(testkit): finish the subscriber consolidation; measure missing_docs rather than enable it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ npm install -g @ast-grep/cli     # via npm
 
 The workspace is gated at a hard **100%** on lines, regions, and functions, with no way to opt out. Coverage-suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov annotations) are banned by the ast-grep lint above, so code can't be hidden from measurement; it has to be refactored until it's testable. The *only* un-unit-tested code is the thin `lev` binary entrypoint (`crates/leviath-cli/src/main.rs`): the composition root that wires real terminal, stdin, network, and subprocess I/O into the library's tested cores. It's excluded from coverage measurement and guarded by a CI check that requires maintainer sign-off to change.
 
+### Where a test module lives
+
+Inline `#[cfg(test)] mod tests` in the file under test is the default; 205 files use it. A sibling `foo_tests.rs` (or `foo/tests.rs`) is the sanctioned alternative, used by 24 — but only for one reason.
+
+The difference is what gets measured. An inline test module is part of the file, so the gate counts its *scaffolding* too: a helper written to build fixtures has to itself be exercised on every branch, or it fails the gate. llvm-cov excludes the sibling layout by default, so a test module whose helpers would otherwise need tests of their own belongs there. Reach for it when the scaffolding is the problem, not because a file is getting long.
+
+Shared scaffolding goes further out: `leviath-testkit` is a dev-dependency-only crate for fixtures used by more than one crate (the always-on tracing subscriber, mock HTTP servers), and it is excluded from measurement entirely. Add to it rather than copying a helper into a second crate — that copying is exactly what it was created to stop.
+
 ## Running coverage locally
 
 `cargo xtask coverage` gates each workspace package with `cargo llvm-cov --package <pkg> --fail-under-{lines,functions,regions} 100`. llvm-cov does the counting *and* the gating; there's no custom parsing or aggregation. CI enforces a hard **100%** on all three metrics on Linux, macOS, and Windows. Any file below 100% fails the build, and a browsable HTML report lands in the gitignored `coverage/` folder.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,14 @@ unsafe_code = "forbid"
 # `#[expect(clippy::string_slice, reason = "...")]` naming the construct that
 # guarantees it. "Looks fine" is exactly the unstated invariant this lint exists to
 # stop.
+# NOTE on `missing_docs`: measured, not enabled. Turning it on flags 325 items
+# (leviath-cli 166, leviath-core 109, runtime 18, mcp 15, providers 14, tools 3),
+# and CI runs with `-D warnings`, so "warn" is "deny" here. 240 of the 325 are
+# struct fields - largely serde payload types whose field names already say what
+# they are, and a doc comment restating a field name is the noise this repo's
+# comment policy exists to keep out. The 52 non-field items (functions, methods,
+# structs, enums) are worth documenting and would make the lint affordable;
+# that is a focused piece of work, not a flag flip.
 [workspace.lints.clippy]
 string_slice = "deny"
 

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -157,19 +157,4 @@ mod tests {
         let err = serde_json::to_string(&PoisonSerialize).unwrap_err();
         assert!(err.to_string().contains("PoisonSerialize always fails"));
     }
-
-    /// Exercises the span-related trait methods (`new_span`, `record`,
-    /// `record_follows_from`, `enter`, `exit`, `event`) that plain
-    /// `tracing::info!`/`warn!` event macros elsewhere don't reach.
-    #[test]
-    fn always_on_subscriber_span_methods_are_all_no_ops() {
-        with_tracing(|| {
-            let span = tracing::info_span!("test-span", field = tracing::field::Empty);
-            span.record("field", 1);
-            let other = tracing::info_span!("other-span");
-            span.follows_from(&other);
-            let _enter = span.enter();
-            tracing::info!(parent: &span, "inside span");
-        });
-    }
 }

--- a/crates/leviath-core/Cargo.toml
+++ b/crates/leviath-core/Cargo.toml
@@ -31,6 +31,9 @@ glob = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
+# The always-on tracing subscriber, so log-macro bodies run under test.
+# Shared rather than copied: three copies of it had already drifted apart.
+leviath-testkit = { workspace = true }
 # A redirecting server, so the redirect policy is verified by following one
 # rather than by testing the decision it delegates to.
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -558,73 +558,7 @@ impl RegionDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Minimal no-op `Subscriber` that reports every callsite as enabled.
-    ///
-    /// Without an active subscriber, `tracing::warn!`/`info!`/`debug!` calls
-    /// short-circuit their field-argument evaluation before ever reaching it
-    /// (no subscriber means the "is this level enabled" check fails first) --
-    /// so a multi-line `tracing::warn!(...)` call's field-list lines show as
-    /// uncovered by `cargo llvm-cov` even when the surrounding branch
-    /// genuinely executes and is asserted on. This bare `Subscriber` impl is
-    /// the proven-working pattern used across this workspace.
-    struct AlwaysOnSubscriber;
-
-    impl tracing::Subscriber for AlwaysOnSubscriber {
-        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
-            true
-        }
-        fn register_callsite(
-            &self,
-            _metadata: &'static tracing::Metadata<'static>,
-        ) -> tracing::subscriber::Interest {
-            tracing::subscriber::Interest::always()
-        }
-        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-            tracing::span::Id::from_u64(1)
-        }
-        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
-        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
-        fn event(&self, event: &tracing::Event<'_>) {
-            // `register_callsite` always returns `Interest::always()`, so
-            // tracing's dispatch macros cache every callsite as
-            // "always enabled" and never call `enabled` again afterward.
-            // Call it directly here (with real metadata from a live event)
-            // so this trait-impl boilerplate method isn't itself left
-            // uncovered.
-            assert!(self.enabled(event.metadata()));
-        }
-        fn enter(&self, _span: &tracing::span::Id) {}
-        fn exit(&self, _span: &tracing::span::Id) {}
-        fn max_level_hint(&self) -> Option<tracing::metadata::LevelFilter> {
-            Some(tracing::metadata::LevelFilter::TRACE)
-        }
-    }
-
-    fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
-        static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-        INSTALLED.get_or_init(|| {
-            let _ = tracing::subscriber::set_global_default(AlwaysOnSubscriber);
-            tracing::callsite::rebuild_interest_cache();
-        });
-        f()
-    }
-
-    #[test]
-    fn always_on_subscriber_span_methods_are_all_no_ops() {
-        // This file only ever uses `tracing::warn!` event macros, never
-        // `tracing::span!`, so the span-related trait methods above are
-        // otherwise dead code from `with_tracing`'s callers. Exercise them
-        // directly via a real span so they're not left uncovered themselves.
-        with_tracing(|| {
-            let span = tracing::info_span!("test-span", field = tracing::field::Empty);
-            span.record("field", 1);
-            let other = tracing::info_span!("other-span");
-            span.follows_from(&other);
-            let _enter = span.enter();
-            tracing::info!(parent: &span, "inside span");
-        });
-    }
+    use leviath_testkit::with_tracing;
 
     #[test]
     fn test_layout_creation() {

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -40,6 +40,9 @@ keyring-core = { version = "1", optional = true }
 nix = { workspace = true }
 
 [dev-dependencies]
+# The always-on tracing subscriber, so log-macro bodies run under test.
+# Shared rather than copied: three copies of it had already drifted apart.
+leviath-testkit = { workspace = true }
 tempfile = "3"
 # `std::env::set_var` is unsafe and this crate forbids unsafe, so environment
 # manipulation in tests goes through closures.

--- a/crates/leviath-sys/src/browser.rs
+++ b/crates/leviath-sys/src/browser.rs
@@ -77,6 +77,7 @@ pub fn open_url(url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leviath_testkit::with_tracing;
 
     #[test]
     fn macos_uses_open() {
@@ -123,63 +124,6 @@ mod tests {
             Err(std::io::Error::other("no browser"))
         }
         with_tracing(|| assert!(!open_url_via(boom, "https://x.example")));
-    }
-
-    /// An always-enabled [`tracing::Subscriber`], so macro bodies actually run.
-    struct AlwaysOnSubscriber;
-
-    impl tracing::Subscriber for AlwaysOnSubscriber {
-        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
-            true
-        }
-        fn register_callsite(
-            &self,
-            _metadata: &'static tracing::Metadata<'static>,
-        ) -> tracing::subscriber::Interest {
-            tracing::subscriber::Interest::always()
-        }
-        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-            tracing::span::Id::from_u64(1)
-        }
-        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
-        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
-        fn event(&self, event: &tracing::Event<'_>) {
-            // Callsites are cached as always-enabled, so the macros never call
-            // `enabled`; call it here so it is exercised.
-            assert!(self.enabled(event.metadata()));
-        }
-        fn enter(&self, _span: &tracing::span::Id) {}
-        fn exit(&self, _span: &tracing::span::Id) {}
-        fn max_level_hint(&self) -> Option<tracing::metadata::LevelFilter> {
-            Some(tracing::metadata::LevelFilter::TRACE)
-        }
-    }
-
-    /// Exercise the span methods the logging path never reaches on its own, so
-    /// the shim above is fully covered rather than only its `event` arm.
-    #[test]
-    fn always_on_subscriber_span_methods_are_all_no_ops() {
-        with_tracing(|| {
-            let span = tracing::info_span!("test-span", field = tracing::field::Empty);
-            span.record("field", 1);
-            let other = tracing::info_span!("other-span");
-            span.follows_from(&other);
-            let _enter = span.enter();
-            tracing::info!(parent: &span, "inside span");
-        });
-    }
-
-    /// Install [`AlwaysOnSubscriber`] once per test binary and run `f` under it.
-    fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
-        static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-        INSTALLED.get_or_init(|| {
-            // Required: callsites registered before the global default is set
-            // are cached as interest=never, so without this the macro bodies
-            // stay unreachable.
-            let _ = tracing::subscriber::set_global_default(AlwaysOnSubscriber);
-            tracing::callsite::rebuild_interest_cache();
-        });
-        f()
     }
 
     #[test]


### PR DESCRIPTION
Last of the Phase 3 hygiene PRs. Two commits.

### The last two `AlwaysOnSubscriber` copies

`leviath-testkit`'s module doc says it exists precisely to stop copies of the always-on
tracing subscriber drifting apart. Two survived, in `leviath-sys` and `leviath-core`, each
with a test that existed only to cover its own copy of the span methods. Neither crate had
the dev-dependency — and testkit depends on nothing but `tracing` and `tokio`, so there was
never a cycle in the way, just a missing line in two manifests.

**124 lines of duplicated scaffolding gone**, with the two coverage-only tests that existed
solely to exercise the duplicate.

`leviath-cli`'s copy of that test goes too, for a different reason: it already imported
`with_tracing` from testkit, so it was exercising *testkit's* subscriber — and testkit is
excluded from coverage measurement by design (`xtask/src/coverage.rs`). It contributed to no
gate. Dead weight rather than duplication.

The coverage gate is the check that matters, since all of this is scaffolding that exists to
make measurement work. `leviath-sys`, `leviath-core` and `leviath-cli` are all still clean.

### The `*_tests.rs` question, written down rather than migrated

205 files use an inline `#[cfg(test)] mod tests`; 24 use a sibling file. The difference is
not style, it is what gets measured: an inline module is part of the file, so the gate counts
its *scaffolding* — a fixture helper has to itself be exercised on every branch or it fails.
llvm-cov excludes the sibling layout by default, so a test module whose helpers would
otherwise need tests of their own belongs there.

CONTRIBUTING now says that, plus the rule that shared fixtures go to `leviath-testkit`
rather than being copied into a second crate — which is exactly the drift the commit above
cleaned up.

**Deliberately not migrating the 205 inline modules.** The asymmetry is real, but after the
consolidation above the artifacts it manufactures are gone, and rewriting thousands of lines
to keep them gone is the worst churn-to-value ratio on the list.

### `missing_docs`: measured, not enabled — and the plan was wrong by 40×

The plan called for turning it on after documenting "the handful" of undocumented public
items. **There are 325**, and CI runs with `RUSTFLAGS: -D warnings`, so `"warn"` is `"deny"`
here.

| Crate | Items |
|---|---|
| leviath-cli | 166 |
| leviath-core | 109 |
| leviath-runtime | 18 |
| leviath-mcp | 15 |
| leviath-providers | 14 |
| leviath-tools | 3 |

**240 of the 325 are struct fields**, largely on serde payload types whose names already say
what they are. A doc comment restating a field name is precisely the noise this repo's
comment policy exists to keep out, so writing 240 of them to satisfy a lint would trade real
quality for a green check. The other 52 — functions, methods, structs, enums — are worth
writing and would make the lint affordable; that is a focused piece of work, not a flag flip.

The measurement is recorded beside the lint table in the root manifest, so whoever picks it
up starts from the number rather than rediscovering it.

**One thing worth flagging about the measurement itself:** my first attempt added a second
`[workspace.lints.rust]` table. TOML let it silently shadow the first, the lint never
applied, and the count came back **zero**. I only caught it because I probed with a
deliberately undocumented `pub fn` and got no warning. The 325 is from the merged-table
version, verified firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
