### PR TITLE
feat(release): ship static musl Linux binaries (#286)

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -167,6 +167,25 @@ jobs:
             os: ubuntu-latest
             artifact: leviath-linux-arm64
             ext: tar.gz
+          # Statically linked, for containers older than the runner's glibc
+          # (issue #286). The gnu builds above link against whatever the
+          # runner ships and so demand GLIBC_2.38+ at run time, which is newer
+          # than most task/CI images - `curl a binary into a container` fails
+          # on anything below Ubuntu 24.04. These need nothing from the image.
+          #
+          # arm64 builds on a native ARM runner rather than cross-compiling:
+          # `aws-lc-sys` is the crypto backend (see the note on the cross
+          # toolchain below) and pointing its cmake build at a musl cross
+          # toolchain is a great deal more work than asking for the right
+          # runner. Free for public repos.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact: leviath-linux-x64-musl
+            ext: tar.gz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            artifact: leviath-linux-arm64-musl
+            ext: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: leviath-macos-arm64
@@ -195,15 +214,24 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
-      # aarch64-linux is cross-compiled from the x64 runner (hosted ARM
-      # runners aren't available for private repos on this plan). rustls
-      # keeps this simple: the only C to cross-compile is ring's, which
-      # just needs the gcc cross toolchain.
+      # aarch64-linux-gnu is cross-compiled from the x64 runner, which the gcc
+      # cross toolchain is enough for. (`aws-lc-sys` is the crypto backend, not
+      # ring - it builds here because its cmake picks the cross compiler up
+      # from `CC_aarch64_unknown_linux_gnu` below. The musl arm64 target does
+      # not get the same treatment; see the matrix note.)
       - name: Install aarch64 Linux cross toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+      # `musl-gcc`, which is what `aws-lc-sys` compiles its C through for a
+      # musl target. Both musl targets build for the runner's own
+      # architecture, so this is the native musl toolchain, not a cross one.
+      - name: Install the musl toolchain
+        if: endsWith(matrix.target, '-linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
       # Linker hardening, appended to the workflow-level `-D warnings`.
       #
       # It has to be spelled here rather than in `.cargo/config.toml`: the
@@ -220,6 +248,11 @@ jobs:
       #   - macOS: nothing to add. The Apple linker rejects `-z` options, and the
       #     platform's own protections (hardened runtime once signed, ASLR) are
       #     not rustc flags.
+      #   - Linux musl: nothing to add either, and deliberately so. RELRO and
+      #     BIND_NOW harden the GOT against being rewritten between dynamic
+      #     relocation and use; a fully static non-PIE binary has no dynamic
+      #     relocation and no GOT to protect, so the flags would be decoration.
+      #     `*-linux-gnu` below therefore stays an exact match, not `*-linux-*`.
       - name: Build release binary
         shell: bash
         env:
@@ -303,8 +336,8 @@ jobs:
           # all - the install script and both taps would resolve it and find
           # nothing to download. Count what arrived against the build matrix.
           found=$(find release -type f | wc -l)
-          if [ "$found" -ne 5 ]; then
-            echo "::error::expected 5 platform archives, found $found:"
+          if [ "$found" -ne 7 ]; then
+            echo "::error::expected 7 platform archives, found $found:"
             ls -la release/
             exit 1
           fi

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -83,6 +83,27 @@ cargo install leviath-cli
 The install scripts and package manifests live in the
 [distribution repo](https://github.com/GEMISIS/leviath-dist).
 
+### Running inside a container
+
+Every channel ships seven archives: glibc and **musl** builds for Linux on x64 and arm64, plus
+macOS on both and Windows on x64.
+
+Reach for the musl ones when you are dropping `lev` into an image you did not build. The glibc
+binaries link against the release runner's C library and so need `GLIBC_2.38` or newer, which is
+Ubuntu 24.04 and up; anything older fails at exec with a `version not found` message before it runs
+a line of Leviath. The musl archives are statically linked and need nothing from the image at all.
+
+```bash
+# glibc: fine on a modern host, fails on an older container image
+curl -fsSLO https://github.com/GEMISIS/leviath/releases/download/alpha/leviath-linux-x64.tar.gz
+
+# musl: runs anywhere
+curl -fsSLO https://github.com/GEMISIS/leviath/releases/download/alpha/leviath-linux-x64-musl.tar.gz
+```
+
+They are the same binary otherwise. The glibc builds stay the default because they use the
+platform's own resolver and NSS configuration, which is what you want on a machine you control.
+
 ## Verifying a download
 
 Every release carries a `SHA256SUMS` file generated at build time and


### PR DESCRIPTION
feat(release): ship static musl Linux binaries (#286)

The Linux archives link against the release runner's glibc, so they demand
`GLIBC_2.38`/`2.39` and fail at exec on anything older than Ubuntu 24.04 - which
is most task and CI images. "curl a binary into a container" is the case, and it
did not work.

Two new targets, `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`,
alongside the existing glibc builds. Seven archives per channel now. Only
`alpha.yml` builds anything - beta and prod promote its artifacts - so this is a
one-file change plus the count guard.

### Verified, not assumed

I could not test this in CI without publishing a release, so I built it in
Docker instead. `aarch64-unknown-linux-musl` is the harder of the two and the
one I ran:

```
$ file .../aarch64-unknown-linux-musl/release/lev
ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped

$ ldd .../lev
/lib/ld-musl-aarch64.so.1: ...: Not a valid dynamic program

$ docker run --platform linux/arm64 ubuntu:20.04 /src/.../lev --version
lev 0.2.0
```

`ubuntu:20.04` is glibc 2.31, well below the 2.38 in the report, and it runs.
Built twice: once on `rust:alpine` to prove the code compiles for musl, and once
on `ubuntu:24.04` with `musl-tools` + `rustup target add` to prove the *runner
setup* does, since that is the part that ships. 2m56s on the Ubuntu path.

x86_64-musl uses the identical setup on a native x64 runner, which is the
better-supported direction of the two; I did not rebuild it under emulation.

### Two stale premises found on the way

The comment justifying the aarch64 cross toolchain says "the only C to
cross-compile is ring's". **`ring` is not in the build at all** - `cargo tree -i
ring` prints "nothing to print", and the crypto backend is `aws-lc-rs`. Corrected
in place, because that comment is what someone would reason from next.

And "hosted ARM runners aren't available for private repos on this plan": the
repo is public. So arm64 musl builds on a native `ubuntu-24.04-arm` runner rather
than cross-compiling, which is what makes it tractable - pointing `aws-lc-sys`'s
cmake build at a musl cross toolchain is a great deal more work than asking for
the right runner.

### Details worth knowing

**The count guard is load-bearing.** `Prepare release files` hard-fails unless it
finds exactly N archives, so 5 became 7. Without that the release job would have
failed after every build succeeded.

**No hardening flags for musl, deliberately.** RELRO and BIND_NOW protect the GOT
between dynamic relocation and use; a static non-PIE binary has neither. So the
`*-linux-gnu` match stays exact rather than widening to `*-linux-*`, and the
comment says why - otherwise the next person "fixes" the inconsistency.

**Not in this repo:** `install.sh` lives in `GEMISIS/leviath-dist` and does its
own platform detection. It will keep resolving the glibc archives until it is
taught about these, which is the right default for a machine you control. Worth a
follow-up there if you want containers to get musl automatically.

Docs: a "Running inside a container" section on the releases page, saying which
to reach for and why, with the failure message people will have searched for.

Closes #286

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
