### PR TITLE
refactor(main): move the daemon-readiness backoff into the measured library

### DIFF
--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -86,6 +86,9 @@ tempfile = "3"
 
 [dev-dependencies]
 leviath-testkit = { workspace = true }
+# `start_paused`, so the daemon-readiness backoff is tested by moving a virtual
+# clock rather than by sleeping through its five-second timeout.
+tokio = { workspace = true, features = ["test-util"] }
 # An in-memory credential store installed as the process default, so the
 # `KeychainStore` adapter is tested against the real `leviath_sys::keychain`
 # path rather than a stand-in. No CI runner has an unlocked login keychain, and

--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -28,11 +28,19 @@ pub const SERVICE_LABEL: &str = "dev.leviath.daemon";
 #[cfg(target_os = "macos")]
 pub const LEGACY_SERVICE_LABELS: &[&str] = &["ai.sunforge.leviath"];
 
+/// A supervisor invocation: the program to run and its arguments.
+///
+/// `launchctl` and `systemctl` are both spawned this way. Named rather than
+/// written out at each of the six places it appears, because a bare
+/// `(String, Vec<String>)` says nothing about which of the two strings is the
+/// program.
+pub type SupervisorCommand = (String, Vec<String>);
+
 /// The cleanup a legacy label needs: the unit file it wrote and the
 /// `launchctl bootout` that deregisters it. Pure data - running the commands
 /// is the caller's subprocess I/O, same split as [`ServiceUnit`].
 #[cfg(target_os = "macos")]
-pub fn legacy_cleanup(config_home: &Path, uid: u32) -> Vec<(PathBuf, (String, Vec<String>))> {
+pub fn legacy_cleanup(config_home: &Path, uid: u32) -> Vec<(PathBuf, SupervisorCommand)> {
     LEGACY_SERVICE_LABELS
         .iter()
         .map(|label| {
@@ -60,9 +68,9 @@ pub struct ServiceUnit {
     /// The file's contents.
     pub contents: String,
     /// Command + args that tell the supervisor to pick it up.
-    pub activate: (String, Vec<String>),
+    pub activate: SupervisorCommand,
     /// Command + args that tell the supervisor to let it go.
-    pub deactivate: (String, Vec<String>),
+    pub deactivate: SupervisorCommand,
 }
 
 // ── macOS: a launchd user agent ──────────────────────────────────────────────
@@ -301,6 +309,52 @@ pub fn uninstall(unit: &ServiceUnit) -> Result<bool> {
     }
 }
 
+/// Turn a failed supervisor command into the error the user reads.
+///
+/// Split from the spawn so the message is tested: it names the command that
+/// failed, because "`launchctl` failed" with no argv is unactionable, and the
+/// argv is the part a user can retry by hand.
+pub fn supervisor_failure(cmd: &SupervisorCommand, stderr: &[u8]) -> anyhow::Error {
+    anyhow::anyhow!(
+        "`{} {}` failed: {}",
+        cmd.0,
+        cmd.1.join(" "),
+        String::from_utf8_lossy(stderr).trim()
+    )
+}
+
+/// Deregister and delete every service registration left under a previous
+/// label, returning the paths actually removed so the caller can report them.
+///
+/// Best-effort by design: on a machine that never carried the old label, every
+/// step is a no-op. The effects are injected so that "which files does this
+/// decide to remove" is testable without a supervisor or a real home
+/// directory - `run` deregisters, `remove` deletes and says whether there was
+/// anything there.
+#[cfg(target_os = "macos")]
+pub fn remove_legacy_with(
+    user_home: Option<PathBuf>,
+    uid: u32,
+    run: &mut dyn FnMut(&SupervisorCommand),
+    remove: &mut dyn FnMut(&Path) -> bool,
+) -> Vec<PathBuf> {
+    let Some(user_home) = user_home else {
+        return Vec::new();
+    };
+    // Infallible here: the macOS `config_home` only joins onto the home path.
+    // A `let Ok(..) else` would be a branch this platform can never take.
+    let config_home = config_home(&user_home)
+        .expect("infallible: the macOS config_home only joins onto the home path");
+    let mut removed = Vec::new();
+    for (path, bootout) in legacy_cleanup(&config_home, uid) {
+        run(&bootout);
+        if remove(&path) {
+            removed.push(path);
+        }
+    }
+    removed
+}
+
 /// The line `lev daemon status` adds about supervision.
 pub fn format_supervision(installed: bool, path: &Path) -> String {
     if installed {
@@ -324,6 +378,84 @@ fn display(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── supervisor_failure ───────────────────────────────────────────────
+
+    #[test]
+    fn supervisor_failure_names_the_command_and_its_stderr() {
+        let err = supervisor_failure(
+            &(
+                "launchctl".to_string(),
+                vec!["bootstrap".to_string(), "gui/501".to_string()],
+            ),
+            b"  Load failed: 5: Input/output error\n",
+        )
+        .to_string();
+        // The argv, so the user can retry it by hand.
+        assert!(err.contains("`launchctl bootstrap gui/501`"), "{err}");
+        // The supervisor's own words, trimmed.
+        assert!(err.contains("Load failed: 5: Input/output error"), "{err}");
+        assert!(!err.contains('\n'), "stderr should be trimmed: {err}");
+    }
+
+    #[test]
+    fn supervisor_failure_survives_non_utf8_stderr() {
+        let err = supervisor_failure(&("x".to_string(), vec![]), &[0xff, 0xfe]).to_string();
+        assert!(err.contains("`x `"), "{err}");
+    }
+
+    // ─── remove_legacy_with (macOS only: nothing else ever had a rename) ──
+
+    /// Both halves in one test on purpose. A separate no-home case would pass
+    /// closures that are never called, and an uncalled closure body is an
+    /// uncovered region - the gate would read a correct test as a hole.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn remove_legacy_with_no_home_directory_does_nothing() {
+        let calls = std::cell::Cell::new(0);
+        let mut run = |_: &SupervisorCommand| calls.set(calls.get() + 1);
+        let mut remove = |_: &Path| {
+            calls.set(calls.get() + 1);
+            false
+        };
+
+        assert!(remove_legacy_with(None, 501, &mut run, &mut remove).is_empty());
+        assert_eq!(calls.get(), 0, "no home means no supervisor and no unlink");
+
+        // The same closures against a real home, so both bodies run and the
+        // zero above is a measured difference rather than an absence.
+        assert!(
+            remove_legacy_with(Some(PathBuf::from("/u")), 501, &mut run, &mut remove).is_empty()
+        );
+        assert!(calls.get() > 0, "the injected effects were never reached");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn remove_legacy_with_deregisters_before_deleting() {
+        // Order matters: deleting the plist first would leave the label still
+        // bootstrapped with no file to point at.
+        let events: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
+        let removed = remove_legacy_with(
+            Some(PathBuf::from("/u")),
+            501,
+            &mut |cmd| {
+                events
+                    .borrow_mut()
+                    .push(format!("run {} {}", cmd.0, cmd.1.join(" ")));
+            },
+            &mut |path| {
+                events
+                    .borrow_mut()
+                    .push(format!("remove {}", path.display()));
+                true
+            },
+        );
+        let events = events.into_inner();
+        assert_eq!(removed.len(), LEGACY_SERVICE_LABELS.len());
+        assert!(events[0].starts_with("run launchctl bootout"), "{events:?}");
+        assert!(events[1].starts_with("remove "), "{events:?}");
+    }
 
     /// A unit that needs no platform support to construct, for the shared
     /// filesystem helpers.

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -9,6 +9,7 @@ pub mod config_reload;
 pub mod fanout_spawner;
 pub mod gate_rules;
 pub mod mcp_pool;
+pub mod readiness;
 pub mod recovery;
 pub mod sandbox_manager;
 pub mod script_host;

--- a/crates/leviath-cli/src/daemon/readiness.rs
+++ b/crates/leviath-cli/src/daemon/readiness.rs
@@ -1,0 +1,120 @@
+//! Waiting for the daemon to appear or go away.
+//!
+//! Both directions are the same shape: ask a cheap predicate whether the state
+//! has flipped yet, and keep asking until it has or the wait is over. The
+//! predicate is a socket probe, so this lives here rather than in `main.rs` -
+//! the timing is a decision worth testing, and the probe is the only part that
+//! needs a real socket.
+
+use std::time::Duration;
+
+/// How long to keep asking before giving up.
+pub const READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// First gap between polls.
+const FIRST_DELAY: Duration = Duration::from_millis(2);
+
+/// Ceiling the gap doubles up to.
+const MAX_DELAY: Duration = Duration::from_millis(50);
+
+/// Poll `done` until it returns true or [`READY_TIMEOUT`] elapses, starting at
+/// 2ms and doubling to a 50ms ceiling. Returns whether it flipped in time.
+///
+/// The backoff is the point. The daemon boots in about 20ms, so a fixed 50ms
+/// tick spent more time waiting than the daemon spent starting - it was most
+/// of the measured 97ms cold `lev run`. Doubling to the same 50ms ceiling
+/// leaves the slow path (a daemon that genuinely takes seconds) unchanged
+/// while making the common path cost one 2ms sleep.
+///
+/// `done` is checked before the first sleep, so a predicate that is already
+/// true costs nothing.
+///
+/// `&mut dyn FnMut` rather than `impl FnMut`: a generic parameter gives rustc
+/// one monomorphization per call site and llvm-cov instruments each
+/// separately - it reported 18 of 26 instantiations as 0-hit here even though
+/// the union of them covers every line. A trait object is one instantiation
+/// however many callers there are. Same reason `run/task.rs`'s
+/// `resolve_task_with` takes one, and the cost is a vtable dispatch on a loop
+/// that sleeps between iterations.
+pub async fn poll_until(done: &mut dyn FnMut() -> bool) -> bool {
+    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    let mut delay = FIRST_DELAY;
+    while !done() {
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(MAX_DELAY);
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// Drive the backoff against a virtual clock: `tokio::time::pause` makes
+    /// `sleep` return as soon as nothing else can run, so a five-second
+    /// timeout is tested without waiting five seconds.
+    #[tokio::test(start_paused = true)]
+    async fn an_already_true_predicate_returns_without_sleeping() {
+        let started = tokio::time::Instant::now();
+        assert!(poll_until(&mut || true).await);
+        assert_eq!(tokio::time::Instant::now(), started, "it slept anyway");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_predicate_that_never_flips_gives_up_at_the_timeout() {
+        let started = tokio::time::Instant::now();
+        assert!(!poll_until(&mut || false).await);
+        assert!(
+            tokio::time::Instant::now() - started >= READY_TIMEOUT,
+            "gave up early"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_returns_as_soon_as_the_predicate_flips() {
+        let calls = Cell::new(0);
+        assert!(
+            poll_until(&mut || {
+                calls.set(calls.get() + 1);
+                calls.get() == 4
+            })
+            .await
+        );
+        assert_eq!(calls.get(), 4, "it kept polling after the flip");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_delay_doubles_and_then_holds_at_the_ceiling() {
+        // Record the gap between polls by reading the virtual clock inside the
+        // predicate. Asserting on the sequence is what pins the backoff; a
+        // test that only checked the total would pass on a fixed tick.
+        let gaps = std::cell::RefCell::new(Vec::new());
+        let last = Cell::new(tokio::time::Instant::now());
+        let calls = Cell::new(0);
+        poll_until(&mut || {
+            let now = tokio::time::Instant::now();
+            gaps.borrow_mut().push(now - last.get());
+            last.set(now);
+            calls.set(calls.get() + 1);
+            calls.get() == 8
+        })
+        .await;
+
+        let gaps = gaps.borrow();
+        // gaps[0] is the first call, before any sleep.
+        assert_eq!(gaps[0], Duration::ZERO);
+        assert_eq!(gaps[1], FIRST_DELAY);
+        assert_eq!(gaps[2], FIRST_DELAY * 2);
+        assert_eq!(gaps[3], FIRST_DELAY * 4);
+        assert_eq!(gaps[4], FIRST_DELAY * 8);
+        assert_eq!(gaps[5], FIRST_DELAY * 16);
+        // 2ms doubled five times is 64ms, past the ceiling, so it clamps and
+        // stays there rather than growing without bound.
+        assert_eq!(gaps[6], MAX_DELAY);
+        assert_eq!(gaps[7], MAX_DELAY);
+    }
+}

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -22,6 +22,7 @@ use tracing::info;
 
 use leviath_cli::commands;
 use leviath_cli::commands::dashboard::{CrosstermEventSource, DashboardArgs, TerminalSetup};
+use leviath_cli::daemon::readiness::poll_until;
 use leviath_cli::dispatch::{Commands, RiskyExecutors, apply_region_flags, dispatch};
 
 /// mimalloc instead of the platform allocator. The daemon's workload is a
@@ -310,7 +311,7 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
         let _ = control_client()?
             .request(&leviath_runtime::control_socket::ControlRequest::Shutdown)
             .await;
-        poll_until(|| !is_daemon_running(&id)).await;
+        poll_until(&mut || !is_daemon_running(&id)).await;
     }
     let exe = std::env::current_exe()?;
     let mut cmd = std::process::Command::new(exe);
@@ -320,28 +321,10 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
         .stderr(std::process::Stdio::null());
     leviath_sys::process::configure_detached(&mut cmd);
     cmd.spawn()?;
-    if poll_until(|| is_daemon_running(&id)).await {
+    if poll_until(&mut || is_daemon_running(&id)).await {
         return Ok(());
     }
     anyhow::bail!("the leviath daemon did not start within 5s");
-}
-
-/// Poll `done` until it returns true or ~5s elapses, sleeping 2ms at first
-/// and doubling to a 50ms ceiling. The daemon boots in ~20ms, so the old
-/// fixed 50ms tick spent more time waiting than the daemon spent starting -
-/// it was most of the measured 97ms cold `lev run`. Backoff keeps the
-/// slow-path cost (a daemon that genuinely takes seconds) unchanged.
-async fn poll_until(mut done: impl FnMut() -> bool) -> bool {
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-    let mut delay = std::time::Duration::from_millis(2);
-    while !done() {
-        if tokio::time::Instant::now() >= deadline {
-            return false;
-        }
-        tokio::time::sleep(delay).await;
-        delay = (delay * 2).min(std::time::Duration::from_millis(50));
-    }
-    true
 }
 
 /// `lev daemon start`: auto-start a detached daemon if none is running.
@@ -377,7 +360,7 @@ async fn real_daemon_stop() -> anyhow::Result<()> {
             None => return Err(e),
         }
     }
-    if poll_until(|| !is_daemon_running(&id)).await {
+    if poll_until(&mut || !is_daemon_running(&id)).await {
         println!("daemon stopped");
         return Ok(());
     }
@@ -444,12 +427,10 @@ fn run_supervisor(cmd: &(String, Vec<String>)) -> anyhow::Result<()> {
     if out.status.success() {
         return Ok(());
     }
-    anyhow::bail!(
-        "`{} {}` failed: {}",
-        cmd.0,
-        cmd.1.join(" "),
-        String::from_utf8_lossy(&out.stderr).trim()
-    )
+    Err(commands::daemon_service::supervisor_failure(
+        cmd,
+        &out.stderr,
+    ))
 }
 
 /// `lev daemon install`: write the platform service file and hand it to the
@@ -488,19 +469,16 @@ fn real_daemon_uninstall() -> anyhow::Result<()> {
 /// that never had the old label, every step is a no-op.
 #[cfg(target_os = "macos")]
 fn remove_legacy_services() {
-    let Some(user_home) = dirs::home_dir() else {
-        return;
-    };
-    let Ok(config_home) = commands::daemon_service::config_home(&user_home) else {
-        return;
-    };
-    for (path, bootout) in
-        commands::daemon_service::legacy_cleanup(&config_home, leviath_sys::current_uid())
-    {
-        let _ = run_supervisor(&bootout);
-        if std::fs::remove_file(&path).is_ok() {
-            println!("removed legacy service file {}", path.display());
-        }
+    let removed = commands::daemon_service::remove_legacy_with(
+        dirs::home_dir(),
+        leviath_sys::current_uid(),
+        &mut |bootout| {
+            let _ = run_supervisor(bootout);
+        },
+        &mut |path| std::fs::remove_file(path).is_ok(),
+    );
+    for path in removed {
+        println!("removed legacy service file {}", path.display());
     }
 }
 


### PR DESCRIPTION
First of the Phase 4 `main.rs` shrink. **Deliberately small** — this is the one item in the
plan where a mistake is a broken daemon rather than a failed test, so it moves the piece
with the clearest test story and stops.

`main.rs` is 809 lines of entirely unmeasured code sitting behind a 100% gate. The fix is
not to lower the gate or to measure the composition root, but to move *logic* out of it and
leave real I/O wiring behind.

### What moved

**`poll_until`** → `daemon::readiness`. Twelve lines of pure timing logic, now with four
tests against `tokio::time`'s virtual clock — a five-second timeout verified without waiting
five seconds. One asserts the *sequence* of gaps (2, 4, 8, 16, 32, then 50, 50), because a
test checking only the total would pass just as happily against the fixed 50ms tick this
backoff replaced.

**`supervisor_failure`** and **`remove_legacy_with`** → `daemon_service`, where the rest of
that decision already lives. The legacy cleanup takes its effects as injected closures, so
"deregister before unlinking" is asserted on *order* rather than against a real launchd —
getting that backwards leaves a label bootstrapped with no file behind it.

### Three things the gate caught, which is the argument for moving code at all

**A generic became a hole the moment it was measured.** `poll_until` took `impl FnMut`, so
rustc emitted one monomorphization per call site and llvm-cov reported **18 of 26
instantiations as 0-hit** while every line was genuinely covered. `&mut dyn FnMut` is one
instantiation for all callers — the same seam `run/task.rs`'s `resolve_task_with` already
uses for the same reason. Cost: one vtable dispatch on a loop that sleeps between iterations.

**A branch the platform cannot take.** `config_home` is infallible on macOS, so a
`let Ok(..) else` around it was a region no test on that OS could reach. It is an `.expect`
naming the invariant.

**`resolve_service_unit` stays in `main.rs`, deliberately.** Moving it made
`config_home(&user_home)?` a measured error arm — reachable only on Windows, where
`config_home` always fails, and dead on the two platforms that build a unit at all. There is
no honest test for it on macOS or Linux, and reaching for one would mean weakening the gate
or writing a fake. Three `ok_or_else` conversions are not worth that, so I reverted that
part and the commit says why.

### Live verification, because a green suite is not evidence here

`lev daemon status / start / status / restart / status / stop / status / stop` on an
isolated `LEVIATH_HOME`: every step correct, and the whole sequence in **about 80ms** — which
is the backoff working, since `start` returns as soon as the socket answers.

`install` / `uninstall` too, since `remove_legacy_with` is only reachable from those. I
checked **first** that no leviath plist and no launchd registration existed, so the round
trip could not clobber anything, and confirmed **after** that `~/Library/LaunchAgents` and
`launchctl list` are back to empty. Install registered `dev.leviath.daemon`, `status`
reported it supervised, uninstall removed both, and a second uninstall said "no leviath
service was installed" rather than failing.

⚠️ **Not verified on Linux** — I have no Linux host. The systemd path through
`resolve_service_unit` is unchanged by this PR and `remove_legacy_with` is macOS-only by
`#[cfg]`, so nothing here is Linux-specific. Worth a smoke there before a later `main.rs` PR
touches shared ground.

**main.rs: 809 → 778.** `cargo xtask coverage --package leviath-cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
