### PR TITLE
feat(hooks): the stage-hook framework and its outcome contract (#260, 1/5)

### DIFF
--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -762,6 +762,53 @@ pub struct InteractionPoint {
     pub document_region: Option<String>,
 }
 
+/// Script-backed lifecycle hooks for a stage: `[stages.<name>.hooks]`.
+///
+/// Each field names a `.rhai` file, resolved relative to the blueprint
+/// directory exactly as a custom region's script is. Every hook is optional and
+/// an agent that declares none pays nothing - no file is read and no engine is
+/// built (issue #260).
+///
+/// The hook a script implements is the function it defines, named for the
+/// field: a file given as `on_stage_enter` must define `fn on_stage_enter(ctx)`.
+/// One file may back several hooks by defining several functions.
+///
+/// Hooks are a **return-value contract**, like region hooks: Rhai passes
+/// arguments by value, so mutating `ctx` in place does nothing and the script
+/// must return its decision. See `leviath_scripting::stage_hook`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct StageHooks {
+    /// Fires as the agent enters the stage, before its first inference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_stage_enter: Option<String>,
+    /// Fires when the stage finishes, before transition evaluation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_stage_exit: Option<String>,
+}
+
+impl StageHooks {
+    /// Whether any hook is declared. The whole feature is skipped when not -
+    /// no file read, no compile, no engine.
+    pub fn is_empty(&self) -> bool {
+        self.on_stage_enter.is_none() && self.on_stage_exit.is_none()
+    }
+
+    /// Every script path this stage declares, with the hook it backs.
+    ///
+    /// Returned as pairs rather than a set because the same file may back more
+    /// than one hook, and the caller needs to know which function to look for.
+    pub fn declared(&self) -> Vec<(&'static str, &str)> {
+        let mut out = Vec::new();
+        if let Some(p) = self.on_stage_enter.as_deref() {
+            out.push(("on_stage_enter", p));
+        }
+        if let Some(p) = self.on_stage_exit.as_deref() {
+            out.push(("on_stage_exit", p));
+        }
+        out
+    }
+}
+
 /// A single execution stage in an agent's workflow.
 ///
 /// Stages allow an agent to use different models or configurations for
@@ -937,6 +984,10 @@ pub struct Stage {
     /// a fan-out worker whose summary its merge stage depends on.
     #[serde(default)]
     pub require_output: bool,
+    /// Script-backed lifecycle hooks: `[stages.<name>.hooks]`. Absent ⇒ none,
+    /// and nothing about the scripting engine is touched for this stage.
+    #[serde(default, skip_serializing_if = "StageHooks::is_empty")]
+    pub hooks: StageHooks,
 }
 
 /// Default value for bool fields that should default to true.
@@ -974,6 +1025,7 @@ impl Stage {
             tool_result_routing: None,
             output: None,
             require_output: false,
+            hooks: StageHooks::default(),
         }
     }
 

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -790,6 +790,11 @@ fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
         stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
     }
 
+    // Script-backed lifecycle hooks: [stages.<name>.hooks]
+    if let Some(hooks_table) = stage_value.get("hooks").and_then(|v| v.as_table()) {
+        stage.hooks = parse_stage_hooks(stage_name, hooks_table)?;
+    }
+
     // Parse the stage's declared output shape: [stages.<name>.output].
     // Narrows [agent.output]; whoever starts the run overrides both.
     if let Some(output_table) = stage_value.get("output").and_then(|v| v.as_table()) {
@@ -856,6 +861,37 @@ fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
     }
 
     Ok(stage)
+}
+
+/// Parse `[stages.<name>.hooks]` into the stage's [`StageHooks`].
+///
+/// An unknown key is a hard error rather than an ignored line. A blueprint that
+/// writes `on_stage_entry` (or a hook this build does not implement yet) has
+/// asked for behaviour it will silently not get, and a silently-ignored hook
+/// reads exactly like one that ran and chose to do nothing.
+fn parse_stage_hooks(
+    stage_name: &str,
+    table: &toml::value::Table,
+) -> Result<crate::blueprint::StageHooks> {
+    let mut hooks = crate::blueprint::StageHooks::default();
+    for (key, value) in table {
+        let Some(path) = value.as_str() else {
+            return Err(Error::Other(format!(
+                "stage '{stage_name}': hook '{key}' must be a path to a .rhai file, got: {value}"
+            )));
+        };
+        match key.as_str() {
+            "on_stage_enter" => hooks.on_stage_enter = Some(path.to_string()),
+            "on_stage_exit" => hooks.on_stage_exit = Some(path.to_string()),
+            other => {
+                return Err(Error::Other(format!(
+                    "stage '{stage_name}': unknown hook '{other}' \
+                     (this build implements: on_stage_enter, on_stage_exit)"
+                )));
+            }
+        }
+    }
+    Ok(hooks)
 }
 
 /// Parse `[compaction]` over the defaults, leaving any field the manifest does
@@ -1491,6 +1527,68 @@ fn parse_sandbox_config(table: &toml::value::Table) -> Result<crate::sandbox::To
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── [stages.<name>.hooks] ────────────────────────────────────────────
+
+    fn stage_with_hooks(body: &str) -> Result<crate::Stage> {
+        let toml_src = format!("[stages.main]\n{body}\n");
+        let parsed: toml::Value = toml::from_str(&toml_src).expect("fixture parses");
+        let stage_value = parsed
+            .get("stages")
+            .and_then(|v| v.get("main"))
+            .expect("fixture shape");
+        parse_stage("main", stage_value)
+    }
+
+    #[test]
+    fn a_stage_declaring_no_hooks_has_none() {
+        let stage = stage_with_hooks("mode = \"autonomous\"").expect("parses");
+        assert!(stage.hooks.is_empty());
+        assert!(stage.hooks.declared().is_empty());
+    }
+
+    #[test]
+    fn both_hooks_parse_and_report_the_function_they_back() {
+        let stage = stage_with_hooks(
+            "[stages.main.hooks]\non_stage_enter = \"a.rhai\"\non_stage_exit = \"b.rhai\"",
+        )
+        .expect("parses");
+        assert!(!stage.hooks.is_empty());
+        assert_eq!(
+            stage.hooks.declared(),
+            vec![("on_stage_enter", "a.rhai"), ("on_stage_exit", "b.rhai")]
+        );
+    }
+
+    #[test]
+    fn one_file_may_back_both_hooks() {
+        let stage = stage_with_hooks(
+            "[stages.main.hooks]\non_stage_enter = \"h.rhai\"\non_stage_exit = \"h.rhai\"",
+        )
+        .expect("parses");
+        let paths: Vec<&str> = stage.hooks.declared().iter().map(|(_, p)| *p).collect();
+        assert_eq!(paths, vec!["h.rhai", "h.rhai"]);
+    }
+
+    /// An unrecognised hook is refused rather than ignored. A blueprint writing
+    /// `on_stage_entry` has asked for behaviour it would silently not get, and
+    /// a hook that never runs reads exactly like one that ran and did nothing.
+    #[test]
+    fn an_unknown_hook_name_is_refused_and_lists_the_real_ones() {
+        let err = stage_with_hooks("[stages.main.hooks]\non_stage_entry = \"a.rhai\"")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown hook 'on_stage_entry'"), "{err}");
+        assert!(err.contains("on_stage_enter"), "{err}");
+    }
+
+    #[test]
+    fn a_hook_that_is_not_a_path_is_refused() {
+        let err = stage_with_hooks("[stages.main.hooks]\non_stage_enter = 42")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be a path"), "{err}");
+    }
 
     /// Extract the `points` vec from a `StageMode::InteractivePoints`.
     /// Panics (with a diagnostic) when the mode is any other variant.

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -11,6 +11,7 @@ pub mod functions;
 pub mod output_validator;
 pub mod region_hook;
 pub mod sandbox;
+pub mod stage_hook;
 pub mod tool;
 pub mod types;
 

--- a/crates/leviath-scripting/src/stage_hook.rs
+++ b/crates/leviath-scripting/src/stage_hook.rs
@@ -1,0 +1,446 @@
+//! Script-backed stage lifecycle hooks (`[stages.<name>.hooks]`, issue #260).
+//!
+//! Where a custom region's script owns one region's behaviour, these let a
+//! blueprint observe and steer the agent's own lifecycle: what the context
+//! holds as a stage opens, what happens as it closes, and (in later hooks) what
+//! is about to be inferred or called.
+//!
+//! Same shape as [`crate::region_hook`], deliberately - a blueprint author who
+//! has written one has written the other:
+//!
+//! - **A return-value contract.** Rhai passes arguments by value, so mutating
+//!   `ctx` in place does nothing; the script returns its decision.
+//! - **Compiled once**, at agent spawn, by the CLI. A missing or malformed
+//!   script is a spawn error, not a runtime surprise.
+//! - **A fresh hardened engine per call** ([`crate::harden`]): no filesystem,
+//!   no network, no `eval`, operation-bounded.
+//! - **JSON at the boundary**, so `leviath-runtime` interprets the outcome
+//!   without depending on `rhai`.
+//!
+//! # The outcome contract
+//!
+//! Every hook returns one of four things, and the same four everywhere, so a
+//! reader does not have to learn a vocabulary per hook:
+//!
+//! | script returns | meaning |
+//! |---|---|
+//! | `()`, `true` | [`HookOutcome::Allow`] - proceed unchanged |
+//! | `false` | [`HookOutcome::Cancel`] with no reason given |
+//! | `#{ action: "allow" }` | as above, written out |
+//! | `#{ action: "modify", value: ... }` | [`HookOutcome::Modify`] - proceed with `value` |
+//! | `#{ action: "cancel", reason: "..." }` | [`HookOutcome::Cancel`] |
+//! | `#{ action: "retry" }` | [`HookOutcome::Retry`] |
+//!
+//! What `Modify` and `Retry` *mean* is the calling hook's business - the shape
+//! of `value` differs between "the regions to write" and "the request to send",
+//! and not every hook can honour `Retry`. This module decides only that the
+//! script returned a well-formed decision; the caller decides whether it is one
+//! it can act on. That split is why an unknown `action` is an error here (a
+//! typo'd `"modfiy"` must not read as `Allow`) while an unhonourable one is
+//! reported by the caller.
+
+use rhai::{AST, Dynamic, Engine, Scope};
+
+/// Operation budget for stage hooks.
+///
+/// The same 100k a region hook gets, and for the same reason: these are pure
+/// data transforms over a context snapshot, not the IO-driving script tools and
+/// providers that are given 500k.
+const STAGE_HOOK_MAX_OPERATIONS: u64 = 100_000;
+
+/// The hooks this build implements, as the function names a script defines.
+///
+/// The blueprint field and the Rhai function share a name on purpose: a
+/// blueprint saying `on_stage_enter = "hooks.rhai"` means "call
+/// `fn on_stage_enter(ctx)` in that file", with nothing in between to look up.
+pub const HOOK_NAMES: &[&str] = &["on_stage_enter", "on_stage_exit"];
+
+/// What a hook decided.
+///
+/// Deliberately not `Option<Value>`: "proceed unchanged" and "proceed with
+/// this" are different answers, and so is "do not proceed". Collapsing them
+/// would make a cancelling hook indistinguishable from one that returned
+/// nothing, which is the failure mode the taint gate's own history warns about.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HookOutcome {
+    /// Proceed unchanged.
+    Allow,
+    /// Proceed, using this value instead. Its shape is the caller's contract.
+    Modify(serde_json::Value),
+    /// Do not proceed. The reason is shown to the operator and, where the
+    /// caller can, written into the agent's context so the model learns why.
+    Cancel(Option<String>),
+    /// Do the thing again. Not every caller can honour this; one that cannot
+    /// says so rather than silently treating it as `Allow`.
+    Retry,
+}
+
+/// A compiled stage-hook script, ready to call.
+///
+/// Compiled once at spawn and shared via `Arc`, keyed by the path as written in
+/// the blueprint - the same lifecycle a [`crate::region_hook::RegionScript`]
+/// has, so one file backing several hooks is compiled once.
+#[derive(Debug, Clone)]
+pub struct HookScript {
+    /// The script path as written in the blueprint - log/error context only.
+    pub path: String,
+    ast: AST,
+    defined: Vec<String>,
+}
+
+impl HookScript {
+    /// Whether this script defines the named hook.
+    pub fn defines(&self, hook: &str) -> bool {
+        self.defined.iter().any(|d| d == hook)
+    }
+
+    /// Every hook this script defines, in [`HOOK_NAMES`] order.
+    pub fn defined(&self) -> &[String] {
+        &self.defined
+    }
+}
+
+/// Build the hardened engine every stage-hook call runs on.
+fn build_engine() -> Engine {
+    let mut engine = Engine::new();
+    crate::harden(&mut engine, STAGE_HOOK_MAX_OPERATIONS);
+    crate::functions::register_functions(&mut engine);
+    crate::types::register_types(&mut engine);
+    engine
+}
+
+/// Compile a stage-hook script and record which hooks it defines.
+///
+/// `wanted` is what the blueprint asked this file for. A file that does not
+/// define a hook it was named for is a compile error: the blueprint asked for
+/// behaviour that would otherwise never run, and a hook that never runs looks
+/// exactly like one that ran and allowed everything.
+///
+/// Every hook takes exactly one parameter (`ctx`); a different arity is
+/// rejected here rather than failing at the first call, mid-run.
+pub fn compile(path: &str, source: &str, wanted: &[&str]) -> crate::Result<HookScript> {
+    let engine = build_engine();
+    let ast = engine
+        .compile(source)
+        .map_err(|e| crate::Error::CompilationFailed(format!("{path}: {e}")))?;
+
+    let arity_of = |name: &str| -> Option<usize> {
+        ast.iter_functions()
+            .find(|f| f.name == name)
+            .map(|f| f.params.len())
+    };
+
+    let mut defined = Vec::new();
+    for hook in HOOK_NAMES {
+        match arity_of(hook) {
+            Some(1) => defined.push((*hook).to_string()),
+            Some(n) => {
+                return Err(crate::Error::ValidationFailed(format!(
+                    "{path}: fn {hook} must take exactly one parameter (ctx), found {n}"
+                )));
+            }
+            None => {}
+        }
+    }
+
+    for hook in wanted {
+        if !defined.iter().any(|d| d == hook) {
+            return Err(crate::Error::ValidationFailed(format!(
+                "{path}: the blueprint names this file for '{hook}', but it defines no \
+                 fn {hook}(ctx)"
+            )));
+        }
+    }
+
+    Ok(HookScript {
+        path: path.to_string(),
+        ast,
+        defined,
+    })
+}
+
+/// Call `hook(ctx)` and interpret the decision.
+///
+/// The caller supplies `ctx` as JSON and gets a [`HookOutcome`]; nothing about
+/// `rhai` crosses this boundary.
+pub fn run(script: &HookScript, hook: &str, ctx: serde_json::Value) -> crate::Result<HookOutcome> {
+    let engine = build_engine();
+    // Total conversion: every JSON value has a Dynamic representation, so a
+    // failure here is a programmer error, not a script error (same stance as
+    // the region hooks and the provider layer).
+    let ctx_dyn = rhai::serde::to_dynamic(ctx).expect("JSON always converts to Dynamic");
+    let result: Dynamic = engine
+        .call_fn(&mut Scope::new(), &script.ast, hook, (ctx_dyn,))
+        .map_err(|e| crate::Error::ExecutionFailed(format!("{}: {hook}: {e}", script.path)))?;
+
+    if result.is_unit() {
+        return Ok(HookOutcome::Allow);
+    }
+    if let Ok(b) = result.as_bool() {
+        return Ok(match b {
+            true => HookOutcome::Allow,
+            false => HookOutcome::Cancel(None),
+        });
+    }
+
+    let value = rhai::serde::from_dynamic::<serde_json::Value>(&result).map_err(|e| {
+        crate::Error::ValidationFailed(format!(
+            "{}: {hook} returned a value that is not plain data: {e}",
+            script.path
+        ))
+    })?;
+    outcome_from(&script.path, hook, value)
+}
+
+/// Read a returned map into an outcome.
+///
+/// Split out so every arm is reachable from a plain value in tests, without
+/// standing up an engine to produce each shape.
+fn outcome_from(path: &str, hook: &str, value: serde_json::Value) -> crate::Result<HookOutcome> {
+    let bad = |what: String| crate::Error::ValidationFailed(format!("{path}: {hook}: {what}"));
+
+    let Some(obj) = value.as_object() else {
+        return Err(bad(format!(
+            "expected (), a bool, or a map with an 'action', got: {value}"
+        )));
+    };
+    let Some(action) = obj.get("action").and_then(|a| a.as_str()) else {
+        return Err(bad(
+            "the returned map has no 'action' (expected allow, modify, cancel, or retry)"
+                .to_string(),
+        ));
+    };
+    match action {
+        "allow" => Ok(HookOutcome::Allow),
+        "retry" => Ok(HookOutcome::Retry),
+        "cancel" => Ok(HookOutcome::Cancel(
+            obj.get("reason")
+                .and_then(|r| r.as_str())
+                .map(str::to_string),
+        )),
+        // A `modify` with no `value` is rejected rather than read as `allow`:
+        // the script asked to change something and naming nothing is a bug in
+        // it, not an instruction to proceed.
+        "modify" => match obj.get("value") {
+            Some(v) => Ok(HookOutcome::Modify(v.clone())),
+            None => Err(bad(
+                "action 'modify' needs a 'value' saying what to proceed with".to_string(),
+            )),
+        },
+        other => Err(bad(format!(
+            "unknown action '{other}' (expected allow, modify, cancel, or retry)"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn script(src: &str) -> HookScript {
+        compile("hooks.rhai", src, &[]).expect("compiles")
+    }
+
+    // ─── compile ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_script_records_every_hook_it_defines() {
+        let s = script("fn on_stage_enter(ctx) { () } fn on_stage_exit(ctx) { () }");
+        assert!(s.defines("on_stage_enter"));
+        assert!(s.defines("on_stage_exit"));
+        assert_eq!(s.defined(), ["on_stage_enter", "on_stage_exit"]);
+    }
+
+    #[test]
+    fn a_hook_the_script_does_not_define_is_not_claimed() {
+        let s = script("fn on_stage_enter(ctx) { () }");
+        assert!(s.defines("on_stage_enter"));
+        assert!(!s.defines("on_stage_exit"));
+    }
+
+    #[test]
+    fn a_syntax_error_names_the_file() {
+        let err = compile("hooks.rhai", "fn on_stage_enter(ctx) {", &[])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("hooks.rhai"), "{err}");
+    }
+
+    /// Arity is checked at compile rather than at the first call: a hook that
+    /// takes the wrong number of arguments fails on entry to some stage,
+    /// possibly minutes in, and the blueprint author is not there to see it.
+    #[test]
+    fn a_hook_with_the_wrong_arity_is_rejected_at_compile() {
+        let err = compile("hooks.rhai", "fn on_stage_enter(a, b) { () }", &[])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("exactly one parameter"), "{err}");
+        assert!(err.contains("found 2"), "{err}");
+    }
+
+    /// The case that matters most: the blueprint asked this file for a hook and
+    /// the file does not implement it. Silently accepting would make a
+    /// never-called hook indistinguishable from one that allowed everything.
+    #[test]
+    fn a_file_named_for_a_hook_it_does_not_define_is_rejected() {
+        let err = compile(
+            "hooks.rhai",
+            "fn on_stage_exit(ctx) { () }",
+            &["on_stage_enter"],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("on_stage_enter"), "{err}");
+        assert!(err.contains("defines no"), "{err}");
+    }
+
+    #[test]
+    fn a_file_that_defines_what_was_asked_for_compiles() {
+        assert!(
+            compile(
+                "hooks.rhai",
+                "fn on_stage_enter(ctx) { () }",
+                &["on_stage_enter"]
+            )
+            .is_ok()
+        );
+    }
+
+    // ─── the outcome contract, through a real engine ──────────────────────
+
+    fn run_returning(body: &str) -> crate::Result<HookOutcome> {
+        let s = script(&format!("fn on_stage_enter(ctx) {{ {body} }}"));
+        run(&s, "on_stage_enter", serde_json::json!({"stage": "main"}))
+    }
+
+    #[test]
+    fn unit_and_true_both_allow() {
+        assert_eq!(run_returning("()").unwrap(), HookOutcome::Allow);
+        assert_eq!(run_returning("true").unwrap(), HookOutcome::Allow);
+    }
+
+    /// `false` cancels rather than allowing. Reading a bare `false` as "no
+    /// opinion" is how a hook that meant to stop something silently does not.
+    #[test]
+    fn false_cancels_with_no_reason() {
+        assert_eq!(run_returning("false").unwrap(), HookOutcome::Cancel(None));
+    }
+
+    #[test]
+    fn a_written_out_allow_is_the_same_as_unit() {
+        assert_eq!(
+            run_returning(r#"#{ action: "allow" }"#).unwrap(),
+            HookOutcome::Allow
+        );
+    }
+
+    #[test]
+    fn modify_carries_its_value() {
+        let got = run_returning(r#"#{ action: "modify", value: #{ notes: "seeded" } }"#).unwrap();
+        assert_eq!(
+            got,
+            HookOutcome::Modify(serde_json::json!({"notes": "seeded"}))
+        );
+    }
+
+    #[test]
+    fn cancel_carries_its_reason() {
+        assert_eq!(
+            run_returning(r#"#{ action: "cancel", reason: "over budget" }"#).unwrap(),
+            HookOutcome::Cancel(Some("over budget".to_string()))
+        );
+        assert_eq!(
+            run_returning(r#"#{ action: "cancel" }"#).unwrap(),
+            HookOutcome::Cancel(None)
+        );
+    }
+
+    #[test]
+    fn retry_is_its_own_outcome() {
+        assert_eq!(
+            run_returning(r#"#{ action: "retry" }"#).unwrap(),
+            HookOutcome::Retry
+        );
+    }
+
+    #[test]
+    fn the_ctx_reaches_the_script() {
+        let s = script(r#"fn on_stage_enter(ctx) { #{ action: "modify", value: ctx.stage } }"#);
+        let got = run(&s, "on_stage_enter", serde_json::json!({"stage": "review"})).unwrap();
+        assert_eq!(got, HookOutcome::Modify(serde_json::json!("review")));
+    }
+
+    // ─── malformed decisions ──────────────────────────────────────────────
+
+    /// A typo must not read as `Allow`. This is the whole reason an unknown
+    /// action is an error rather than a default.
+    #[test]
+    fn an_unknown_action_is_an_error_not_an_allow() {
+        let err = run_returning(r#"#{ action: "modfiy" }"#)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown action 'modfiy'"), "{err}");
+    }
+
+    #[test]
+    fn a_map_without_an_action_is_an_error() {
+        let err = run_returning(r#"#{ value: 1 }"#).unwrap_err().to_string();
+        assert!(err.contains("no 'action'"), "{err}");
+    }
+
+    /// `modify` naming nothing is a bug in the script, not an instruction to
+    /// proceed unchanged - it asked to change something and said what to.
+    #[test]
+    fn modify_without_a_value_is_an_error() {
+        let err = run_returning(r#"#{ action: "modify" }"#)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("needs a 'value'"), "{err}");
+    }
+
+    #[test]
+    fn a_bare_scalar_is_an_error() {
+        let err = run_returning("42").unwrap_err().to_string();
+        assert!(err.contains("expected (), a bool, or a map"), "{err}");
+    }
+
+    #[test]
+    fn a_script_that_throws_reports_the_hook_and_file() {
+        let err = run_returning(r#"throw "nope""#).unwrap_err().to_string();
+        assert!(err.contains("hooks.rhai"), "{err}");
+        assert!(err.contains("on_stage_enter"), "{err}");
+    }
+
+    #[test]
+    fn calling_a_hook_the_script_lacks_is_an_execution_error() {
+        let s = script("fn on_stage_enter(ctx) { () }");
+        assert!(run(&s, "on_stage_exit", serde_json::json!({})).is_err());
+    }
+
+    /// A value with no JSON representation cannot cross the boundary. The
+    /// caller gets a validation error naming the file, not a panic.
+    #[test]
+    fn a_return_that_is_not_plain_data_is_rejected() {
+        let err = run_returning("|| 1").unwrap_err().to_string();
+        assert!(err.contains("hooks.rhai"), "{err}");
+    }
+
+    // ─── the sandbox actually applies ─────────────────────────────────────
+
+    /// The hardening is not decoration: a hook is agent-adjacent code and must
+    /// not be able to reach the filesystem or spin forever.
+    #[test]
+    fn a_hook_cannot_reach_the_host() {
+        let s = script(r#"fn on_stage_enter(ctx) { open_file("/etc/passwd") }"#);
+        assert!(run(&s, "on_stage_enter", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn a_runaway_hook_is_stopped_by_the_operation_budget() {
+        let s = script("fn on_stage_enter(ctx) { let i = 0; while true { i += 1; } }");
+        let err = run(&s, "on_stage_enter", serde_json::json!({}))
+            .unwrap_err()
+            .to_string();
+        assert!(!err.is_empty(), "a runaway must fail, not hang");
+    }
+}


### PR DESCRIPTION
First of the multi-PR series for #260. This one is **the contract every later hook inherits**,
plus the blueprint and compile surface. The call sites follow in subsequent PRs — nothing in
here is wired into the pipeline yet, deliberately, so the contract can be argued with before
seven call sites depend on it.

### The outcome contract

Every hook returns one of four decisions, and the same four everywhere, so a blueprint author
does not learn a vocabulary per hook:

| script returns | meaning |
|---|---|
| `()` , `true` | allow, unchanged |
| `false` | cancel, no reason given |
| `#{ action: "modify", value: ... }` | proceed with `value` |
| `#{ action: "cancel", reason: "..." }` | do not proceed |
| `#{ action: "retry" }` | do it again |

`stage_hook` decides only that the script returned a **well-formed** decision. What `Modify`
and `Retry` *mean* is the calling hook's business — the shape of `value` differs between "the
regions to write" and "the request to send", and not every caller can honour `Retry`. That
split is why an unknown action is an error here (a typo'd `"modfiy"` must not read as allow)
while an *unhonourable* one is the caller's to report.

`HookOutcome` is deliberately not `Option<Value>`: unchanged, changed, and refused are three
answers, and collapsing them makes a hook that meant to stop something indistinguishable from
one that returned nothing.

### Shape borrowed wholesale from region hooks

A blueprint author who has written a custom region has already written one of these:
return-value contract (Rhai passes by value, so mutating `ctx` does nothing), compiled once at
spawn, a fresh hardened engine per call, JSON at the boundary so `leviath-runtime` needs no
`rhai` dependency. Same 100k operation budget, for the same reason — these are data transforms,
not the IO-driving script tools that get 500k.

```toml
[stages.implement.hooks]
on_stage_enter = "hooks/seed.rhai"
on_stage_exit  = "hooks/summarise.rhai"
```

The blueprint field and the Rhai function share a name on purpose: `on_stage_enter =
"hooks.rhai"` means "call `fn on_stage_enter(ctx)` in that file", with nothing in between to
look up. One file may back several hooks.

### Two things refused rather than ignored

- An **unknown hook name** in `[stages.<name>.hooks]` fails the parse (`on_stage_entry` →
  error naming the real ones).
- A file the blueprint **names for a hook it does not define** fails the compile.

Same hazard both times: a hook that never runs looks exactly like one that ran and allowed
everything, and the blueprint author is not there to notice. Arity is checked at compile too,
rather than failing at the first call some minutes into a run.

A stage that declares no hooks reads no file and builds no engine.

### Tests

22 in `stage_hook`, 5 in the manifest — every outcome shape driven through a real engine, both
refusals above, and two showing the sandbox is not decoration: a hook reaching for the
filesystem fails, and a `while true` is stopped by the operation budget rather than hanging
the tick.

`cargo xtask coverage` clean on `leviath-core` and `leviath-scripting`.

### What comes next

| PR | hooks |
|---|---|
| this one | framework + contract |
| 2 | `on_stage_enter`, `on_stage_exit` call sites |
| 3 | `before_inference`, `after_inference` |
| 4 | `on_tool_call` — needs care about how it composes with the taint gate |
| 5 | `on_completion`, `on_error` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
