### PR TITLE
docs: document leviath-cli, and drop the last missing_docs exemption (#290)

### DIFF
--- a/crates/leviath-cli/src/approvals.rs
+++ b/crates/leviath-cli/src/approvals.rs
@@ -181,8 +181,11 @@ impl Default for SafeCommands {
 /// their config rather than in a manifest they downloaded.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentSafeCommands {
+    /// Tool names this agent asks to have pre-approved.
     #[serde(default)]
     pub tools: Vec<String>,
+    /// Shell grant-key prefixes it asks to have pre-approved. A prefix that
+    /// could write a file or run an unnamed program is refused at load.
     #[serde(default)]
     pub shell: Vec<String>,
     /// Honour this agent's own `[safe_commands]` block. Off by default:

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -22,7 +22,10 @@ pub enum AgentAction {
     /// Not installed.
     Install,
     /// Installed at a different version.
-    Update { from: String },
+    Update {
+        /// The version currently on disk, so the offer can say what it replaces.
+        from: String,
+    },
     /// Installed at the bundled version, but the files on disk differ from the
     /// bundled ones.
     Modified,

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -3,6 +3,7 @@
 use clap::Args;
 use std::path::Path;
 
+/// Arguments for `lev add`.
 #[derive(Args)]
 pub struct AddArgs {
     /// Path to an agent directory or a .leviath-bundle file
@@ -14,6 +15,7 @@ fn agents_dir_or_error(dir: Option<std::path::PathBuf>) -> anyhow::Result<std::p
     dir.ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
 }
 
+/// Run `lev add`: install an agent from a directory or a bundle file.
 pub async fn execute(args: AddArgs) -> anyhow::Result<()> {
     let installer = leviath_package::AgentInstaller::new();
     let agents_dir = resolve_agents_dir()?;

--- a/crates/leviath-cli/src/commands/approvals.rs
+++ b/crates/leviath-cli/src/commands/approvals.rs
@@ -17,10 +17,12 @@ use crate::config::Config;
 /// Arguments for `lev approvals`.
 #[derive(Args)]
 pub struct ApprovalsArgs {
+    /// Which approvals subcommand to run.
     #[command(subcommand)]
     pub command: ApprovalsCommand,
 }
 
+/// The `lev approvals` subcommands.
 #[derive(Subcommand)]
 pub enum ApprovalsCommand {
     /// Show what runs without an approval prompt, and where each entry came from

--- a/crates/leviath-cli/src/commands/auth.rs
+++ b/crates/leviath-cli/src/commands/auth.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use clap::{Args, Subcommand};
 use leviath_core::{CredentialStore, CredentialStoreKind};
 
+/// Arguments for `lev auth`.
 #[derive(Debug, Args)]
 pub struct AuthArgs {
     #[command(subcommand)]

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use std::fs;
 use std::path::Path;
 
+/// Arguments for `lev create`.
 #[derive(Args)]
 pub struct CreateArgs {
     /// Blueprint name
@@ -15,6 +16,7 @@ pub struct CreateArgs {
     pub template: String,
 }
 
+/// Run `lev create`: scaffold a new agent from a template.
 pub async fn execute(args: CreateArgs) -> anyhow::Result<()> {
     execute_with(args, &|path, contents| fs::write(path, contents))
 }

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -11,6 +11,7 @@ use leviath_core::interaction;
 
 use ratatui::style::Color;
 
+/// Arguments for `lev dash`. It takes none; the dashboard is interactive.
 #[derive(Args)]
 pub struct DashboardArgs {}
 
@@ -136,17 +137,23 @@ pub(super) enum ConfirmAction {
 /// Display status for agents in the dashboard.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentDisplayStatus {
+    /// Working.
     Active,
+    /// Blocked on a person answering.
     Waiting,
+    /// Finished, with nothing further to accept.
     Complete,
     /// All required work done; still accepting optional follow-up input.
     CompleteInteractive,
+    /// Stopped by a failure, carrying its message.
     Error(String),
+    /// Loaded but not currently doing anything.
     Idle,
     /// Paused by the user; resumable with `r` (or `lev resume`). Distinct from
     /// `Idle` because a paused run is deliberate unfinished business, not a run
     /// that merely has not ticked yet.
     Paused,
+    /// Stopped from outside, by `lev kill` or a shutting-down daemon.
     Cancelled,
     /// On disk the run claims to be live, but the daemon has no such run and its
     /// metadata has not been touched in a long time - so nothing is driving it.
@@ -206,11 +213,17 @@ impl AgentDisplayStatus {
 /// An agent displayed in the dashboard.
 #[derive(Debug, Clone)]
 pub struct DashboardAgent {
+    /// The run id, which is also what every action against this row quotes.
     pub id: String,
+    /// The blueprint's name, as the manifest declares it.
     pub blueprint_name: String,
+    /// The stage the run is in, by name.
     pub stage: String,
+    /// That stage's position in the blueprint's list.
     pub stage_index: usize,
+    /// How many stages the blueprint has, so the pair renders as "3 of 7".
     pub num_stages: usize,
+    /// What the row shows, including states no other status enum has.
     pub status: AgentDisplayStatus,
     /// Cumulative prompt (input) tokens for background runs.
     pub tokens_in: usize,
@@ -218,7 +231,9 @@ pub struct DashboardAgent {
     pub tokens_out: usize,
     /// Cumulative tokens read from provider cache.
     pub cached_tokens: usize,
+    /// Inference turns taken in the current stage.
     pub iteration: usize,
+    /// The question a waiting run is asking, in one line, for the list row.
     pub waiting_prompt: Option<String>,
     /// Full structured interaction request (populated for WaitingInput agents)
     pub pending_request: Option<interaction::InteractionRequest>,

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -8,6 +8,7 @@ use super::resolve_cwd;
 use crate::config::Config;
 use leviath_core::manifest::parse_manifest;
 
+/// Arguments for `lev list`.
 #[derive(Args)]
 pub struct ListArgs {
     /// Filter by type (agents, blueprints, all)
@@ -136,6 +137,7 @@ fn print_agent(info: &AgentInfo) {
     }
 }
 
+/// Run `lev list`: show the installed agents.
 pub async fn execute(args: ListArgs) -> anyhow::Result<()> {
     // Propagate, don't default: a config that exists but doesn't parse would
     // silently list from the default `agent_paths`, hiding the user's own

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -8,6 +8,7 @@ use clap::{Args, Subcommand};
 use crate::config::Config;
 use leviath_mcp::{AuthStore, MCPClient, MCPServerConfig, OAuthClient};
 
+/// Arguments for `lev mcp`.
 #[derive(Args)]
 pub struct McpArgs {
     #[command(subcommand)]

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -8,12 +8,15 @@ use crate::config::Config;
 
 // ─── CLI types ────────────────────────────────────────────────────────────────
 
+/// Arguments for `lev models`.
 #[derive(Args)]
 pub struct ModelsArgs {
+    /// Which models subcommand to run.
     #[command(subcommand)]
     pub command: ModelsCommand,
 }
 
+/// The `lev models` subcommands.
 #[derive(Subcommand)]
 pub enum ModelsCommand {
     /// List available models and their capabilities
@@ -22,6 +25,7 @@ pub enum ModelsCommand {
     Show(ShowArgs),
 }
 
+/// Arguments for `lev models list`.
 #[derive(Args)]
 pub struct ListArgs {
     /// Filter by provider name (anthropic, openai, ollama, openrouter)
@@ -55,6 +59,7 @@ struct ModelRow {
     capabilities_overridden: bool,
 }
 
+/// Arguments for `lev models show`.
 #[derive(Args)]
 pub struct ShowArgs {
     /// Model ID to look up
@@ -69,6 +74,7 @@ pub struct ShowArgs {
 
 // ─── Entrypoint ───────────────────────────────────────────────────────────────
 
+/// Run `lev models`: show which provider/model pairs are reachable.
 pub async fn execute(args: ModelsArgs) -> anyhow::Result<()> {
     match args.command {
         ModelsCommand::List(a) => list_with_registry(a, &build_provider_registry_from_config).await,

--- a/crates/leviath-cli/src/commands/pack.rs
+++ b/crates/leviath-cli/src/commands/pack.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use leviath_core::manifest::parse_manifest;
 
+/// Arguments for `lev pack`.
 #[derive(Args)]
 pub struct PackArgs {
     /// Path to agent project (default: current directory)
@@ -17,6 +18,7 @@ pub struct PackArgs {
     pub output: Option<String>,
 }
 
+/// Run `lev pack`: build a distributable bundle from an agent directory.
 pub async fn execute(args: PackArgs) -> anyhow::Result<()> {
     execute_with_bundle(args, &|dir| AgentBundler::new().bundle(dir)).await
 }

--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -2,12 +2,15 @@
 
 use clap::{Args, Subcommand};
 
+/// Arguments for `lev policy`.
 #[derive(Args)]
 pub struct PolicyArgs {
+    /// Which policy subcommand to run.
     #[command(subcommand)]
     pub command: PolicyCommand,
 }
 
+/// The `lev policy` subcommands.
 #[derive(Subcommand)]
 pub enum PolicyCommand {
     /// List current policy rules (static + scripted)
@@ -18,9 +21,11 @@ pub enum PolicyCommand {
     Test(PolicyTestArgs),
 }
 
+/// Arguments for `lev policy list`. It takes none.
 #[derive(Args)]
 pub struct PolicyListArgs {}
 
+/// Arguments for `lev policy add`.
 #[derive(Args)]
 pub struct PolicyAddArgs {
     /// Tool name to create a rule for
@@ -34,6 +39,7 @@ pub struct PolicyAddArgs {
     pub max_sensitivity: String,
 }
 
+/// Arguments for `lev policy test`.
 #[derive(Args)]
 pub struct PolicyTestArgs {
     /// Tool name to test
@@ -47,6 +53,7 @@ pub struct PolicyTestArgs {
     pub taint: String,
 }
 
+/// Run `lev policy`: inspect and edit the taint-gate rules.
 pub async fn execute(args: PolicyArgs) -> anyhow::Result<()> {
     match args.command {
         PolicyCommand::List(_) => execute_list().await,

--- a/crates/leviath-cli/src/commands/remove.rs
+++ b/crates/leviath-cli/src/commands/remove.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 
+/// Arguments for `lev remove`.
 #[derive(Args)]
 pub struct RemoveArgs {
     /// Name of the installed agent to remove
@@ -9,6 +10,7 @@ pub struct RemoveArgs {
     pub name: String,
 }
 
+/// Run `lev remove`: uninstall an agent.
 pub async fn execute(args: RemoveArgs) -> anyhow::Result<()> {
     let installer = leviath_package::AgentInstaller::new();
     remove_agent(&installer, &args.name)

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -8,6 +8,10 @@ use std::path::{Path, PathBuf};
 
 pub use leviath_core::manifest::parse_manifest;
 
+/// Resolve an agent argument to the `agent.leviath` file it names.
+///
+/// Accepts the file itself, a directory containing one, or an installed
+/// agent's name.
 pub fn find_manifest(path: &str) -> anyhow::Result<PathBuf> {
     let p = Path::new(path);
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -47,6 +47,7 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
+/// Run `lev serve`: expose the HTTP + WebSocket API over the daemon.
 pub async fn execute(
     args: ServeArgs,
     control: leviath_runtime::control_socket::ControlClient,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 
+/// Arguments for `lev serve`.
 #[derive(Args)]
 pub struct ServeArgs {
     /// Port to listen on
@@ -78,41 +79,75 @@ pub struct ServeArgs {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerEvent {
+    /// Where a run stands, re-sent whenever any of it changes.
     AgentStatus {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id, and what a per-run subscription filters on.
         run_id: String,
+        /// The run's status, as `RunStatus` renders it.
         status: String,
+        /// The stage it is in, by name.
         stage: String,
+        /// Inference turns taken in that stage, reset on entering a new one.
         iteration: usize,
+        /// Tool calls made across the whole run.
         #[serde(default)]
         tool_calls: usize,
+        /// Whether a client may send this run a mid-run message. False for a
+        /// stage that declared `accepts_messages = false`, and for a run that
+        /// has finished.
         accepts_messages: bool,
     },
+    /// How full the run's context window is, after a turn changed it.
     ContextUpdate {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// Tokens held across every region.
         total_tokens: usize,
+        /// The whole window's budget.
         max_tokens: usize,
     },
+    /// One log line, as also written to the stage's log files.
     Log {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// The line, without a trailing newline. Long lines are truncated for
+        /// the broadcast; the on-disk stage log keeps the whole thing.
         line: String,
     },
+    /// The run is blocked on a person, and this is what it is asking.
     InteractionNeeded {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// The prompt, forwarded as the runtime serialized it, so a new kind of
+        /// request needs no server release.
         request: serde_json::Value,
     },
+    /// A run started, including one spawned as a child of another.
     AgentSpawned {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// The parent's agent id when this is a sub-agent, `None` at the root.
         parent_id: Option<String>,
+        /// The blueprint it was spawned from.
         blueprint: String,
     },
+    /// A run reached a terminal status.
     AgentCompleted {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// The terminal status, as `RunStatus` renders it.
         status: String,
         /// The run's *error*, if it failed. Named `result` since before a run
         /// could produce one; kept for the consumers that read it.
@@ -121,13 +156,21 @@ pub enum ServerEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         final_output: Option<FinalOutputResp>,
     },
+    /// Running token totals for the whole run, after an inference landed.
     Tokens {
+        /// The agent's live id in the world.
         agent_id: String,
+        /// The durable run id.
         run_id: String,
+        /// Input tokens billed so far.
         prompt_tokens: usize,
+        /// Output tokens billed so far.
         completion_tokens: usize,
+        /// Input tokens served from the provider's prompt cache, counted within
+        /// `prompt_tokens` rather than on top of it.
         #[serde(default)]
         cached_tokens: usize,
+        /// Tokens written into the provider's prompt cache.
         #[serde(default)]
         cache_write_tokens: usize,
     },
@@ -136,7 +179,10 @@ pub enum ServerEvent {
     /// next), forwarded verbatim. `event` is the runtime's own serde-tagged
     /// [`WorldEvent`](leviath_runtime::host::WorldEvent) JSON, so clients get
     /// new event kinds without a server release.
-    World { event: serde_json::Value },
+    World {
+        /// The runtime's own serde-tagged event JSON, forwarded as-is.
+        event: serde_json::Value,
+    },
 }
 
 impl ServerEvent {
@@ -160,6 +206,8 @@ impl ServerEvent {
     }
 }
 
+/// What every request handler is given: the config, the event fan-out, and the
+/// control-socket client that reaches the daemon.
 #[derive(Clone)]
 pub struct AppState {
     pub(super) config: Arc<Config>,

--- a/crates/leviath-cli/src/commands/setup/import/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/import/mod.rs
@@ -65,6 +65,7 @@ pub struct Source {
 /// The result of reading one source.
 #[derive(Debug, Clone)]
 pub struct Scan {
+    /// Which harness was scanned.
     pub source: Source,
     /// Servers found, or the reason the file could not be read.
     pub result: Result<Vec<Candidate>, String>,

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -51,6 +51,7 @@ use crossterm::event::{Event, KeyEventKind};
 use state::{VerifyReply, VerifyRequest, Wizard};
 use verify::ProviderVerifier;
 
+/// Arguments for `lev setup`.
 #[derive(Args)]
 pub struct SetupArgs {
     /// Run non-interactively using only flag values (useful for scripting)
@@ -108,7 +109,9 @@ pub type EnvLookup = Box<dyn Fn(&str) -> Option<String> + Send + Sync>;
 /// Everything the wizard needs from the outside world, injected so tests point
 /// it at tempdirs and a fake environment instead of the developer's real home.
 pub struct SetupEnv {
+    /// Where the config is read from and written back to.
     pub config_path: PathBuf,
+    /// Where bundled blueprints are installed.
     pub agents_dir: PathBuf,
     /// Roots for the harness scan.
     pub roots: import::Roots,

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -27,7 +27,9 @@ pub struct SetupPlan {
 /// What actually happened, for the closing summary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Applied {
+    /// The config file that was written.
     pub config_path: PathBuf,
+    /// Blueprints installed, by name.
     pub agents_installed: Vec<String>,
     /// Non-fatal problems worth telling the user about.
     pub warnings: Vec<String>,

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -20,13 +20,21 @@ use crate::config::Config;
 /// The wizard's screens, in order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Step {
+    /// What the wizard is about to do, before it touches anything.
     Welcome,
+    /// Pick which providers to configure.
     Providers,
+    /// Enter or confirm a credential for each picked provider.
     ProviderDetail,
+    /// The default provider and model new runs use.
     Defaults,
+    /// Concurrency, timeouts, and the other numeric ceilings.
     Limits,
+    /// Choose which bundled blueprints to install.
     Agents,
+    /// Import MCP servers found in other harnesses' configs.
     Mcp,
+    /// The whole plan, before anything is written.
     Review,
 }
 
@@ -69,7 +77,9 @@ impl Step {
 /// One row of the provider pick-list.
 #[derive(Debug, Clone)]
 pub struct ProviderRow {
+    /// Which provider this row is for.
     pub provider: Provider,
+    /// Whether the user has picked it.
     pub selected: bool,
     /// The credential as typed. Empty means "no value".
     pub value: String,
@@ -78,6 +88,7 @@ pub struct ProviderRow {
     pub from_env: Option<&'static str>,
     /// Reasoning effort, for the Claude Code transport only.
     pub effort: usize,
+    /// What the last verification attempt concluded.
     pub outcome: Outcome,
     /// A verification is in flight.
     pub checking: bool,
@@ -98,17 +109,23 @@ impl ProviderRow {
 /// One row of the blueprint list.
 #[derive(Debug, Clone)]
 pub struct AgentRow {
+    /// The bundled blueprint this row offers.
     pub agent: &'static BundledAgent,
+    /// What installing it would do: a fresh install, an upgrade, or nothing
+    /// because the same version is already there.
     pub action: AgentAction,
+    /// Whether the user has picked it.
     pub selected: bool,
 }
 
 /// One importable MCP server.
 #[derive(Debug, Clone)]
 pub struct McpRow {
+    /// The server definition as found, before collision handling.
     pub candidate: Candidate,
     /// Which harness it came from.
     pub source: String,
+    /// Whether the user has picked it.
     pub selected: bool,
     /// A server of this name is already in the Leviath config.
     pub collides: bool,
@@ -119,8 +136,11 @@ pub struct McpRow {
 /// A single editable setting on the Defaults / Limits screens.
 #[derive(Debug, Clone)]
 pub struct Field {
+    /// The setting's name, as shown.
     pub label: &'static str,
+    /// One line explaining what it does, shown under the label.
     pub help: &'static str,
+    /// Its current value, which also decides what a key press means.
     pub value: FieldValue,
 }
 
@@ -133,7 +153,12 @@ pub enum FieldValue {
     /// A toggle.
     Bool(bool),
     /// One of a fixed list.
-    Choice { options: Vec<String>, index: usize },
+    Choice {
+        /// Every value this field may take, in the order they are cycled.
+        options: Vec<String>,
+        /// Which one is selected, by position in `options`.
+        index: usize,
+    },
 }
 
 impl FieldValue {
@@ -163,14 +188,19 @@ impl FieldValue {
 /// Asked of the background verifier.
 #[derive(Debug, Clone)]
 pub struct VerifyRequest {
+    /// Which provider to check, matching the row that asked.
     pub provider_id: String,
+    /// The credentials to check, as typed or taken from the environment.
     pub creds: leviath_runtime::provider_creds::ProviderCreds,
 }
 
 /// Answered by the background verifier.
 #[derive(Debug, Clone)]
 pub struct VerifyReply {
+    /// Which provider this answers for. Replies can arrive out of order, so
+    /// this is what routes one back to its row.
     pub provider_id: String,
+    /// What the check concluded.
     pub outcome: Outcome,
 }
 
@@ -186,6 +216,7 @@ pub enum EditTarget {
 /// An in-progress text edit.
 #[derive(Debug, Clone)]
 pub struct Edit {
+    /// Where the text goes when it is committed.
     pub target: EditTarget,
     /// The shared single-line editor (cursor movement, masking).
     pub(crate) line: crate::tui::widgets::line_edit::LineEdit,
@@ -205,26 +236,38 @@ pub enum ConfirmPurpose {
 /// A pending confirmation: the dialog plus what its Yes means.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingConfirm {
+    /// What answering Yes would mean.
     pub purpose: ConfirmPurpose,
     pub(crate) dialog: crate::tui::widgets::confirm::Confirm,
 }
 
 /// The whole wizard.
 pub struct Wizard {
+    /// The screen currently shown.
     pub step: Step,
     /// Selected row within the current step.
     pub cursor: usize,
+    /// Every provider the wizard offers, picked or not.
     pub providers: Vec<ProviderRow>,
     /// Which selected provider the credential screen is showing.
     pub detail: usize,
+    /// The Defaults screen's settings.
     pub defaults: Vec<Field>,
+    /// The Limits screen's settings.
     pub limits: Vec<Field>,
+    /// Every bundled blueprint the wizard offers.
     pub agents: Vec<AgentRow>,
+    /// MCP servers found in other harnesses' configs.
     pub mcp: Vec<McpRow>,
+    /// Harnesses whose config could not be read, shown rather than swallowed
+    /// so an empty MCP list is distinguishable from a failed scan.
     pub mcp_scan_errors: Vec<String>,
+    /// The text edit in progress, if any. While this is set, typing goes here
+    /// rather than to the screen's own key bindings.
     pub edit: Option<Edit>,
     /// Show credentials in clear text.
     pub reveal: bool,
+    /// The help overlay is on screen.
     pub show_help: bool,
     /// A confirmation dialog is on screen, and (after Ctrl-C) it is the only
     /// thing keys mean until it is answered.
@@ -236,6 +279,7 @@ pub struct Wizard {
     /// hard gate on saving: the transport cannot be written to the config
     /// without it, and deselecting the transport withdraws it.
     pub claude_code_tos_accepted: bool,
+    /// The user asked to leave and the loop should stop.
     pub should_quit: bool,
     /// Set once the plan has been applied, so the loop knows to stop.
     pub finished: bool,
@@ -250,9 +294,12 @@ pub struct Wizard {
     /// `lev dash` once had a unit test launch a real browser, and this is the
     /// same shape of hazard.
     pub opener: leviath_mcp::BrowserOpener,
+    /// Where a credential check is sent. Verification runs off the UI thread
+    /// so a slow provider cannot freeze the wizard.
     pub verify_tx: mpsc::UnboundedSender<VerifyRequest>,
     verify_rx: Option<mpsc::UnboundedReceiver<VerifyRequest>>,
     reply_tx: mpsc::UnboundedSender<VerifyReply>,
+    /// Where finished checks arrive, drained once per tick.
     pub reply_rx: mpsc::UnboundedReceiver<VerifyReply>,
     /// Tick counter, for the spinner.
     pub ticks: u64,

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -30,9 +30,15 @@ pub enum Outcome {
     /// Not attempted - `--no-verify`, or no credential to check.
     Skipped,
     /// The provider answered. Carries its model ids, for the model picker.
-    Reachable { models: Vec<String> },
+    Reachable {
+        /// The model ids it advertised, which is what the model picker offers.
+        models: Vec<String>,
+    },
     /// The provider refused or could not be reached.
-    Failed { message: String },
+    Failed {
+        /// What went wrong, shown next to the provider's row.
+        message: String,
+    },
 }
 
 impl Outcome {
@@ -66,6 +72,9 @@ impl Outcome {
 /// tests never open a socket.
 #[allow(async_fn_in_trait)] // callers are concrete; no `dyn` and no boxing needed
 pub trait ProviderVerifier {
+    /// Ask the provider whether these credentials work, and what models they
+    /// reach. Never fails: an unreachable provider is an [`Outcome::Failed`],
+    /// not an error, because the wizard reports it rather than stopping.
     async fn verify(&self, creds: &ProviderCreds) -> Outcome;
 }
 

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 use leviath_core::manifest::parse_manifest;
 use leviath_core::truncate_at_boundary;
 
+/// Arguments for `lev test`.
 #[derive(Args)]
 pub struct TestArgs {
     /// Path to agent project
@@ -46,6 +47,7 @@ struct TestFile {
     test: Vec<TestCase>,
 }
 
+/// Run `lev test`: drive a blueprint's declared test cases.
 pub async fn execute(args: TestArgs) -> anyhow::Result<()> {
     execute_with_registry(args, Box::new(build_registry_from_config)).await
 }

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::lint::{LintEnv, LintFinding, LintSeverity, lint_manifest};
 
+/// Arguments for `lev validate`.
 #[derive(Args)]
 pub struct ValidateArgs {
     /// Path to the agent directory or agent.leviath file
@@ -24,8 +25,11 @@ pub struct ValidateArgs {
 /// The blueprint itself, for a caller that wants to know what it just validated.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct BlueprintSummary {
+    /// The blueprint's `[agent] name`.
     pub name: String,
+    /// Its declared version.
     pub version: String,
+    /// Its one-line description.
     pub description: String,
     /// Null when the manifest names no `entry_stage`, in which case the first
     /// stage is the entry.
@@ -49,9 +53,13 @@ pub struct ValidateReport {
     pub blueprint: Option<BlueprintSummary>,
     /// Present when it did not.
     pub error: Option<String>,
+    /// Everything the lint had to say, at every severity.
     pub findings: Vec<LintFinding>,
+    /// How many findings are errors. Non-zero means the blueprint will not run.
     pub errors: usize,
+    /// How many are warnings: it runs, but something looks wrong.
     pub warnings: usize,
+    /// How many are notes: things worth seeing that are not problems.
     pub notes: usize,
 }
 
@@ -382,6 +390,7 @@ fn print_script_tool_report(path: &std::path::Path) {
     }
 }
 
+/// Run `lev validate`: check a blueprint and print what is wrong with it.
 pub async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
     let config = crate::config::Config::load().ok();
     match execute_reporting_outcome(&args, config.as_ref())? {

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -23,6 +23,7 @@ pub struct AgentSource {
     /// what identifies the checkout on disk, while the blueprint's own name is
     /// what the agent calls itself.
     pub run_stem: String,
+    /// The parsed blueprint itself.
     pub blueprint: leviath_core::Blueprint,
 }
 

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -34,18 +34,25 @@ pub struct DaemonFanOutSpawner {
     /// Spawn-time config, read fresh per worker so a `config.toml` edit reaches
     /// fan-out workers too (shared with the daemon's main spawner).
     pub config: Arc<crate::daemon::config_reload::ConfigReloader>,
+    /// The daemon-wide MCP executor, for servers configured globally.
     pub shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
+    /// Tool definitions from `shared_mcp`, resolved once rather than per worker.
     pub mcp_tool_defs: Vec<Tool>,
     /// Shared MCP pool for per-agent `[[mcp_servers]]` - a fan-out worker
     /// advertises its blueprint's already-connected servers and lazily warms any
     /// uncached ones for subsequent workers of the same type.
     pub mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
+    /// Where a worker's prompts go. Shared with the daemon, so a fan-out
+    /// worker's question reaches the same place as any other run's.
     pub hub: InteractionHub,
+    /// Where a worker's own sub-agent spawns are sent.
     pub subagent_tx: UnboundedSender<SubAgentOp>,
+    /// The tool dispatcher every worker's calls go through.
     pub tool_service: Arc<CliToolService>,
     /// `~/.leviath/agents`, for resolving `worker_query`. `None` when there is no
     /// home directory.
     pub agents_dir: Option<PathBuf>,
+    /// The clock, injected so a test can stamp a worker deterministically.
     pub now_secs: fn() -> i64,
 }
 

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -21,6 +21,7 @@
 
 use crate::commands;
 
+/// Every `lev` subcommand. Each variant's doc comment is what `--help` prints.
 #[derive(clap::Subcommand)]
 pub enum Commands {
     /// Create a new agent blueprint

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -1,21 +1,15 @@
 //! Leviath CLI library - re-exports for integration tests.
 //!
-//! # Why `missing_docs` is off here
+//! `missing_docs` applies here like everywhere else in the workspace. This crate
+//! ships the `lev` binary rather than a library anyone calls, so the case for
+//! exempting it was real - and the case against turned out to be stronger: the
+//! `pub` surface is what the integration tests drive, and a wire type like
+//! [`commands::serve::ServerEvent`] is read by clients that never see this
+//! source. An undocumented field there is a gap for somebody.
 //!
-//! It is on for the whole workspace, because the other crates publish a library
-//! whose docs render on docs.rs and get called by people who did not write them.
-//! This crate publishes the `lev` **binary**. Its `pub` surface is `pub` so the
-//! integration tests in `tests/` can reach it, not because anything outside
-//! calls it - `execute(args: AddArgs)` is `lev add`, and a doc comment saying so
-//! restates the module path.
-//!
-//! The 166 items that would be flagged here are mostly clap `Args` fields, which
-//! already carry their user-facing text in `#[arg(help = ...)]` or a doc comment
-//! clap consumes. Requiring a second description for the rustdoc reader who does
-//! not exist is the noise this repo's comment policy is written to keep out.
-//!
-//! Tracked in #290 if that reasoning stops holding.
-#![allow(missing_docs)]
+//! What the rule asks for is a sentence saying something the name does not. A
+//! clap `Args` field already carries its user-facing text for `--help`; the
+//! struct around it says which command it belongs to.
 
 pub mod approvals;
 pub mod bundled;

--- a/crates/leviath-cli/src/lint.rs
+++ b/crates/leviath-cli/src/lint.rs
@@ -72,6 +72,7 @@ impl LintSeverity {
 /// file, which no deserializer can produce.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LintFinding {
+    /// How much this matters, and therefore whether it fails the check.
     pub severity: LintSeverity,
     /// Stable slug (`"unknown-tool"`), so a finding can be referenced in an
     /// issue or grepped for in daemon logs without quoting prose.

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -16,9 +16,14 @@ use crate::config::{Config, ToolPolicy};
 /// Cheap to clone (all fields are `Arc`s). The `call` method dispatches
 /// to the appropriate executor.
 pub struct ToolRegistry {
+    /// The built-in tools, over this agent's workdir.
     pub builtins: Arc<BuiltinTools>,
+    /// The MCP executor, shared because connections are per-server rather than
+    /// per-agent.
     pub mcp: Arc<Mutex<ToolExecutor>>,
+    /// MCP tool definitions to advertise, resolved once at spawn.
     pub mcp_tool_defs: Vec<Tool>,
+    /// Which names dispatch to `builtins` rather than to MCP.
     pub builtin_names: HashSet<String>,
 }
 

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -37,6 +37,8 @@ use std::time::Duration;
 /// loop can be driven by canned events in tests instead of blocking on a real
 /// terminal.
 pub trait EventSource {
+    /// Wait up to `timeout` for one input event. `Ok(None)` means the timeout
+    /// elapsed with nothing to read, which is what lets a UI loop tick.
     fn poll_event(&mut self, timeout: Duration) -> std::io::Result<Option<Event>>;
 }
 
@@ -52,6 +54,7 @@ pub struct CrosstermEventSource {
 
 #[allow(clippy::new_without_default)] // constructed only by the binary's real UI entrypoints
 impl CrosstermEventSource {
+    /// Read from the real terminal.
     pub fn new() -> Self {
         Self {
             poll_fn: crossterm::event::poll,
@@ -75,10 +78,18 @@ impl EventSource for CrosstermEventSource {
 /// crossterm implementation (`CrosstermSetup`) lives in the binary, since it
 /// can only be exercised against a real terminal.
 pub trait TerminalSetup {
+    /// The backend the terminal draws through: crossterm in production, a
+    /// `TestBackend` under test.
     type B: ratatui::backend::Backend;
+    /// Take over the terminal - raw mode and the alternate screen.
     fn enable(&mut self) -> anyhow::Result<()>;
+    /// Build the terminal the UI draws into. Called after [`Self::enable`].
     fn create_terminal(&mut self) -> anyhow::Result<Terminal<Self::B>>;
+    /// Hand the terminal back. Must tolerate being called twice: the panic
+    /// hook calls it too, and a panic during teardown would otherwise leave a
+    /// terminal in raw mode.
     fn disable(&mut self);
+    /// Print whatever should remain on screen after the UI exits.
     fn print_done(&self);
 }
 


### PR DESCRIPTION
docs: document leviath-cli, and drop the last missing_docs exemption (#290)

#291 turned `missing_docs` on workspace-wide and documented the five library
crates, but left `leviath-cli` behind a crate-root `#![allow(missing_docs)]`. The
argument was that this crate ships the `lev` binary, its `pub` surface is `pub`
so `tests/` can reach it, and a clap `Args` field already carries its text in
`#[arg(help = ...)]`.

That holds for a good share of the 166. It does not hold for all of them, and the
exception that matters is `ServerEvent` - the WebSocket wire contract, read by
clients that never see this source. Nine variants and forty fields, telling a
consumer what `cached_tokens` counts and whether `accepts_messages` can change
mid-run, none of it written down anywhere. An `#[allow]` covering the whole crate
covered that too.

So: all 166 documented, the allow deleted, and the lint now has no exemption
anywhere in the workspace.

### Where the writing went

The rule the repo already follows is "say something the name does not", and it is
what decided how much each item got.

- **`ServerEvent`** got the most, because it is API. `cached_tokens` is counted
  *within* `prompt_tokens` rather than on top - the difference between a correct
  cost figure and one that double-counts. `accepts_messages` is false both for a
  stage that declined messages and for a run that has finished.
- **`AgentDisplayStatus`** distinguishes `Cancelled` from `Error`: nothing went
  wrong, someone decided.
- **`Wizard`** says why verification runs off the UI thread, and that
  `mcp_scan_errors` exists so an empty list is distinguishable from a failed scan.
- **`TerminalSetup::disable`** says it must tolerate being called twice, because
  the panic hook calls it too and a panic during teardown would otherwise leave a
  terminal in raw mode.
- **Command modules** got one line each: `XArgs` names its command, `execute`
  says what the command does. That is the whole honest content, and it is more
  than the module path gave.

### Checks

`RUSTFLAGS="-D warnings" cargo build --workspace --all-features`,
`cargo clippy --workspace --all-targets --all-features`, and
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` all clean - the
three gates that enforce this. Full suite green, `cargo xtask coverage` clean on
leviath-cli.

Closes #290

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
