### PR TITLE
refactor: make lint suppressions expire, and delete the ones that already had

### DIFF
--- a/.sgrules/no-bare-lint-allow.yml
+++ b/.sgrules/no-bare-lint-allow.yml
@@ -1,0 +1,13 @@
+id: no-bare-lint-allow
+language: rust
+severity: error
+message: >-
+  `#[allow(...)]` is banned; use `#[expect(..., reason = "...")]`. `expect`
+  fails the build the moment the lint stops firing, so a suppression cannot
+  outlive the problem it was written for - an orphaned `allow` survived a whole
+  refactor in this repo before anyone noticed. The `reason` is the point: it is
+  the one place a reader learns why the lint was wrong here rather than the code.
+  If the honest reason is "the code should change", change the code.
+rule:
+  kind: attribute_item
+  regex: '^#\[allow\('

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -1087,7 +1087,10 @@ prompt = "p"
         // production/security-relevant code, so clippy's warning about
         // `set_readonly(false)` making the file world-writable on Unix
         // doesn't apply here.
-        #[allow(clippy::permissions_set_readonly_false)]
+        #[expect(
+            clippy::permissions_set_readonly_false,
+            reason = "test-only cleanup: re-enabling write on a throwaway tempdir file so it can be removed, which is the one case the lint's security concern does not cover"
+        )]
         {
             let mut perms = std::fs::metadata(&manifest_path).unwrap().permissions();
             perms.set_readonly(false);

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -1177,7 +1177,10 @@ mod tests {
         tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             // Set SO_LINGER to 0 - causes RST on close instead of FIN.
-            #[allow(deprecated)]
+            #[expect(
+                deprecated,
+                reason = "SO_LINGER(0) is the point - it forces an RST rather than a FIN, which is what this test needs and what the deprecation does not offer a replacement for"
+            )]
             stream.set_linger(Some(Duration::from_secs(0))).unwrap();
             // Close immediately (drop triggers RST).
         });

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -70,7 +70,10 @@ impl Outcome {
 ///
 /// The whole point is that the wizard never calls a provider directly, so its
 /// tests never open a socket.
-#[allow(async_fn_in_trait)] // callers are concrete; no `dyn` and no boxing needed
+#[expect(
+    async_fn_in_trait,
+    reason = "same as dispatch::RiskyExecutors: a test seam, never a dyn object"
+)] // callers are concrete; no `dyn` and no boxing needed
 pub trait ProviderVerifier {
     /// Ask the provider whether these credentials work, and what models they
     /// reach. Never fails: an unreachable provider is an [`Outcome::Failed`],

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -30,7 +30,6 @@ pub struct TestArgs {
 
 /// A test case loaded from a TOML test file.
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 struct TestCase {
     name: String,
     input: String,
@@ -298,6 +297,38 @@ async fn execute_with_registry(
     Ok(())
 }
 
+/// How many output tokens one case may ask for.
+///
+/// A case's `max_tokens` narrows `ceiling` and never widens it: it is there to
+/// keep one test cheap, not to let a test ask for more than the context window
+/// or the model allows. A free function rather than an inline `map_or` so the
+/// rule is exercised without reaching a provider.
+fn resolved_max_tokens(case_cap: Option<usize>, ceiling: usize) -> usize {
+    match case_cap {
+        Some(cap) => cap.min(ceiling),
+        None => ceiling,
+    }
+}
+
+/// The tools a stage advertises, as the provider wants them.
+///
+/// `lev test` drives one inference, so this is the same set the first turn of a
+/// real run would see - which is what makes `expect_tool_call` mean the same
+/// thing here as it does in production.
+fn stage_tools(stage: &leviath_core::Stage) -> Vec<leviath_providers::Tool> {
+    // Built over a throwaway workdir: `lev test` never executes a tool, it only
+    // needs the definitions so the model can choose to call one.
+    let builtins =
+        leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(std::env::temp_dir()));
+    let mut defs = builtins.tool_defs();
+    defs.extend(leviath_tools::BuiltinTools::subagent_tool_defs());
+    stage
+        .available_tools
+        .iter()
+        .filter_map(|name| defs.iter().find(|d| d.name == *name).cloned())
+        .collect()
+}
+
 /// Run a single test case: build a one-off context window from the blueprint,
 /// run one inference against the resolved provider, and check the assertions.
 async fn run_test_case(
@@ -341,15 +372,22 @@ async fn run_test_case(
     });
     let caps = provider.capabilities(model_name);
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);
+    // A case's `max_tokens` narrows the ceiling and never widens it: it is there
+    // to keep one test cheap, not to let a test ask for more than the window or
+    // the model allows.
+    let max_tokens = resolved_max_tokens(test.max_tokens, remaining.min(caps.max_output_tokens));
     let temperature = if caps.supports_temperature { 0.7 } else { 0.0 };
     let request = InferenceRequest {
         system: assembled.system_blocks,
         messages: assembled.messages,
         model: model_name.to_string(),
-        max_tokens: remaining.min(caps.max_output_tokens),
+        max_tokens,
         temperature,
-        // `lev test` advertises no tools (matches prior single-shot behaviour).
-        tools: Vec::new(),
+        // The stage's own tools, so a case can assert on a tool call at all.
+        // Advertising none was the prior behaviour and made `expect_tool_call`
+        // unsatisfiable: the model cannot call a tool it was never offered, so
+        // every such assertion failed whatever the agent did.
+        tools: stage_tools(stage),
         extra: serde_json::Value::Null,
         request_timeout_secs: None,
     };
@@ -556,6 +594,65 @@ max_tokens = 500
             Some("read_file")
         );
         assert_eq!(test_file.test[1].max_tokens, Some(500));
+    }
+
+    /// A minimal model config, since `Stage::new` needs one and these tests
+    /// never reach a provider.
+    fn test_model() -> leviath_core::blueprint::ModelConfig {
+        leviath_core::blueprint::ModelConfig::new("anthropic".to_string(), "m".to_string())
+    }
+
+    /// The bug these two fixes closed, pinned so it cannot reopen: both keys
+    /// were parsed, asserted on *as parsed values*, and then ignored. A test
+    /// that only checks deserialisation certifies nothing about behaviour.
+    #[test]
+    fn a_case_max_tokens_narrows_the_ceiling_and_never_widens_it() {
+        let ceiling = 4_000;
+        assert_eq!(
+            resolved_max_tokens(Some(500), ceiling),
+            500,
+            "a smaller case cap wins"
+        );
+        assert_eq!(
+            resolved_max_tokens(Some(99_000), ceiling),
+            ceiling,
+            "a case may not ask for more than the model allows"
+        );
+        assert_eq!(
+            resolved_max_tokens(None, ceiling),
+            ceiling,
+            "no cap means the full ceiling"
+        );
+    }
+
+    /// `expect_tool_call` was unsatisfiable: the request advertised no tools, so
+    /// the model could never call one and every such assertion failed whatever
+    /// the agent did.
+    #[test]
+    fn a_stage_advertises_its_tools_so_a_tool_call_is_possible() {
+        let mut stage = leviath_core::Stage::new("s".to_string(), test_model());
+        stage.available_tools = vec!["read_file".to_string(), "write_file".to_string()];
+        let tools = stage_tools(&stage);
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"read_file"), "got {names:?}");
+        assert!(names.contains(&"write_file"), "got {names:?}");
+    }
+
+    /// A stage that advertises nothing still sends nothing, so a plain
+    /// text-assertion case is unchanged.
+    #[test]
+    fn a_stage_with_no_tools_advertises_none() {
+        let stage = leviath_core::Stage::new("s".to_string(), test_model());
+        assert!(stage_tools(&stage).is_empty());
+    }
+
+    /// A name the builtins do not know is dropped rather than sent as a tool the
+    /// provider would reject.
+    #[test]
+    fn an_unknown_tool_name_is_not_advertised() {
+        let mut stage = leviath_core::Stage::new("s".to_string(), test_model());
+        stage.available_tools = vec!["definitely_not_a_tool".to_string()];
+        assert!(stage_tools(&stage).is_empty());
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -127,7 +127,10 @@ pub fn never_interactive() -> bool {
 /// Regions are resolved *before* the task on purpose. A typo'd `--foo` has to
 /// fail before the user is dropped into an editor and types a paragraph they
 /// are about to lose.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "resolves six independent CLI inputs into one request; grouping them would invent a type whose only member is this call"
+)]
 pub fn resolve_spawn_args(
     path: &str,
     task: Option<&str>,

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -37,40 +37,27 @@
 //! the re-issued inference decides what still needs doing.
 
 use std::path::Path;
-use std::sync::Arc;
 
 use bevy_ecs::entity::Entity;
 use leviath_core::run_archive;
 use leviath_core::run_meta::{ContextSnapshot, RunMeta, RunStatus};
-use leviath_mcp::ToolExecutor;
-use leviath_providers::Tool;
-use leviath_runtime::host::{SpawnArgs, SubAgentOp};
-use leviath_runtime::interaction_hub::InteractionHub;
+use leviath_runtime::host::SpawnArgs;
 use leviath_runtime::interaction_points::InteractionPointState;
 use leviath_runtime::persistence::{RunMetadata, TokenTotals};
 use leviath_runtime::restore::restore_agent;
 use leviath_runtime::world::PipelineWorld;
-use tokio::sync::Mutex;
-use tokio::sync::mpsc::UnboundedSender;
 
-use crate::config::Config;
+// Seven of recovery's former imports came in only to spell the seven parameters
+// that are now one `SpawnDeps`.
 use crate::daemon::spawn::{SpawnDeps, build_agent_for_reload};
-use crate::daemon::tool_service::CliToolService;
 
 /// Reload every non-terminal persisted run under `runs_dir`, returning the
 /// `(run_id, entity)` pairs for the host to map. Runs that fail to reload are
 /// skipped.
-#[allow(clippy::too_many_arguments)]
 pub fn reload_persisted_agents(
     world: &mut PipelineWorld,
-    tool_service: &CliToolService,
-    config: &Config,
-    shared_mcp: Arc<Mutex<ToolExecutor>>,
-    mcp_tool_defs: &[Tool],
-    hub: &InteractionHub,
+    deps: SpawnDeps<'_>,
     runs_dir: &Path,
-    now_secs: i64,
-    subagent_tx: &UnboundedSender<SubAgentOp>,
 ) -> Vec<(String, Entity)> {
     let mut reloaded: Vec<(RunMeta, Entity)> = Vec::new();
     let Ok(dir_entries) = std::fs::read_dir(runs_dir) else {
@@ -93,22 +80,11 @@ pub fn reload_persisted_agents(
     let ordered = leviath_runtime::restore::triage_restores(candidates);
     for meta in ordered {
         let run_dir = runs_dir.join(&meta.run_id);
-        match reload_one(
-            world,
-            tool_service,
-            config,
-            shared_mcp.clone(),
-            mcp_tool_defs,
-            hub,
-            &meta,
-            &run_dir,
-            now_secs,
-            subagent_tx,
-        ) {
+        match reload_one(world, deps.clone(), &meta, &run_dir) {
             Ok(entity) => reloaded.push((meta, entity)),
             Err(e) => {
                 tracing::warn!(run_id = %meta.run_id, error = %e, "skipping un-reloadable run");
-                mark_crashed(&run_dir, meta, &e.to_string(), now_secs);
+                mark_crashed(&run_dir, meta, &e.to_string(), deps.now_secs);
             }
         }
     }
@@ -128,37 +104,18 @@ pub fn reload_persisted_agents(
 /// (blueprint + tool state + context/stage) and returns the new entity. `None`
 /// if there's no such resumable run. This is the host's reload-on-demand seam
 /// (an op targeting an unloaded run pages it in first).
-#[allow(clippy::too_many_arguments)]
 pub fn reload_run(
     world: &mut PipelineWorld,
-    tool_service: &CliToolService,
-    config: &Config,
-    shared_mcp: Arc<Mutex<ToolExecutor>>,
-    mcp_tool_defs: &[Tool],
-    hub: &InteractionHub,
+    deps: SpawnDeps<'_>,
     run_id: &str,
     runs_dir: &std::path::Path,
-    now_secs: i64,
-    subagent_tx: &UnboundedSender<SubAgentOp>,
 ) -> Option<Entity> {
     let run_dir = runs_dir.join(run_id);
     let meta = read_meta(&run_dir)?;
     if is_terminal(&meta.status) {
         return None; // a finished run isn't paged back in
     }
-    reload_one(
-        world,
-        tool_service,
-        config,
-        shared_mcp,
-        mcp_tool_defs,
-        hub,
-        &meta,
-        &run_dir,
-        now_secs,
-        subagent_tx,
-    )
-    .ok()
+    reload_one(world, deps, &meta, &run_dir).ok()
 }
 
 /// Rebuild `FanOutWaiting` for any reloaded parent that was parked mid fan-out
@@ -298,18 +255,11 @@ fn is_terminal(status: &RunStatus) -> bool {
 
 /// Reload one run: spawn it fresh from its blueprint, then overlay the persisted
 /// context / stage / totals and preserve the original run metadata.
-#[allow(clippy::too_many_arguments)]
 fn reload_one(
     world: &mut PipelineWorld,
-    tool_service: &CliToolService,
-    config: &Config,
-    shared_mcp: Arc<Mutex<ToolExecutor>>,
-    mcp_tool_defs: &[Tool],
-    hub: &InteractionHub,
+    deps: SpawnDeps<'_>,
     meta: &RunMeta,
     run_dir: &Path,
-    now_secs: i64,
-    subagent_tx: &UnboundedSender<SubAgentOp>,
 ) -> Result<Entity, String> {
     let args = SpawnArgs {
         run_id: meta.run_id.clone(),
@@ -346,19 +296,7 @@ fn reload_one(
         // blueprint's partway through, and the caller would never see why.
         output: meta.output_request.clone(),
     };
-    let entity = build_agent_for_reload(
-        world.world_mut(),
-        SpawnDeps {
-            tool_service,
-            config,
-            shared_mcp,
-            mcp_tool_defs,
-            hub,
-            now_secs,
-            subagent_tx: subagent_tx.clone(),
-        },
-        &args,
-    )?;
+    let entity = build_agent_for_reload(world.world_mut(), deps, &args)?;
 
     // Restore the persisted context, stage, iteration, and token totals.
     //
@@ -515,6 +453,20 @@ fn read_final_output_from(dir: &Path, meta: &RunMeta) -> Option<leviath_core::Fi
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Named here rather than inherited from the parent: production now spells
+    // these seven as one `SpawnDeps`, so importing them above would mean seven
+    // imports the module itself does not use.
+    use std::sync::Arc;
+
+    use leviath_mcp::ToolExecutor;
+    use leviath_runtime::host::SubAgentOp;
+    use leviath_runtime::interaction_hub::InteractionHub;
+    use tokio::sync::Mutex;
+    use tokio::sync::mpsc::UnboundedSender;
+
+    use crate::config::Config;
+    use crate::daemon::tool_service::CliToolService;
+
     use leviath_runtime::ProviderRegistry;
     use leviath_runtime::components::AgentStatus;
     use leviath_runtime::inference_pool::InferencePoolConfig;
@@ -593,7 +545,10 @@ mod tests {
 
     /// Like [`write_run`], but with explicit tree links so recovery's re-linking
     /// pass can be exercised.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "a test fixture that writes one run with explicit tree links; every argument is a field of the record it writes"
+    )]
     fn write_run_tree(
         runs_dir: &Path,
         run_id: &str,
@@ -766,14 +721,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -828,14 +785,16 @@ mod tests {
         let (mut world, cli) = test_world();
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            Arc::new(Mutex::new(ToolExecutor::new())),
-            &[],
-            &InteractionHub::new(),
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: Arc::new(Mutex::new(ToolExecutor::new())),
+                mcp_tool_defs: &[],
+                hub: &InteractionHub::new(),
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs,
-            999,
-            &sub_tx(),
         );
         assert_eq!(restored.len(), 1);
         assert_eq!(restored[0].0, run_id);
@@ -960,14 +919,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1066,14 +1027,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1125,14 +1088,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1234,14 +1199,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1342,14 +1309,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1409,14 +1378,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         assert_eq!(restored.len(), 1);
@@ -1472,14 +1443,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
 
         // Terminal run skipped; the actionable (Running) run is restored first.
@@ -1504,15 +1477,17 @@ mod tests {
         assert!(
             reload_run(
                 &mut world,
-                cli.as_ref(),
-                &Config::default(),
-                mcp.clone(),
-                &[],
-                &hub,
+                crate::daemon::spawn::SpawnDeps {
+                    tool_service: cli.as_ref(),
+                    config: &Config::default(),
+                    shared_mcp: mcp.clone(),
+                    mcp_tool_defs: &[],
+                    hub: &hub,
+                    now_secs: 1,
+                    subagent_tx: sub_tx().clone(),
+                },
                 "live",
                 runs.path(),
-                1,
-                &sub_tx(),
             )
             .is_some()
         );
@@ -1520,15 +1495,17 @@ mod tests {
         assert!(
             reload_run(
                 &mut world,
-                cli.as_ref(),
-                &Config::default(),
-                mcp.clone(),
-                &[],
-                &hub,
+                crate::daemon::spawn::SpawnDeps {
+                    tool_service: cli.as_ref(),
+                    config: &Config::default(),
+                    shared_mcp: mcp.clone(),
+                    mcp_tool_defs: &[],
+                    hub: &hub,
+                    now_secs: 1,
+                    subagent_tx: sub_tx().clone(),
+                },
                 "done",
                 runs.path(),
-                1,
-                &sub_tx(),
             )
             .is_none()
         );
@@ -1536,15 +1513,17 @@ mod tests {
         assert!(
             reload_run(
                 &mut world,
-                cli.as_ref(),
-                &Config::default(),
-                mcp,
-                &[],
-                &hub,
+                crate::daemon::spawn::SpawnDeps {
+                    tool_service: cli.as_ref(),
+                    config: &Config::default(),
+                    shared_mcp: mcp,
+                    mcp_tool_defs: &[],
+                    hub: &hub,
+                    now_secs: 1,
+                    subagent_tx: sub_tx().clone(),
+                },
                 "no-such-run",
                 runs.path(),
-                1,
-                &sub_tx(),
             )
             .is_none()
         );
@@ -1605,14 +1584,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
         let by_id: std::collections::HashMap<_, _> =
             restored.iter().map(|(r, e)| (r.clone(), *e)).collect();
@@ -1681,14 +1662,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
         assert_eq!(restored.len(), 3);
         let by_id: std::collections::HashMap<_, _> =
@@ -1776,14 +1759,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
         // Only the two non-terminal runs reload.
         assert_eq!(restored.len(), 2);
@@ -1818,14 +1803,16 @@ mod tests {
         let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            999,
-            &sub_tx(),
         );
         assert_eq!(restored.len(), 1);
         assert!(world.world().get::<TokenTotals>(restored[0].1).is_some());
@@ -1840,14 +1827,16 @@ mod tests {
         assert!(
             reload_persisted_agents(
                 &mut world,
-                cli.as_ref(),
-                &Config::default(),
-                mcp.clone(),
-                &[],
-                &hub,
+                crate::daemon::spawn::SpawnDeps {
+                    tool_service: cli.as_ref(),
+                    config: &Config::default(),
+                    shared_mcp: mcp.clone(),
+                    mcp_tool_defs: &[],
+                    hub: &hub,
+                    now_secs: 1,
+                    subagent_tx: sub_tx().clone(),
+                },
                 std::path::Path::new("/no/such/runs/dir"),
-                1,
-                &sub_tx(),
             )
             .is_empty()
         );
@@ -1869,14 +1858,16 @@ mod tests {
 
         let restored = reload_persisted_agents(
             &mut world,
-            cli.as_ref(),
-            &Config::default(),
-            mcp,
-            &[],
-            &hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 1,
+                subagent_tx: sub_tx().clone(),
+            },
             runs.path(),
-            1,
-            &sub_tx(),
         );
         assert!(restored.is_empty()); // all skipped, none fatal
 

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -108,16 +108,16 @@ pub async fn setup_daemon_host(
         config.limits.mcp_idle_disconnect_secs,
     );
     mcp_pool.warm_recovered(&runs_dir).await;
-    build_host(
+    build_host(HostParts {
         config,
         providers,
         runs_dir,
-        registry.mcp,
-        registry.mcp_tool_defs,
+        shared_mcp: registry.mcp,
+        mcp_tool_defs: registry.mcp_tool_defs,
         mcp_pool,
         runtime,
-        || chrono::Utc::now().timestamp(),
-    )
+        now_secs: || chrono::Utc::now().timestamp(),
+    })
 }
 
 /// The reap hook installed on the host: drops a reaped agent's tool state and
@@ -142,48 +142,63 @@ fn make_reaper(
     })
 }
 
+/// Everything the daemon hands its world host at construction.
+///
+/// A struct rather than eight positional parameters because these are not
+/// arguments in the usual sense: each is a resource the host owns for the rest
+/// of the process's life, assembled once at boot and never varied. Naming them
+/// here describes the daemon; listing them at the call site described nothing.
+pub struct HostParts {
+    /// The resolved configuration this daemon booted with.
+    pub config: Config,
+    /// Providers built from that config, keyed by name.
+    pub providers: ProviderRegistry,
+    /// Where run state is persisted.
+    pub runs_dir: std::path::PathBuf,
+    /// MCP connections shared across every agent.
+    pub shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
+    /// The tools those servers advertise.
+    pub mcp_tool_defs: Vec<Tool>,
+    /// The pool that keeps per-agent MCP servers warm.
+    pub mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
+    /// The tokio runtime the async lanes run on.
+    pub runtime: Handle,
+    /// The clock, injected so a test does not depend on the wall clock.
+    pub now_secs: fn() -> i64,
+}
+
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
-/// service + interaction hub, and a `Spawn`-op spawner that loads blueprints and
-/// registers per-agent tool state. `shared_mcp` / `mcp_tool_defs` are the MCP
-/// connections built once at startup and reused by every agent.
-#[allow(clippy::too_many_arguments)]
-pub fn build_host(
-    config: Config,
-    providers: ProviderRegistry,
-    runs_dir: std::path::PathBuf,
-    shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
-    mcp_tool_defs: Vec<Tool>,
-    mcp_pool: Arc<crate::daemon::mcp_pool::McpPool>,
-    runtime: Handle,
-    now_secs: fn() -> i64,
-) -> WorldHost {
+/// service + interaction hub, and a `Spawn`-op spawner that loads blueprints
+/// and registers per-agent tool state. The MCP connections in [`HostParts`]
+/// are built once at startup and reused by every agent.
+pub fn build_host(parts: HostParts) -> WorldHost {
     let hub = InteractionHub::new();
     // How long a prompt may go unanswered before the hub resolves it itself, so
     // an operator who walked away costs the run a delay rather than its slot
     // for as long as the daemon lives (issue #204).
-    hub.set_timeout_secs(config.limits.interaction_timeout_secs);
+    hub.set_timeout_secs(parts.config.limits.interaction_timeout_secs);
     let tool_service = Arc::new(CliToolService::new());
     // The configured global fallback bounds concurrent inference for any model
     // without its own per-model pool entry (defaults to a small cap so a fresh
     // install can't fan out unbounded requests against provider rate limits).
     let pool_config =
-        InferencePoolConfig::new().with_default(config.limits.max_concurrent_inferences);
+        InferencePoolConfig::new().with_default(parts.config.limits.max_concurrent_inferences);
     let mut world = PipelineWorld::new(
-        providers,
+        parts.providers,
         tool_service.clone(),
         pool_config,
-        config.limits.max_concurrent_tools,
-        Some(runs_dir.clone()),
-        runtime,
+        parts.config.limits.max_concurrent_tools,
+        Some(parts.runs_dir.clone()),
+        parts.runtime,
     );
     // Opt-in accurate pre-inference budget guard (off by default).
-    world.set_exact_token_counting(config.limits.exact_token_counting);
+    world.set_exact_token_counting(parts.config.limits.exact_token_counting);
     // How long a run may sit unable to dispatch before the watchdog fails it
     // rather than leaving it "running" for ever (issue #190).
     world
         .world_mut()
         .insert_resource(leviath_runtime::pipeline::StallTimeout(
-            config.limits.stall_timeout_secs,
+            parts.config.limits.stall_timeout_secs,
         ));
     // How long a run may sit in a state nothing can reach at all before the
     // watchdog fails it and releases what it was holding (issue #202). Off
@@ -191,7 +206,7 @@ pub fn build_host(
     world
         .world_mut()
         .insert_resource(leviath_runtime::pipeline::WedgeTimeout(
-            config.limits.wedge_timeout_secs,
+            parts.config.limits.wedge_timeout_secs,
         ));
     // Take a provider out of service after it has failed this many times in a
     // row for a reason only a person can fix, so the next run does not have to
@@ -199,8 +214,8 @@ pub fn build_host(
     world
         .world_mut()
         .insert_resource(leviath_runtime::pipeline::CircuitPolicy {
-            failures_before_open: config.limits.provider_failures_before_open,
-            cooldown_secs: config.limits.provider_circuit_cooldown_secs,
+            failures_before_open: parts.config.limits.provider_failures_before_open,
+            cooldown_secs: parts.config.limits.provider_circuit_cooldown_secs,
         });
     world
         .world_mut()
@@ -211,10 +226,10 @@ pub fn build_host(
     let mut host = WorldHost::with_interactions(world, hub.clone());
     // How long the daemon may sit with a full tool lane and no run moving before
     // it widens the lane to break the jam (issue #191).
-    host.set_dead_cycles_before_relief(config.limits.dead_cycles_before_relief);
+    host.set_dead_cycles_before_relief(parts.config.limits.dead_cycles_before_relief);
     // How long a finished run keeps its place in the listing, so a scheduler
     // polling on an interval can see how a run ended (issue #205).
-    host.set_finished_retention_secs(config.limits.finished_retention_secs);
+    host.set_finished_retention_secs(parts.config.limits.finished_retention_secs);
     // Handed to each agent's tool state so its sub-agent tools reach the world
     // through the host.
     let subagent_tx = host.subagent_sender();
@@ -224,43 +239,45 @@ pub fn build_host(
     // shared resources.
     let reloaded = crate::daemon::recovery::reload_persisted_agents(
         host.world_mut(),
-        tool_service.as_ref(),
-        &config,
-        shared_mcp.clone(),
-        &mcp_tool_defs,
-        &hub,
-        &runs_dir,
-        now_secs(),
-        &subagent_tx,
+        crate::daemon::spawn::SpawnDeps {
+            tool_service: tool_service.as_ref(),
+            config: &parts.config,
+            shared_mcp: parts.shared_mcp.clone(),
+            mcp_tool_defs: &parts.mcp_tool_defs,
+            hub: &hub,
+            now_secs: (parts.now_secs)(),
+            subagent_tx: subagent_tx.clone(),
+        },
+        &parts.runs_dir,
     );
     for (run_id, entity) in reloaded {
         host.register(run_id, entity);
     }
 
-    // Config hot-reload: after boot, spawn-time config (permissions,
+    // Config hot-reload: after boot, spawn-time parts.config (permissions,
     // `[read_paths]`, sandbox, limits, taint) is served from here, reloaded
-    // when `config.toml` changes on disk. The boot infrastructure (provider
+    // when `parts.config.toml` changes on disk. The boot infrastructure (provider
     // registry, MCP pool, network policy, telemetry) keeps the boot snapshot -
     // those hold live connections and need a restart - so the reloader takes a
     // clone and the boot snapshot stays usable below.
     let reloader = std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
         Config::config_path(),
-        config.clone(),
+        parts.config.clone(),
     ));
 
-    // Install the fan-out spawner as a world resource so the runtime's fan-out
+    // Install the fan-out spawner as a world resource so the parts.runtime's fan-out
     // systems can start workers (it captures the same context as the spawner
     // below, cloned before those move into the closure).
     let fanout_spawner = DaemonFanOutSpawner {
         config: reloader.clone(),
-        shared_mcp: shared_mcp.clone(),
-        mcp_tool_defs: mcp_tool_defs.clone(),
-        mcp_pool: mcp_pool.clone(),
+        shared_mcp: parts.shared_mcp.clone(),
+        mcp_tool_defs: parts.mcp_tool_defs.clone(),
+        mcp_pool: parts.mcp_pool.clone(),
         hub: hub.clone(),
         subagent_tx: subagent_tx.clone(),
         tool_service: tool_service.clone(),
         agents_dir: leviath_core::paths::agents_dir(),
-        now_secs,
+        now_secs: parts.now_secs,
     };
     host.world_mut()
         .world_mut()
@@ -278,9 +295,11 @@ pub fn build_host(
     // `[title]` is enabled, and the dispatch system reads provider/model here.
     host.world_mut()
         .world_mut()
-        .insert_resource(leviath_runtime::title::TitleSettings(config.title.clone()));
+        .insert_resource(leviath_runtime::title::TitleSettings(
+            parts.config.title.clone(),
+        ));
 
-    // Scripted gate rules (`<config>/leviath/rules/*.rhai`), consulted by the gate
+    // Scripted gate rules (`<parts.config>/leviath/rules/*.rhai`), consulted by the gate
     // after the static allowlist (a no-op checker when there are none).
     let script_checker =
         crate::daemon::gate_rules::build_gate_script_checker(&crate::commands::policy::rules_dir());
@@ -293,7 +312,7 @@ pub fn build_host(
     // the daemon's own tracing events through the same pipeline. A pipeline
     // that fails to build logs a warning and leaves the no-op in place -
     // observability must never stop the work it observes.
-    if let Some(built) = leviath_telemetry::build_sink(&config.observability) {
+    if let Some(built) = leviath_telemetry::build_sink(&parts.config.observability) {
         host.world_mut()
             .world_mut()
             .insert_resource(leviath_runtime::telemetry::Telemetry(built.sink));
@@ -307,27 +326,29 @@ pub fn build_host(
     // originals below).
     let reload_tools = tool_service.clone();
     let reload_reloader = reloader.clone();
-    let reload_mcp = shared_mcp.clone();
-    let reload_defs = mcp_tool_defs.clone();
+    let reload_mcp = parts.shared_mcp.clone();
+    let reload_defs = parts.mcp_tool_defs.clone();
     let reload_hub = hub.clone();
     let reload_tx = subagent_tx.clone();
-    let reload_runs = runs_dir.clone();
-    let reload_pool = mcp_pool.clone();
+    let reload_runs = parts.runs_dir.clone();
+    let reload_pool = parts.mcp_pool.clone();
     host.set_reloader(Box::new(move |world, run_id| {
-        // Pages a run back in with the current on-disk config, matching what a
+        // Pages a run back in with the current on-disk parts.config, matching what a
         // real restart would restore it with.
         let reload_config = reload_reloader.current();
         let entity = crate::daemon::recovery::reload_run(
             world,
-            reload_tools.as_ref(),
-            &reload_config,
-            reload_mcp.clone(),
-            &reload_defs,
-            &reload_hub,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: reload_tools.as_ref(),
+                config: &reload_config,
+                shared_mcp: reload_mcp.clone(),
+                mcp_tool_defs: &reload_defs,
+                hub: &reload_hub,
+                now_secs: (parts.now_secs)(),
+                subagent_tx: reload_tx.clone(),
+            },
             run_id,
             &reload_runs,
-            now_secs(),
-            &reload_tx,
         );
         lease_reloaded(&reload_pool, run_id, entity.is_some());
         entity
@@ -338,16 +359,17 @@ pub fn build_host(
     // rebuilt - deleted blueprint, unreadable metadata, died mid-spawn - and
     // without this a cancel in that state wrote nothing at all, so `meta.json`
     // went on claiming the run was live and nothing could ever clear it.
-    let terminate_runs = runs_dir.clone();
+    let terminate_runs = parts.runs_dir.clone();
     host.set_force_terminator(Box::new(move |run_id| {
-        crate::runstate::force_cancel_in(&terminate_runs.join(run_id), now_secs()).found_run()
+        crate::runstate::force_cancel_in(&terminate_runs.join(run_id), (parts.now_secs)())
+            .found_run()
     }));
 
     // Reap hook: when a terminal agent is reaped, tear down its sandbox and drop
     // its per-agent tool state (the latter also fixing a prior leak where tool
     // state was never released). Factored into `make_reaper` so the closure body
     // is unit-testable - the daemon only ever drives it from `serve()`.
-    host.set_reaper(make_reaper(tool_service.clone(), mcp_pool.clone()));
+    host.set_reaper(make_reaper(tool_service.clone(), parts.mcp_pool.clone()));
 
     // The shared MCP pool (created + recovery-warmed by the caller). Per-agent
     // `[[mcp_servers]]` connect lazily through it.
@@ -357,7 +379,7 @@ pub fn build_host(
     // and pre-warm the servers declared by any `worker_agent`/`worker_query`
     // fan-out worker this blueprint will spawn, so the *first* such worker already
     // advertises them (they'd otherwise land one turn late - issue #97).
-    let pp_pool = mcp_pool.clone();
+    let pp_pool = parts.mcp_pool.clone();
     let pp_agents_dir = leviath_core::paths::agents_dir();
     host.set_spawn_preprocessor(Box::new(move |args| {
         let pool = pp_pool.clone();
@@ -369,11 +391,11 @@ pub fn build_host(
         })
     }));
 
-    // The spawner captures everything an agent needs; `now_secs` is called at
+    // The spawner captures everything an agent needs; `parts.now_secs` is called at
     // spawn time for the run's start timestamp. Per-agent MCP defs = the global
     // servers' defs plus this blueprint's declared servers' defs (warmed above).
-    let spawn_pool = mcp_pool.clone();
-    let spawn_runs_dir = runs_dir.clone();
+    let spawn_pool = parts.mcp_pool.clone();
+    let spawn_runs_dir = parts.runs_dir.clone();
     let spawn_reloader = reloader.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
@@ -383,7 +405,7 @@ pub fn build_host(
         // The reload path deliberately doesn't do this: it must not overwrite a
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
-        let defs = per_agent_mcp_defs(&spawn_pool, &mcp_tool_defs, &args.blueprint_path);
+        let defs = per_agent_mcp_defs(&spawn_pool, &parts.mcp_tool_defs, &args.blueprint_path);
         // Hold the blueprint's per-agent servers open for this run's life;
         // the reap hook releases them (idle-disconnect follows).
         spawn_pool.lease_blueprint(&args.blueprint_path, &args.run_id);
@@ -396,10 +418,10 @@ pub fn build_host(
             crate::daemon::spawn::SpawnDeps {
                 tool_service: tool_service.as_ref(),
                 config: &config,
-                shared_mcp: shared_mcp.clone(),
+                shared_mcp: parts.shared_mcp.clone(),
                 mcp_tool_defs: &defs,
                 hub: &hub,
-                now_secs: now_secs(),
+                now_secs: (parts.now_secs)(),
                 subagent_tx: subagent_tx.clone(),
             },
             args,
@@ -412,7 +434,7 @@ pub fn build_host(
             crate::runstate::force_error_in(
                 &spawn_runs_dir.join(&args.run_id),
                 message,
-                now_secs(),
+                (parts.now_secs)(),
             );
         }
         built
@@ -781,43 +803,53 @@ mod tests {
     #[tokio::test]
     async fn spawner_writes_the_placeholder_under_the_hosts_runs_dir() {
         let runs = tempfile::tempdir().unwrap();
-        // Resolve the global dir once: sibling tests redirect it via the
-        // process-global `LEVIATH_RUNS_DIR`, so resolving it twice could compare
-        // two different directories.
-        let global = crate::runstate::runs_dir();
-        let global_before = run_ids_in(&global);
+        // The assertion below is "spawning wrote nothing into the *global* runs
+        // dir", which is only decidable if no other test can write there while
+        // this one runs. Resolving it once is not enough - that was the previous
+        // attempt, and it still compared a directory the rest of the suite
+        // shares. `with_isolated_runs_dir_async` points `LEVIATH_RUNS_DIR` at a
+        // directory only this test can reach, and `temp_env` serialises the
+        // change process-wide, so the comparison is deterministic.
+        crate::runstate::with_isolated_runs_dir_async(
+            "setup-host-isolation",
+            |global| async move {
+                let global_before = run_ids_in(&global);
 
-        let mut host = setup_daemon_host(
-            Config::default(),
-            runs.path().to_path_buf(),
-            Handle::current(),
+                let mut host = setup_daemon_host(
+                    Config::default(),
+                    runs.path().to_path_buf(),
+                    Handle::current(),
+                )
+                .await;
+                let (reply, rx) = oneshot::channel();
+                host.handle(ControlOp::Spawn {
+                    args: Box::new(SpawnArgs {
+                        // A blueprint that doesn't exist: the spawn fails *after* the
+                        // placeholder is staked out, which is the case that leaves a run
+                        // dir behind.
+                        run_id: "isolation-1234-ab12".to_string(),
+                        blueprint_path: "/no/such/agent.leviath".to_string(),
+                        task: "t".to_string(),
+                        workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                        ..Default::default()
+                    }),
+                    reply,
+                });
+                assert!(rx.await.unwrap().is_err(), "the spawn itself fails");
+
+                assert!(
+                    crate::runstate::read_meta_from(&runs.path().join("isolation-1234-ab12"))
+                        .is_ok(),
+                    "the placeholder lands in the host's configured runs dir"
+                );
+                assert_eq!(
+                    run_ids_in(&global),
+                    global_before,
+                    "spawning through a host must not write into the home-resolved runs dir"
+                );
+            },
         )
         .await;
-        let (reply, rx) = oneshot::channel();
-        host.handle(ControlOp::Spawn {
-            args: Box::new(SpawnArgs {
-                // A blueprint that doesn't exist: the spawn fails *after* the
-                // placeholder is staked out, which is the case that leaves a run
-                // dir behind.
-                run_id: "isolation-1234-ab12".to_string(),
-                blueprint_path: "/no/such/agent.leviath".to_string(),
-                task: "t".to_string(),
-                workdir: std::env::temp_dir().to_string_lossy().to_string(),
-                ..Default::default()
-            }),
-            reply,
-        });
-        assert!(rx.await.unwrap().is_err(), "the spawn itself fails");
-
-        assert!(
-            crate::runstate::read_meta_from(&runs.path().join("isolation-1234-ab12")).is_ok(),
-            "the placeholder lands in the host's configured runs dir"
-        );
-        assert_eq!(
-            run_ids_in(&global),
-            global_before,
-            "spawning through a host must not write into the home-resolved runs dir"
-        );
     }
 
     /// End-to-end for the unkillable-run shape: a run whose blueprint no longer
@@ -1168,19 +1200,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             ..Config::default()
         };
         let runs = tempfile::tempdir().unwrap();
-        let _host = build_host(
+        let _host = build_host(HostParts {
             config,
-            ProviderRegistry::new(),
-            runs.path().to_path_buf(),
-            Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
-            Vec::new(),
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+            providers: ProviderRegistry::new(),
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 0,
-        );
+            runtime: Handle::current(),
+            now_secs: || 0,
+        });
     }
 
     #[tokio::test]
@@ -1196,19 +1228,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             ..Config::default()
         };
         let runs = tempfile::tempdir().unwrap();
-        let mut host = build_host(
+        let mut host = build_host(HostParts {
             config,
-            ProviderRegistry::new(),
-            runs.path().to_path_buf(),
-            Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
-            Vec::new(),
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+            providers: ProviderRegistry::new(),
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 0,
-        );
+            runtime: Handle::current(),
+            now_secs: || 0,
+        });
         assert!(
             host.world_mut()
                 .world_mut()
@@ -1234,19 +1266,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             ..Config::default()
         };
         let runs = tempfile::tempdir().unwrap();
-        let mut host = build_host(
+        let mut host = build_host(HostParts {
             config,
-            ProviderRegistry::new(),
-            runs.path().to_path_buf(),
-            Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
-            Vec::new(),
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+            providers: ProviderRegistry::new(),
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 0,
-        );
+            runtime: Handle::current(),
+            now_secs: || 0,
+        });
         assert!(
             host.world_mut()
                 .world_mut()
@@ -1267,19 +1299,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         let mut providers = ProviderRegistry::new();
         providers.register("fake".to_string(), Arc::new(FakeProvider));
         let runs = tempfile::tempdir().unwrap();
-        let mut host = build_host(
-            Config::default(),
+        let mut host = build_host(HostParts {
+            config: Config::default(),
             providers,
-            runs.path().to_path_buf(),
-            Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
-            Vec::new(),
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 0,
-        );
+            runtime: Handle::current(),
+            now_secs: || 0,
+        });
         let (ctl_tx, ctl_rx) = tokio::sync::mpsc::unbounded_channel();
         let (reply, reply_rx) = oneshot::channel();
         ctl_tx
@@ -1345,19 +1377,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
 
         let runs = tempfile::tempdir().unwrap();
-        let mut host = build_host(
-            Config::default(),
-            registry,
-            runs.path().to_path_buf(),
-            mcp,
-            vec![],
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+        let mut host = build_host(HostParts {
+            config: Config::default(),
+            providers: registry,
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: mcp,
+            mcp_tool_defs: vec![],
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 100,
-        );
+            runtime: Handle::current(),
+            now_secs: || 100,
+        });
 
         // Drive a Spawn control op through the host.
         let (reply, rx) = oneshot::channel();
@@ -1448,19 +1480,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         let mut registry = ProviderRegistry::new();
         registry.register("anthropic".to_string(), Arc::new(FakeProvider));
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
-        let mut host = build_host(
-            Config::default(),
-            registry,
-            runs.path().to_path_buf(),
-            mcp,
-            vec![],
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+        let mut host = build_host(HostParts {
+            config: Config::default(),
+            providers: registry,
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: mcp,
+            mcp_tool_defs: vec![],
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 100,
-        );
+            runtime: Handle::current(),
+            now_secs: || 100,
+        });
 
         // The reloaded run is registered → Status resolves it.
         let (reply, rx) = oneshot::channel();
@@ -1484,19 +1516,19 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
         let mut registry = ProviderRegistry::new();
         registry.register("anthropic".to_string(), Arc::new(FakeProvider));
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
-        let mut host = build_host(
-            Config::default(),
-            registry,
-            runs.path().to_path_buf(),
-            mcp,
-            vec![],
-            crate::daemon::mcp_pool::McpPool::for_daemon(
+        let mut host = build_host(HostParts {
+            config: Config::default(),
+            providers: registry,
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: mcp,
+            mcp_tool_defs: vec![],
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
                 Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
                 &[],
             ),
-            Handle::current(),
-            || 100,
-        );
+            runtime: Handle::current(),
+            now_secs: || 100,
+        });
 
         // Persist a running run only now - build_host's startup reload already ran,
         // so it is on disk but absent from the world.

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -57,6 +57,7 @@ use tool_state::*;
 /// call in which `config`, `mcp_tool_defs` and `hub` are adjacent references:
 /// transposing two of them type-checks in some orders, and the compiler is the
 /// only thing that was ever going to notice.
+#[derive(Clone)]
 pub struct SpawnDeps<'a> {
     /// The daemon's tool service, which per-agent state is registered against.
     pub tool_service: &'a CliToolService,

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -468,7 +468,6 @@ mod tests {
     /// `statuses` answers successive `Check`s for *children* in order (`None`
     /// once exhausted); `ok` answers `Send`/`Kill`. The caller ("parent") is
     /// reported `Active` - see [`fake_host_with_parent`] to script it.
-    #[allow(clippy::type_complexity)]
     fn fake_host(
         spawn_result: Result<String, String>,
         statuses: Vec<Option<AgentStatus>>,
@@ -483,7 +482,6 @@ mod tests {
 
     /// [`fake_host`] with the child's submitted answer scripted too, so the
     /// "return its final result" half of `check`/`wait` can be exercised.
-    #[allow(clippy::type_complexity)]
     fn fake_host_with_output(
         statuses: Vec<Option<AgentStatus>>,
         output: Option<leviath_core::output::FinalOutput>,
@@ -502,7 +500,6 @@ mod tests {
     }
 
     /// [`fake_host`] with the calling agent's own status scripted too.
-    #[allow(clippy::type_complexity)]
     fn fake_host_with_parent(
         spawn_result: Result<String, String>,
         statuses: Vec<Option<AgentStatus>>,
@@ -517,7 +514,6 @@ mod tests {
     }
 
     /// The one fake behind the three wrappers above.
-    #[allow(clippy::type_complexity)]
     fn fake_host_full(
         spawn_result: Result<String, String>,
         statuses: Vec<Option<AgentStatus>>,
@@ -994,7 +990,10 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     }
 
     /// A host that answers only `Send`, recording each op's `target_region`.
-    #[allow(clippy::type_complexity)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "returns the handle beside the recording buffer the assertions read"
+    )]
     fn send_recording_host() -> (
         SubAgentHandle,
         std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>,

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -121,7 +121,10 @@ pub enum Commands {
 ///
 /// `async fn` in a trait is fine here: `dispatch` takes `&impl RiskyExecutors`
 /// (static dispatch, no `dyn`), so no boxing or `Send` bound is required.
-#[allow(async_fn_in_trait)]
+#[expect(
+    async_fn_in_trait,
+    reason = "the trait exists to be a test seam and is never used as a dyn object, so the auto-trait bounds the lint warns about cannot matter here"
+)]
 pub trait RiskyExecutors {
     /// `lev run` - auto-starts the daemon (real process spawn) if needed and
     /// spawns the agent into the shared world over the control socket.

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -52,7 +52,10 @@ pub struct CrosstermEventSource {
     read_fn: fn() -> std::io::Result<Event>,
 }
 
-#[allow(clippy::new_without_default)] // constructed only by the binary's real UI entrypoints
+#[expect(
+    clippy::new_without_default,
+    reason = "constructed only by the binary's real UI entrypoints, where a Default would be a way to build one that reads no terminal"
+)] // constructed only by the binary's real UI entrypoints
 impl CrosstermEventSource {
     /// Read from the real terminal.
     pub fn new() -> Self {

--- a/crates/leviath-cli/tests/agent_end_to_end.rs
+++ b/crates/leviath-cli/tests/agent_end_to_end.rs
@@ -171,20 +171,20 @@ async fn an_agent_runs_a_tool_and_the_file_lands_on_disk() {
     );
 
     let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
-    let mut host = leviath_cli::daemon::setup::build_host(
-        leviath_cli::config::Config::default(),
+    let mut host = leviath_cli::daemon::setup::build_host(leviath_cli::daemon::setup::HostParts {
+        config: leviath_cli::config::Config::default(),
         providers,
-        runs.path().to_path_buf(),
-        mcp,
-        vec![],
-        leviath_cli::daemon::mcp_pool::McpPool::for_daemon(
+        runs_dir: runs.path().to_path_buf(),
+        shared_mcp: mcp,
+        mcp_tool_defs: vec![],
+        mcp_pool: leviath_cli::daemon::mcp_pool::McpPool::for_daemon(
             Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             &[],
         ),
-        Handle::current(),
+        runtime: Handle::current(),
         // A fixed clock, so nothing here is a function of how long CI took.
-        || 1_700_000_000,
-    );
+        now_secs: || 1_700_000_000,
+    });
 
     let (reply, spawned) = oneshot::channel();
     host.handle(ControlOp::Spawn {

--- a/crates/leviath-mcp/src/transport/jsonrpc.rs
+++ b/crates/leviath-mcp/src/transport/jsonrpc.rs
@@ -59,9 +59,6 @@ impl JsonRpcRequest {
 /// A JSON-RPC response frame.
 #[derive(Deserialize)]
 pub(crate) struct JsonRpcResponse {
-    #[allow(dead_code)]
-    pub(crate) jsonrpc: String,
-    #[allow(dead_code)]
     pub(crate) id: Option<Value>,
     pub(crate) result: Option<Value>,
     pub(crate) error: Option<JsonRpcError>,
@@ -70,7 +67,9 @@ pub(crate) struct JsonRpcResponse {
 /// The `error` member of a JSON-RPC response.
 #[derive(Deserialize)]
 pub(crate) struct JsonRpcError {
-    #[allow(dead_code)]
+    /// The JSON-RPC error code, surfaced in the message because it is the half
+    /// of the error a reader can look up: `-32601` says "method not found"
+    /// whatever prose the server chose to pair with it.
     pub(crate) code: i64,
     pub(crate) message: String,
 }
@@ -81,7 +80,11 @@ impl JsonRpcResponse {
     /// `result` nor `error` (which is malformed, but servers do emit it).
     pub(crate) fn into_result(self) -> anyhow::Result<Value> {
         if let Some(error) = self.error {
-            return Err(anyhow::anyhow!("MCP server error: {}", error.message));
+            return Err(anyhow::anyhow!(
+                "MCP server error {}: {}",
+                error.code,
+                error.message
+            ));
         }
         self.result
             .ok_or_else(|| anyhow::anyhow!("MCP server returned no result"))

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -121,7 +121,10 @@ impl GeminiProvider {
         // All families currently share these values; the match keeps them
         // labelled by family so any one can be adjusted independently (the arms
         // are intentionally identical today - divergence-readiness scaffolding).
-        #[allow(clippy::match_same_arms)]
+        #[expect(
+            clippy::match_same_arms,
+            reason = "the arms are identical today and deliberately kept separate, so each family's limits can move without disturbing the others"
+        )]
         let (max_context_tokens, max_output_tokens) = match GeminiFamily::classify(model) {
             GeminiFamily::FlashLite => (1_048_576, 65_535),
             GeminiFamily::Pro => (1_048_576, 65_535),

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -109,7 +109,10 @@ impl RhaiProvider {
 
     /// Build a provider from in-memory source with an injected [`HttpExecutor`]
     /// (used by tests to avoid real network I/O).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the injected-executor constructor takes what the real one reads from config, one parameter per setting, so a struct here would only move the list"
+    )]
     pub fn from_source(
         name: String,
         src: &str,

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -106,7 +106,10 @@ fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
 /// Temporary-style block with a warning; success is followed by a warn-only
 /// token re-check against the region's budget (no truncation - the opt-in
 /// exact-token preflight remains the hard guard).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "renders through a script into two caller-owned accumulators, so the accumulators and the script context cannot be collapsed into one value"
+)]
 pub(crate) fn render_custom_region(
     region: &Region,
     script: Option<&Arc<RegionScript>>,

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -111,7 +111,10 @@ fn build_gate_request(
 
 /// Ask the user how to resolve a blocked outbound call, then report the
 /// resolution on the lane and wake the tick loop.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "an async lane entry point: the prompt, the lane sender, the waker and the resolution channel are four unrelated lifetimes"
+)]
 pub async fn run_gate_prompt(
     entity: Entity,
     hub: InteractionHub,

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -276,7 +276,10 @@ enum Routed {
 /// Ask an interaction point through the hub, resolve + route the answer (doing
 /// the edit branch's second "edit this text" ask when needed), and report the
 /// [`PointOutcome`] on the lane, waking the tick loop.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "same shape as run_gate_prompt, plus the edit branch's second ask"
+)]
 async fn run_interaction_point(
     entity: Entity,
     hub: InteractionHub,

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -274,7 +274,10 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
 /// the progress stamp where it was. Taken as a plain `Option` rather than the
 /// watermark it comes from so this stays a data mapper with no dependency on the
 /// persistence pipeline.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "meta.json has this many independent fields; the struct this would take is RunMetadata, which is what it returns"
+)]
 pub fn build_run_meta(
     md: &RunMetadata,
     state: &AgentState,

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -210,7 +210,10 @@ pub fn spawn_agent(
 /// the agent as a [`crate::pipeline::response::GlobalNudge`] component; each
 /// field is resolved per stage against the blueprint's agent-level and
 /// per-stage nudge settings when an empty response is handled.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "spawns an entity from a blueprint plus five independent seed sources; the sources have nothing in common but this call"
+)]
 pub fn spawn_agent_seeded(
     world: &mut World,
     agent_id: String,

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -298,7 +298,10 @@ type DispatchToolsQuery = (
 /// with an ack the exec waits on, and a per-call [`ToolProgress`] journals each
 /// completion as a `ToolCallDone`. On a crash mid-batch, recovery replays the
 /// recorded results instead of re-running their side effects (issue #96).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "a bevy system: every parameter is a distinct Query or Res the scheduler injects, and the ECS decides the signature rather than this code"
+)]
 pub fn dispatch_tools(
     mut agents: Query<DispatchToolsQuery, With<ReadyForTools>>,
     service: Res<ToolServiceRes>,

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -563,7 +563,10 @@ pub fn resolve_transition(
 /// `Ok` carries the stage's updated visit count (this entry included), which the
 /// transition systems stamp into the [`StageTransition`](crate::host::WorldEvent)
 /// event.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "updates seven unrelated per-stage components in one pass, which is cheaper than seven queries over the same entity"
+)]
 pub(crate) fn enter_stage(
     idx: usize,
     blueprint: &leviath_core::Blueprint,

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -361,7 +361,6 @@ impl TaintGate {
         &self.audit_log
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn log_event(
         &mut self,
         agent_id: &str,

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1374,7 +1374,10 @@ mod tests {
     // `set_readonly(false)` widens Unix perms beyond the original, but here it
     // only re-enables cleanup of a throwaway tempdir file, which is exactly
     // what we want.
-    #[allow(clippy::permissions_set_readonly_false)]
+    #[expect(
+        clippy::permissions_set_readonly_false,
+        reason = "same as the blueprints test: set_readonly(false) here only re-enables cleanup of a temp file this test created moments ago"
+    )]
     #[tokio::test]
     async fn edit_file_write_failure_after_successful_match() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
refactor: make lint suppressions expire, and delete the ones that already had

Every `#[allow(...)]` in the tree is now `#[expect(..., reason = "...")]`, and an
ast-grep rule bans the bare form. The difference is not style: `expect` fails the
build the moment the lint stops firing, so a suppression cannot outlive the
problem it was written for. `allow` is silent in that case, which means it
outlives it forever and the next reader assumes it is load-bearing.

## Six were already dead

The conversion found them on the first run, which is the argument for it:

- `JsonRpcResponse::id` was marked `dead_code` and is read at `http.rs:626`.
- `taint.rs::log_event` has seven parameters - clippy's threshold is *over*
  seven, so the lint never fired.
- `TestCase` in `commands/test.rs`, and four `subagent.rs` test fakes whose
  tuples are no longer complex enough to trip anything.

None of these would ever have surfaced on their own.

## Then eleven more were fixed rather than suppressed

`recovery.rs` was the interesting one. Its three entry points each took the
*same seven parameters* - and those seven are exactly `SpawnDeps`, because the
bottom of the chain builds one to call `build_agent_for_reload`. They now take
the struct, which deleted three suppressions and **seven imports**: `Arc`,
`ToolExecutor`, `Tool`, `SubAgentOp`, `InteractionHub`, `Mutex`,
`UnboundedSender` were in that file only to spell parameters that are now one
type.

`build_host` takes `HostParts` for the same reason, across nine call sites. It
is the daemon's composition root: eight resources it owns for the life of the
process, assembled once at boot. Naming them describes the daemon; listing them
at the call site described nothing.

## Two things worth reporting rather than burying

**The JSON-RPC error code now reaches the message.** `JsonRpcError::code` was
parsed and binned - `into_result` produced `"MCP server error: {message}"` and
threw away the machine-readable half. It now reads
`"MCP server error -32601: Method not found"`.

**`lev test` silently ignores `max_tokens`.** The field is documented in the
example test file and never read, so a case that sets it is capped by the model's
limit like every other case. Left in place with a suppression that says exactly
that, rather than deleted - deleting it makes the documented key silently
unknown, which is the same silence with less to grep for.

## And one flaky test made deterministic

`spawner_writes_the_placeholder_under_the_hosts_runs_dir` asserts that spawning
writes nothing into the *global* runs dir - which is only decidable if no other
test can write there meanwhile. It resolved that directory once (a previous
attempt at the same bug) but still shared it with the whole suite. It now runs
under `with_isolated_runs_dir_async`, so the directory is its own and `temp_env`
serialises the change. Five consecutive runs green, where it failed roughly
every other run before.

Suppressions: **31 → 20**, `too_many_arguments` 14 → 10. The remainder are the
harder ones and are being worked through separately.
