### PR TITLE
chore(deps): raise version floors to what is tested, route four through the workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,20 @@ cargo llvm-cov --package <crate> --lib --html --open   # browsable per-crate rep
 
 > Branch coverage isn't collected: `cargo llvm-cov --branch` reliably SIGSEGVs inside LLVM's own coverage-mapping code ([open upstream bug](https://github.com/llvm/llvm-project/issues/119558)). See the doc comment atop `xtask/src/coverage.rs` for the full investigation.
 
+## Dependencies
+
+Declare a dependency in `[workspace.dependencies]` and reference it from a crate as `{ workspace = true }`. A version written inline in a crate manifest is invisible to anyone reading the root, which is how one crate ends up on a different minor from the rest without anybody deciding that.
+
+A version requirement here records **the minimum this workspace has actually been tested against, as of the last time someone deliberately raised it** — not the oldest version that might still compile. Raising a floor to match `Cargo.lock` is a no-op for resolution (the lock already picks that version), so it costs nothing and stops the requirement drifting into a claim nobody has checked. Do it when you notice the gap; there is no obligation to chase every release.
+
+To find genuinely duplicated dependencies, ask cargo:
+
+```bash
+cargo tree --duplicates
+```
+
+Not `Cargo.lock`. The lockfile records **unenabled optional** dependencies too, so a crate can appear there while never being compiled — `cargo tree -i <crate>` printing "nothing to print" is the tell. Trimming a feature to remove such an entry changes neither the build nor the lockfile.
+
 ## Cutting a release
 
 Releases are triggered by a version bump, not by a schedule. Merging a bump to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,10 +87,10 @@ leviath-testkit = { path = "crates/leviath-testkit" }
 # External dependencies
 bevy_ecs = { version = "0.19", features = ["multi_threaded"] }
 bevy_tasks = "0.19"
-tokio = { version = "1.41", features = ["full"] }
+tokio = { version = "1.53", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 # rustls instead of default native-tls: keeps Linux binaries free of a
 # runtime libssl dependency (single static binary) and lets the
 # aarch64-linux release target cross-compile without an OpenSSL sysroot.
@@ -118,12 +118,12 @@ thiserror = "2.0"
 toml = { version = "1.0", features = ["preserve_order"] }
 anyhow = "1.0"
 chrono = "0.4"
-rhai = { version = "1.20", features = ["sync", "serde"] }
+rhai = { version = "1.25", features = ["sync", "serde"] }
 glob = "0.3"
 # Compiled once per [read_paths] entry at spawn; already in the lock file
 # transitively, named here so the allowlist matcher in `leviath-core` uses the
 # same version everywhere.
-regex = "1"
+regex = "1.13"
 # Already in the tree via reqwest; named explicitly so `leviath-core` can hold
 # the outbound-URL policy (`leviath_core::net`) without depending on reqwest.
 # `reqwest::Url` IS this crate's `Url`, so the two interoperate directly.

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -56,7 +56,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rhai = { workspace = true }
 glob = { workspace = true }
-dirs = "6.0.0"
+dirs = { workspace = true }
 chrono = { workspace = true }
 bevy_ecs = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tiktoken-rs = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 futures-core = { workspace = true }
 tokio-stream = { workspace = true }
 bytes = "1"

--- a/crates/leviath-runtime/Cargo.toml
+++ b/crates/leviath-runtime/Cargo.toml
@@ -41,11 +41,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 [dev-dependencies]
 leviath-testkit = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 # `start_paused` / `advance`, so the interaction deadline is tested by moving a
 # virtual clock rather than by sleeping through a real hour.
 tokio = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
Phase 3 dependency housekeeping. No code changes; the lockfile does not move.

### Floors that record a guess, replaced by floors that record a test

`tokio = "1.41"`, `rhai = "1.20"`, `clap = "4.5"` and `regex = "1"` were the versions
someone last thought about, not versions anyone has run. The lock resolves 1.53.1, 1.25.1,
4.6.4 and 1.13.1, so those are the real tested minimums and the requirements now say so.

Resolution-neutral by construction, and **verified**: `Cargo.lock` is byte-identical after
the change. This matches the honesty rationale the manifest already states for
`rust-version` — a floor is a claim about what has been tested, and a floor twelve minors
below the lock is a claim nobody has checked.

### Four declarations that bypassed the workspace table

`dirs` in `leviath-cli`, and `async-trait` in `leviath-providers` and twice in
`leviath-runtime`, were written inline. All four already had a `[workspace.dependencies]`
entry to use. A version written inline is invisible to anyone reading the root manifest,
which is how one crate ends up on a different minor from the rest without anybody deciding
that.

### The ratatui/termwiz trim: premise falsified, no change

The audit reported ~25 termwiz packages reachable through ratatui's default features.
`cargo tree -i termwiz` prints nothing — it never compiles. They appear in `Cargo.lock`
only because Cargo locks *unenabled optional* dependencies, and `default-features = false`
would not remove them from the lockfile either. There is nothing to trim.

CONTRIBUTING gains that as a rule, since the mistake is easy to repeat: duplicate analysis
is `cargo tree --duplicates`, not reading the lockfile. It also records what a floor means,
so raising one to meet the lock stays a cheap deliberate act rather than a treadmill.

### Verification

`cargo deny check`: advisories ok, bans ok, licenses ok, sources ok. Full workspace test
suite green. `Cargo.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
