### PR TITLE
fix(output): the resolved output spec outranks the stage prompt (#282)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "chrono",
  "dirs",
  "glob",
+ "leviath-testkit",
  "regex",
  "reqwest",
  "serde",
@@ -2547,6 +2548,7 @@ version = "0.2.0"
 dependencies = [
  "keyring",
  "keyring-core",
+ "leviath-testkit",
  "nix 0.31.3",
  "temp-env",
  "tempfile",

--- a/crates/leviath-core/src/output.rs
+++ b/crates/leviath-core/src/output.rs
@@ -291,6 +291,16 @@ pub fn resolve_output_spec(
 /// most for a format the model has no prior knowledge of, which is exactly the
 /// case this module is built to support.
 ///
+/// A constrained spec closes with a precedence sentence, because without one
+/// this text and the stage's own system prompt are two peer instructions and
+/// which wins is model-dependent (issue #282: a stage prompt saying "lead with
+/// the diagnosis" beat `--output-instructions "reply with only the integer"` on
+/// some models and lost on others). By the time this runs, [`resolve_output_spec`]
+/// has already picked one winner per field - a caller's flag replaces the
+/// blueprint's line rather than joining it - so there is exactly one shape here
+/// and it is the one that should govern. The sentence is scoped to presentation
+/// so a bare `format` does not read as licence to drop content.
+///
 /// Returns an empty string for a spec that constrains nothing, so callers can
 /// append it unconditionally.
 pub fn describe_spec(spec: &OutputSpec) -> String {
@@ -310,6 +320,14 @@ pub fn describe_spec(spec: &OutputSpec) -> String {
         parts.push(format!(
             "Here is an example of the expected shape:\n{example}"
         ));
+    }
+    if !parts.is_empty() {
+        parts.push(
+            "This governs how the answer is presented. Where anything else you were told says \
+             to present it differently - its length, its structure, what to lead with - follow \
+             this."
+                .to_string(),
+        );
     }
     parts.join("\n\n")
 }
@@ -548,6 +566,48 @@ mod tests {
         assert!(described.contains("One card per finding."));
         assert!(described.contains("valid against this schema"));
         assert!(described.contains("{\"root\": {}}"));
+    }
+
+    /// Issue #282. Without this the spec and the stage's own system prompt are
+    /// two peer instructions, and a strongly-shaped stage prompt wins on some
+    /// models and loses on others.
+    #[test]
+    fn a_constrained_spec_says_it_outranks_the_stage_prompt() {
+        let described = describe_spec(&OutputSpec {
+            instructions: Some("Reply with only the integer.".to_string()),
+            ..OutputSpec::default()
+        });
+        assert!(
+            described.contains("Where anything else you were told"),
+            "{described}"
+        );
+        // Last, so it is read as governing what precedes it rather than as one
+        // more line the next paragraph can override.
+        assert!(
+            described.trim_end().ends_with("follow this."),
+            "{described}"
+        );
+    }
+
+    /// A format on its own is still a shape, so it still outranks a prompt that
+    /// describes a different one.
+    #[test]
+    fn a_format_only_spec_claims_precedence_too() {
+        let described = describe_spec(&OutputSpec {
+            format: Some("text".to_string()),
+            ..OutputSpec::default()
+        });
+        assert!(
+            described.contains("Where anything else you were told"),
+            "{described}"
+        );
+    }
+
+    /// The claim is scoped to presentation. A spec that constrains nothing must
+    /// not tell a model to disregard its stage prompt.
+    #[test]
+    fn an_unconstrained_spec_claims_nothing() {
+        assert!(!describe_spec(&OutputSpec::default()).contains("follow this"));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -9890,6 +9890,39 @@ fn stage_setup_from_folds_a_required_output_into_the_system_prompt() {
     assert!(prompt.contains("{\"root\": {}}"), "{prompt}");
 }
 
+/// Issue #282. The stage's own prompt and the resolved spec are both just text
+/// to a model, so the spec has to come last *and* say it governs. Ordering on
+/// its own is what the reported build already did, and a strong stage prompt
+/// still won on some models.
+#[test]
+fn a_required_outputs_shape_comes_after_the_stage_prompt_and_outranks_it() {
+    let spec = leviath_core::output::OutputSpec {
+        format: Some("text".to_string()),
+        instructions: Some("Reply with only the integer.".to_string()),
+        ..Default::default()
+    };
+    let mut s = stage_named("summary", None, false, None);
+    s.require_output = true;
+    s.config.insert(
+        "system_prompt".to_string(),
+        serde_json::Value::String("Lead with the diagnosis.".to_string()),
+    );
+    let prompt = stage_setup_from(&s, hints(true), Default::default(), Some(spec))
+        .system_prompt
+        .expect("a required output always produces instructions");
+    let stage_at = prompt
+        .find("Lead with the diagnosis.")
+        .expect("stage prompt");
+    let caller_at = prompt
+        .find("Reply with only the integer.")
+        .expect("the caller's instructions");
+    let rule_at = prompt
+        .find("Where anything else you were told")
+        .expect("the precedence rule");
+    assert!(stage_at < caller_at, "{prompt}");
+    assert!(caller_at < rule_at, "{prompt}");
+}
+
 /// A stage that declares a shape but is not required to submit is left alone:
 /// declaring is not demanding.
 #[test]

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -170,6 +170,22 @@ One rule breaks that pattern on purpose. If you name a `format` and supply no sc
 blueprint declared is dropped. A check written for one shape says nothing about another. Supply your
 own schema alongside your format when you want the answer validated.
 
+### It outranks the stage's prompt
+
+A stage's `system_prompt` often has opinions about presentation of its own. The bundled
+`log-analyzer` tells its summary stage to lead with the diagnosis and name the report file, which is
+good default behaviour and directly at odds with `--output-instructions "reply with only the
+integer"`.
+
+Once the three levels above have combined, the winning spec is stated to the model as the one that
+governs how the answer is presented, and the stage prompt yields to it wherever the two disagree. So
+a caller who passes `--output-format` or `--output-instructions` does not have to know what the
+blueprint's prompt says, and a blueprint author does not have to strip presentation guidance out of
+a prompt to leave room for callers who may never pass anything.
+
+The claim is scoped to presentation: length, structure, what to lead with. It does not tell the
+model to disregard what the stage prompt asked it to *do*.
+
 ## Checking the shape, with a JSON Schema
 
 ```toml


### PR DESCRIPTION
fix(output): the resolved output spec outranks the stage prompt (#282)

`--output-instructions "reply with only the integer"` and the bundled
log-analyzer's summary prompt ("Lead with the diagnosis... Name the report file
you wrote") are both, as far as a model is concerned, sentences in the same
system prompt. Which one wins was model-dependent: haiku complied 8/8, sonnet
returned narrative in 3/8.

### Not already fixed by structured output

Worth stating, because it was the first guess. `submit_output` plus schema
validation genuinely does enforce shape - a mismatched submission is refused
back to the model with the validator's message and the next turn self-corrects.
But that path only exists when a schema exists. The reported case is
`--output-format text` with prose instructions, so there is nothing to validate
and both instructions stay peers.

### Ordering was already right

The other guess. `stage_setup_from` already appends the resolved spec *after*
the stage's `system_prompt`, and it does so for every stage at spawn, not just
the entry one, so a summary stage reached by transition gets it too. Ordering
alone is what the reported build did, and a strong stage prompt still beat it.

### What changed

`describe_spec` closes a constrained spec with a sentence saying it governs
presentation and that anything above describing the answer differently yields to
it. Both render sites pick this up, since both append `describe_spec` last: the
output stage's system prompt and the `submit_output` tool description.

Provenance needs no plumbing here. `resolve_output_spec` has already picked one
winner per field by this point - a caller's flag replaces the blueprint's line
rather than joining it - so there is exactly one shape being described, and it
is by construction the one that should govern. That also makes the rule coherent
for a spec that came from the blueprint: an author's `[stages.X.output]` block
is the contract, and their prose prompt is guidance.

The claim is deliberately scoped to presentation - length, structure, what to
lead with - so a spec carrying nothing but `format = "text"` does not read as
licence to drop the content the stage prompt asked for.

The bundled log-analyzer is left alone. Leading with the diagnosis is the right
default for a caller who passes no flags, and after this a caller who does pass
them wins without the blueprint having to give up its default.

### Tests

Four. Three in `output.rs` pin that a constrained spec claims precedence, that a
format on its own counts as constrained, and that an empty spec claims nothing.
The fourth sits in the pipeline tests where the property actually lives: it
asserts the stage prompt, then the caller's instructions, then the precedence
rule, in that order in the assembled system prompt. Asserting the sentence is
merely present would pass against a version that put it first, which is the
arrangement that does not work.

`cargo xtask coverage` clean on leviath-core and leviath-runtime,
`cargo xtask docs --check` clean, full suite green.

Closes #282

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
