### PR TITLE
feat(limits): bound what a run writes, and never fill the disk (#252)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2556,7 @@ dependencies = [
 name = "leviath-sys"
 version = "0.2.0"
 dependencies = [
+ "fs4",
  "keyring",
  "keyring-core",
  "leviath-testkit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,9 @@ anyhow = "1.0"
 chrono = "0.4"
 rhai = { version = "1.25", features = ["sync", "serde"] }
 glob = "0.3"
+# Free-space queries for the disk guard (`leviath-sys::disk`). Pure Rust over
+# `rustix`; `std` has no equivalent and the workspace forbids `unsafe`.
+fs4 = "1.1"
 # Compiled once per [read_paths] entry at spawn; already in the lock file
 # transitively, named here so the allowlist matcher in `leviath-core` uses the
 # same version everywhere.

--- a/crates/leviath-cli/src/commands/setup/state.rs
+++ b/crates/leviath-cli/src/commands/setup/state.rs
@@ -1107,8 +1107,45 @@ fn limits_fields(config: &Config) -> Vec<Field> {
             help: "Resolve a prompt nobody answered after this long, so the run carries on. 0 waits for ever.",
             value: FieldValue::Number(Some(config.limits.interaction_timeout_secs)),
         },
+        // The two write ceilings are unset in code and offered with a value
+        // here, so a fresh install has one written down where it can be seen
+        // and cleared. Clearing the field stores nothing, which is unlimited.
+        Field {
+            label: "Max bytes one tool call may write",
+            help: "Stops a single command that writes until the disk fills. Clear it for no limit.",
+            value: FieldValue::Number(Some(
+                config
+                    .limits
+                    .max_tool_call_write_bytes
+                    .unwrap_or(SUGGESTED_CALL_WRITE_BYTES),
+            )),
+        },
+        Field {
+            label: "Max bytes one run may write",
+            help: "The same ceiling across a whole run, which several ordinary-looking calls can reach. Clear it for no limit.",
+            value: FieldValue::Number(Some(
+                config
+                    .limits
+                    .max_run_write_bytes
+                    .unwrap_or(SUGGESTED_RUN_WRITE_BYTES),
+            )),
+        },
     ]
 }
+
+/// What `lev setup` offers as a per-call write ceiling.
+///
+/// 2 GiB is far above anything a tool call legitimately writes - a large build
+/// log, a full database dump - and far below the 14 GB a single runaway append
+/// reached in the incident this exists for. The gap between those two numbers
+/// is wide enough that the value does not need to be right, only present.
+const SUGGESTED_CALL_WRITE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// What `lev setup` offers as a per-run write ceiling.
+///
+/// Five times the per-call figure, so a run doing genuinely heavy work has room
+/// for several large writes while three runaway calls still stop.
+const SUGGESTED_RUN_WRITE_BYTES: u64 = 5 * SUGGESTED_CALL_WRITE_BYTES;
 
 /// Write the Limits screen's fields back into a config.
 fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
@@ -1159,6 +1196,13 @@ fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
                 config.limits.interaction_timeout_secs =
                     n.unwrap_or(Config::default().limits.interaction_timeout_secs)
             }
+            // The write ceilings break the rule above, and deliberately: here
+            // an unset field means *no limit*, not "keep the default". They are
+            // the only two settings whose absence is a real choice a user makes
+            // - deleting the line is how you say "let it write" - so unset
+            // stores `None` rather than reinstating a number they just removed.
+            (11, FieldValue::Number(n)) => config.limits.max_tool_call_write_bytes = *n,
+            (12, FieldValue::Number(n)) => config.limits.max_run_write_bytes = *n,
             _ => {}
         }
     }

--- a/crates/leviath-cli/src/config.rs
+++ b/crates/leviath-cli/src/config.rs
@@ -759,6 +759,46 @@ pub struct LimitsConfig {
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_interaction_timeout_secs")]
     pub interaction_timeout_secs: u64,
+
+    /// Most bytes one tool call may write to disk. Unset is unlimited.
+    ///
+    /// **Unset in code, set by `lev setup`.** How much an agent should write is
+    /// a judgement about what you are doing with it, so nothing is imposed on a
+    /// user who never opened this file - but a fresh install gets a concrete
+    /// number written here, where it is visible and can be deleted outright.
+    ///
+    /// The incident behind it (issue #252) was a single shell call appending in
+    /// a loop until the 60-second timeout: about 14 GB, from one call that
+    /// looked ordinary.
+    ///
+    /// A shell redirect is measured *after* the call, since the bytes go from
+    /// the shell to the file without passing through Leviath. So this stops the
+    /// call after the one that overran, not the one that did. `write_file` is
+    /// measured before, and is stopped outright.
+    ///
+    /// Running out of disk is checked separately and is never configurable: see
+    /// [`leviath_core::write_limits::MIN_FREE_BYTES`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tool_call_write_bytes: Option<u64>,
+
+    /// Most bytes a whole run may write to disk. Unset is unlimited.
+    ///
+    /// The companion to `max_tool_call_write_bytes`, and the one that catches
+    /// what a per-call ceiling cannot: three calls of 12-14 GB each are
+    /// individually plausible and collectively a full disk. Same defaulting -
+    /// unset in code, written by `lev setup`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_run_write_bytes: Option<u64>,
+}
+
+impl LimitsConfig {
+    /// The write ceilings in effect, for the engine.
+    pub fn write_limits(&self) -> leviath_core::write_limits::WriteLimits {
+        leviath_core::write_limits::WriteLimits {
+            per_call: self.max_tool_call_write_bytes,
+            per_run: self.max_run_write_bytes,
+        }
+    }
 }
 
 impl Default for LimitsConfig {
@@ -777,6 +817,12 @@ impl Default for LimitsConfig {
             provider_failures_before_open: default_provider_failures_before_open(),
             provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
             interaction_timeout_secs: default_interaction_timeout_secs(),
+            // Deliberately `None` here and concrete in `lev setup`: the code
+            // imposes no ceiling on a user who never opened the config, and a
+            // fresh install gets a number written where it can be seen and
+            // deleted. See the field docs.
+            max_tool_call_write_bytes: None,
+            max_run_write_bytes: None,
         }
     }
 }
@@ -3566,6 +3612,8 @@ enabled = false
             taint_tracking: false,
             limits: LimitsConfig {
                 mcp_idle_disconnect_secs: default_mcp_idle_disconnect_secs(),
+                max_tool_call_write_bytes: None,
+                max_run_write_bytes: None,
                 max_concurrent_inferences: Some(4),
                 max_concurrent_tools: 3,
                 default_max_iterations: Some(99),

--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -407,6 +407,11 @@ fn build_tool_state(
         .cloned()
         .unwrap_or_default();
     Arc::new(AgentToolState {
+        // One budget per run, so the per-run ceiling spans every batch rather
+        // than resetting with each one.
+        writes: Arc::new(crate::daemon::tool_service::WriteBudget::new(
+            config.limits.write_limits(),
+        )),
         builtins,
         mcp,
         builtin_names,

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -36,10 +36,83 @@ use crate::tools::resolve_policy;
 /// Everything one agent needs to execute a tool call: the executors, its policy
 /// layers, and its interaction backend. All fields are cheap `Arc`s so a clone is
 /// moved into each `exec_for` closure. The stage-scoped fields
+/// One run's write ceilings and what it has spent of them (issue #252).
+///
+/// The count is what a *tool call reported writing*, which for a shell redirect
+/// is the target's size measured after the call. That is an approximation in
+/// one direction worth naming: a command that overwrites the same file twice is
+/// counted twice, so a run that rewrites one file in a loop reaches its budget
+/// sooner than the disk does. Erring that way is the point - the alternative is
+/// tracking per-path deltas, which a command writing to a path Leviath cannot
+/// name defeats anyway.
+pub struct WriteBudget {
+    limits: leviath_core::write_limits::WriteLimits,
+    written: std::sync::atomic::AtomicU64,
+    /// The filesystem probe, injected so a test can drive the disk-full arm
+    /// without one. `fn` rather than a closure: one coverage instance.
+    available: fn(&std::path::Path) -> Option<u64>,
+}
+
+impl WriteBudget {
+    /// A budget over the real filesystem.
+    pub fn new(limits: leviath_core::write_limits::WriteLimits) -> Self {
+        Self::with_probe(limits, leviath_sys::disk::available_bytes)
+    }
+
+    /// A budget whose free-space probe is supplied.
+    pub fn with_probe(
+        limits: leviath_core::write_limits::WriteLimits,
+        available: fn(&std::path::Path) -> Option<u64>,
+    ) -> Self {
+        Self {
+            limits,
+            written: std::sync::atomic::AtomicU64::new(0),
+            available,
+        }
+    }
+
+    /// Whether a write of `bytes` into `workdir` may proceed.
+    ///
+    /// Does not record anything: a refused write must not spend the budget it
+    /// was refused by, or one oversized call would exhaust the run.
+    pub fn check(
+        &self,
+        workdir: &std::path::Path,
+        bytes: u64,
+    ) -> leviath_core::write_limits::WriteVerdict {
+        leviath_core::write_limits::check_write(
+            self.limits,
+            self.written.load(std::sync::atomic::Ordering::Relaxed),
+            bytes,
+            (self.available)(workdir),
+        )
+    }
+
+    /// Record bytes a call actually wrote.
+    pub fn record(&self, bytes: u64) {
+        self.written
+            .fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// What this run has written so far.
+    pub fn written(&self) -> u64 {
+        self.written.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Everything one agent needs to execute a tool call: the executors, its policy
+/// layers, and its interaction backend. All fields are cheap `Arc`s so a clone
+/// is moved into each `exec_for` closure. The stage-scoped fields
 /// (`stage_perms`/`stage_name`) are shared handles the host updates as the agent
 /// changes stage.
 #[derive(Clone)]
 pub struct AgentToolState {
+    /// The write ceilings in effect, and what this run has spent of them.
+    ///
+    /// Shared rather than copied because the running total has to survive
+    /// across every batch this run makes - a per-run budget that reset per
+    /// batch would bound nothing.
+    pub writes: Arc<WriteBudget>,
     /// Built-in tool executor (holds the agent's workdir).
     pub builtins: Arc<leviath_tools::BuiltinTools>,
     /// MCP tool executor.
@@ -364,6 +437,29 @@ pub async fn dispatch_tools(
             continue;
         }
 
+        // How much this call would add to the run's disk footprint, and whether
+        // there is room for it (issue #252). Checked before the policy layers
+        // for the same reason containment is: a full disk is not a permission
+        // question, and no `--yolo` should be able to fill one.
+        if let Some(refusal) = crate::tools::write_budget_refusal(
+            &tc.name,
+            &tc.arguments,
+            state.builtins.workdir(),
+            &state.writes,
+        ) {
+            progress(&tc.id, &refusal);
+            slots.push((tc.id.clone(), Some(refusal)));
+            continue;
+        }
+        // Charged here, not after it runs. Every call in a batch is authorized
+        // before any of them execute, so a budget charged only on completion
+        // would let all of them check against a total none had spent - two
+        // 8-byte writes would both pass a 10-byte run budget. A refused call
+        // reaches `continue` above and is charged nothing.
+        if let Some(declared) = crate::tools::declared_write_bytes(&tc.name, &tc.arguments) {
+            state.writes.record(declared);
+        }
+
         let is_builtin = state.builtin_names.contains(&tc.name);
         // What a scoped approval for *this specific call* would be remembered
         // under. For a shell call that is one key per command in the line, not
@@ -456,6 +552,15 @@ pub async fn dispatch_tools(
         let progress = &progress;
         async move {
             let result = execute_tool(&state, *is_builtin, tc).await;
+            // Charge the run for what this call actually put on disk. A shell
+            // redirect is only measurable here, after the fact - see
+            // `write_budget_refusal` for why that is inherent rather than a
+            // shortcut.
+            state.writes.record(crate::tools::measured_write_bytes(
+                &tc.name,
+                &tc.arguments,
+                state.builtins.workdir(),
+            ));
             progress(&tc.id, &result);
             result
         }
@@ -682,6 +787,56 @@ mod tests {
 
     /// Empty script-tool fields (no discovered tools, a deny-all host) for tests
     /// that don't exercise script tools.
+    /// A budget that stops nothing, over a filesystem reporting plenty of room.
+    /// The default for every test that is not about the ceilings themselves,
+    /// so adding them changed no existing expectation.
+    fn unlimited_writes() -> WriteBudget {
+        WriteBudget::with_probe(Default::default(), |_| {
+            Some(leviath_core::write_limits::MIN_FREE_BYTES * 100)
+        })
+    }
+
+    /// A state over `workdir` with every write tool allowed and `budget` in
+    /// effect, so a test about the ceilings is not also a test about policy.
+    fn state_with_writes(workdir: &std::path::Path, budget: WriteBudget) -> Arc<AgentToolState> {
+        let builtins = Arc::new(leviath_tools::BuiltinTools::new(
+            leviath_tools::ToolContext::new(workdir.to_path_buf()),
+        ));
+        let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
+        let mut global = HashMap::new();
+        for tool in ["write_file", "edit_file", "shell"] {
+            global.insert(tool.to_string(), ToolPolicy::Allow);
+        }
+        let (script_tools, script_tool_names, script_host) = no_script_fields();
+        Arc::new(AgentToolState {
+            writes: Arc::new(budget),
+            builtins,
+            mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            builtin_names,
+            launch_overrides: Arc::new(HashMap::new()),
+            safe_keys: Arc::new(HashSet::new()),
+            run_allows: Arc::new(Mutex::new(HashSet::new())),
+            stage_allows: Arc::new(StdMutex::new(HashSet::new())),
+            stage_allows_index: Arc::new(StdMutex::new(None)),
+            stage_perms: Arc::new(StdMutex::new(HashMap::new())),
+            stage_perms_by_index: Arc::new(Vec::new()),
+            stage_required: Arc::new(StdMutex::new(HashSet::new())),
+            stage_required_by_index: Arc::new(Vec::new()),
+            agent_perms: Arc::new(HashMap::new()),
+            global_perms: Arc::new(global),
+            blueprint_may_loosen: false,
+            interaction: InteractionHub::new().backend_for("agent-a"),
+            unattended: false,
+            stage_name: Arc::new(StdMutex::new("main".to_string())),
+            subagent: None,
+            sandbox: None,
+            script_tools,
+            script_tool_names,
+            script_host,
+            dynamic: None,
+        })
+    }
+
     fn no_script_fields() -> ScriptFields {
         let allow = crate::daemon::script_host::ScriptAllow {
             http_get: false,
@@ -714,6 +869,7 @@ mod tests {
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(mcp)),
             builtin_names,
@@ -795,6 +951,7 @@ mod tests {
         ));
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -895,6 +1052,7 @@ mod tests {
         allow.insert("write_file".to_string(), ToolPolicy::Allow);
         allow.insert("edit_file".to_string(), ToolPolicy::Allow);
         Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -1150,6 +1308,7 @@ mod tests {
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -1349,6 +1508,7 @@ mod tests {
         global.insert("write_file".to_string(), ToolPolicy::Deny);
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -1416,6 +1576,7 @@ mod tests {
         global.insert("write_file".to_string(), ToolPolicy::Allow);
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -1476,6 +1637,217 @@ mod tests {
         assert!(wrote_inside, "{allowed}");
     }
 
+    // ─── Write ceilings (issue #252) ─────────────────────────────────────────
+
+    /// The production constructor, against the machine's real filesystem.
+    ///
+    /// Every other test here injects a probe, which proves the arithmetic and
+    /// nothing about whether the arithmetic is wired to a real disk. This one
+    /// asks the actual syscall - and needs no disk to do it, because a write
+    /// larger than any filesystem is refused by reading the number, not by
+    /// filling anything.
+    #[test]
+    fn the_real_probe_refuses_a_write_no_filesystem_could_hold() {
+        let dir = tempfile::tempdir().unwrap();
+        let budget = WriteBudget::new(Default::default());
+
+        // Larger than any disk, so this is a refusal on measurement.
+        let refusal = budget
+            .check(dir.path(), u64::MAX / 2)
+            .refusal()
+            .unwrap_or_default();
+        assert!(refusal.contains("nearly out of disk"), "{refusal}");
+        // The control, and the one that matters: an ordinary write on a machine
+        // with room is allowed. Without it the test above would pass on a probe
+        // that refused everything.
+        assert_eq!(
+            budget.check(dir.path(), 1024),
+            leviath_core::write_limits::WriteVerdict::Allow
+        );
+        // Nothing was spent by either question.
+        assert_eq!(budget.written(), 0);
+    }
+
+    /// Recording accumulates, and a refusal spends nothing - otherwise one
+    /// oversized call would exhaust a run's budget by being rejected.
+    #[test]
+    fn a_budget_records_what_was_written_and_nothing_for_a_refusal() {
+        let budget = WriteBudget::with_probe(
+            leviath_core::write_limits::WriteLimits {
+                per_call: Some(10),
+                per_run: None,
+            },
+            |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+        );
+        let dir = tempfile::tempdir().unwrap();
+
+        budget.record(4);
+        budget.record(6);
+        assert_eq!(budget.written(), 10);
+        // A check never records, whatever it decides.
+        let _ = budget.check(dir.path(), 100);
+        assert_eq!(budget.written(), 10);
+    }
+
+    /// A `write_file` declares its size, so an oversized one is stopped before
+    /// a byte reaches the disk. The file not existing afterwards is the
+    /// assertion that matters; the message alone would not distinguish
+    /// "refused" from "wrote it and then complained".
+    #[tokio::test]
+    async fn an_oversized_write_file_is_refused_before_it_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_writes(
+            dir.path(),
+            WriteBudget::with_probe(
+                leviath_core::write_limits::WriteLimits {
+                    per_call: Some(8),
+                    per_run: None,
+                },
+                |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+            ),
+        );
+
+        let out = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "write_file",
+                serde_json::json!({"path": "big.txt", "content": "far too many bytes"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+
+        let result = out[0].1.clone();
+        assert!(result.contains("per-call limit"), "{result}");
+        assert!(!dir.path().join("big.txt").exists(), "it wrote anyway");
+    }
+
+    /// The control: the same tool under the same ceiling writes when it fits.
+    #[tokio::test]
+    async fn a_write_file_within_the_ceiling_still_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_writes(
+            dir.path(),
+            WriteBudget::with_probe(
+                leviath_core::write_limits::WriteLimits {
+                    per_call: Some(1024),
+                    per_run: None,
+                },
+                |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+            ),
+        );
+
+        let out = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "write_file",
+                serde_json::json!({"path": "small.txt", "content": "fits"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+
+        let result = out[0].1.clone();
+        assert!(!result.contains("[denied]"), "{result}");
+        assert!(dir.path().join("small.txt").exists());
+    }
+
+    /// A nearly-full disk refuses the write whatever the ceilings say, and the
+    /// message must not send anyone to raise a limit that is not the problem.
+    #[tokio::test]
+    async fn a_nearly_full_disk_refuses_a_write_with_no_ceiling_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_writes(
+            dir.path(),
+            // No limits at all - the code default - and a filesystem with
+            // almost nothing left.
+            WriteBudget::with_probe(Default::default(), |_| Some(1024)),
+        );
+
+        let out = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "write_file",
+                serde_json::json!({"path": "x.txt", "content": "hi"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+
+        let result = out[0].1.clone();
+        assert!(result.contains("nearly out of disk"), "{result}");
+        assert!(!result.contains("max_"), "sent them to a config key");
+        assert!(!dir.path().join("x.txt").exists());
+    }
+
+    /// The per-run ceiling spans calls, which is the case a per-call ceiling
+    /// misses: two writes that each fit, and together do not.
+    #[tokio::test]
+    async fn the_run_ceiling_stops_the_second_of_two_calls_that_each_fit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_writes(
+            dir.path(),
+            WriteBudget::with_probe(
+                leviath_core::write_limits::WriteLimits {
+                    per_call: Some(100),
+                    per_run: Some(10),
+                },
+                |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+            ),
+        );
+
+        let out = dispatch_tools(
+            state,
+            vec![
+                call(
+                    "c1",
+                    "write_file",
+                    serde_json::json!({"path": "a.txt", "content": "12345678"}),
+                ),
+                call(
+                    "c2",
+                    "write_file",
+                    serde_json::json!({"path": "b.txt", "content": "12345678"}),
+                ),
+            ],
+            noop_progress(),
+        )
+        .await;
+
+        let first = out[0].1.clone();
+        let second = out[1].1.clone();
+        assert!(!first.contains("[denied]"), "first should fit: {first}");
+        assert!(second.contains("budget"), "{second}");
+        assert!(dir.path().join("a.txt").exists());
+        assert!(!dir.path().join("b.txt").exists());
+    }
+
+    /// A run with no ceilings writes freely, which is the shipped default: how
+    /// much an agent should write is the user's call, not the engine's.
+    #[tokio::test]
+    async fn the_default_configuration_imposes_no_write_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_writes(dir.path(), unlimited_writes());
+
+        let out = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "write_file",
+                serde_json::json!({"path": "big.txt", "content": "x".repeat(200_000)}),
+            )],
+            noop_progress(),
+        )
+        .await;
+
+        let result = out[0].1.clone();
+        assert!(!result.contains("[denied]"), "{result}");
+        assert!(dir.path().join("big.txt").exists());
+    }
+
     #[tokio::test]
     async fn exec_for_without_state_errors() {
         let service = CliToolService::new();
@@ -1529,6 +1901,7 @@ mod tests {
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
@@ -2099,6 +2472,7 @@ mod tests {
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let (script_tools, script_tool_names, script_host) = no_script_fields();
         let state = Arc::new(AgentToolState {
+            writes: Arc::new(unlimited_writes()),
             builtins,
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -361,6 +361,102 @@ pub fn escaping_write_refusal(
     ))
 }
 
+/// How many bytes this call declares it will write, when that is knowable
+/// before it runs.
+///
+/// `write_file` and `edit_file` carry their content as an argument, so the
+/// figure is exact and the call can be stopped before a byte lands. A shell
+/// redirect cannot be: the bytes go from the shell to the file without passing
+/// through Leviath, so `None` here means "unknown, measure afterwards" rather
+/// than "writes nothing".
+pub fn declared_write_bytes(tool_name: &str, arguments: &serde_json::Value) -> Option<u64> {
+    let field = match leviath_tools::canonical_tool_name(tool_name) {
+        "write_file" => "content",
+        "edit_file" => "new_str",
+        _ => return None,
+    };
+    arguments
+        .get(field)
+        .and_then(|v| v.as_str())
+        .map(|s| s.len() as u64)
+}
+
+/// Refuse a call that would take the run past a write ceiling, or fill the disk.
+///
+/// Returns the refusal, or `None` to proceed.
+///
+/// Two shapes of call reach here and they are not symmetric. A `write_file`
+/// declares its size, so it is judged before it runs and nothing is written. A
+/// shell redirect does not, so it is judged on what the run has *already*
+/// spent - which stops the call after the one that overran, not the one that
+/// did. That asymmetry is inherent: Leviath never sees those bytes, and the
+/// alternative is refusing every redirect on a run near its budget.
+///
+/// The disk check applies to both, and to a shell call with any write target at
+/// all: a machine with no room left should not be handed a command that writes,
+/// whatever its size turns out to be.
+pub fn write_budget_refusal(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    workdir: &std::path::Path,
+    budget: &crate::daemon::tool_service::WriteBudget,
+) -> Option<String> {
+    let declared = declared_write_bytes(tool_name, arguments);
+    let writes_something = declared.is_some()
+        || (leviath_tools::canonical_tool_name(tool_name) == "shell"
+            && arguments
+                .get("command")
+                .and_then(|v| v.as_str())
+                .is_some_and(crate::shell_keys::writes_a_file));
+    if !writes_something {
+        return None;
+    }
+    budget.check(workdir, declared.unwrap_or(0)).refusal()
+}
+
+/// How many bytes a *finished* shell call put on disk, for charging the run's
+/// budget.
+///
+/// The current size of every literal redirect target, measured now that the
+/// command has run - which is the only moment those bytes are visible to
+/// Leviath at all.
+///
+/// Zero for a declaring tool. Those are charged when they are checked, before
+/// the batch runs: a batch's calls are all authorized before any of them
+/// execute, so a per-run budget charged only afterwards would let every call in
+/// one batch check against a budget none of them had spent yet. Charging a
+/// known size up front is what makes the second write in a two-write batch see
+/// the first.
+///
+/// A target that no longer exists, or was never created, contributes nothing: a
+/// command that failed should not spend the run's budget on a file it did not
+/// write.
+pub fn measured_write_bytes(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    workdir: &std::path::Path,
+) -> u64 {
+    if declared_write_bytes(tool_name, arguments).is_some() {
+        return 0;
+    }
+    if leviath_tools::canonical_tool_name(tool_name) != "shell" {
+        return 0;
+    }
+    let Some(command) = arguments.get("command").and_then(|v| v.as_str()) else {
+        return 0;
+    };
+    crate::shell_keys::write_target_paths(command)
+        .into_iter()
+        .map(|target| {
+            let path = match std::path::Path::new(&target).is_absolute() {
+                true => std::path::PathBuf::from(&target),
+                false => workdir.join(&target),
+            };
+            std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0)
+        })
+        .sum()
+}
+
 /// Tools a blueprint may declare *more* permissively than the built-in default
 /// without the user opting in.
 ///
@@ -893,6 +989,87 @@ mod policy_tests {
         assert_eq!(
             escaping_write_refusal("shell", &serde_json::json!({}), dir.path()),
             None
+        );
+    }
+
+    // ─── Write accounting (issue #252) ───────────────────────────────────────
+
+    /// What each tool declares it will write, which is what lets an oversized
+    /// `write_file` be stopped before a byte lands.
+    #[test]
+    fn a_declaring_tool_reports_its_size_and_a_shell_call_does_not() {
+        assert_eq!(
+            declared_write_bytes("write_file", &serde_json::json!({"content": "abcd"})),
+            Some(4)
+        );
+        assert_eq!(
+            declared_write_bytes("edit_file", &serde_json::json!({"new_str": "abc"})),
+            Some(3)
+        );
+        // A shell redirect's bytes never pass through Leviath, so there is
+        // nothing to declare - `None` means "measure afterwards", not "writes
+        // nothing".
+        assert_eq!(
+            declared_write_bytes("shell", &shell_call("echo x > out.txt")),
+            None
+        );
+        // A declaring tool with the field missing declares nothing either.
+        assert_eq!(
+            declared_write_bytes("write_file", &serde_json::json!({})),
+            None
+        );
+    }
+
+    /// Measuring runs after the call, so a declaring tool contributes nothing
+    /// here - it was charged when it was checked - and a shell call is charged
+    /// what its targets actually weigh.
+    #[test]
+    fn measuring_charges_the_shell_and_not_the_declaring_tools() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("out.txt"), "0123456789").expect("write");
+
+        assert_eq!(
+            measured_write_bytes("shell", &shell_call("echo x > out.txt"), dir.path()),
+            10
+        );
+        // Already charged at check time.
+        assert_eq!(
+            measured_write_bytes(
+                "write_file",
+                &serde_json::json!({"path": "a", "content": "abcd"}),
+                dir.path()
+            ),
+            0
+        );
+        // A target the command never created costs nothing: a failed command
+        // must not spend the run's budget on a file it did not write.
+        assert_eq!(
+            measured_write_bytes("shell", &shell_call("echo x > absent.txt"), dir.path()),
+            0
+        );
+        // Not a writing call at all.
+        assert_eq!(
+            measured_write_bytes("shell", &shell_call("ls -la"), dir.path()),
+            0
+        );
+        // An absolute target is measured where it points, not joined onto the
+        // workdir - which would name a path that does not exist and charge the
+        // run nothing for a file it really wrote.
+        let absolute = dir.path().join("out.txt");
+        let command = format!("echo x > {}", absolute.display());
+        assert_eq!(
+            measured_write_bytes("shell", &shell_call(&command), dir.path()),
+            10
+        );
+        // A shell call with no `command` argument names nothing to measure.
+        assert_eq!(
+            measured_write_bytes("shell", &serde_json::json!({}), dir.path()),
+            0
+        );
+        // And a tool that is neither.
+        assert_eq!(
+            measured_write_bytes("read_file", &serde_json::json!({"path": "a"}), dir.path()),
+            0
         );
     }
 

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod secrets;
 pub mod taint;
 pub mod telemetry;
 pub mod text;
+pub mod write_limits;
 
 pub use blueprint::{
     Blueprint, ContextTransform, EdgeTransform, FileTrackingConfig, NudgeConfig, ReadPathsConfig,

--- a/crates/leviath-core/src/write_limits.rs
+++ b/crates/leviath-core/src/write_limits.rs
@@ -1,0 +1,146 @@
+//! Deciding whether an agent may write, and how much.
+//!
+//! Three questions, deliberately answered separately because they are not the
+//! same kind of thing (issue #252):
+//!
+//! 1. **Will this fill the disk?** Always asked, not configurable away. A run
+//!    that filled `C:` took the machine down with it, and every other process
+//!    on it. Nobody wants that outcome, so nothing offers it.
+//! 2. **Is one call writing an absurd amount?** Off unless configured. The
+//!    reported incident was a single shell call appending in a loop until the
+//!    60-second timeout - about 14 GB - and a per-call ceiling is what would
+//!    have caught it.
+//! 3. **Is the whole run writing an absurd amount?** Also off unless
+//!    configured. Three calls of 12-14 GB each is the shape 2 alone misses.
+//!
+//! **2 and 3 default to off in code and on in a fresh config.** How much an
+//! agent should be allowed to write is a judgement about what the user is doing
+//! with it, not something this crate can know - so the code imposes nothing.
+//! `lev setup` writes concrete values into `config.toml`, where they are
+//! visible and can be deleted outright by anyone who wants no ceiling.
+
+use serde::{Deserialize, Serialize};
+
+/// How much free space must remain before a write is refused.
+///
+/// Chosen to leave a machine usable rather than merely alive: below a gigabyte,
+/// a desktop OS starts failing at things a person notices - swap, browser
+/// caches, save dialogs - well before the disk is literally full. Refusing the
+/// agent's write at that point costs one tool call; not refusing it costs the
+/// session.
+pub const MIN_FREE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// The ceilings in effect for one run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct WriteLimits {
+    /// Most one tool call may write. `None` is unlimited.
+    pub per_call: Option<u64>,
+    /// Most the whole run may write. `None` is unlimited.
+    pub per_run: Option<u64>,
+}
+
+/// Why a write was refused, or that it was not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteVerdict {
+    /// Nothing objected.
+    Allow,
+    /// The filesystem is nearly full.
+    OutOfSpace {
+        /// Bytes still writable.
+        available: u64,
+        /// Bytes that must remain.
+        required: u64,
+    },
+    /// This one call is over the per-call ceiling.
+    CallTooLarge {
+        /// Bytes this call would write.
+        bytes: u64,
+        /// The ceiling.
+        limit: u64,
+    },
+    /// The run has spent its budget.
+    RunTooLarge {
+        /// Bytes written so far, including this call.
+        written: u64,
+        /// The ceiling.
+        limit: u64,
+    },
+}
+
+impl WriteVerdict {
+    /// The message an agent reads, or `None` when it was allowed.
+    ///
+    /// Each names the number that was exceeded, because "write refused" with no
+    /// figure leaves a model guessing whether to retry smaller or stop - and
+    /// the retry is what turns one refusal into a loop.
+    pub fn refusal(&self) -> Option<String> {
+        match self {
+            Self::Allow => None,
+            Self::OutOfSpace {
+                available,
+                required,
+            } => Some(format!(
+                "[denied] Refusing to write: only {available} bytes are free on this filesystem \
+                 and {required} must remain. This is not a limit you can raise - the machine is \
+                 nearly out of disk. Free some space, or write somewhere with room."
+            )),
+            Self::CallTooLarge { bytes, limit } => Some(format!(
+                "[denied] This call would write {bytes} bytes, over the {limit}-byte per-call \
+                 limit. Write less in one go, or raise `[limits] max_tool_call_write_bytes` in \
+                 the Leviath config (deleting the line removes the limit)."
+            )),
+            Self::RunTooLarge { written, limit } => Some(format!(
+                "[denied] This run has written {written} bytes, over its {limit}-byte budget. \
+                 Raise `[limits] max_run_write_bytes` in the Leviath config, or delete the line \
+                 to remove the limit."
+            )),
+        }
+    }
+}
+
+/// Whether a write of `bytes` may proceed.
+///
+/// `available` is what the filesystem reports, or `None` when it could not be
+/// measured. An unmeasurable filesystem **allows** the write: a guard that
+/// cannot see has nothing to say, and refusing on it would block every write on
+/// any filesystem the probe cannot read. The other two ceilings still apply.
+///
+/// `already_written` counts the run so far, *excluding* this call.
+///
+/// Checked in that order on purpose. Running out of disk is the only one that
+/// harms anything outside this run, so it is reported first when more than one
+/// applies - a user reading "over the per-call limit" would go raise the limit,
+/// which is exactly wrong when the real problem is a full disk.
+pub fn check_write(
+    limits: WriteLimits,
+    already_written: u64,
+    bytes: u64,
+    available: Option<u64>,
+) -> WriteVerdict {
+    if let Some(available) = available
+        && available.saturating_sub(bytes) < MIN_FREE_BYTES
+    {
+        return WriteVerdict::OutOfSpace {
+            available,
+            required: MIN_FREE_BYTES,
+        };
+    }
+    if let Some(limit) = limits.per_call
+        && bytes > limit
+    {
+        return WriteVerdict::CallTooLarge { bytes, limit };
+    }
+    let total = already_written.saturating_add(bytes);
+    if let Some(limit) = limits.per_run
+        && total > limit
+    {
+        return WriteVerdict::RunTooLarge {
+            written: total,
+            limit,
+        };
+    }
+    WriteVerdict::Allow
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-core/src/write_limits/tests.rs
+++ b/crates/leviath-core/src/write_limits/tests.rs
@@ -1,0 +1,182 @@
+//! Tests for the write ceilings.
+
+use super::*;
+
+/// No limits configured is the code default, and it must impose nothing beyond
+/// the disk - how much an agent should write is the user's judgement.
+///
+/// "Any size" means any size that fits: 50 GB onto a disk with 100 GB free is
+/// allowed with no ceiling configured, which is the case the default is for.
+/// A write larger than the free space is refused whatever the config says, and
+/// that is the next test.
+#[test]
+fn unconfigured_limits_allow_anything_that_fits() {
+    let free = MIN_FREE_BYTES * 100;
+    assert_eq!(
+        check_write(WriteLimits::default(), 0, free / 2, Some(free)),
+        WriteVerdict::Allow
+    );
+}
+
+/// The one ceiling nobody can configure away, because filling the disk harms
+/// every other process on the machine rather than just this run.
+#[test]
+fn a_write_that_would_fill_the_disk_is_refused() {
+    let verdict = check_write(WriteLimits::default(), 0, 500, Some(MIN_FREE_BYTES + 100));
+    assert_eq!(
+        verdict,
+        WriteVerdict::OutOfSpace {
+            available: MIN_FREE_BYTES + 100,
+            required: MIN_FREE_BYTES,
+        }
+    );
+    // The control: the same write with room to spare is fine.
+    assert_eq!(
+        check_write(WriteLimits::default(), 0, 500, Some(MIN_FREE_BYTES * 2)),
+        WriteVerdict::Allow
+    );
+}
+
+/// A filesystem the probe cannot read allows the write. A guard that cannot
+/// measure has nothing to say, and refusing would block every write on any
+/// filesystem `fs4` does not understand.
+#[test]
+fn an_unmeasurable_filesystem_does_not_refuse() {
+    assert_eq!(
+        check_write(WriteLimits::default(), 0, u64::MAX / 2, None),
+        WriteVerdict::Allow
+    );
+}
+
+/// ...but the configured ceilings still apply to it, so an unmeasurable
+/// filesystem is not a way around them.
+#[test]
+fn an_unmeasurable_filesystem_still_obeys_the_configured_ceilings() {
+    let limits = WriteLimits {
+        per_call: Some(100),
+        per_run: None,
+    };
+    assert!(matches!(
+        check_write(limits, 0, 101, None),
+        WriteVerdict::CallTooLarge { .. }
+    ));
+}
+
+#[test]
+fn the_per_call_ceiling_is_exclusive_at_the_boundary() {
+    let limits = WriteLimits {
+        per_call: Some(100),
+        per_run: None,
+    };
+    let plenty = Some(MIN_FREE_BYTES * 100);
+    assert_eq!(check_write(limits, 0, 100, plenty), WriteVerdict::Allow);
+    assert_eq!(
+        check_write(limits, 0, 101, plenty),
+        WriteVerdict::CallTooLarge {
+            bytes: 101,
+            limit: 100
+        }
+    );
+}
+
+/// The per-run ceiling counts what came before, which is the case a per-call
+/// ceiling alone misses: three calls of 14 GB each are individually plausible.
+#[test]
+fn the_per_run_ceiling_counts_earlier_calls() {
+    let limits = WriteLimits {
+        per_call: Some(1000),
+        per_run: Some(1000),
+    };
+    let plenty = Some(MIN_FREE_BYTES * 100);
+    // Under both, alone.
+    assert_eq!(check_write(limits, 0, 600, plenty), WriteVerdict::Allow);
+    // Under the per-call ceiling, over the run's.
+    assert_eq!(
+        check_write(limits, 600, 600, plenty),
+        WriteVerdict::RunTooLarge {
+            written: 1200,
+            limit: 1000
+        }
+    );
+}
+
+/// A run already over budget stays refused even for a zero-byte write, rather
+/// than letting an empty call slip past and reset anything.
+#[test]
+fn a_run_already_over_budget_refuses_even_an_empty_write() {
+    let limits = WriteLimits {
+        per_call: None,
+        per_run: Some(100),
+    };
+    assert!(matches!(
+        check_write(limits, 200, 0, Some(MIN_FREE_BYTES * 100)),
+        WriteVerdict::RunTooLarge { .. }
+    ));
+}
+
+/// Disk first when more than one applies. A user told "over the per-call limit"
+/// goes and raises the limit, which is exactly wrong when the real problem is
+/// that the machine is nearly full.
+#[test]
+fn a_full_disk_is_reported_before_a_configured_ceiling() {
+    let limits = WriteLimits {
+        per_call: Some(10),
+        per_run: Some(10),
+    };
+    assert!(matches!(
+        check_write(limits, 0, 5_000, Some(MIN_FREE_BYTES)),
+        WriteVerdict::OutOfSpace { .. }
+    ));
+}
+
+/// Accumulating the run total must not wrap, or a large enough history would
+/// silently come back under the ceiling.
+#[test]
+fn a_run_total_that_would_overflow_saturates_rather_than_wrapping() {
+    let limits = WriteLimits {
+        per_call: None,
+        per_run: Some(100),
+    };
+    assert!(matches!(
+        check_write(limits, u64::MAX, 10, Some(MIN_FREE_BYTES * 100)),
+        WriteVerdict::RunTooLarge { .. }
+    ));
+}
+
+/// Every refusal names the number that was exceeded: a bare "write refused"
+/// leaves a model guessing whether to retry smaller, and the retry is what
+/// turns one refusal into a loop.
+#[test]
+fn every_refusal_names_its_number_and_allow_says_nothing() {
+    assert_eq!(WriteVerdict::Allow.refusal(), None);
+    for verdict in [
+        WriteVerdict::OutOfSpace {
+            available: 7,
+            required: 9,
+        },
+        WriteVerdict::CallTooLarge {
+            bytes: 11,
+            limit: 13,
+        },
+        WriteVerdict::RunTooLarge {
+            written: 17,
+            limit: 19,
+        },
+    ] {
+        let message = verdict.refusal().expect("a refusal explains itself");
+        assert!(message.starts_with("[denied]"), "{message}");
+        assert!(
+            message.chars().any(|c| c.is_ascii_digit()),
+            "no figure in: {message}"
+        );
+    }
+    // The disk refusal must not point at a config key: there is none, and
+    // sending someone to raise a limit that does not exist wastes their time.
+    let disk = WriteVerdict::OutOfSpace {
+        available: 7,
+        required: 9,
+    }
+    .refusal()
+    .expect("a refusal");
+    assert!(!disk.contains("max_"), "{disk}");
+}

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -23,6 +23,13 @@ keychain = ["dep:keyring", "dep:keyring-core"]
 [dependencies]
 tracing = { workspace = true }
 
+# Free-space queries (`disk`). There is no such API in `std`, and this crate
+# forbids `unsafe`, so the syscall is delegated - the same arrangement `nix`
+# has here. `fs4` over the older `fs2` because it reaches the platform through
+# `rustix` rather than `libc`, which is one less C dependency in a binary that
+# is otherwise pure Rust plus its TLS stack.
+fs4 = { workspace = true }
+
 # The OS credential store (macOS Keychain / Windows Credential Manager / Secret
 # Service). Optional: see the `keychain` feature above. `keyring-core` is used
 # directly for the `Entry` API so tests can install an in-memory store as the

--- a/crates/leviath-sys/src/disk.rs
+++ b/crates/leviath-sys/src/disk.rs
@@ -19,6 +19,19 @@ use std::path::Path;
 /// an unanswerable probe would block writes on any filesystem `fs4` cannot
 /// read; allowing on it is what the caller does, because a guard that cannot
 /// measure has nothing to say.
+///
+/// # A path that does not exist answers differently per platform
+///
+/// On Windows `fs4` resolves the path to its volume first
+/// (`GetVolumePathNameW`), which succeeds for a path nothing has created yet, so
+/// `C:\nope\nope` reports `C:`'s free space. On Unix `statvfs` needs the path
+/// itself and fails.
+///
+/// Neither is wrong - "how much room is there where this would go" is a
+/// reasonable question to answer for a path that does not exist yet - so this
+/// does not normalize them. Nothing depends on it: the only caller asks about a
+/// run's working directory, which exists by the time anything writes into it.
+/// Do not build a "does this path exist" check on top of this.
 pub fn available_bytes(path: &Path) -> Option<u64> {
     fs4::available_space(path).ok()
 }
@@ -91,12 +104,18 @@ mod tests {
         );
     }
 
-    /// A path that does not exist cannot be measured, and the caller has to be
-    /// able to tell that apart from "measured, and it is zero".
+    /// An unmeasurable path answers `None`, and the caller has to be able to
+    /// tell that apart from "measured, and it is zero".
+    ///
+    /// The empty path rather than a missing one, and that distinction is the
+    /// whole reason this comment exists. A *missing* path is unmeasurable on
+    /// Unix and perfectly measurable on Windows, where `fs4` resolves to the
+    /// volume first - so asserting `None` for one passed on three CI legs and
+    /// failed on the fourth, and left this branch unreachable there. An empty
+    /// path has no volume to resolve to on either.
     #[test]
     fn an_unmeasurable_path_answers_none() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let gone = dir.path().join("no").join("such").join("place");
-        assert_eq!(available_bytes(&gone), None);
+        assert_eq!(available_bytes(Path::new("")), None);
+        assert_eq!(total_bytes(Path::new("")), None);
     }
 }

--- a/crates/leviath-sys/src/disk.rs
+++ b/crates/leviath-sys/src/disk.rs
@@ -1,0 +1,102 @@
+//! How much room is left on the filesystem a path lives on.
+//!
+//! Leviath asks this before letting an agent write, because the failure it
+//! guards against is not a bad write but a full disk: a run that filled `C:`
+//! took the machine down with it, and every other process on it (issue #252).
+//!
+//! There is no free-space API in `std`, and this workspace forbids `unsafe`, so
+//! the syscall is delegated to `fs4` - the same arrangement `nix` has here for
+//! process and permission calls.
+
+use std::path::Path;
+
+/// Bytes still writable on the filesystem containing `path`, or `None` when the
+/// question cannot be answered.
+///
+/// `None` is not "no space". It means the probe failed - an unmounted path, a
+/// filesystem that does not report statistics, a permissions error - and a
+/// caller must treat it as "unknown" rather than as either extreme. Refusing on
+/// an unanswerable probe would block writes on any filesystem `fs4` cannot
+/// read; allowing on it is what the caller does, because a guard that cannot
+/// measure has nothing to say.
+pub fn available_bytes(path: &Path) -> Option<u64> {
+    fs4::available_space(path).ok()
+}
+
+/// Total size of the filesystem containing `path`, or `None` when the question
+/// cannot be answered.
+///
+/// Only used to check [`available_bytes`] against something: a free-space probe
+/// wired to the wrong syscall still returns a plausible number, and "is it less
+/// than the disk it is on" is the cheapest question that catches that.
+pub fn total_bytes(path: &Path) -> Option<u64> {
+    fs4::total_space(path).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The probe answers for a real directory. Asserted as "some plausible
+    /// number" rather than a value: the point is that the syscall works and is
+    /// wired to the right path, and any concrete figure would be a test that
+    /// fails when someone's disk fills.
+    #[test]
+    fn available_bytes_answers_for_a_real_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let free = available_bytes(dir.path()).expect("a temp dir reports its free space");
+        // A machine that genuinely has under a megabyte free cannot have
+        // created the tempdir above, so this is a wiring check, not a
+        // disk-capacity assumption.
+        assert!(free > 1024 * 1024, "implausible free space: {free}");
+    }
+
+    /// Free space cannot exceed the disk it is on.
+    ///
+    /// The cheapest assertion that catches a probe wired to the wrong syscall:
+    /// a wrong one still returns a plausible-looking number, and "greater than
+    /// a megabyte" would not notice. Runs on every platform in CI, which is the
+    /// point - the three OSes reach three different system calls underneath.
+    #[test]
+    fn available_space_never_exceeds_the_filesystem_it_is_on() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let free = available_bytes(dir.path()).expect("free space");
+        let total = total_bytes(dir.path()).expect("total space");
+        assert!(total > 0, "a filesystem with no size");
+        assert!(free <= total, "{free} free on a {total} filesystem");
+    }
+
+    /// A directory and a file inside it are on the same filesystem, so they
+    /// report the same space. Catches a probe that answers about the *path*
+    /// rather than the filesystem containing it, which would be a different
+    /// (and wrong) question.
+    ///
+    /// Compared with a tolerance rather than for equality: the two calls are
+    /// not atomic, and anything else on the machine may write between them.
+    #[test]
+    fn a_file_and_its_directory_report_the_same_filesystem() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("probe.txt");
+        std::fs::write(&file, b"probe").expect("write");
+
+        let from_dir = available_bytes(dir.path()).expect("free space via the directory");
+        let from_file = available_bytes(&file).expect("free space via the file");
+        let drift = from_dir.abs_diff(from_file);
+        // 64 MiB of slack: generous enough that an unrelated process writing
+        // during the test cannot fail it, tight enough that two different
+        // filesystems would not pass.
+        assert!(
+            drift < 64 * 1024 * 1024,
+            "{from_dir} vs {from_file} differ by {drift}"
+        );
+    }
+
+    /// A path that does not exist cannot be measured, and the caller has to be
+    /// able to tell that apart from "measured, and it is zero".
+    #[test]
+    fn an_unmeasurable_path_answers_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let gone = dir.path().join("no").join("such").join("place");
+        assert_eq!(available_bytes(&gone), None);
+    }
+}

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -30,6 +30,7 @@
 mod platform;
 
 pub mod browser;
+pub mod disk;
 pub mod editor;
 pub mod keychain;
 pub mod perms;

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -112,6 +112,8 @@ wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is o
 provider_failures_before_open  = 3     # pull a provider after this many failures in a row
 provider_circuit_cooldown_secs = 300   # how long before it is tried again
 interaction_timeout_secs  = 3600 # release a prompt nobody answered
+max_tool_call_write_bytes = 2147483648   # 2 GiB; delete the line for no limit
+max_run_write_bytes       = 10737418240  # 10 GiB; delete the line for no limit
 ```
 
 | Key | Default | Notes |
@@ -128,8 +130,10 @@ interaction_timeout_secs  = 3600 # release a prompt nobody answered
 | `provider_failures_before_open` | `3` | Failures in a row before a provider is pulled. See below |
 | `provider_circuit_cooldown_secs` | `300` | How long a pulled provider waits before one request tests it. A success restores it, a failure restarts the wait |
 | `interaction_timeout_secs` | `3600` | How long a prompt may go unanswered. See below |
+| `max_tool_call_write_bytes` | unset | Most one tool call may write. See below |
+| `max_run_write_bytes` | unset | Most a whole run may write. See below |
 
-Six of those need more than a table cell.
+Seven of those need more than a table cell.
 
 **`exact_token_counting`** measures each assembled request before sending it and refuses one that
 would overflow the window. On providers with a remote counting endpoint that costs a network round
@@ -162,6 +166,26 @@ never counts as consent. `0` waits indefinitely. See
 [when nobody answers](/docs/interaction#when-nobody-answers).
 
 <a id="security"></a>
+
+**`max_tool_call_write_bytes`** and **`max_run_write_bytes`** bound how much an agent puts on disk.
+Both are **unset in code and written by `lev setup`**, which is the unusual part and deliberate: how
+much an agent should be allowed to write depends on what you are doing with it, so Leviath imposes
+nothing on a config it did not write. A fresh install gets concrete numbers here, where you can see
+them and **delete the line to remove the limit**.
+
+The incident behind them was a single shell call appending in a loop until the 60-second timeout -
+about 14 GB from one call that looked ordinary - repeated until the disk was full.
+
+They work differently because they have to. `write_file` and `edit_file` carry their content as an
+argument, so an oversized one is refused before a byte lands. A shell redirect does not: those bytes
+go from the shell to the file without passing through Leviath, so the target is measured *after* the
+call. That stops the call after the one that overran, not the one that did.
+
+Running out of disk is separate and **not configurable**. Leviath refuses any write that would leave
+under a gigabyte free, whatever these two say and whatever `--yolo` says, because filling the disk
+harms every other process on the machine rather than just the run. A filesystem whose free space
+cannot be read is treated as unknown and allowed - a guard that cannot measure has nothing to say -
+and the two ceilings above still apply to it.
 
 ## `[security]`
 

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -38,6 +38,11 @@ wedge_timeout_secs = 0
 provider_failures_before_open = 3
 provider_circuit_cooldown_secs = 300
 interaction_timeout_secs = 3600
+# How much an agent may write to disk. Unset in code and written by `lev setup`:
+# delete either line to remove that limit. Running out of disk is refused
+# separately and is not configurable.
+max_tool_call_write_bytes = 2147483648
+max_run_write_bytes = 10737418240
 
 [security]
 allow_seed_commands = true

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -18,70 +18,156 @@
     "agent_paths": {
       "type": "array",
       "description": "Extra directories to scan for blueprints. Read by `lev list` and the serve API, but not by `lev run <name>`, which resolves installed names and paths only.",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "openrouter_api_key": { "type": "string" },
-    "ollama_base_url": { "type": "string", "default": "http://localhost:11434" },
-    "request_timeout_secs": { "type": "integer", "minimum": 1 },
-    "taint_tracking": { "type": "boolean", "default": false },
-    "batch_tool_hint": { "type": "boolean", "default": true },
-    "shell_hint": { "type": "boolean", "default": true },
+    "openrouter_api_key": {
+      "type": "string"
+    },
+    "ollama_base_url": {
+      "type": "string",
+      "default": "http://localhost:11434"
+    },
+    "request_timeout_secs": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "taint_tracking": {
+      "type": "boolean",
+      "default": false
+    },
+    "batch_tool_hint": {
+      "type": "boolean",
+      "default": true
+    },
+    "shell_hint": {
+      "type": "boolean",
+      "default": true
+    },
     "allow": {
       "type": "array",
       "description": "Tools allowed outright, the config-file form of repeated --allow.",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-
     "providers": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "anthropic_api_key": { "type": "string" },
-        "openai_api_key": { "type": "string" },
-        "google_api_key": { "type": "string" },
-        "claude_code_enabled": { "type": "boolean", "default": false },
-        "claude_code_binary": { "type": "string" },
+        "anthropic_api_key": {
+          "type": "string"
+        },
+        "openai_api_key": {
+          "type": "string"
+        },
+        "google_api_key": {
+          "type": "string"
+        },
+        "claude_code_enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "claude_code_binary": {
+          "type": "string"
+        },
         "claude_code_effort": {
-          "enum": ["low", "medium", "high", "xhigh", "max"]
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ]
         },
         "fallback_order": {
           "type": "array",
           "description": "Host-wide failover chain, best first, as \"provider/model\" strings. Tried after the blueprint's own list.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
-
     "limits": {
       "type": "object",
       "description": "The daemon reads these once at startup, so a change needs `lev daemon restart`.",
       "additionalProperties": false,
       "properties": {
-        "max_concurrent_inferences": { "type": "integer", "minimum": 1, "default": 8 },
-        "max_concurrent_tools": { "type": "integer", "minimum": 1, "default": 8 },
-        "default_max_iterations": { "type": "integer", "minimum": 1, "default": 50 },
-        "exact_token_counting": { "type": "boolean", "default": false },
-        "script_shell_timeout_secs": { "type": "integer", "minimum": 0, "default": 60 },
-        "stall_timeout_secs": { "type": "integer", "minimum": 0, "default": 60 },
-        "dead_cycles_before_relief": { "type": "integer", "minimum": 0, "default": 10 },
+        "max_concurrent_inferences": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 8
+        },
+        "max_concurrent_tools": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 8
+        },
+        "default_max_iterations": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 50
+        },
+        "exact_token_counting": {
+          "type": "boolean",
+          "default": false
+        },
+        "script_shell_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 60
+        },
+        "stall_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 60
+        },
+        "dead_cycles_before_relief": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 10
+        },
         "finished_retention_secs": {
           "type": "integer",
           "minimum": 0,
           "default": 300,
           "description": "How long a finished run stays in the `finished` list of `lev ps`."
         },
-        "wedge_timeout_secs": { "type": "integer", "minimum": 0, "default": 0 },
-        "provider_failures_before_open": { "type": "integer", "minimum": 1, "default": 3 },
-        "provider_circuit_cooldown_secs": { "type": "integer", "minimum": 0, "default": 300 },
+        "wedge_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "provider_failures_before_open": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3
+        },
+        "provider_circuit_cooldown_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 300
+        },
         "interaction_timeout_secs": {
           "type": "integer",
           "minimum": 0,
           "default": 3600,
           "description": "How long a prompt waits for a person before resolving as cancelled. `0` waits forever. This is what releases an interaction point that holds under --yolo, so the default means such a run sits for an hour looking dead."
+        },
+        "max_tool_call_write_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Most bytes one tool call may write to disk. Absent is unlimited. Unset in code and written by `lev setup`, so deleting the key removes the limit rather than restoring a default. `write_file` is refused before it writes; a shell redirect is measured after the call, so it stops the call after the one that overran. Running out of disk is refused separately and is not configurable."
+        },
+        "max_run_write_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Most bytes a whole run may write to disk. Absent is unlimited. Catches what a per-call ceiling cannot: several individually plausible calls that together fill a disk. Same defaulting as max_tool_call_write_bytes."
         }
       }
     },
-
     "security": {
       "type": "object",
       "additionalProperties": false,
@@ -91,110 +177,238 @@
           "default": true,
           "description": "Whether a blueprint's `seed = { command = ... }` regions may run. They execute at spawn, before any approval prompt."
         },
-        "allow_local_network": { "type": "boolean", "default": false },
+        "allow_local_network": {
+          "type": "boolean",
+          "default": false
+        },
         "allow_env_vars": {
           "type": "array",
           "description": "Credential-looking variables a Rhai script may read. Matched exactly and case-insensitively; \"*\" means a variable literally named `*`, not everything.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "allow_blueprint_read_paths": { "type": "boolean", "default": false },
-        "allow_blueprint_safe_commands": { "type": "boolean", "default": false, "description": "Honour every blueprint's own [safe_commands]. Off by default: declaring is not granting, so an installed agent cannot pre-approve its own shell." },
-        "allow_blueprint_permissions": { "type": "boolean", "default": false, "description": "Honour every blueprint's own [tool_permissions] even where it exceeds the built-in default for a tool you have not configured. Off by default: a blueprint may still pre-approve web_search and web_fetch, and anything else is clamped to the default." },
-        "shell_env": { "type": "string", "enum": ["filtered", "strict", "custom", "inherit"], "default": "filtered", "description": "Which of the daemon's environment variables a shell tool call, a Rhai shell(), and a command seed inherit." },
-        "shell_env_withhold": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Names withheld under shell_env = \"custom\". Ignored under every other mode." },
-        "read_paths": { "type": "array", "items": { "type": "string" } },
-        "credential_store": { "enum": ["file", "keychain"], "default": "file" }
+        "allow_blueprint_read_paths": {
+          "type": "boolean",
+          "default": false
+        },
+        "allow_blueprint_safe_commands": {
+          "type": "boolean",
+          "default": false,
+          "description": "Honour every blueprint's own [safe_commands]. Off by default: declaring is not granting, so an installed agent cannot pre-approve its own shell."
+        },
+        "allow_blueprint_permissions": {
+          "type": "boolean",
+          "default": false,
+          "description": "Honour every blueprint's own [tool_permissions] even where it exceeds the built-in default for a tool you have not configured. Off by default: a blueprint may still pre-approve web_search and web_fetch, and anything else is clamped to the default."
+        },
+        "shell_env": {
+          "type": "string",
+          "enum": [
+            "filtered",
+            "strict",
+            "custom",
+            "inherit"
+          ],
+          "default": "filtered",
+          "description": "Which of the daemon's environment variables a shell tool call, a Rhai shell(), and a command seed inherit."
+        },
+        "shell_env_withhold": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Names withheld under shell_env = \"custom\". Ignored under every other mode."
+        },
+        "read_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "credential_store": {
+          "enum": [
+            "file",
+            "keychain"
+          ],
+          "default": "file"
+        }
       }
     },
-
     "webhook": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "max_retries": { "type": "integer", "minimum": 0, "default": 3 },
-        "base_delay_ms": { "type": "integer", "minimum": 0, "default": 500 },
-        "max_delay_ms": { "type": "integer", "minimum": 0, "default": 30000 },
-        "timeout_secs": { "type": "integer", "minimum": 1, "default": 10 }
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 3
+        },
+        "base_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 500
+        },
+        "max_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 30000
+        },
+        "timeout_secs": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 10
+        }
       }
     },
-
     "observability": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean" },
-        "exporter": { "enum": ["otlp", "stdout", "none"] },
+        "enabled": {
+          "type": "boolean"
+        },
+        "exporter": {
+          "enum": [
+            "otlp",
+            "stdout",
+            "none"
+          ]
+        },
         "endpoint": {
           "type": "string",
           "description": "OTLP over HTTP/protobuf only. The gRPC port 4317 will not work."
         },
-        "service_name": { "type": "string" }
+        "service_name": {
+          "type": "string"
+        }
       }
     },
-
     "nudge": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean" },
-        "max": { "type": "integer", "minimum": 0 },
-        "text": { "type": "string" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "text": {
+          "type": "string"
+        }
       }
     },
-
     "title": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean", "default": true },
-        "provider": { "type": "string" },
-        "model": { "type": "string" }
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        }
       }
     },
-
     "sandbox": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "kind": { "enum": ["none", "namespace", "container"] },
-        "image": { "type": "string" },
-        "engine": { "enum": ["docker", "podman", "nerdctl", "finch"] },
-        "network": { "type": "boolean" },
-        "mounts": { "type": "array", "items": { "type": "string" } },
-        "persist": { "type": "boolean" },
-        "on_unavailable": { "enum": ["error", "warn"] }
+        "kind": {
+          "enum": [
+            "none",
+            "namespace",
+            "container"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "engine": {
+          "enum": [
+            "docker",
+            "podman",
+            "nerdctl",
+            "finch"
+          ]
+        },
+        "network": {
+          "type": "boolean"
+        },
+        "mounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "persist": {
+          "type": "boolean"
+        },
+        "on_unavailable": {
+          "enum": [
+            "error",
+            "warn"
+          ]
+        }
       }
     },
-
     "tool_permissions": {
       "type": "object",
       "description": "Tool name to policy, machine-wide. A blueprint may tighten this, never loosen it.",
-      "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+      "additionalProperties": {
+        "enum": [
+          "allow",
+          "ask",
+          "deny"
+        ]
+      }
     },
-
     "agent_tool_permissions": {
       "type": "object",
       "description": "Per-agent overrides, keyed by agent name. The escape hatch above the machine-wide ceiling.",
       "additionalProperties": {
         "type": "object",
-        "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+        "additionalProperties": {
+          "enum": [
+            "allow",
+            "ask",
+            "deny"
+          ]
+        }
       }
     },
-
     "tool_script_permissions": {
       "type": "object",
       "description": "What a Rhai tool script may do. `inherit` defers to the equivalent built-in tool's policy.",
       "additionalProperties": false,
       "properties": {
-        "http_get": { "$ref": "#/$defs/scriptPermission" },
-        "http_post": { "$ref": "#/$defs/scriptPermission" },
-        "shell": { "$ref": "#/$defs/scriptPermission" },
-        "read_file": { "$ref": "#/$defs/scriptPermission" },
-        "write_file": { "$ref": "#/$defs/scriptPermission" },
-        "env_var": { "$ref": "#/$defs/scriptPermission" }
+        "http_get": {
+          "$ref": "#/$defs/scriptPermission"
+        },
+        "http_post": {
+          "$ref": "#/$defs/scriptPermission"
+        },
+        "shell": {
+          "$ref": "#/$defs/scriptPermission"
+        },
+        "read_file": {
+          "$ref": "#/$defs/scriptPermission"
+        },
+        "write_file": {
+          "$ref": "#/$defs/scriptPermission"
+        },
+        "env_var": {
+          "$ref": "#/$defs/scriptPermission"
+        }
       }
     },
-
     "agent_read_paths": {
       "type": "object",
       "description": "Read grants outside the workdir, keyed by agent name. A blueprint's [read_paths] is inert until granted here.",
@@ -202,22 +416,41 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "allow": { "type": "array", "items": { "type": "string" } }
+          "allow": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
-
     "safe_commands": {
       "type": "object",
       "additionalProperties": false,
       "description": "What runs without an approval prompt, for tools whose policy is `ask`. Entries are argument-scoped, in the same key space a \"for this run\" grant uses, and can only turn `ask` into `allow`.",
       "properties": {
-        "defaults": { "type": "boolean", "default": true, "description": "Ship the built-in read-only verb list (ls, cat, grep, git status, ...)." },
-        "tools": { "type": "array", "items": { "type": "string" }, "description": "Tools that never prompt whatever their arguments. Built-in names, or MCP names as advertised (server__tool)." },
-        "shell": { "type": "array", "items": { "type": "string" }, "description": "A program, optionally with the subcommand that narrows it: \"git status\", never \"git\" or \"cargo test --lib\"." }
+        "defaults": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ship the built-in read-only verb list (ls, cat, grep, git status, ...)."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tools that never prompt whatever their arguments. Built-in names, or MCP names as advertised (server__tool)."
+        },
+        "shell": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A program, optionally with the subcommand that narrows it: \"git status\", never \"git\" or \"cargo test --lib\"."
+        }
       }
     },
-
     "agent_safe_commands": {
       "type": "object",
       "description": "Per-agent additions to [safe_commands], keyed by agent name.",
@@ -225,13 +458,26 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "tools": { "type": "array", "items": { "type": "string" } },
-          "shell": { "type": "array", "items": { "type": "string" } },
-          "allow_blueprint": { "type": "boolean", "default": false, "description": "Honour this agent's own [safe_commands] block." }
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shell": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allow_blueprint": {
+            "type": "boolean",
+            "default": false,
+            "description": "Honour this agent's own [safe_commands] block."
+          }
         }
       }
     },
-
     "rate_limits": {
       "type": "object",
       "description": "Keyed by built-in provider name.",
@@ -239,12 +485,17 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "requests_per_minute": { "type": "integer", "minimum": 1 },
-          "tokens_per_minute": { "type": "integer", "minimum": 1 }
+          "requests_per_minute": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "tokens_per_minute": {
+            "type": "integer",
+            "minimum": 1
+          }
         }
       }
     },
-
     "model_capabilities": {
       "type": "object",
       "description": "Keyed by model id. Overrides what Leviath believes about a model.",
@@ -252,16 +503,29 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "supports_temperature": { "type": "boolean" },
-          "supports_streaming": { "type": "boolean" },
-          "supports_tools": { "type": "boolean" },
-          "supports_system_prompt": { "type": "boolean" },
-          "max_context_tokens": { "type": "integer", "minimum": 1 },
-          "max_output_tokens": { "type": "integer", "minimum": 1 }
+          "supports_temperature": {
+            "type": "boolean"
+          },
+          "supports_streaming": {
+            "type": "boolean"
+          },
+          "supports_tools": {
+            "type": "boolean"
+          },
+          "supports_system_prompt": {
+            "type": "boolean"
+          },
+          "max_context_tokens": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "max_output_tokens": {
+            "type": "integer",
+            "minimum": 1
+          }
         }
       }
     },
-
     "model_providers": {
       "type": "object",
       "description": "Overrides for Rhai script providers, keyed by the name an agent references. Any key not listed here is forwarded verbatim to the script's initialize().",
@@ -269,44 +533,87 @@
         "type": "object",
         "additionalProperties": true,
         "properties": {
-          "script": { "type": "string" },
-          "api_key": { "type": "string" },
-          "base_url": { "type": "string" },
+          "script": {
+            "type": "string"
+          },
+          "api_key": {
+            "type": "string"
+          },
+          "base_url": {
+            "type": "string"
+          },
           "rate_limit": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "requests_per_minute": { "type": "integer", "minimum": 1 },
-              "tokens_per_minute": { "type": "integer", "minimum": 1 }
+              "requests_per_minute": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "tokens_per_minute": {
+                "type": "integer",
+                "minimum": 1
+              }
             }
           }
         }
       }
     },
-
     "mcp_servers": {
       "type": "array",
       "description": "MCP tool servers to connect to. `${VAR}` interpolates in headers and env.",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
-          "name": { "type": "string" },
+          "name": {
+            "type": "string"
+          },
           "transport": {
-            "enum": ["stdio", "http"],
+            "enum": [
+              "stdio",
+              "http"
+            ],
             "description": "Inferred from whichever of command or url is present when omitted."
           },
-          "url": { "type": "string" },
-          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
-          "command": { "type": "string" },
-          "args": { "type": "array", "items": { "type": "string" } },
-          "env": { "type": "object", "additionalProperties": { "type": "string" } }
+          "url": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "command": {
+            "type": "string"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
         }
       }
     }
   },
   "$defs": {
-    "scriptPermission": { "enum": ["allow", "deny", "inherit"] }
+    "scriptPermission": {
+      "enum": [
+        "allow",
+        "deny",
+        "inherit"
+      ]
+    }
   }
 }


### PR DESCRIPTION
feat(limits): bound what a run writes, and never fill the disk (#252)

Three questions, answered separately because they are not the same kind of
thing.

### Filling the disk is refused, always

No configuration turns this off and `--yolo` does not lift it. A write that
would leave under a gigabyte free is refused, because filling the disk harms
every other process on the machine rather than just the run - which is what
happened in the report: `C:` hit 0 bytes and took the session with it.

A filesystem whose free space cannot be read is treated as *unknown* and
allowed. A guard that cannot measure has nothing to say, and refusing would
block every write on any filesystem the probe does not understand.

### Two ceilings, unset in code and written by `lev setup`

`[limits] max_tool_call_write_bytes` and `max_run_write_bytes`. Both default to
**unset**, which is unlimited: how much an agent should be allowed to write
depends on what you are doing with it, and the engine cannot know that.

`lev setup` offers concrete values (2 GiB and 10 GiB), so a fresh install has
numbers written into `config.toml` where they are visible - and **clearing the
field stores nothing**, which is how you remove the limit. That is the one place
these two break the wizard's usual rule that an empty field means "keep the
default": here an empty field is a real choice.

### The two are not symmetric, and cannot be

`write_file` and `edit_file` carry their content as an argument, so an oversized
one is refused before a byte lands. A shell redirect does not - those bytes go
from the shell to the file without passing through Leviath - so its target is
measured *after* the call. That stops the call after the one that overran, not
the one that did. Inherent, not a shortcut, and said plainly in the docs.

A declaring tool is charged when it is **checked**, not when it completes. Every
call in a batch is authorized before any of them execute, so a budget charged on
completion would let two 8-byte writes both pass a 10-byte run budget. There is a
test for exactly that.

### Reading the disk

`leviath_sys::disk` over `fs4` - `std` has no free-space API and this workspace
forbids `unsafe`, so the syscall is delegated the way `nix` already is here.
`fs4` rather than `fs2` because it reaches the platform through `rustix` instead
of `libc`. `cargo deny` passes: advisories, bans, licenses, sources.

**Verified against `df`**, not just asserted:

    fs4   available= 33,900,777,472  total=994,662,584,320
    df    available= 33,900,777,472  total=994,662,584,320

Zero drift on both figures.

### Tests, and what they run on

Every one is a unit test that runs on all four CI legs (ubuntu, ubuntu-arm,
macos, windows), and none of them fills a disk.

The probe's own tests assert invariants rather than numbers, because a number
would fail when someone's disk fills: free space never exceeds the filesystem it
is on (which is what catches a probe wired to the wrong syscall - a wrong one
still returns a plausible figure), and a file and its directory report the same
filesystem. The three OSes reach three different system calls underneath, so
these earn their place on each.

The guard is proven against the **real** probe with no disk consumed: a write
larger than any filesystem is refused by reading the number, and the control
asserts an ordinary write on the same machine is allowed - without which the
first would pass on a probe that refused everything.

The dispatch tests assert the file does not exist afterwards, not just that a
refusal was returned; the message alone would not tell "refused" from "wrote it
and then complained".

`cargo xtask coverage` clean on leviath-sys, leviath-core and leviath-cli, full
suite 34/34, clippy clean, `cargo xtask docs --check` clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
