### PR TITLE
docs: require doc comments on the published crates, and write the 159 missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,14 @@ categories = ["development-tools"]
 # dependencies (nix, temp-env) plus ONE audited in-repo exception: leviath-alloc,
 # a single-call crate that deliberately does not opt into these lints (its lib.rs
 # carries the audit note). Nothing else writes unsafe.
+# Every public item in the published library crates carries a doc comment, and
+# CI's `RUSTFLAGS: -D warnings` turns this "warn" into a blocking error, so a PR
+# that adds undocumented public API does not merge. `leviath-cli` opts out at its
+# crate root (see the note there): it ships as the `lev` binary, and its `pub`
+# surface is command plumbing rather than API anyone calls.
 [workspace.lints.rust]
 unsafe_code = "forbid"
+missing_docs = "warn"
 
 # `&s[a..b]` on a `&str` panics when an index lands inside a multi-byte character.
 # That is not hypothetical here: it aborted the daemon twice (issues #109 and #115,
@@ -52,14 +58,6 @@ unsafe_code = "forbid"
 # `#[expect(clippy::string_slice, reason = "...")]` naming the construct that
 # guarantees it. "Looks fine" is exactly the unstated invariant this lint exists to
 # stop.
-# NOTE on `missing_docs`: measured, not enabled. Turning it on flags 325 items
-# (leviath-cli 166, leviath-core 109, runtime 18, mcp 15, providers 14, tools 3),
-# and CI runs with `-D warnings`, so "warn" is "deny" here. 240 of the 325 are
-# struct fields - largely serde payload types whose field names already say what
-# they are, and a doc comment restating a field name is the noise this repo's
-# comment policy exists to keep out. The 52 non-field items (functions, methods,
-# structs, enums) are worth documenting and would make the lint affordable;
-# that is a focused piece of work, not a flag flip.
 [workspace.lints.clippy]
 string_slice = "deny"
 

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -1,4 +1,21 @@
 //! Leviath CLI library - re-exports for integration tests.
+//!
+//! # Why `missing_docs` is off here
+//!
+//! It is on for the whole workspace, because the other crates publish a library
+//! whose docs render on docs.rs and get called by people who did not write them.
+//! This crate publishes the `lev` **binary**. Its `pub` surface is `pub` so the
+//! integration tests in `tests/` can reach it, not because anything outside
+//! calls it - `execute(args: AddArgs)` is `lev add`, and a doc comment saying so
+//! restates the module path.
+//!
+//! The 166 items that would be flagged here are mostly clap `Args` fields, which
+//! already carry their user-facing text in `#[arg(help = ...)]` or a doc comment
+//! clap consumes. Requiring a second description for the rustdoc reader who does
+//! not exist is the noise this repo's comment policy is written to keep out.
+//!
+//! Tracked in #290 if that reasoning stops holding.
+#![allow(missing_docs)]
 
 pub mod approvals;
 pub mod bundled;

--- a/crates/leviath-core/src/blueprint.rs
+++ b/crates/leviath-core/src/blueprint.rs
@@ -1150,6 +1150,7 @@ pub struct ModelEntry {
 }
 
 impl ModelEntry {
+    /// One provider/model pair in a stage's fallback list.
     pub fn new(provider: String, model: String) -> Self {
         Self { provider, model }
     }
@@ -1506,15 +1507,22 @@ pub enum EdgeTransform {
 
     /// LLM-compact stage content into summary
     Compact {
+        /// What to ask the compaction model for, replacing the built-in
+        /// instruction. `None` uses the default summary prompt.
         #[serde(default)]
         prompt: Option<String>,
     },
 
     /// Per-region rules
     Custom {
+        /// Regions copied through untouched.
         carry: Vec<String>,
+        /// Regions replaced by an LLM summary of themselves.
         compact: Vec<String>,
+        /// Regions emptied on the way across.
         clear: Vec<String>,
+        /// The instruction used for everything in `compact`. `None` uses the
+        /// default summary prompt.
         compact_prompt: Option<String>,
     },
 }
@@ -1555,7 +1563,10 @@ pub enum ContentTransform {
     Summarize,
 
     /// Extract specific fields
-    Extract { fields: Vec<String> },
+    Extract {
+        /// Which fields to keep, by name. Anything else is dropped.
+        fields: Vec<String>,
+    },
 }
 
 #[cfg(test)]

--- a/crates/leviath-core/src/cache.rs
+++ b/crates/leviath-core/src/cache.rs
@@ -15,7 +15,12 @@ pub enum CacheHint {
     UntilChanged,
     /// Cache the stable prefix of a sliding window.
     /// `stable_fraction` is 0.0..1.0 (default 0.75 = oldest 75% of messages are stable).
-    SlidingPrefix { stable_fraction: f32 },
+    SlidingPrefix {
+        /// How much of the window counts as stable, in `0.0..1.0`. The oldest
+        /// that fraction is cached; the newest tail is not, because it is what
+        /// changes every turn and would invalidate the whole prefix with it.
+        stable_fraction: f32,
+    },
     /// Never cache (temporary, clearable, new messages).
     Never,
 }

--- a/crates/leviath-core/src/error.rs
+++ b/crates/leviath-core/src/error.rs
@@ -14,11 +14,21 @@ pub enum ValidationError {
 
     /// Stage-level validation failure
     #[error("Invalid stage '{stage}': {message}")]
-    Stage { stage: String, message: String },
+    Stage {
+        /// The offending stage's name.
+        stage: String,
+        /// What is wrong with it.
+        message: String,
+    },
 
     /// Region-level validation failure
     #[error("Invalid region '{region}': {message}")]
-    Region { region: String, message: String },
+    Region {
+        /// The offending region's name.
+        region: String,
+        /// What is wrong with it.
+        message: String,
+    },
 
     /// Layout-level validation failure
     #[error("Invalid layout: {0}")]
@@ -31,8 +41,11 @@ pub enum ValidationError {
     /// Transition validation failure
     #[error("Invalid transition from '{from}' to '{to}': {message}")]
     Transition {
+        /// The stage the edge leaves.
         from: String,
+        /// The stage the edge names as its target, which may not exist.
         to: String,
+        /// What is wrong with it.
         message: String,
     },
 }
@@ -50,12 +63,20 @@ pub enum Error {
 
     /// Content exceeds region's token budget
     #[error("Content exceeds token budget: {used} > {max}")]
-    TokenBudgetExceeded { used: usize, max: usize },
+    TokenBudgetExceeded {
+        /// Tokens the write would have brought the region to.
+        used: usize,
+        /// The region's ceiling.
+        max: usize,
+    },
 
     /// Pinned regions alone exceed total token budget
     #[error("Pinned regions ({pinned_tokens}) exceed total budget ({total_budget})")]
     PinnedRegionsOverBudget {
+        /// Tokens held by regions that can never be evicted, which is what makes
+        /// this unrecoverable rather than a matter of dropping something.
         pinned_tokens: usize,
+        /// The whole window's budget.
         total_budget: usize,
     },
 

--- a/crates/leviath-core/src/net.rs
+++ b/crates/leviath-core/src/net.rs
@@ -105,6 +105,17 @@ fn redirect_decision(
     check_url(url, allow_local).map_err(|e| format!("refused to follow redirect: {e}"))
 }
 
+/// A client whose redirects are policed by [`check_url`], so a permitted first
+/// hop cannot be turned into a request somewhere else.
+///
+/// The SSRF check on the URL a caller passes is worth little on its own: a
+/// cooperating server answers `302` and the default policy follows it to
+/// `169.254.169.254` with the original headers attached. Every redirect is
+/// re-checked here, and the chain is capped at five hops.
+///
+/// `allow_local` is threaded through to the same check, so a caller that
+/// legitimately talks to `localhost` (an Ollama endpoint) does not have to
+/// choose between that and having a redirect policy at all.
 pub fn checked_client(timeouts: ClientTimeouts, allow_local: bool) -> reqwest::Client {
     client_builder(timeouts)
         .redirect(reqwest::redirect::Policy::custom(

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -21,11 +21,21 @@ pub enum EntryKind {
     /// User message in conversation.
     UserMessage,
     /// Assistant response with optional tool calls.
-    AssistantTurn { tool_calls: Vec<SerializedToolCall> },
+    AssistantTurn {
+        /// The calls the model asked for, empty when it only spoke. Kept with
+        /// the turn so a reloaded context replays the same request shape the
+        /// provider originally saw.
+        tool_calls: Vec<SerializedToolCall>,
+    },
     /// Tool execution result, paired with a tool_call_id.
     ToolResult {
+        /// The `AssistantTurn` call this answers. Providers reject a result
+        /// whose id does not match a call they were shown.
         tool_call_id: String,
+        /// The tool that produced it, for display and telemetry.
         tool_name: String,
+        /// Whether the tool refused or failed, so a reload does not present a
+        /// failure back to the model as a successful result.
         is_error: bool,
     },
 }
@@ -33,8 +43,12 @@ pub enum EntryKind {
 /// A serialized tool call stored within an `AssistantTurn` entry.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SerializedToolCall {
+    /// The provider-assigned call id, which the matching
+    /// [`EntryKind::ToolResult`] must quote back.
     pub id: String,
+    /// The tool the model asked for, as it named it.
     pub name: String,
+    /// The arguments as the model supplied them, unvalidated and untransformed.
     pub arguments: serde_json::Value,
     /// Opaque provider token that must be replayed with this call
     /// (Gemini's `thought_signature`). Persisted so it survives a restart.
@@ -874,13 +888,21 @@ pub enum ContentFormat {
     Mermaid,
 
     /// Source code in a specific language
-    Code { language: String },
+    Code {
+        /// The language label, used for the fence and nothing else - no
+        /// per-language parsing happens.
+        language: String,
+    },
 
     /// Markdown formatted text
     Markdown,
 
     /// Custom format with user-defined validation
-    Custom { format_name: String },
+    Custom {
+        /// The author's own name for the format, matched against the validator
+        /// registered for it.
+        format_name: String,
+    },
 }
 
 /// Trait for content validators.

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -14,9 +14,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunStatus {
+    /// Accepted and being set up; no inference has been issued yet.
     Starting,
+    /// Working: inferring, calling tools, or moving between stages.
     Running,
+    /// Blocked on a person. A human-in-the-loop tool or an interaction point is
+    /// waiting for an answer, and the run holds its concurrency slot until it
+    /// gets one.
     WaitingInput,
+    /// Finished, with nothing further to accept.
     Complete,
     /// All required stages done; agent still accepts optional follow-up input.
     /// Shown as "Complete" in the dashboard - no kill option, input still enabled.
@@ -24,7 +30,10 @@ pub enum RunStatus {
     /// Paused by the user; resumes on request and is restored paused after a
     /// daemon restart.
     Paused,
+    /// Stopped by a failure. `RunMeta::error` carries what went wrong.
     Error,
+    /// Stopped from outside, by `lev kill` or a shutting-down daemon. Distinct
+    /// from [`Error`](Self::Error): nothing went wrong, someone decided.
     Cancelled,
 }
 
@@ -46,11 +55,19 @@ impl std::fmt::Display for RunStatus {
 /// Metadata for a single background agent run.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunMeta {
+    /// Identifies the run everywhere, and names its directory under
+    /// `~/.leviath/runs/`. Assigned at spawn and never reused.
     pub run_id: String,
+    /// The blueprint's `[agent] name`, not the file it was loaded from. Two runs
+    /// of the same agent from different paths share this.
     pub agent_name: String,
     /// Absolute path to the agent manifest directory
     pub agent_path: String,
+    /// The task text the run was started with, verbatim.
     pub task: String,
+    /// The `provider/model` actually resolved for the entry stage, or `None`
+    /// before resolution. Later stages may use a different one; this is not
+    /// rewritten to follow them.
     pub model: Option<String>,
     /// Always 0. There is no worker process per run: the daemon hosts every run
     /// as an entity in one shared world, so no run has a pid of its own.
@@ -63,12 +80,24 @@ pub struct RunMeta {
     /// `status` and `last_progress_at` off disk for what became of it.
     #[serde(default)]
     pub pid: u32,
+    /// Where the run stands. The durable counterpart to the ECS world's live
+    /// `AgentStatus`, and the one that survives a daemon restart.
     pub status: RunStatus,
+    /// Name of the stage the run is in, matching a key under `[stages]`.
     pub current_stage: String,
+    /// Zero-based position of `current_stage` in the blueprint's stage list.
+    /// Not a progress measure: stages can loop and revisit.
     pub stage_index: usize,
+    /// How many stages the blueprint declares, so a reader can render
+    /// `stage_index` as "3 of 7" without loading the manifest.
     pub num_stages: usize,
+    /// Inference turns taken in the current stage, reset on entering a new one.
+    /// Compared against the stage's `max_iterations`.
     pub iteration: usize,
+    /// Cumulative input tokens billed across every inference this run has made,
+    /// including retries.
     pub prompt_tokens: usize,
+    /// Cumulative output tokens billed across every inference this run has made.
     pub completion_tokens: usize,
     /// Cumulative tokens read from provider cache.
     #[serde(default)]
@@ -97,6 +126,8 @@ pub struct RunMeta {
     /// saved context, so it really has just moved.
     #[serde(default)]
     pub last_progress_at: Option<i64>,
+    /// What went wrong, set alongside [`RunStatus::Error`]. `None` on every
+    /// other status.
     pub error: Option<String>,
     /// Short human-readable title generated from the task prompt (None until generated).
     #[serde(default)]
@@ -290,6 +321,12 @@ impl RunMeta {
         }
     }
 
+    /// A newly accepted run: [`RunStatus::Starting`], both timestamps now, every
+    /// counter at zero and every optional field unset.
+    ///
+    /// Only the seven values a caller genuinely knows at spawn are parameters.
+    /// Everything else is filled in by the daemon as the run proceeds, so taking
+    /// them here would invite a caller to invent a stage or a token count.
     pub fn new(
         run_id: String,
         agent_name: String,
@@ -338,6 +375,11 @@ impl RunMeta {
         }
     }
 
+    /// Stamp `updated_at` with the current time.
+    ///
+    /// Deliberately does **not** touch `last_progress_at`: the 30-second
+    /// persistence heartbeat calls this, and a run that is wedged must not look
+    /// like one that just moved. See [`RunMeta::last_progress_at`].
     pub fn touch(&mut self) {
         self.updated_at = now_secs();
     }
@@ -346,12 +388,17 @@ impl RunMeta {
 /// One content entry within a region, captured at snapshot time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RegionEntrySnapshot {
+    /// The entry's text, exactly as it sat in the live region.
     pub content: String,
+    /// The entry's token cost as counted when it was added, carried through the
+    /// snapshot so a reload does not have to re-tokenize to rebuild budgets.
     pub tokens: usize,
     /// The entry's role/kind, so a snapshot round-trips faithfully when the
     /// daemon reloads it on restart. Defaults to `Text` for older snapshots.
     #[serde(default)]
     pub kind: crate::region::EntryKind,
+    /// Free-form structured data an entry writer attached, passed through
+    /// untouched. Nothing in the engine interprets it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
     /// Key for HashMap region entries (file paths, section names, etc.)
@@ -375,10 +422,14 @@ pub struct RegionEntrySnapshot {
 /// Per-region token snapshot written by the background worker after each inference.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RegionSnapshot {
+    /// The region's name, matching its key under `[context.regions]`.
     pub name: String,
     /// Stringified kind: "pinned", "temporary", "clearable", "sliding", "compacting", "history"
     pub kind: String,
+    /// Tokens the region held when the snapshot was taken.
     pub current_tokens: usize,
+    /// The region's ceiling at snapshot time, already resolved against the
+    /// model in front of it, so a percentage budget appears here as a number.
     pub max_tokens: usize,
     /// Actual content entries stored in this region (empty for zero-token regions).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -388,9 +439,15 @@ pub struct RegionSnapshot {
 /// Snapshot of the full context window, written to `context.json` alongside `meta.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ContextSnapshot {
+    /// The stage the run was in when this was written.
     pub stage_name: String,
+    /// Tokens held across every region, which is what the next request costs
+    /// before the model's reply.
     pub total_tokens: usize,
+    /// The whole window's budget, from the blueprint's `total_budget_tokens` or
+    /// the model's own limit.
     pub max_tokens: usize,
+    /// Every region, in layout order.
     pub regions: Vec<RegionSnapshot>,
 }
 
@@ -398,10 +455,15 @@ pub struct ContextSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum StageRunStatus {
+    /// Declared but not yet entered.
     Pending,
+    /// The stage the run is in right now. At most one stage is `Active`.
     Active,
+    /// Entered, and blocked on a person answering.
     WaitingInput,
+    /// Finished and left. A stage that loops back becomes `Active` again.
     Complete,
+    /// Ended in a failure. The run's own `error` carries the message.
     Error,
 }
 
@@ -420,10 +482,17 @@ impl std::fmt::Display for StageRunStatus {
 /// Metadata record for a single stage within a run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StageRecord {
+    /// The stage's name, matching its key under `[stages]`.
     pub name: String,
+    /// Zero-based position in the blueprint's stage list.
     pub index: usize,
+    /// Where this stage stands.
     pub status: StageRunStatus,
+    /// Input tokens billed while this stage was active. A revisited stage keeps
+    /// accumulating rather than resetting, so the run's total is the sum.
     pub prompt_tokens: usize,
+    /// Output tokens billed while this stage was active, accumulating the same
+    /// way.
     pub completion_tokens: usize,
     /// Tokens read from provider cache in this stage.
     #[serde(default)]
@@ -435,6 +504,8 @@ pub struct StageRecord {
 }
 
 impl StageRecord {
+    /// A stage the run has not entered yet: [`StageRunStatus::Pending`], zero
+    /// tokens, and neither timestamp set.
     pub fn new(name: String, index: usize) -> Self {
         Self {
             name,

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -259,6 +259,11 @@ impl RegionTaint {
         }
     }
 
+    /// The taint recorded for the entry at `index`, or `None` when the index is
+    /// past the end.
+    ///
+    /// Returns `Option` rather than defaulting to `Public` so a caller cannot
+    /// mistake "no such entry" for "that entry is clean".
     pub fn entry_taint(&self, index: usize) -> Option<TaintLevel> {
         self.entry_taints.get(index).copied()
     }
@@ -424,9 +429,16 @@ pub enum GateDecisionSource {
     /// Taint exceeded clearance - automatic block, before any user decision.
     AutoBlock,
     /// Matched a static allowlist rule.
-    AllowlistRule { rule_index: usize },
+    AllowlistRule {
+        /// Which rule matched, by position in the configured list, so a decision
+        /// can be traced back to the line that made it.
+        rule_index: usize,
+    },
     /// Matched a scripted (Rhai) rule.
-    ScriptedRule { script_name: String },
+    ScriptedRule {
+        /// The script that allowed it, by path as declared.
+        script_name: String,
+    },
     /// User allowed once interactively.
     UserAllowOnce,
     /// User created an "always allow" rule.

--- a/crates/leviath-core/src/telemetry.rs
+++ b/crates/leviath-core/src/telemetry.rs
@@ -28,7 +28,9 @@ pub enum LogKind {
 pub enum TelemetryEvent {
     /// An agent run became visible to the observer.
     RunStarted {
+        /// The run this is about; the correlation key for every later event.
         run_id: String,
+        /// The blueprint's `[agent] name`.
         agent_name: String,
         /// The run-level model hint from spawn metadata, if one was recorded.
         model: Option<String>,
@@ -38,41 +40,67 @@ pub enum TelemetryEvent {
         /// spawned - its earlier life was traced (if at all) by a previous
         /// daemon process, so this trace starts mid-run.
         recovered: bool,
+        /// When it happened, in milliseconds since the Unix epoch.
         at_ms: i64,
     },
     /// The run entered a stage (including the first).
     StageEntered {
+        /// The run this is about.
         run_id: String,
+        /// Zero-based position of the stage in the blueprint's stage list.
         stage_index: usize,
+        /// The stage's name, matching its key under `[stages]`.
         stage_name: String,
+        /// When it happened, in milliseconds since the Unix epoch.
         at_ms: i64,
     },
     /// The run left a stage; token counts are the stage's own totals.
     StageExited {
+        /// The run this is about.
         run_id: String,
+        /// Zero-based position of the stage in the blueprint's stage list.
         stage_index: usize,
+        /// The stage's name, matching its key under `[stages]`.
         stage_name: String,
+        /// Input tokens billed across this stage's whole life, so a revisited
+        /// stage reports the accumulated figure rather than the last visit's.
         prompt_tokens: usize,
+        /// Output tokens billed across this stage's whole life.
         completion_tokens: usize,
+        /// When it happened, in milliseconds since the Unix epoch.
         at_ms: i64,
     },
     /// One inference call finished (successfully or not).
     InferenceCompleted {
+        /// The run this is about.
         run_id: String,
+        /// The stage the call was made from.
         stage_name: String,
+        /// Which provider served it, after fallback resolution - so this is the
+        /// one that answered, not the one the blueprint listed first.
         provider: String,
+        /// The model identifier sent on the wire.
         model: String,
         /// Wall-clock time of the provider call, including retries.
         latency_ms: u64,
+        /// Input tokens this single call billed.
         prompt_tokens: usize,
+        /// Output tokens this single call billed.
         completion_tokens: usize,
+        /// Input tokens served from the provider's prompt cache, already counted
+        /// within `prompt_tokens` rather than in addition to it.
         cached_tokens: usize,
+        /// Whether a response came back. A refusal or a tool call is still a
+        /// success; only a failed call is not.
         success: bool,
     },
     /// One tool call finished.
     ToolCallCompleted {
+        /// The run this is about.
         run_id: String,
+        /// The stage the call was made from.
         stage_name: String,
+        /// The tool as the model named it, before alias resolution.
         tool_name: String,
         /// Wall-clock time of the batch the call ran in. Tool calls execute
         /// in batches and the executor reports one duration per batch, so
@@ -84,29 +112,43 @@ pub enum TelemetryEvent {
     },
     /// A context compaction finished.
     CompactionCompleted {
+        /// The run this is about.
         run_id: String,
+        /// The stage whose context was compacted.
         stage_name: String,
+        /// Whether the compaction produced a usable summary. A failure leaves
+        /// the region as it was rather than emptying it.
         success: bool,
     },
     /// The run reached a terminal status; totals are run-wide.
     RunCompleted {
+        /// The run this is about.
         run_id: String,
         /// The terminal status label: `complete`, `error`, or `cancelled`.
         status: String,
+        /// Input tokens billed across the whole run.
         prompt_tokens: usize,
+        /// Output tokens billed across the whole run.
         completion_tokens: usize,
+        /// How many tool calls the run made, across every stage.
         tool_calls: usize,
         /// Whether the run stopped having modified nothing, when its blueprint
         /// gave it a way to. `complete` says the pipeline reached the end, not
         /// that it achieved anything; this is the difference.
         empty_output: bool,
+        /// When it happened, in milliseconds since the Unix epoch.
         at_ms: i64,
     },
     /// One per-run log line, as also written to the stage's log files.
     Log {
+        /// The run this is about. An OTLP sink uses it to look up the run's open
+        /// span and stamp the record with its trace context.
         run_id: String,
+        /// Which stage's log files the line also went to.
         stage_index: usize,
+        /// Which log the line belongs in.
         kind: LogKind,
+        /// The line itself, without a trailing newline.
         line: String,
     },
 }

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -91,35 +91,49 @@ pub struct EmbeddedResource {
 pub enum ToolResultContent {
     /// Text content
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        /// The text itself.
+        text: String,
+    },
     /// Image content (base64 encoded)
     #[serde(rename = "image")]
     Image {
+        /// Base64-encoded bytes.
         data: String,
+        /// The media type those bytes are in.
         #[serde(rename = "mimeType")]
         mime_type: String,
     },
     /// Audio content (base64 encoded)
     #[serde(rename = "audio")]
     Audio {
+        /// Base64-encoded bytes.
         data: String,
+        /// The media type those bytes are in.
         #[serde(rename = "mimeType")]
         mime_type: String,
     },
     /// A link to a resource the client may fetch or subscribe to.
     #[serde(rename = "resource_link")]
     ResourceLink {
+        /// Where the resource lives, in the server's own URI scheme.
         uri: String,
+        /// A short label for it. Empty when the server sent none.
         #[serde(default)]
         name: String,
+        /// A longer description, when the server supplied one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+        /// The media type behind the link, when the server declared it.
         #[serde(rename = "mimeType", default, skip_serializing_if = "Option::is_none")]
         mime_type: Option<String>,
     },
     /// An embedded resource, whose payload is nested under `resource`.
     #[serde(rename = "resource")]
-    Resource { resource: EmbeddedResource },
+    Resource {
+        /// The resource, carried inline rather than linked.
+        resource: EmbeddedResource,
+    },
     /// Any content block this client does not model.
     ///
     /// Internally-tagged enums can't carry the original payload in a catch-all

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -89,13 +89,19 @@ pub struct MCPServerConfig {
 pub enum ResolvedTransport<'a> {
     /// Spawn `command` with `args` and `env`.
     Stdio {
+        /// The executable to run.
         command: &'a str,
+        /// Its arguments, passed without shell interpretation.
         args: &'a [String],
+        /// Variables to add to the child's environment, on top of whatever
+        /// `child_env_allowed` lets through from this process.
         env: &'a HashMap<String, String>,
     },
     /// Connect to `url` with `headers`.
     Http {
+        /// The server's endpoint.
         url: &'a str,
+        /// Headers to send on every request, with any `${VAR}` already expanded.
         headers: &'a HashMap<String, String>,
     },
 }

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -264,6 +264,11 @@ fn drop_unpaired_tool_turns(messages: Vec<serde_json::Value>) -> Vec<serde_json:
         .collect()
 }
 
+/// Render a request as an OpenAI chat-completions body.
+///
+/// Shared by every provider speaking that dialect - OpenAI itself, OpenRouter,
+/// and any `base_url` pointed at a compatible server - so one change to the wire
+/// shape reaches all of them rather than three copies drifting apart.
 pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Value {
     let messages = openai_messages(request);
 
@@ -377,6 +382,11 @@ fn reasoning_text(message: &serde_json::Value) -> Option<String> {
     (!joined.trim().is_empty()).then_some(joined)
 }
 
+/// Read an OpenAI chat-completions response back into an [`InferenceResponse`].
+///
+/// The counterpart to [`build_openai_request_body`], and shared for the same
+/// reason. Handles the gateway case where a `200` body carries an `error`
+/// object: see the comment inside for what that cost before it was unpacked.
 pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceResponse> {
     // A gateway does not always use the status line to report a failure.
     // OpenRouter answers 200 with `{"error":{"code":…,"message":…}}` when an

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -139,7 +139,11 @@ pub enum ProviderError {
     /// provider response for the logs; the message leads with what to do.
     #[error("{} ({detail})", .reason.remedy())]
     Unavailable {
+        /// Which kind of intervention is needed, which is what decides the
+        /// remedy text a user sees.
         reason: UnavailableReason,
+        /// The provider's own response, kept for the logs. Not shown first: it
+        /// is usually less actionable than the remedy.
         detail: String,
     },
 
@@ -153,7 +157,12 @@ pub enum ProviderError {
 
     /// Token limit exceeded
     #[error("Token limit exceeded: {used} > {max}")]
-    TokenLimitExceeded { used: usize, max: usize },
+    TokenLimitExceeded {
+        /// Tokens the request would have sent.
+        used: usize,
+        /// The model's context limit.
+        max: usize,
+    },
 
     /// Other error
     #[error("{0}")]
@@ -332,12 +341,18 @@ impl MessageContent {
 pub enum ContentBlock {
     /// A text content block.
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        /// The text itself.
+        text: String,
+    },
     /// A tool use request from the assistant.
     #[serde(rename = "tool_use")]
     ToolUse {
+        /// Provider-assigned call id, which the matching result must quote back.
         id: String,
+        /// The tool the model asked for.
         name: String,
+        /// Arguments as the model supplied them, before any validation.
         input: serde_json::Value,
         /// See [`ToolCall::thought_signature`]: replayed verbatim so a
         /// provider that requires it accepts the follow-up request.
@@ -347,8 +362,12 @@ pub enum ContentBlock {
     /// A tool result from executing a tool.
     #[serde(rename = "tool_result")]
     ToolResult {
+        /// The [`ContentBlock::ToolUse`] id this answers.
         tool_use_id: String,
+        /// The tool's output as text. Every provider takes a string here, so a
+        /// structured result is already rendered by this point.
         content: String,
+        /// Whether the tool refused or failed.
         is_error: bool,
     },
 }
@@ -652,6 +671,16 @@ fn same_origin_hop(attempt: &reqwest::redirect::Attempt<'_>) -> bool {
     })
 }
 
+/// The HTTP client every provider talks through.
+///
+/// Redirects are capped and confined to the origin the request started on. That
+/// second part is the load-bearing one: reqwest strips `Authorization` across
+/// origins by itself but leaves custom headers alone, and the provider keys
+/// travel as `x-api-key` and `x-goog-api-key`. A redirect to another host would
+/// hand them over.
+///
+/// `timeout_secs` of `None` leaves the request untimed, which is what a
+/// streaming call needs - a long generation is not a stalled one.
 pub fn build_http_client(timeout_secs: Option<u64>) -> reqwest::Client {
     reqwest::Client::builder()
         .pool_max_idle_per_host(0)

--- a/crates/leviath-runtime/src/components.rs
+++ b/crates/leviath-runtime/src/components.rs
@@ -135,7 +135,10 @@ pub enum AgentStatus {
     Complete,
 
     /// Agent encountered an error
-    Error { message: String },
+    Error {
+        /// What went wrong, as shown to the user and written to the run record.
+        message: String,
+    },
 
     /// Agent was cancelled by the user or system
     Cancelled,

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -101,16 +101,28 @@ pub struct InteractionPointState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PointOutcome {
     /// A plain option (no directive/abort/edit) ⇒ complete the point.
-    Approve { user_text: String },
+    Approve {
+        /// The option's label, injected into context so the next turn knows
+        /// which choice was made.
+        user_text: String,
+    },
     /// An abort option ⇒ cancel the run immediately.
     Abort,
     /// A directive option ⇒ inject the directive and re-run inference in-stage.
     Directive {
+        /// The option's label, injected so the next turn knows what was chosen.
         user_text: String,
+        /// The instruction attached to that option, injected alongside it.
         directive: String,
     },
     /// An edit option ⇒ inject the user's edited text and re-present the point.
-    Edit { user_text: String, edited: String },
+    Edit {
+        /// The option's label.
+        user_text: String,
+        /// What the user actually wrote, which is authoritative over whatever
+        /// was presented for editing.
+        edited: String,
+    },
     /// A point declaring `unattended = "ask"` expired or was cancelled with no
     /// answer ⇒ stop the run rather than proceed past a checkpoint nobody made.
     Unanswered,

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -197,6 +197,12 @@ pub(crate) fn reconcile_stage_ledger(
     }
 }
 
+/// Hand each agent's current state to the persistence lane, which writes it to
+/// disk off the schedule thread.
+///
+/// Coalescing lives here rather than in the lane: an agent whose digest has not
+/// changed since its last send is skipped, so a world full of idle runs costs
+/// nothing per tick.
 #[allow(clippy::type_complexity)]
 pub fn dispatch_persistence(
     mut agents: Query<(

--- a/crates/leviath-runtime/src/telemetry.rs
+++ b/crates/leviath-runtime/src/telemetry.rs
@@ -33,22 +33,39 @@ pub struct Telemetry(pub Arc<dyn TelemetrySink>);
 pub enum ActivityRecord {
     /// An inference call finished (either way).
     Inference {
+        /// The provider that answered, after fallback resolution.
         provider: String,
+        /// The model identifier sent on the wire.
         model: String,
+        /// Wall-clock time of the call, including retries.
         latency_ms: u64,
+        /// Input tokens this call billed.
         prompt_tokens: usize,
+        /// Output tokens this call billed.
         completion_tokens: usize,
+        /// Input tokens served from the provider's prompt cache, counted within
+        /// `prompt_tokens` rather than on top of it.
         cached_tokens: usize,
+        /// Whether a response came back at all.
         success: bool,
     },
     /// One tool call out of a finished batch.
     ToolCall {
+        /// The tool as the model named it.
         tool_name: String,
+        /// Wall-clock time of the whole batch. The executor reports one figure
+        /// per batch, so every call in it carries the same number.
         batch_latency_ms: u64,
+        /// Derived from the `[error] ` result-text convention, so a heuristic
+        /// rather than a structured status.
         success: bool,
     },
     /// A compaction pass finished.
-    Compaction { success: bool },
+    Compaction {
+        /// Whether it produced a usable summary. A failure leaves the region
+        /// alone rather than emptying it.
+        success: bool,
+    },
 }
 
 /// Buffered [`ActivityRecord`]s awaiting the observer. Inserted alongside

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -32,8 +32,14 @@ pub struct ToolContext {
 /// struct serves the shell tool, a Rhai `shell()`, and a command seed.
 #[derive(Debug, Clone, Default)]
 pub struct ShellEnvPolicy {
+    /// Which of the four filtering modes is in effect.
     pub mode: leviath_core::ShellEnvMode,
+    /// Names handed over under every mode, from `[security] allow_env_vars`.
+    /// The same list a Rhai `env_var` read goes through, so there is one answer
+    /// to "may agent-supplied code see this variable".
     pub allow_env_vars: Vec<String>,
+    /// Names withheld under `custom`, where the built-in name-shape heuristic
+    /// is off and only the explicit lists govern. Ignored in the other modes.
     pub withhold: Vec<String>,
 }
 


### PR DESCRIPTION
docs: require doc comments on the published crates, and write the 159 missing

`missing_docs` was measured but not enabled, on the argument that 240 of the 325
items it flags are struct fields whose names already say what they are. Enabling
it means writing those anyway, so the question was whether the lint pays for the
noise.

It does, for the crates that publish a library. Their docs render on docs.rs and
get read by people who did not write them, and an undocumented `pub fn
checked_client` is a real gap someone hits. So the lint is on workspace-wide, and
CI's existing `RUSTFLAGS: -D warnings` turns "warn" into a blocking error with no
workflow change: a PR that adds undocumented public API does not merge. Verified
by adding an undocumented field and watching the build fail, not by assuming.

### 159 items, and what got written

All of `leviath-core` (109), plus runtime 18, mcp 15, providers 14, tools 3.

The rule the repo already followed - say what is not obvious, leave the obvious
alone - is what the lint cannot see, so the risk was 159 comments restating field
names. Where a field genuinely had nothing to add, the fix was to find the thing
a reader would actually want:

- `RunMeta::run_id` says it also names the directory under `~/.leviath/runs/`.
- `RunMeta::model` says it is the *entry* stage's resolved model and is not
  rewritten when a later stage uses a different one.
- `StageRecord::prompt_tokens` says a revisited stage accumulates rather than
  resetting, which is the only reason the per-stage numbers add up to the run's.
- `TelemetryEvent::InferenceCompleted::cached_tokens` says it is counted *within*
  `prompt_tokens`, not on top - the difference between a correct cost figure and
  one that double-counts.
- `RunStatus::Cancelled` says it is distinct from `Error` because nothing went
  wrong, someone decided.

Two enums earned real explanations rather than labels: `RunStatus` and
`StageRunStatus` both had documented variants only where past confusion had
forced it, so the undocumented ones were the ones nobody had had to explain yet.

### leviath-cli opts out, and says why

Its 166 stay behind a `#![allow(missing_docs)]` at the crate root carrying the
argument: this crate ships the `lev` **binary**, its `pub` surface is `pub` so
the integration tests can reach it, and most of the flagged items are clap `Args`
fields whose user-facing text already lives in `#[arg(help = ...)]`. Tracked in
#290 so the allow points somewhere instead of being a bare suppression.

### Checks

`RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features`
and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` both clean -
the two gates that will enforce this. Full suite green, `cargo xtask coverage`
clean on leviath-core.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
