### PR TITLE
fix: three findings from the round-3 audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,12 @@ categories = ["development-tools"]
 # dependencies (nix, temp-env) plus ONE audited in-repo exception: leviath-alloc,
 # a single-call crate that deliberately does not opt into these lints (its lib.rs
 # carries the audit note). Nothing else writes unsafe.
-# Every public item in the published library crates carries a doc comment, and
-# CI's `RUSTFLAGS: -D warnings` turns this "warn" into a blocking error, so a PR
-# that adds undocumented public API does not merge. `leviath-cli` opts out at its
-# crate root (see the note there): it ships as the `lev` binary, and its `pub`
-# surface is command plumbing rather than API anyone calls.
+# Every public item carries a doc comment, and CI's `RUSTFLAGS: -D warnings`
+# turns this "warn" into a blocking error, so a PR that adds undocumented public
+# API does not merge. There are no exemptions -- `leviath-cli` was the obvious
+# candidate for one and deliberately does not take it, because its `pub` surface
+# is what the integration tests drive and its wire types are read by clients that
+# never see this source. Its crate root says so.
 [workspace.lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"

--- a/crates/leviath-cli/src/commands/remove.rs
+++ b/crates/leviath-cli/src/commands/remove.rs
@@ -35,9 +35,7 @@ fn remove_agent_with(
     name: &str,
     uninstall: &dyn Fn(&str) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
-    // Verify it's actually installed first
-    let installed = installer.get_installed(name).unwrap();
-    if installed.is_none() {
+    if installer.get_installed(name).is_none() {
         anyhow::bail!(
             "Agent '{}' is not installed. Use `lev list` to see installed agents.",
             name
@@ -109,11 +107,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let installer = leviath_package::AgentInstaller::with_install_dir(dir.path().to_path_buf());
         install_test_agent(&installer, "my-agent");
-        assert!(installer.get_installed("my-agent").unwrap().is_some());
+        assert!(installer.get_installed("my-agent").is_some());
 
         remove_agent(&installer, "my-agent").unwrap();
 
-        assert!(installer.get_installed("my-agent").unwrap().is_none());
+        assert!(installer.get_installed("my-agent").is_none());
     }
 
     // ─── execute() ───────────────────────────────────────────────────────

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -384,17 +384,30 @@ impl AgentInstaller {
         Ok(agents)
     }
 
-    /// Get information about a specific installed agent.
-    pub fn get_installed(&self, name: &str) -> anyhow::Result<Option<InstalledAgent>> {
+    /// Get information about a specific installed agent, or `None` if it is not
+    /// installed.
+    ///
+    /// Infallible on purpose, and the signature now says so. A manifest that
+    /// cannot be read or parsed still means *installed* - the directory and the
+    /// file are both there - so it reports the agent with whatever metadata it
+    /// could recover rather than failing. That is the state you would run
+    /// `lev remove` to fix, and an error here would be the one thing standing
+    /// between the user and the fix.
+    ///
+    /// It previously returned `anyhow::Result` and never once returned `Err`,
+    /// which left its only production caller `.unwrap()`-ing an infallible
+    /// result inside a function that returns `Result` - a panic waiting for
+    /// whoever made this propagate.
+    pub fn get_installed(&self, name: &str) -> Option<InstalledAgent> {
         let agent_dir = self.install_dir.join(name);
 
         if !agent_dir.exists() {
-            return Ok(None);
+            return None;
         }
 
         let manifest_path = agent_dir.join("agent.leviath");
         if !manifest_path.exists() {
-            return Ok(None);
+            return None;
         }
 
         let content = fs::read_to_string(&manifest_path).unwrap_or_default();
@@ -414,12 +427,12 @@ impl AgentInstaller {
             .unwrap_or("")
             .to_string();
 
-        Ok(Some(InstalledAgent {
+        Some(InstalledAgent {
             name: name.to_string(),
             version,
             path: agent_dir,
             description,
-        }))
+        })
     }
 }
 
@@ -829,7 +842,7 @@ description = "{}"
         let bundle = make_bundle("findme", "3.2.1", "Find this agent");
         installer.install_from_bytes("findme", &bundle).unwrap();
 
-        let agent = installer.get_installed("findme").unwrap().unwrap();
+        let agent = installer.get_installed("findme").unwrap();
         assert_eq!(agent.name, "findme");
         assert_eq!(agent.version, "3.2.1");
         assert_eq!(agent.description, "Find this agent");
@@ -839,7 +852,7 @@ description = "{}"
     fn get_installed_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let installer = AgentInstaller::with_install_dir(dir.path().to_path_buf());
-        assert!(installer.get_installed("nope").unwrap().is_none());
+        assert!(installer.get_installed("nope").is_none());
     }
 
     #[test]
@@ -849,7 +862,7 @@ description = "{}"
 
         // Create directory but no agent.leviath
         fs::create_dir_all(dir.path().join("empty-agent")).unwrap();
-        assert!(installer.get_installed("empty-agent").unwrap().is_none());
+        assert!(installer.get_installed("empty-agent").is_none());
     }
 
     // ─── AgentInstaller::new / Default ─────────────────────────────────

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -70,7 +70,9 @@ fn register_pure_fns(engine: &mut Engine, env_allowlist: Arc<Vec<String>>) {
     engine.register_fn("parse_json", parse_json_fn);
     engine.register_fn("to_json", to_json_fn);
     engine.register_fn("parse_sse", parse_sse_fn);
-    engine.register_fn("encode_uri", |s: &str| percent_encode(s));
+    engine.register_fn("encode_uri", |s: &str| {
+        leviath_scripting::tool::percent_encode(s)
+    });
     engine.register_fn("encode_base64", |s: &str| {
         base64::engine::general_purpose::STANDARD.encode(s)
     });
@@ -144,32 +146,6 @@ fn count_tokens_heuristic_fn(text: &str, hint: &str) -> i64 {
         _ => "general",
     };
     crate::tokenizer::count_tokens(text, model) as i64
-}
-
-/// Percent-encode for a URL component (RFC 3986 unreserved set passes through).
-fn percent_encode(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for &byte in input.as_bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(byte as char);
-            }
-            _ => {
-                out.push('%');
-                out.push(hex_digit(byte >> 4));
-                out.push(hex_digit(byte & 0x0f));
-            }
-        }
-    }
-    out
-}
-
-/// Map a nibble (0–15) to its uppercase hex digit.
-fn hex_digit(nibble: u8) -> char {
-    match nibble {
-        0..=9 => (b'0' + nibble) as char,
-        _ => (b'A' + (nibble - 10)) as char,
-    }
 }
 
 /// Convert a Rhai object-map of headers into a `BTreeMap<String,String>`.

--- a/crates/leviath-providers/src/rhai_provider/engine/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine/tests.rs
@@ -146,12 +146,6 @@ fn count_tokens_heuristic_dispatches_by_hint() {
 }
 
 #[test]
-fn hex_digit_covers_both_arms() {
-    assert_eq!(hex_digit(5), '5');
-    assert_eq!(hex_digit(12), 'C');
-}
-
-#[test]
 fn to_json_fn_serializes_a_value() {
     let mut m = rhai::Map::new();
     m.insert("a".into(), 1_i64.into());

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -647,7 +647,12 @@ fn to_json_fn(v: &Dynamic) -> HostRes<String> {
 /// Percent-encode a string for use in a URL query component. Unreserved
 /// characters (`A-Z a-z 0-9 - _ . ~`, per RFC 3986) pass through; every other
 /// byte becomes `%XX`.
-fn percent_encode(input: &str) -> String {
+///
+/// Public because the script *provider* engine registers the same `encode_uri`
+/// host function and had a byte-identical copy of this. Two encoders that
+/// scripts reach by the same name is a difference waiting to be discovered by
+/// whoever writes a `.rhai` that works in one and not the other.
+pub fn percent_encode(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for &byte in input.as_bytes() {
         match byte {


### PR DESCRIPTION
fix: three findings from the round-3 audit

**One `encode_uri`, not two.** `percent_encode` and `hex_digit` were
byte-identical in `leviath-scripting/src/tool.rs` and
`leviath-providers/src/rhai_provider/engine.rs`, and both register a Rhai host
function called `encode_uri`. Two encoders reachable by the same name from a
`.rhai` file is a difference waiting to be found by whoever writes a script that
works in one engine and not the other. Providers already depends on scripting,
so the copy is gone and the shared one is `pub`. The provider test that only
covered its private `hex_digit` goes with it; the behavioural
`encode_uri_passes_unreserved_and_encodes_rest`, which drives the real engine,
now exercises the shared function.

**The lint policy said the opposite of the code.** The root manifest claimed
`leviath-cli` opts out of `missing_docs` "at its crate root (see the note
there)". The note there says it deliberately does not, and gives the reason. The
code was right; the comment governing the workspace's lint policy was wrong,
which is the more dangerous direction for a stale comment to point.

**A latent panic in `lev remove`.** `remove_agent_with` returns
`anyhow::Result<()>` and did `installer.get_installed(name).unwrap()`. It cannot
panic today because `get_installed` never returns `Err` - every fallible step
inside it uses `unwrap_or_default`. That is the problem: the signature promised
a failure mode it never had, and the first person to make it propagate would
have turned `lev remove` into a panic.

Fixed by removing the lie rather than the unwrap: `get_installed` now returns
`Option<InstalledAgent>`, which is what it always meant. A manifest that cannot
be read or parsed still counts as installed, and the doc comment now says why -
that is precisely the state you would run `lev remove` to fix, so an error there
would stand between the user and the fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
