### PR TITLE
feat(serve): optional TLS, and a page a browser can accept a certificate on (#300)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +422,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1545,6 +1576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs4"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2413,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-server",
  "bevy_ecs",
  "chrono",
  "clap",
@@ -2405,12 +2447,14 @@ dependencies = [
  "ratatui-textarea",
  "reqwest",
  "rhai",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "temp-env",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "toml",
  "tower",
  "tower-http 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,12 @@ pulldown-cmark = "0.13"
 # maintained alongside the framework itself.
 ratatui-textarea = { version = "0.9", features = ["crossterm"] }
 axum = { version = "0.8", features = ["ws"] }
+# HTTPS for `lev serve` (issue #300). Its `tls-rustls` feature resolves to
+# `rustls/aws-lc-rs` - the same provider the outbound reqwest stack already
+# uses - so this adds a server-side TLS *listener* without adding a second TLS
+# implementation or a second crypto provider, which is what the policy above
+# is about.
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 tower-http = { version = "0.7", features = ["cors"] }
 
 # ── Release profile ──────────────────────────────────────────────────────────

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -71,6 +71,7 @@ libc = { workspace = true }
 pulldown-cmark = { workspace = true }
 ratatui-textarea = { workspace = true }
 axum = { workspace = true }
+axum-server = { workspace = true }
 tower-http = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
@@ -86,6 +87,16 @@ tempfile = "3"
 
 [dev-dependencies]
 leviath-testkit = { workspace = true }
+# A TLS *client*, so the HTTPS server is tested with a real handshake against a
+# root store holding exactly the test certificate. Verifying rather than
+# skipping verification is the point: a client that accepted anything would
+# pass against a server that never presented a certificate at all. Both come in
+# with `axum-server`'s `tls-rustls`, so this adds nothing to the tree.
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+# PEM parsing for that root store. `rustls-pki-types` rather than the more
+# obvious `rustls-pemfile`, which is unmaintained (RUSTSEC-2025-0134) and whose
+# API moved here. Already in the tree via `axum-server`.
+rustls-pki-types = { version = "1", features = ["std"] }
 # `start_paused`, so the daemon-readiness backoff is tested by moving a virtual
 # clock rather than by sleeping through its five-second timeout.
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -17,6 +17,7 @@ mod runs;
 mod search;
 #[cfg(test)]
 mod testutil;
+mod tls;
 mod tree;
 mod types;
 mod websocket;
@@ -337,6 +338,17 @@ async fn execute_with_shutdown(
             auth::require_auth,
         ))
         .with_state(state);
+
+    // Merged *after* the auth layer, which is the entire point: a browser tab
+    // cannot send an `Authorization` header, and this page exists to be opened
+    // in one. With a self-signed certificate that is how a user reaches the
+    // interstitial and accepts it, after which the console's `fetch` to the
+    // same origin inherits the exception.
+    //
+    // Deliberately says almost nothing. It is a new unauthenticated surface,
+    // and a visitor who can load it already knows the port is open - so it adds
+    // no version, no run counts, no endpoint list.
+    let app = app.merge(Router::new().route("/", get(status_page)));
     // Applied by branching on the router rather than layering an `Option`:
     // `Option<CorsLayer>` is not a `Layer`, and a permissive-but-unused layer
     // would be exactly the default this change removes.
@@ -345,9 +357,19 @@ async fn execute_with_shutdown(
         None => app,
     };
 
+    // Resolved and loaded before the listener binds. A server that binds and
+    // then fails every handshake looks like a network fault from the other
+    // machine; one that refuses to start names the file it could not read.
+    let tls = tls::resolve(args.tls_cert.clone(), args.tls_key.clone())?;
+    let tls_config = match &tls {
+        Some(paths) => Some(tls::load(paths).await?),
+        None => None,
+    };
+
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
-    tracing::info!("Listening on http://{}", addr);
-    println!("Leviath API server listening on http://{}", addr);
+    let scheme = tls::scheme(tls.as_ref());
+    tracing::info!("Listening on {}://{}", scheme, addr);
+    println!("Leviath API server listening on {scheme}://{addr}");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     if let Some(ready) = ready {
@@ -358,13 +380,76 @@ async fn execute_with_shutdown(
             .expect("infallible: a freshly bound TcpListener always has a local address");
         let _ = ready.send(local_addr);
     }
-    // axum::serve with graceful shutdown always returns Ok(()) - discard the
-    // infallible Result so LLVM-cov does not instrument an unreachable Err branch.
-    let _ = axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown)
-        .await;
+
+    match tls_config {
+        // axum::serve with graceful shutdown always returns Ok(()) - discard the
+        // infallible Result so LLVM-cov does not instrument an unreachable Err branch.
+        None => {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown)
+                .await;
+        }
+        Some(config) => serve_tls(listener, app, config, shutdown).await,
+    }
 
     Ok(())
+}
+
+/// Serve over TLS on an already-bound listener, until `shutdown` resolves.
+///
+/// Takes the listener rather than an address so the bind, the `ready` report
+/// and the "port already in use" error are the same code on both schemes -
+/// letting `axum-server` bind would have given HTTPS its own second copy of all
+/// three, and a `--port 0` test no way to learn the port.
+///
+/// Shutdown is bridged rather than shared: `axum-server` signals through a
+/// `Handle` instead of taking a future, so a task waits on the same future the
+/// plain path awaits and converts it into a `graceful_shutdown` call.
+async fn serve_tls(
+    listener: tokio::net::TcpListener,
+    app: Router,
+    config: axum_server::tls_rustls::RustlsConfig,
+    shutdown: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
+) {
+    let handle = axum_server::Handle::new();
+    let signal = handle.clone();
+    tokio::spawn(async move {
+        shutdown.await;
+        // Some(..) rather than None: a connection that never closes would
+        // otherwise hold the process open for ever, and a WebSocket subscriber
+        // is exactly such a connection.
+        signal.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
+    });
+    // Handed over still non-blocking, which is how tokio left it. Setting it
+    // back to blocking looks tidier and *panics*: `from_tcp` re-registers the
+    // socket with tokio, which refuses a blocking one. That is also why both
+    // conversions below cannot fail here - a bound, non-blocking listener is
+    // exactly what they accept.
+    let std_listener = listener
+        .into_std()
+        .expect("infallible: a bound tokio listener always converts back");
+    let server = axum_server::from_tcp_rustls(std_listener, config)
+        .expect("infallible: the listener is bound and non-blocking, which is all this checks");
+    // Discarded for the same reason the plain path discards `axum::serve`'s:
+    // with a shutdown signal wired up this resolves to `Ok(())`, and an
+    // unreachable `Err` branch is a region the coverage gate cannot forgive.
+    let _ = server.handle(handle).serve(app.into_make_service()).await;
+}
+
+/// The unauthenticated page at `GET /`.
+///
+/// Exists so a user can open the endpoint in a browser tab, meet the
+/// certificate interstitial, and accept it - after which the console's `fetch`
+/// to that origin inherits the exception. Strictly the mechanism does not need
+/// a page (the interstitial precedes any response, so even a 401 would do), but
+/// landing on an auth error reads like a mistake rather than confirmation.
+async fn status_page() -> axum::response::Html<&'static str> {
+    axum::response::Html(
+        "<!doctype html><meta charset=utf-8><title>Leviath</title>\
+         <body style=\"font:16px system-ui;margin:4rem auto;max-width:30rem\">\
+         <h1>Leviath is running.</h1>\
+         <p>The API needs a token; this page does not serve it.</p>",
+    )
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -1054,6 +1139,8 @@ prompt = "Run"
             allow_admin: false,
             workdir_root: None,
             no_remote_yolo: false,
+            tls_cert: None,
+            tls_key: None,
         };
         assert_eq!(args.port, 3000);
         assert_eq!(args.host, "127.0.0.1");
@@ -1152,6 +1239,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(execute_with_shutdown(
@@ -1200,6 +1289,207 @@ prompt = "Run"
         .await;
     }
 
+    /// The whole feature, end to end: a real TLS handshake against a real
+    /// listener, and the status page answering without a token.
+    ///
+    /// Everything else about TLS is tested in `tls::tests` against files. This
+    /// is the one that would catch the wiring being wrong - a certificate that
+    /// loads but a server that never speaks TLS, or a `/` route that ended up
+    /// inside the auth layer after all.
+    #[tokio::test]
+    async fn execute_serves_https_and_the_status_page_needs_no_token() {
+        crate::config::with_isolated_config_path_async("serve-mod-tls", |_fake_dir| async move {
+            with_tracing(|| {});
+            let dir = tempfile::tempdir().expect("tempdir");
+            let cert = dir.path().join("cert.pem");
+            let key = dir.path().join("key.pem");
+            std::fs::write(&cert, tls::tests::TEST_CERT).expect("write cert");
+            std::fs::write(&key, tls::tests::TEST_KEY).expect("write key");
+
+            let args = ServeArgs {
+                port: 0,
+                host: "127.0.0.1".to_string(),
+                cors: None,
+                token: Some("test-token".to_string()),
+                allow_admin: false,
+                workdir_root: None,
+                no_remote_yolo: false,
+                tls_cert: Some(cert),
+                tls_key: Some(key),
+            };
+            let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+            let handle = tokio::spawn(execute_with_shutdown(
+                args,
+                no_daemon_control(),
+                Box::pin(std::future::pending()),
+                Some(ready_tx),
+            ));
+            let addr = ready_rx.await.expect("server reports its address");
+
+            // A client that trusts exactly this certificate, so a successful
+            // response proves the server presented it - not that verification
+            // was skipped.
+            let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+            use rustls_pki_types::pem::PemObject;
+            for der in
+                rustls_pki_types::CertificateDer::pem_slice_iter(tls::tests::TEST_CA.as_bytes())
+            {
+                roots
+                    .add(der.expect("a parseable certificate"))
+                    .expect("add to the root store");
+            }
+            let client_config = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+            let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+
+            let stream = tokio::net::TcpStream::connect(addr).await.expect("connect");
+            let server_name = tokio_rustls::rustls::pki_types::ServerName::try_from("localhost")
+                .expect("a valid name");
+            let mut tls_stream = connector
+                .connect(server_name, stream)
+                .await
+                .expect("the TLS handshake succeeds against the served certificate");
+
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            tls_stream
+                .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .await
+                .expect("write");
+            let mut resp = Vec::new();
+            tls_stream.read_to_end(&mut resp).await.expect("read");
+            let text = String::from_utf8_lossy(&resp).into_owned();
+
+            // No `Authorization` header was sent, and the page still answers -
+            // which is the property the certificate-accepting flow depends on.
+            assert!(text.starts_with("HTTP/1.1 200"), "{text}");
+            assert!(text.contains("Leviath is running."), "{text}");
+
+            handle.abort();
+        })
+        .await;
+    }
+
+    /// Both TLS failures stop the server before it binds, which is the whole
+    /// point: one that binds and then rejects every handshake looks like a
+    /// network fault from the other machine.
+    #[tokio::test]
+    async fn a_bad_tls_configuration_stops_the_server_before_it_binds() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-tls-bad",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                let dir = tempfile::tempdir().expect("tempdir");
+                let cert = dir.path().join("cert.pem");
+                std::fs::write(&cert, "not a certificate").expect("write");
+
+                let base = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: None,
+                    token: Some("test-token".to_string()),
+                    allow_admin: false,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
+                };
+
+                // One flag without the other.
+                let lone = ServeArgs {
+                    tls_cert: Some(cert.clone()),
+                    ..base.clone()
+                };
+                let err = execute_with_shutdown(
+                    lone,
+                    no_daemon_control(),
+                    Box::pin(std::future::pending()),
+                    None,
+                )
+                .await
+                .expect_err("one TLS flag alone is refused");
+                let message = format!("{err:#}");
+                assert!(message.contains("--tls-key"), "{message}");
+
+                // Both flags, but the certificate will not parse.
+                let key = dir.path().join("key.pem");
+                std::fs::write(&key, tls::tests::TEST_KEY).expect("write");
+                let unreadable = ServeArgs {
+                    tls_cert: Some(cert),
+                    tls_key: Some(key),
+                    ..base
+                };
+                let err = execute_with_shutdown(
+                    unreadable,
+                    no_daemon_control(),
+                    Box::pin(std::future::pending()),
+                    None,
+                )
+                .await
+                .expect_err("a malformed certificate is refused");
+                let message = format!("{err:#}");
+                assert!(message.contains("cert.pem"), "{message}");
+            },
+        )
+        .await;
+    }
+
+    /// The HTTPS server stops when its shutdown future resolves.
+    ///
+    /// `axum-server` signals through a `Handle` rather than taking a future, so
+    /// this is the one place the two shutdown models are bridged - and a bridge
+    /// that never fires would leave `lev serve` unkillable by anything short of
+    /// a signal.
+    #[tokio::test]
+    async fn https_shuts_down_when_its_signal_resolves() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-tls-shutdown",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                let dir = tempfile::tempdir().expect("tempdir");
+                let cert = dir.path().join("cert.pem");
+                let key = dir.path().join("key.pem");
+                std::fs::write(&cert, tls::tests::TEST_CERT).expect("write cert");
+                std::fs::write(&key, tls::tests::TEST_KEY).expect("write key");
+
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: None,
+                    token: Some("test-token".to_string()),
+                    allow_admin: false,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                    tls_cert: Some(cert),
+                    tls_key: Some(key),
+                };
+                let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let server = tokio::spawn(execute_with_shutdown(
+                    args,
+                    no_daemon_control(),
+                    Box::pin(async move {
+                        let _ = stop_rx.await;
+                    }),
+                    Some(ready_tx),
+                ));
+                ready_rx.await.expect("server reports its address");
+
+                stop_tx.send(()).expect("the server is listening for this");
+                // Returns rather than being aborted, which is what proves the
+                // signal reached `axum-server` instead of the task simply being
+                // killed.
+                let finished = tokio::time::timeout(std::time::Duration::from_secs(10), server)
+                    .await
+                    .expect("the server should stop on its own");
+                finished
+                    .expect("the task should not panic")
+                    .expect("a clean shutdown is not an error");
+            },
+        )
+        .await;
+    }
+
     /// A browser preflight for a request carrying `Authorization` must be
     /// allowed. `Access-Control-Allow-Headers: *` does NOT cover `Authorization`
     /// per the Fetch spec, so the header has to be listed explicitly — without
@@ -1219,6 +1509,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(execute_with_shutdown(
@@ -1271,6 +1563,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(execute_with_shutdown(
@@ -1305,6 +1599,8 @@ prompt = "Run"
                 allow_admin: false,
                 workdir_root: None,
                 no_remote_yolo: false,
+                tls_cert: None,
+                tls_key: None,
             };
             let result = execute(args, no_daemon_control()).await;
             assert!(result.is_err());
@@ -1341,6 +1637,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let result = execute(args, no_daemon_control()).await;
                 assert_execute_failed_on_malformed_config(&result);
@@ -1371,6 +1669,8 @@ prompt = "Run"
             allow_admin: false,
             workdir_root: None,
             no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1422,6 +1722,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let result = execute(args, no_daemon_control()).await;
                 assert_execute_failed_on_port_in_use(&result);
@@ -1442,6 +1744,8 @@ prompt = "Run"
                 allow_admin: false,
                 workdir_root: None,
                 no_remote_yolo: false,
+                tls_cert: None,
+                tls_key: None,
             };
             let result = execute(args, no_daemon_control()).await;
             assert!(result.is_err(), "must refuse to start unauthenticated");
@@ -1464,6 +1768,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1512,6 +1818,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1557,6 +1865,8 @@ prompt = "Run"
                     allow_admin: false,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 }
             }
 
@@ -1624,6 +1934,8 @@ prompt = "Run"
                     allow_admin,
                     workdir_root: None,
                     no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
                 };
                 let server = tokio::spawn(execute_with_shutdown(
                     args,

--- a/crates/leviath-cli/src/commands/serve/tls.rs
+++ b/crates/leviath-cli/src/commands/serve/tls.rs
@@ -1,0 +1,94 @@
+//! Serving the API over HTTPS (issue #300).
+//!
+//! # Why this exists at all
+//!
+//! The browser console at `https://leviath.dev/lair` cannot call a `lev serve`
+//! that is not on loopback. Browsers block a mixed-content request *inside the
+//! browser*, before it is sent - so the server never sees it and no response
+//! header lifts it. `--cors` is not involved and cannot help.
+//!
+//! Loopback is the only exemption, and this is the part that surprises people:
+//! `http://localhost` is treated as potentially trustworthy, and
+//! `http://192.168.1.50:3000` is blocked exactly like a public address.
+//!
+//! # Bring your own certificate
+//!
+//! Nothing here generates one. A self-signed certificate made on the user's
+//! behalf would not fix the console anyway - a subresource `fetch` gets no
+//! interstitial to click through - so it would make `lev serve` look secure
+//! while teaching people to click past TLS warnings. `mkcert` and
+//! `tailscale cert` both produce certificates that actually work; the docs
+//! explain which to reach for.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+/// A certificate and its key, both present.
+///
+/// Constructing one is the only way to reach the HTTPS path, which is what
+/// makes "one flag without the other" unrepresentable rather than a check
+/// somebody has to remember.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsPaths {
+    /// PEM certificate chain, leaf first.
+    pub cert: PathBuf,
+    /// PEM private key for the leaf.
+    pub key: PathBuf,
+}
+
+/// Decide whether to serve HTTPS, from the two flags.
+///
+/// One flag without the other is an error rather than a silent fallback to
+/// HTTP. Falling back would start a server on the scheme the user did not ask
+/// for, and they would find out from a mixed-content error in a browser on
+/// another machine - which is the failure this whole feature exists to end.
+pub fn resolve(cert: Option<PathBuf>, key: Option<PathBuf>) -> Result<Option<TlsPaths>> {
+    match (cert, key) {
+        (Some(cert), Some(key)) => Ok(Some(TlsPaths { cert, key })),
+        (None, None) => Ok(None),
+        (Some(_), None) => {
+            anyhow::bail!("--tls-cert was given without --tls-key; HTTPS needs both")
+        }
+        (None, Some(_)) => {
+            anyhow::bail!("--tls-key was given without --tls-cert; HTTPS needs both")
+        }
+    }
+}
+
+/// The URL scheme the server will actually answer on.
+///
+/// Used for the startup banner, which matters more than it looks: the line it
+/// prints is the URL a user copies into the console, and a banner saying
+/// `http://` for an HTTPS server sends them to an endpoint that cannot work.
+pub fn scheme(tls: Option<&TlsPaths>) -> &'static str {
+    match tls {
+        Some(_) => "https",
+        None => "http",
+    }
+}
+
+/// Read the certificate and key into a server config.
+///
+/// Fails before the listener is bound. A server that binds and then rejects
+/// every handshake looks like a network problem from the other machine and is
+/// far harder to diagnose than one that refuses to start with a message naming
+/// the file it could not read.
+///
+/// The error names the path, because "invalid certificate" without one is
+/// unactionable when two files were supplied.
+pub async fn load(paths: &TlsPaths) -> Result<axum_server::tls_rustls::RustlsConfig> {
+    axum_server::tls_rustls::RustlsConfig::from_pem_file(&paths.cert, &paths.key)
+        .await
+        .with_context(|| {
+            format!(
+                "loading the TLS certificate ({}) and key ({}). Both must be PEM, the key must \
+                 match the certificate, and both must be readable by the user running `lev serve`",
+                paths.cert.display(),
+                paths.key.display()
+            )
+        })
+}
+
+#[cfg(test)]
+pub(super) mod tests;

--- a/crates/leviath-cli/src/commands/serve/tls/tests.rs
+++ b/crates/leviath-cli/src/commands/serve/tls/tests.rs
@@ -1,0 +1,189 @@
+//! Tests for the HTTPS options.
+//!
+//! The fixture is a CA plus a leaf signed by it, not a single self-signed
+//! certificate. That is the shape `mkcert` and `tailscale cert` produce, and
+//! the only one rustls accepts: a self-signed `CA:TRUE` certificate presented
+//! as a leaf is refused with `CaUsedAsEndEntity`, which is what the first
+//! attempt at this fixture hit.
+//!
+//! These are *test* keys. They are meant to be public.
+
+use super::*;
+
+/// The leaf the test server presents, for `localhost` and `127.0.0.1`.
+pub(in crate::commands::serve) const TEST_CERT: &str = "\
+-----BEGIN CERTIFICATE-----\n\
+MIIDQDCCAiigAwIBAgIUXd1FYsTOC1BJ/iYYlEpnrXlCieAwDQYJKoZIhvcNAQEL\n\
+BQAwGjEYMBYGA1UEAwwPbGV2aWF0aC10ZXN0LWNhMCAXDTI2MDgwNzE3Mzk0OFoY\n\
+DzIxMjYwNzE0MTczOTQ4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqG\n\
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgd9uh1tMXJluB9pgow9k7z+czIoQ6uyxj\n\
+s6Az6qoGnCoWKi7bbBZqAXD5l+8XL2SJgWKpZK3jDBHxM2E1QcXHflcx9ckQ7srf\n\
+KBi3U//gR50oDy89LbsnS+E4EqEJdnYjB8o8xO/NZEoMG7BQoNriBm2U1WwJc1wT\n\
+Foo1Tn89dc3ElKNMhnn6yGMS4MSeO5ndmgswzC0b8QVRR3Q5+YLA6B0cxTCgJhgQ\n\
+08fFy8eDC3Gfb2+Ngi5xM9s6y8cxyvN/txxpqGrxyUmyMfkuOHUrGCAJICYFEgJT\n\
+xKro52uMWRFQWM/Y6og1PI7J5RewdIq46AS0qkPUW16rqA1Tbir3AgMBAAGjgYEw\n\
+fzAMBgNVHRMBAf8EAjAAMBoGA1UdEQQTMBGCCWxvY2FsaG9zdIcEfwAAATATBgNV\n\
+HSUEDDAKBggrBgEFBQcDATAdBgNVHQ4EFgQUswEtzuEJXpH9i/oi/DfN3flF63Aw\n\
+HwYDVR0jBBgwFoAUmei4bzoEpByfyoDxT1M/rJj9AocwDQYJKoZIhvcNAQELBQAD\n\
+ggEBACrXlonhJUaF6D+g/jRQLxBJDoU/XH0ozzHHApUtW2aKkjGq7h9aJvO31tRP\n\
+GQdQ8SUdl76MjQtUpPMqMjvo2Z6nUfy3322rG5aSoNA/TIKr9lXVuPUhYNv4jAdy\n\
+I2cdqk4QGa9VGAM/K0SiptN9yFgauJKcERvXIJS07h15AHYu5eaKgqgCIs6xoDE1\n\
+RDsjyTAui8Q2yo4KYWd0Cl1cgNmYeD1Ah/EdodofqOCWw6CaamwXJKaBFRFbTu7r\n\
+gtAVi+06SPY2st9XV6vVbEgiVO5/W+Sr+ZYbtuO1aPXy608fX2Uq5ZSVRMXe506f\n\
+LQAU0yFPk6VjFvO3IkpsitaxhZY=\n\
+-----END CERTIFICATE-----\n\
+";
+
+/// The private key for [`TEST_CERT`].
+pub(in crate::commands::serve) const TEST_KEY: &str = "\
+-----BEGIN PRIVATE KEY-----\n\
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCgd9uh1tMXJluB\n\
+9pgow9k7z+czIoQ6uyxjs6Az6qoGnCoWKi7bbBZqAXD5l+8XL2SJgWKpZK3jDBHx\n\
+M2E1QcXHflcx9ckQ7srfKBi3U//gR50oDy89LbsnS+E4EqEJdnYjB8o8xO/NZEoM\n\
+G7BQoNriBm2U1WwJc1wTFoo1Tn89dc3ElKNMhnn6yGMS4MSeO5ndmgswzC0b8QVR\n\
+R3Q5+YLA6B0cxTCgJhgQ08fFy8eDC3Gfb2+Ngi5xM9s6y8cxyvN/txxpqGrxyUmy\n\
+MfkuOHUrGCAJICYFEgJTxKro52uMWRFQWM/Y6og1PI7J5RewdIq46AS0qkPUW16r\n\
+qA1Tbir3AgMBAAECggEAGzip7/be4U72+AGKh2PN3qkimdiRoNruqU0n8Jau2Cc2\n\
+toLaZwubc8khzp15CDBYeEEUKRM0sk7yXj3ukBfDwtdKWGXPAYnYrWmCY9sijXvo\n\
+i4qj41d2J7DmGFqEqfPID6I7KvrniSqpqwspakwXRX98qGJaDPJeXLiWontZ92VX\n\
+IGJfrFS6y8nt093D0jO3+KEjnCfK87L6t62oFCaFZyBnAinzTW0Ur7pkbvfQIjhu\n\
+bwbK1HAbuSD23XCR2jeX/MqlT52kSVNtmubNFZKcPVQ99bw+f+JQqJNCkL0CWXlf\n\
+35R+MMdNTqmlMq7fVnvHhBs4E8FxKPTgxI9I3Ed/CQKBgQDZI1iY57jH6vUp4xxl\n\
+KcNpOmu1UYX1pmwfwHLouOmDcog5CfK6kF13E4k03goh/qoNXEDn9ltCvFWVwljo\n\
++vNxd/B9ESADHFxEJA0SguPp9eqrbAnqMFuExLMyTuJtIDfjGlyAMYL7ov2E6Tmp\n\
+AdQGg4zwniXy8zmro0ImIkhp3wKBgQC9MA7ZaT/5dLM8jZ8853Dxr44q1A//Zo2m\n\
+GbFUwzFrXgmJlp3hXoPPkMC7YMeHDUvJ++6Hs0Tl2i3Fenzyb8bX5ll2M9c9bj/h\n\
+G5mFOREmFkyRzPF6Q9ghr0Lzzm075IgIdaVp1zJa9f/PcIz9kQX+0SkywpteH0S6\n\
+uaU0m0IR6QKBgEZcAbVqQKHnLJHqGaVeJwfN+mDCjdnPl3GidpmacXA6iJGS+6gg\n\
+Z2jSV79dw4LIdmnl3tJLLb8uL71bQFweFQxLhQ3BotHfOraJyAKbjyacnPH3DC9q\n\
+g/09j6NZlF0v92wLerW/VWYcpnGO8TQmd4G01tKRLFLRJXrMZ/7bVQOZAoGAZKVZ\n\
+cP4WI66a397z1OHHazwa5Nv2OsgjGTdX6KEC/HyFlGXFTi0K8HSwo76jx0wigqz9\n\
+Q8HyKFm+ue0k5ZDjdt47v69qlWq+nxIgxQgMAHgiefpOiN3o8FqdwriR0igM2ntD\n\
+6Z+rUUrHsWLODuOFDf/V7AQtxY/a739tzSO/rWkCgYBJMVvtGA8RlK4m5FW0DOWn\n\
+N54yKTNjjna8hlpU0OkDWr4ZwQE8/nA0Qjy5z+F5D9iJyMQXi9xYiIa9ujV3QLV3\n\
+cos46d3Sft85iusSowLlsAYen9cJDD2/1ixWLexq/UGxZUhGgK1dczW6CaUzQNbr\n\
+PBNcpgqZ15Ykb785enlsPA==\n\
+-----END PRIVATE KEY-----\n\
+";
+
+/// The CA that signed [`TEST_CERT`]. A test client trusts this and
+/// nothing else, so a successful handshake proves the server presented the
+/// certificate rather than that verification was skipped.
+pub(in crate::commands::serve) const TEST_CA: &str = "\
+-----BEGIN CERTIFICATE-----\n\
+MIIDFzCCAf+gAwIBAgIUanluj/0KYtGjT8cIEBr6AiU3N6cwDQYJKoZIhvcNAQEL\n\
+BQAwGjEYMBYGA1UEAwwPbGV2aWF0aC10ZXN0LWNhMCAXDTI2MDgwNzE3Mzk0OFoY\n\
+DzIxMjYwNzE0MTczOTQ4WjAaMRgwFgYDVQQDDA9sZXZpYXRoLXRlc3QtY2EwggEi\n\
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCpnMOJa+v8tC9WPYuDJRWJHdzu\n\
+7OZWuLu/r9Ay7iVpzGIRcgjiswJxCBCvS2b1uWmmiJ+yYeX37WmiV3GczqeJ/UUK\n\
+iLp132+5IWlJeVUDztPye+O1rePwMXh4IgwiulUvPqdprWNkwYaRodH2YJ494uyV\n\
+Rd3hJjkaR6kGGE4uemWeaXMB+NhlLynZ47G80pL/u25byEKVTn5YVbf3tbJJZ5qH\n\
+BgNWZfi3rZ9stJKaBVjn2UHqVQW3VRYLKQ2rCOHVelkHT+vnDII5gyZTJw85mzx/\n\
+dzfMn07EZ+0ZYSdUwMs7YJOipFtfMVz/qXfbnvf/AYmZngrTwUTGJAJ7+65jAgMB\n\
+AAGjUzBRMB0GA1UdDgQWBBSZ6LhvOgSkHJ/KgPFPUz+smP0ChzAfBgNVHSMEGDAW\n\
+gBSZ6LhvOgSkHJ/KgPFPUz+smP0ChzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3\n\
+DQEBCwUAA4IBAQBzV0LyKKAqYjtU4JEY+NXFC2yyXh+Fu/ziPKe9sHtuGaQbO6nn\n\
+06mpJjLNexQTjll8yO76bpnkqqFGVrOr5+SeS02fcz/4mpTNT6tHDN3NNLCobEua\n\
+vPKwTucTjrJBPs6m3DSOa3bDivnE03WC3kAE85TBFHjbZLo2QlPuy9GXFFyFoX/s\n\
+vZJtL2jEkqivbF94pff+BrytJLQPllDc4bXfJwHN8b9QcWy/nSMqzRpJlypOw/qk\n\
+sjq7fzKRZap1kLQ4zOmY05uCp68rHt1HzgW5FnPrpmANR5BAyv/bfxDsrA3luAuS\n\
+TbB6I3BD/IpHkuDpC3XnWxvEU04E00uQRFxc\n\
+-----END CERTIFICATE-----\n\
+";
+
+/// Write the fixture to disk and hand back the paths.
+fn fixture(dir: &std::path::Path) -> TlsPaths {
+    let cert = dir.join("cert.pem");
+    let key = dir.join("key.pem");
+    std::fs::write(&cert, TEST_CERT).expect("write cert");
+    std::fs::write(&key, TEST_KEY).expect("write key");
+    TlsPaths { cert, key }
+}
+
+/// Both flags or neither. One alone is refused rather than falling back to
+/// HTTP: falling back would start the server on a scheme the user did not ask
+/// for, and they would find out from a mixed-content error in a browser on
+/// another machine - the exact failure this feature exists to end.
+#[test]
+fn one_tls_flag_without_the_other_is_refused() {
+    let cert = PathBuf::from("c.pem");
+    let key = PathBuf::from("k.pem");
+
+    assert_eq!(resolve(None, None).expect("neither is fine"), None);
+    assert_eq!(
+        resolve(Some(cert.clone()), Some(key.clone())).expect("both is fine"),
+        Some(TlsPaths {
+            cert: cert.clone(),
+            key: key.clone()
+        })
+    );
+
+    let missing_key = resolve(Some(cert), None).expect_err("cert alone is refused");
+    let message = missing_key.to_string();
+    assert!(message.contains("--tls-key"), "{message}");
+    let missing_cert = resolve(None, Some(key)).expect_err("key alone is refused");
+    let message = missing_cert.to_string();
+    assert!(message.contains("--tls-cert"), "{message}");
+}
+
+/// The banner has to say what the server will actually answer on: the line it
+/// prints is the URL a user copies into the console.
+#[test]
+fn the_scheme_follows_whether_tls_was_configured() {
+    assert_eq!(scheme(None), "http");
+    let paths = TlsPaths {
+        cert: PathBuf::from("c"),
+        key: PathBuf::from("k"),
+    };
+    assert_eq!(scheme(Some(&paths)), "https");
+}
+
+#[tokio::test]
+async fn a_real_certificate_and_key_load() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    load(&fixture(dir.path())).await.expect("the fixture loads");
+}
+
+/// Failing at startup is the whole point: a server that binds and then rejects
+/// every handshake looks like a network fault from the other machine.
+#[tokio::test]
+async fn an_unreadable_certificate_fails_before_the_server_starts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut paths = fixture(dir.path());
+    paths.cert = dir.path().join("absent.pem");
+
+    let err = load(&paths).await.expect_err("a missing certificate fails");
+    // Names the file, because "invalid certificate" is unactionable when two
+    // were supplied.
+    let message = format!("{err:#}");
+    assert!(message.contains("absent.pem"), "{message}");
+}
+
+#[tokio::test]
+async fn a_malformed_certificate_fails_before_the_server_starts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let paths = fixture(dir.path());
+    std::fs::write(&paths.cert, "this is not a certificate").expect("write");
+
+    let err = load(&paths)
+        .await
+        .expect_err("a malformed certificate fails");
+    let message = format!("{err:#}");
+    assert!(message.contains("cert.pem"), "{message}");
+}
+
+/// A key that is not the certificate's key is the failure that would otherwise
+/// surface as a handshake error long after startup.
+#[tokio::test]
+async fn a_key_that_does_not_match_the_certificate_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let paths = fixture(dir.path());
+    // A syntactically valid PEM block that is not this certificate's key.
+    std::fs::write(
+        &paths.key,
+        "-----BEGIN PRIVATE KEY-----\nbm90IGEga2V5\n-----END PRIVATE KEY-----\n",
+    )
+    .expect("write");
+
+    assert!(load(&paths).await.is_err(), "a mismatched key must fail");
+}

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 
 /// Arguments for `lev serve`.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct ServeArgs {
     /// Port to listen on
     #[arg(short, long, default_value = "3000")]
@@ -63,6 +63,23 @@ pub struct ServeArgs {
     /// filesystem. Set this to the directory the API is meant to work in.
     #[arg(long)]
     pub workdir_root: Option<PathBuf>,
+
+    /// PEM certificate chain to serve HTTPS with. Needs `--tls-key` too.
+    ///
+    /// Bring your own; Leviath never generates one. Without HTTPS the browser
+    /// console cannot reach a `lev serve` that is not on loopback - the browser
+    /// blocks the request before sending it, so no server-side header and no
+    /// `--cors` value can help. A LAN address is blocked exactly like a public
+    /// one.
+    ///
+    /// `mkcert` and `tailscale cert` both produce certificates that work here.
+    /// See the "reaching a Leviath on another machine" section of the docs.
+    #[arg(long, value_name = "PATH")]
+    pub tls_cert: Option<PathBuf>,
+
+    /// PEM private key for `--tls-cert`. Needs `--tls-cert` too.
+    #[arg(long, value_name = "PATH")]
+    pub tls_key: Option<PathBuf>,
 
     /// Refuse `"yolo": true` and `"allow": [...]` on spawn requests, so an API
     /// caller cannot waive approval prompts for an agent running on the host.

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -427,6 +427,8 @@ mod tests {
             allow_admin: false,
             workdir_root: None,
             no_remote_yolo: false,
+            tls_cert: None,
+            tls_key: None,
         };
         let result = dispatch(Commands::Serve(args), &MockRisky).await;
         assert!(result.is_ok());

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -24,7 +24,15 @@ lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.d
   (`ps`).
 - **CORS is closed by default.** Pass `--cors <origin>` (e.g. `https://leviath.dev`) or `--cors "*"`
   to allow a browser to call it cross-origin.
-- **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network.
+- **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network - and without
+  `--tls-cert`, puts the bearer token on the wire in cleartext for anyone on that network to read.
+  If the address is publicly routable, that is the open internet. See
+  [reaching a Leviath on another machine](#reaching-a-leviath-on-another-machine).
+- **`--tls-cert` / `--tls-key`** serve HTTPS instead of HTTP. Off by default, bring your own
+  certificate; Leviath never generates one.
+- **`GET /` needs no token.** It returns a fixed "Leviath is running." page and nothing else - no
+  version, no run counts, no endpoint list. It exists so a certificate can be accepted in a browser
+  tab; see the section below.
 - **`--allow-admin`** mounts the mutating admin routes. `GET /api/config` and
   `GET /api/mcp/servers` are always available. The writes are only mounted with `--allow-admin`, and
   the route is genuinely absent without it rather than gated by a check inside the handler. What you
@@ -41,6 +49,87 @@ lev serve --port 3000 --token "$(openssl rand -hex 16)" --cors https://leviath.d
 > [!CAUTION]
 > `lev serve` runs LLM-driven tools with whatever permissions the blueprint grants. Treat it as
 > trusted-network only unless hardened. See [Security](/docs/security).
+
+## Reaching a Leviath on another machine
+
+The short version: **`http://` only works on loopback.** Everything else needs HTTPS or a tunnel.
+
+A browser treats `http://localhost` and `http://127.0.0.1` as potentially trustworthy, which is the
+only reason the default setup works from a page served over HTTPS. Every other address is blocked,
+and **a LAN address is blocked exactly like a public one** - `http://192.168.1.50:3000` fails just as
+`http://34.132.206.6:8080` does:
+
+```
+Mixed Content: The page at 'https://leviath.dev/lair' was loaded over HTTPS, but requested an
+insecure resource 'http://34.132.206.6:8080/api/config'. This request has been blocked.
+```
+
+Two things that are *not* the problem, because they are what people reach for first:
+
+- **It is not CORS.** The request is killed inside the browser before it is sent, so it never reaches
+  Leviath and `--cors` is never consulted. No response header on either side lifts a mixed-content
+  block.
+- **The site cannot fix it.** leviath.dev is HTTPS-only, and an HTTPS page may not call `http://`.
+
+Pick whichever of these suits you.
+
+### mkcert, if the browser and Leviath are on machines you control
+
+The best outcome: a certificate that is *fully* trusted, with no interstitial and nothing to accept.
+[mkcert](https://github.com/FiloSottile/mkcert) installs a local CA into your OS and browser trust
+stores and will issue for a bare IP.
+
+```bash
+mkcert -install                      # once, on the machine running the BROWSER
+mkcert 192.168.1.50                  # on the machine running Leviath
+lev serve --host 0.0.0.0 --port 3000 \
+  --tls-cert ./192.168.1.50.pem --tls-key ./192.168.1.50-key.pem \
+  --cors https://leviath.dev --token "$LEVIATH_API_TOKEN"
+```
+
+Installing a CA into your trust store is a real trust decision: anything holding that CA's key can
+issue a certificate your browser will believe. `mkcert` keeps the key on the machine that made it.
+
+### Tailscale, for a publicly-trusted name
+
+`tailscale cert` issues a real certificate for your `*.ts.net` hostname, so nothing needs installing
+in a trust store and the port never faces the internet.
+
+```bash
+tailscale cert my-box.tail1234.ts.net
+lev serve --host 0.0.0.0 --tls-cert my-box.tail1234.ts.net.crt \
+  --tls-key my-box.tail1234.ts.net.key --cors https://leviath.dev
+```
+
+### Self-signed, as a fallback
+
+Works, with one manual step and one caveat.
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout key.pem -out cert.pem -subj "/CN=leviath" \
+  -addext "subjectAltName=IP:192.168.1.50"
+lev serve --host 0.0.0.0 --tls-cert cert.pem --tls-key key.pem --cors https://leviath.dev
+```
+
+Then **open `https://192.168.1.50:3000/` in a browser tab and accept the warning.** That is what the
+unauthenticated `GET /` page is for: the console's requests are subresource `fetch` calls, which get
+no interstitial to click through, so the exception has to be established in a tab first. Afterwards
+the console works.
+
+Chrome discards accepted exceptions when the browser restarts, so this comes back. Firefox keeps
+them. iOS Safari is unreliable about it.
+
+### SSH forward, if you would rather not deal with certificates
+
+Nothing to install on either end, and it puts you back inside the loopback exemption.
+
+```bash
+ssh -N -L 3000:127.0.0.1:3000 you@that-machine
+```
+
+Then point the console at `http://127.0.0.1:3000`. Leave Leviath on its default `127.0.0.1` bind for
+this - `--host 0.0.0.0` is not wanted and only widens the exposure.
 
 ## Auth flow
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -391,6 +391,13 @@ Start the [REST and WebSocket API](/docs/api).
 | `--allow-admin` | off | Mount the MCP administration and config-write routes |
 | `--workdir-root <PATH>` | unset | Restrict agent working directories to this root |
 | `--no-remote-yolo` | off | Refuse `"yolo": true` and `"allow": [...]` on spawn requests |
+| `--tls-cert <PATH>` | unset | PEM certificate chain. Serves HTTPS; needs `--tls-key` too |
+| `--tls-key <PATH>` | unset | PEM private key for `--tls-cert` |
+
+> [!TIP]
+> A browser cannot call an `http://` Leviath that is not on loopback, whatever `--cors` says - not
+> even on a LAN. That is what the TLS flags are for. See
+> [reaching a Leviath on another machine](/docs/api#reaching-a-leviath-on-another-machine).
 
 > [!WARNING]
 > Prefer `LEVIATH_API_TOKEN` over `--token`. A command-line argument is visible in `ps` to every

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -46,6 +46,28 @@
     }
   ],
   "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Liveness page (no token required)",
+        "description": "A minimal HTML page saying the server is running. **The only route that does not require the bearer token**, because it exists to be opened in a browser tab and a tab cannot send an `Authorization` header.\n\nIts purpose is TLS, not status: with a self-signed certificate, opening this in a tab is how a user reaches the certificate interstitial and accepts it, after which a browser console's `fetch` to the same origin inherits the exception.\n\nIt deliberately reports nothing else - no version, no run counts, no endpoint list. Anyone who can load it already knows the port is open, and that should remain all they learn.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The server is running.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/blueprints": {
       "get": {
         "tags": [


### PR DESCRIPTION
feat(serve): optional TLS, and a page a browser can accept a certificate on (#300)

The browser console cannot call a `lev serve` that is not on loopback. The
request is killed inside the browser before it is sent, so Leviath never sees it
and `--cors` is never consulted - and a LAN address is blocked exactly like a
public one, which is the part that surprises people.

### `--tls-cert` / `--tls-key`

Opt-in, bring-your-own, never generated. Both or neither: one alone is an error
rather than a silent fall back to HTTP, because falling back would start the
server on a scheme the user did not ask for and they would find out from a
mixed-content error in a browser on another machine - the exact failure this
ends.

Resolved and loaded **before the listener binds**. A server that binds and then
rejects every handshake looks like a network fault from the other end; one that
refuses to start names the file it could not read.

`axum-server` with `tls-rustls`, which resolves to `rustls/aws-lc-rs` - the same
provider the outbound reqwest stack already uses, so this adds a TLS *listener*
without a second TLS implementation or a second crypto provider. That is what
`Cargo.toml`'s "rustls, never native-tls" note is actually about.

The listener is still bound by us, not by `axum-server`, so the bind, the
`ready` report and the "port already in use" error stay one piece of code on
both schemes. The banner prints the real scheme, because the line it prints is
the URL a user copies into the console.

### `GET /`, with no token

A browser tab cannot send an `Authorization` header, so this route is merged
*after* the auth layer. With a self-signed certificate, opening it in a tab is
how a user reaches the interstitial and accepts it; the console's `fetch` to the
same origin then inherits the exception.

It says "Leviath is running." and nothing else - no version, no run counts, no
endpoint list. It is a new unauthenticated surface, and anyone who can load it
already knows the port is open. Documented in the OpenAPI spec as the only route
with no security requirement, since that is worth knowing.

### Docs

A "reaching a Leviath on another machine" section covering, in order of how well
they work: **mkcert** (fully trusted, no interstitial - and installing a CA is a
real trust decision, said as one), **Tailscale** (`tailscale cert`, publicly
trusted, port never faces the internet), **self-signed** (with the accept-it-in-a-tab
step and the caveat that Chrome forgets exceptions on restart), and **an SSH
forward** for anyone who would rather not touch certificates at all.

Plus the two corrections that caused this: `--host 0.0.0.0` without TLS puts the
bearer token on the wire in cleartext, and `--cors` is unrelated to any of it.

### Tests

The one that matters does a **real TLS handshake** against the running server,
with a client whose root store holds the test CA and nothing else - so a green
result proves the server presented the certificate rather than that verification
was skipped. It then fetches `/` with no `Authorization` header and asserts a
200, which is the property the whole certificate-accepting flow depends on.

Two more drive `execute_with_shutdown` to failure (one flag alone; a malformed
certificate) and one proves the HTTPS server **returns on its own** when its
shutdown future resolves rather than being aborted - `axum-server` signals
through a `Handle` instead of taking a future, and a bridge that never fired
would leave `lev serve` unkillable.

Three things the tests caught that I had wrong:

- Setting the listener back to blocking before handing it over looks tidier and
  **panics**: tokio refuses to register a blocking socket.
- A self-signed `CA:TRUE` certificate is rejected as a leaf
  (`CaUsedAsEndEntity`). The fixture is now a CA plus a leaf signed by it, which
  is also the shape `mkcert` and `tailscale cert` produce.
- `rustls-pemfile` is unmaintained (RUSTSEC-2025-0134) and failed `cargo deny`.
  Its API moved into `rustls-pki-types`, already in the tree.

`cargo xtask coverage` clean on leviath-cli, full suite 34/34, clippy clean,
`cargo deny check` clean, `cargo xtask docs --check` clean.

Closes #300

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
