### PR TITLE
feat(hooks): fire on_stage_enter, and resolve hook scripts at spawn (#260, 2/5)

### DIFF
--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -155,6 +155,46 @@ pub(crate) fn resolve_output_validators(
     Ok(compiled)
 }
 
+/// Compile every stage-hook script the blueprint declares, keyed by the path as
+/// written (issue #260).
+///
+/// Fail-fast at spawn, exactly as region scripts are: an unreadable file, one
+/// that does not compile, or one the blueprint names for a hook it does not
+/// define is a spawn error rather than a surprise partway through a run. One
+/// file backing several hooks is read and compiled once.
+///
+/// Returns an empty map when no stage declares a hook, so the agent gets a
+/// component that every lookup misses rather than a special case.
+pub(crate) fn resolve_stage_hook_scripts(
+    blueprint: &Blueprint,
+    blueprint_path: &str,
+) -> Result<HashMap<String, Arc<leviath_scripting::stage_hook::HookScript>>, String> {
+    let base = std::path::Path::new(blueprint_path)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
+
+    // Gather what each file is wanted for before compiling, so a file backing
+    // two hooks is checked for both in one pass.
+    let mut wanted: HashMap<&str, Vec<&str>> = HashMap::new();
+    for stage in &blueprint.stages {
+        for (hook, path) in stage.hooks.declared() {
+            wanted.entry(path).or_default().push(hook);
+        }
+    }
+
+    let mut scripts = HashMap::new();
+    for (path, hooks) in wanted {
+        let full = base.join(path);
+        let source = std::fs::read_to_string(&full)
+            .map_err(|e| format!("cannot read stage hook script '{}': {e}", full.display()))?;
+        let compiled = leviath_scripting::stage_hook::compile(path, &source, &hooks)
+            .map_err(|e| format!("stage hook script '{path}' failed to compile: {e}"))?;
+        scripts.insert(path.to_string(), Arc::new(compiled));
+    }
+    Ok(scripts)
+}
+
 pub(crate) fn resolve_region_scripts(
     blueprint: &Blueprint,
     blueprint_path: &str,
@@ -1066,6 +1106,7 @@ fn build_agent_inner(
     // AND reloads (the hooks must work after a restart), and a broken script
     // is a hard error either way.
     let region_scripts = resolve_region_scripts(&blueprint, &args.blueprint_path)?;
+    let stage_hooks = resolve_stage_hook_scripts(&blueprint, &args.blueprint_path)?;
     let output_validators = resolve_output_validators(&blueprint, &args.blueprint_path)?;
 
     // Whether any stage can produce a file change the framework would see -
@@ -1091,6 +1132,16 @@ fn build_agent_inner(
         config.nudge.clone(),
         region_scripts,
     )?;
+
+    // Stage hooks, only when some stage declares one. Withholding the component
+    // rather than attaching an empty map is what makes "no hooks, no cost"
+    // literal: the hook systems' queries then skip the agent at the archetype
+    // level and never look at it again.
+    if !stage_hooks.is_empty() {
+        world
+            .entity_mut(entity)
+            .insert(leviath_runtime::components::StageHookScripts(stage_hooks));
+    }
 
     // 7. Attach run metadata / token totals / persistence watermark (+ optional
     // compaction settings).
@@ -1737,6 +1788,97 @@ system = { kind = "pinned", max_tokens = 1000 }
             resolve_output_validators(&bp, &manifest.to_string_lossy()).expect_err("wrong arity");
 
         assert!(err.contains("failed to compile"), "{err}");
+    }
+
+    // ─── resolve_stage_hook_scripts (issue #260) ─────────────────────────
+
+    fn hooked_manifest(hooks: &str) -> leviath_core::Blueprint {
+        leviath_core::manifest::parse_manifest(&format!(
+            "[agent]\nname = \"h\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = {{ provider = \"anthropic\", model = \"m\" }}\n{hooks}"
+        ))
+        .expect("the fixture manifest parses")
+    }
+
+    #[test]
+    fn stage_hooks_are_empty_when_no_stage_declares_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        let bp = hooked_manifest("");
+        let got = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn a_declared_hook_is_compiled_and_keyed_by_its_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(dir.path().join("h.rhai"), "fn on_stage_enter(ctx) { () }").unwrap();
+        let bp = hooked_manifest("[stages.main.hooks]\non_stage_enter = \"h.rhai\"\n");
+
+        let got = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert_eq!(got.len(), 1);
+        assert!(got["h.rhai"].defines("on_stage_enter"));
+    }
+
+    /// One file backing both hooks is read and compiled once, not twice.
+    #[test]
+    fn one_file_backing_two_hooks_is_compiled_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            dir.path().join("h.rhai"),
+            "fn on_stage_enter(ctx) { () } fn on_stage_exit(ctx) { () }",
+        )
+        .unwrap();
+        let bp = hooked_manifest(
+            "[stages.main.hooks]\non_stage_enter = \"h.rhai\"\non_stage_exit = \"h.rhai\"\n",
+        );
+
+        let got = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy()).unwrap();
+        assert_eq!(got.len(), 1, "one entry, not one per hook");
+        assert!(got["h.rhai"].defines("on_stage_enter"));
+        assert!(got["h.rhai"].defines("on_stage_exit"));
+    }
+
+    /// Fail-fast at spawn: a missing script must not become a runtime surprise
+    /// partway through a run.
+    #[test]
+    fn a_missing_hook_script_fails_the_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        let bp = hooked_manifest("[stages.main.hooks]\non_stage_enter = \"gone.rhai\"\n");
+
+        let err = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy())
+            .expect_err("a missing script is a spawn error");
+        assert!(err.contains("cannot read stage hook script"), "{err}");
+    }
+
+    #[test]
+    fn a_hook_script_that_does_not_compile_fails_the_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(dir.path().join("h.rhai"), "fn on_stage_enter(ctx) {").unwrap();
+        let bp = hooked_manifest("[stages.main.hooks]\non_stage_enter = \"h.rhai\"\n");
+
+        let err = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy())
+            .expect_err("a broken script is a spawn error");
+        assert!(err.contains("failed to compile"), "{err}");
+    }
+
+    /// The blueprint named this file for a hook it does not implement. Letting
+    /// that spawn would give a hook that never runs, which looks exactly like
+    /// one that ran and allowed everything.
+    #[test]
+    fn a_file_that_lacks_the_hook_it_was_named_for_fails_the_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(dir.path().join("h.rhai"), "fn on_stage_exit(ctx) { () }").unwrap();
+        let bp = hooked_manifest("[stages.main.hooks]\non_stage_enter = \"h.rhai\"\n");
+
+        let err = resolve_stage_hook_scripts(&bp, &manifest.to_string_lossy())
+            .expect_err("a file missing its named hook is a spawn error");
+        assert!(err.contains("defines no"), "{err}");
     }
 
     #[test]
@@ -3363,6 +3505,77 @@ system_prompt = "be brief"
         )
         .unwrap();
         manifest
+    }
+
+    /// A blueprint declaring a stage hook spawns with the compiled script
+    /// attached - the branch that only runs when some stage declared one.
+    #[tokio::test]
+    async fn build_agent_attaches_declared_stage_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("h.rhai"), "fn on_stage_enter(ctx) { () }").unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"h\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+             [stages.main.hooks]\non_stage_enter = \"h.rhai\"\n",
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect("spawn succeeds");
+
+        let scripts = world
+            .world_mut()
+            .get::<leviath_runtime::components::StageHookScripts>(entity)
+            .expect("the hook script is attached");
+        assert!(scripts.0.contains_key("h.rhai"));
+    }
+
+    /// A broken hook script fails the spawn rather than the run - the `?` on
+    /// the resolver, which is the whole point of resolving at spawn.
+    #[tokio::test]
+    async fn build_agent_refuses_a_broken_stage_hook() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("h.rhai"), "fn on_stage_enter(ctx) {").unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"h\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+             [stages.main.hooks]\non_stage_enter = \"h.rhai\"\n",
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let err = build_agent(
+            world.world_mut(),
+            cli.as_ref(),
+            &Config::default(),
+            mcp,
+            &[],
+            &hub,
+            &spawn_args(&manifest.to_string_lossy()),
+            100,
+            sub_tx(),
+        )
+        .expect_err("a broken hook script must fail the spawn");
+        assert!(err.contains("failed to compile"), "{err}");
     }
 
     /// A granted `[read_paths]` spawns cleanly, with taint on so the read-tool

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -343,6 +343,43 @@ pub struct ContextWindow {
     >,
 }
 
+/// Compiled stage-hook scripts for an agent, keyed by the script path the
+/// blueprint wrote (issue #260).
+///
+/// Populated once at spawn by the CLI, which resolves blueprint-dir-relative
+/// paths and compile-checks the files - the same lifecycle
+/// [`ContextWindow::region_scripts`] has, and for the same reason: a broken
+/// script must fail the spawn, not the run.
+///
+/// The component is absent entirely on an agent whose blueprint declares no
+/// hooks, so the hook systems' queries skip it and nothing about the scripting
+/// engine is touched.
+#[derive(Component, Debug, Clone, Default)]
+pub struct StageHookScripts(
+    pub std::collections::HashMap<String, std::sync::Arc<leviath_scripting::stage_hook::HookScript>>,
+);
+
+impl StageHookScripts {
+    /// The compiled script backing `hook` for this stage, when the stage
+    /// declares one and it is on file.
+    ///
+    /// Returns `None` rather than erroring on a miss: spawn already refused a
+    /// blueprint whose script was unreadable or did not define what it was
+    /// named for, so a miss here means the stage simply has no such hook.
+    pub fn script_for(
+        &self,
+        stage: &leviath_core::Stage,
+        hook: &str,
+    ) -> Option<std::sync::Arc<leviath_scripting::stage_hook::HookScript>> {
+        let path = match hook {
+            "on_stage_enter" => stage.hooks.on_stage_enter.as_deref(),
+            "on_stage_exit" => stage.hooks.on_stage_exit.as_deref(),
+            _ => None,
+        }?;
+        self.0.get(path).cloned()
+    }
+}
+
 impl ContextWindow {
     /// Create a new context window with the specified budget.
     pub fn new(max_tokens: usize) -> Self {
@@ -4269,5 +4306,65 @@ mod tests {
         ] {
             assert!(!reason.needs_a_person(), "{reason} resolves on its own");
         }
+    }
+}
+
+#[cfg(test)]
+mod stage_hook_scripts_tests {
+    use super::*;
+
+    fn scripts(path: &str) -> StageHookScripts {
+        let compiled = leviath_scripting::stage_hook::compile(
+            path,
+            "fn on_stage_enter(ctx) { () } fn on_stage_exit(ctx) { () }",
+            &[],
+        )
+        .expect("compiles");
+        let mut m = std::collections::HashMap::new();
+        m.insert(path.to_string(), std::sync::Arc::new(compiled));
+        StageHookScripts(m)
+    }
+
+    fn stage_declaring(enter: Option<&str>, exit: Option<&str>) -> leviath_core::Stage {
+        let mut s = leviath_core::Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        );
+        s.hooks.on_stage_enter = enter.map(str::to_string);
+        s.hooks.on_stage_exit = exit.map(str::to_string);
+        s
+    }
+
+    #[test]
+    fn each_hook_resolves_to_the_file_its_stage_named() {
+        let s = scripts("h.rhai");
+        let stage = stage_declaring(Some("h.rhai"), Some("h.rhai"));
+        assert!(s.script_for(&stage, "on_stage_enter").is_some());
+        assert!(s.script_for(&stage, "on_stage_exit").is_some());
+    }
+
+    #[test]
+    fn a_hook_the_stage_did_not_declare_resolves_to_nothing() {
+        let s = scripts("h.rhai");
+        let stage = stage_declaring(Some("h.rhai"), None);
+        assert!(s.script_for(&stage, "on_stage_exit").is_none());
+    }
+
+    /// A hook name this build does not implement resolves to nothing rather
+    /// than panicking - the caller asks by string.
+    #[test]
+    fn an_unknown_hook_name_resolves_to_nothing() {
+        let s = scripts("h.rhai");
+        let stage = stage_declaring(Some("h.rhai"), None);
+        assert!(s.script_for(&stage, "on_nothing").is_none());
+    }
+
+    /// Declared but not on file: spawn already refused that, so a miss here
+    /// means the stage simply has no such hook.
+    #[test]
+    fn a_declared_path_with_no_compiled_script_resolves_to_nothing() {
+        let s = scripts("other.rhai");
+        let stage = stage_declaring(Some("h.rhai"), None);
+        assert!(s.script_for(&stage, "on_stage_enter").is_none());
     }
 }

--- a/crates/leviath-runtime/src/pipeline/hooks.rs
+++ b/crates/leviath-runtime/src/pipeline/hooks.rs
@@ -1,0 +1,155 @@
+//! Running a stage's script hooks (issue #260).
+//!
+//! The contract lives in [`leviath_scripting::stage_hook`]; this module is the
+//! pipeline half - when each hook fires, what the script is shown, and what
+//! each outcome does to the agent.
+//!
+//! # Where `on_stage_enter` fires
+//!
+//! On the [`StageJustEntered`] marker the transition systems already set, and
+//! **before** `sync_tool_stages`, which consumes it. That puts the hook after
+//! the stage's layout and system prompt are in place (so it can read and write
+//! real regions) and before the first inference of the stage is built (so what
+//! it writes is in the request).
+//!
+//! Firing off a marker rather than inside `enter_stage` is deliberate:
+//! `enter_stage` is a pure function called from three places, and threading the
+//! compiled scripts plus an error channel through all of them would put script
+//! execution in the middle of a transition. Here it is one system, one query,
+//! and the failure modes stay at the tick boundary.
+
+use super::*;
+use crate::components::StageHookScripts;
+use leviath_scripting::stage_hook::{HookOutcome, run};
+
+/// The `ctx` a stage hook is shown.
+///
+/// Deliberately a snapshot rather than a handle: Rhai passes by value, so a
+/// script could not mutate a live window even if it were given one, and
+/// building the map is what makes the contract inspectable.
+fn stage_ctx(stage_name: &str, index: usize, window: &ContextWindow) -> serde_json::Value {
+    // Entries joined, not the entry list: a hook that wants to seed or rewrite a
+    // region thinks in text, and handing it the internal entry shape would make
+    // the ctx an implementation detail scripts then depend on.
+    let regions: serde_json::Map<String, serde_json::Value> = window
+        .regions
+        .iter()
+        .map(|r| {
+            let text = r
+                .content
+                .iter()
+                .map(|e| e.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            (r.name.clone(), serde_json::Value::String(text))
+        })
+        .collect();
+    serde_json::json!({
+        "stage": stage_name,
+        "stage_index": index,
+        "regions": regions,
+    })
+}
+
+/// Apply a `modify` outcome: write each named region's new content.
+///
+/// A name the window does not have is reported rather than ignored. The script
+/// asked to write somewhere that does not exist, which is a bug in the script
+/// or a stale region name in the blueprint - and silently dropping it would
+/// look exactly like a hook that ran and chose to write nothing.
+fn apply_modify(window: &mut ContextWindow, value: &serde_json::Value) -> Result<(), String> {
+    let Some(obj) = value.as_object() else {
+        return Err(format!(
+            "on_stage_enter: 'value' must be a map of region name to content, got: {value}"
+        ));
+    };
+    for (name, content) in obj {
+        let Some(text) = content.as_str() else {
+            return Err(format!(
+                "on_stage_enter: region '{name}' must be given a string, got: {content}"
+            ));
+        };
+        let Some(region) = window.get_region_mut(name) else {
+            return Err(format!(
+                "on_stage_enter: no region '{name}' in this stage's layout"
+            ));
+        };
+        // Replace, not append: the hook was shown the region's whole text and
+        // returned what it should be. Appending would make a hook that echoes
+        // its input double the region every time the stage is re-entered.
+        region.clear();
+        if !text.is_empty() {
+            region
+                .add_entry(text.to_string(), leviath_core::estimate_tokens(text))
+                .map_err(|e| format!("on_stage_enter: writing region '{name}': {e}"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Run every entering agent's `on_stage_enter` hook.
+///
+/// Ordered before `sync_tool_stages` (which clears [`StageJustEntered`]) and
+/// therefore before the stage's first inference is built.
+pub fn run_stage_enter_hooks(
+    mut agents: Query<(
+        Entity,
+        &StageJustEntered,
+        &AgentBlueprint,
+        &StageHookScripts,
+        &mut ContextWindow,
+        &mut AgentState,
+    )>,
+) {
+    crate::tick_scope::clear();
+    for (entity, entered, bp, scripts, mut window, mut state) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        let Some(stage) = bp.0.stages.get(entered.index) else {
+            continue;
+        };
+        let Some(script) = scripts.script_for(stage, "on_stage_enter") else {
+            continue;
+        };
+
+        let ctx = stage_ctx(&entered.name, entered.index, &window);
+        let outcome = match run(&script, "on_stage_enter", ctx) {
+            Ok(o) => o,
+            Err(e) => {
+                // A hook that fails is not a hook that allowed. Failing the run
+                // is the same stance `enter_stage` takes on a prompt that will
+                // not fit: the stage cannot start as configured.
+                state.status = AgentStatus::Error {
+                    message: format!("on_stage_enter hook failed: {e}"),
+                };
+                continue;
+            }
+        };
+
+        match outcome {
+            HookOutcome::Allow => {}
+            HookOutcome::Modify(value) => {
+                if let Err(e) = apply_modify(&mut window, &value) {
+                    state.status = AgentStatus::Error { message: e };
+                }
+            }
+            HookOutcome::Cancel(reason) => {
+                let why = reason.unwrap_or_else(|| "no reason given".to_string());
+                state.status = AgentStatus::Error {
+                    message: format!("on_stage_enter refused stage '{}': {why}", entered.name),
+                };
+            }
+            // Retrying entry into a stage the agent is already in has no
+            // meaning. Saying so beats treating it as `Allow`, which would let
+            // a script think it had asked for something.
+            HookOutcome::Retry => {
+                state.status = AgentStatus::Error {
+                    message: format!(
+                        "on_stage_enter returned 'retry', which this hook cannot honour \
+                         (stage '{}' is already entered)",
+                        entered.name
+                    ),
+                };
+            }
+        }
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -34,6 +34,8 @@ use crate::tool_bridge::{BoxedToolExec, ToolJob, ToolOutcome};
 // Sections of the former single-file pipeline, one per concern.
 mod transition;
 pub use transition::*;
+mod hooks;
+pub use hooks::*;
 mod watchdog;
 pub use watchdog::*;
 mod requirements;

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -10229,3 +10229,364 @@ fn entering_a_stage_clears_the_output_reentry_count() {
     world.flush();
     assert!(world.get::<OutputReentries>(e).is_none());
 }
+
+// ─── on_stage_enter (issue #260) ─────────────────────────────────────────────
+
+fn hook_scripts(src: &str, wanted: &[&str]) -> crate::components::StageHookScripts {
+    let compiled = leviath_scripting::stage_hook::compile("h.rhai", src, wanted)
+        .expect("the fixture script compiles");
+    let mut map = std::collections::HashMap::new();
+    map.insert("h.rhai".to_string(), std::sync::Arc::new(compiled));
+    crate::components::StageHookScripts(map)
+}
+
+/// A one-stage blueprint whose stage names `h.rhai` for `on_stage_enter`.
+fn hooked_bp() -> AgentBlueprint {
+    let mut stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    stage.hooks.on_stage_enter = Some("h.rhai".to_string());
+    AgentBlueprint(blueprint(vec![stage]))
+}
+
+fn spawn_hooked(world: &mut World, src: &str) -> Entity {
+    world
+        .spawn((
+            hooked_bp(),
+            agent_state(),
+            conv_window(),
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            hook_scripts(src, &["on_stage_enter"]),
+        ))
+        .id()
+}
+
+fn run_stage_hooks(world: &mut World) {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(run_stage_enter_hooks);
+    schedule.run(world);
+}
+
+fn region_text(world: &World, e: Entity, name: &str) -> String {
+    world
+        .get::<ContextWindow>(e)
+        .expect("window")
+        .get_region(name)
+        .expect("region")
+        .content
+        .iter()
+        .map(|x| x.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn a_hook_that_allows_changes_nothing_and_leaves_the_agent_running() {
+    let mut world = World::new();
+    let e = spawn_hooked(&mut world, "fn on_stage_enter(ctx) { () }");
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+    assert!(matches!(
+        world.get::<AgentState>(e).expect("state").status,
+        AgentStatus::Active | AgentStatus::Idle
+    ));
+}
+
+/// The hook's whole point: seed a region before the stage's first inference.
+#[test]
+fn a_hook_can_write_a_region_on_entry() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: "seeded" } } }"#,
+    );
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "seeded");
+}
+
+/// The script is shown the stage it is entering, not a placeholder.
+#[test]
+fn the_hook_sees_the_stage_it_is_entering() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: ctx.stage } } }"#,
+    );
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "main");
+}
+
+/// Replace, not append - otherwise a hook that echoes its input doubles the
+/// region every time the stage is re-entered.
+#[test]
+fn writing_a_region_replaces_it_rather_than_appending() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: "once" } } }"#,
+    );
+    run_stage_hooks(&mut world);
+    // Re-enter the same stage; the marker is what drives the hook.
+    world.entity_mut(e).insert(StageJustEntered {
+        index: 0,
+        name: "main".to_string(),
+    });
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "once");
+}
+
+#[test]
+fn a_hook_can_refuse_the_stage_and_the_reason_reaches_the_run() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "cancel", reason: "over budget" } }"#,
+    );
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("a refused stage must error the run");
+    };
+    assert!(message.contains("over budget"), "{message}");
+}
+
+/// A hook that throws is not a hook that allowed. Treating a failed script as
+/// permission is how a gate silently stops gating.
+#[test]
+fn a_hook_that_fails_errors_the_run_rather_than_proceeding() {
+    let mut world = World::new();
+    let e = spawn_hooked(&mut world, r#"fn on_stage_enter(ctx) { throw "boom" }"#);
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("a failing hook must error the run");
+    };
+    assert!(message.contains("on_stage_enter hook failed"), "{message}");
+}
+
+#[test]
+fn writing_a_region_the_stage_does_not_have_errors_rather_than_being_dropped() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ nope: "x" } } }"#,
+    );
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("writing an unknown region must error");
+    };
+    assert!(message.contains("no region 'nope'"), "{message}");
+}
+
+#[test]
+fn a_non_string_region_value_errors() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: 42 } } }"#,
+    );
+    run_stage_hooks(&mut world);
+    assert!(matches!(
+        world.get::<AgentState>(e).expect("state").status,
+        AgentStatus::Error { .. }
+    ));
+}
+
+#[test]
+fn a_modify_value_that_is_not_a_map_errors() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "modify", value: "just a string" } }"#,
+    );
+    run_stage_hooks(&mut world);
+    assert!(matches!(
+        world.get::<AgentState>(e).expect("state").status,
+        AgentStatus::Error { .. }
+    ));
+}
+
+/// `retry` has no meaning for a stage already entered. Saying so beats treating
+/// it as allow, which would let a script believe it had asked for something.
+#[test]
+fn retry_is_reported_as_unhonourable_rather_than_silently_allowed() {
+    let mut world = World::new();
+    let e = spawn_hooked(
+        &mut world,
+        r#"fn on_stage_enter(ctx) { #{ action: "retry" } }"#,
+    );
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("an unhonourable outcome must be reported");
+    };
+    assert!(message.contains("cannot honour"), "{message}");
+}
+
+/// An agent with no hook component is skipped entirely - this is what "no
+/// hooks, no cost" means, and the system must not panic on its absence.
+#[test]
+fn an_agent_without_hooks_is_untouched() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            hooked_bp(),
+            agent_state(),
+            conv_window(),
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+        ))
+        .id();
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+}
+
+/// A stage index the blueprint does not have cannot be looked up; the system
+/// skips rather than panicking on the slice.
+#[test]
+fn an_out_of_range_stage_index_is_skipped() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            hooked_bp(),
+            agent_state(),
+            conv_window(),
+            StageJustEntered {
+                index: 99,
+                name: "gone".to_string(),
+            },
+            hook_scripts(
+                r#"fn on_stage_enter(ctx) { #{ action: "cancel", reason: "should not run" } }"#,
+                &["on_stage_enter"],
+            ),
+        ))
+        .id();
+    run_stage_hooks(&mut world);
+    assert!(!matches!(
+        world.get::<AgentState>(e).expect("state").status,
+        AgentStatus::Error { .. }
+    ));
+}
+
+/// A stage that declares no hook is not run even when the agent carries
+/// scripts - another stage in the same blueprint may have declared them.
+#[test]
+fn a_stage_that_declares_no_hook_does_not_run_one() {
+    let mut world = World::new();
+    let stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    let e = world
+        .spawn((
+            AgentBlueprint(blueprint(vec![stage])),
+            agent_state(),
+            conv_window(),
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            hook_scripts(
+                r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: "ran" } } }"#,
+                &["on_stage_enter"],
+            ),
+        ))
+        .id();
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+}
+
+/// A write the region cannot hold is reported, not swallowed. `add_entry`
+/// refuses an entry over the region's budget, and a hook whose write silently
+/// vanished would look exactly like one that chose to write nothing.
+#[test]
+fn a_region_write_that_does_not_fit_errors() {
+    let mut world = World::new();
+    let mut window = ContextWindow::new(10_000);
+    // A budget too small for anything the hook could write.
+    window.add_region(Region::new(
+        "conversation".to_string(),
+        RegionKind::Clearable,
+        1,
+    ));
+    let e = world
+        .spawn((
+            hooked_bp(),
+            agent_state(),
+            window,
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            hook_scripts(
+                r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: "a much longer string than one token" } } }"#,
+                &["on_stage_enter"],
+            ),
+        ))
+        .id();
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("a write that does not fit must error");
+    };
+    assert!(
+        message.contains("writing region 'conversation'"),
+        "{message}"
+    );
+}
+
+/// Writing an empty string clears the region rather than storing a blank
+/// entry - "" is how a hook says "there should be nothing here".
+#[test]
+fn writing_an_empty_string_clears_the_region() {
+    let mut world = World::new();
+    let mut window = conv_window();
+    window
+        .get_region_mut("conversation")
+        .expect("region")
+        .add_entry("something".to_string(), 1)
+        .expect("seeded");
+    let e = world
+        .spawn((
+            hooked_bp(),
+            agent_state(),
+            window,
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            hook_scripts(
+                r#"fn on_stage_enter(ctx) { #{ action: "modify", value: #{ conversation: "" } } }"#,
+                &["on_stage_enter"],
+            ),
+        ))
+        .id();
+    run_stage_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+    assert!(
+        world
+            .get::<ContextWindow>(e)
+            .expect("window")
+            .get_region("conversation")
+            .expect("region")
+            .content
+            .is_empty(),
+        "an empty write leaves no entry behind"
+    );
+}
+
+/// A bare `false` refuses with no reason. The message still has to say the
+/// stage was refused, or an operator sees a failed run and no cause at all.
+#[test]
+fn a_refusal_without_a_reason_still_says_it_was_refused() {
+    let mut world = World::new();
+    let e = spawn_hooked(&mut world, "fn on_stage_enter(ctx) { false }");
+    run_stage_hooks(&mut world);
+    let AgentStatus::Error { message } = &world.get::<AgentState>(e).expect("state").status else {
+        panic!("a bare false must refuse");
+    };
+    assert!(message.contains("refused stage 'main'"), "{message}");
+    assert!(message.contains("no reason given"), "{message}");
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -45,7 +45,8 @@ use crate::pipeline::{
     dispatch_tools, dispatch_transition_choice, enforce_max_iterations, fail_stalled_dispatch,
     fail_wedged_runs, gate_requires_children, handle_empty_response, poll_dynamic_tool_refresh,
     process_response, reflect_interaction_status, refresh_advertised_tools,
-    require_context_regions, require_final_output, resolve_transition, sync_tool_stages,
+    require_context_regions, require_final_output, resolve_transition, run_stage_enter_hooks,
+    sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::ToolLane;
@@ -370,6 +371,11 @@ impl PipelineWorld {
                 // `StageJustEntered` marker) and before `dispatch_persistence`
                 // (which drains the log buffer this system only reads).
                 crate::telemetry::observe_lifecycle,
+                // A stage's `on_stage_enter` script, before `sync_tool_stages`
+                // consumes the `StageJustEntered` marker it fires on - so the
+                // hook sees the stage's layout and prompt already in place, and
+                // whatever it writes is in the stage's first request.
+                run_stage_enter_hooks,
                 sync_tool_stages,
                 // Store any finished run title, then start newly-marked ones.
                 // Collect precedes persistence so a landed title is written on


### PR DESCRIPTION
feat(hooks): fire on_stage_enter, and resolve hook scripts at spawn

Second of the series for #260. The framework landed in #278; this wires the
first hook to a call site and proves the contract end to end.

### Where it fires, and why there

On the `StageJustEntered` marker the transition systems already set, scheduled
before `sync_tool_stages`, which consumes it. That puts the hook after the
stage's layout and system prompt are in place - so it can read and write real
regions - and before the stage's first inference is built, so what it writes is
in that request.

Firing off a marker rather than inside `enter_stage` is deliberate. `enter_stage`
is a pure function called from three places, and threading the compiled scripts
plus an error channel through all of them would put script execution in the
middle of a transition. As a system it is one query, and the failure modes stay
at the tick boundary.

### What a hook sees and can do

`ctx` is `#{ stage, stage_index, regions }`, with each region's entries joined
into text - a hook that wants to seed or rewrite thinks in text, and handing it
the internal entry shape would make the ctx an implementation detail scripts
then depend on.

`modify` replaces a region rather than appending: the hook was shown the whole
text and returned what it should be, so appending would make a hook that echoes
its input double the region on every re-entry. Writing `""` clears it.

### Failures are failures, not permission

A hook that throws, refuses, names a region the stage does not have, returns a
non-string, or returns `retry` (which entry cannot honour) errors the run. A
failing script must never read as one that allowed - that is how a gate quietly
stops gating.

### Resolution at spawn

`resolve_stage_hook_scripts` reads and compiles each declared file once, keyed
by path, checking each is defined for every hook it was named for. Unreadable,
uncompilable, or missing-the-named-hook all fail the spawn, matching how region
scripts already behave.

The component is attached **only when some stage declared a hook**. Withholding
it rather than attaching an empty map is what makes "no hooks, no cost" literal:
the system's query then skips those agents at the archetype level.

### Tests

18 new. Both refusal paths, both malformed-write paths, the empty-string clear,
a write that will not fit its region, re-entry proving replace-not-append, an
out-of-range stage index, an agent with no hooks, a stage that declared none
while a sibling did, and the two spawn failures.

1156 runtime tests and 3026 cli tests passing; `cargo xtask coverage` clean on
both.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
