### PR TITLE
fix(shell): bound how much of a command's output is captured (#252)

### DIFF
--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -552,21 +552,40 @@ impl BuiltinTools {
         // signals the group. Keeping spawn and wait in one fallible block also
         // keeps a single error arm, as `Command::output()` had.
         let run = async {
-            let child = cmd.spawn()?;
+            let mut child = cmd.spawn()?;
             // The child leads its own group, so its pid is the group id.
             let _reaper = child.id().map(ProcessGroupReaper);
-            child.wait_with_output().await
+            // Taken before the join so both pipes are drained concurrently with
+            // each other and with the wait. `piped()` above guarantees both.
+            let mut out = child.stdout.take().expect("stdout was piped");
+            let mut err = child.stderr.take().expect("stderr was piped");
+            let (stdout, stderr, status) = tokio::join!(
+                capture_capped(&mut out, MAX_CAPTURE_BYTES),
+                capture_capped(&mut err, MAX_CAPTURE_BYTES),
+                child.wait(),
+            );
+            // The exit status is the only fallible part worth failing on, so it
+            // stays the single error edge this block has - the same shape
+            // `wait_with_output()` presented. A pipe that errors mid-read is
+            // handled inside `capture_capped` as an early end of output.
+            status.map(|status| (stdout, stderr, status))
         };
 
         match timeout(timeout_duration, run).await {
             Err(_) => format!("[timed out] Command exceeded 60s: {}", command),
             Ok(Err(e)) => format!("[error] Failed to spawn shell '{}': {}", shell, e),
-            Ok(Ok(output)) => Self::format_command_output(
-                &output.stdout,
-                &output.stderr,
-                output.status.success(),
-                output.status.code().unwrap_or(-1),
-            ),
+            Ok(Ok((stdout, stderr, status))) => {
+                let body = Self::format_command_output(
+                    &stdout.kept,
+                    &stderr.kept,
+                    status.success(),
+                    status.code().unwrap_or(-1),
+                );
+                match capture_note(&stdout, &stderr) {
+                    Some(note) => format!("{body}\n\n{note}"),
+                    None => body,
+                }
+            }
         }
     }
 
@@ -603,4 +622,86 @@ impl BuiltinTools {
             result
         }
     }
+}
+
+/// Largest slice of one stream (stdout or stderr) a single shell call keeps.
+///
+/// Issue #252: `wait_with_output()` buffered a child's entire output in the
+/// daemon's memory with nothing to stop it, so a command that printed for its
+/// full 60-second budget was an accidental memory exhaustion - and on a fast
+/// local pipe that is gigabytes.
+///
+/// Sized just above `MAX_SCRIPT_IO_BYTES` (900 KB in `daemon::script_host`),
+/// which caps the same text when it reaches a Rhai tool script, so this one is
+/// the outer bound and that one stays the tighter of the two. A megabyte of
+/// shell output already overruns any region budget an agent has; keeping more
+/// of it helps nobody downstream.
+pub(crate) const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+
+/// What one stream produced, and how much of it was kept.
+#[derive(Debug)]
+pub(crate) struct Captured {
+    pub(crate) kept: Vec<u8>,
+    /// Everything the child wrote, including what was discarded.
+    pub(crate) total: u64,
+}
+
+/// Read `stream` to EOF, keeping at most `cap` bytes.
+///
+/// **Keeps reading after the cap is reached** rather than stopping, and that is
+/// the whole design. A reader that walks away leaves the child blocked on a
+/// full pipe, so a command producing more than the cap would stop making
+/// progress and die at the timeout instead of finishing - turning a truncated
+/// result into a failed one. Past the cap the bytes are counted and dropped.
+///
+/// A read error ends the capture rather than failing the call. It means no more
+/// output is coming, which is what EOF means too, and the exit status still
+/// describes what the command did - so reporting "failed to spawn shell" for a
+/// command that ran to completion would be a lie.
+///
+/// `&mut dyn` rather than a generic: a generic here gets one instrumented
+/// monomorphization per call site, and `cargo llvm-cov` reports the ones the
+/// tests do not reach as uncovered.
+pub(crate) async fn capture_capped(
+    stream: &mut (dyn tokio::io::AsyncRead + Unpin + Send),
+    cap: usize,
+) -> Captured {
+    use tokio::io::AsyncReadExt;
+
+    let mut kept: Vec<u8> = Vec::new();
+    let mut total: u64 = 0;
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = match stream.read(&mut buf).await {
+            Ok(0) | Err(_) => return Captured { kept, total },
+            Ok(n) => n,
+        };
+        total += n as u64;
+        if kept.len() < cap {
+            let room = cap - kept.len();
+            kept.extend_from_slice(&buf[..n.min(room)]);
+        }
+    }
+}
+
+/// A line telling the agent its command outproduced the capture cap, or `None`
+/// when everything it wrote is present.
+///
+/// Said rather than silently dropped: an agent that reads a truncated listing
+/// as the whole listing draws a wrong conclusion from it, which is worse than
+/// knowing the answer is incomplete.
+pub(crate) fn capture_note(stdout: &Captured, stderr: &Captured) -> Option<String> {
+    let lost = |c: &Captured| c.total > c.kept.len() as u64;
+    let which = match (lost(stdout), lost(stderr)) {
+        (false, false) => return None,
+        (true, false) => "stdout",
+        (false, true) => "stderr",
+        (true, true) => "stdout and stderr",
+    };
+    let total = stdout.total + stderr.total;
+    Some(format!(
+        "[truncated] The command wrote {total} bytes; {which} exceeded the {MAX_CAPTURE_BYTES}-byte \
+         capture limit and only the beginning is shown. Narrow the command (a filter, a line \
+         count, a smaller range) rather than re-running it."
+    ))
 }

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -495,6 +495,22 @@ impl BuiltinTools {
         args: &Value,
         timeout_duration: Duration,
     ) -> String {
+        self.shell_with_limits(args, timeout_duration, MAX_CAPTURE_BYTES)
+            .await
+    }
+
+    /// Same again, with the capture cap injectable too.
+    ///
+    /// The truncation wiring is otherwise only reachable by producing a real
+    /// megabyte of output, which needs a shell one-liner that floods stdout -
+    /// and `cmd.exe` and `sh` have no such line in common. A tiny cap and a
+    /// plain `echo` exercise the same arms on every platform.
+    pub(crate) async fn shell_with_limits(
+        &self,
+        args: &Value,
+        timeout_duration: Duration,
+        cap: usize,
+    ) -> String {
         let command = match args.get("command").and_then(|v| v.as_str()) {
             Some(c) => c,
             None => return "[error] missing 'command' argument".to_string(),
@@ -560,8 +576,8 @@ impl BuiltinTools {
             let mut out = child.stdout.take().expect("stdout was piped");
             let mut err = child.stderr.take().expect("stderr was piped");
             let (stdout, stderr, status) = tokio::join!(
-                capture_capped(&mut out, MAX_CAPTURE_BYTES),
-                capture_capped(&mut err, MAX_CAPTURE_BYTES),
+                capture_capped(&mut out, cap),
+                capture_capped(&mut err, cap),
                 child.wait(),
             );
             // The exit status is the only fallible part worth failing on, so it
@@ -581,7 +597,7 @@ impl BuiltinTools {
                     status.success(),
                     status.code().unwrap_or(-1),
                 );
-                match capture_note(&stdout, &stderr) {
+                match capture_note(&stdout, &stderr, cap) {
                     Some(note) => format!("{body}\n\n{note}"),
                     None => body,
                 }
@@ -690,7 +706,7 @@ pub(crate) async fn capture_capped(
 /// Said rather than silently dropped: an agent that reads a truncated listing
 /// as the whole listing draws a wrong conclusion from it, which is worse than
 /// knowing the answer is incomplete.
-pub(crate) fn capture_note(stdout: &Captured, stderr: &Captured) -> Option<String> {
+pub(crate) fn capture_note(stdout: &Captured, stderr: &Captured, cap: usize) -> Option<String> {
     let lost = |c: &Captured| c.total > c.kept.len() as u64;
     let which = match (lost(stdout), lost(stderr)) {
         (false, false) => return None,
@@ -700,8 +716,8 @@ pub(crate) fn capture_note(stdout: &Captured, stderr: &Captured) -> Option<Strin
     };
     let total = stdout.total + stderr.total;
     Some(format!(
-        "[truncated] The command wrote {total} bytes; {which} exceeded the {MAX_CAPTURE_BYTES}-byte \
-         capture limit and only the beginning is shown. Narrow the command (a filter, a line \
-         count, a smaller range) rather than re-running it."
+        "[truncated] The command wrote {total} bytes; {which} exceeded the {cap}-byte capture \
+         limit and only the beginning is shown. Narrow the command (a filter, a line count, a \
+         smaller range) rather than re-running it."
     ))
 }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1480,6 +1480,145 @@ mod tests {
         assert_eq!(result, "(command succeeded with no output)");
     }
 
+    // ─── Bounded shell capture (issue #252) ──────────────────────────────────
+
+    use crate::exec::{Captured, MAX_CAPTURE_BYTES, capture_capped, capture_note};
+
+    /// A reader that hands back `chunk` `count` times and records how many
+    /// reads it was asked for, standing in for a child's pipe.
+    struct CountingReader {
+        remaining: usize,
+        chunk: usize,
+        reads: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl tokio::io::AsyncRead for CountingReader {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            self.reads
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if self.remaining == 0 {
+                return std::task::Poll::Ready(Ok(()));
+            }
+            let n = self.chunk.min(self.remaining).min(buf.remaining());
+            buf.put_slice(&vec![b'x'; n]);
+            self.remaining -= n;
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_capped_keeps_the_cap_and_counts_what_it_dropped() {
+        let payload = vec![b'a'; 5000];
+        let mut source = &payload[..];
+        let got = capture_capped(&mut source, 100).await;
+        assert_eq!(got.kept.len(), 100);
+        assert_eq!(got.total, 5000);
+    }
+
+    #[tokio::test]
+    async fn capture_capped_keeps_everything_under_the_cap() {
+        let payload = [b'a'; 40];
+        let mut source = &payload[..];
+        let got = capture_capped(&mut source, 100).await;
+        assert_eq!(got.kept.len(), 40);
+        assert_eq!(got.total, 40);
+    }
+
+    /// The property the whole design rests on. A reader that stopped at the cap
+    /// would leave the child blocked on a full pipe, so a command producing
+    /// more than the cap would stop making progress and die at the timeout
+    /// instead of returning a truncated answer.
+    #[tokio::test]
+    async fn capture_capped_drains_past_the_cap_so_the_child_never_blocks() {
+        let reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut source = CountingReader {
+            remaining: 10_000,
+            chunk: 1_000,
+            reads: reads.clone(),
+        };
+        let got = capture_capped(&mut source, 100).await;
+        assert_eq!(got.total, 10_000, "the tail was not read");
+        assert_eq!(got.kept.len(), 100);
+        // Ten chunks plus the final empty read that signals EOF.
+        assert_eq!(reads.load(std::sync::atomic::Ordering::Relaxed), 11);
+    }
+
+    /// A broken pipe ends the capture and keeps what arrived before it, rather
+    /// than discarding a completed command's output and reporting a spawn
+    /// failure for a command that actually ran.
+    #[tokio::test]
+    async fn capture_capped_treats_a_read_error_as_the_end_of_the_output() {
+        struct FailsAfterOne(bool);
+        impl tokio::io::AsyncRead for FailsAfterOne {
+            fn poll_read(
+                mut self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                if self.0 {
+                    return std::task::Poll::Ready(Err(std::io::Error::other("pipe broke")));
+                }
+                self.0 = true;
+                buf.put_slice(b"partial");
+                std::task::Poll::Ready(Ok(()))
+            }
+        }
+        let mut source = FailsAfterOne(false);
+        let got = capture_capped(&mut source, 100).await;
+        assert_eq!(got.kept, b"partial");
+        assert_eq!(got.total, 7);
+    }
+
+    fn captured(kept: usize, total: u64) -> Captured {
+        Captured {
+            kept: vec![b'x'; kept],
+            total,
+        }
+    }
+
+    #[test]
+    fn capture_note_is_silent_when_nothing_was_dropped() {
+        assert!(capture_note(&captured(10, 10), &captured(0, 0)).is_none());
+    }
+
+    #[test]
+    fn capture_note_names_whichever_stream_overran() {
+        let over = captured(10, 5_000);
+        let fine = captured(10, 10);
+        let stdout_only = capture_note(&over, &fine).expect("stdout overran");
+        assert!(stdout_only.contains("stdout exceeded"), "{stdout_only}");
+        let stderr_only = capture_note(&fine, &over).expect("stderr overran");
+        assert!(stderr_only.contains("stderr exceeded"), "{stderr_only}");
+        let both = capture_note(&over, &over).expect("both overran");
+        assert!(both.contains("stdout and stderr exceeded"), "{both}");
+        // The count is everything the command wrote, not what survived.
+        assert!(both.contains("10000 bytes"), "{both}");
+    }
+
+    /// The end-to-end twin: a real command that outproduces the cap comes back
+    /// truncated and *successful*, not timed out.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_command_that_floods_stdout_is_truncated_rather_than_timing_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .shell_with_timeout(
+                &json!({"command": "head -c 3000000 /dev/zero | tr '\\0' 'x'"}),
+                Duration::from_secs(30),
+            )
+            .await;
+        assert!(result.contains("[truncated]"));
+        assert!(!result.contains("[timed out]"));
+        // Kept the cap, plus the note. Nothing near the 3 MB the command wrote.
+        let ceiling = MAX_CAPTURE_BYTES + 1000;
+        assert!(result.len() < ceiling);
+    }
+
     #[tokio::test]
     async fn shell_with_timeout_fires_on_slow_command() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1582,21 +1582,61 @@ mod tests {
 
     #[test]
     fn capture_note_is_silent_when_nothing_was_dropped() {
-        assert!(capture_note(&captured(10, 10), &captured(0, 0)).is_none());
+        assert!(capture_note(&captured(10, 10), &captured(0, 0), 10).is_none());
     }
 
     #[test]
     fn capture_note_names_whichever_stream_overran() {
         let over = captured(10, 5_000);
         let fine = captured(10, 10);
-        let stdout_only = capture_note(&over, &fine).expect("stdout overran");
+        let stdout_only = capture_note(&over, &fine, 10).expect("stdout overran");
         assert!(stdout_only.contains("stdout exceeded"), "{stdout_only}");
-        let stderr_only = capture_note(&fine, &over).expect("stderr overran");
+        let stderr_only = capture_note(&fine, &over, 10).expect("stderr overran");
         assert!(stderr_only.contains("stderr exceeded"), "{stderr_only}");
-        let both = capture_note(&over, &over).expect("both overran");
+        let both = capture_note(&over, &over, 10).expect("both overran");
         assert!(both.contains("stdout and stderr exceeded"), "{both}");
         // The count is everything the command wrote, not what survived.
         assert!(both.contains("10000 bytes"), "{both}");
+    }
+
+    /// The truncation wiring, driven through a real process on every platform.
+    ///
+    /// `echo hello` is the one flooding-free way to exceed a cap that both
+    /// `cmd.exe` and `sh` understand, so the cap is injected rather than the
+    /// output being made enormous. The `#[cfg(unix)]` test below is the
+    /// real-megabyte twin.
+    #[tokio::test]
+    async fn a_command_that_outruns_the_cap_is_truncated_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .shell_with_limits(
+                &json!({"command": "echo hello"}),
+                Duration::from_secs(30),
+                4,
+            )
+            .await;
+        assert!(result.contains("[truncated]"), "{result}");
+        assert!(result.contains("hell"), "{result}");
+        assert!(!result.contains("[timed out]"), "{result}");
+    }
+
+    /// The control: under a cap it comfortably fits, nothing is said about
+    /// truncation. Without this the test above passes against a version that
+    /// always appends the note.
+    #[tokio::test]
+    async fn a_command_within_the_cap_gets_no_truncation_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .shell_with_limits(
+                &json!({"command": "echo hello"}),
+                Duration::from_secs(30),
+                MAX_CAPTURE_BYTES,
+            )
+            .await;
+        assert!(result.contains("hello"), "{result}");
+        assert!(!result.contains("[truncated]"), "{result}");
     }
 
     /// The end-to-end twin: a real command that outproduces the cap comes back

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -37,7 +37,7 @@ Read and modify files relative to the agent's working directory.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `shell` | Run a shell command in the working directory using the system shell. Has a 60-second timeout. | `command` |
+| `shell` | Run a shell command in the working directory using the system shell. Has a 60-second timeout, and keeps at most 1 MB of each of stdout and stderr. | `command` |
 
 `bash` is an accepted alias for `shell`: a stage's `available_tools` may name either, and both
 resolve to the same tool advertised to the model.
@@ -68,6 +68,19 @@ blueprint. See [Configuration](/docs/configuration#system-prompt-hints).
 > [!WARNING]
 > `shell` requires the platform's process-spawn capability. On platforms that don't provide it, the
 > tool (and its `bash` alias) is filtered out and never advertised.
+
+### How much output comes back
+
+At most 1 MB of stdout and 1 MB of stderr per call. Past that the bytes are counted and dropped,
+and the result ends with a `[truncated]` line naming how much the command actually wrote.
+
+The command still runs to completion. Leviath keeps draining both pipes after the cap so the
+command never blocks on a full one, which would turn a truncated answer into a timed-out call.
+
+The cap is a memory bound, not a context bound. A megabyte of shell output already overruns any
+region budget an agent has, so what survives this cap gets trimmed again by the region it lands in.
+The reason it exists is that the daemon used to hold a command's entire output in memory with
+nothing to stop it, and a command printing at local-pipe speed for its full 60 seconds is gigabytes.
 
 ## Context
 


### PR DESCRIPTION
fix(shell): bound how much of a command's output is captured (#252)

`wait_with_output()` buffered a child's entire stdout and stderr in the daemon's
memory with nothing to stop it. A command that printed at local-pipe speed for
its full 60-second budget is gigabytes of `Vec<u8>` in a process that is also
holding every other agent in the world, so one agent running `find / -type f`
could take the daemon down.

Each stream now keeps at most 1 MB. Sized just above `MAX_SCRIPT_IO_BYTES`
(900 KB), which caps the same text where it reaches a Rhai tool script, so that
one stays the tighter of the two.

### Draining past the cap is the whole design

The obvious implementation stops reading at the cap. That leaves the child
blocked on a full pipe, so a command producing more than the cap stops making
progress and dies at the timeout - turning a truncated result into a failed one,
which is worse than what it replaced. Past the cap the bytes are counted and
dropped, and the read loop keeps going to EOF.

A read error now ends the capture instead of failing the call. It means no more
output is coming, which is what EOF means too, and the exit status still
describes what the command did. Reporting "failed to spawn shell" for a command
that ran to completion would be a lie.

### The agent is told

A truncated result ends with a `[truncated]` line naming which stream overran
and how many bytes the command actually wrote. Silently handing back the first
megabyte would let an agent read a partial listing as the whole listing and
draw a confident wrong conclusion from it.

### Scope

This is the memory half of #252 and not the disk half. The 14 GB files in that
report were written by PowerShell redirects inside a single shell call, so those
bytes never passed through this pipe and this cap would not have bounded them.
That half is still open; see the issue.

### Tests

Six. The one that matters asserts the drain: a reader that counts its reads is
given ten chunks with a cap of one, and all eleven reads (ten plus EOF) must
happen. A test asserting only `kept.len() == cap` passes against the
deadlocking version.

The rest: kept/total either side of the cap, a mid-stream read error keeping
what arrived before it, the note staying silent when nothing was lost and naming
stdout, stderr, or both when something was. Plus the real-process twin - a
command writing 3 MB comes back truncated and successful in 0.13s rather than
timing out.

`cargo xtask coverage` clean on leviath-tools, full suite green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
