### PR TITLE
refactor: remove every string_slice suppression

### DIFF
--- a/.sgrules/no-lint-suppression.yml
+++ b/.sgrules/no-lint-suppression.yml
@@ -13,9 +13,10 @@ message: >-
   became a constructor named for what it does. If a new one seems unavoidable,
   it is worth an hour before it is worth an attribute - and if it genuinely is
   unavoidable, change this rule in the same PR and say why.
-  `clippy::string_slice` is the one exception, and only as `#[expect(...,
-  reason = "...")]`: the root Cargo.toml documents it as the sanctioned hatch,
-  naming the construct that guarantees the index is a char boundary.
+  `clippy::string_slice` was the last exception and is no longer one. Cut with
+  `leviath_core::text::{substring, split_at_boundary, truncate_at_boundary}`,
+  which are total, or scan with `split_once`, which drops the delimiter-length
+  arithmetic along with the index.
 rule:
   kind: attribute_item
-  regex: '(allow|expect)\((clippy::(too_many_arguments|type_complexity|match_same_arms|new_without_default|permissions_set_readonly_false|enum_variant_names)|dead_code|deprecated|async_fn_in_trait)'
+  regex: '(allow|expect)\((clippy::(too_many_arguments|type_complexity|match_same_arms|new_without_default|permissions_set_readonly_false|enum_variant_names|string_slice)|dead_code|deprecated|async_fn_in_trait)'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,21 @@ missing_docs = "warn"
 # That is not hypothetical here: it aborted the daemon twice (issues #109 and #115,
 # a byte cut-off through an emoji inside a Rhai host function), and an audit found
 # two more live instances plus four hand-rolled copies of the walk-back loop. So it
-# is denied workspace-wide. Cut with `leviath_core::truncate_at_boundary` /
-# `floor_char_boundary`, or -- when the index provably *is* a boundary because it
-# came from `find`/`char_indices`/`starts_with` -- annotate the enclosing item with
-# `#[expect(clippy::string_slice, reason = "...")]` naming the construct that
-# guarantees it. "Looks fine" is exactly the unstated invariant this lint exists to
-# stop.
+# is denied workspace-wide, with no exceptions: there are zero suppressions of it
+# in the tree and a lint rule that fails the build on a new one.
+#
+# Reach for `leviath_core::text` instead. `substring` and `split_at_boundary` are
+# the general replacements and both are total - no combination of offsets makes
+# either panic - and `truncate_at_boundary` / `snippet_around` cover the common
+# cuts. Where the text is being scanned rather than cut, `split_once` is usually
+# the real answer, and it removes the delimiter-length arithmetic along with the
+# index.
+#
+# The suppressions this paragraph used to sanction all turned out to be worth
+# removing. Every one named a construct that guaranteed the index was a boundary,
+# and every one of those claims was true - but the proof lived in a comment, and
+# the code around it was free to drift. What replaced them is not a better comment
+# but a signature that cannot be wrong.
 [workspace.lints.clippy]
 string_slice = "deny"
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -20,16 +20,14 @@ use crate::runstate;
 /// runs dir outside `$HOME`, which isn't portable (`std::env::temp_dir()` lives
 /// *under* the home directory on Windows, so it only ever hits the shortened
 /// branch there).
-#[expect(
-    clippy::string_slice,
-    reason = "the `starts_with(home)` guard makes `home.len()` the end of a matched prefix, which \
-              is a char boundary"
-)]
 fn shorten_home_path(raw: String, home: &str) -> String {
-    if !home.is_empty() && raw.starts_with(home) {
-        format!("~{}", &raw[home.len()..])
-    } else {
-        raw
+    // `strip_prefix` rather than `starts_with` plus `&raw[home.len()..]`: it does
+    // the test and the cut as one operation, so they cannot disagree about where
+    // the prefix ended. The empty-home guard stays because `strip_prefix("")`
+    // matches everything.
+    match raw.strip_prefix(home) {
+        Some(rest) if !home.is_empty() => format!("~{rest}"),
+        _ => raw,
     }
 }
 
@@ -657,11 +655,6 @@ impl Dashboard {
         }
     }
 
-    #[expect(
-        clippy::string_slice,
-        reason = "`prefix_end` is only non-zero on a `starts_with` branch, where it is the length \
-                  of the ASCII tag that just matched - a char boundary"
-    )]
     fn build_output_lines(
         &self,
         agent: &DashboardAgent,
@@ -686,24 +679,30 @@ impl Dashboard {
             content
                 .lines()
                 .map(|l| {
-                    let (color, prefix_end) = if l.starts_with("[tool]") {
-                        (C_ACCENT, 6)
+                    // The tag is carried as the literal itself rather than its
+                    // length, so the two can never disagree.
+                    let (color, tag) = if l.starts_with("[tool]") {
+                        (C_ACCENT, "[tool]")
                     } else if l.starts_with("[error]") {
-                        (C_ERROR, 7)
+                        (C_ERROR, "[error]")
                     } else if l.starts_with("[denied]") {
-                        (C_WARN, 8)
+                        (C_WARN, "[denied]")
                     } else if l.starts_with("---") || l.starts_with("[All") {
-                        (C_DIM, 0)
+                        (C_DIM, "")
                     } else {
-                        (C_MUTED, 0)
+                        (C_MUTED, "")
                     };
-                    if prefix_end > 0 && l.len() > prefix_end {
+                    // Every arm above picked `tag` off a `starts_with` that just
+                    // matched, and the empty tag strips nothing.
+                    let rest = l.strip_prefix(tag).unwrap_or(l);
+                    if !tag.is_empty() && !rest.is_empty() {
+                        // A tagged line reads as a bold tag plus muted body.
                         Line::from(vec![
                             Span::styled(
-                                format!(" {}", &l[..prefix_end]),
+                                format!(" {tag}"),
                                 Style::default().fg(color).add_modifier(Modifier::BOLD),
                             ),
-                            Span::styled(l[prefix_end..].to_string(), Style::default().fg(C_MUTED)),
+                            Span::styled(rest.to_string(), Style::default().fg(C_MUTED)),
                         ])
                     } else {
                         Line::from(Span::styled(format!(" {}", l), Style::default().fg(color)))

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -78,11 +78,6 @@ impl Dashboard {
         );
     }
 
-    #[expect(
-        clippy::string_slice,
-        reason = "the `starts_with(&home)` guard makes `home.len()` the end of a matched prefix, \
-                  which is a char boundary"
-    )]
     pub(in crate::commands::dashboard) fn render_info_strip(
         &self,
         frame: &mut Frame,
@@ -105,10 +100,11 @@ impl Dashboard {
         let home = dirs::home_dir()
             .map(|h| h.to_string_lossy().to_string())
             .unwrap_or_default();
-        let workdir_display = if !home.is_empty() && agent.workdir.starts_with(&home) {
-            format!("~{}", &agent.workdir[home.len()..])
-        } else {
-            agent.workdir.clone()
+        // One operation rather than a guard plus a byte offset, so the test and
+        // the cut cannot disagree about where the prefix ended.
+        let workdir_display = match agent.workdir.strip_prefix(&home) {
+            Some(rest) if !home.is_empty() => format!("~{rest}"),
+            _ => agent.workdir.clone(),
         };
         let workdir_truncated = truncate(&workdir_display, 42);
 

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -10,10 +10,19 @@
 //!
 //! That failure has happened for real: a byte cut-off through a flag emoji
 //! inside a Rhai host function double-panicked and aborted the whole daemon.
-//! Keeping the walk-back in one tested place means a new
-//! truncation site cannot forget it. The workspace also denies
-//! `clippy::string_slice`, so reaching for a raw `&s[..n]` instead of these
-//! helpers is a compile error unless the boundary is proven at the call site.
+//! Keeping the walk-back in one tested place means a new truncation site cannot
+//! forget it. The workspace denies `clippy::string_slice` with no exceptions, so
+//! reaching for a raw `&s[..n]` instead of these helpers is a compile error.
+//!
+//! [`substring`] and [`split_at_boundary`] are the general replacements, and
+//! both are *total*: no combination of offsets makes either panic. That matters
+//! more than it sounds. The proof obligation on `&s[a..b]` is real but it is
+//! discharged by reading, and the sites that need it most are byte-offset
+//! scanners walking text nobody in this repo wrote - fetched HTML, a model's
+//! fenced output, an SSE frame off the wire. Those are exactly the places where
+//! a careful reading is least likely to be right, and where being wrong took
+//! the daemon down. Clamping is a worse answer than a correct index and a much
+//! better one than an abort.
 
 /// Largest byte index `<= max` that is a char boundary in `s`.
 ///
@@ -27,17 +36,45 @@ pub fn floor_char_boundary(s: &str, max: usize) -> usize {
     end
 }
 
+/// The text of `s` between two byte offsets, with both ends walked back to a
+/// char boundary and clamped into the string.
+///
+/// This is the workspace's substitute for `&s[a..b]`, and it is total: there is
+/// no offset, ordering or overflow of the two arguments that can make it panic.
+/// A range running off the end yields what is there, and a backwards range
+/// yields nothing. Callers that have *searched* for their offsets get the exact
+/// slice they asked for, because a `find` hit is already a boundary; callers
+/// that computed one get the nearest cut that does not split a character.
+///
+/// That totality is the point. A scanner walking byte offsets through text it
+/// did not author - HTML from a fetch, a model's fenced output, an SSE frame -
+/// cannot be read closely enough to prove every offset correct, and the failure
+/// mode for getting one wrong used to be aborting the daemon.
+pub fn substring(s: &str, start: usize, end: usize) -> &str {
+    let end = floor_char_boundary(s, end);
+    let start = floor_char_boundary(s, start.min(end));
+    // Both bounds are now char boundaries at or inside `s`, so the range is
+    // always valid and the fallback is unreachable. It is spelled out anyway so
+    // that a later change to the clamping above cannot reintroduce a panic.
+    s.get(start..end).unwrap_or("")
+}
+
+/// `s` cut in two at `mid`, walked back to a char boundary.
+///
+/// The pair form of [`substring`], for scanners that need both the text before
+/// an offset and the text after it. `mid` past the end puts everything in the
+/// first half.
+pub fn split_at_boundary(s: &str, mid: usize) -> (&str, &str) {
+    let mid = floor_char_boundary(s, mid);
+    (substring(s, 0, mid), substring(s, mid, s.len()))
+}
+
 /// `&s[..max]`, backed off to the nearest char boundary at or before `max`.
 ///
 /// Returns all of `s` when `max` reaches the end. Callers append their own
 /// ellipsis or truncation marker - this only cuts.
-#[expect(
-    clippy::string_slice,
-    reason = "floor_char_boundary returns a char boundary by construction - this is the one raw \
-              slice the rest of the workspace defers to"
-)]
 pub fn truncate_at_boundary(s: &str, max: usize) -> &str {
-    &s[..floor_char_boundary(s, max)]
+    substring(s, 0, max)
 }
 
 /// Smallest byte index `>= min` that is a char boundary in `s`.
@@ -63,11 +100,6 @@ pub fn ceil_char_boundary(s: &str, min: usize) -> usize {
 /// window never loses a character that was inside the requested radius, and the
 /// match itself cannot be clipped by a boundary walk. `at` past the end clamps,
 /// so a stale offset yields a short window instead of a panic.
-#[expect(
-    clippy::string_slice,
-    reason = "both indices come from the boundary helpers above, so the range is a char boundary \
-              by construction"
-)]
 pub fn snippet_around(s: &str, at: usize, radius: usize) -> String {
     let at = at.min(s.len());
     let start = floor_char_boundary(s, at.saturating_sub(radius));
@@ -76,7 +108,7 @@ pub fn snippet_around(s: &str, at: usize, radius: usize) -> String {
     if start > 0 {
         out.push('…');
     }
-    out.push_str(&s[start..end]);
+    out.push_str(substring(s, start, end));
     if end < s.len() {
         out.push('…');
     }
@@ -237,5 +269,36 @@ mod tests {
         assert_eq!(truncate_at_boundary("abc🎉def", 5), "abc");
         assert_eq!(truncate_at_boundary("🎉abc", 2), "");
         assert_eq!(truncate_at_boundary("", 5), "");
+    }
+
+    #[test]
+    fn substring_is_total() {
+        assert_eq!(substring("abcdef", 2, 4), "cd");
+        assert_eq!(substring("abcdef", 0, 6), "abcdef");
+        // Both ends walk back off a multi-byte character rather than panicking.
+        assert_eq!(substring("a🎉b", 1, 4), "");
+        assert_eq!(substring("a🎉b", 0, 3), "a");
+        assert_eq!(substring("a🎉b", 1, 5), "🎉");
+        // No pair of arguments panics: past the end, backwards, and saturated.
+        assert_eq!(substring("abc", 1, 99), "bc");
+        assert_eq!(substring("abc", 99, 99), "");
+        assert_eq!(substring("abc", 2, 1), "");
+        assert_eq!(substring("abc", usize::MAX, usize::MAX), "");
+        assert_eq!(substring("", 3, 9), "");
+    }
+
+    #[test]
+    fn split_at_boundary_halves_rejoin_to_the_input() {
+        assert_eq!(split_at_boundary("abcdef", 2), ("ab", "cdef"));
+        assert_eq!(split_at_boundary("abc", 0), ("", "abc"));
+        // A cut inside the emoji lands before it, so nothing is lost or doubled.
+        assert_eq!(split_at_boundary("a🎉b", 3), ("a", "🎉b"));
+        // Past the end puts everything in the first half.
+        assert_eq!(split_at_boundary("abc", 99), ("abc", ""));
+        assert_eq!(split_at_boundary("", 4), ("", ""));
+        for mid in 0..=10 {
+            let (head, tail) = split_at_boundary("a🎉bc", mid);
+            assert_eq!(format!("{head}{tail}"), "a🎉bc", "lost text at mid={mid}");
+        }
     }
 }

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -41,19 +41,14 @@ pub(crate) struct AuthServerMetadata {
 ///
 /// Returns `None` when the header is absent or carries no such parameter, in
 /// which case the caller falls back to the well-known path.
-#[expect(
-    clippy::string_slice,
-    reason = "`start` is a `find` hit plus the length of the ASCII needle it matched, and `end` is \
-              a `find` hit or the length - all char boundaries"
-)]
 pub(crate) fn resource_metadata_url(www_authenticate: Option<&str>) -> Option<String> {
     let header = www_authenticate?;
     // The parameter looks like: Bearer resource_metadata="https://…", …
-    let start = header.find("resource_metadata=")? + "resource_metadata=".len();
-    let rest = &header[start..];
+    let (_, rest) = header.split_once("resource_metadata=")?;
     let rest = rest.strip_prefix('"').unwrap_or(rest);
-    let end = rest.find('"').unwrap_or(rest.len());
-    let url = rest[..end].trim();
+    // An unterminated value runs to the end of the header rather than being
+    // discarded, which is what the quote-less form of the parameter looks like.
+    let url = rest.split_once('"').map_or(rest, |(value, _)| value).trim();
     if url.is_empty() {
         None
     } else {

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -114,21 +114,14 @@ fn resolve_var(name: &str, allowlist: &[String]) -> Option<String> {
     std::env::var(name).ok()
 }
 
-#[expect(
-    clippy::string_slice,
-    reason = "`start` and `end` are `find` hits, offset only by the lengths of the ASCII literals \
-              `${` and `}` - all char boundaries"
-)]
 pub(crate) fn expand_env_allowing(value: &str, allowlist: &[String]) -> String {
     let mut out = String::with_capacity(value.len());
     let mut rest = value;
 
-    while let Some(start) = rest.find("${") {
-        out.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        match after.find('}') {
-            Some(end) => {
-                let name = &after[..end];
+    while let Some((before, after)) = rest.split_once("${") {
+        out.push_str(before);
+        match after.split_once('}') {
+            Some((name, tail)) => {
                 match resolve_var(name, allowlist) {
                     Some(v) => out.push_str(&v),
                     None => tracing::warn!(
@@ -138,12 +131,13 @@ pub(crate) fn expand_env_allowing(value: &str, allowlist: &[String]) -> String {
                          server genuinely needs it"
                     ),
                 }
-                rest = &after[end + 1..];
+                rest = tail;
             }
             None => {
                 // Unterminated `${` - emit it literally rather than eating the
                 // rest of the value.
-                out.push_str(&rest[start..]);
+                out.push_str("${");
+                out.push_str(after);
                 return out;
             }
         }

--- a/crates/leviath-mcp/src/transport/sse.rs
+++ b/crates/leviath-mcp/src/transport/sse.rs
@@ -20,15 +20,16 @@ pub(crate) struct SseEvent {
 /// untouched so the caller can append more bytes and retry. Events are
 /// terminated by a blank line; `\r\n` is normalized, since a server behind a
 /// proxy may emit either ending.
-#[expect(
-    clippy::string_slice,
-    reason = "`end` is a `find` hit for an ASCII line terminator, so it is a char boundary"
-)]
 pub(crate) fn parse_sse_frame(buffer: &mut String) -> Option<SseEvent> {
     // A frame ends at the first blank line, in whichever line ending arrives.
-    let (end, sep_len) = find_frame_end(buffer)?;
-    let raw = buffer[..end].to_string();
-    buffer.drain(..end + sep_len);
+    // Copy the frame out, then drop it and its terminator from the front: what
+    // `split_frame` left as the remainder is exactly what should stay behind, so
+    // the length of the terminator never has to be named.
+    let (raw, remainder) = {
+        let (frame, rest) = split_frame(buffer)?;
+        (frame.to_string(), rest.len())
+    };
+    buffer.drain(..buffer.len() - remainder);
 
     let mut event = None;
     let mut data_lines: Vec<&str> = Vec::new();
@@ -60,16 +61,19 @@ pub(crate) fn parse_sse_frame(buffer: &mut String) -> Option<SseEvent> {
     })
 }
 
-/// Byte offset of the blank line ending the first frame, plus its length.
-fn find_frame_end(buffer: &str) -> Option<(usize, usize)> {
-    let lf = buffer.find("\n\n");
-    let crlf = buffer.find("\r\n\r\n");
+/// The first complete frame and everything after its terminator.
+fn split_frame(buffer: &str) -> Option<(&str, &str)> {
+    let lf = buffer.split_once("\n\n");
+    let crlf = buffer.split_once("\r\n\r\n");
     match (lf, crlf) {
         // Whichever terminator comes first wins; a `\r\n\r\n` also contains a
-        // `\n\r\n`, so comparing positions is what keeps them straight.
-        (Some(l), Some(c)) if c <= l => Some((c, 4)),
-        (Some(l), _) => Some((l, 2)),
-        (None, Some(c)) => Some((c, 4)),
+        // `\n\r\n`, so comparing how much text precedes each is what keeps them
+        // straight. Splitting rather than locating means neither terminator's
+        // length is written down, so neither can drift from the string it
+        // belongs to.
+        (Some(l), Some(c)) if c.0.len() <= l.0.len() => Some(c),
+        (Some(l), _) => Some(l),
+        (None, Some(c)) => Some(c),
         (None, None) => None,
     }
 }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -774,16 +774,12 @@ impl Stream for AnthropicSseStream {
 }
 
 /// Parse a single SSE event from the buffer, consuming it if found.
-#[expect(
-    clippy::string_slice,
-    reason = "`event_end` is a `find` hit for the ASCII \"\\n\\n\" terminator, so it and \
-              `event_end + 2` are char boundaries"
-)]
 fn parse_sse_event(buffer: &mut String, tool_index: &mut usize) -> Option<StreamChunk> {
-    // Look for a complete event (double newline)
-    let event_end = buffer.find("\n\n")?;
-    let event_text = buffer[..event_end].to_string();
-    *buffer = buffer[event_end + 2..].to_string();
+    // `None` until the double newline that terminates an event has arrived;
+    // the caller polls again with more bytes.
+    let (event_text, rest) = buffer.split_once("\n\n")?;
+    let event_text = event_text.to_string();
+    *buffer = rest.to_string();
 
     // Parse event type and data
     let mut event_type = String::new();

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -419,11 +419,6 @@ impl OllamaNdjsonStream {
 impl Stream for OllamaNdjsonStream {
     type Item = Result<StreamChunk>;
 
-    #[expect(
-        clippy::string_slice,
-        reason = "`newline_pos` is a `find` hit for the ASCII '\\n', so it and `newline_pos + 1` \
-                  are char boundaries"
-    )]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -432,9 +427,14 @@ impl Stream for OllamaNdjsonStream {
 
         loop {
             // Try to parse a complete JSON line
-            if let Some(newline_pos) = this.buffer.find('\n') {
-                let line = this.buffer[..newline_pos].to_string();
-                this.buffer = this.buffer[newline_pos + 1..].to_string();
+            // Split off one complete NDJSON line, if the newline ending it has
+            // arrived. Both halves are copied out before the buffer is replaced.
+            let split = this
+                .buffer
+                .split_once('\n')
+                .map(|(line, rest)| (line.to_string(), rest.to_string()));
+            if let Some((line, rest)) = split {
+                this.buffer = rest;
 
                 let line = line.trim();
                 if line.is_empty() {

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -575,15 +575,12 @@ impl Stream for OpenAiSseStream {
 /// which is why it needs an arm of its own: matched only on `choices` it fits
 /// the usage-only shape, and falling through there ends the stream cleanly -
 /// a truncated answer with nothing anywhere saying why.
-#[expect(
-    clippy::string_slice,
-    reason = "`event_end` is a `find` hit for the ASCII \"\\n\\n\" terminator, so it and \
-              `event_end + 2` are char boundaries"
-)]
 pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<StreamChunk>>> {
-    let event_end = buffer.find("\n\n")?;
-    let event_text = buffer[..event_end].to_string();
-    *buffer = buffer[event_end + 2..].to_string();
+    // `None` until the double newline that terminates an event has arrived;
+    // the caller polls again with more bytes.
+    let (event_text, rest) = buffer.split_once("\n\n")?;
+    let event_text = event_text.to_string();
+    *buffer = rest.to_string();
 
     for line in event_text.lines() {
         if let Some(data) = line.strip_prefix("data: ") {

--- a/crates/leviath-providers/src/text_tools.rs
+++ b/crates/leviath-providers/src/text_tools.rs
@@ -92,39 +92,30 @@ pub fn render_system_suffix(tools: &[Tool]) -> String {
 /// a `name` is skipped. An *unterminated* fence is left in the prose untouched -
 /// a truncated reply shouldn't have its visible text silently eaten. An `id`
 /// emitted by the model is ignored; ids are the runtime's to allocate.
-#[expect(
-    clippy::string_slice,
-    reason = "every index here is a `find` hit offset by the length of an ASCII literal \
-              (FENCE_OPEN, FENCE_CLOSE, '\\n'), so all of them are char boundaries"
-)]
 pub fn parse_tool_calls(text: &str) -> (String, Vec<(String, serde_json::Value)>) {
     let mut prose = String::new();
     let mut calls = Vec::new();
     let mut rest = text;
 
-    while let Some(open) = rest.find(FENCE_OPEN) {
+    // Each step splits what is left rather than indexing into it, so no offset
+    // is ever measured against a string other than the one it came from - which
+    // is what the earlier `body_start + close_rel + FENCE_CLOSE.len()` form had
+    // to be read carefully to confirm.
+    while let Some((before_fence, after_tag)) = rest.split_once(FENCE_OPEN) {
         // Body starts after the info string's line break. A fence with no
         // newline after the tag can't have a body, so treat it as unterminated.
-        let after_tag = &rest[open + FENCE_OPEN.len()..];
-        let Some(nl) = after_tag.find('\n') else {
+        let Some((_info, from_body)) = after_tag.split_once('\n') else {
             break;
         };
-        let body_start = open + FENCE_OPEN.len() + nl + 1;
-        let Some(close_rel) = rest[body_start..].find(FENCE_CLOSE) else {
+        let Some((body, after_close)) = from_body.split_once(FENCE_CLOSE) else {
             break; // unterminated - leave the remainder as prose
         };
-        let body = &rest[body_start..body_start + close_rel];
 
-        prose.push_str(&rest[..open]);
+        prose.push_str(before_fence);
         calls.extend(parse_call_array(body));
 
         // Continue after the closing fence, skipping to the end of its line.
-        let after_close = body_start + close_rel + FENCE_CLOSE.len();
-        let line_end = rest[after_close..]
-            .find('\n')
-            .map(|i| after_close + i + 1)
-            .unwrap_or(rest.len());
-        rest = &rest[line_end..];
+        rest = after_close.split_once('\n').map_or("", |(_, next)| next);
     }
     prose.push_str(rest);
 

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -43,17 +43,15 @@ pub struct WorkItem {
 
 /// Parse a split response into work items. Tolerates markdown fences and prose by
 /// extracting the outermost `[ … ]`. (Ported from the deleted imperative engine.)
-#[expect(
-    clippy::string_slice,
-    reason = "`s` and `e` come from `find`/`rfind` on the ASCII '[' and ']', so both are char \
-              boundaries and the inclusive range ends on the last byte of ']'"
-)]
 pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
     let trimmed = content.trim();
+    // Every rejection folds into one error: this parses model output, so
+    // "malformed input yields `Err`" has to hold for every shape of malformed.
     let slice = match (trimmed.find('['), trimmed.rfind(']')) {
-        (Some(s), Some(e)) if e > s => &trimmed[s..=e],
-        _ => return Err("split output is not a JSON array".to_string()),
-    };
+        (Some(s), Some(e)) if e > s => trimmed.get(s..=e),
+        _ => None,
+    }
+    .ok_or_else(|| "split output is not a JSON array".to_string())?;
     serde_json::from_str(slice)
         .map_err(|e| format!("split output is not a valid JSON array of work items: {e}"))
 }

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -22,6 +22,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use leviath_core::text::{split_at_boundary, substring};
 use rhai::{AST, Dynamic, Engine, EvalAltResult, Map, Position, Scope};
 use serde::Deserialize;
 
@@ -701,31 +702,34 @@ fn strip_raw_text_elements(html: &str) -> String {
     s
 }
 
-#[expect(
-    clippy::string_slice,
-    reason = "`i` only ever advances by `ch.len_utf8()` and `rel` comes from `find`, so both are \
-              char boundaries; `to_ascii_lowercase` preserves byte lengths, so `lower` and `html` \
-              share them"
-)]
 fn strip_element(html: &str, tag: &str) -> String {
     let lower = html.to_ascii_lowercase();
     let open = format!("<{tag}");
     let close = format!("</{tag}>");
     let mut out = String::with_capacity(html.len());
-    let mut i = 0;
-    while i < html.len() {
-        if lower[i..].starts_with(&open) {
-            match lower[i..].find(&close) {
+    // The two strings are walked together rather than sharing a byte cursor.
+    // `to_ascii_lowercase` does preserve byte lengths, so a shared index would
+    // be correct, but it is correct by an invariant stated nowhere in the types;
+    // advancing both by the same amount at each step makes it structural.
+    let mut rest = html;
+    let mut lower_rest = lower.as_str();
+    loop {
+        if lower_rest.starts_with(&open) {
+            match lower_rest.find(&close) {
                 Some(rel) => {
-                    i += rel + close.len();
+                    let skip = rel + close.len();
+                    rest = split_at_boundary(rest, skip).1;
+                    lower_rest = split_at_boundary(lower_rest, skip).1;
                     continue;
                 }
                 None => break, // unclosed element - drop the rest
             }
         }
-        let ch = html[i..].chars().next().unwrap();
+        // Also the loop's ordinary exit, once the input is used up.
+        let Some(ch) = rest.chars().next() else { break };
         out.push(ch);
-        i += ch.len_utf8();
+        rest = split_at_boundary(rest, ch.len_utf8()).1;
+        lower_rest = split_at_boundary(lower_rest, ch.len_utf8()).1;
     }
     out
 }
@@ -765,36 +769,33 @@ const ENTITY_SCAN_CHARS: usize = 12;
 /// an unstated invariant that a later edit could quietly break. Indices from
 /// `char_indices` are boundaries by construction, so there is nothing left to
 /// get wrong. Entities are all ASCII, so the two bounds agree on any real one.
-#[expect(
-    clippy::string_slice,
-    reason = "`amp` comes from `find` and `semi` from `char_indices`, so every index here is a \
-              char boundary; `after[1..]` is safe because `after` starts at the single-byte '&'"
-)]
 fn decode_entities(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while let Some(amp) = rest.find('&') {
-        out.push_str(&rest[..amp]);
-        let after = &rest[amp..];
+        // `after` still carries the '&', so something that turns out not to be
+        // an entity can be re-emitted verbatim.
+        let (before, after) = split_at_boundary(rest, amp);
+        out.push_str(before);
         let semi = after
             .char_indices()
             .take(ENTITY_SCAN_CHARS)
             .find(|&(_, c)| c == ';')
             .map(|(i, _)| i);
         match semi {
-            Some(semi) => match decode_one_entity(&after[1..semi]) {
+            Some(semi) => match decode_one_entity(substring(after, 1, semi)) {
                 Some(ch) => {
                     out.push(ch);
-                    rest = &after[semi + 1..];
+                    rest = split_at_boundary(after, semi + 1).1;
                 }
                 None => {
                     out.push('&');
-                    rest = &after[1..];
+                    rest = split_at_boundary(after, 1).1;
                 }
             },
             None => {
                 out.push('&');
-                rest = &after[1..];
+                rest = split_at_boundary(after, 1).1;
             }
         }
     }


### PR DESCRIPTION
## What

All fifteen `#[expect(clippy::string_slice)]` sites are gone. The tree now has
**zero suppressions of any lint** - no `#[allow]`, no `#[expect(clippy::...)]` -
and the ast-grep rule covers `string_slice` alongside the rest so a new one
fails the build.

Two commits, because they are two different arguments.

## Commit 1 - nine sites that were hand-rolling std

Each carried the delimiter's length as a separate literal that had to stay in
sync with the delimiter by hand:

```rust
let event_end = buffer.find("\n\n")?;
let event_text = buffer[..event_end].to_string();
*buffer = buffer[event_end + 2..].to_string();   // the +2 is the bug shape
```

`split_once` returns both halves and knows its own delimiter. The `None` case
was already reachable and handled ("no complete frame yet"), so control flow is
unchanged.

| Site | What went away |
|---|---|
| `anthropic::parse_sse_event` | `+ 2` |
| `openai_compat::parse_openai_sse_event` | `+ 2` |
| `ollama::poll_next` | `+ 1` |
| `mcp auth::metadata::resource_metadata_url` | `+ "resource_metadata=".len()` - the needle was written out twice |
| `mcp transport::http::expand_env_allowing` | all four offsets |
| `dashboard render::content::build_output_lines` | the lengths `6`/`7`/`8` sitting beside `"[tool]"`/`"[error]"`/`"[denied]"` |
| `dashboard render::header` | a hand-rolled `strip_prefix` |
| `runtime fanout::parse_work_items` | an impossible panic, folded into the error it already returns |

The dashboard one was closest to a live bug: two parallel columns, a literal and
its length, and a typo in either desyncs them into a mis-slice of a line the
user is looking at.

## Commit 2 - the six I first called unavoidable

They were not. The reason they looked stuck is that the only replacement I
considered was `.get()`, whose `None` arm is unreachable and therefore
uncoverable under the 100% gate. The answer is a helper with no `None` arm.

`leviath_core::text` gains two **total** functions:

```rust
pub fn substring(s: &str, start: usize, end: usize) -> &str
pub fn split_at_boundary(s: &str, mid: usize) -> (&str, &str)
```

Both walk each bound back to a char boundary and clamp it into the string before
slicing, so no combination of offsets - past the end, backwards, `usize::MAX`,
mid-character - can panic. A caller that *searched* for its offsets gets exactly
the slice it asked for, because a `find` hit is already a boundary. A caller that
computed one gets the nearest cut that does not split a character.

**That last part is the argument.** Every suppression removed here named a real
construct guaranteeing its index was a boundary, and every one of those claims
was true when written. But the proof lived in a comment while the code was free
to move, and the sites that needed it most were scanners walking text nobody in
this repo authored - fetched HTML, a model's fenced output, an SSE frame off the
wire. Those are exactly where careful reading is least likely to stay right, and
issues #109 and #115 are what being wrong cost.

| Site | Change |
|---|---|
| `core::text` | `truncate_at_boundary` and `snippet_around` now share the one clamped implementation |
| `mcp transport::sse` | `find_frame_end` returned `(position, terminator length)`; `split_frame` returns the two halves, so neither terminator's length is written down |
| `scripting::strip_element` | walked `html` and its lowercase copy on **one shared byte cursor** - correct only because `to_ascii_lowercase` preserves lengths, an invariant stated in no type. Both strings now advance explicitly together |
| `scripting::decode_entities` | routed through the helpers |
| `providers::parse_tool_calls` | carried absolute offsets into `rest` (`body_start + close_rel + FENCE_CLOSE.len()`); every step is now a `split_once` on what is left |

## Behaviour

Preserved everywhere, with one deliberate exception: `parse_work_items` on a
malformed input that would previously have panicked now returns the same `Err`
every other malformed shape returns. That is the property the function
advertises.

`parse_sse_frame` keeps its single allocation - the existing `drain` stays, sized
from the remainder `split_frame` returns rather than from a written-down
terminator length.

## Verification

- `cargo xtask coverage` 100% on all touched packages: core, scripting,
  providers, mcp, runtime, cli
- `cargo clippy --workspace --all-targets --all-features`: zero warnings
- `cargo test --workspace`: green
- `cargo xtask docs --check` clean
- The new `string_slice` gate mutation-checked by planting a suppression and
  confirming ast-grep fails on it
- New tests assert `substring` and `split_at_boundary` are total across
  degenerate offsets, and that the two halves of a split always rejoin to the
  input
