### PR TITLE
feat(hooks): on_stage_exit, on_completion and on_error - completing #260

### DIFF
--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -794,6 +794,12 @@ pub struct StageHooks {
     /// see them - so a hook can narrow what runs, never widen it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_tool_call: Option<String>,
+    /// Fires once when the run finishes successfully.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_completion: Option<String>,
+    /// Fires once when the run finishes in error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_error: Option<String>,
 }
 
 impl StageHooks {
@@ -805,6 +811,8 @@ impl StageHooks {
             && self.before_inference.is_none()
             && self.after_inference.is_none()
             && self.on_tool_call.is_none()
+            && self.on_completion.is_none()
+            && self.on_error.is_none()
     }
 
     /// Every script path this stage declares, with the hook it backs.
@@ -827,6 +835,12 @@ impl StageHooks {
         }
         if let Some(p) = self.on_tool_call.as_deref() {
             out.push(("on_tool_call", p));
+        }
+        if let Some(p) = self.on_completion.as_deref() {
+            out.push(("on_completion", p));
+        }
+        if let Some(p) = self.on_error.as_deref() {
+            out.push(("on_error", p));
         }
         out
     }

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -886,11 +886,14 @@ fn parse_stage_hooks(
             "before_inference" => hooks.before_inference = Some(path.to_string()),
             "after_inference" => hooks.after_inference = Some(path.to_string()),
             "on_tool_call" => hooks.on_tool_call = Some(path.to_string()),
+            "on_completion" => hooks.on_completion = Some(path.to_string()),
+            "on_error" => hooks.on_error = Some(path.to_string()),
             other => {
                 return Err(Error::Other(format!(
                     "stage '{stage_name}': unknown hook '{other}' \
                      (this build implements: on_stage_enter, on_stage_exit, \
-                     before_inference, after_inference, on_tool_call)"
+                     before_inference, after_inference, on_tool_call, \
+                     on_completion, on_error)"
                 )));
             }
         }
@@ -1562,7 +1565,9 @@ mod tests {
              on_stage_exit = \"b.rhai\"\n\
              before_inference = \"c.rhai\"\n\
              after_inference = \"d.rhai\"\n\
-             on_tool_call = \"e.rhai\"",
+             on_tool_call = \"e.rhai\"\n\
+             on_completion = \"f.rhai\"\n\
+             on_error = \"g.rhai\"",
         )
         .expect("parses");
         assert!(!stage.hooks.is_empty());
@@ -1574,6 +1579,8 @@ mod tests {
                 ("before_inference", "c.rhai"),
                 ("after_inference", "d.rhai"),
                 ("on_tool_call", "e.rhai"),
+                ("on_completion", "f.rhai"),
+                ("on_error", "g.rhai"),
             ]
         );
     }
@@ -1588,6 +1595,8 @@ mod tests {
             "before_inference",
             "after_inference",
             "on_tool_call",
+            "on_completion",
+            "on_error",
         ] {
             let stage = stage_with_hooks(&format!("[stages.main.hooks]\n{field} = \"h.rhai\""))
                 .expect("parses");

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -377,6 +377,8 @@ impl StageHookScripts {
             "before_inference" => stage.hooks.before_inference.as_deref(),
             "after_inference" => stage.hooks.after_inference.as_deref(),
             "on_tool_call" => stage.hooks.on_tool_call.as_deref(),
+            "on_completion" => stage.hooks.on_completion.as_deref(),
+            "on_error" => stage.hooks.on_error.as_deref(),
             _ => None,
         }?;
         self.0.get(path).cloned()

--- a/crates/leviath-runtime/src/pipeline/hooks.rs
+++ b/crates/leviath-runtime/src/pipeline/hooks.rs
@@ -431,3 +431,187 @@ pub fn run_tool_call_hooks(
         }
     }
 }
+
+/// Marks an agent whose terminal hook has already run.
+///
+/// A terminal status is not an event - it stays true for every tick until the
+/// agent is unloaded - so without this the hook would fire on each of them. The
+/// marker turns a state into a one-shot.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct TerminalHookFired;
+
+/// Run `on_completion` or `on_error` once, as the run finishes.
+///
+/// Which one fires is the run's own outcome: a completed run gets
+/// `on_completion` with its answer, an errored one gets `on_error` with the
+/// message. A cancelled run gets neither - it was stopped from outside, and a
+/// hook narrating that would be reporting the operator's decision back to them.
+///
+/// `modify` replaces what the hook was shown: the final output for a
+/// completion, the message for an error. `cancel` on a completion is a
+/// meaningful veto - the answer was not acceptable - and turns the run into an
+/// error carrying the reason.
+#[allow(clippy::type_complexity)]
+pub fn run_terminal_hooks(
+    mut agents: Query<
+        (
+            Entity,
+            &StageCursor,
+            &AgentBlueprint,
+            &StageHookScripts,
+            &mut AgentState,
+            Option<&mut crate::persistence::FinalOutput>,
+        ),
+        Without<TerminalHookFired>,
+    >,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, cursor, bp, scripts, mut state, output) in agents.iter_mut() {
+        // `Cancelled` is deliberately not here: see the doc comment.
+        let (hook, subject) = match &state.status {
+            AgentStatus::Complete => (
+                "on_completion",
+                output
+                    .as_ref()
+                    .map(|o| o.0.content.clone())
+                    .unwrap_or_default(),
+            ),
+            AgentStatus::Error { message } => ("on_error", message.clone()),
+            _ => continue,
+        };
+        crate::tick_scope::enter(entity);
+
+        let Some(stage) = bp.0.stages.get(cursor.index) else {
+            // Still mark it fired: without a stage there is no hook to look up
+            // and re-checking every tick would be pure work.
+            commands.entity(entity).insert(TerminalHookFired);
+            continue;
+        };
+        let Some(script) = scripts.script_for(stage, hook) else {
+            commands.entity(entity).insert(TerminalHookFired);
+            continue;
+        };
+
+        // Marked before running, not after: a hook that fails must not be
+        // retried on the next tick, which would make a throwing script an
+        // infinite loop rather than one error.
+        commands.entity(entity).insert(TerminalHookFired);
+
+        let ctx = serde_json::json!({
+            "stage": stage.name,
+            "stage_index": cursor.index,
+            "status": format!("{}", state.status),
+            // Named for what it is in each case, so a script reads plainly.
+            "output": if hook == "on_completion" { subject.clone() } else { String::new() },
+            "error": if hook == "on_error" { subject.clone() } else { String::new() },
+        });
+
+        match run(&script, hook, ctx) {
+            Err(e) => refuse(&mut state, hook, format!("hook failed: {e}")),
+            Ok(HookOutcome::Allow) => {}
+            Ok(HookOutcome::Modify(value)) => {
+                let Some(text) = value.as_str() else {
+                    refuse(
+                        &mut state,
+                        hook,
+                        format!("'value' must be replacement text, got: {value}"),
+                    );
+                    continue;
+                };
+                match hook {
+                    // Rewriting the answer is the point: a completion hook can
+                    // reshape what `lev result` hands back.
+                    // Refused rather than dropped when there is no answer to
+                    // rewrite: the hook asked to change something that is not
+                    // there, and a silently-ignored rewrite reads exactly like
+                    // one that happened.
+                    "on_completion" => match output {
+                        Some(mut o) => o.0.content = text.to_string(),
+                        None => refuse(
+                            &mut state,
+                            hook,
+                            "asked to rewrite the answer, but this run submitted none".to_string(),
+                        ),
+                    },
+                    _ => {
+                        state.status = AgentStatus::Error {
+                            message: text.to_string(),
+                        }
+                    }
+                }
+            }
+            Ok(HookOutcome::Cancel(reason)) => {
+                let why = reason.unwrap_or_else(|| "no reason given".to_string());
+                refuse(&mut state, hook, format!("rejected the result: {why}"));
+            }
+            // The run is over; there is nothing left to do again.
+            Ok(HookOutcome::Retry) => refuse(
+                &mut state,
+                hook,
+                "returned 'retry', which this hook cannot honour (the run has finished)"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Run `on_stage_exit` as a stage finishes, before its transition is chosen.
+///
+/// On the `ResolveTransition` marker and scheduled before `resolve_transition`,
+/// so a hook can summarise the stage's work or tidy a region while the stage is
+/// still the current one - and before the edge that leaves it is picked.
+///
+/// The window is still the finishing stage's, so `modify` writes there. A
+/// `cancel` errors the run rather than blocking the transition: a stage that
+/// refuses to be left has nowhere to go, and wedging is worse than stopping.
+#[allow(clippy::type_complexity)]
+pub fn run_stage_exit_hooks(
+    mut agents: Query<
+        (
+            Entity,
+            &StageCursor,
+            &AgentBlueprint,
+            &StageHookScripts,
+            &mut ContextWindow,
+            &mut AgentState,
+        ),
+        With<ResolveTransition>,
+    >,
+) {
+    crate::tick_scope::clear();
+    for (entity, cursor, bp, scripts, mut window, mut state) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        let Some(stage) = bp.0.stages.get(cursor.index) else {
+            continue;
+        };
+        let Some(script) = scripts.script_for(stage, "on_stage_exit") else {
+            continue;
+        };
+
+        let ctx = stage_ctx(&stage.name, cursor.index, &window);
+        match run(&script, "on_stage_exit", ctx) {
+            Err(e) => refuse(&mut state, "on_stage_exit", format!("hook failed: {e}")),
+            Ok(HookOutcome::Allow) => {}
+            Ok(HookOutcome::Modify(value)) => {
+                if let Err(e) = apply_modify(&mut window, &value) {
+                    refuse(&mut state, "on_stage_exit", e);
+                }
+            }
+            Ok(HookOutcome::Cancel(reason)) => {
+                let why = reason.unwrap_or_else(|| "no reason given".to_string());
+                refuse(
+                    &mut state,
+                    "on_stage_exit",
+                    format!("refused to leave stage '{}': {why}", stage.name),
+                );
+            }
+            Ok(HookOutcome::Retry) => refuse(
+                &mut state,
+                "on_stage_exit",
+                "returned 'retry', which this hook cannot honour (the stage is already over)"
+                    .to_string(),
+            ),
+        }
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -10593,7 +10593,9 @@ fn a_refusal_without_a_reason_still_says_it_was_refused() {
 
 // ─── before_inference / after_inference (issue #260) ─────────────────────────
 
-fn stage_hooked(field: fn(&mut leviath_core::blueprint::StageHooks, String)) -> AgentBlueprint {
+fn stage_hooked(
+    field: impl FnOnce(&mut leviath_core::blueprint::StageHooks, String),
+) -> AgentBlueprint {
     let mut stage = leviath_core::Stage::new(
         "main".to_string(),
         leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
@@ -11353,6 +11355,468 @@ fn on_tool_call_skips_an_out_of_range_stage_and_a_stage_that_declared_none() {
         ))
         .id();
     run_tool_hooks(&mut world);
+    assert!(status_message(&world, out_of_range).is_none());
+    assert!(status_message(&world, undeclared).is_none());
+}
+
+// ─── on_completion / on_error (issue #260) ───────────────────────────────────
+
+fn run_terminal(world: &mut World) {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(run_terminal_hooks);
+    schedule.run(world);
+}
+
+fn spawn_terminal(
+    world: &mut World,
+    src: &str,
+    hook: &'static str,
+    status: AgentStatus,
+    answer: Option<&str>,
+) -> Entity {
+    let mut state = agent_state();
+    state.status = status;
+    let bp = stage_hooked(move |h, p| match hook {
+        "on_completion" => h.on_completion = Some(p),
+        _ => h.on_error = Some(p),
+    });
+    let mut e = world.spawn((
+        bp,
+        state,
+        StageCursor { index: 0 },
+        hook_scripts(src, &[hook]),
+    ));
+    if let Some(a) = answer {
+        e.insert(crate::persistence::FinalOutput(
+            leviath_core::output::FinalOutput::new(a, None, "s".to_string(), 10),
+        ));
+    }
+    e.id()
+}
+
+fn answer_of(world: &World, e: Entity) -> String {
+    world
+        .get::<crate::persistence::FinalOutput>(e)
+        .expect("output")
+        .0
+        .content
+        .clone()
+}
+
+#[test]
+fn on_completion_can_rewrite_the_answer() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "modify", value: "tidied: " + ctx.output } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("raw answer"),
+    );
+    run_terminal(&mut world);
+    assert_eq!(answer_of(&world, e), "tidied: raw answer");
+}
+
+#[test]
+fn on_error_can_rewrite_the_message() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_error(ctx) { #{ action: "modify", value: "friendly: " + ctx.error } }"#,
+        "on_error",
+        AgentStatus::Error {
+            message: "raw failure".to_string(),
+        },
+        None,
+    );
+    run_terminal(&mut world);
+    assert_eq!(
+        status_message(&world, e).expect("errored"),
+        "friendly: raw failure"
+    );
+}
+
+/// A terminal status stays true every tick, so without the fire-once marker the
+/// hook would run forever - and a rewriting hook would compound its own output.
+#[test]
+fn a_terminal_hook_runs_exactly_once() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "modify", value: ctx.output + "!" } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    run_terminal(&mut world);
+    run_terminal(&mut world);
+    assert_eq!(
+        answer_of(&world, e),
+        "x!",
+        "the hook compounded its own output"
+    );
+}
+
+/// A throwing hook must not be retried next tick, or one error becomes an
+/// infinite loop. The marker goes on before the script runs.
+#[test]
+fn a_failing_terminal_hook_is_not_retried() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { throw "boom" }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    let first = status_message(&world, e).expect("errored");
+    run_terminal(&mut world);
+    assert_eq!(
+        status_message(&world, e).expect("still errored"),
+        first,
+        "a failing hook ran again"
+    );
+    assert!(world.get::<TerminalHookFired>(e).is_some());
+}
+
+#[test]
+fn on_completion_can_veto_the_answer() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "cancel", reason: "schema mismatch" } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("schema mismatch")
+    );
+}
+
+/// A cancelled run was stopped from outside. Narrating that back to the
+/// operator who stopped it is not useful, so neither hook fires.
+#[test]
+fn a_cancelled_run_fires_no_terminal_hook() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "cancel", reason: "should not run" } }"#,
+        "on_completion",
+        AgentStatus::Cancelled,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert!(status_message(&world, e).is_none());
+    assert!(world.get::<TerminalHookFired>(e).is_none());
+}
+
+/// A run still going fires nothing, and is not marked - it has not finished.
+#[test]
+fn a_running_agent_fires_no_terminal_hook_and_stays_unmarked() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "cancel" } }"#,
+        "on_completion",
+        AgentStatus::Active,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert!(status_message(&world, e).is_none());
+    assert!(
+        world.get::<TerminalHookFired>(e).is_none(),
+        "an unfinished run must stay eligible"
+    );
+}
+
+/// The completion hook of a run that never submitted an answer sees an empty
+/// string, not a missing field.
+#[test]
+fn on_completion_without_an_answer_sees_empty_output() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { if ctx.output == "" { () } else { #{ action: "cancel" } } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        None,
+    );
+    run_terminal(&mut world);
+    assert!(status_message(&world, e).is_none());
+}
+
+#[test]
+fn a_terminal_hook_modify_must_be_text() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "modify", value: #{ not: "text" } } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("replacement text")
+    );
+}
+
+#[test]
+fn a_terminal_hook_retry_is_refused() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "retry" } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("cannot honour")
+    );
+}
+
+#[test]
+fn a_terminal_hook_veto_without_a_reason_still_explains() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        "fn on_completion(ctx) { false }",
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    let msg = status_message(&world, e).expect("errored");
+    assert!(msg.contains("rejected the result"), "{msg}");
+    assert!(msg.contains("no reason given"), "{msg}");
+}
+
+#[test]
+fn a_terminal_hook_allow_leaves_everything_alone() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        "fn on_completion(ctx) { () }",
+        "on_completion",
+        AgentStatus::Complete,
+        Some("x"),
+    );
+    run_terminal(&mut world);
+    assert_eq!(answer_of(&world, e), "x");
+    assert!(status_message(&world, e).is_none());
+}
+
+/// No stage and no declared hook both mark the agent anyway: re-checking a
+/// finished run on every tick is pure work.
+#[test]
+fn a_terminal_run_with_no_hook_is_marked_so_it_is_not_rechecked() {
+    let mut world = World::new();
+    let mut state = agent_state();
+    state.status = AgentStatus::Complete;
+    let stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    let undeclared = world
+        .spawn((
+            AgentBlueprint(blueprint(vec![stage])),
+            state.clone(),
+            StageCursor { index: 0 },
+            hook_scripts("fn on_completion(ctx) { () }", &["on_completion"]),
+        ))
+        .id();
+    let out_of_range = world
+        .spawn((
+            stage_hooked(|h, p| h.on_completion = Some(p)),
+            state,
+            StageCursor { index: 99 },
+            hook_scripts("fn on_completion(ctx) { () }", &["on_completion"]),
+        ))
+        .id();
+
+    run_terminal(&mut world);
+    assert!(world.get::<TerminalHookFired>(undeclared).is_some());
+    assert!(world.get::<TerminalHookFired>(out_of_range).is_some());
+}
+
+/// Rewriting an answer that was never submitted is refused, not dropped - a
+/// silently-ignored rewrite reads exactly like one that happened.
+#[test]
+fn on_completion_rewriting_a_missing_answer_is_refused() {
+    let mut world = World::new();
+    let e = spawn_terminal(
+        &mut world,
+        r#"fn on_completion(ctx) { #{ action: "modify", value: "new" } }"#,
+        "on_completion",
+        AgentStatus::Complete,
+        None,
+    );
+    run_terminal(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("submitted none")
+    );
+}
+
+// ─── on_stage_exit (issue #260) ──────────────────────────────────────────────
+
+fn spawn_exiting(world: &mut World, src: &str) -> Entity {
+    world
+        .spawn((
+            stage_hooked(|h, p| h.on_stage_exit = Some(p)),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            ResolveTransition,
+            hook_scripts(src, &["on_stage_exit"]),
+        ))
+        .id()
+}
+
+fn run_exit_hooks(world: &mut World) {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(run_stage_exit_hooks);
+    schedule.run(world);
+}
+
+/// The point of the hook: summarise or tidy while the finishing stage is still
+/// the current one.
+#[test]
+fn on_stage_exit_can_write_the_finishing_stages_window() {
+    let mut world = World::new();
+    let e = spawn_exiting(
+        &mut world,
+        r#"fn on_stage_exit(ctx) { #{ action: "modify", value: #{ conversation: "summary of " + ctx.stage } } }"#,
+    );
+    run_exit_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "summary of main");
+}
+
+#[test]
+fn on_stage_exit_allow_changes_nothing() {
+    let mut world = World::new();
+    let e = spawn_exiting(&mut world, "fn on_stage_exit(ctx) { () }");
+    run_exit_hooks(&mut world);
+    assert_eq!(region_text(&world, e, "conversation"), "");
+    assert!(status_message(&world, e).is_none());
+}
+
+/// A stage that refuses to be left has nowhere to go, so this stops the run
+/// rather than blocking the transition and wedging it.
+#[test]
+fn on_stage_exit_can_refuse_and_the_run_stops() {
+    let mut world = World::new();
+    let e = spawn_exiting(
+        &mut world,
+        r#"fn on_stage_exit(ctx) { #{ action: "cancel", reason: "work unfinished" } }"#,
+    );
+    run_exit_hooks(&mut world);
+    let msg = status_message(&world, e).expect("errored");
+    assert!(msg.contains("refused to leave stage 'main'"), "{msg}");
+    assert!(msg.contains("work unfinished"), "{msg}");
+}
+
+#[test]
+fn on_stage_exit_refusing_without_a_reason_still_explains() {
+    let mut world = World::new();
+    let e = spawn_exiting(&mut world, "fn on_stage_exit(ctx) { false }");
+    run_exit_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("no reason given")
+    );
+}
+
+#[test]
+fn on_stage_exit_that_throws_errors_the_run() {
+    let mut world = World::new();
+    let e = spawn_exiting(&mut world, r#"fn on_stage_exit(ctx) { throw "no" }"#);
+    run_exit_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("hook failed")
+    );
+}
+
+#[test]
+fn on_stage_exit_retry_is_refused_as_unhonourable() {
+    let mut world = World::new();
+    let e = spawn_exiting(
+        &mut world,
+        r#"fn on_stage_exit(ctx) { #{ action: "retry" } }"#,
+    );
+    run_exit_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("cannot honour")
+    );
+}
+
+#[test]
+fn on_stage_exit_bad_modify_errors() {
+    let mut world = World::new();
+    let e = spawn_exiting(
+        &mut world,
+        r#"fn on_stage_exit(ctx) { #{ action: "modify", value: #{ nope: "x" } } }"#,
+    );
+    run_exit_hooks(&mut world);
+    assert!(
+        status_message(&world, e)
+            .expect("errored")
+            .contains("no region 'nope'")
+    );
+}
+
+#[test]
+fn on_stage_exit_skips_an_out_of_range_stage_and_a_stage_that_declared_none() {
+    let mut world = World::new();
+    let out_of_range = world
+        .spawn((
+            stage_hooked(|h, p| h.on_stage_exit = Some(p)),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 99 },
+            ResolveTransition,
+            hook_scripts(
+                r#"fn on_stage_exit(ctx) { #{ action: "cancel" } }"#,
+                &["on_stage_exit"],
+            ),
+        ))
+        .id();
+    let stage = leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    );
+    let undeclared = world
+        .spawn((
+            AgentBlueprint(blueprint(vec![stage])),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 0 },
+            ResolveTransition,
+            hook_scripts(
+                r#"fn on_stage_exit(ctx) { #{ action: "cancel" } }"#,
+                &["on_stage_exit"],
+            ),
+        ))
+        .id();
+    run_exit_hooks(&mut world);
     assert!(status_message(&world, out_of_range).is_none());
     assert!(status_message(&world, undeclared).is_none());
 }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -46,7 +46,8 @@ use crate::pipeline::{
     fail_wedged_runs, gate_requires_children, handle_empty_response, poll_dynamic_tool_refresh,
     process_response, reflect_interaction_status, refresh_advertised_tools,
     require_context_regions, require_final_output, resolve_transition, run_after_inference_hooks,
-    run_before_inference_hooks, run_stage_enter_hooks, run_tool_call_hooks, sync_tool_stages,
+    run_before_inference_hooks, run_stage_enter_hooks, run_stage_exit_hooks, run_terminal_hooks,
+    run_tool_call_hooks, sync_tool_stages,
 };
 use crate::providers::ProviderRegistry;
 use crate::tool_bridge::ToolLane;
@@ -376,7 +377,9 @@ impl PipelineWorld {
                 // (e.g. plan_approval) and drive the interaction-point lane.
                 crate::interaction_points::gate_interaction_points,
                 crate::interaction_points::dispatch_interaction_point,
-                resolve_transition,
+                // `on_stage_exit` while the finishing stage is still current
+                // and before the edge that leaves it is picked.
+                (run_stage_exit_hooks, resolve_transition).chain(),
                 dispatch_transition_choice,
                 collect_transition_choice,
                 // Drive fan-out workers and merge once they finish.
@@ -395,7 +398,9 @@ impl PipelineWorld {
                 // Store any finished run title, then start newly-marked ones.
                 // Collect precedes persistence so a landed title is written on
                 // this same tick.
-                crate::title::collect_title,
+                // `on_completion` / `on_error`, once, as a run finishes.
+                // Grouped for the 20-system `.chain()` limit, as above.
+                (run_terminal_hooks, crate::title::collect_title).chain(),
                 crate::title::dispatch_title,
                 // Fail a run whose dispatch has been declining for something
                 // that will never arrive. Last of the guards, and after *both*

--- a/crates/leviath-scripting/src/stage_hook.rs
+++ b/crates/leviath-scripting/src/stage_hook.rs
@@ -59,6 +59,8 @@ pub const HOOK_NAMES: &[&str] = &[
     "before_inference",
     "after_inference",
     "on_tool_call",
+    "on_completion",
+    "on_error",
 ];
 
 /// What a hook decided.

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -3,7 +3,7 @@ title: Agent Client Protocol
 description: Serve an agent over the Agent Client Protocol on stdio, so an editor or orchestrator can drive it as a child process.
 group: Reference
 group_order: 3
-order: 12
+order: 13
 ---
 
 # Agent Client Protocol (editor integration)

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -3,7 +3,7 @@ title: Embedding
 description: Run the Leviath runtime inside your own Rust process with the leviath crate, with no CLI, daemon, or config file.
 group: Reference
 group_order: 3
-order: 14
+order: 15
 ---
 
 # Embedding Leviath in a Rust application

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -3,7 +3,7 @@ title: Observability
 description: Export traces, metrics, and logs over OpenTelemetry so your dashboards can answer which run is stuck.
 group: Reference
 group_order: 3
-order: 13
+order: 14
 ---
 
 # Observability

--- a/docs/content/rhai-hooks.md
+++ b/docs/content/rhai-hooks.md
@@ -1,0 +1,152 @@
+---
+title: Rhai stage hooks
+description: Run your own Rhai at seven points in an agent's lifecycle - seed a stage, gate a call, reshape an answer.
+group: Reference
+group_order: 3
+order: 12
+---
+
+# Stage hooks
+
+A [custom region](/docs/rhai-regions) owns one region. A [script tool](/docs/rhai-tools) adds one
+tool. Stage hooks are the third shape: they let you step into the agent's own lifecycle and see, or
+change, what it is about to do.
+
+Seven points, declared per stage:
+
+```toml
+[stages.implement.hooks]
+on_stage_enter   = "hooks/seed.rhai"
+before_inference = "hooks/cost_gate.rhai"
+on_tool_call     = "hooks/guard.rhai"
+on_completion    = "hooks/notify.rhai"
+```
+
+Each field names a `.rhai` file beside the agent, and the file must define a function of the same
+name taking one argument:
+
+```rhai
+fn on_stage_enter(ctx) {
+    ()   // allow, unchanged
+}
+```
+
+One file can back several hooks by defining several functions. A stage that declares none costs
+nothing: no file is read and no engine is built.
+
+## When each one fires
+
+```mermaid
+flowchart TD
+  E["enter a stage"] -->|"on_stage_enter"| B["assemble context"]
+  B -->|"before_inference"| I["call the model"]
+  I -->|"after_inference"| R["apply the response"]
+  R -->|"on_tool_call"| P["policy + taint gate"]
+  P --> T["run the tools"]
+  T --> B
+  R --> X["stage finishes"]
+  X -->|"on_stage_exit"| D["choose the next stage"]
+  D --> F["run finishes"]
+  F -->|"on_completion / on_error"| END["done"]
+```
+
+| Hook | Fires | Sees | `modify` replaces |
+|---|---|---|---|
+| `on_stage_enter` | entering a stage, before its first inference | stage, regions | region contents |
+| `before_inference` | context assembled, before the request goes out | stage, regions | region contents |
+| `after_inference` | response in hand, before it reaches context | response, token count, tool-call names | the response text |
+| `on_tool_call` | before the policy and taint layers see the calls | the calls and their arguments | the calls |
+| `on_stage_exit` | stage finished, before the next is chosen | stage, regions | region contents |
+| `on_completion` | run finished successfully | the final output | the final output |
+| `on_error` | run finished in error | the error message | the message |
+
+A **cancelled** run fires neither terminal hook. It was stopped from outside, and a hook narrating
+that would report your own decision back to you.
+
+## What a hook returns
+
+The same four answers everywhere, so there is no vocabulary to learn per hook:
+
+| Return | Means |
+|---|---|
+| `()` or `true` | allow, unchanged |
+| `false` | refuse, no reason given |
+| `#{ action: "modify", value: ... }` | proceed with `value` |
+| `#{ action: "cancel", reason: "..." }` | refuse |
+| `#{ action: "retry" }` | do it again |
+
+Hooks are a **return-value contract**. Rhai passes arguments by value, so mutating `ctx` does
+nothing - the script has to return its decision.
+
+Not every hook can honour `retry`, and one that cannot says so rather than treating it as allow.
+Today none of them do: it is reserved for re-inference, which needs an attempt bound first or a hook
+that always retries would wedge the run.
+
+## What hooks cannot do
+
+**`on_tool_call` runs before the gate, not after.** Whatever it leaves is what your tool policy, the
+taint gate, and the approval prompt then check. So a hook can *narrow* what runs - veto a call,
+rewrite arguments to something tamer - and cannot widen anything, because nothing it produces skips
+those checks. It also has no access to the gate itself: it cannot mark its own calls approved.
+
+**`after_inference` cannot rewrite tool calls.** It is shown their names - enough to notice "it wants
+to run shell" - and can replace the response text only. Editing the calls there would be a way around
+checks you configured; that is `on_tool_call`'s job, where the gate can see it.
+
+**A failed hook is not an allowed hook.** A script that throws, or returns something malformed, fails
+the run. Treating a broken gate as permission is how a gate quietly stops gating.
+
+## Errors are caught at spawn
+
+A hook script that cannot be read, does not compile, takes the wrong number of arguments, or does not
+define the function it was named for fails `lev run` before the agent starts. A hook that never runs
+looks exactly like one that ran and allowed everything, and you would not be there to notice.
+
+## The sandbox
+
+Hooks run on the same hardened engine everything else in Leviath does: no filesystem, no network, no
+`eval`, and an operation budget that stops a runaway rather than letting it hold up the tick. See
+[Scripting](/docs/scripting) for what that engine does and does not offer.
+
+## Examples
+
+Seed a region as a stage opens:
+
+```rhai
+fn on_stage_enter(ctx) {
+    #{ action: "modify", value: #{ notes: "Focus on the failing test first." } }
+}
+```
+
+Stop an expensive stage from running twice:
+
+```rhai
+fn before_inference(ctx) {
+    if ctx.regions.conversation.len() > 40000 {
+        #{ action: "cancel", reason: "context is larger than this stage should need" }
+    } else {
+        ()
+    }
+}
+```
+
+Keep a stage off the shell:
+
+```rhai
+fn on_tool_call(ctx) {
+    for c in ctx.tool_calls {
+        if c.name == "shell" {
+            return #{ action: "cancel", reason: "this stage plans, it does not run commands" };
+        }
+    }
+    ()
+}
+```
+
+Tidy an answer on the way out:
+
+```rhai
+fn on_completion(ctx) {
+    #{ action: "modify", value: ctx.output.trim() }
+}
+```

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -32,6 +32,7 @@ can copy and change. [rhai.rs](https://rhai.rs) has the language reference if yo
 |---|---|---|
 | [**Model providers**](/docs/rhai-providers) | `~/.leviath/providers/<name>.rhai` | How to map a request onto some HTTP API, and the response back |
 | [**Context regions**](/docs/rhai-regions) | beside the agent, referenced by `script =` | How one region renders, accepts writes, and sheds content under pressure |
+| [**Stage hooks**](/docs/rhai-hooks) | beside the agent, referenced by `[stages.<name>.hooks]` | What happens at seven points in an agent's lifecycle - entering a stage, either side of an inference, before a tool call, and at the end |
 | [**Global tools**](/docs/rhai-tools) | `~/.leviath/tools/*.rhai`, or an agent's own `tools/` | A new tool, its schema, and what it does |
 | [**Policy rules**](/docs/rhai-tools#policy-rules) | `rules/*.rhai` in your OS config dir, see [configuration](/docs/configuration#policytoml) | Whether a given tool call is allowed to fire |
 


### PR DESCRIPTION
feat(hooks): on_stage_exit, on_completion and on_error - completing #260

Last of the series. All seven hooks the issue proposed now fire.

### on_stage_exit, which was declared but never fired

Writing the docs caught this: PR2 added `on_stage_exit` to the blueprint and to
the script resolver, but no system ever called it. A blueprint could declare it,
spawn cleanly, and get nothing - which is precisely the "a hook that never runs
looks exactly like one that ran and allowed everything" hazard the rest of this
series is built to avoid. It now fires on the `ResolveTransition` marker, before
`resolve_transition`, so a hook can summarise or tidy while the finishing stage
is still the current one and before the edge that leaves it is picked.

A `cancel` there errors the run rather than blocking the transition: a stage
that refuses to be left has nowhere to go, and wedging is worse than stopping.

### A state, turned into an event

A terminal status is not an event - it stays true every tick until the agent is
unloaded - so a hook keyed on it would fire forever, and a rewriting hook would
compound its own output. A `TerminalHookFired` marker makes it a one-shot, and
there is a test that runs the schedule three times and asserts the answer gained
exactly one `!`.

The marker goes on **before** the script runs, not after. A hook that throws
must not be retried next tick, or one error becomes an infinite loop.

### Which hook, and one that fires neither

A completed run gets `on_completion` with its answer; an errored one gets
`on_error` with the message. A **cancelled** run gets neither: it was stopped
from outside, and a hook narrating that would be reporting the operator's own
decision back to them.

`modify` replaces what the hook was shown - the final output for a completion,
the message for an error. `cancel` on a completion is a real veto ("that answer
is not acceptable") and turns the run into an error carrying the reason.

Rewriting an answer on a run that submitted none is refused rather than dropped,
for the same reason writing an unknown region is: a silently-ignored rewrite
reads exactly like one that happened.

### Tests

23 new, including the two that pin the one-shot: three schedule runs producing
one rewrite, and a throwing hook whose message is unchanged after a second run.
Plus the cancelled-run case, an unfinished run staying unmarked and eligible, a
completion with no answer seeing an empty string, both veto paths, `retry`
refused, a non-text modify, and the no-stage / no-declared-hook cases still
being marked so a finished run is not re-checked every tick.

All 34 workspace test binaries green; `cargo xtask coverage` clean on
`leviath-core`, `leviath-scripting`, and `leviath-runtime`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
