### PR TITLE
refactor(daemon): name build_tool_state's twenty-one arguments

### DIFF
--- a/crates/leviath-cli/src/daemon/spawn.rs
+++ b/crates/leviath-cli/src/daemon/spawn.rs
@@ -374,51 +374,83 @@ fn discover_script_tools(
 /// `stage_perms_by_index` holds every stage's `[tool_permissions]` (in stage
 /// order); the entry stage's map seeds `stage_perms`, and the pipeline's
 /// `sync_stage` swaps in the right one as the agent changes stage.
-#[allow(clippy::too_many_arguments)]
-fn build_tool_state(
+/// Everything [`build_tool_state`] assembles an agent's tool state from.
+///
+/// A struct rather than twenty-one positional parameters, and the reason is
+/// narrower than the lint: three of them - `run_id`, `entry_stage` and
+/// `agent_name` - are all `&str`. Transposing any two of those compiles
+/// silently and produces a run whose approvals are keyed to the wrong name.
+/// Nothing else in this file was ever going to catch that.
+struct ToolStateParts<'a> {
+    /// The built-in tools, over this agent's workdir.
     builtins: Arc<leviath_tools::BuiltinTools>,
+    /// Their names, for deciding what is a builtin at dispatch.
     builtin_names: HashSet<String>,
+    /// MCP connections shared across agents.
     mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
-    config: &Config,
-    hub: &InteractionHub,
-    run_id: &str,
-    entry_stage: &str,
+    /// The resolved daemon configuration.
+    config: &'a Config,
+    /// Where this agent's prompts are parked.
+    hub: &'a InteractionHub,
+    /// This run's id, which grants are recorded against.
+    run_id: &'a str,
+    /// The stage the agent enters at.
+    entry_stage: &'a str,
+    /// That stage's index in the blueprint.
     entry_index: usize,
+    /// Per-stage tool policies, indexed by stage.
     stage_perms_by_index: Vec<HashMap<String, String>>,
+    /// Per-stage required tools, indexed by stage.
     stage_required_by_index: Vec<HashSet<String>>,
+    /// Agent-wide tool policies from the blueprint.
     agent_perms: HashMap<String, String>,
-    agent_name: &str,
+    /// The blueprint's name, for policy lookup and messages.
+    agent_name: &'a str,
+    /// `--allow` / `--yolo` overrides for this launch.
     launch_overrides: HashMap<String, crate::config::ToolPolicy>,
+    /// Handle for the sub-agent tools, when this agent may spawn.
     subagent: Option<SubAgentHandle>,
+    /// The sandbox shell calls run in, when one is configured.
     sandbox: Option<Arc<crate::daemon::sandbox_manager::SandboxManager>>,
+    /// Rhai tools discovered for this agent.
     script_tools: leviath_scripting::ScriptToolSet,
+    /// Their names, kept apart so a rescan can diff against them.
     script_tool_names: HashSet<String>,
+    /// The host those scripts call back into.
     script_host: Arc<dyn leviath_scripting::ScriptHost>,
+    /// Re-resolution context, for a blueprint that rescans mid-run.
     dynamic: Option<Arc<crate::daemon::tool_service::DynamicToolCtx>>,
+    /// Whether this run answers its own prompts (`--yolo`).
     unattended: bool,
-    blueprint_safe: Option<&leviath_core::blueprint::SafeCommandsConfig>,
-) -> Arc<AgentToolState> {
-    let entry_perms = stage_perms_by_index
-        .get(entry_index)
+    /// `[safe_commands]` the blueprint declares, if the user opted in.
+    blueprint_safe: Option<&'a leviath_core::blueprint::SafeCommandsConfig>,
+}
+
+fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState> {
+    let entry_perms = parts
+        .stage_perms_by_index
+        .get(parts.entry_index)
         .cloned()
         .unwrap_or_default();
-    let entry_required = stage_required_by_index
-        .get(entry_index)
+    let entry_required = parts
+        .stage_required_by_index
+        .get(parts.entry_index)
         .cloned()
         .unwrap_or_default();
     Arc::new(AgentToolState {
         // One budget per run, so the per-run ceiling spans every batch rather
         // than resetting with each one.
         writes: Arc::new(crate::daemon::tool_service::WriteBudget::new(
-            config.limits.write_limits(),
+            parts.config.limits.write_limits(),
         )),
-        builtins,
-        mcp,
-        builtin_names,
-        launch_overrides: Arc::new(launch_overrides),
+        builtins: parts.builtins,
+        mcp: parts.mcp,
+        builtin_names: parts.builtin_names,
+        launch_overrides: Arc::new(parts.launch_overrides),
         safe_keys: Arc::new(
-            config
-                .safe_keys_for_agent(agent_name, blueprint_safe)
+            parts
+                .config
+                .safe_keys_for_agent(parts.agent_name, parts.blueprint_safe)
                 .into_keys()
                 .collect(),
         ),
@@ -426,25 +458,25 @@ fn build_tool_state(
         stage_allows: Arc::new(StdMutex::new(HashSet::new())),
         stage_allows_index: Arc::new(StdMutex::new(None)),
         stage_perms: Arc::new(StdMutex::new(entry_perms)),
-        stage_perms_by_index: Arc::new(stage_perms_by_index),
+        stage_perms_by_index: Arc::new(parts.stage_perms_by_index),
         stage_required: Arc::new(StdMutex::new(entry_required)),
-        stage_required_by_index: Arc::new(stage_required_by_index),
-        agent_perms: Arc::new(agent_perms),
-        blueprint_may_loosen: config.security.allow_blueprint_permissions,
+        stage_required_by_index: Arc::new(parts.stage_required_by_index),
+        agent_perms: Arc::new(parts.agent_perms),
+        blueprint_may_loosen: parts.config.security.allow_blueprint_permissions,
         // The ceiling a blueprint may tighten but not loosen: the user's global
         // `[tool_permissions]` plus any `[agent_tool_permissions.<name>]` grant
         // they made for this specific agent. Resolved once here so every later
         // `resolve_policy` reads one flat map.
-        global_perms: Arc::new(config.permissions_for_agent(agent_name)),
-        interaction: hub.backend_for(run_id),
-        unattended,
-        stage_name: Arc::new(StdMutex::new(entry_stage.to_string())),
-        subagent,
-        sandbox,
-        script_tools: Arc::new(StdMutex::new(script_tools)),
-        script_tool_names: Arc::new(StdMutex::new(script_tool_names)),
-        script_host,
-        dynamic,
+        global_perms: Arc::new(parts.config.permissions_for_agent(parts.agent_name)),
+        interaction: parts.hub.backend_for(parts.run_id),
+        unattended: parts.unattended,
+        stage_name: Arc::new(StdMutex::new(parts.entry_stage.to_string())),
+        subagent: parts.subagent,
+        sandbox: parts.sandbox,
+        script_tools: Arc::new(StdMutex::new(parts.script_tools)),
+        script_tool_names: Arc::new(StdMutex::new(parts.script_tool_names)),
+        script_host: parts.script_host,
+        dynamic: parts.dynamic,
     })
 }
 
@@ -1389,29 +1421,29 @@ fn build_agent_inner(
             dirty: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     });
-    let state = build_tool_state(
+    let state = build_tool_state(ToolStateParts {
         builtins,
         builtin_names,
-        deps.shared_mcp,
-        deps.config,
-        deps.hub,
-        &args.run_id,
-        &entry_stage,
+        mcp: deps.shared_mcp,
+        config: deps.config,
+        hub: deps.hub,
+        run_id: &args.run_id,
+        entry_stage: &entry_stage,
         entry_index,
         stage_perms_by_index,
         stage_required_by_index,
         agent_perms,
-        &agent_name,
+        agent_name: &agent_name,
         launch_overrides,
-        Some(subagent),
+        subagent: Some(subagent),
         sandbox,
         script_tools,
         script_tool_names,
         script_host,
         dynamic,
-        args.yolo,
-        blueprint_safe.as_ref(),
-    );
+        unattended: args.yolo,
+        blueprint_safe: blueprint_safe.as_ref(),
+    });
     deps.tool_service.register(entity, state);
 
     Ok(entity)


### PR DESCRIPTION
refactor(daemon): name build_tool_state's twenty-one arguments

`build_tool_state` took 21 positional parameters from a single caller. It now
takes one `ToolStateParts`, and `spawn.rs` has no `too_many_arguments`
suppression left.

The lint is not the reason. Three of those parameters - `run_id`, `entry_stage`
and `agent_name` - are all `&str`, sitting at positions 6, 7 and 12. Transposing
any two of them compiles cleanly and produces a run whose tool approvals are
keyed to the wrong name: a grant recorded against the stage name instead of the
run, or against the run instead of the blueprint. Nothing in the type system was
going to catch that, and nothing in the test suite was looking for it. Named
fields make it unrepresentable.

Every field carries a line saying what it is, which twenty-one positional
arguments could not.

Mechanical, and the two things that needed care are worth recording:

- The rename to field access has to be **scoped to the function body**. Run to
  end-of-file and it rewrites `let config = ...` bindings in the test module
  below into `let parts.config = ...`. That is how the `SpawnDeps` change failed
  first time too.
- The body builds `AgentToolState` with **shorthand initializers** (`builtins,`
  meaning `builtins: builtins`). Shorthand cannot take a path, so eight of them
  needed expanding to `builtins: parts.builtins`. A mechanical rename that only
  looks at identifiers will produce code that does not parse here.

Behaviour is unchanged: a struct and field accesses, nothing else. 408 daemon
tests pass and the package holds 100%.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMQmZ1ruXrUuKteXyFZxeg
