### PR TITLE
feat(run): confirm a workdir an agent should probably not be pointed at (#252)

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -904,6 +904,7 @@ mod tests {
                 let mut setup = TestSetup {
                     enable_should_fail: true,
                     create_should_fail: false,
+                    draw_should_fail: false,
                 };
                 let mut events = TestEventSource::new(vec![]);
                 let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;
@@ -925,6 +926,7 @@ mod tests {
                 let mut setup = TestSetup {
                     enable_should_fail: false,
                     create_should_fail: true,
+                    draw_should_fail: false,
                 };
                 let mut events = TestEventSource::new(vec![]);
                 let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -892,6 +892,7 @@ mod tests {
         let mut enable_fails = TestSetup {
             enable_should_fail: true,
             create_should_fail: false,
+            draw_should_fail: false,
         };
         assert!(
             execute_core(&mut wizard, &env, &mut enable_fails, &mut events)
@@ -902,6 +903,7 @@ mod tests {
         let mut create_fails = TestSetup {
             enable_should_fail: false,
             create_should_fail: true,
+            draw_should_fail: false,
         };
         assert!(
             execute_core(&mut wizard, &env, &mut create_fails, &mut events)

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -324,6 +324,22 @@ pub struct ReadPathGrants {
 /// tracking for one agent - this one holds machine-wide switches.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecurityConfig {
+    /// Directories a run's workdir may sit under without being confirmed.
+    ///
+    /// **Empty by default**, which means "ask once about anything alarming"
+    /// rather than "ask about everything": a workdir is only questioned when it
+    /// is a home directory or a filesystem root, which is where an agent's file
+    /// writes do the most damage and the least good. Listing a path here says
+    /// "yes, I work there" and silences the prompt for it and everything under
+    /// it.
+    ///
+    /// This exists because the workdir defaults to wherever `lev run` was
+    /// invoked, and running from `~` is an easy thing to do by accident - issue
+    /// #252 is a machine that lost 115 GB to an agent writing under a profile
+    /// root. Confirming is cheap; noticing afterwards is not.
+    #[serde(default)]
+    pub allowed_workdirs: Vec<String>,
+
     /// Whether a blueprint's `seed = { command = "..." }` regions may run.
     ///
     /// **On by default.** A command seed executes at spawn - before the first
@@ -497,6 +513,7 @@ pub struct SecurityConfig {
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self {
+            allowed_workdirs: Vec::new(),
             allow_seed_commands: true,
             allow_local_network: false,
             allow_env_vars: Vec::new(),
@@ -3596,6 +3613,7 @@ enabled = false
                 env_var: ScriptPermission::Allow,
             },
             security: SecurityConfig {
+                allowed_workdirs: Vec::new(),
                 allow_seed_commands: false,
                 allow_local_network: true,
                 allow_env_vars: vec!["MY_PROVIDER_KEY".to_string()],

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -18,3 +18,4 @@ pub mod shell_keys;
 mod test_support;
 pub mod tools;
 pub mod tui;
+pub mod workdir_guard;

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -229,6 +229,35 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
     // directory branch already handles and what the docs have always promised.
     let path = args.path.as_deref().unwrap_or(".");
     let workdir = commands::run::effective_workdir(args.workdir, std::env::current_dir()?)?;
+    // Confirm a workdir an agent probably should not be pointed at (issue
+    // #252). Before resolving the task, so a cancelled run has not opened an
+    // editor first; `--yolo` and any non-terminal caller proceed with a warning
+    // rather than being refused.
+    {
+        let allowed = leviath_cli::config::Config::load()
+            .map(|c| c.security.allowed_workdirs)
+            .unwrap_or_default();
+        // `--yolo` means unattended, so it takes the warn-and-proceed path even
+        // on a terminal: the flag's whole meaning is "do not stop to ask".
+        let interactive = std::io::IsTerminal::is_terminal(&io::stdin()) && !args.yolo;
+        let ok = leviath_cli::workdir_guard::check(
+            std::path::Path::new(&workdir),
+            dirs::home_dir().as_deref(),
+            &allowed,
+            interactive,
+            &mut CrosstermSetup {
+                viewport: Viewport::Fullscreen,
+                mouse_capture: false,
+                enabled: false,
+            },
+            &mut CrosstermEventSource::new(),
+        )
+        .await;
+        if !ok {
+            println!("cancelled");
+            return Ok(());
+        }
+    }
     let spawn_args = leviath_cli::daemon::client::resolve_spawn_args(
         path,
         args.task.as_deref(),

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -265,6 +265,9 @@ mod test_doubles {
     pub(crate) struct TestSetup {
         pub(crate) enable_should_fail: bool,
         pub(crate) create_should_fail: bool,
+        /// Hand back a backend whose every draw fails, so a loop's draw-error
+        /// arm is reachable without a second `TerminalSetup` implementation.
+        pub(crate) draw_should_fail: bool,
     }
 
     impl TestSetup {
@@ -272,6 +275,7 @@ mod test_doubles {
             Self {
                 enable_should_fail: false,
                 create_should_fail: false,
+                draw_should_fail: false,
             }
         }
     }
@@ -290,7 +294,11 @@ mod test_doubles {
             if self.create_should_fail {
                 anyhow::bail!("simulated create_terminal failure");
             }
-            Terminal::new(TestBackendHarness::new(80, 24)).map_err(anyhow::Error::from)
+            let backend = match self.draw_should_fail {
+                true => TestBackendHarness::failing(80, 24),
+                false => TestBackendHarness::new(80, 24),
+            };
+            Terminal::new(backend).map_err(anyhow::Error::from)
         }
 
         fn disable(&mut self) {}
@@ -488,12 +496,14 @@ mod tests {
         let mut enable_fails = TestSetup {
             enable_should_fail: true,
             create_should_fail: false,
+            draw_should_fail: false,
         };
         assert!(enable_fails.enable().is_err());
 
         let mut create_fails = TestSetup {
             enable_should_fail: false,
             create_should_fail: true,
+            draw_should_fail: false,
         };
         assert!(create_fails.create_terminal().is_err());
     }

--- a/crates/leviath-cli/src/workdir_guard.rs
+++ b/crates/leviath-cli/src/workdir_guard.rs
@@ -1,0 +1,528 @@
+//! Confirming a workdir that is somewhere an agent probably should not write.
+//!
+//! `lev run`'s workdir defaults to wherever it was invoked, and running from a
+//! home directory is an easy accident. Issue #252 is a machine that lost 115 GB
+//! to an agent writing under a profile root; the agent was doing what it was
+//! told, in the directory it was given.
+//!
+//! So this asks - once, and only about the two shapes that are alarming:
+//!
+//! - a **home directory** (`~`, `/home/x`, `/Users/x`, `C:\Users\x`), where an
+//!   agent's writes land among everything the user owns, and
+//! - a **filesystem root** (`/`, `C:\`), where they land among everything.
+//!
+//! Anything else - a project directory, a scratch dir, a repo checkout - passes
+//! without a word. This is deliberately not an allowlist that must be populated
+//! before leviath is usable: a tool that asks about everything trains people to
+//! say yes to everything, which is the failure mode it would be trying to stop.
+//!
+//! With no terminal to ask on - CI, a pipe, `--yolo` - the run **proceeds**
+//! with a warning rather than being refused; breaking every unattended
+//! caller to enforce a prompt would trade one failure mode for a worse one.
+//!
+//! The decision is a pure function over paths ([`assess`]) so it can be tested
+//! without a filesystem or a terminal; asking the question is the caller's.
+
+/// What to do about a run's workdir.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkdirVerdict {
+    /// Nothing alarming, or the user has already said they work here.
+    Proceed,
+    /// Worth confirming. Carries what to tell the user.
+    Confirm(WorkdirConcern),
+}
+
+/// Why a workdir was questioned. Separate from the message so the caller can
+/// render it as a prompt, a refusal, or a log line without re-deriving it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkdirConcern {
+    /// The workdir is the user's home directory itself.
+    HomeDirectory,
+    /// The workdir is a filesystem root.
+    FilesystemRoot,
+}
+
+impl WorkdirConcern {
+    /// One line saying what is alarming about it.
+    pub fn headline(&self) -> &'static str {
+        match self {
+            Self::HomeDirectory => "That is your home directory.",
+            Self::FilesystemRoot => "That is a filesystem root.",
+        }
+    }
+
+    /// What an agent could do there, concretely rather than in the abstract.
+    pub fn detail(&self) -> &'static str {
+        match self {
+            Self::HomeDirectory => {
+                "An agent's file tools are confined to its workdir, so this run could read \
+                 and write anything in your home - including SSH keys, browser data, and \
+                 every other project you have."
+            }
+            Self::FilesystemRoot => {
+                "An agent's file tools are confined to its workdir, so this run would be \
+                 confined to the whole machine."
+            }
+        }
+    }
+}
+
+/// Decide whether `workdir` needs confirming.
+///
+/// `home` is the user's home directory (`None` when it cannot be resolved, in
+/// which case the home check simply cannot fire). `allowed` is
+/// `[security] allowed_workdirs`; a workdir at or under any entry proceeds.
+///
+/// Comparison is textual on already-canonicalised paths - `effective_workdir`
+/// canonicalises the `--workdir` flag, and the invocation directory is
+/// canonical by construction. This deliberately does not touch the filesystem:
+/// the check runs on every `lev run`, and a stat storm on the startup path
+/// would be a poor trade for catching a symlinked home.
+pub fn assess(
+    workdir: &std::path::Path,
+    home: Option<&std::path::Path>,
+    allowed: &[String],
+) -> WorkdirVerdict {
+    if allowed.iter().any(|a| is_within(workdir, a.as_ref())) {
+        return WorkdirVerdict::Proceed;
+    }
+    if workdir.parent().is_none() {
+        return WorkdirVerdict::Confirm(WorkdirConcern::FilesystemRoot);
+    }
+    if home.is_some_and(|h| h == workdir) {
+        return WorkdirVerdict::Confirm(WorkdirConcern::HomeDirectory);
+    }
+    WorkdirVerdict::Proceed
+}
+
+/// Whether `path` is `base` or sits under it.
+///
+/// Component-wise rather than a string prefix: `/home/alice-old` starts with
+/// `/home/alice` as text and is a different directory.
+fn is_within(path: &std::path::Path, base: &std::path::Path) -> bool {
+    // An empty entry would otherwise match everything, silencing the guard for
+    // every workdir - a typo in the config should not disable it.
+    if base.as_os_str().is_empty() {
+        return false;
+    }
+    path.starts_with(base)
+}
+
+/// What to warn when there is no terminal to ask on.
+///
+/// The run **proceeds**. Refusing would break every unattended caller - CI, a
+/// pipe, `--yolo` - and a prompt nobody can answer is worse still, because it
+/// parks the run until something times it out and reads as a hang.
+///
+/// The cost of that choice is that the guard is advisory in exactly the
+/// unattended case issue #252 came from, so this line is the whole mitigation:
+/// it goes to stderr on every such run, names the directory, and says how to
+/// silence it. Someone reading the log afterwards should be able to find the
+/// moment an agent was pointed at a home directory.
+pub fn non_interactive_warning(workdir: &std::path::Path, concern: &WorkdirConcern) -> String {
+    format!(
+        "warning: running in '{}'. {} {}\n\
+         Proceeding without confirmation - there is no terminal to ask on. Silence this by \
+         adding it to your config:\n\n\
+         [security]\nallowed_workdirs = [\"{}\"]\n\n\
+         Or pass --workdir to run somewhere else.",
+        workdir.display(),
+        concern.headline(),
+        concern.detail(),
+        workdir.display(),
+    )
+}
+
+// ─── Asking ──────────────────────────────────────────────────────────────────
+
+/// Put the question on screen and wait for an answer.
+///
+/// Generic over the same [`crate::tui::TerminalSetup`]/[`crate::tui::EventSource`] seams `lev setup`
+/// uses, so the whole flow runs against a `TestBackend` with canned keys - the
+/// real crossterm pair lives in the binary, where the terminal I/O belongs.
+///
+/// Returns whether to proceed. Anything that is not an explicit yes is a no:
+/// Esc, `n`, a closed event source, or a draw that fails. A confirmation that
+/// defaults to yes on an error is not a confirmation.
+pub async fn confirm_core<S: crate::tui::TerminalSetup, E: crate::tui::EventSource>(
+    workdir: &std::path::Path,
+    concern: &WorkdirConcern,
+    setup: &mut S,
+    events: &mut E,
+) -> bool {
+    use crate::tui::widgets::confirm::{Confirm, ConfirmOutcome};
+    use ratatui::text::Line;
+
+    let mut dialog = Confirm::new(
+        "Confirm working directory",
+        vec![
+            Line::from(format!("{}", workdir.display())),
+            Line::from(""),
+            Line::from(concern.headline()),
+            Line::from(""),
+            Line::from(concern.detail()),
+            Line::from(""),
+            Line::from("Add it to [security] allowed_workdirs to stop being asked."),
+        ],
+        "Run here",
+        "Cancel",
+    )
+    .danger();
+
+    if setup.enable().is_err() {
+        return false;
+    }
+    let Ok(mut terminal) = setup.create_terminal() else {
+        setup.disable();
+        return false;
+    };
+
+    let answer = loop {
+        if terminal.draw(|f| dialog.draw(f, f.area())).is_err() {
+            break false;
+        }
+        match events.poll_event(std::time::Duration::from_millis(120)) {
+            Ok(Some(crossterm::event::Event::Key(key)))
+                if key.kind == crossterm::event::KeyEventKind::Press =>
+            {
+                match dialog.handle(&key) {
+                    ConfirmOutcome::Yes => break true,
+                    ConfirmOutcome::No => break false,
+                    ConfirmOutcome::Pending => {}
+                }
+            }
+            // A tick, a resize, a key release: keep drawing and asking.
+            Ok(_) => {}
+            // The event source is gone. Nobody is going to answer, and the safe
+            // answer is the one that does not run.
+            Err(_) => break false,
+        }
+    };
+
+    setup.disable();
+    answer
+}
+
+/// The whole check, for `lev run`: assess, then ask or warn.
+///
+/// Returns whether the run may proceed. `interactive` is whether there is a
+/// terminal to ask on - when there is not (CI, a pipe, `--yolo`), the run
+/// proceeds with [`non_interactive_warning`] on stderr rather than being
+/// refused, because refusing would break every unattended caller.
+pub async fn check<S: crate::tui::TerminalSetup, E: crate::tui::EventSource>(
+    workdir: &std::path::Path,
+    home: Option<&std::path::Path>,
+    allowed: &[String],
+    interactive: bool,
+    setup: &mut S,
+    events: &mut E,
+) -> bool {
+    let WorkdirVerdict::Confirm(concern) = assess(workdir, home, allowed) else {
+        return true;
+    };
+    if !interactive {
+        eprintln!("{}", non_interactive_warning(workdir, &concern));
+        return true;
+    }
+    confirm_core(workdir, &concern, setup, events).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn home() -> Option<&'static Path> {
+        Some(Path::new("/Users/alice"))
+    }
+
+    #[test]
+    fn an_ordinary_project_directory_passes() {
+        assert_eq!(
+            assess(Path::new("/Users/alice/code/leviath"), home(), &[]),
+            WorkdirVerdict::Proceed
+        );
+    }
+
+    #[test]
+    fn the_home_directory_itself_is_questioned() {
+        assert_eq!(
+            assess(Path::new("/Users/alice"), home(), &[]),
+            WorkdirVerdict::Confirm(WorkdirConcern::HomeDirectory)
+        );
+    }
+
+    /// A directory *inside* home is the normal case and must not prompt -
+    /// otherwise the guard fires on nearly every run and stops being read.
+    #[test]
+    fn a_directory_under_home_is_not_questioned() {
+        assert_eq!(
+            assess(Path::new("/Users/alice/projects"), home(), &[]),
+            WorkdirVerdict::Proceed
+        );
+    }
+
+    #[test]
+    fn a_filesystem_root_is_questioned() {
+        assert_eq!(
+            assess(Path::new("/"), home(), &[]),
+            WorkdirVerdict::Confirm(WorkdirConcern::FilesystemRoot)
+        );
+    }
+
+    #[test]
+    fn an_allowed_directory_proceeds_even_when_it_is_home() {
+        assert_eq!(
+            assess(
+                Path::new("/Users/alice"),
+                home(),
+                &["/Users/alice".to_string()]
+            ),
+            WorkdirVerdict::Proceed
+        );
+    }
+
+    #[test]
+    fn an_allowed_directory_covers_what_is_under_it() {
+        assert_eq!(
+            assess(Path::new("/"), home(), &["/".to_string()]),
+            WorkdirVerdict::Proceed
+        );
+    }
+
+    /// Textual prefixes are not enough: these are different directories.
+    #[test]
+    fn a_sibling_with_a_shared_prefix_is_not_allowed_by_it() {
+        assert_eq!(
+            assess(
+                Path::new("/Users/alice-old"),
+                Some(Path::new("/Users/alice-old")),
+                &["/Users/alice".to_string()]
+            ),
+            WorkdirVerdict::Confirm(WorkdirConcern::HomeDirectory)
+        );
+    }
+
+    /// A typo that produced an empty entry must not silence the guard for
+    /// every workdir.
+    #[test]
+    fn an_empty_allowed_entry_matches_nothing() {
+        assert_eq!(
+            assess(Path::new("/Users/alice"), home(), &[String::new()]),
+            WorkdirVerdict::Confirm(WorkdirConcern::HomeDirectory)
+        );
+    }
+
+    #[test]
+    fn without_a_resolvable_home_the_home_check_cannot_fire() {
+        assert_eq!(
+            assess(Path::new("/Users/alice"), None, &[]),
+            WorkdirVerdict::Proceed
+        );
+    }
+
+    #[test]
+    fn both_concerns_explain_themselves() {
+        for c in [
+            WorkdirConcern::HomeDirectory,
+            WorkdirConcern::FilesystemRoot,
+        ] {
+            assert!(c.headline().ends_with('.'), "{c:?}");
+            assert!(c.detail().contains("confined"), "{c:?}");
+        }
+    }
+
+    /// The warning is the whole mitigation on the unattended path, so it has to
+    /// carry all three things someone needs: where it ran, that it was not
+    /// confirmed, and how to stop being asked.
+    #[test]
+    fn the_warning_names_the_directory_the_choice_and_the_fix() {
+        let msg =
+            non_interactive_warning(Path::new("/Users/alice"), &WorkdirConcern::HomeDirectory);
+        assert!(msg.contains("/Users/alice"), "{msg}");
+        assert!(msg.contains("Proceeding without confirmation"), "{msg}");
+        assert!(
+            msg.contains("allowed_workdirs = [\"/Users/alice\"]"),
+            "{msg}"
+        );
+        assert!(msg.contains("--workdir"), "{msg}");
+    }
+
+    // ─── the dialog ───────────────────────────────────────────────────────
+
+    use crate::tui::{TestEventSource, TestSetup};
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    async fn ask(events: Vec<Option<Event>>) -> bool {
+        confirm_core(
+            Path::new("/Users/alice"),
+            &WorkdirConcern::HomeDirectory,
+            &mut TestSetup::new(),
+            &mut TestEventSource::new_with_nones(events),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn y_runs_here() {
+        assert!(ask(vec![Some(key(KeyCode::Char('y')))]).await);
+    }
+
+    #[tokio::test]
+    async fn n_cancels() {
+        assert!(!ask(vec![Some(key(KeyCode::Char('n')))]).await);
+    }
+
+    #[tokio::test]
+    async fn esc_cancels() {
+        assert!(!ask(vec![Some(key(KeyCode::Esc))]).await);
+    }
+
+    /// Focus starts on Cancel, so a bare Enter must not run. This is the whole
+    /// point of using the two-button dialog rather than "y accepts, anything
+    /// else dismisses".
+    #[tokio::test]
+    async fn enter_alone_takes_the_safe_answer() {
+        assert!(!ask(vec![Some(key(KeyCode::Enter))]).await);
+    }
+
+    #[tokio::test]
+    async fn moving_focus_then_entering_runs_here() {
+        assert!(ask(vec![Some(key(KeyCode::Right)), Some(key(KeyCode::Enter)),]).await);
+    }
+
+    /// Ticks with no input keep the dialog up rather than answering it.
+    #[tokio::test]
+    async fn a_quiet_poll_does_not_answer() {
+        assert!(ask(vec![None, None, Some(key(KeyCode::Char('y')))]).await);
+    }
+
+    /// Every way of failing to ask resolves to "do not run". A confirmation
+    /// that defaults to yes when it cannot be shown is not a confirmation.
+    #[tokio::test]
+    async fn a_terminal_that_will_not_enable_cancels() {
+        let mut setup = TestSetup::new();
+        setup.enable_should_fail = true;
+        assert!(
+            !confirm_core(
+                Path::new("/Users/alice"),
+                &WorkdirConcern::HomeDirectory,
+                &mut setup,
+                &mut TestEventSource::new(vec![key(KeyCode::Char('y'))]),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn a_terminal_that_will_not_open_cancels() {
+        let mut setup = TestSetup::new();
+        setup.create_should_fail = true;
+        assert!(
+            !confirm_core(
+                Path::new("/Users/alice"),
+                &WorkdirConcern::HomeDirectory,
+                &mut setup,
+                &mut TestEventSource::new(vec![key(KeyCode::Char('y'))]),
+            )
+            .await
+        );
+    }
+
+    /// A terminal that cannot be drawn to cannot have shown the question, so
+    /// the answer is no. Same stance as the two failures above.
+    #[tokio::test]
+    async fn a_terminal_that_cannot_be_drawn_to_cancels() {
+        let mut setup = TestSetup::new();
+        setup.draw_should_fail = true;
+        assert!(
+            !confirm_core(
+                Path::new("/Users/alice"),
+                &WorkdirConcern::HomeDirectory,
+                &mut setup,
+                &mut TestEventSource::new(vec![key(KeyCode::Char('y'))]),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn an_event_source_that_dies_cancels() {
+        assert!(
+            !confirm_core(
+                Path::new("/Users/alice"),
+                &WorkdirConcern::HomeDirectory,
+                &mut TestSetup::new(),
+                &mut TestEventSource::failing(),
+            )
+            .await
+        );
+    }
+
+    /// A key *release* is not an answer - on Windows crossterm reports both
+    /// press and release, and answering on either would take the first of a
+    /// pair as two answers.
+    #[tokio::test]
+    async fn a_key_release_is_not_an_answer() {
+        let release = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        ));
+        assert!(!ask(vec![Some(release), Some(key(KeyCode::Esc))]).await);
+    }
+
+    // ─── the entry point ──────────────────────────────────────────────────
+
+    async fn check_in(dir: &str, interactive: bool, events: Vec<Event>) -> bool {
+        check(
+            Path::new(dir),
+            home(),
+            &[],
+            interactive,
+            &mut TestSetup::new(),
+            &mut TestEventSource::new(events),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn an_unremarkable_workdir_never_asks() {
+        // No events at all: if it tried to ask, the source would run dry and
+        // the answer would be "no", so `true` here proves it did not ask.
+        assert!(check_in("/Users/alice/code", true, vec![]).await);
+    }
+
+    #[tokio::test]
+    async fn an_alarming_workdir_asks_when_there_is_a_terminal() {
+        assert!(check_in("/Users/alice", true, vec![key(KeyCode::Char('y'))]).await);
+        assert!(!check_in("/Users/alice", true, vec![key(KeyCode::Char('n'))]).await);
+    }
+
+    /// The unattended path proceeds rather than refusing - breaking CI to
+    /// enforce a prompt trades one failure mode for a worse one. Again the
+    /// empty event list is the evidence that nothing was asked.
+    #[tokio::test]
+    async fn without_a_terminal_it_proceeds_rather_than_refusing() {
+        assert!(check_in("/Users/alice", false, vec![]).await);
+    }
+
+    #[tokio::test]
+    async fn an_allowed_workdir_does_not_ask_even_interactively() {
+        assert!(
+            check(
+                Path::new("/Users/alice"),
+                home(),
+                &["/Users/alice".to_string()],
+                true,
+                &mut TestSetup::new(),
+                &mut TestEventSource::new(vec![]),
+            )
+            .await
+        );
+    }
+}


### PR DESCRIPTION
Toward #252. `lev run`'s workdir defaults to wherever it was invoked, and running from a home
directory is an easy accident — that issue is a machine that lost 115 GB to an agent writing
under a profile root, doing exactly what it was told, in the directory it was given.

`lev run` now asks **once**, and only about the two shapes that are alarming:

- a **home directory**, where an agent's writes land among SSH keys, browser data, and every
  other project you have;
- a **filesystem root**, where "confined to the workdir" means the whole machine.

Anything else — a project dir, a scratch dir, a checkout — passes without a word. This is
deliberately **not** an allowlist you must populate before leviath is usable: a tool that asks
about everything trains people to say yes to everything, which is the failure mode it would be
trying to prevent. `[security] allowed_workdirs` silences it per path.

### Unattended runs proceed rather than being refused

With no terminal to ask on — CI, a pipe, `--yolo` — the run **warns and continues**. Refusing
would break every unattended caller, and a prompt nobody can answer parks the run until
something times it out, which reads as a hang.

Worth being explicit about the tradeoff: this makes the guard *advisory* in exactly the
unattended case #252 came from. So the warning is the whole mitigation, and it is written to
carry all three things someone needs afterwards — where it ran, that it was not confirmed, and
the config line to silence it:

```
warning: running in '/Users/gemisis'. That is your home directory. An agent's file tools
are confined to its workdir, so this run could read and write anything in your home -
including SSH keys, browser data, and every other project you have.
Proceeding without confirmation - there is no terminal to ask on. Silence this by adding
it to your config:

[security]
allowed_workdirs = ["/Users/gemisis"]
```

`--yolo` takes this path even on a terminal — the flag's whole meaning is "do not stop to ask".

### Shape

The decision is a pure function over paths (`assess`), tested without a filesystem or a
terminal. Asking reuses the crate's existing `Confirm` widget — two explicit buttons, focus on
the safe one — through the same injected `TerminalSetup`/`EventSource` seams `lev setup` uses,
so the whole dialog runs against a `TestBackend` with canned keys while the real crossterm pair
stays in the binary.

Path comparison is component-wise, not textual: `/home/alice-old` starts with `/home/alice` as
a string and is a different directory. An empty `allowed_workdirs` entry matches nothing, so a
typo cannot silently disable the guard.

### Every way of failing to ask is a "no"

Enable failure, terminal-open failure, draw failure, a dead event source, Esc, and a bare Enter
(focus starts on Cancel) all decline. A confirmation that defaults to yes when it cannot be
shown is not a confirmation. `TestSetup` gains a `draw_should_fail` switch so the draw-error arm
is reachable without a second `TerminalSetup` implementation.

### Verified live

Against a real daemon with stdin not a terminal:

| cwd | warned | run spawned |
|---|---|---|
| `/tmp/lvsec` (ordinary) | no | yes |
| `~` with `--yolo` | **yes** | yes |

26 unit tests; `cargo xtask coverage --package leviath-cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
