### PR TITLE
ci: run the tests on ARM Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,26 @@ permissions:
   contents: read
 
 jobs:
+  # Four legs, not three. `ubuntu-24.04-arm` is here because the release builds
+  # ship `aarch64-unknown-linux-{gnu,musl}` and nothing had ever run them on an
+  # ARM machine: `macos-latest` is Apple Silicon, so macOS was covered by
+  # accident, while the Linux ARM binaries went out tested only on x64.
+  #
+  # Deliberately *only* this job. Clippy and Coverage are per-OS because a
+  # `#[cfg]` arm invisible to one platform is invisible to its lint and its
+  # coverage map - but architecture changes no `cfg`, so an ARM leg there would
+  # compile and measure byte-identical code for eleven more jobs and no new
+  # information. What differs at runtime is execution: alignment, atomic
+  # widths, and whatever the C dependencies (mimalloc, aws-lc-sys) do per
+  # architecture. That is what `cargo test` exercises and why this is the leg
+  # that earns it.
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable


### PR DESCRIPTION
The release builds ship `aarch64-unknown-linux-gnu` and
`aarch64-unknown-linux-musl`, and nothing had ever run them on an ARM machine.
macOS was covered by accident - `macos-latest` is Apple Silicon - while the
Linux ARM binaries went out tested only on x64.

`ubuntu-24.04-arm` is free now that the repo is public, which is the same
reason #293 could build the arm64 musl target natively instead of fighting
`aws-lc-sys` cross-compilation.

Only the Test job. Clippy and Coverage are per-OS because a `#[cfg]` arm
invisible to one platform is invisible to its lint and its coverage map, but
architecture changes no `cfg` - an ARM leg there would compile and measure
byte-identical code for eleven more jobs and no new information. What differs at
runtime is execution: alignment, atomic widths, and whatever the C dependencies
(mimalloc, aws-lc-sys) do per architecture. That is what `cargo test` exercises.

The release matrix is left alone deliberately. `aarch64-unknown-linux-gnu` is
still cross-compiled from x64 and now *could* build natively, which would drop
the `gcc-aarch64-linux-gnu` install and the `CC_*` env - but that path works
today and I cannot verify a change to it without publishing a release.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg

