### PR TITLE
refactor: param structs for four of the long signatures

### DIFF
--- a/.sgrules/no-lint-suppression.yml
+++ b/.sgrules/no-lint-suppression.yml
@@ -1,0 +1,21 @@
+id: no-lint-suppression
+language: rust
+severity: error
+message: >-
+  This lint may not be suppressed. Every one of these was cleared from the tree
+  by changing the code, and the fix was usually better than the suppression:
+  `too_many_arguments` became parameter structs (and `SystemParam` for the bevy
+  system), `permissions_set_readonly_false` became restoring the file's original
+  permissions rather than synthesising "not read-only", `deprecated` became
+  socket2 (the layer that owns socket options), `async_fn_in_trait` became an
+  explicit `impl Future` that states whether the future is `Send`,
+  `match_same_arms` became one named constant per case, and `new_without_default`
+  became a constructor named for what it does. If a new one seems unavoidable,
+  it is worth an hour before it is worth an attribute - and if it genuinely is
+  unavoidable, change this rule in the same PR and say why.
+  `clippy::string_slice` is the one exception, and only as `#[expect(...,
+  reason = "...")]`: the root Cargo.toml documents it as the sanctioned hatch,
+  naming the construct that guarantees the index is a char boundary.
+rule:
+  kind: attribute_item
+  regex: '(allow|expect)\((clippy::(too_many_arguments|type_complexity|match_same_arms|new_without_default|permissions_set_readonly_false|enum_variant_names)|dead_code|deprecated|async_fn_in_trait)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,41 @@ npm install -g @ast-grep/cli     # via npm
 
 The workspace is gated at a hard **100%** on lines, regions, and functions, with no way to opt out. Coverage-suppression markers (`#[cfg(not(test))]`, `coverage(off)`, tarpaulin/lcov/grcov annotations) are banned by the ast-grep lint above, so code can't be hidden from measurement; it has to be refactored until it's testable. The *only* un-unit-tested code is the thin `lev` binary entrypoint (`crates/leviath-cli/src/main.rs`): the composition root that wires real terminal, stdin, network, and subprocess I/O into the library's tested cores. It's excluded from coverage measurement and guarded by a CI check that requires maintainer sign-off to change.
 
+### Suppressing a lint
+
+You cannot. `cargo xtask`'s ast-grep rules fail the build on `#[allow(...)]` or
+`#[expect(...)]` for `too_many_arguments`, `type_complexity`, `dead_code`,
+`deprecated`, `async_fn_in_trait`, `match_same_arms`, `new_without_default`,
+`permissions_set_readonly_false` and `enum_variant_names`.
+
+Every one of those was cleared from this tree by changing the code, and in each
+case the change was better than the suppression it replaced:
+
+| Lint | What it turned into |
+|---|---|
+| `too_many_arguments` | Parameter structs, and `#[derive(SystemParam)]` for the bevy system. One of them exposed the same three fields written out twice, now a single `PromptLane<T>` |
+| `permissions_set_readonly_false` | Restoring the file's *original* permissions instead of synthesising "not read-only" — which on Unix hands back `0o666` for a file that was `0o644` |
+| `deprecated` | `socket2`, the layer that owns socket options, rather than tokio's wrapper that deprecates the option because it blocks a *runtime* thread |
+| `async_fn_in_trait` | An explicit `impl Future` that states whether the future is `Send`. Adding the bound to `RiskyExecutors` did not compile, which is the useful answer: those futures hold non-`Send` state across awaits and the `async fn` left that unsaid |
+| `match_same_arms` | One named constant per case, so "these can move independently" is expressed rather than commented |
+| `new_without_default` | A constructor named for what it does (`open`, not `new`) |
+| `dead_code` | Deleting the field, or wiring it up — `lev test` had two keys that parsed and did nothing |
+
+`clippy::string_slice` is the one exception, and only as `#[expect(..., reason =
+"...")]` naming the construct that guarantees the index is a char boundary. The
+root `Cargo.toml` explains why that one has a hatch: it exists because slicing a
+`&str` aborted the daemon twice.
+
+`#[expect]` rather than `#[allow]` for that exception, and the difference
+matters: `expect` fails the build the moment the lint stops firing, so a
+suppression cannot outlive the problem it was written for. Converting the tree
+from `allow` to `expect` found **six** that were already dead, including a
+`dead_code` on a field that was being read.
+
+If a new suppression looks unavoidable, it is worth an hour before it is worth an
+attribute. If it genuinely is unavoidable, change `.sgrules/no-lint-suppression.yml`
+in the same PR and say why.
+
 ### How long a file may be
 
 `cargo xtask structure` holds every source file to **1,200 lines of production code**, and the pre-commit hook and CI both run it. It costs about a tenth of a second: it reads files and counts, nothing more.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "socket2",
  "temp-env",
  "tempfile",
  "tokio",

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -87,6 +87,15 @@ tempfile = "3"
 
 [dev-dependencies]
 leviath-testkit = { workspace = true }
+# `SO_LINGER(0)` on one websocket test's socket, to force an RST rather than a
+# FIN. Tokio deprecates its own `set_linger` because the option blocks a runtime
+# thread on drop - a real hazard, and irrelevant to a socket the test closes
+# immediately. socket2 is the layer that owns socket options, is already in the
+# tree as a tokio dependency, and makes no claim about a runtime, so this is
+# using the right API rather than silencing the wrong one.
+socket2 = "0.6"
+
+
 # A TLS *client*, so the HTTPS server is tested with a real handshake against a
 # root store holding exactly the test certificate. Verifying rather than
 # skipping verification is the point: a client that accepted anything would

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -494,22 +494,22 @@ async fn spawn_and_wait(
     // `--yolo`: a probe that stops to ask a person for a tool approval has
     // stopped being a probe. It advertises no tools, so this waives nothing
     // that could actually run.
-    let args = crate::daemon::client::resolve_spawn_args(
-        &manifest.to_string_lossy(),
-        Some(PROBE_PROMPT),
+    let args = crate::daemon::client::resolve_spawn_args(crate::daemon::client::LaunchRequest {
+        path: &manifest.to_string_lossy(),
+        task: Some(PROBE_PROMPT),
         // The probe brings its own task, so the editor fallback is unreachable.
         // Answering "not a terminal" anyway makes that structural rather than
         // incidental: a doctor that opened an editor would be a bad joke.
-        &|| false,
-        None,
-        &workdir.to_string_lossy(),
-        true,
-        Vec::new(),
-        None,
-        std::collections::HashMap::new(),
-        false,
-        None,
-    );
+        stdin_is_terminal: &|| false,
+        model: None,
+        workdir: &workdir.to_string_lossy(),
+        yolo: true,
+        allow: Vec::new(),
+        max_depth: None,
+        regions: std::collections::HashMap::new(),
+        no_seed_commands: false,
+        output_request: None,
+    });
     let args = match args {
         Ok(args) => args,
         Err(e) => return DaemonOutcome::Failed(format!("could not build the spawn request: {e}")),

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -1068,7 +1068,8 @@ prompt = "p"
         std::fs::create_dir_all(&dir).unwrap();
         let manifest_path = dir.join("agent.leviath");
         std::fs::write(&manifest_path, test_manifest()).unwrap();
-        let mut perms = std::fs::metadata(&manifest_path).unwrap().permissions();
+        let original = std::fs::metadata(&manifest_path).unwrap().permissions();
+        let mut perms = original.clone();
         perms.set_readonly(true);
         std::fs::set_permissions(&manifest_path, perms).unwrap();
 
@@ -1083,19 +1084,11 @@ prompt = "p"
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
 
-        // Test-only cleanup so the temp dir can be removed afterward - not
-        // production/security-relevant code, so clippy's warning about
-        // `set_readonly(false)` making the file world-writable on Unix
-        // doesn't apply here.
-        #[expect(
-            clippy::permissions_set_readonly_false,
-            reason = "test-only cleanup: re-enabling write on a throwaway tempdir file so it can be removed, which is the one case the lint's security concern does not cover"
-        )]
-        {
-            let mut perms = std::fs::metadata(&manifest_path).unwrap().permissions();
-            perms.set_readonly(false);
-            let _ = std::fs::set_permissions(&manifest_path, perms);
-        }
+        // Put the original permissions back so the directory can be removed on
+        // Windows, where a read-only file cannot be deleted. Restoring what was
+        // there beats `set_readonly(false)`, which on Unix sets *every* write
+        // bit and would hand back a mode the file never had.
+        let _ = std::fs::set_permissions(&manifest_path, original);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -56,31 +56,27 @@ const MAX_HIGHLIGHTS: usize = 5;
 /// timestamps on a run, and each variant is named for the `RunMeta` field it
 /// reads and the query value that selects it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[expect(
-    clippy::enum_variant_names,
-    reason = "named after the fields they read"
-)]
 enum SortKey {
-    StartedAt,
-    UpdatedAt,
-    LastProgressAt,
+    Started,
+    Updated,
+    LastProgress,
 }
 
 impl SortKey {
     fn parse(raw: &str) -> Option<Self> {
         match raw {
-            "started_at" => Some(SortKey::StartedAt),
-            "updated_at" => Some(SortKey::UpdatedAt),
-            "last_progress_at" => Some(SortKey::LastProgressAt),
+            "started_at" => Some(SortKey::Started),
+            "updated_at" => Some(SortKey::Updated),
+            "last_progress_at" => Some(SortKey::LastProgress),
             _ => None,
         }
     }
 
     fn as_str(self) -> &'static str {
         match self {
-            SortKey::StartedAt => "started_at",
-            SortKey::UpdatedAt => "updated_at",
-            SortKey::LastProgressAt => "last_progress_at",
+            SortKey::Started => "started_at",
+            SortKey::Updated => "updated_at",
+            SortKey::LastProgress => "last_progress_at",
         }
     }
 
@@ -92,9 +88,9 @@ impl SortKey {
     /// the key non-null, which the cursor needs.
     fn value(self, meta: &RunMeta) -> i64 {
         match self {
-            SortKey::StartedAt => meta.started_at,
-            SortKey::UpdatedAt => meta.updated_at,
-            SortKey::LastProgressAt => meta.last_progress_at.unwrap_or(meta.started_at),
+            SortKey::Started => meta.started_at,
+            SortKey::Updated => meta.updated_at,
+            SortKey::LastProgress => meta.last_progress_at.unwrap_or(meta.started_at),
         }
     }
 }

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -82,7 +82,7 @@ fn ids(runs: &[RunMeta]) -> Vec<&str> {
 fn defaults_are_a_descending_started_at_page_of_fifty_over_the_cheap_sources() {
     let r = resolve_ok(&[]);
     assert_eq!(r.limit, DEFAULT_LIMIT);
-    assert_eq!(r.sort, SortKey::StartedAt);
+    assert_eq!(r.sort, SortKey::Started);
     assert!(r.descending);
     assert!(r.q.is_none());
     assert_eq!(r.sources, vec![Source::Meta, Source::Files]);
@@ -108,13 +108,10 @@ fn an_unknown_sort_order_or_source_is_refused_by_name() {
 
 #[test]
 fn every_sort_key_and_order_resolves() {
-    assert_eq!(
-        resolve_ok(&[("sort", "updated_at")]).sort,
-        SortKey::UpdatedAt
-    );
+    assert_eq!(resolve_ok(&[("sort", "updated_at")]).sort, SortKey::Updated);
     assert_eq!(
         resolve_ok(&[("sort", "last_progress_at")]).sort,
-        SortKey::LastProgressAt
+        SortKey::LastProgress
     );
     assert!(!resolve_ok(&[("order", "asc")]).descending);
 }
@@ -264,10 +261,10 @@ fn runs_sharing_a_sort_value_are_broken_apart_by_id() {
 fn a_missing_last_progress_at_falls_back_to_started_at() {
     let mut meta = meta_at("a", 500);
     meta.last_progress_at = None;
-    assert_eq!(SortKey::LastProgressAt.value(&meta), 500);
+    assert_eq!(SortKey::LastProgress.value(&meta), 500);
     meta.last_progress_at = Some(900);
-    assert_eq!(SortKey::LastProgressAt.value(&meta), 900);
-    assert_eq!(SortKey::UpdatedAt.value(&meta), 500);
+    assert_eq!(SortKey::LastProgress.value(&meta), 900);
+    assert_eq!(SortKey::Updated.value(&meta), 500);
 }
 
 /// Walking the whole list a page at a time must visit every run exactly once.

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -1176,12 +1176,15 @@ mod tests {
 
         tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
-            // Set SO_LINGER to 0 - causes RST on close instead of FIN.
-            #[expect(
-                deprecated,
-                reason = "SO_LINGER(0) is the point - it forces an RST rather than a FIN, which is what this test needs and what the deprecation does not offer a replacement for"
-            )]
-            stream.set_linger(Some(Duration::from_secs(0))).unwrap();
+            // `SO_LINGER(0)` makes the close send an RST rather than a FIN,
+            // which is the abrupt disconnect this test is about. Set through
+            // socket2 rather than tokio's own (deprecated) `set_linger`: tokio
+            // deprecates it because the option blocks a runtime thread on drop,
+            // which is a real hazard and not one this socket has - it is closed
+            // on the next line.
+            socket2::SockRef::from(&stream)
+                .set_linger(Some(Duration::from_secs(0)))
+                .unwrap();
             // Close immediately (drop triggers RST).
         });
 

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -70,15 +70,16 @@ impl Outcome {
 ///
 /// The whole point is that the wizard never calls a provider directly, so its
 /// tests never open a socket.
-#[expect(
-    async_fn_in_trait,
-    reason = "same as dispatch::RiskyExecutors: a test seam, never a dyn object"
-)] // callers are concrete; no `dyn` and no boxing needed
 pub trait ProviderVerifier {
     /// Ask the provider whether these credentials work, and what models they
     /// reach. Never fails: an unreachable provider is an [`Outcome::Failed`],
     /// not an error, because the wizard reports it rather than stopping.
-    async fn verify(&self, creds: &ProviderCreds) -> Outcome;
+    ///
+    /// Returns `impl Future` rather than being an `async fn` so the `Send`
+    /// bound is part of the contract. An `async fn` in a trait leaves it
+    /// unstated, which is fine while every caller is concrete and becomes a
+    /// silent constraint the moment one is not.
+    fn verify(&self, creds: &ProviderCreds) -> impl std::future::Future<Output = Outcome> + Send;
 }
 
 /// `--no-verify`: report everything as unchecked without a round trip.

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -115,6 +115,37 @@ pub fn never_interactive() -> bool {
     false
 }
 
+/// What `lev run` was asked for, before any of it is resolved.
+///
+/// One struct because these are one thing: the command line. Each field is a
+/// flag the user typed, and grouping them keeps the difference between "what was
+/// asked for" and "what that resolves to" visible - `resolve_spawn_args` turns
+/// this into a [`SpawnArgs`], and the two are deliberately different types.
+pub struct LaunchRequest<'a> {
+    /// The blueprint path or name, as given.
+    pub path: &'a str,
+    /// The task text, if it was given rather than read from stdin or an editor.
+    pub task: Option<&'a str>,
+    /// Whether stdin is a terminal, injected so the editor path is testable.
+    pub stdin_is_terminal: &'a dyn Fn() -> bool,
+    /// `--model`, overriding the blueprint's choice.
+    pub model: Option<String>,
+    /// The working directory tools run in.
+    pub workdir: &'a str,
+    /// `--yolo`: run unattended.
+    pub yolo: bool,
+    /// `--allow`: tools permitted outright.
+    pub allow: Vec<String>,
+    /// `--max-depth`: sub-agent tree cap.
+    pub max_depth: Option<usize>,
+    /// `--<region>` seeds, keyed by caller-input region name.
+    pub regions: HashMap<String, String>,
+    /// `--no-seed-commands`: refuse the blueprint's command seeds.
+    pub no_seed_commands: bool,
+    /// The output shape the caller asked for, overriding the blueprint's.
+    pub output_request: Option<leviath_core::output::OutputSpec>,
+}
+
 /// Resolve the local inputs of a spawn request: find and parse the manifest,
 /// resolve the `--<region>` flags, resolve the task, and mint a run id from the
 /// agent's directory name.
@@ -127,23 +158,20 @@ pub fn never_interactive() -> bool {
 /// Regions are resolved *before* the task on purpose. A typo'd `--foo` has to
 /// fail before the user is dropped into an editor and types a paragraph they
 /// are about to lose.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "resolves six independent CLI inputs into one request; grouping them would invent a type whose only member is this call"
-)]
-pub fn resolve_spawn_args(
-    path: &str,
-    task: Option<&str>,
-    stdin_is_terminal: &dyn Fn() -> bool,
-    model: Option<String>,
-    workdir: &str,
-    yolo: bool,
-    allow: Vec<String>,
-    max_depth: Option<usize>,
-    regions: HashMap<String, String>,
-    no_seed_commands: bool,
-    output_request: Option<leviath_core::output::OutputSpec>,
-) -> anyhow::Result<SpawnArgs> {
+pub fn resolve_spawn_args(req: LaunchRequest<'_>) -> anyhow::Result<SpawnArgs> {
+    let LaunchRequest {
+        path,
+        task,
+        stdin_is_terminal,
+        model,
+        workdir,
+        yolo,
+        allow,
+        max_depth,
+        regions,
+        no_seed_commands,
+        output_request,
+    } = req;
     let source = load_agent_source(path)?;
     let resolved_regions = resolve_regions(&source.blueprint, regions)?;
     let task = resolve_task(
@@ -440,19 +468,19 @@ mod tests {
         std::fs::create_dir_all(&agent_dir).unwrap();
         let manifest = write_manifest(&agent_dir);
 
-        let args = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some("do it"),
-            &never_interactive,
-            Some("m".to_string()),
-            "/work",
-            false,
-            Vec::new(),
-            None,
-            HashMap::new(),
-            false,
-            None,
-        )
+        let args = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("do it"),
+            stdin_is_terminal: &never_interactive,
+            model: Some("m".to_string()),
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap();
         assert!(args.run_id.contains("my-agent"));
         assert_eq!(args.task, "do it");
@@ -498,19 +526,19 @@ mod tests {
         // uncovered region under the 100% gate.
         assert!(relative.is_relative(), "expected a relative path");
 
-        let args = resolve_spawn_args(
-            relative.to_str().unwrap(),
-            Some("do it"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
-            HashMap::new(),
-            false,
-            None,
-        )
+        let args = resolve_spawn_args(LaunchRequest {
+            path: relative.to_str().unwrap(),
+            task: Some("do it"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap();
         assert!(
             std::path::Path::new(&args.blueprint_path).is_absolute(),
@@ -523,19 +551,19 @@ mod tests {
     #[test]
     fn resolve_spawn_args_errors_on_missing_manifest() {
         assert!(
-            resolve_spawn_args(
-                "/no/such/agent",
-                Some("t"),
-                &never_interactive,
-                None,
-                "/work",
-                false,
-                Vec::new(),
-                None,
-                HashMap::new(),
-                false,
-                None,
-            )
+            resolve_spawn_args(LaunchRequest {
+                path: "/no/such/agent",
+                task: Some("t"),
+                stdin_is_terminal: &never_interactive,
+                model: None,
+                workdir: "/work",
+                yolo: false,
+                allow: Vec::new(),
+                max_depth: None,
+                regions: HashMap::new(),
+                no_seed_commands: false,
+                output_request: None,
+            })
             .is_err()
         );
     }
@@ -551,19 +579,19 @@ mod tests {
         let task_file = dir.path().join("task.md");
         std::fs::write(&task_file, "  summarize the README  \n").unwrap();
 
-        let args = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some(task_file.to_str().unwrap()),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
-            HashMap::new(),
-            false,
-            None,
-        )
+        let args = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some(task_file.to_str().unwrap()),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap();
         assert_eq!(args.task, "summarize the README");
     }
@@ -577,19 +605,19 @@ mod tests {
         std::fs::create_dir_all(&agent_dir).unwrap();
         let manifest = write_manifest(&agent_dir);
 
-        let err = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            None,
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
-            HashMap::new(),
-            false,
-            None,
-        )
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: None,
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("No task provided"), "got: {err}");
     }
@@ -602,19 +630,19 @@ mod tests {
         let manifest = write_region_manifest(&dir.path().join("reviewer"));
         let regions = HashMap::from([("bogus".to_string(), "x".to_string())]);
 
-        let err = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            None,
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: None,
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("unknown region"), "got: {err}");
     }
@@ -657,19 +685,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
             "criteria".to_string(),
             format!("@{}", policy.to_string_lossy()),
         )]);
-        let args = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some("review it"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let args = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("review it"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap();
         // `@path` was read and trimmed.
         assert_eq!(
@@ -705,19 +733,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         .unwrap();
         let manifest = agent_dir.join("agent.leviath");
         let regions = HashMap::from([("foo".to_string(), "x".to_string())]);
-        let err = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some("t"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("t"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("(none)"), "got: {err}");
     }
@@ -730,19 +758,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         let agent_dir = dir.path().join("dirmanifest");
         std::fs::create_dir_all(agent_dir.join("agent.leviath")).unwrap();
         let regions = HashMap::from([("x".to_string(), "y".to_string())]);
-        let err = resolve_spawn_args(
-            agent_dir.to_str().unwrap(),
-            Some("t"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: agent_dir.to_str().unwrap(),
+            task: Some("t"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("read manifest"), "got: {err}");
     }
@@ -758,19 +786,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         )
         .unwrap();
         let regions = HashMap::from([("x".to_string(), "y".to_string())]);
-        let err = resolve_spawn_args(
-            agent_dir.join("agent.leviath").to_str().unwrap(),
-            Some("t"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: agent_dir.join("agent.leviath").to_str().unwrap(),
+            task: Some("t"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("parse manifest"), "got: {err}");
     }
@@ -782,19 +810,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         let dir = tempfile::tempdir().unwrap();
         let manifest = write_region_manifest(&dir.path().join("reviewer"));
         let regions = HashMap::from([("criteria".to_string(), "@/no/such/file.md".to_string())]);
-        let err = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some("review it"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("review it"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(
             err.to_string().contains("Failed to read region file"),
@@ -807,19 +835,19 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
         let dir = tempfile::tempdir().unwrap();
         let manifest = write_region_manifest(&dir.path().join("reviewer"));
         let regions = HashMap::from([("bogus".to_string(), "x".to_string())]);
-        let err = resolve_spawn_args(
-            manifest.to_str().unwrap(),
-            Some("review it"),
-            &never_interactive,
-            None,
-            "/work",
-            false,
-            Vec::new(),
-            None,
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("review it"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
             regions,
-            false,
-            None,
-        )
+            no_seed_commands: false,
+            output_request: None,
+        })
         .unwrap_err();
         assert!(
             err.to_string().contains("unknown region '--bogus'"),

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -114,24 +114,24 @@ impl FanOutSpawner for DaemonFanOutSpawner {
             resolve_worker_source(config, &parent_path, self.agents_dir.as_deref())?;
 
         let task = format_worker_task(item_id, item_context);
-        let mut args = resolve_spawn_args(
-            &resolve_path,
-            Some(&task),
-            &never_interactive,
-            None,
-            &workdir,
-            unattended,
-            Vec::new(),
-            None,
+        let mut args = resolve_spawn_args(crate::daemon::client::LaunchRequest {
+            path: &resolve_path,
+            task: Some(&task),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: &workdir,
+            yolo: unattended,
+            allow: Vec::new(),
+            max_depth: None,
             // Fan-out workers get their split of the parent task via `task`.
-            std::collections::HashMap::new(),
+            regions: std::collections::HashMap::new(),
             // Workers share the parent's workdir and are splits of a task the
             // parent already scoped, so re-running a repo-scan command seed once
             // per worker would be pure waste (and up to `max_workers` copies of
             // the same output).
-            true,
+            no_seed_commands: true,
             output_request,
-        )
+        })
         .map_err(|e| format!("resolve worker blueprint: {e}"))?;
         // Nest the worker under its fan-out parent in the run tree.
         args.parent_run_id = Some(parent_run_id);

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -530,36 +530,51 @@ mod tests {
         status: RunStatus,
         context: Option<&ContextSnapshot>,
     ) {
-        write_run_tree(
+        write_run_tree(RunFixture {
             runs_dir,
             run_id,
             agent_path,
             status,
             context,
-            None,
-            &[],
-            0,
-            0,
-        );
+            parent_run_id: None,
+            children: &[],
+            depth: 0,
+            max_child_depth: 0,
+        });
     }
 
     /// Like [`write_run`], but with explicit tree links so recovery's re-linking
     /// pass can be exercised.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "a test fixture that writes one run with explicit tree links; every argument is a field of the record it writes"
-    )]
-    fn write_run_tree(
-        runs_dir: &Path,
-        run_id: &str,
-        agent_path: &str,
+    /// One persisted run, as a fixture writes it.
+    ///
+    /// A struct because every field is a column of the record being written, and
+    /// a nine-argument call in which three are `&str` and two are `usize` is a
+    /// transposition waiting to happen in a file whose whole job is asserting on
+    /// what got written.
+    struct RunFixture<'a> {
+        runs_dir: &'a Path,
+        run_id: &'a str,
+        agent_path: &'a str,
         status: RunStatus,
-        context: Option<&ContextSnapshot>,
-        parent_run_id: Option<&str>,
-        children: &[&str],
+        context: Option<&'a ContextSnapshot>,
+        parent_run_id: Option<&'a str>,
+        children: &'a [&'a str],
         depth: usize,
         max_child_depth: usize,
-    ) {
+    }
+
+    fn write_run_tree(f: RunFixture<'_>) {
+        let RunFixture {
+            runs_dir,
+            run_id,
+            agent_path,
+            status,
+            context,
+            parent_run_id,
+            children,
+            depth,
+            max_child_depth,
+        } = f;
         let dir = runs_dir.join(run_id);
         std::fs::create_dir_all(&dir).unwrap();
         let meta = RunMeta {
@@ -1623,39 +1638,39 @@ mod tests {
         let runs = tempfile::tempdir().unwrap();
 
         // A parent with two children + a child that records its parent + depth.
-        write_run_tree(
-            runs.path(),
-            "parent",
-            mpath,
-            RunStatus::WaitingInput,
-            None,
-            None,
-            &["child-a", "child-b"],
-            0,
-            4,
-        );
-        write_run_tree(
-            runs.path(),
-            "child-a",
-            mpath,
-            RunStatus::Running,
-            None,
-            Some("parent"),
-            &[],
-            1,
-            0,
-        );
-        write_run_tree(
-            runs.path(),
-            "child-b",
-            mpath,
-            RunStatus::Running,
-            None,
-            Some("parent"),
-            &[],
-            1,
-            0,
-        );
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "parent",
+            agent_path: mpath,
+            status: RunStatus::WaitingInput,
+            context: None,
+            parent_run_id: None,
+            children: &["child-a", "child-b"],
+            depth: 0,
+            max_child_depth: 4,
+        });
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "child-a",
+            agent_path: mpath,
+            status: RunStatus::Running,
+            context: None,
+            parent_run_id: Some("parent"),
+            children: &[],
+            depth: 1,
+            max_child_depth: 0,
+        });
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "child-b",
+            agent_path: mpath,
+            status: RunStatus::Running,
+            context: None,
+            parent_run_id: Some("parent"),
+            children: &[],
+            depth: 1,
+            max_child_depth: 0,
+        });
 
         let (mut world, cli) = test_world();
         let hub = InteractionHub::new();
@@ -1708,51 +1723,52 @@ mod tests {
         let runs = tempfile::tempdir().unwrap();
 
         // Parent lists a child that is terminal (won't reload) → no SubAgentChildren.
-        write_run_tree(
-            runs.path(),
-            "lonely-parent",
-            mpath,
-            RunStatus::WaitingInput,
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "lonely-parent",
+            agent_path: mpath,
+            status: RunStatus::WaitingInput,
+            context: None,
+            parent_run_id: None,
+            children: &["gone-child"],
+            depth: 0,
+            max_child_depth: 2,
+        });
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "gone-child",
+            agent_path: mpath,
+            status: RunStatus::Complete,
+            context: // terminal → skipped by recovery
             None,
-            None,
-            &["gone-child"],
-            0,
-            2,
-        );
-        write_run_tree(
-            runs.path(),
-            "gone-child",
-            mpath,
-            RunStatus::Complete, // terminal → skipped by recovery
-            None,
-            Some("lonely-parent"),
-            &[],
-            1,
-            0,
-        );
+            parent_run_id: Some("lonely-parent"),
+            children: &[],
+            depth: 1,
+            max_child_depth: 0,
+        });
         // Child whose parent is terminal (won't reload) → left unlinked.
-        write_run_tree(
-            runs.path(),
-            "orphan",
-            mpath,
-            RunStatus::Running,
-            None,
-            Some("gone-parent"),
-            &[],
-            1,
-            0,
-        );
-        write_run_tree(
-            runs.path(),
-            "gone-parent",
-            mpath,
-            RunStatus::Error,
-            None,
-            None,
-            &["orphan"],
-            0,
-            2,
-        );
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "orphan",
+            agent_path: mpath,
+            status: RunStatus::Running,
+            context: None,
+            parent_run_id: Some("gone-parent"),
+            children: &[],
+            depth: 1,
+            max_child_depth: 0,
+        });
+        write_run_tree(RunFixture {
+            runs_dir: runs.path(),
+            run_id: "gone-parent",
+            agent_path: mpath,
+            status: RunStatus::Error,
+            context: None,
+            parent_run_id: None,
+            children: &["orphan"],
+            depth: 0,
+            max_child_depth: 2,
+        });
 
         let (mut world, cli) = test_world();
         let hub = InteractionHub::new();

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -450,16 +450,18 @@ fn build_agent_inner(
     // 6. Spawn the agent.
     let entity = spawn_agent_seeded(
         world,
-        args.run_id.clone(),
-        blueprint,
-        &seeds,
-        stages,
-        leviath_core::config::PromptHints {
-            batch_tool: deps.config.batch_tool_hint,
-            shell: deps.config.shell_hint,
+        leviath_runtime::pipeline::SeededSpawn {
+            agent_id: args.run_id.clone(),
+            blueprint,
+            seeds,
+            stages,
+            global_hints: leviath_core::config::PromptHints {
+                batch_tool: deps.config.batch_tool_hint,
+                shell: deps.config.shell_hint,
+            },
+            global_nudge: deps.config.nudge.clone(),
+            region_scripts,
         },
-        deps.config.nudge.clone(),
-        region_scripts,
     )?;
 
     // Stage hooks, only when some stage declares one. Withholding the component

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -146,20 +146,20 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
         }
     };
 
-    let spawn_args = match resolve_spawn_args(
-        blueprint,
-        Some(&full_task),
-        &never_interactive,
-        None,
-        &h.workdir,
-        h.unattended,
-        Vec::new(),
-        child_max_depth,
-        // Sub-agents receive their whole task via `full_task`; no region flags.
+    let spawn_args = match resolve_spawn_args(crate::daemon::client::LaunchRequest {
+        path: blueprint,
+        task: Some(&full_task),
+        stdin_is_terminal: &never_interactive,
+        model: None,
+        workdir: &h.workdir,
+        yolo: h.unattended,
+        allow: Vec::new(),
+        max_depth: child_max_depth,
+        regions: // Sub-agents receive their whole task via `full_task`; no region flags.
         std::collections::HashMap::new(),
-        h.no_seed_commands,
-        child_output,
-    ) {
+        no_seed_commands: h.no_seed_commands,
+        output_request: child_output,
+    }) {
         Ok(a) => a,
         Err(e) => return format!("[error] cannot spawn '{blueprint}': {e}"),
     };

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -989,16 +989,18 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         );
     }
 
+    /// A host that answers only `Send`, plus what a test needs to assert on it.
+    struct SendRecordingHost {
+        /// The handle under test.
+        handle: SubAgentHandle,
+        /// Each `Send` op's `target_region`, in arrival order.
+        regions: std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>,
+        /// The service loop, joined at the end of the test.
+        task: tokio::task::JoinHandle<()>,
+    }
+
     /// A host that answers only `Send`, recording each op's `target_region`.
-    #[expect(
-        clippy::type_complexity,
-        reason = "returns the handle beside the recording buffer the assertions read"
-    )]
-    fn send_recording_host() -> (
-        SubAgentHandle,
-        std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>,
-        tokio::task::JoinHandle<()>,
-    ) {
+    fn send_recording_host() -> SendRecordingHost {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let regions = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let regions_task = regions.clone();
@@ -1019,7 +1021,11 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                 }
             }
         });
-        (handle_with(tx), regions, task)
+        SendRecordingHost {
+            handle: handle_with(tx),
+            regions,
+            task,
+        }
     }
 
     /// `target_region` was schema-advertised and documented but never read on
@@ -1027,7 +1033,11 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     /// documented default (conversation), so they forward as `None`.
     #[tokio::test]
     async fn send_forwards_target_region() {
-        let (h, regions, task) = send_recording_host();
+        let SendRecordingHost {
+            handle: h,
+            regions,
+            task,
+        } = send_recording_host();
         for args in [
             json!({ "agent_id": "c", "message": "hi", "target_region": "notes" }),
             json!({ "agent_id": "c", "message": "hi" }),

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -121,48 +121,94 @@ pub enum Commands {
 ///
 /// `async fn` in a trait is fine here: `dispatch` takes `&impl RiskyExecutors`
 /// (static dispatch, no `dyn`), so no boxing or `Send` bound is required.
-#[expect(
-    async_fn_in_trait,
-    reason = "the trait exists to be a test seam and is never used as a dyn object, so the auto-trait bounds the lint warns about cannot matter here"
-)]
 pub trait RiskyExecutors {
+    // Each method returns `impl Future` rather than being an `async fn`, so what
+    // the future promises is stated rather than inferred.
+    //
+    // Deliberately **not** `+ Send`. These run on the CLI's single-threaded
+    // entry path and hold non-`Send` state across awaits - the daemon-readiness
+    // poll takes a `&mut dyn FnMut() -> bool`, and the TUI paths hold terminal
+    // handles. Adding the bound does not compile, which is the useful answer:
+    // an `async fn` here left that unsaid, and this says it.
     /// `lev run` - auto-starts the daemon (real process spawn) if needed and
     /// spawns the agent into the shared world over the control socket.
-    async fn run(&self, args: commands::run::RunArgs) -> anyhow::Result<()>;
+    fn run(
+        &self,
+        args: commands::run::RunArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev ps` - resolves the control-socket path and queries the daemon.
-    async fn ps(&self, args: commands::ps::PsArgs) -> anyhow::Result<()>;
+    fn ps(
+        &self,
+        args: commands::ps::PsArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev msg` - resolves the control-socket path and sends a message.
-    async fn msg(&self, args: commands::ctl::MsgArgs) -> anyhow::Result<()>;
+    fn msg(
+        &self,
+        args: commands::ctl::MsgArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev cancel` - resolves the control-socket path and cancels a run.
-    async fn cancel(&self, args: commands::ctl::CancelArgs) -> anyhow::Result<()>;
+    fn cancel(
+        &self,
+        args: commands::ctl::CancelArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev pause` - resolves the control-socket path and pauses a run.
-    async fn pause(&self, args: commands::ctl::PauseArgs) -> anyhow::Result<()>;
+    fn pause(
+        &self,
+        args: commands::ctl::PauseArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev resume` - resolves the control-socket path and resumes a run.
-    async fn resume(&self, args: commands::ctl::ResumeArgs) -> anyhow::Result<()>;
+    fn resume(
+        &self,
+        args: commands::ctl::ResumeArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev respond` - resolves the control-socket path and answers/lists interactions.
-    async fn respond(&self, args: commands::ctl::RespondArgs) -> anyhow::Result<()>;
+    fn respond(
+        &self,
+        args: commands::ctl::RespondArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev doctor` - makes real billed inference calls, and (unless
     /// `--no-daemon`) auto-starts the daemon and spawns a throwaway run.
-    async fn doctor(&self, args: commands::doctor::DoctorArgs) -> anyhow::Result<()>;
+    fn doctor(
+        &self,
+        args: commands::doctor::DoctorArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev setup` - interactive (blocking stdin) or `--non-interactive`.
-    async fn setup(&self, args: commands::setup::SetupArgs) -> anyhow::Result<()>;
+    fn setup(
+        &self,
+        args: commands::setup::SetupArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev dash` - takes over the real terminal and blocks on real keyboard input.
-    async fn dashboard(&self, args: commands::dashboard::DashboardArgs) -> anyhow::Result<()>;
+    fn dashboard(
+        &self,
+        args: commands::dashboard::DashboardArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev serve` - binds a real port and serves indefinitely.
-    async fn serve(&self, args: commands::serve::ServeArgs) -> anyhow::Result<()>;
+    fn serve(
+        &self,
+        args: commands::serve::ServeArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev agent-client` - takes over real stdin/stdout to speak the Agent
     /// Client Protocol against the shared-world daemon.
-    async fn agent_client(
+    fn agent_client(
         &self,
         args: commands::agent_client::AgentClientArgs,
-    ) -> anyhow::Result<()>;
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev daemon` - binds the control socket and serves the shared world.
-    async fn daemon(&self, args: commands::daemon::DaemonArgs) -> anyhow::Result<()>;
+    fn daemon(
+        &self,
+        args: commands::daemon::DaemonArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev mcp` - rewrites config, opens a browser for OAuth, touches the token store.
-    async fn mcp(&self, args: commands::mcp::McpArgs) -> anyhow::Result<()>;
+    fn mcp(
+        &self,
+        args: commands::mcp::McpArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
 
     /// `lev auth` - reads the config file and may write the OS credential store.
-    async fn auth(&self, args: commands::auth::AuthArgs) -> anyhow::Result<()>;
+    fn auth(
+        &self,
+        args: commands::auth::AuthArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
 }
 
 /// Inject argv-prescanned dynamic `--<region>` seed flags into a parsed

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -250,7 +250,7 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
                 mouse_capture: false,
                 enabled: false,
             },
-            &mut CrosstermEventSource::new(),
+            &mut CrosstermEventSource::open(),
         )
         .await;
         if !ok {
@@ -621,7 +621,7 @@ async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
         mouse_capture: true,
         enabled: false,
     };
-    let mut events = CrosstermEventSource::new();
+    let mut events = CrosstermEventSource::open();
     commands::dashboard::execute_with(control, &mut setup, &mut events, real_yank).await
 }
 
@@ -687,7 +687,7 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
                 mouse_capture: false,
                 enabled: false,
             },
-            &mut CrosstermEventSource::new(),
+            &mut CrosstermEventSource::open(),
             false,
         )
         .await;
@@ -706,7 +706,7 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
         mouse_capture: false,
         enabled: false,
     };
-    let mut events = CrosstermEventSource::new();
+    let mut events = CrosstermEventSource::open();
     commands::setup::execute_core(&mut wizard, &env, &mut setup, &mut events).await
 }
 

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -259,21 +259,23 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
         }
     }
     let spawn_args = leviath_cli::daemon::client::resolve_spawn_args(
-        path,
-        args.task.as_deref(),
-        &|| std::io::IsTerminal::is_terminal(&io::stdin()),
-        args.model,
-        &workdir,
-        args.yolo,
-        args.allow,
-        args.max_depth,
-        args.regions,
-        args.no_seed_commands,
-        commands::run::output_request(
-            args.output_format,
-            args.output_instructions,
-            args.output_schema,
-        )?,
+        leviath_cli::daemon::client::LaunchRequest {
+            path,
+            task: args.task.as_deref(),
+            stdin_is_terminal: &|| std::io::IsTerminal::is_terminal(&io::stdin()),
+            model: args.model,
+            workdir: &workdir,
+            yolo: args.yolo,
+            allow: args.allow,
+            max_depth: args.max_depth,
+            regions: args.regions,
+            no_seed_commands: args.no_seed_commands,
+            output_request: commands::run::output_request(
+                args.output_format,
+                args.output_instructions,
+                args.output_schema,
+            )?,
+        },
     )?;
     // Deliberately after the resolve, not before. No `--task` opens an editor,
     // and a user can sit in vim for twenty minutes: checking daemon liveness

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -45,20 +45,21 @@ pub trait EventSource {
 /// Production [`EventSource`]: reads real terminal input via crossterm.
 /// Uses injectable function pointers for `poll` and `read` so the two
 /// branches of `poll_event` can be exercised in unit tests without a real
-/// TTY.  In production, construct via [`CrosstermEventSource::new`]. Wired
+/// TTY.  In production, construct via [`CrosstermEventSource::open`]. Wired
 /// into the real UIs only by the binary.
 pub struct CrosstermEventSource {
     poll_fn: fn(Duration) -> std::io::Result<bool>,
     read_fn: fn() -> std::io::Result<Event>,
 }
 
-#[expect(
-    clippy::new_without_default,
-    reason = "constructed only by the binary's real UI entrypoints, where a Default would be a way to build one that reads no terminal"
-)] // constructed only by the binary's real UI entrypoints
 impl CrosstermEventSource {
-    /// Read from the real terminal.
-    pub fn new() -> Self {
+    /// Open a source over the real terminal.
+    ///
+    /// Named `open` rather than `new` deliberately. A `new` with no arguments
+    /// invites a `Default` impl, and a defaulted event source is one that reads
+    /// no terminal - which is exactly the thing a test should have to ask for
+    /// explicitly rather than get by writing `..Default::default()`.
+    pub fn open() -> Self {
         Self {
             poll_fn: crossterm::event::poll,
             read_fn: crossterm::event::read,
@@ -404,7 +405,7 @@ mod tests {
     fn crossterm_event_source_new_stores_the_real_crossterm_functions() {
         // Taking a function's address never invokes it, so constructing the
         // production source touches no real terminal state.
-        let _source = CrosstermEventSource::new();
+        let _source = CrosstermEventSource::open();
     }
 
     #[test]

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -31,6 +31,30 @@ enum GeminiFamily {
 }
 
 impl GeminiFamily {
+    /// `(max_context_tokens, max_output_tokens)` for the Flash-Lite family.
+    const FLASH_LITE_LIMITS: (usize, usize) = (1_048_576, 65_535);
+    /// The same, for Pro.
+    const PRO_LIMITS: (usize, usize) = (1_048_576, 65_535);
+    /// The same, for Flash.
+    const FLASH_LIMITS: (usize, usize) = (1_048_576, 65_535);
+    /// The same, for anything this classifier does not recognise.
+    const OTHER_LIMITS: (usize, usize) = (1_048_576, 65_535);
+
+    /// This family's context and output ceilings.
+    ///
+    /// Four named constants that happen to agree today, rather than one shared
+    /// value: the point is that a family's limits can move without disturbing
+    /// the others, and four constants say that where four identical match arms
+    /// only looked like an oversight - which is what the lint kept reporting.
+    const fn limits(self) -> (usize, usize) {
+        match self {
+            Self::FlashLite => Self::FLASH_LITE_LIMITS,
+            Self::Pro => Self::PRO_LIMITS,
+            Self::Flash => Self::FLASH_LIMITS,
+            Self::Other => Self::OTHER_LIMITS,
+        }
+    }
+
     fn classify(model: &str) -> Self {
         if model.contains("flash-lite") {
             GeminiFamily::FlashLite
@@ -118,19 +142,7 @@ impl GeminiProvider {
     /// - gemini-3-flash (complex multimodal/agentic)
     /// - gemini-3.1-flash-lite (cost-efficient, high-volume)
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // All families currently share these values; the match keeps them
-        // labelled by family so any one can be adjusted independently (the arms
-        // are intentionally identical today - divergence-readiness scaffolding).
-        #[expect(
-            clippy::match_same_arms,
-            reason = "the arms are identical today and deliberately kept separate, so each family's limits can move without disturbing the others"
-        )]
-        let (max_context_tokens, max_output_tokens) = match GeminiFamily::classify(model) {
-            GeminiFamily::FlashLite => (1_048_576, 65_535),
-            GeminiFamily::Pro => (1_048_576, 65_535),
-            GeminiFamily::Flash => (1_048_576, 65_535),
-            GeminiFamily::Other => (1_048_576, 65_535),
-        };
+        let (max_context_tokens, max_output_tokens) = GeminiFamily::classify(model).limits();
         ModelCapabilities {
             supports_temperature: true,
             supports_streaming: true,

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -75,6 +75,27 @@ pub struct RhaiProvider {
     env_allowlist: Arc<Vec<String>>,
 }
 
+/// What a script provider is configured with, as distinct from the script
+/// itself and the executor it runs against.
+///
+/// Held apart from those two because they are the parts a test substitutes: the
+/// source is what is under test and the executor is what keeps it off the
+/// network, while everything here comes from `config.toml` either way.
+pub struct ScriptProviderSettings {
+    /// The provider name this script is registered under.
+    pub name: String,
+    /// The `initialize` block from the config.
+    pub init_config: serde_json::Value,
+    /// Per-model capabilities the config declares.
+    pub caps: HashMap<String, ModelCapabilities>,
+    /// Rate limiting, when configured.
+    pub rate_limit: Option<RateLimitConfig>,
+    /// Per-request timeout, when configured.
+    pub request_timeout_secs: Option<u64>,
+    /// Environment variables the script may read.
+    pub env_allowlist: Arc<Vec<String>>,
+}
+
 impl RhaiProvider {
     /// Load a provider from a script file, using the production reqwest-backed
     /// HTTP executor. Reads + compiles the script and runs `initialize(config)`
@@ -96,33 +117,34 @@ impl RhaiProvider {
             ))
         })?;
         Self::from_source(
-            name,
             &src,
-            init_config,
-            caps,
-            rate_limit,
-            request_timeout_secs,
             Arc::new(ReqwestExecutor::new()),
-            env_allowlist,
+            ScriptProviderSettings {
+                name,
+                init_config,
+                caps,
+                rate_limit,
+                request_timeout_secs,
+                env_allowlist,
+            },
         )
     }
 
     /// Build a provider from in-memory source with an injected [`HttpExecutor`]
     /// (used by tests to avoid real network I/O).
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "the injected-executor constructor takes what the real one reads from config, one parameter per setting, so a struct here would only move the list"
-    )]
     pub fn from_source(
-        name: String,
         src: &str,
-        init_config: serde_json::Value,
-        caps: HashMap<String, ModelCapabilities>,
-        rate_limit: Option<RateLimitConfig>,
-        request_timeout_secs: Option<u64>,
         executor: Arc<dyn HttpExecutor>,
-        env_allowlist: Arc<Vec<String>>,
+        settings: ScriptProviderSettings,
     ) -> Result<Self> {
+        let ScriptProviderSettings {
+            name,
+            init_config,
+            caps,
+            rate_limit,
+            request_timeout_secs,
+            env_allowlist,
+        } = settings;
         let meta = parse_provider_annotations(src);
         let init_engine = build_init_engine(env_allowlist.clone());
         let ast = init_engine

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -88,14 +88,16 @@ fn request(model: &str) -> InferenceRequest {
 
 fn build(src: &str, executor: Arc<FakeExecutor>) -> Result<RhaiProvider> {
     RhaiProvider::from_source(
-        "test".to_string(),
         src,
-        serde_json::json!({}),
-        HashMap::new(),
-        None,
-        None,
         executor,
-        no_env_allowlist(),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
 }
 
@@ -105,14 +107,16 @@ fn build_rl(
     rate_limit: Option<RateLimitConfig>,
 ) -> RhaiProvider {
     RhaiProvider::from_source(
-        "test".to_string(),
         src,
-        serde_json::json!({}),
-        HashMap::new(),
-        rate_limit,
-        None,
         executor,
-        no_env_allowlist(),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            rate_limit,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .unwrap()
 }
@@ -151,14 +155,16 @@ fn from_source_initialize_receives_config() {
     let src = "fn initialize(config) { #{ m: config.model } }\n\
                fn inference(s, r) { #{ content: s.m } }";
     let p = RhaiProvider::from_source(
-        "test".into(),
         src,
-        serde_json::json!({ "model": "cfg-model" }),
-        HashMap::new(),
-        None,
-        None,
         FakeExecutor::new(),
-        no_env_allowlist(),
+        ScriptProviderSettings {
+            name: "test".into(),
+            init_config: serde_json::json!({ "model": "cfg-model" }),
+            caps: HashMap::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .unwrap();
     let out = tokio_block(p.infer(&request("ignored")));
@@ -401,14 +407,16 @@ fn capabilities_and_metadata() {
         },
     );
     let p = RhaiProvider::from_source(
-        "test".into(),
         &src,
-        serde_json::json!({}),
-        caps,
-        None,
-        None,
         FakeExecutor::new(),
-        no_env_allowlist(),
+        ScriptProviderSettings {
+            name: "test".into(),
+            init_config: serde_json::json!({}),
+            caps,
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .unwrap();
 
@@ -681,14 +689,16 @@ fn sample_groq_script_compiles_and_initializes() {
     // and advertise its optional functions.
     let src = include_str!("../../../../docs/examples/groq.rhai");
     let p = RhaiProvider::from_source(
-        "groq".to_string(),
         src,
-        serde_json::json!({ "api_key": "test-key" }),
-        HashMap::new(),
-        None,
-        None,
         FakeExecutor::new(),
-        no_env_allowlist(),
+        ScriptProviderSettings {
+            name: "groq".to_string(),
+            init_config: serde_json::json!({ "api_key": "test-key" }),
+            caps: HashMap::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .unwrap();
     assert_eq!(p.meta().provider.as_deref(), Some("groq"));

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -715,14 +715,18 @@ impl ContextWindow {
                 // so a custom region is never silently dropped.
                 leviath_core::RegionKind::Custom { script, persistent } => {
                     crate::custom_region::render_custom_region(
-                        region,
-                        self.region_scripts.get(script),
-                        *persistent,
-                        meta,
-                        self.current_tokens,
-                        self.max_tokens,
-                        &mut system_blocks,
-                        &mut messages,
+                        crate::custom_region::RegionRender {
+                            region,
+                            script: self.region_scripts.get(script),
+                            persistent: *persistent,
+                            meta,
+                            window_current: self.current_tokens,
+                            window_max: self.max_tokens,
+                        },
+                        crate::custom_region::RenderSink {
+                            system_blocks: &mut system_blocks,
+                            messages: &mut messages,
+                        },
                     );
                 }
 

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -106,20 +106,50 @@ fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
 /// Temporary-style block with a warning; success is followed by a warn-only
 /// token re-check against the region's budget (no truncation - the opt-in
 /// exact-token preflight remains the hard guard).
-#[expect(
-    clippy::too_many_arguments,
-    reason = "renders through a script into two caller-owned accumulators, so the accumulators and the script context cannot be collapsed into one value"
-)]
-pub(crate) fn render_custom_region(
-    region: &Region,
-    script: Option<&Arc<RegionScript>>,
-    persistent: bool,
-    meta: &AssembleMeta,
-    window_current: usize,
-    window_max: usize,
-    system_blocks: &mut Vec<leviath_providers::SystemBlock>,
-    messages: &mut Vec<leviath_providers::Message>,
-) {
+/// What one custom region is rendered from.
+///
+/// The window figures travel with the region rather than the accumulators
+/// because a render hook is told how full the window is so it can decide how
+/// much to emit - they describe the input, not where the output lands.
+pub(crate) struct RegionRender<'a> {
+    /// The region being rendered.
+    pub region: &'a Region,
+    /// Its render hook, when it declares one.
+    pub script: Option<&'a Arc<RegionScript>>,
+    /// Whether the region persists across stage transitions.
+    pub persistent: bool,
+    /// Stage metadata the hook sees.
+    pub meta: &'a AssembleMeta,
+    /// How full the window is right now.
+    pub window_current: usize,
+    /// How full it may get.
+    pub window_max: usize,
+}
+
+/// Where a rendered region's output is appended.
+///
+/// The caller owns both accumulators and interleaves several regions into them,
+/// so they are borrowed together rather than returned.
+pub(crate) struct RenderSink<'a> {
+    /// System blocks, for regions that render into the system prompt.
+    pub system_blocks: &'a mut Vec<leviath_providers::SystemBlock>,
+    /// Messages, for regions that render into the conversation.
+    pub messages: &'a mut Vec<leviath_providers::Message>,
+}
+
+pub(crate) fn render_custom_region(render: RegionRender<'_>, out: RenderSink<'_>) {
+    let RegionRender {
+        region,
+        script,
+        persistent,
+        meta,
+        window_current,
+        window_max,
+    } = render;
+    let RenderSink {
+        system_blocks,
+        messages,
+    } = out;
     let Some(script) = script else {
         // No compiled script on the window (plain `assemble()` callers, or a
         // spawn path that skipped resolution). Same shape as a hook failure.
@@ -556,18 +586,22 @@ mod tests {
         let mut messages = Vec::new();
         with_tracing(|| {
             render_custom_region(
-                region,
-                script,
-                persistent,
-                &AssembleMeta {
-                    stage_name: "plan".to_string(),
-                    stage_iterations: 2,
-                    model: "m1".to_string(),
+                RegionRender {
+                    region,
+                    script,
+                    persistent,
+                    meta: &AssembleMeta {
+                        stage_name: "plan".to_string(),
+                        stage_iterations: 2,
+                        model: "m1".to_string(),
+                    },
+                    window_current: 50,
+                    window_max: 2000,
                 },
-                50,
-                2000,
-                &mut blocks,
-                &mut messages,
+                RenderSink {
+                    system_blocks: &mut blocks,
+                    messages: &mut messages,
+                },
             )
         });
         (blocks, messages)

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -111,14 +111,16 @@ impl EmbedSpawner {
 
         let entity = spawn_agent_seeded(
             world.world_mut(),
-            args.run_id.clone(),
+            crate::pipeline::SeededSpawn {
+            agent_id: args.run_id.clone(),
             blueprint,
-            &seeds,
+            seeds,
             stages,
-            self.hints,
-            // The default nudge policy; blueprints override per stage/agent.
+            global_hints: self.hints,
+            global_nudge: // The default nudge policy; blueprints override per stage/agent.
             leviath_core::NudgeConfig::default(),
-            HashMap::new(),
+            region_scripts: HashMap::new(),
+        },
         )?;
 
         // Metadata + counters, so events, persistence, and status all work.

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -28,7 +28,7 @@ use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::dynamic_interaction::InteractionBackend;
-use crate::interaction_hub::InteractionHub;
+use crate::interaction_hub::PromptLane;
 use crate::taint::GateResolution;
 
 /// Marks an agent holding its tool batch while `n` gate prompts are outstanding.
@@ -111,21 +111,41 @@ fn build_gate_request(
 
 /// Ask the user how to resolve a blocked outbound call, then report the
 /// resolution on the lane and wake the tick loop.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "an async lane entry point: the prompt, the lane sender, the waker and the resolution channel are four unrelated lifetimes"
-)]
-pub async fn run_gate_prompt(
-    entity: Entity,
-    hub: InteractionHub,
-    agent_id: String,
-    tool_id: String,
-    tool_name: String,
-    taint: TaintLevel,
-    clearance: TaintLevel,
-    outcomes: UnboundedSender<GatePromptOutcome>,
-    wake: Arc<Notify>,
-) {
+/// The call being gated: who is asking, for what, and how the taint levels
+/// compare.
+///
+/// Held apart from the lane it reports on because these six answer "what is the
+/// user being asked about" and the other three answer "where does the answer
+/// go" - and only the first six ever appear in the prompt.
+pub struct GatedCall {
+    /// The agent whose call is blocked.
+    pub entity: Entity,
+    /// That agent's run id, for the hub's per-agent backend.
+    pub agent_id: String,
+    /// The tool call's id, which the resolution is matched back to.
+    pub tool_id: String,
+    /// The tool being called, as the prompt names it.
+    pub tool_name: String,
+    /// How tainted the data reaching this call is.
+    pub taint: TaintLevel,
+    /// What the call is cleared for.
+    pub clearance: TaintLevel,
+}
+
+pub async fn run_gate_prompt(call: GatedCall, lane: PromptLane<GatePromptOutcome>) {
+    let GatedCall {
+        entity,
+        agent_id,
+        tool_id,
+        tool_name,
+        taint,
+        clearance,
+    } = call;
+    let PromptLane {
+        hub,
+        outcomes,
+        wake,
+    } = lane;
     let backend = hub.backend_for(agent_id);
     let req = build_gate_request(format!("gate-{tool_id}"), &tool_name, taint, clearance);
     let resolution = resolution_from_answer(&backend.ask(req).await);
@@ -190,7 +210,10 @@ pub fn collect_gate_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Production reaches the hub only through `PromptLane`, so the type itself
+    // is named here rather than imported above and left unused there.
     use crate::components::AgentState;
+    use crate::interaction_hub::InteractionHub;
     use crate::pipeline::ReadyForTools;
     use crate::taint::TaintGate;
     use leviath_core::SecurityConfig;
@@ -237,15 +260,20 @@ mod tests {
         let task = {
             let hub = hub.clone();
             tokio::spawn(run_gate_prompt(
-                Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id"),
-                hub,
-                "run".to_string(),
-                "c1".to_string(),
-                "shell".to_string(),
-                TaintLevel::Internal,
-                TaintLevel::Public,
-                tx,
-                Arc::new(Notify::new()),
+                GatedCall {
+                    entity: Entity::from_raw_u32(1)
+                        .expect("a small literal index is always a valid entity id"),
+                    agent_id: "run".to_string(),
+                    tool_id: "c1".to_string(),
+                    tool_name: "shell".to_string(),
+                    taint: TaintLevel::Internal,
+                    clearance: TaintLevel::Public,
+                },
+                PromptLane {
+                    hub,
+                    outcomes: tx,
+                    wake: Arc::new(Notify::new()),
+                },
             ))
         };
         for _ in 0..8 {

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -277,3 +277,18 @@ impl InteractionBackend for HubInteractionBackend {
 #[cfg(test)]
 #[path = "interaction_hub_tests.rs"]
 mod tests;
+
+/// Where a prompt's answer goes once a person gives one.
+///
+/// Both prompt paths - the taint gate and blueprint interaction points - are the
+/// same three things: the hub that owns the conversation, the channel the
+/// resolution is reported on, and the driver to wake once it is. Only the
+/// outcome type differs, so this is generic over it rather than written twice.
+pub struct PromptLane<T> {
+    /// The hub that owns the conversation with the user.
+    pub hub: InteractionHub,
+    /// The channel the resolution is reported on.
+    pub outcomes: tokio::sync::mpsc::UnboundedSender<T>,
+    /// The driver to wake once it is.
+    pub wake: std::sync::Arc<tokio::sync::Notify>,
+}

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -38,7 +38,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::components::{AgentState, AgentStatus, ContextWindow, InferenceResult};
 use crate::dynamic_interaction::InteractionBackend;
-use crate::interaction_hub::InteractionHub;
+use crate::interaction_hub::{InteractionHub, PromptLane};
 use crate::pipeline::{
     AgentBlueprint, ReadyToInfer, ResolveTransition, StageCursor, StageIoBuffer,
 };
@@ -276,20 +276,39 @@ enum Routed {
 /// Ask an interaction point through the hub, resolve + route the answer (doing
 /// the edit branch's second "edit this text" ask when needed), and report the
 /// [`PointOutcome`] on the lane, waking the tick loop.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "same shape as run_gate_prompt, plus the edit branch's second ask"
-)]
-async fn run_interaction_point(
-    entity: Entity,
-    hub: InteractionHub,
-    agent_id: String,
-    point: InteractionPoint,
-    body: String,
-    round: usize,
-    outcomes: UnboundedSender<InteractionPointOutcome>,
-    wake: Arc<Notify>,
-) {
+/// The point being asked: whose run, which point, on what text, and how many
+/// times it has come round already.
+///
+/// Held apart from the lane it reports on for the same reason as
+/// the taint gate's own `GatedCall`: these five are what the person sees, and
+/// the lane is only where their answer goes.
+pub struct PointAsk {
+    /// The agent parked on this point.
+    pub entity: Entity,
+    /// That agent's run id, which the request id is namespaced by so two runs
+    /// at the same point never collide in the shared hub.
+    pub agent_id: String,
+    /// The point as the blueprint declared it.
+    pub point: InteractionPoint,
+    /// The text being asked about.
+    pub body: String,
+    /// Which round of this point the run is on.
+    pub round: usize,
+}
+
+async fn run_interaction_point(ask: PointAsk, lane: PromptLane<InteractionPointOutcome>) {
+    let PointAsk {
+        entity,
+        agent_id,
+        point,
+        body,
+        round,
+    } = ask;
+    let PromptLane {
+        hub,
+        outcomes,
+        wake,
+    } = lane;
     // Request ids are prefixed with the run id so concurrent runs at the same
     // point (same name/round) never collide in the shared hub.
     let ask_id = format!("{agent_id}-point-{}-{round}", point.name);
@@ -412,14 +431,18 @@ pub fn restore_interaction_point(world: &mut World, entity: Entity, state: Inter
 
     // Re-open the request in the hub and await it, exactly as a live dispatch would.
     runtime.spawn(run_interaction_point(
-        entity,
-        hub,
-        agent_id,
-        point,
-        state.body,
-        state.round,
-        outcomes,
-        wake,
+        PointAsk {
+            entity,
+            agent_id,
+            point,
+            body: state.body,
+            round: state.round,
+        },
+        PromptLane {
+            hub,
+            outcomes,
+            wake,
+        },
     ));
 }
 
@@ -571,14 +594,18 @@ pub fn dispatch_interaction_point(
             continue;
         }
         stage.runtime.spawn(run_interaction_point(
-            entity,
-            hub.clone(),
-            state.agent_id.clone(),
-            point,
-            body,
-            rounds.map_or(0, |r| r.0),
-            stage.outcomes.clone(),
-            stage.wake.clone(),
+            PointAsk {
+                entity,
+                agent_id: state.agent_id.clone(),
+                point,
+                body,
+                round: rounds.map_or(0, |r| r.0),
+            },
+            PromptLane {
+                hub: hub.clone(),
+                outcomes: stage.outcomes.clone(),
+                wake: stage.wake.clone(),
+            },
         ));
         commands
             .entity(entity)
@@ -1284,14 +1311,18 @@ mod tests {
             let mut point = plan_point();
             point.unattended = policy;
             let task = tokio::spawn(run_interaction_point(
-                Entity::from_raw_u32(1).unwrap(),
-                hub.clone(),
-                "run-1".to_string(),
-                point,
-                "the plan".to_string(),
-                0,
-                tx,
-                Arc::new(Notify::new()),
+                PointAsk {
+                    entity: Entity::from_raw_u32(1).unwrap(),
+                    agent_id: "run-1".to_string(),
+                    point,
+                    body: "the plan".to_string(),
+                    round: 0,
+                },
+                PromptLane {
+                    hub: hub.clone(),
+                    outcomes: tx,
+                    wake: Arc::new(Notify::new()),
+                },
             ));
             // Expiring and cancelling hand back the same neutral response, and
             // cancelling does not need a clock. The id is the one
@@ -1807,14 +1838,19 @@ mod tests {
         let task = {
             let hub = hub.clone();
             tokio::spawn(run_interaction_point(
-                Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id"),
-                hub,
-                "run".to_string(),
-                point,
-                "body".to_string(),
-                0,
-                tx,
-                Arc::new(Notify::new()),
+                PointAsk {
+                    entity: Entity::from_raw_u32(1)
+                        .expect("a small literal index is always a valid entity id"),
+                    agent_id: "run".to_string(),
+                    point,
+                    body: "body".to_string(),
+                    round: 0,
+                },
+                PromptLane {
+                    hub,
+                    outcomes: tx,
+                    wake: Arc::new(Notify::new()),
+                },
             ))
         };
         for _ in 0..8 {
@@ -1875,14 +1911,19 @@ mod tests {
         let task = {
             let hub = hub.clone();
             tokio::spawn(run_interaction_point(
-                Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id"),
-                hub,
-                "run".to_string(),
-                plan_point(),
-                "body".to_string(),
-                0,
-                tx,
-                Arc::new(Notify::new()),
+                PointAsk {
+                    entity: Entity::from_raw_u32(1)
+                        .expect("a small literal index is always a valid entity id"),
+                    agent_id: "run".to_string(),
+                    point: plan_point(),
+                    body: "body".to_string(),
+                    round: 0,
+                },
+                PromptLane {
+                    hub,
+                    outcomes: tx,
+                    wake: Arc::new(Notify::new()),
+                },
             ))
         };
         // Answer the point with the edit option.

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -264,6 +264,38 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
     }
 }
 
+/// The agent components `meta.json` is built from.
+///
+/// Held apart from [`RunPosition`] because these are read off the entity while
+/// the position is stamped onto it: one is what the agent *is*, the other is
+/// where it has got to.
+pub struct RunMetaSources<'a> {
+    /// The run's immutable metadata, fixed at spawn.
+    pub md: &'a RunMetadata,
+    /// The agent's live state.
+    pub state: &'a AgentState,
+    /// Token totals accumulated so far.
+    pub totals: &'a TokenTotals,
+    /// Outcome flags the blueprint's shape decides.
+    pub flags: &'a RunOutcomeFlags,
+    /// The submitted answer, when the run has produced one.
+    pub final_output: Option<&'a FinalOutput>,
+}
+
+/// Where the run has got to, and when.
+pub struct RunPosition {
+    /// Index of the stage the agent is in.
+    pub stage_index: usize,
+    /// The moment `updated_at` is stamped with.
+    pub now_secs: i64,
+    /// When the run last actually moved, as distinct from last being touched.
+    pub last_progress_at: Option<i64>,
+    /// How deep in the sub-agent tree this run sits.
+    pub depth: usize,
+    /// How deep the tree may go.
+    pub max_child_depth: usize,
+}
+
 /// Build the run metadata (`meta.json`) from an agent's live components, stamping
 /// `updated_at` with `now_secs`. `stage_index` is the agent's current stage
 /// position within its blueprint.
@@ -274,22 +306,21 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
 /// the progress stamp where it was. Taken as a plain `Option` rather than the
 /// watermark it comes from so this stays a data mapper with no dependency on the
 /// persistence pipeline.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "meta.json has this many independent fields; the struct this would take is RunMetadata, which is what it returns"
-)]
-pub fn build_run_meta(
-    md: &RunMetadata,
-    state: &AgentState,
-    totals: &TokenTotals,
-    flags: &RunOutcomeFlags,
-    stage_index: usize,
-    now_secs: i64,
-    last_progress_at: Option<i64>,
-    depth: usize,
-    max_child_depth: usize,
-    final_output: Option<&FinalOutput>,
-) -> RunMeta {
+pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
+    let RunMetaSources {
+        md,
+        state,
+        totals,
+        flags,
+        final_output,
+    } = sources;
+    let RunPosition {
+        stage_index,
+        now_secs,
+        last_progress_at,
+        depth,
+        max_child_depth,
+    } = at;
     let status = run_status_from(&state.status);
     let mut flags = flags.0.clone();
     // Having submitted an output is itself production, so this is settled before
@@ -592,16 +623,20 @@ mod tests {
         let mut st = state(AgentStatus::Active);
         st.spawned_children_ids = vec!["child-a".to_string(), "child-b".to_string()];
         let meta = build_run_meta(
-            &md,
-            &st,
-            &totals,
-            &RunOutcomeFlags::default(),
-            1,
-            2000,
-            Some(1900),
-            1,
-            4,
-            None,
+            RunMetaSources {
+                md: &md,
+                state: &st,
+                totals: &totals,
+                flags: &RunOutcomeFlags::default(),
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 1,
+                now_secs: 2000,
+                last_progress_at: Some(1900),
+                depth: 1,
+                max_child_depth: 4,
+            },
         );
 
         assert_eq!(meta.run_id, "run-1");
@@ -637,16 +672,20 @@ mod tests {
         let mut md = metadata();
         md.unattended = true;
         let meta = build_run_meta(
-            &md,
-            &state(AgentStatus::Active),
-            &TokenTotals::default(),
-            &RunOutcomeFlags::default(),
-            1,
-            2000,
-            None,
-            1,
-            4,
-            None,
+            RunMetaSources {
+                md: &md,
+                state: &state(AgentStatus::Active),
+                totals: &TokenTotals::default(),
+                flags: &RunOutcomeFlags::default(),
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 1,
+                now_secs: 2000,
+                last_progress_at: None,
+                depth: 1,
+                max_child_depth: 4,
+            },
         );
         assert!(meta.yolo);
     }
@@ -657,16 +696,20 @@ mod tests {
         flags.0.gates_forced = 2;
         // Still running with nothing written: not (yet) an empty run.
         let running = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Active),
-            &TokenTotals::default(),
-            &flags,
-            0,
-            1000,
-            None,
-            0,
-            0,
-            None,
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Active),
+                totals: &TokenTotals::default(),
+                flags: &flags,
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 1000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         assert!(!running.flags.empty_output);
         assert_eq!(running.flags.gates_forced, 2);
@@ -680,16 +723,20 @@ mod tests {
             },
         ] {
             let meta = build_run_meta(
-                &metadata(),
-                &state(status),
-                &TokenTotals::default(),
-                &flags,
-                0,
-                1000,
-                None,
-                0,
-                0,
-                None,
+                RunMetaSources {
+                    md: &metadata(),
+                    state: &state(status),
+                    totals: &TokenTotals::default(),
+                    flags: &flags,
+                    final_output: None,
+                },
+                RunPosition {
+                    stage_index: 0,
+                    now_secs: 1000,
+                    last_progress_at: None,
+                    depth: 0,
+                    max_child_depth: 0,
+                },
             );
             assert!(meta.flags.empty_output);
         }
@@ -698,16 +745,20 @@ mod tests {
         let mut wrote = RunOutcomeFlags::default();
         wrote.0.record_modification("src/a.rs");
         let meta = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Complete),
-            &TokenTotals::default(),
-            &wrote,
-            0,
-            1000,
-            None,
-            0,
-            0,
-            None,
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Complete),
+                totals: &TokenTotals::default(),
+                flags: &wrote,
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 1000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         assert!(!meta.flags.empty_output);
         assert_eq!(meta.flags.modified_files, vec!["src/a.rs".to_string()]);
@@ -717,16 +768,20 @@ mod tests {
         let mut incapable = RunOutcomeFlags::default();
         incapable.0.no_output_tools = true;
         let meta = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Complete),
-            &TokenTotals::default(),
-            &incapable,
-            0,
-            1000,
-            None,
-            0,
-            0,
-            None,
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Complete),
+                totals: &TokenTotals::default(),
+                flags: &incapable,
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 1000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         assert!(!meta.flags.empty_output);
         assert!(meta.flags.no_output_tools);
@@ -735,18 +790,22 @@ mod tests {
     #[test]
     fn build_run_meta_carries_error_message() {
         let meta = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Error {
-                message: "boom".to_string(),
-            }),
-            &TokenTotals::default(),
-            &RunOutcomeFlags::default(),
-            2,
-            3000,
-            None,
-            0,
-            0,
-            None,
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Error {
+                    message: "boom".to_string(),
+                }),
+                totals: &TokenTotals::default(),
+                flags: &RunOutcomeFlags::default(),
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 2,
+                now_secs: 3000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         assert_eq!(meta.status, RunStatus::Error);
         assert_eq!(meta.error.as_deref(), Some("boom"));
@@ -766,16 +825,20 @@ mod tests {
             1234,
         ));
         let meta = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Complete),
-            &TokenTotals::default(),
-            &RunOutcomeFlags::default(),
-            0,
-            1000,
-            None,
-            0,
-            0,
-            Some(&submitted),
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Complete),
+                totals: &TokenTotals::default(),
+                flags: &RunOutcomeFlags::default(),
+                final_output: Some(&submitted),
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 1000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         let carried = meta.final_output.expect("the submission reached meta.json");
         // The descriptor, not the bytes: `meta.json` is parsed for every run on
@@ -796,16 +859,20 @@ mod tests {
     #[test]
     fn a_run_that_submits_nothing_is_still_judged_empty() {
         let meta = build_run_meta(
-            &metadata(),
-            &state(AgentStatus::Complete),
-            &TokenTotals::default(),
-            &RunOutcomeFlags::default(),
-            0,
-            1000,
-            None,
-            0,
-            0,
-            None,
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Complete),
+                totals: &TokenTotals::default(),
+                flags: &RunOutcomeFlags::default(),
+                final_output: None,
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 1000,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
         );
         assert!(meta.final_output.is_none());
         assert!(!meta.flags.produced_output);

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -343,16 +343,20 @@ pub fn dispatch_persistence(
         // what lets an observer reading `meta.json` tell a slow run from a wedged
         // one, which `updated_at` (which is `now` either way) cannot.
         let meta = build_run_meta(
-            md,
-            state,
-            totals,
-            &flags,
-            cursor.index,
-            now,
-            watermark.last_progress_at(),
-            depth,
-            max_child_depth,
-            final_output,
+            crate::persistence::RunMetaSources {
+                md,
+                state,
+                totals,
+                flags: &flags,
+                final_output,
+            },
+            crate::persistence::RunPosition {
+                stage_index: cursor.index,
+                now_secs: now,
+                last_progress_at: watermark.last_progress_at(),
+                depth,
+                max_child_depth,
+            },
         );
         let context = build_context_snapshot(window, &state.current_stage);
         let stages = ledger.as_deref().map(|l| l.0.clone()).unwrap_or_default();

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -191,14 +191,41 @@ pub fn spawn_agent(
     // blueprint to the built-in defaults.
     spawn_agent_seeded(
         world,
-        agent_id,
-        blueprint,
-        &seeds,
-        stages,
-        global_hints,
-        leviath_core::NudgeConfig::default(),
-        std::collections::HashMap::new(),
+        SeededSpawn {
+            agent_id,
+            blueprint,
+            seeds,
+            stages,
+            global_hints,
+            global_nudge: leviath_core::NudgeConfig::default(),
+            region_scripts: std::collections::HashMap::new(),
+        },
     )
+}
+
+/// Everything a seeded spawn needs besides the world it spawns into.
+///
+/// The blueprint and its resolved stages travel with the seeds and the global
+/// defaults because all six are the same decision made at different layers:
+/// what this agent starts with. The caller resolves them; this consumes them.
+pub struct SeededSpawn {
+    /// The run id this agent is registered under.
+    pub agent_id: String,
+    /// The blueprint being spawned.
+    pub blueprint: leviath_core::Blueprint,
+    /// Content for named caller-input regions, keyed by region name.
+    pub seeds: std::collections::HashMap<String, String>,
+    /// The blueprint's stages, already resolved against the provider registry.
+    pub stages: Vec<ResolvedStage>,
+    /// Config-level prompt hints, applied where the blueprint says nothing.
+    pub global_hints: leviath_core::config::PromptHints,
+    /// The config-level nudge, likewise.
+    pub global_nudge: leviath_core::NudgeConfig,
+    /// Compiled render hooks, keyed by region name.
+    pub region_scripts: std::collections::HashMap<
+        String,
+        std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
+    >,
 }
 
 /// Like [`spawn_agent`], but seeds the context window from a name→content map
@@ -210,23 +237,17 @@ pub fn spawn_agent(
 /// the agent as a [`crate::pipeline::response::GlobalNudge`] component; each
 /// field is resolved per stage against the blueprint's agent-level and
 /// per-stage nudge settings when an empty response is handled.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "spawns an entity from a blueprint plus five independent seed sources; the sources have nothing in common but this call"
-)]
-pub fn spawn_agent_seeded(
-    world: &mut World,
-    agent_id: String,
-    mut blueprint: leviath_core::Blueprint,
-    seeds: &std::collections::HashMap<String, String>,
-    stages: Vec<ResolvedStage>,
-    global_hints: leviath_core::config::PromptHints,
-    global_nudge: leviath_core::NudgeConfig,
-    region_scripts: std::collections::HashMap<
-        String,
-        std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
-    >,
-) -> Result<Entity, String> {
+pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entity, String> {
+    let SeededSpawn {
+        agent_id,
+        mut blueprint,
+        seeds,
+        stages,
+        global_hints,
+        global_nudge,
+        region_scripts,
+    } = spawn;
+    let seeds = &seeds;
     // Resolve any percentage region budgets against each stage's model context
     // window (the only place the model - and hence the window - is known). The
     // global layout resolves against the entry stage (stage 0); each per-stage

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -285,6 +285,28 @@ type DispatchToolsQuery = (
     Option<&'static crate::components::OutputValidators>,
 );
 
+/// The resources the daemon installs, which a bare world does not have.
+///
+/// Every field is optional because `lev run` drives these same systems with no
+/// daemon behind them: no gate lane to prompt through, no persistence lane, no
+/// event sink. Bundled as one `SystemParam` so a system's signature stays about
+/// what it *queries* rather than listing the six things that might be wired.
+#[derive(bevy_ecs::system::SystemParam)]
+pub struct DaemonServices<'w> {
+    /// The taint-gate policy, when one is configured.
+    pub policy: Option<Res<'w, PolicyGate>>,
+    /// Rhai rules the gate consults before blocking.
+    pub script_rules: Option<Res<'w, GateScriptRules>>,
+    /// The hub a blocked call can prompt through.
+    pub hub: Option<Res<'w, InteractionHub>>,
+    /// The lane a gate prompt's answer comes back on.
+    pub gate_stage: Option<Res<'w, crate::gate_prompt::GatePromptStage>>,
+    /// The lane run state is written on.
+    pub persist: Option<Res<'w, PersistenceStage>>,
+    /// Where world events are broadcast.
+    pub sink: Option<Res<'w, crate::host::WorldEventSink>>,
+}
+
 /// Tool-dispatch system: for each `ReadyForTools` agent, apply its `context_*`
 /// tool calls inline (they mutate the ECS window) and hand the rest to the
 /// sequential tool lane, moving it to `AwaitingTools`. If a batch is *all*
@@ -298,22 +320,21 @@ type DispatchToolsQuery = (
 /// with an ack the exec waits on, and a per-call [`ToolProgress`] journals each
 /// completion as a `ToolCallDone`. On a crash mid-batch, recovery replays the
 /// recorded results instead of re-running their side effects (issue #96).
-#[expect(
-    clippy::too_many_arguments,
-    reason = "a bevy system: every parameter is a distinct Query or Res the scheduler injects, and the ECS decides the signature rather than this code"
-)]
 pub fn dispatch_tools(
     mut agents: Query<DispatchToolsQuery, With<ReadyForTools>>,
     service: Res<ToolServiceRes>,
     stage: Res<ToolStage>,
-    policy: Option<Res<PolicyGate>>,
-    script_rules: Option<Res<GateScriptRules>>,
-    hub: Option<Res<InteractionHub>>,
-    gate_stage: Option<Res<crate::gate_prompt::GatePromptStage>>,
-    persist: Option<Res<PersistenceStage>>,
-    sink: Option<Res<crate::host::WorldEventSink>>,
+    daemon: DaemonServices,
     mut commands: Commands,
 ) {
+    let DaemonServices {
+        policy,
+        script_rules,
+        hub,
+        gate_stage,
+        persist,
+        sink,
+    } = daemon;
     crate::tick_scope::clear();
     let default_policy = leviath_core::PolicyConfig::default();
     let policy_ref = policy.as_ref().map(|p| &p.0).unwrap_or(&default_policy);
@@ -511,15 +532,19 @@ pub fn dispatch_tools(
                 gate_stage
                     .runtime
                     .spawn(crate::gate_prompt::run_gate_prompt(
-                        entity,
-                        (*hub).clone(),
-                        state.agent_id.clone(),
-                        tool_id,
-                        name,
-                        taint,
-                        clearance,
-                        gate_stage.outcomes.clone(),
-                        gate_stage.wake.clone(),
+                        crate::gate_prompt::GatedCall {
+                            entity,
+                            agent_id: state.agent_id.clone(),
+                            tool_id,
+                            tool_name: name,
+                            taint,
+                            clearance,
+                        },
+                        crate::interaction_hub::PromptLane {
+                            hub: (*hub).clone(),
+                            outcomes: gate_stage.outcomes.clone(),
+                            wake: gate_stage.wake.clone(),
+                        },
                     ));
             }
             commands

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -500,12 +500,14 @@ pub fn resolve_transition(
                 match enter_stage(
                     idx,
                     &bp.0,
-                    &mut cursor,
-                    &mut state,
-                    &mut progress,
-                    &mut visits,
                     setup,
-                    &mut window,
+                    StageEntry {
+                        cursor: &mut cursor,
+                        state: &mut state,
+                        progress: &mut progress,
+                        visits: &mut visits,
+                        window: &mut window,
+                    },
                 ) {
                     Ok(visit) => {
                         // Entering a stage is active work; clears a prior error
@@ -563,20 +565,39 @@ pub fn resolve_transition(
 /// `Ok` carries the stage's updated visit count (this entry included), which the
 /// transition systems stamp into the [`StageTransition`](crate::host::WorldEvent)
 /// event.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "updates seven unrelated per-stage components in one pass, which is cheaper than seven queries over the same entity"
-)]
+/// The per-agent components entering a stage rewrites.
+///
+/// Borrowed together because entering a stage is one atomic edit across all
+/// five: the cursor moves, per-stage progress resets, the visit count bumps,
+/// `accepts_messages` is set from the new stage's mode, and the window is
+/// re-laid-out. Doing them through five separate queries over the same entity
+/// would cost five passes to say one thing.
+pub(crate) struct StageEntry<'a> {
+    /// Where in the blueprint the agent is.
+    pub cursor: &'a mut StageCursor,
+    /// The agent's live state.
+    pub state: &'a mut AgentState,
+    /// Per-stage counters, reset on entry.
+    pub progress: &'a mut StageProgress,
+    /// How many times each stage has been entered.
+    pub visits: &'a mut VisitCounts,
+    /// The context window, re-laid-out for the new stage.
+    pub window: &'a mut ContextWindow,
+}
+
 pub(crate) fn enter_stage(
     idx: usize,
     blueprint: &leviath_core::Blueprint,
-    cursor: &mut StageCursor,
-    state: &mut AgentState,
-    progress: &mut StageProgress,
-    visits: &mut VisitCounts,
     setup: &StageSetup,
-    window: &mut ContextWindow,
+    entry: StageEntry<'_>,
 ) -> Result<usize, String> {
+    let StageEntry {
+        cursor,
+        state,
+        progress,
+        visits,
+        window,
+    } = entry;
     cursor.index = idx;
     let name = blueprint.stages[idx].name.clone();
     state.current_stage = name.clone();
@@ -730,12 +751,14 @@ pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
         match enter_stage(
             target_idx,
             &bp,
-            &mut cursor,
-            &mut state,
-            &mut progress,
-            &mut visits,
             &setup,
-            &mut window,
+            StageEntry {
+                cursor: &mut cursor,
+                state: &mut state,
+                progress: &mut progress,
+                visits: &mut visits,
+                window: &mut window,
+            },
         ) {
             Ok(_) => Some((stage_inf, setup, name)),
             Err(message) => {

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -365,12 +365,14 @@ pub fn collect_transition_choice(
                 match enter_stage(
                     idx,
                     &bp.0,
-                    &mut cursor,
-                    &mut state,
-                    &mut progress,
-                    &mut visits,
                     setup,
-                    &mut window,
+                    StageEntry {
+                        cursor: &mut cursor,
+                        state: &mut state,
+                        progress: &mut progress,
+                        visits: &mut visits,
+                        window: &mut window,
+                    },
                 ) {
                     Ok(visit) => {
                         // No `status = Active` here, unlike the same sequence in

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1371,13 +1371,6 @@ mod tests {
         assert!(result.contains("Failed to read directory"));
     }
 
-    // `set_readonly(false)` widens Unix perms beyond the original, but here it
-    // only re-enables cleanup of a throwaway tempdir file, which is exactly
-    // what we want.
-    #[expect(
-        clippy::permissions_set_readonly_false,
-        reason = "same as the blueprints test: set_readonly(false) here only re-enables cleanup of a temp file this test created moments ago"
-    )]
     #[tokio::test]
     async fn edit_file_write_failure_after_successful_match() {
         let dir = tempfile::tempdir().unwrap();
@@ -1388,8 +1381,10 @@ mod tests {
         // Make the file read-only so the read succeeds but the write-back
         // fails. `set_readonly(true)` is cross-platform (clears the write bits
         // on Unix; sets the read-only attribute on Windows), so the write
-        // error arm is exercised on every OS.
-        let mut perms = fs::metadata(&file_path).unwrap().permissions();
+        // error arm is exercised on every OS. The original permissions are kept
+        // so they can be put back exactly, rather than reconstructed.
+        let original = fs::metadata(&file_path).unwrap().permissions();
+        let mut perms = original.clone();
         perms.set_readonly(true);
         fs::set_permissions(&file_path, perms).unwrap();
 
@@ -1400,10 +1395,11 @@ mod tests {
             )
             .await;
 
-        // Restore permissions so tempdir cleanup can remove the file.
-        let mut perms = fs::metadata(&file_path).unwrap().permissions();
-        perms.set_readonly(false);
-        fs::set_permissions(&file_path, perms).unwrap();
+        // Put the original permissions back so tempdir cleanup can remove the
+        // file on Windows, where a read-only file cannot be deleted. Restoring
+        // what was there beats `set_readonly(false)`, which on Unix sets *every*
+        // write bit and would hand back 0o666 for a file that was 0o644.
+        fs::set_permissions(&file_path, original).unwrap();
 
         assert!(result.contains("[error]"));
         assert!(result.contains("Failed to write"));


### PR DESCRIPTION
`run_gate_prompt` (9 args), `run_interaction_point` (8), `dispatch_tools` (10) and `build_run_meta` (10) no longer suppress `too_many_arguments`.

## The two prompt paths

Both split the same way: what the person is being asked about, and where their answer goes. `GatedCall` / `PointAsk` carry the first; **`PromptLane<T>` carries the second — one type for both**, because "ask through this hub, report on this channel, wake this driver" was written out twice with only the outcome type differing.

## `dispatch_tools` — I was wrong about this one

I claimed earlier that a bevy system's signature is fixed by the framework and its parameters cannot be grouped. That was wrong. `#[derive(SystemParam)]` exists for exactly this.

Its six optional resources are one coherent thing — what the daemon wired that a bare world did not, which is why every one is `Option<Res<..>>`: `lev run` drives these same systems with no gate lane, no persistence lane, no event sink. They are now `DaemonServices`, and the signature is about what the system *queries* again rather than listing six things that might be present.

## `build_run_meta`

Splits into `RunMetaSources` (the components read off the entity) and `RunPosition` (where the run has got to, stamped onto them). One is what the agent *is*, the other is where it has reached. Ten call sites rewritten.

## A trap worth recording

Inserting a param struct above a function lands it **between that function's doc comment and the function**, so the doc silently starts describing the struct and the function fails `missing_docs`. Hit three times in this change. A related one: a doc link to an item in a private module (`crate::gate_prompt::GatedCall`) fails `cargo doc` even though the code compiles.

1,155 runtime tests pass; workspace green.