### PR TITLE
feat(hooks): before_inference and after_inference (#260, 3/5)

### DIFF
--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -784,13 +784,22 @@ pub struct StageHooks {
     /// Fires when the stage finishes, before transition evaluation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_stage_exit: Option<String>,
+    /// Fires with the context assembled, before the request is dispatched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_inference: Option<String>,
+    /// Fires with the model's response in hand, before it reaches context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_inference: Option<String>,
 }
 
 impl StageHooks {
     /// Whether any hook is declared. The whole feature is skipped when not -
     /// no file read, no compile, no engine.
     pub fn is_empty(&self) -> bool {
-        self.on_stage_enter.is_none() && self.on_stage_exit.is_none()
+        self.on_stage_enter.is_none()
+            && self.on_stage_exit.is_none()
+            && self.before_inference.is_none()
+            && self.after_inference.is_none()
     }
 
     /// Every script path this stage declares, with the hook it backs.
@@ -804,6 +813,12 @@ impl StageHooks {
         }
         if let Some(p) = self.on_stage_exit.as_deref() {
             out.push(("on_stage_exit", p));
+        }
+        if let Some(p) = self.before_inference.as_deref() {
+            out.push(("before_inference", p));
+        }
+        if let Some(p) = self.after_inference.as_deref() {
+            out.push(("after_inference", p));
         }
         out
     }

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -883,10 +883,13 @@ fn parse_stage_hooks(
         match key.as_str() {
             "on_stage_enter" => hooks.on_stage_enter = Some(path.to_string()),
             "on_stage_exit" => hooks.on_stage_exit = Some(path.to_string()),
+            "before_inference" => hooks.before_inference = Some(path.to_string()),
+            "after_inference" => hooks.after_inference = Some(path.to_string()),
             other => {
                 return Err(Error::Other(format!(
                     "stage '{stage_name}': unknown hook '{other}' \
-                     (this build implements: on_stage_enter, on_stage_exit)"
+                     (this build implements: on_stage_enter, on_stage_exit, \
+                     before_inference, after_inference)"
                 )));
             }
         }
@@ -1547,17 +1550,46 @@ mod tests {
         assert!(stage.hooks.declared().is_empty());
     }
 
+    /// Every hook this build implements, in one fixture: each parses, and each
+    /// reports the function it backs. A hook that parsed but never appeared in
+    /// `declared()` would be resolved at spawn and then never called.
     #[test]
-    fn both_hooks_parse_and_report_the_function_they_back() {
+    fn every_hook_parses_and_reports_the_function_it_backs() {
         let stage = stage_with_hooks(
-            "[stages.main.hooks]\non_stage_enter = \"a.rhai\"\non_stage_exit = \"b.rhai\"",
+            "[stages.main.hooks]\n\
+             on_stage_enter = \"a.rhai\"\n\
+             on_stage_exit = \"b.rhai\"\n\
+             before_inference = \"c.rhai\"\n\
+             after_inference = \"d.rhai\"",
         )
         .expect("parses");
         assert!(!stage.hooks.is_empty());
         assert_eq!(
             stage.hooks.declared(),
-            vec![("on_stage_enter", "a.rhai"), ("on_stage_exit", "b.rhai")]
+            vec![
+                ("on_stage_enter", "a.rhai"),
+                ("on_stage_exit", "b.rhai"),
+                ("before_inference", "c.rhai"),
+                ("after_inference", "d.rhai"),
+            ]
         );
+    }
+
+    /// Each hook alone also leaves `is_empty` false - a stage declaring only
+    /// the newest hook must still get its scripts resolved.
+    #[test]
+    fn any_single_hook_makes_the_stage_hooked() {
+        for field in [
+            "on_stage_enter",
+            "on_stage_exit",
+            "before_inference",
+            "after_inference",
+        ] {
+            let stage = stage_with_hooks(&format!("[stages.main.hooks]\n{field} = \"h.rhai\""))
+                .expect("parses");
+            assert!(!stage.hooks.is_empty(), "{field}");
+            assert_eq!(stage.hooks.declared(), vec![(field, "h.rhai")], "{field}");
+        }
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -374,6 +374,8 @@ impl StageHookScripts {
         let path = match hook {
             "on_stage_enter" => stage.hooks.on_stage_enter.as_deref(),
             "on_stage_exit" => stage.hooks.on_stage_exit.as_deref(),
+            "before_inference" => stage.hooks.before_inference.as_deref(),
+            "after_inference" => stage.hooks.after_inference.as_deref(),
             _ => None,
         }?;
         self.0.get(path).cloned()

--- a/crates/leviath-runtime/src/pipeline/hooks.rs
+++ b/crates/leviath-runtime/src/pipeline/hooks.rs
@@ -153,3 +153,162 @@ pub fn run_stage_enter_hooks(
         }
     }
 }
+
+/// Set the agent's status from a hook outcome the caller could not honour.
+///
+/// Shared by the hooks below so "a failed hook is not an allowed hook" is
+/// written once rather than restated per call site with a chance to drift.
+fn refuse(state: &mut AgentState, hook: &str, what: String) {
+    state.status = AgentStatus::Error {
+        message: format!("{hook}: {what}"),
+    };
+}
+
+/// Run `before_inference` for every agent about to infer.
+///
+/// Scheduled before `dispatch_inference`, on the same `ReadyToInfer` marker it
+/// queries. The context window is assembled by then, so `modify` here reaches
+/// the request: `build_request` reads the window fresh at dispatch.
+///
+/// Fired from its own system rather than inside `dispatch_inference` because
+/// that system's per-agent body runs in parallel on the compute pool, where a
+/// panicking script would be attributed by different machinery. Sequential here
+/// costs a query pass and keeps script failures at the tick boundary.
+#[allow(clippy::type_complexity)]
+pub fn run_before_inference_hooks(
+    mut agents: Query<
+        (
+            Entity,
+            &StageCursor,
+            &AgentBlueprint,
+            &StageHookScripts,
+            &mut ContextWindow,
+            &mut AgentState,
+        ),
+        With<ReadyToInfer>,
+    >,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, cursor, bp, scripts, mut window, mut state) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        let Some(stage) = bp.0.stages.get(cursor.index) else {
+            continue;
+        };
+        let Some(script) = scripts.script_for(stage, "before_inference") else {
+            continue;
+        };
+
+        let ctx = stage_ctx(&stage.name, cursor.index, &window);
+        match run(&script, "before_inference", ctx) {
+            Err(e) => refuse(&mut state, "before_inference", format!("hook failed: {e}")),
+            Ok(HookOutcome::Allow) => {}
+            Ok(HookOutcome::Modify(value)) => {
+                if let Err(e) = apply_modify(&mut window, &value) {
+                    refuse(&mut state, "before_inference", e);
+                }
+            }
+            // Skipping the call is what `cancel` means here, and the agent
+            // stops rather than silently inferring anyway. `ReadyToInfer` is
+            // removed so `dispatch_inference` does not pick it up this tick.
+            Ok(HookOutcome::Cancel(reason)) => {
+                let why = reason.unwrap_or_else(|| "no reason given".to_string());
+                refuse(
+                    &mut state,
+                    "before_inference",
+                    format!("refused the inference: {why}"),
+                );
+                commands.entity(entity).remove::<ReadyToInfer>();
+            }
+            // Nothing has happened yet, so there is nothing to do again.
+            Ok(HookOutcome::Retry) => refuse(
+                &mut state,
+                "before_inference",
+                "returned 'retry', which this hook cannot honour (nothing has run yet)".to_string(),
+            ),
+        }
+    }
+}
+
+/// Run `after_inference` with the model's response in hand.
+///
+/// Scheduled before `process_response`, on the `ProcessResponse` marker, so the
+/// hook sees the response before anything is written to context or any tool
+/// call is dispatched from it.
+///
+/// `modify` replaces the response **text**. It deliberately cannot rewrite the
+/// tool calls: those are about to be checked by the policy and taint layers, and
+/// a hook that could rewrite them would be a way around checks the operator
+/// configured. Steering tool calls is `on_tool_call`'s job, where the gate can
+/// see it.
+#[allow(clippy::type_complexity)]
+pub fn run_after_inference_hooks(
+    mut agents: Query<
+        (
+            Entity,
+            &StageCursor,
+            &AgentBlueprint,
+            &StageHookScripts,
+            &mut crate::components::InferenceResult,
+            &mut AgentState,
+        ),
+        With<ProcessResponse>,
+    >,
+) {
+    crate::tick_scope::clear();
+    for (entity, cursor, bp, scripts, mut result, mut state) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        let Some(stage) = bp.0.stages.get(cursor.index) else {
+            continue;
+        };
+        let Some(script) = scripts.script_for(stage, "after_inference") else {
+            continue;
+        };
+
+        let ctx = serde_json::json!({
+            "stage": stage.name,
+            "stage_index": cursor.index,
+            "response": result.response,
+            "tokens_used": result.tokens_used,
+            // Names only: enough for a hook to notice "it wants to run shell"
+            // without implying it can rewrite the call.
+            "tool_calls": result
+                .tool_calls
+                .iter()
+                .map(|c| c.name.clone())
+                .collect::<Vec<_>>(),
+        });
+
+        match run(&script, "after_inference", ctx) {
+            Err(e) => refuse(&mut state, "after_inference", format!("hook failed: {e}")),
+            Ok(HookOutcome::Allow) => {}
+            Ok(HookOutcome::Modify(value)) => match value.as_str() {
+                Some(text) => result.response = text.to_string(),
+                None => refuse(
+                    &mut state,
+                    "after_inference",
+                    format!("'value' must be the replacement response text, got: {value}"),
+                ),
+            },
+            Ok(HookOutcome::Cancel(reason)) => {
+                let why = reason.unwrap_or_else(|| "no reason given".to_string());
+                refuse(
+                    &mut state,
+                    "after_inference",
+                    format!("rejected the response: {why}"),
+                );
+            }
+            // Re-inferring is a real thing to want here (a malformed answer),
+            // but it needs the request rebuilt and the attempt counted, or a
+            // hook that always retries wedges the run. Refused explicitly until
+            // that is built, rather than silently ignored.
+            Ok(HookOutcome::Retry) => refuse(
+                &mut state,
+                "after_inference",
+                "returned 'retry', which is not implemented yet - re-inference needs an \
+                 attempt bound so a hook cannot wedge the run"
+                    .to_string(),
+            ),
+        }
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -10590,3 +10590,423 @@ fn a_refusal_without_a_reason_still_says_it_was_refused() {
     assert!(message.contains("refused stage 'main'"), "{message}");
     assert!(message.contains("no reason given"), "{message}");
 }
+
+// ─── before_inference / after_inference (issue #260) ─────────────────────────
+
+fn stage_hooked(field: fn(&mut leviath_core::blueprint::StageHooks, String)) -> AgentBlueprint {
+    let mut stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    field(&mut stage.hooks, "h.rhai".to_string());
+    AgentBlueprint(blueprint(vec![stage]))
+}
+
+fn run_before_hooks(world: &mut World) {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(run_before_inference_hooks);
+    schedule.run(world);
+}
+
+fn run_after_hooks(world: &mut World) {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(run_after_inference_hooks);
+    schedule.run(world);
+}
+
+fn spawn_before(world: &mut World, src: &str) -> Entity {
+    world
+        .spawn((
+            stage_hooked(|h, p| h.before_inference = Some(p)),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            ReadyToInfer,
+            hook_scripts(src, &["before_inference"]),
+        ))
+        .id()
+}
+
+fn spawn_after(world: &mut World, src: &str) -> Entity {
+    world
+        .spawn((
+            stage_hooked(|h, p| h.after_inference = Some(p)),
+            agent_state(),
+            StageCursor { index: 0 },
+            ProcessResponse,
+            crate::components::InferenceResult {
+                response: "the raw answer".to_string(),
+                tool_calls: vec![],
+                tokens_used: 7,
+                timestamp: 0,
+            },
+            hook_scripts(src, &["after_inference"]),
+        ))
+        .id()
+}
+
+fn status_message(world: &World, e: Entity) -> Option<String> {
+    match &world.get::<AgentState>(e).expect("state").status {
+        AgentStatus::Error { message } => Some(message.clone()),
+        _ => None,
+    }
+}
+
+#[test]
+fn before_inference_can_seed_the_window_the_request_is_built_from() {
+    let mut world = World::new();
+    let e = spawn_before(
+        &mut world,
+        r#"fn before_inference(ctx) { #{ action: "modify", value: #{ conversation: "injected" } } }"#,
+    );
+    run_before_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "injected");
+    assert!(status_message(&world, e).is_none());
+}
+
+/// A refused inference stops the agent *and* takes back `ReadyToInfer`, so
+/// `dispatch_inference` cannot pick it up in the same tick - refusing while
+/// still letting the call go is not refusing.
+#[test]
+fn before_inference_can_refuse_the_call_and_the_agent_stops_being_ready() {
+    let mut world = World::new();
+    let e = spawn_before(
+        &mut world,
+        r#"fn before_inference(ctx) { #{ action: "cancel", reason: "over budget" } }"#,
+    );
+    run_before_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("over budget")
+    );
+    assert!(
+        world.get::<ReadyToInfer>(e).is_none(),
+        "a refused inference must not stay dispatchable"
+    );
+}
+
+#[test]
+fn before_inference_that_throws_errors_the_run() {
+    let mut world = World::new();
+    let e = spawn_before(&mut world, r#"fn before_inference(ctx) { throw "no" }"#);
+    run_before_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("hook failed")
+    );
+}
+
+#[test]
+fn before_inference_retry_is_refused_as_unhonourable() {
+    let mut world = World::new();
+    let e = spawn_before(
+        &mut world,
+        r#"fn before_inference(ctx) { #{ action: "retry" } }"#,
+    );
+    run_before_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("cannot honour")
+    );
+}
+
+#[test]
+fn before_inference_bad_modify_errors() {
+    let mut world = World::new();
+    let e = spawn_before(
+        &mut world,
+        r#"fn before_inference(ctx) { #{ action: "modify", value: #{ nope: "x" } } }"#,
+    );
+    run_before_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("no region 'nope'")
+    );
+}
+
+#[test]
+fn before_inference_allow_changes_nothing() {
+    let mut world = World::new();
+    let e = spawn_before(&mut world, "fn before_inference(ctx) { () }");
+    run_before_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+    assert!(status_message(&world, e).is_none());
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+}
+
+#[test]
+fn before_inference_skips_an_out_of_range_stage() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            stage_hooked(|h, p| h.before_inference = Some(p)),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 99 },
+            ReadyToInfer,
+            hook_scripts(
+                r#"fn before_inference(ctx) { #{ action: "cancel" } }"#,
+                &["before_inference"],
+            ),
+        ))
+        .id();
+    run_before_hooks(&mut world);
+    assert!(status_message(&world, e).is_none());
+}
+
+#[test]
+fn before_inference_skips_a_stage_that_declared_none() {
+    let mut world = World::new();
+    let stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    let e = world
+        .spawn((
+            AgentBlueprint(blueprint(vec![stage])),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            ReadyToInfer,
+            hook_scripts(
+                r#"fn before_inference(ctx) { #{ action: "cancel" } }"#,
+                &["before_inference"],
+            ),
+        ))
+        .id();
+    run_before_hooks(&mut world);
+    assert!(status_message(&world, e).is_none());
+}
+
+// ── after_inference ──
+
+#[test]
+fn after_inference_can_rewrite_the_response() {
+    let mut world = World::new();
+    let e = spawn_after(
+        &mut world,
+        r#"fn after_inference(ctx) { #{ action: "modify", value: "cleaned up" } }"#,
+    );
+    run_after_hooks(&mut world);
+    assert_eq!(
+        world
+            .get::<crate::components::InferenceResult>(e)
+            .expect("result")
+            .response,
+        "cleaned up"
+    );
+}
+
+/// The hook is shown the real response, not a placeholder.
+#[test]
+fn after_inference_sees_the_response_and_its_token_count() {
+    let mut world = World::new();
+    let e = spawn_after(
+        &mut world,
+        r#"fn after_inference(ctx) { #{ action: "modify", value: ctx.response + "/" + ctx.tokens_used } }"#,
+    );
+    run_after_hooks(&mut world);
+    assert_eq!(
+        world
+            .get::<crate::components::InferenceResult>(e)
+            .expect("result")
+            .response,
+        "the raw answer/7"
+    );
+}
+
+#[test]
+fn after_inference_can_reject_the_response() {
+    let mut world = World::new();
+    let e = spawn_after(
+        &mut world,
+        r#"fn after_inference(ctx) { #{ action: "cancel", reason: "not valid json" } }"#,
+    );
+    run_after_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("not valid json")
+    );
+}
+
+#[test]
+fn after_inference_modify_must_be_text() {
+    let mut world = World::new();
+    let e = spawn_after(
+        &mut world,
+        r#"fn after_inference(ctx) { #{ action: "modify", value: #{ not: "text" } } }"#,
+    );
+    run_after_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("replacement response text")
+    );
+}
+
+/// Re-inference needs an attempt bound before it can be offered, or a hook that
+/// always retries wedges the run. Refused explicitly rather than ignored.
+#[test]
+fn after_inference_retry_is_refused_with_the_reason_it_is_not_implemented() {
+    let mut world = World::new();
+    let e = spawn_after(
+        &mut world,
+        r#"fn after_inference(ctx) { #{ action: "retry" } }"#,
+    );
+    run_after_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("not implemented yet")
+    );
+}
+
+#[test]
+fn after_inference_that_throws_errors_the_run() {
+    let mut world = World::new();
+    let e = spawn_after(&mut world, r#"fn after_inference(ctx) { throw "no" }"#);
+    run_after_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("hook failed")
+    );
+}
+
+#[test]
+fn after_inference_allow_leaves_the_response_alone() {
+    let mut world = World::new();
+    let e = spawn_after(&mut world, "fn after_inference(ctx) { () }");
+    run_after_hooks(&mut world);
+    assert_eq!(
+        world
+            .get::<crate::components::InferenceResult>(e)
+            .expect("result")
+            .response,
+        "the raw answer"
+    );
+    assert!(status_message(&world, e).is_none());
+}
+
+/// Tool calls reach the hook as names only. It can notice what the model wants
+/// to run; it cannot rewrite the call, because the policy and taint layers are
+/// about to check exactly those and a hook that could edit them would be a way
+/// around checks the operator configured.
+#[test]
+fn after_inference_sees_tool_call_names_but_cannot_change_them() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            stage_hooked(|h, p| h.after_inference = Some(p)),
+            agent_state(),
+            StageCursor { index: 0 },
+            ProcessResponse,
+            crate::components::InferenceResult {
+                response: String::new(),
+                tool_calls: vec![crate::components::ToolCall {
+                    tool_id: "c1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: serde_json::json!({"command": "ls"}),
+                    thought_signature: None,
+                }],
+                tokens_used: 0,
+                timestamp: 0,
+            },
+            hook_scripts(
+                r#"fn after_inference(ctx) { #{ action: "modify", value: ctx.tool_calls[0] } }"#,
+                &["after_inference"],
+            ),
+        ))
+        .id();
+    run_after_hooks(&mut world);
+    let result = world
+        .get::<crate::components::InferenceResult>(e)
+        .expect("result");
+    assert_eq!(result.response, "shell", "the hook saw the call's name");
+    assert_eq!(
+        result.tool_calls.len(),
+        1,
+        "and the call itself is untouched"
+    );
+    assert_eq!(result.tool_calls[0].name, "shell");
+    assert_eq!(result.tool_calls[0].arguments["command"], "ls");
+}
+
+#[test]
+fn after_inference_skips_an_out_of_range_stage() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            stage_hooked(|h, p| h.after_inference = Some(p)),
+            agent_state(),
+            StageCursor { index: 99 },
+            ProcessResponse,
+            crate::components::InferenceResult {
+                response: "x".to_string(),
+                tool_calls: vec![],
+                tokens_used: 0,
+                timestamp: 0,
+            },
+            hook_scripts(
+                r#"fn after_inference(ctx) { #{ action: "cancel" } }"#,
+                &["after_inference"],
+            ),
+        ))
+        .id();
+    run_after_hooks(&mut world);
+    assert!(status_message(&world, e).is_none());
+}
+
+#[test]
+fn after_inference_skips_a_stage_that_declared_none() {
+    let mut world = World::new();
+    let stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    let e = world
+        .spawn((
+            AgentBlueprint(blueprint(vec![stage])),
+            agent_state(),
+            StageCursor { index: 0 },
+            ProcessResponse,
+            crate::components::InferenceResult {
+                response: "x".to_string(),
+                tool_calls: vec![],
+                tokens_used: 0,
+                timestamp: 0,
+            },
+            hook_scripts(
+                r#"fn after_inference(ctx) { #{ action: "cancel" } }"#,
+                &["after_inference"],
+            ),
+        ))
+        .id();
+    run_after_hooks(&mut world);
+    assert!(status_message(&world, e).is_none());
+}
+
+/// A bare `false` from either inference hook refuses with no reason given, and
+/// the message still has to say what was refused - an operator seeing a failed
+/// run needs the cause, not just the failure.
+#[test]
+fn an_inference_hook_refusing_without_a_reason_still_says_what_it_refused() {
+    let mut world = World::new();
+    let before = spawn_before(&mut world, "fn before_inference(ctx) { false }");
+    run_before_hooks(&mut world);
+    let msg = status_message(&world, before).expect("errored");
+    assert!(msg.contains("refused the inference"), "{msg}");
+    assert!(msg.contains("no reason given"), "{msg}");
+
+    let mut world = World::new();
+    let after = spawn_after(&mut world, "fn after_inference(ctx) { false }");
+    run_after_hooks(&mut world);
+    let msg = status_message(&world, after).expect("errored");
+    assert!(msg.contains("rejected the response"), "{msg}");
+    assert!(msg.contains("no reason given"), "{msg}");
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -45,8 +45,8 @@ use crate::pipeline::{
     dispatch_tools, dispatch_transition_choice, enforce_max_iterations, fail_stalled_dispatch,
     fail_wedged_runs, gate_requires_children, handle_empty_response, poll_dynamic_tool_refresh,
     process_response, reflect_interaction_status, refresh_advertised_tools,
-    require_context_regions, require_final_output, resolve_transition, run_stage_enter_hooks,
-    sync_tool_stages,
+    require_context_regions, require_final_output, resolve_transition, run_after_inference_hooks,
+    run_before_inference_hooks, run_stage_enter_hooks, sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::ToolLane;
@@ -328,11 +328,24 @@ impl PipelineWorld {
                 // because it needs `&mut StageInference` and dispatch fans out.
                 // Nested rather than inline: the outer tuple is at bevy's
                 // 20-system limit for `.chain()`.
-                (crate::pipeline::rotate_open_circuits, dispatch_inference).chain(),
+                // Nested tuples here and below for the same reason the circuit
+                // pair already was: the outer tuple is at bevy's 20-system
+                // `.chain()` limit, and grouping preserves the ordering.
+                //
+                // `before_inference` runs with the window assembled and before
+                // the request is built from it.
+                (
+                    run_before_inference_hooks,
+                    crate::pipeline::rotate_open_circuits,
+                    dispatch_inference,
+                )
+                    .chain(),
                 collect_inference,
                 // Intercept a fan-out stage's split response before normal routing.
                 crate::fanout::fan_out_split,
-                process_response,
+                // `after_inference` sees the response before anything is
+                // written to context or dispatched from it.
+                (run_after_inference_hooks, process_response).chain(),
                 // Apply resolved taint gate prompts (re-arming ReadyForTools)
                 // before the tool dispatch re-runs the held batch.
                 crate::gate_prompt::collect_gate_prompt,

--- a/crates/leviath-scripting/src/stage_hook.rs
+++ b/crates/leviath-scripting/src/stage_hook.rs
@@ -53,7 +53,12 @@ const STAGE_HOOK_MAX_OPERATIONS: u64 = 100_000;
 /// The blueprint field and the Rhai function share a name on purpose: a
 /// blueprint saying `on_stage_enter = "hooks.rhai"` means "call
 /// `fn on_stage_enter(ctx)` in that file", with nothing in between to look up.
-pub const HOOK_NAMES: &[&str] = &["on_stage_enter", "on_stage_exit"];
+pub const HOOK_NAMES: &[&str] = &[
+    "on_stage_enter",
+    "on_stage_exit",
+    "before_inference",
+    "after_inference",
+];
 
 /// What a hook decided.
 ///


### PR DESCRIPTION
feat(hooks): before_inference and after_inference

Third of the series for #260.

### Where they fire

`before_inference` on the `ReadyToInfer` marker, scheduled before
`dispatch_inference`. The window is assembled by then, so a `modify` reaches the
request - `build_request` reads the window fresh at dispatch.

`after_inference` on the `ProcessResponse` marker, before `process_response`, so
the hook sees the model's response before anything is written to context or
dispatched from it.

Both are their own systems rather than edits inside the existing ones.
`dispatch_inference` runs its per-agent body in parallel on the compute pool,
where a panicking script would be attributed by different machinery; sequential
systems cost a query pass and keep script failures at the tick boundary.

### `after_inference` cannot rewrite tool calls, deliberately

It is shown the call *names* - enough to notice "it wants to run shell" - and
`modify` replaces the response **text** only. The policy and taint layers are
about to check exactly those calls, and a hook that could edit them would be a
way around checks the operator configured. Steering tool calls is
`on_tool_call`'s job, where the gate can see it. There is a test asserting the
calls come through untouched.

### Refusing actually refuses

A `before_inference` cancel also takes back `ReadyToInfer`, so
`dispatch_inference` cannot pick the agent up in the same tick. Erroring the run
while still letting the call go would not be refusing it.

`retry` is refused by both, with different reasons, rather than being quietly
read as allow: nothing has run yet at `before_inference`, and at
`after_inference` re-inference needs the request rebuilt and the attempt counted
or a hook that always retries wedges the run. Saying so beats a script believing
it asked for something.

### Schedule

Two nested tuples. The outer tuple was at bevy's 20-system `.chain()` limit -
the circuit pair was already grouped for that reason - so grouping preserves the
ordering rather than reordering to fit.

### Tests

21 new: both modify paths, both refusals, both refusals *without* a reason, both
`retry` refusals, a malformed modify for each, an out-of-range stage and a stage
declaring no hook for each, the tool-calls-untouched assertion, and the ctx
round trip showing each hook sees real values rather than placeholders.

All 34 workspace test binaries green; `cargo xtask coverage` clean on
`leviath-core`, `leviath-scripting`, and `leviath-runtime`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
