### PR TITLE
refactor(daemon): move the lifecycle decisions out of the unmeasured binary

### DIFF
--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -367,7 +367,9 @@ pub fn remove_legacy_with(
 /// Deactivation is deliberately unchecked. It fails when nothing is registered,
 /// which is the normal case on a first install and not a problem.
 ///
-/// The effects are injected for the same reason [`remove_legacy_with`]'s are:
+/// The effects are injected for the same reason `remove_legacy_with`'s are
+/// (deliberately not a link: that function is macOS-only, so the link would not
+/// resolve when rustdoc runs on any other platform):
 /// `run` shells out to `launchctl`/`systemctl`, and nothing about the sequence
 /// needs a real supervisor to be checked.
 pub fn install_with(

--- a/crates/leviath-cli/src/commands/daemon_service.rs
+++ b/crates/leviath-cli/src/commands/daemon_service.rs
@@ -355,6 +355,62 @@ pub fn remove_legacy_with(
     removed
 }
 
+/// Register the service with the platform supervisor, returning the lines to
+/// report.
+///
+/// The *order* is the part worth testing and the part that was easy to get
+/// wrong: re-registering a live service is an error on both platforms, so any
+/// previous registration is dropped first and legacy labels are cleaned before
+/// the new one is activated. Get that backwards and `install` stops being
+/// idempotent, or leaves a second supervised daemon behind.
+///
+/// Deactivation is deliberately unchecked. It fails when nothing is registered,
+/// which is the normal case on a first install and not a problem.
+///
+/// The effects are injected for the same reason [`remove_legacy_with`]'s are:
+/// `run` shells out to `launchctl`/`systemctl`, and nothing about the sequence
+/// needs a real supervisor to be checked.
+pub fn install_with(
+    unit: &ServiceUnit,
+    run: &mut dyn FnMut(&SupervisorCommand) -> Result<()>,
+    remove_legacy: &mut dyn FnMut() -> Vec<PathBuf>,
+) -> Result<Vec<String>> {
+    let path = install(unit)?;
+    let mut lines = vec![format!("wrote {}", path.display())];
+    let _ = run(&unit.deactivate);
+    lines.extend(
+        remove_legacy()
+            .iter()
+            .map(|p| format!("removed legacy service file {}", p.display())),
+    );
+    run(&unit.activate)?;
+    lines.push("the leviath daemon is now supervised and will restart automatically".to_string());
+    Ok(lines)
+}
+
+/// Deregister the service and remove its file, returning the lines to report.
+///
+/// Deregistration is unchecked for the same reason it is in [`install_with`]:
+/// it fails when nothing is registered, and that is the desired end state
+/// either way. Only the file removal is reported, because it is the only step
+/// whose outcome the user could not have predicted.
+pub fn uninstall_with(
+    unit: &ServiceUnit,
+    run: &mut dyn FnMut(&SupervisorCommand) -> Result<()>,
+    remove_legacy: &mut dyn FnMut() -> Vec<PathBuf>,
+) -> Result<Vec<String>> {
+    let _ = run(&unit.deactivate);
+    let mut lines: Vec<String> = remove_legacy()
+        .iter()
+        .map(|p| format!("removed legacy service file {}", p.display()))
+        .collect();
+    lines.push(match uninstall(unit)? {
+        true => format!("removed {}", unit.path.display()),
+        false => "no leviath service was installed".to_string(),
+    });
+    Ok(lines)
+}
+
 /// The line `lev daemon status` adds about supervision.
 pub fn format_supervision(installed: bool, path: &Path) -> String {
     if installed {
@@ -466,6 +522,136 @@ mod tests {
             activate: ("sup".to_string(), vec!["on".to_string()]),
             deactivate: ("sup".to_string(), vec!["off".to_string()]),
         }
+    }
+
+    /// Record every supervisor command, so the *order* can be asserted rather
+    /// than just the outcome.
+    type SupervisorLog = std::rc::Rc<std::cell::RefCell<Vec<String>>>;
+
+    fn recording() -> (SupervisorLog, impl FnMut(&SupervisorCommand) -> Result<()>) {
+        let log: SupervisorLog = Default::default();
+        let sink = log.clone();
+        (log, move |cmd: &SupervisorCommand| {
+            sink.borrow_mut().push(cmd.1.join(" "));
+            Ok(())
+        })
+    }
+
+    /// The ordering is the whole point: deactivate, clean legacy labels, *then*
+    /// activate. Re-registering a live service is an error on both platforms,
+    /// so activating first makes `install` non-idempotent.
+    #[test]
+    fn install_deactivates_and_cleans_before_it_activates() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("leviath.unit"));
+        let (log, mut run) = recording();
+        let legacy = dir.path().join("old.plist");
+        let mut remove_legacy = || vec![legacy.clone()];
+
+        let lines = install_with(&unit, &mut run, &mut remove_legacy).unwrap();
+        assert_eq!(
+            *log.borrow(),
+            ["off", "on"],
+            "activated before deactivating"
+        );
+        assert!(lines[0].starts_with("wrote "), "{lines:?}");
+        assert!(lines[1].contains("legacy service file"), "{lines:?}");
+        assert!(lines[2].contains("supervised"), "{lines:?}");
+        assert!(unit.path.exists());
+    }
+
+    /// A failed *activation* is the one that matters, and must not be swallowed
+    /// the way the deactivation is.
+    #[test]
+    fn install_reports_a_failed_activation() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("leviath.unit"));
+        let mut run = |cmd: &SupervisorCommand| match cmd.1[0].as_str() {
+            "on" => Err(anyhow::anyhow!("supervisor said no")),
+            _ => Ok(()),
+        };
+        let err = install_with(&unit, &mut run, &mut Vec::new)
+            .expect_err("a failed activation propagates");
+        assert!(err.to_string().contains("supervisor said no"), "{err}");
+    }
+
+    /// Deregistration fails when nothing is registered, which is the normal
+    /// first-run case. Propagating it would make `uninstall` fail on a machine
+    /// that simply had nothing installed.
+    #[test]
+    fn uninstall_ignores_a_failed_deregistration() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("leviath.unit"));
+        install(&unit).unwrap();
+        let mut run = |_: &SupervisorCommand| Err(anyhow::anyhow!("nothing registered"));
+
+        let lines = uninstall_with(&unit, &mut run, &mut Vec::new).unwrap();
+        assert_eq!(lines, [format!("removed {}", unit.path.display())]);
+        assert!(!unit.path.exists());
+    }
+
+    /// A unit file that cannot be written stops the install before anything
+    /// reaches the supervisor - registering a service whose file is missing
+    /// would leave the machine referencing nothing.
+    #[test]
+    fn install_stops_when_the_unit_cannot_be_written() {
+        let dir = tempfile::tempdir().unwrap();
+        // A *file* where the unit's parent directory would go, so
+        // `create_dir_all` cannot succeed.
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, "not a directory").unwrap();
+        let unit = bare_unit(blocker.join("nested").join("leviath.unit"));
+        let (log, mut run) = recording();
+
+        assert!(install_with(&unit, &mut run, &mut Vec::new).is_err());
+        assert!(
+            log.borrow().is_empty(),
+            "the supervisor was called for a unit that was never written"
+        );
+    }
+
+    /// A unit path that cannot be removed is an error, and distinct from one
+    /// that was not there - "no leviath service was installed" would be a lie
+    /// about a file still sitting on disk.
+    #[test]
+    fn uninstall_propagates_a_removal_it_could_not_do() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory where the unit file would be: `remove_file` refuses it
+        // with something other than NotFound on every platform.
+        let unit = bare_unit(dir.path().join("leviath.unit"));
+        std::fs::create_dir(&unit.path).unwrap();
+        let (_log, mut run) = recording();
+
+        assert!(uninstall_with(&unit, &mut run, &mut Vec::new).is_err());
+    }
+
+    /// Legacy files removed during an uninstall are reported too, not only
+    /// during an install.
+    #[test]
+    fn uninstall_reports_legacy_files_it_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("leviath.unit"));
+        install(&unit).unwrap();
+        let legacy = dir.path().join("old.plist");
+        let mut remove_legacy = || vec![legacy.clone()];
+        let (_log, mut run) = recording();
+
+        let lines = uninstall_with(&unit, &mut run, &mut remove_legacy).unwrap();
+        assert!(lines[0].contains("legacy service file"), "{lines:?}");
+        assert!(lines[1].starts_with("removed "), "{lines:?}");
+    }
+
+    /// Nothing to remove reads differently from something removed, so a user
+    /// can tell "cleaned up" from "there was nothing there".
+    #[test]
+    fn uninstall_says_when_there_was_nothing_installed() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = bare_unit(dir.path().join("absent.unit"));
+        let (log, mut run) = recording();
+
+        let lines = uninstall_with(&unit, &mut run, &mut Vec::new).unwrap();
+        assert_eq!(lines, ["no leviath service was installed"]);
+        assert_eq!(*log.borrow(), ["off"]);
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/lifecycle.rs
+++ b/crates/leviath-cli/src/daemon/lifecycle.rs
@@ -1,0 +1,104 @@
+//! Deciding what `lev daemon start` / `stop` / `status` should do.
+//!
+//! Each function here is the *judgement* part of a subcommand: given what was
+//! observed about the daemon, what has to happen and what gets printed. The
+//! observing is left to the caller, for the reason
+//! [`readiness::poll_until`](super::readiness::poll_until) takes its predicate
+//! as an argument - the sequencing is worth testing, and only the probe needs a
+//! real socket or a real process.
+
+/// What has to happen before a daemon on the current build is running.
+///
+/// Returned rather than performed, so `main.rs` supplies the socket probe and
+/// the process spawn while the decision between these three cases stays here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StartSteps {
+    /// Shut down what is running before spawning.
+    ///
+    /// Only ever true alongside `spawn`: the reason to stop a daemon here is to
+    /// replace it, never to leave the machine without one.
+    pub shutdown_first: bool,
+    /// Spawn a daemon.
+    pub spawn: bool,
+}
+
+impl StartSteps {
+    /// Nothing to do; one is already up on this build.
+    const SATISFIED: Self = Self {
+        shutdown_first: false,
+        spawn: false,
+    };
+}
+
+/// What `lev` must do to reach "a daemon on the current build is running".
+///
+/// A daemon on an older build is restarted rather than reused. It cannot pick
+/// up new code, and the alternative - talking to it anyway - means a `lev` that
+/// was just rebuilt silently drives the previous build's engine. The restart is
+/// safe because the daemon reloads its persisted agents on startup, so
+/// in-flight runs survive the swap.
+///
+/// `stale` is only meaningful when `running`; a build marker left by a daemon
+/// that has since exited says nothing about what is about to be spawned.
+pub fn start_steps(running: bool, stale: bool) -> StartSteps {
+    match (running, stale) {
+        (true, false) => StartSteps::SATISFIED,
+        (true, true) => StartSteps {
+            shutdown_first: true,
+            spawn: true,
+        },
+        (false, _) => StartSteps {
+            shutdown_first: false,
+            spawn: true,
+        },
+    }
+}
+
+/// What to do when the control channel would not accept a shutdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopFallback {
+    /// Signal the recorded process group instead.
+    ///
+    /// Without this a daemon that cannot be talked to cannot be stopped either,
+    /// and `lev daemon restart` - which stops before it starts - could never
+    /// recover one that had wedged.
+    Signal(u32),
+    /// Nothing recorded a pid, so the control-channel error is the whole story
+    /// and is reported as-is rather than replaced by a vaguer one.
+    Propagate,
+}
+
+/// Decide the fallback for a refused shutdown, given the recorded pid.
+pub fn stop_fallback(recorded_pid: Option<u32>) -> StopFallback {
+    match recorded_pid {
+        Some(pid) => StopFallback::Signal(pid),
+        None => StopFallback::Propagate,
+    }
+}
+
+/// The line `lev daemon stop` prints, or the error it fails with.
+///
+/// `was_running` and `stopped` are separate observations because they answer
+/// different questions and the pair "nothing was running" and "it did not stop"
+/// must not read the same: the first is a success.
+pub fn stop_outcome(was_running: bool, stopped: bool) -> Result<&'static str, &'static str> {
+    match (was_running, stopped) {
+        (false, _) => Ok("daemon not running"),
+        (true, true) => Ok("daemon stopped"),
+        (true, false) => Err("the leviath daemon did not shut down within 5s"),
+    }
+}
+
+/// The lines `lev daemon status` prints.
+///
+/// `supervision` is `None` on a platform with no supported supervisor, where
+/// there is genuinely nothing to report - as distinct from a supported platform
+/// with nothing installed, which says so.
+pub fn status_lines(running: bool, agents: usize, supervision: Option<String>) -> Vec<String> {
+    let mut lines = vec![crate::commands::daemon::format_status(running, agents)];
+    lines.extend(supervision);
+    lines
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/daemon/lifecycle/tests.rs
+++ b/crates/leviath-cli/src/daemon/lifecycle/tests.rs
@@ -1,0 +1,75 @@
+//! Tests for the daemon-lifecycle decisions.
+
+use super::*;
+
+/// The case the stale check exists for. A `lev` that was just rebuilt must not
+/// silently drive the previous build's engine, so a running-but-stale daemon is
+/// replaced rather than reused.
+#[test]
+fn a_stale_daemon_is_replaced_rather_than_reused() {
+    let steps = start_steps(true, true);
+    assert!(steps.shutdown_first);
+    assert!(steps.spawn);
+}
+
+/// The control, so the test above is not passing because everything restarts:
+/// a current daemon is left alone, which is the common path and the one that
+/// must cost nothing.
+#[test]
+fn a_current_daemon_is_left_alone() {
+    assert_eq!(start_steps(true, false), StartSteps::SATISFIED);
+}
+
+/// Nothing running means spawn, and nothing to shut down first. The `stale`
+/// reading is ignored: a build marker left by a daemon that has since exited
+/// says nothing about the one about to be spawned.
+#[test]
+fn nothing_running_spawns_without_a_shutdown() {
+    for stale in [true, false] {
+        let steps = start_steps(false, stale);
+        assert!(!steps.shutdown_first, "stale={stale}");
+        assert!(steps.spawn, "stale={stale}");
+    }
+}
+
+/// The invariant behind the pair: stopping is only ever a prelude to starting.
+/// A combination that shut the daemon down and did not replace it would leave
+/// the machine without one, which no caller of this asks for.
+#[test]
+fn a_shutdown_is_never_ordered_without_a_spawn() {
+    for running in [true, false] {
+        for stale in [true, false] {
+            let steps = start_steps(running, stale);
+            assert!(
+                !steps.shutdown_first || steps.spawn,
+                "running={running} stale={stale} would stop without starting"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_recorded_pid_is_signalled_and_a_missing_one_propagates() {
+    assert_eq!(stop_fallback(Some(4321)), StopFallback::Signal(4321));
+    assert_eq!(stop_fallback(None), StopFallback::Propagate);
+}
+
+/// "Nothing was running" is a success, and must not read like "it would not
+/// stop" - which is the failure.
+/// A platform with no supervisor prints one line, not a line saying nothing is
+/// installed - those are different facts.
+#[test]
+fn status_omits_supervision_when_there_is_none_to_report() {
+    assert_eq!(status_lines(true, 3, None).len(), 1);
+    let with = status_lines(true, 3, Some("supervised".to_string()));
+    assert_eq!(with.len(), 2);
+    assert_eq!(with[1], "supervised");
+}
+
+#[test]
+fn not_running_is_a_success_and_not_stopping_is_not() {
+    assert_eq!(stop_outcome(false, false), Ok("daemon not running"));
+    assert_eq!(stop_outcome(false, true), Ok("daemon not running"));
+    assert_eq!(stop_outcome(true, true), Ok("daemon stopped"));
+    assert!(stop_outcome(true, false).is_err());
+}

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -8,6 +8,7 @@ pub mod client;
 pub mod config_reload;
 pub mod fanout_spawner;
 pub mod gate_rules;
+pub mod lifecycle;
 pub mod mcp_pool;
 pub mod readiness;
 pub mod recovery;

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -326,13 +326,15 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
     use leviath_runtime::control_socket::is_daemon_running;
     let id = control_address()
         .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the control socket"))?;
-    if is_daemon_running(&id) {
-        if !daemon_build_is_stale(read_build_marker().as_deref()) {
-            return Ok(()); // already running the current build
-        }
-        // A daemon from an older build is running. It cannot pick up new code, so
-        // restart it cleanly - it reloads its persisted agents on startup, so
-        // in-flight runs survive the swap.
+    let running = is_daemon_running(&id);
+    let steps = leviath_cli::daemon::lifecycle::start_steps(
+        running,
+        running && daemon_build_is_stale(read_build_marker().as_deref()),
+    );
+    if !steps.spawn {
+        return Ok(());
+    }
+    if steps.shutdown_first {
         eprintln!("leviath daemon is on an older build; restarting to load {CURRENT_BUILD}…");
         // Shut down quietly (straight over the control socket) rather than via
         // `daemon::send_shutdown`, whose stdout "daemon shutting down" line would
@@ -370,30 +372,32 @@ async fn real_daemon_stop() -> anyhow::Result<()> {
     use leviath_runtime::control_socket::is_daemon_running;
     let id = leviath_cli::daemon::setup::control_address()
         .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the control socket"))?;
+    use leviath_cli::daemon::lifecycle::{StopFallback, stop_fallback, stop_outcome};
     if !is_daemon_running(&id) {
-        println!("daemon not running");
+        println!("{}", stop_outcome(false, false).unwrap_or_default());
         return Ok(());
     }
-    // Ask politely first. If the control channel refuses or is wedged, fall back
-    // to signalling the recorded process - otherwise a daemon that cannot be
-    // talked to cannot be stopped either, and `lev daemon restart` (which stops
-    // before it starts) could never recover.
+    // Ask politely first; the fallback for a refusal is `stop_fallback`'s call.
     if let Err(e) = commands::daemon::send_shutdown(&control_client()?).await {
         let dir = leviath_cli::daemon::setup::control_dir()
             .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the daemon pid"))?;
-        match leviath_runtime::control_socket::ControlToken::read_pid(&dir) {
-            Some(pid) => {
+        match stop_fallback(leviath_runtime::control_socket::ControlToken::read_pid(
+            &dir,
+        )) {
+            StopFallback::Signal(pid) => {
                 eprintln!("control channel did not answer ({e}); signalling pid {pid}");
                 let _ = leviath_sys::kill_process_group(pid);
             }
-            None => return Err(e),
+            StopFallback::Propagate => return Err(e),
         }
     }
-    if poll_until(&mut || !is_daemon_running(&id)).await {
-        println!("daemon stopped");
-        return Ok(());
+    match stop_outcome(true, poll_until(&mut || !is_daemon_running(&id)).await) {
+        Ok(line) => {
+            println!("{line}");
+            Ok(())
+        }
+        Err(e) => anyhow::bail!(e),
     }
-    anyhow::bail!("the leviath daemon did not shut down within 5s");
 }
 
 /// `lev daemon status`: report whether the daemon is running and its agent count.
@@ -410,14 +414,13 @@ async fn real_daemon_status() -> anyhow::Result<()> {
     } else {
         0
     };
-    println!("{}", commands::daemon::format_status(running, count));
     // Supervision is best-effort information: on a platform with no supported
     // supervisor there is simply nothing to report.
-    if let Ok(unit) = resolve_service_unit() {
-        println!(
-            "{}",
-            commands::daemon_service::format_supervision(unit.path.exists(), &unit.path)
-        );
+    let supervision = resolve_service_unit()
+        .ok()
+        .map(|unit| commands::daemon_service::format_supervision(unit.path.exists(), &unit.path));
+    for line in leviath_cli::daemon::lifecycle::status_lines(running, count, supervision) {
+        println!("{line}");
     }
     Ok(())
 }
@@ -466,28 +469,27 @@ fn run_supervisor(cmd: &(String, Vec<String>)) -> anyhow::Result<()> {
 /// supervisor, so the daemon starts at login and is restarted if it ever dies.
 fn real_daemon_install() -> anyhow::Result<()> {
     let unit = resolve_service_unit()?;
-    let path = commands::daemon_service::install(&unit)?;
-    println!("wrote {}", path.display());
-    // Re-registering a live service is an error on both platforms; drop any
-    // previous registration first so `install` is idempotent.
-    let _ = run_supervisor(&unit.deactivate);
-    remove_legacy_services();
-    run_supervisor(&unit.activate)?;
-    println!("the leviath daemon is now supervised and will restart automatically");
+    let lines = commands::daemon_service::install_with(
+        &unit,
+        &mut run_supervisor,
+        &mut remove_legacy_services,
+    )?;
+    for line in lines {
+        println!("{line}");
+    }
     Ok(())
 }
 
 /// `lev daemon uninstall`: deregister from the supervisor and remove the file.
 fn real_daemon_uninstall() -> anyhow::Result<()> {
     let unit = resolve_service_unit()?;
-    // Deregistration fails when nothing is registered; that's the desired end
-    // state either way, so only the file removal is reported.
-    let _ = run_supervisor(&unit.deactivate);
-    remove_legacy_services();
-    if commands::daemon_service::uninstall(&unit)? {
-        println!("removed {}", unit.path.display());
-    } else {
-        println!("no leviath service was installed");
+    let lines = commands::daemon_service::uninstall_with(
+        &unit,
+        &mut run_supervisor,
+        &mut remove_legacy_services,
+    )?;
+    for line in lines {
+        println!("{line}");
     }
     Ok(())
 }
@@ -497,24 +499,23 @@ fn real_daemon_uninstall() -> anyhow::Result<()> {
 /// a second supervised daemon behind. Best-effort by design: on a machine
 /// that never had the old label, every step is a no-op.
 #[cfg(target_os = "macos")]
-fn remove_legacy_services() {
-    let removed = commands::daemon_service::remove_legacy_with(
+fn remove_legacy_services() -> Vec<std::path::PathBuf> {
+    commands::daemon_service::remove_legacy_with(
         dirs::home_dir(),
         leviath_sys::current_uid(),
         &mut |bootout| {
             let _ = run_supervisor(bootout);
         },
         &mut |path| std::fs::remove_file(path).is_ok(),
-    );
-    for path in removed {
-        println!("removed legacy service file {}", path.display());
-    }
+    )
 }
 
 /// Only macOS ever shipped under a different label; elsewhere there is
 /// nothing legacy to clean up.
 #[cfg(not(target_os = "macos"))]
-fn remove_legacy_services() {}
+fn remove_legacy_services() -> Vec<std::path::PathBuf> {
+    Vec::new()
+}
 
 /// Real `lev daemon`: bind the platform control socket and drive the shared world
 /// until Ctrl-C. Wiring only - the world, host, tool service, and spawner it


### PR DESCRIPTION
Phase 4 of the cleanup plan. The premise it was written on has partly expired -
`poll_until`, `format_status`, `service_unit`, `install`/`uninstall` and
`remove_legacy_with` were all extracted by earlier PRs - so what was left in
`main.rs` is mostly honest wiring. What was left that is *not* wiring:

**`daemon/lifecycle.rs`** holds the judgements: `start_steps` (already current,
stale so replace, or nothing running), `stop_fallback` (signal the recorded pid,
or propagate the control error), `stop_outcome` and `status_lines`.

**`daemon_service::{install_with, uninstall_with}`** hold the *ordering*, which
is the part that was easy to get wrong: deactivate, clean legacy labels, then
activate. Backwards, and `install` stops being idempotent or leaves a second
supervised daemon behind. They return the lines to print rather than printing,
so a test can assert them.

`main.rs` is 817 lines against 816, and that is the honest number: the shims
cost what the logic did. The line count was never the point - what moved is the
*decision-making*, out of code the coverage gate does not measure and into code
it does. `RealExecutors` and `CrosstermSetup` stay, because a composition root
is what they are.

### Tests

11 new. The one worth naming asserts the invariant rather than a case:
`start_steps` may never order a shutdown without a spawn, checked across all
four inputs - a combination that stopped the daemon and did not replace it would
leave the machine without one.

Plus install ordering (asserted as a recorded command sequence, not an outcome),
a failed activation propagating where a failed deactivation does not, and an
unwritable unit file stopping before anything reaches the supervisor.

### Smoked against a real daemon

`cargo xtask coverage` passing is not evidence these still work, so:
`lev daemon stop/status/start/start/status/restart/stop/stop` against an
isolated `LEVIATH_HOME`, 11 assertions, all passing - including the
already-current no-op and stop-when-nothing-running, which are the two paths
`start_steps` and `stop_outcome` decide.

`install`/`uninstall` were **not** smoked: they register a real launchd agent on
the developer's machine. Their sequencing is covered by the new tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg

