### PR TITLE
fix: lock poisoning and HTTPS-client failure stop aborting the daemon

### DIFF
--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -641,7 +641,9 @@ pub enum DaemonTarget<'a> {
 /// requires it. Every caller passes a plain `fn` item, which always is.
 pub async fn run_checks(
     args: &DoctorArgs,
-    build_registry: &(dyn Fn(&Config) -> ProviderRegistry + Sync),
+    build_registry: &(
+         dyn Fn(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> + Sync
+     ),
     daemon: DaemonTarget<'_>,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
@@ -659,7 +661,18 @@ pub async fn run_checks(
         eprintln!("Warning: {warning}");
     }
 
-    let registry = build_registry(&config);
+    // A registry that will not build is the most basic thing `doctor` can
+    // report, so it becomes a failed check rather than stopping the run.
+    let registry = match build_registry(&config) {
+        Ok(registry) => registry,
+        Err(e) => {
+            checks.push(Check::fail(
+                "providers",
+                format!("could not build any provider client: {e}"),
+            ));
+            return checks;
+        }
+    };
     checks.push(config_check(&config, &registry));
 
     let (check, resolved) = resolve_check(&config, args.model.as_deref(), &registry);
@@ -704,7 +717,9 @@ pub async fn run_checks(
 /// process exits non-zero and `lev doctor` works as a CI gate.
 async fn execute_with_registry(
     args: DoctorArgs,
-    build_registry: &(dyn Fn(&Config) -> ProviderRegistry + Sync),
+    build_registry: &(
+         dyn Fn(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> + Sync
+     ),
     daemon: DaemonTarget<'_>,
 ) -> anyhow::Result<()> {
     let checks = run_checks(&args, build_registry, daemon).await;

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -784,8 +784,10 @@ async fn cleanup_run_removes_the_run_and_its_saved_state() {
 // ─── run_checks ───────────────────────────────────────────────────────────────
 
 /// A registry builder that ignores the config and always yields `registry`.
-fn always(registry: ProviderRegistry) -> impl Fn(&Config) -> ProviderRegistry {
-    move |_| registry.clone()
+fn always(
+    registry: ProviderRegistry,
+) -> impl Fn(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    move |_| Ok(registry.clone())
 }
 
 /// Write the smallest `config.toml` that parses, naming `provider`/`model` as
@@ -954,4 +956,30 @@ async fn execute_wires_the_real_registry_builder() {
     })
     .await;
     assert_eq!(err.to_string(), "doctor failed at: resolve");
+}
+
+/// A registry builder that fails the way a machine with an unreadable root
+/// certificate store would.
+fn cannot_build(_config: &Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    Err(leviath_providers::ProviderError::ClientBuild(
+        "no roots".to_string(),
+    ))
+}
+
+#[tokio::test]
+async fn a_registry_that_will_not_build_is_reported_as_a_failed_check() {
+    let checks = with_env(|root| async move {
+        write_config(&root, "anthropic", None, "");
+        run_checks(&DoctorArgs::default(), &cannot_build, DaemonTarget::Skip).await
+    })
+    .await;
+    let providers = checks
+        .iter()
+        .find(|c| c.name == "providers")
+        .expect("a providers check");
+    assert!(
+        providers
+            .detail
+            .contains("could not build any provider client")
+    );
 }

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -454,7 +454,12 @@ fn builtin_table() -> Vec<BuiltinEntry> {
 /// passed, so every call site shares a single instrumented instantiation.
 async fn list_with_registry(
     args: ListArgs,
-    build_registry: &dyn Fn(&Config) -> leviath_runtime::ProviderRegistry,
+    build_registry: &dyn Fn(
+        &Config,
+    ) -> Result<
+        leviath_runtime::ProviderRegistry,
+        leviath_providers::ProviderError,
+    >,
 ) -> anyhow::Result<()> {
     let config = Config::load()?;
     for warning in config.validate_keys() {
@@ -476,7 +481,7 @@ async fn list_with_registry(
     // knows about made a user with one key scroll past dozens of models they
     // had no credential for, and hid whether their own key had been picked up
     // at all. `--all` restores the full catalogue for shopping around.
-    let registry = build_registry(&config);
+    let registry = build_registry(&config)?;
     let available: std::collections::HashSet<String> = registry
         .provider_names()
         .into_iter()
@@ -620,7 +625,12 @@ async fn list_with_registry(
 /// [`list_with_registry`] for why.
 async fn show_with_registry(
     args: ShowArgs,
-    build_registry: &dyn Fn(&Config) -> leviath_runtime::ProviderRegistry,
+    build_registry: &dyn Fn(
+        &Config,
+    ) -> Result<
+        leviath_runtime::ProviderRegistry,
+        leviath_providers::ProviderError,
+    >,
 ) -> anyhow::Result<()> {
     let config = Config::load()?;
     for warning in config.validate_keys() {
@@ -652,7 +662,7 @@ async fn show_with_registry(
     if args.remote
         && let Some(ref provider_name) = args.provider
     {
-        let registry = build_registry(&config);
+        let registry = build_registry(&config)?;
         if let Some(provider) = registry.get(provider_name) {
             match provider.list_models().await {
                 Ok(models) => {
@@ -1588,7 +1598,8 @@ mod tests {
         provider_name: &'static str,
         models: Vec<ModelInfo>,
         fail: bool,
-    ) -> impl Fn(&Config) -> leviath_runtime::ProviderRegistry {
+    ) -> impl Fn(&Config) -> Result<leviath_runtime::ProviderRegistry, leviath_providers::ProviderError>
+    {
         // `Fn` (not `FnOnce`) so the closure can be called through the
         // `&dyn Fn` trait object `list_with_registry`/`show_with_registry`
         // now take - see the doc comment on `list_with_registry` for why.
@@ -1604,7 +1615,7 @@ mod tests {
                     fail,
                 }),
             );
-            registry
+            Ok(registry)
         }
     }
 
@@ -2183,6 +2194,59 @@ mod tests {
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
                 assert!(result.is_err());
+            },
+        )
+        .await;
+    }
+
+    /// A builder that fails the way a machine with no readable root
+    /// certificate store would.
+    fn cannot_build(
+        _config: &Config,
+    ) -> Result<leviath_runtime::ProviderRegistry, leviath_providers::ProviderError> {
+        Err(leviath_providers::ProviderError::ClientBuild(
+            "no roots".to_string(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn list_reports_a_registry_that_will_not_build() {
+        crate::config::with_isolated_config_path_async(
+            "models-list_reports_a_registry_that_will_not_build",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: None,
+                    all: false,
+                    json: false,
+                };
+                let err = list_with_registry(args, &cannot_build)
+                    .await
+                    .expect_err("a failing registry builder should fail the command");
+                assert!(err.to_string().contains("root certificate store"));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn show_reports_a_registry_that_will_not_build() {
+        crate::config::with_isolated_config_path_async(
+            "models-show_reports_a_registry_that_will_not_build",
+            |_fake_dir| async move {
+                // Both `remote` and `provider`: the registry is only built
+                // when the two are given together.
+                let args = ShowArgs {
+                    // A model the built-in table does not know, so the lookup
+                    // falls through to the registry instead of returning early.
+                    model: "not-a-built-in-model".to_string(),
+                    provider: Some("anthropic".to_string()),
+                    remote: true,
+                };
+                let err = show_with_registry(args, &cannot_build)
+                    .await
+                    .expect_err("a failing registry builder should fail the command");
+                assert!(err.to_string().contains("root certificate store"));
             },
         )
         .await;

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -99,9 +99,33 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
 /// a [`ScriptProviderLayer`](leviath_runtime::script_provider::ScriptProviderLayer)
 /// is then attached so Rhai *script providers* resolve lazily and
 /// hot-reload from `~/.leviath/providers/`.
-pub fn build_provider_registry_from_config(config: &Config) -> ProviderRegistry {
-    let registry = build_provider_registry(&provider_creds_from_config(config));
-    attach_script_layer(registry, crate::config::providers_dir(), config)
+pub fn build_provider_registry_from_config(
+    config: &Config,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    build_provider_registry_from_config_with(
+        config,
+        &leviath_providers::provider::build_http_client,
+    )
+}
+
+/// [`build_provider_registry_from_config`], with client construction injected.
+///
+/// The seam that makes "this machine cannot build an HTTPS client" reachable
+/// from a test: reqwest will not fail to build one in any environment a test can
+/// arrange, so the failure has to be handed in.
+pub fn build_provider_registry_from_config_with(
+    config: &Config,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    let registry = leviath_runtime::provider_creds::build_provider_registry_with(
+        &provider_creds_from_config(config),
+        build_client,
+    )?;
+    Ok(attach_script_layer(
+        registry,
+        crate::config::providers_dir(),
+        config,
+    ))
 }
 
 /// Attach a [`ScriptProviderLayer`](leviath_runtime::script_provider::ScriptProviderLayer)
@@ -165,7 +189,8 @@ mod tests {
     #[test]
     fn build_provider_registry_with_empty_config() {
         let config = Config::default();
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         // Ollama needs no key and is always on.
         assert!(registry.has("ollama"));
         // Claude Code needs no key either, but is opt-in - a default config
@@ -187,7 +212,8 @@ mod tests {
             },
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
     }
 
@@ -200,7 +226,8 @@ mod tests {
             },
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("openai"));
     }
 
@@ -216,7 +243,8 @@ mod tests {
             },
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("google"));
     }
 
@@ -226,7 +254,8 @@ mod tests {
             openrouter_api_key: Some("sk-or-test-12345".to_string()),
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("openrouter"));
     }
 
@@ -236,7 +265,8 @@ mod tests {
             ollama_base_url: Some("http://my-server:11434".to_string()),
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("ollama"));
     }
 
@@ -291,7 +321,8 @@ mod tests {
             ..Config::default()
         };
         temp_env::with_var("LEVIATH_HOME", Some(home.path().as_os_str()), || {
-            let registry = build_provider_registry_from_config(&config);
+            let registry = build_provider_registry_from_config(&config)
+                .expect("an HTTPS client builds in tests");
             assert!(registry.has("groq"));
             assert!(registry.get("groq").is_some());
         });
@@ -315,7 +346,8 @@ mod tests {
             ollama_base_url: Some("http://custom:11434".to_string()),
             ..Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai"));
         assert!(registry.has("google"));
@@ -414,7 +446,8 @@ mod tests {
     #[test]
     fn build_provider_registry_defaults_have_ollama_only() {
         let config = Config::default();
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         // Ollama is present regardless of key configuration; claude-code is not,
         // until the user opts in.
         assert!(registry.has("ollama"));
@@ -443,7 +476,11 @@ mod tests {
         );
         assert_eq!(cc.options.get("effort").map(String::as_str), Some("low"));
         assert!(cc.api_key.is_none());
-        assert!(build_provider_registry_from_config(&config).has("claude-code"));
+        assert!(
+            build_provider_registry_from_config(&config)
+                .expect("an HTTPS client builds in tests")
+                .has("claude-code")
+        );
     }
 
     #[test]
@@ -492,7 +529,8 @@ mod tests {
             },
             ..crate::config::Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         // Verify anthropic provider was registered
         assert!(registry.has("anthropic"));
         // Verify ollama always registered
@@ -521,7 +559,8 @@ mod tests {
             model_capabilities: caps,
             ..crate::config::Config::default()
         };
-        let registry = build_provider_registry_from_config(&config);
+        let registry =
+            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("ollama"));
     }
 

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -5,7 +5,6 @@ use axum::http::StatusCode;
 use axum::response::Json;
 
 use super::types::*;
-use crate::commands::run::build_provider_registry_from_config;
 use crate::config::Config;
 
 /// Redacted view of a config — booleans for keys, never their values.
@@ -112,7 +111,24 @@ pub(super) async fn validate_config_key(Json(req): Json<ValidateKeyReq>) -> Json
 }
 
 pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelEntry>> {
-    let registry = build_provider_registry_from_config(&state.config);
+    models_with(&state, &leviath_providers::provider::build_http_client).await
+}
+
+/// [`get_models`], with client construction injected so the "no usable HTTPS
+/// client" answer is reachable from a test.
+pub(super) async fn models_with(
+    state: &AppState,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Json<Vec<ModelEntry>> {
+    // Nothing to list if no client could be built; the endpoint answers with an
+    // empty set rather than failing the request, matching how it treats a
+    // provider whose `list_models` errors.
+    let Ok(registry) = crate::commands::run::session::build_provider_registry_from_config_with(
+        &state.config,
+        build_client,
+    ) else {
+        return Json(Vec::new());
+    };
     let mut models = Vec::new();
 
     for provider_name in registry.provider_names() {
@@ -584,5 +600,15 @@ mod tests {
         let v: ValidateKeyResp = serde_json::from_slice(&bytes).unwrap();
         assert!(!v.valid);
         assert!(v.message.is_some());
+    }
+
+    #[tokio::test]
+    async fn the_models_endpoint_is_empty_when_no_https_client_can_be_built() {
+        let state = test_state();
+        let Json(models) = super::models_with(&state, &|_t| {
+            Err(leviath_providers::provider::malformed_url_error())
+        })
+        .await;
+        assert!(models.is_empty());
     }
 }

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -98,8 +98,28 @@ impl ProviderVerifier for SkipVerifier {
 /// credentials for a provider name nothing recognises is empty, which drives
 /// the `None` arm, and every other arm is the provider's own I/O.
 pub async fn verify_via_registry(creds: &ProviderCreds) -> Outcome {
-    let registry =
-        leviath_runtime::provider_creds::build_provider_registry(std::slice::from_ref(creds));
+    verify_via_registry_with(creds, &leviath_providers::provider::build_http_client).await
+}
+
+/// [`verify_via_registry`], with client construction injected so the
+/// "no usable HTTPS client" outcome is reachable from a test.
+pub async fn verify_via_registry_with(
+    creds: &ProviderCreds,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Outcome {
+    // A registry that cannot be built is exactly the failure this command
+    // exists to report, so it is an outcome rather than a panic.
+    let registry = match leviath_runtime::provider_creds::build_provider_registry_with(
+        std::slice::from_ref(creds),
+        build_client,
+    ) {
+        Ok(registry) => registry,
+        Err(e) => {
+            return Outcome::Failed {
+                message: e.to_string(),
+            };
+        }
+    };
     let Some(provider) = registry.get(&creds.name) else {
         return Outcome::Failed {
             message: format!("no provider named '{}'", creds.name),
@@ -372,5 +392,23 @@ mod tests {
                 message: "no provider named 'not-a-real-provider'".to_string()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn a_machine_with_no_usable_https_client_reports_a_failed_outcome() {
+        // Needs a key: a keyed provider with none is skipped before any client
+        // is built, which would test the wrong branch.
+        let mut creds = leviath_runtime::provider_creds::ProviderCreds::simple("anthropic");
+        creds.api_key = Some("k".to_string());
+        let outcome = super::verify_via_registry_with(&creds, &|_t| {
+            Err(leviath_providers::provider::malformed_url_error())
+        })
+        .await;
+        // Asserted through `Debug` rather than a `let ... else`: the else arm
+        // is unreachable, and an unreachable arm is an uncovered region under
+        // the 100% gate.
+        let rendered = format!("{outcome:?}");
+        assert!(rendered.starts_with("Failed"), "{rendered}");
+        assert!(rendered.contains("root certificate store"), "{rendered}");
     }
 }

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -54,31 +54,58 @@ pub async fn execute(args: TestArgs) -> anyhow::Result<()> {
 /// Builds the real provider registry from a loaded [`Config`] - the
 /// production `build_registry` passed to [`execute_with_registry`] by
 /// [`execute`].
-fn build_registry_from_config(config: &Config) -> ProviderRegistry {
+fn build_registry_from_config(
+    config: &Config,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    build_registry_from_config_with(config, &leviath_providers::provider::build_http_client)
+}
+
+/// [`build_registry_from_config`], with client construction injected so the
+/// failure path is reachable from a test.
+fn build_registry_from_config_with(
+    config: &Config,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
     let mut reg = ProviderRegistry::new();
+    // `lev test` uses one client for every provider it registers: the command
+    // has no per-provider timeout to honour, so there is nothing to key on.
+    let client = build_client(None)
+        .map_err(|e| leviath_providers::ProviderError::ClientBuild(e.to_string()))?;
 
     if let Some(ref key) = config.providers.anthropic_api_key {
         reg.register(
             "anthropic".to_string(),
-            Arc::new(leviath_providers::AnthropicProvider::new(key.clone())),
+            Arc::new(leviath_providers::AnthropicProvider::new(
+                client.clone(),
+                key.clone(),
+            )),
         );
     }
     if let Some(ref key) = config.providers.openai_api_key {
         reg.register(
             "openai".to_string(),
-            Arc::new(leviath_providers::OpenAIProvider::new(key.clone())),
+            Arc::new(leviath_providers::OpenAIProvider::new(
+                client.clone(),
+                key.clone(),
+            )),
         );
     }
     if let Some(ref key) = config.providers.google_api_key {
         reg.register(
             "google".to_string(),
-            Arc::new(leviath_providers::GeminiProvider::new(key.clone())),
+            Arc::new(leviath_providers::GeminiProvider::new(
+                client.clone(),
+                key.clone(),
+            )),
         );
     }
     if let Some(ref key) = config.openrouter_api_key {
         reg.register(
             "openrouter".to_string(),
-            Arc::new(leviath_providers::OpenRouterProvider::new(key.clone())),
+            Arc::new(leviath_providers::OpenRouterProvider::new(
+                client.clone(),
+                key.clone(),
+            )),
         );
     }
     let ollama_url = config
@@ -88,12 +115,21 @@ fn build_registry_from_config(config: &Config) -> ProviderRegistry {
     reg.register(
         "ollama".to_string(),
         Arc::new(leviath_providers::OllamaProvider::with_base_url(
+            client.clone(),
             ollama_url.to_string(),
         )),
     );
 
-    reg
+    Ok(reg)
 }
+
+/// How `lev test` gets its provider registry.
+///
+/// Fallible because constructing a provider's outbound HTTPS client reads the
+/// machine's root certificate store and can fail; boxed for the
+/// monomorphization reason spelled out on [`execute_with_registry`].
+type RegistryBuilder =
+    Box<dyn FnOnce(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError>>;
 
 /// Core of [`execute`], with provider-registry construction injected so
 /// tests can drive the non-dry-run path with a mock [`Provider`] instead of
@@ -101,9 +137,8 @@ fn build_registry_from_config(config: &Config) -> ProviderRegistry {
 /// through whatever the developer's real `~/.leviath/config.toml` happens to
 /// contain.
 ///
-/// `build_registry` is a boxed trait object (`Box<dyn FnOnce(&Config) ->
-/// ProviderRegistry>`) rather than `impl FnOnce(&Config) -> ProviderRegistry`
-/// so every caller - production's `build_registry_from_config` and every
+/// `build_registry` is a boxed trait object ([`RegistryBuilder`]) rather than an
+/// `impl FnOnce` bound so every caller - production's `build_registry_from_config` and every
 /// test's distinct `mock_registry_builder(...)` closure - shares exactly
 /// ONE monomorphization of this (large, many-branch) function instead of
 /// one per closure type. This was a confirmed generic-monomorphization
@@ -114,7 +149,7 @@ fn build_registry_from_config(config: &Config) -> ProviderRegistry {
 /// in this crate.
 async fn execute_with_registry(
     args: TestArgs,
-    build_registry: Box<dyn FnOnce(&Config) -> ProviderRegistry>,
+    build_registry: RegistryBuilder,
 ) -> anyhow::Result<()> {
     let path = args.path.unwrap_or_else(|| ".".to_string());
     tracing::info!(path = %path, "Running agent tests");
@@ -164,7 +199,7 @@ async fn execute_with_registry(
 
     let registry = if !args.dry_run {
         let config = Config::load()?;
-        Some(build_registry(&config))
+        Some(build_registry(&config)?)
     } else {
         None
     };
@@ -2091,7 +2126,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     fn mock_registry_builder(
         content: &'static str,
         tool_calls: Vec<ToolCall>,
-    ) -> impl FnOnce(&Config) -> ProviderRegistry {
+    ) -> impl FnOnce(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
         move |_config: &Config| {
             let mut reg = ProviderRegistry::new();
             reg.register(
@@ -2101,7 +2136,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                     tool_calls,
                 }),
             );
-            reg
+            Ok(reg)
         }
     }
 
@@ -2584,7 +2619,8 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             ..Config::default()
         };
 
-        let registry = build_registry_from_config(&config);
+        let registry =
+            build_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai"));
         assert!(registry.has("google"));
@@ -2595,7 +2631,8 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     #[test]
     fn build_registry_from_config_no_keys_still_registers_ollama_with_default_url() {
         let config = Config::default();
-        let registry = build_registry_from_config(&config);
+        let registry =
+            build_registry_from_config(&config).expect("an HTTPS client builds in tests");
         assert!(!registry.has("anthropic"));
         assert!(!registry.has("openai"));
         assert!(!registry.has("google"));
@@ -2658,5 +2695,48 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
         assert_eq!(provider.count_tokens("hello", "any-model").await, 5);
         assert_eq!(provider.max_context_tokens("any-model"), 8192);
         assert_eq!(provider.name(), "mock");
+    }
+
+    #[test]
+    fn a_registry_needs_an_https_client_it_can_build() {
+        // `lev test` registers every configured provider against one client;
+        // if that client cannot be built there is nothing to test against.
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("k".to_string());
+        let err = build_registry_from_config_with(&config, &|_t| {
+            Err(leviath_providers::provider::malformed_url_error())
+        })
+        .err()
+        .expect("a failing client factory should fail the registry");
+        assert!(err.to_string().contains("root certificate store"));
+    }
+
+    #[tokio::test]
+    async fn a_real_run_stops_when_the_registry_will_not_build() {
+        // Not a dry run, so the registry is built - and a machine that cannot
+        // build an HTTPS client has nothing to run the cases against.
+        crate::config::with_isolated_config_path_async(
+            "test-a_real_run_stops_when_the_registry_will_not_build",
+            |_fake_dir| async move {
+                let dir = tempfile::tempdir().expect("tempdir");
+                let project = dir.path();
+                write_project_with_test_file(project, "[[test]]\nname = \"t\"\ninput = \"hi\"\n");
+                let args = TestArgs {
+                    path: Some(project.to_str().expect("utf-8 path").to_string()),
+                    filter: None,
+                    dry_run: false,
+                };
+                let failing: RegistryBuilder = Box::new(|_config: &Config| {
+                    Err(leviath_providers::ProviderError::ClientBuild(
+                        "no roots".to_string(),
+                    ))
+                });
+                let err = execute_with_registry(args, failing)
+                    .await
+                    .expect_err("a failing registry builder should stop the run");
+                assert!(err.to_string().contains("no roots"), "{err}");
+            },
+        )
+        .await;
     }
 }

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -18,7 +18,6 @@ use tokio::sync::Mutex;
 
 use leviath_runtime::fanout::FanOutSpawnerRes;
 
-use crate::commands::run::session::build_provider_registry_from_config;
 use crate::config::Config;
 use crate::daemon::fanout_spawner::DaemonFanOutSpawner;
 use crate::daemon::spawn::build_agent;
@@ -85,13 +84,33 @@ pub async fn setup_daemon_host(
     config: Config,
     runs_dir: std::path::PathBuf,
     runtime: Handle,
-) -> WorldHost {
+) -> anyhow::Result<WorldHost> {
+    setup_daemon_host_with(
+        config,
+        runs_dir,
+        runtime,
+        &leviath_providers::provider::build_http_client,
+    )
+    .await
+}
+
+/// [`setup_daemon_host`], with outbound-client construction injected so the
+/// start-up failure path is reachable from a test.
+pub async fn setup_daemon_host_with(
+    config: Config,
+    runs_dir: std::path::PathBuf,
+    runtime: Handle,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> anyhow::Result<WorldHost> {
     // Apply the machine-wide outbound-network policy before anything can fetch.
     // It lives in a process-wide atomic because the shared blocking HTTP client's
     // redirect policy has no per-agent context to consult; see
     // `script_host::set_local_network_allowed`.
     crate::daemon::script_host::set_local_network_allowed(config.security.allow_local_network);
-    let providers = build_provider_registry_from_config(&config);
+    let providers = crate::commands::run::session::build_provider_registry_from_config_with(
+        &config,
+        build_client,
+    )?;
     // MCP connections are shared across agents; the workdir here only seeds the
     // (discarded) built-ins - each agent gets its own over its own workdir.
     let registry = ToolRegistry::build(std::env::temp_dir(), &config).await;
@@ -108,7 +127,7 @@ pub async fn setup_daemon_host(
         config.limits.mcp_idle_disconnect_secs,
     );
     mcp_pool.warm_recovered(&runs_dir).await;
-    build_host(HostParts {
+    Ok(build_host(HostParts {
         config,
         providers,
         runs_dir,
@@ -117,7 +136,7 @@ pub async fn setup_daemon_host(
         mcp_pool,
         runtime,
         now_secs: || chrono::Utc::now().timestamp(),
-    })
+    }))
 }
 
 /// The reap hook installed on the host: drops a reaped agent's tool state and
@@ -684,7 +703,8 @@ mod tests {
             runs.path().to_path_buf(),
             Handle::current(),
         )
-        .await;
+        .await
+        .expect("the daemon host builds in tests");
 
         // Spawning through the wired host exercises the real setup end to end
         // (including the now_secs timestamp closure).
@@ -728,7 +748,8 @@ mod tests {
             runs.path().to_path_buf(),
             Handle::current(),
         )
-        .await;
+        .await
+        .expect("the daemon host builds in tests");
         let (reply, rx) = oneshot::channel();
         host.handle(ControlOp::Spawn {
             args: Box::new(SpawnArgs {
@@ -820,7 +841,8 @@ mod tests {
                     runs.path().to_path_buf(),
                     Handle::current(),
                 )
-                .await;
+                .await
+                .expect("the daemon host builds in tests");
                 let (reply, rx) = oneshot::channel();
                 host.handle(ControlOp::Spawn {
                     args: Box::new(SpawnArgs {
@@ -865,7 +887,8 @@ mod tests {
             runs.path().to_path_buf(),
             Handle::current(),
         )
-        .await;
+        .await
+        .expect("the daemon host builds in tests");
 
         // Staked out *after* startup, so the recovery sweep (which marks
         // un-reloadable runs as crashed) hasn't already dealt with it - this is
@@ -1621,5 +1644,22 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} 
             // A daemon that wrote the current build is not stale.
             assert!(!daemon_build_is_stale(read_build_marker().as_deref()));
         });
+    }
+
+    #[tokio::test]
+    async fn the_daemon_refuses_to_start_without_a_usable_https_client() {
+        // Better than accepting runs it could never infer for: the error names
+        // the cause, where the previous behaviour was a panic at start-up.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("k".to_string());
+        let err =
+            setup_daemon_host_with(config, dir.path().to_path_buf(), Handle::current(), &|_t| {
+                Err(leviath_providers::provider::malformed_url_error())
+            })
+            .await
+            .err()
+            .expect("a failing client factory should stop the daemon starting");
+        assert!(err.to_string().contains("root certificate store"));
     }
 }

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -210,7 +210,7 @@ impl LintEnv {
                 .iter()
                 .flat_map(|s| s.model.models.iter())
                 .map(|e| e.provider.clone())
-                .filter(|p| registry.has(p))
+                .filter(|p| registry.as_ref().is_ok_and(|r| r.has(p)))
                 .collect(),
         );
         self

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -562,7 +562,11 @@ async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
     // Record the build we started from so a later CLI can detect stale code and
     // restart us (must happen right after we win the single-instance bind).
     leviath_cli::daemon::setup::write_build_marker();
-    let mut host = setup_daemon_host(config, runs_dir, tokio::runtime::Handle::current()).await;
+    // Fallible because building a provider's outbound HTTPS client can fail -
+    // in practice when the machine's root certificate store cannot be read. The
+    // daemon refuses to start rather than accepting runs it could never infer
+    // for, and the error names the cause instead of a panic backtrace.
+    let mut host = setup_daemon_host(config, runs_dir, tokio::runtime::Handle::current()).await?;
 
     // Accept connections and feed control ops to the host; `Subscribe`
     // connections stream world events from the host's event sender.

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod run_archive;
 pub mod run_meta;
 pub mod sandbox;
 pub mod secrets;
+pub mod sync;
 pub mod taint;
 pub mod telemetry;
 pub mod text;

--- a/crates/leviath-core/src/sync.rs
+++ b/crates/leviath-core/src/sync.rs
@@ -1,0 +1,61 @@
+//! Taking a lock without a panic path.
+//!
+//! `std::sync::Mutex::lock` returns a `Result` because a thread that panics
+//! while holding the guard *poisons* it, and every later locker is told so. The
+//! workspace used to answer that with `.expect("...")` at 21 sites, which turns
+//! one unrelated panic into a daemon-wide cascade: the first failure poisons a
+//! telemetry mutex, and the next observation - on a healthy run, in a different
+//! subsystem - aborts the process.
+//!
+//! # Why recovering is sound here, and would not be everywhere
+//!
+//! Poisoning is not noise. It reports a real condition: a writer stopped
+//! mid-update, so the value may be half-written and its invariants may not hold.
+//! Ignoring that in general is how a corrupt state gets read as a good one, and
+//! a crate that reaches for [`lock`] to silence a poison it has not thought
+//! about has made its data *less* trustworthy, not more.
+//!
+//! What makes it sound in this workspace is a property of the call sites rather
+//! than of this function: **every critical section guarded this way is
+//! panic-free.** They take the lock, do one bounded thing to a container - push,
+//! clone, read a field, swap an `Option` - and drop it. No indexing, no
+//! `unwrap`, no arithmetic that can overflow, no user input parsed, no callback
+//! invoked. A section like that has no intermediate state to be caught in: a
+//! `Vec::push` either happened or did not, and the `Vec` is a valid `Vec` either
+//! way. Poisoning is therefore unreachable, and this function's recovery is not
+//! papering over a risk - it is stating that the risk does not exist and
+//! degrading gracefully if a future edit ever creates one.
+//!
+//! That invariant is the thing to protect. When adding a call, keep the section
+//! short enough that "can anything in here panic?" is answerable by reading it.
+//! If the answer is ever no, hoist the fallible work out of the lock rather than
+//! reaching for this.
+//!
+//! Locks held across an `.await` are `tokio::sync::Mutex`, which has no
+//! poisoning to begin with and is unaffected by any of this.
+
+use std::sync::{Mutex, MutexGuard, PoisonError, TryLockError};
+
+/// Take `mutex`, recovering the guard if a previous holder panicked.
+///
+/// See the module docs: this is only correct because the sections it guards
+/// cannot panic, so the recovery branch is unreachable rather than merely
+/// tolerated.
+pub fn lock<T: ?Sized>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// [`lock`], but gives up rather than waiting when the mutex is already held.
+///
+/// `None` means "someone else has it right now", not "it is broken": a poisoned
+/// but free mutex still yields its guard, for the reason [`lock`] documents.
+pub fn try_lock<T: ?Sized>(mutex: &Mutex<T>) -> Option<MutexGuard<'_, T>> {
+    match mutex.try_lock() {
+        Ok(guard) => Some(guard),
+        Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+        Err(TryLockError::WouldBlock) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-core/src/sync/tests.rs
+++ b/crates/leviath-core/src/sync/tests.rs
@@ -1,0 +1,69 @@
+//! Tests for poison-recovering locks.
+//!
+//! A sibling file so the scaffolding stays out of the coverage report, matching
+//! the layout used elsewhere in the workspace.
+
+use super::*;
+
+#[test]
+fn an_ordinary_lock_yields_its_value() {
+    let m = Mutex::new(vec![1, 2, 3]);
+    assert_eq!(lock(&m).len(), 3);
+    lock(&m).push(4);
+    assert_eq!(*lock(&m), vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn a_poisoned_mutex_still_yields_its_value() {
+    let m = std::sync::Arc::new(Mutex::new(vec![1, 2, 3]));
+    let poisoner = std::sync::Arc::clone(&m);
+    // Panic while holding the guard, which is what poisons it. The panic is
+    // caught so the test process survives; the hook is silenced so the expected
+    // panic does not look like a failure in the output.
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(move || {
+        let _guard = poisoner.lock().expect("first lock is clean");
+        panic!("poison it");
+    });
+    std::panic::set_hook(hook);
+    assert!(result.is_err(), "the closure should have panicked");
+    assert!(m.is_poisoned(), "the mutex should now be poisoned");
+
+    // The whole point: the value is still readable, and still intact, because
+    // the section that panicked had not modified it.
+    assert_eq!(*lock(&m), vec![1, 2, 3]);
+    lock(&m).push(4);
+    assert_eq!(*lock(&m), vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn try_lock_reports_contention_but_not_poisoning() {
+    let m = Mutex::new(7);
+    assert_eq!(try_lock(&m).map(|g| *g), Some(7));
+
+    // Held elsewhere: `None`, and no blocking.
+    let held = lock(&m);
+    assert!(
+        try_lock(&m).is_none(),
+        "a held mutex should not be handed out"
+    );
+    drop(held);
+    assert_eq!(try_lock(&m).map(|g| *g), Some(7));
+}
+
+#[test]
+fn try_lock_recovers_a_poisoned_but_free_mutex() {
+    let m = std::sync::Arc::new(Mutex::new(7));
+    let poisoner = std::sync::Arc::clone(&m);
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let _ = std::panic::catch_unwind(move || {
+        let _guard = poisoner.lock().expect("first lock is clean");
+        panic!("poison it");
+    });
+    std::panic::set_hook(hook);
+    assert!(m.is_poisoned());
+    // Poisoned but nobody is holding it, so this is a hand-out, not a `None`.
+    assert_eq!(try_lock(&m).map(|g| *g), Some(7));
+}

--- a/crates/leviath-core/src/telemetry.rs
+++ b/crates/leviath-core/src/telemetry.rs
@@ -278,20 +278,17 @@ pub struct MemorySink {
 impl MemorySink {
     /// A snapshot of everything emitted so far, in order.
     pub fn events(&self) -> Vec<TelemetryEvent> {
-        self.events.lock().expect("telemetry event lock").clone()
+        crate::sync::lock(&self.events).clone()
     }
 
     /// Every lane-health sample recorded so far, in order.
     pub fn lane_samples(&self) -> Vec<LaneHealth> {
-        self.lanes.lock().expect("telemetry lane lock").clone()
+        crate::sync::lock(&self.lanes).clone()
     }
 
     /// Every provider-health sample recorded so far, in order.
     pub fn provider_samples(&self) -> Vec<Vec<ProviderHealth>> {
-        self.providers
-            .lock()
-            .expect("telemetry provider lock")
-            .clone()
+        crate::sync::lock(&self.providers).clone()
     }
 
     /// How many times `force_flush` was called.
@@ -302,21 +299,15 @@ impl MemorySink {
 
 impl TelemetrySink for MemorySink {
     fn emit(&self, event: TelemetryEvent) {
-        self.events
-            .lock()
-            .expect("telemetry event lock")
-            .push(event);
+        crate::sync::lock(&self.events).push(event);
     }
 
     fn observe_lanes(&self, health: LaneHealth) {
-        self.lanes.lock().expect("telemetry lane lock").push(health);
+        crate::sync::lock(&self.lanes).push(health);
     }
 
     fn observe_providers(&self, down: &[ProviderHealth]) {
-        self.providers
-            .lock()
-            .expect("telemetry provider lock")
-            .push(down.to_vec());
+        crate::sync::lock(&self.providers).push(down.to_vec());
     }
 
     fn force_flush(&self) {

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -31,7 +31,7 @@ impl StderrTail {
     fn push(&self, line: String) {
         // Poisoning would mean a panic while holding the lock; the only code
         // under it is a push/pop pair, so recover rather than propagate.
-        let mut buf = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        let mut buf = leviath_core::sync::lock(&self.0);
         if buf.len() == STDERR_TAIL_LINES {
             buf.pop_front();
         }
@@ -40,7 +40,7 @@ impl StderrTail {
 
     /// The captured lines, newest last, or `None` if the server said nothing.
     pub(crate) fn snapshot(&self) -> Option<String> {
-        let buf = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        let buf = leviath_core::sync::lock(&self.0);
         if buf.is_empty() {
             return None;
         }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -128,9 +128,9 @@ pub struct AnthropicProvider {
 
 impl AnthropicProvider {
     /// Create a new Anthropic provider.
-    pub fn new(api_key: String) -> Self {
+    pub fn new(client: reqwest::Client, api_key: String) -> Self {
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             api_key,
             base_url: "https://api.anthropic.com/v1".to_string(),
             rate_limiter: None,
@@ -140,9 +140,8 @@ impl AnthropicProvider {
     }
 
     /// Create a new Anthropic provider with full configuration.
-    pub fn with_config(config: ProviderConfig) -> Self {
+    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        let client = crate::provider::build_http_client(config.request_timeout_secs);
         Self {
             client,
             api_key: config.api_key,
@@ -157,13 +156,13 @@ impl AnthropicProvider {
 
     /// Create a new Anthropic provider with per-model capability overrides.
     pub fn with_overrides(
+        client: reqwest::Client,
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
-        timeout_secs: Option<u64>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
-            client: crate::provider::build_http_client(timeout_secs),
+            client,
             api_key,
             base_url: "https://api.anthropic.com/v1".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
@@ -938,7 +937,10 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.name(), "anthropic");
     }
 
@@ -987,13 +989,19 @@ mod tests {
 
     #[test]
     fn test_context_limits() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("claude-sonnet-4-6"), 1_000_000);
     }
 
     #[test]
     fn test_build_request_body() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![crate::SystemBlock {
                 text: "You are helpful.".to_string(),
@@ -1028,7 +1036,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_passes_through_extra_params() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1050,7 +1061,10 @@ mod tests {
 
     #[test]
     fn test_parse_response() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "text", "text": "Hello!" }
@@ -1071,7 +1085,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_with_tool_calls() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "text", "text": "Let me search." },
@@ -1095,7 +1112,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_opus48() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-opus-4-8");
         assert!(!caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -1106,7 +1126,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_opus5() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-opus-5");
         assert!(!caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -1117,7 +1140,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_sonnet46() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-sonnet-4-6");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -1128,7 +1154,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_sonnet5() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-sonnet-5");
         assert!(!caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -1139,7 +1168,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_fable_and_opus46() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         for m in ["claude-fable-5", "claude-mythos-5", "claude-opus-4-6"] {
             let caps = provider.builtin_capabilities(m);
             assert!(caps.supports_streaming);
@@ -1149,7 +1181,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_haiku45() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-haiku-4-5-20251001");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 200_000);
@@ -1158,7 +1193,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_fable5() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-fable-5");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_000_000);
@@ -1167,7 +1205,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_sonnet_46() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-sonnet-4-6");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_000_000);
@@ -1188,8 +1229,12 @@ mod tests {
                 max_output_tokens: 32_768,
             },
         );
-        let provider =
-            AnthropicProvider::with_overrides("test-key".to_string(), overrides, None, None);
+        let provider = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("claude-sonnet-4-6");
         // Override should take precedence over built-in
         assert!(!caps.supports_temperature);
@@ -1198,7 +1243,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_with_cache_breakpoint() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![crate::SystemBlock {
                 text: "You are helpful.".to_string(),
@@ -1240,7 +1288,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_max_4_breakpoints() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let mut messages: Vec<crate::provider::Message> = (0..6)
             .map(|i| crate::provider::Message {
                 role: "user".to_string(),
@@ -1372,7 +1423,10 @@ mod tests {
         // program_flows/plan/task pinned + files hashmap) must consolidate
         // within the 4-block total `cache_control` budget; emitting 5
         // `cache_control` blocks is a hard Anthropic 400.
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let system = vec![
             crate::SystemBlock {
                 text: "architecture".into(),
@@ -1432,7 +1486,10 @@ mod tests {
         use leviath_core::CacheHint;
         // 3 distinct system tiers claim 3 of the 4 breakpoints; the lone message
         // that requests one gets the last slot - and never more than 4 total.
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let system = vec![
             crate::SystemBlock {
                 text: "a".into(),
@@ -1494,7 +1551,10 @@ mod tests {
         use leviath_core::CacheHint;
         // A lone Never block carries no cache_control, so the compact plain-string
         // system form is still used (back-compat).
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![crate::SystemBlock {
                 text: "ephemeral".into(),
@@ -1518,7 +1578,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_with_cache_metrics() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "text", "text": "Hello!" }
@@ -1659,7 +1722,10 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.name(), "anthropic");
     }
 
@@ -1671,7 +1737,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = AnthropicProvider::with_config(config);
+        let provider = AnthropicProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://api.anthropic.com/v1");
     }
 
@@ -1683,7 +1752,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = AnthropicProvider::with_config(config);
+        let provider = AnthropicProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://custom.api.com");
     }
 
@@ -1698,13 +1770,19 @@ mod tests {
             }),
             request_timeout_secs: None,
         };
-        let provider = AnthropicProvider::with_config(config);
+        let provider = AnthropicProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert!(provider.rate_limiter.is_some());
     }
 
     #[test]
     fn test_builtin_capabilities_opus46() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-opus-4-6");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -1716,7 +1794,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_opus47() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-opus-4-7");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_000_000);
@@ -1725,7 +1806,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_mythos5() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("claude-mythos-5");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_000_000);
@@ -1734,7 +1818,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_generic_claude4_fallback() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         // Uses generic claude-4.x fallback (not matching specific model patterns above)
         let caps = provider.builtin_capabilities("claude-haiku-4");
         assert!(!caps.supports_temperature);
@@ -1744,7 +1831,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_unknown_model() {
-        let provider = AnthropicProvider::new("test-key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("some-unknown-model");
         // Should return ModelCapabilities::default()
         let default = ModelCapabilities::default();
@@ -1765,7 +1855,12 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = AnthropicProvider::with_overrides("key".to_string(), overrides, None, None);
+        let provider = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("custom-model");
         assert_eq!(caps.max_context_tokens, 42);
         assert!(!caps.supports_streaming);
@@ -1773,15 +1868,22 @@ mod tests {
 
     #[test]
     fn test_capabilities_falls_through_to_builtin() {
-        let provider =
-            AnthropicProvider::with_overrides("key".to_string(), HashMap::new(), None, None);
+        let provider = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            HashMap::new(),
+            None,
+        );
         let caps = provider.capabilities("claude-sonnet-4-6");
         assert_eq!(caps.max_context_tokens, 1_000_000);
     }
 
     #[test]
     fn test_max_context_tokens_delegates_to_capabilities() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("claude-haiku-4-5"), 200_000);
         assert_eq!(provider.max_context_tokens("claude-opus-4-8"), 1_000_000);
     }
@@ -1812,7 +1914,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_empty_content_blocks() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [],
             "stop_reason": "end_turn",
@@ -1825,7 +1930,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_no_content_field() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "stop_reason": "end_turn",
             "usage": { "input_tokens": 5, "output_tokens": 0 }
@@ -1836,7 +1944,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_no_usage_field() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [{ "type": "text", "text": "Hello" }],
             "stop_reason": "end_turn"
@@ -1848,7 +1959,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_unknown_content_type_ignored() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "image", "data": "abc" },
@@ -1863,7 +1977,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_tool_call_missing_fields() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "tool_use" }
@@ -1879,7 +1996,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_total_tokens_computed() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [{ "type": "text", "text": "ok" }],
             "stop_reason": "end_turn",
@@ -1891,7 +2011,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_with_tools() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1920,7 +2043,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_no_temperature_for_opus48() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1943,7 +2069,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_temperature_for_sonnet46() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1965,7 +2094,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_multiple_system_messages() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![
                 crate::SystemBlock {
@@ -1998,7 +2130,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_no_system_messages() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -2022,7 +2157,10 @@ mod tests {
     fn test_build_request_body_system_block_never_hint_omits_cache_control() {
         // A system block with CacheHint::Never exercises the false branch of
         // the `cache_hint != Never` guard, so no cache_control is attached.
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![crate::SystemBlock {
                 text: "No caching here.".to_string(),
@@ -2052,7 +2190,10 @@ mod tests {
         // A message with cache_breakpoint = true AND block (non-Text) content
         // exercises the MessageContent::Blocks arm of the breakpoint handling,
         // which serializes the content normally rather than wrapping it.
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -2223,7 +2364,10 @@ mod tests {
     fn test_parse_response_text_block_missing_text_field_is_skipped() {
         // A text block with no "text" key - exercises the if-let None branch
         // in parse_response's content iteration.
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [
                 { "type": "text" },
@@ -2384,7 +2528,10 @@ mod tests {
 
     #[test]
     fn test_parse_response_no_stop_reason_defaults_to_complete() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let body = serde_json::json!({
             "content": [{ "type": "text", "text": "hi" }],
             "usage": { "input_tokens": 5, "output_tokens": 2 }
@@ -2397,7 +2544,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_exactly_4_cache_breakpoints() {
-        let provider = AnthropicProvider::new("key".to_string());
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         // Exactly 4 messages with cache_breakpoint = true
         let messages: Vec<crate::provider::Message> = (0..4)
             .map(|i| crate::provider::Message {
@@ -2443,12 +2593,15 @@ mod tests {
     // without a real network call.
 
     fn provider_with_url(url: String) -> AnthropicProvider {
-        AnthropicProvider::with_config(ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: Some(url),
-            rate_limit: None,
-            request_timeout_secs: None,
-        })
+        AnthropicProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            ProviderConfig {
+                api_key: "test-key".to_string(),
+                base_url: Some(url),
+                rate_limit: None,
+                request_timeout_secs: None,
+            },
+        )
     }
 
     fn simple_request() -> InferenceRequest {
@@ -2853,11 +3006,19 @@ mod tests {
             requests_per_minute: 5,
             tokens_per_minute: 1_000,
         };
-        let limited =
-            AnthropicProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        let limited = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            Some(&cfg),
+        );
         assert!(limited.rate_limiter.is_some());
-        let unlimited =
-            AnthropicProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        let unlimited = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            None,
+        );
         assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -88,9 +88,9 @@ pub struct GeminiProvider {
 
 impl GeminiProvider {
     /// Create a new Gemini provider.
-    pub fn new(api_key: String) -> Self {
+    pub fn new(client: reqwest::Client, api_key: String) -> Self {
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             api_key,
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
             rate_limiter: None,
@@ -99,9 +99,8 @@ impl GeminiProvider {
     }
 
     /// Create a new Gemini provider with full configuration.
-    pub fn with_config(config: ProviderConfig) -> Self {
+    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        let client = crate::provider::build_http_client(config.request_timeout_secs);
         Self {
             client,
             api_key: config.api_key,
@@ -115,13 +114,13 @@ impl GeminiProvider {
 
     /// Create a new Gemini provider with per-model capability overrides.
     pub fn with_overrides(
+        client: reqwest::Client,
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
-        timeout_secs: Option<u64>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
-            client: crate::provider::build_http_client(timeout_secs),
+            client,
             api_key,
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
@@ -419,13 +418,19 @@ mod tests {
 
     #[test]
     fn test_provider_name() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.name(), "google");
     }
 
     #[test]
     fn test_default_base_url() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(
             provider.base_url,
             "https://generativelanguage.googleapis.com/v1beta/openai"
@@ -434,7 +439,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gemini_35_flash() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gemini-3.5-flash");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -446,7 +454,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gemini_31_pro() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gemini-3.1-pro-preview");
         assert!(caps.supports_temperature);
         assert!(caps.supports_tools);
@@ -456,7 +467,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gemini_3_flash() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gemini-3-flash");
         assert!(caps.supports_temperature);
         assert!(caps.supports_tools);
@@ -466,7 +480,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gemini_31_flash_lite() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gemini-3.1-flash-lite");
         assert!(caps.supports_temperature);
         assert!(caps.supports_tools);
@@ -476,7 +493,10 @@ mod tests {
 
     #[test]
     fn test_default_capabilities() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gemini-future-model");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -500,8 +520,12 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider =
-            GeminiProvider::with_overrides("test-key".to_string(), overrides, None, None);
+        let provider = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("gemini-3.5-flash");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1);
@@ -588,7 +612,10 @@ mod tests {
 
     #[test]
     fn test_context_limits() {
-        let provider = GeminiProvider::new("test-key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("gemini-3.5-flash"), 1_048_576);
         assert_eq!(
             provider.max_context_tokens("gemini-3.1-pro-preview"),
@@ -606,7 +633,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = GeminiProvider::with_config(config);
+        let provider = GeminiProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert!(
             provider
                 .base_url
@@ -622,7 +652,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = GeminiProvider::with_config(config);
+        let provider = GeminiProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://custom.google.com");
     }
 
@@ -637,7 +670,10 @@ mod tests {
             }),
             request_timeout_secs: None,
         };
-        let provider = GeminiProvider::with_config(config);
+        let provider = GeminiProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert!(provider.rate_limiter.is_some());
     }
 
@@ -754,7 +790,12 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = GeminiProvider::with_overrides("key".to_string(), overrides, None, None);
+        let provider = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("gemini-custom");
         assert_eq!(caps.max_context_tokens, 42);
         assert!(!caps.supports_temperature);
@@ -762,15 +803,22 @@ mod tests {
 
     #[test]
     fn test_capabilities_builtin_fallthrough() {
-        let provider =
-            GeminiProvider::with_overrides("key".to_string(), HashMap::new(), None, None);
+        let provider = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            HashMap::new(),
+            None,
+        );
         let caps = provider.capabilities("gemini-3.5-flash");
         assert_eq!(caps.max_context_tokens, 1_048_576);
     }
 
     #[test]
     fn test_max_context_tokens_delegates() {
-        let provider = GeminiProvider::new("key".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("gemini-3.5-flash"), 1_048_576);
     }
 
@@ -797,12 +845,15 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> GeminiProvider {
-        GeminiProvider::with_config(ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: Some(url),
-            rate_limit: None,
-            request_timeout_secs: None,
-        })
+        GeminiProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            ProviderConfig {
+                api_key: "test-key".to_string(),
+                base_url: Some(url),
+                rate_limit: None,
+                request_timeout_secs: None,
+            },
+        )
     }
 
     fn simple_request() -> InferenceRequest {
@@ -1079,7 +1130,10 @@ mod tests {
 
     #[test]
     fn native_base_strips_openai_suffix() {
-        let provider = GeminiProvider::new("k".to_string());
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+        );
         assert_eq!(
             provider.native_base().as_deref(),
             Some("https://generativelanguage.googleapis.com/v1beta")
@@ -1118,10 +1172,19 @@ mod tests {
             requests_per_minute: 5,
             tokens_per_minute: 1_000,
         };
-        let limited =
-            GeminiProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        let limited = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            Some(&cfg),
+        );
         assert!(limited.rate_limiter.is_some());
-        let unlimited = GeminiProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        let unlimited = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            None,
+        );
         assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -25,21 +25,21 @@ pub struct OllamaProvider {
 
 impl OllamaProvider {
     /// Create a new Ollama provider.
-    pub fn new() -> Self {
+    pub fn new(client: reqwest::Client) -> Self {
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             base_url: "http://localhost:11434".to_string(),
             capability_overrides: HashMap::new(),
         }
     }
 
     /// Create a new Ollama provider with custom base URL.
-    pub fn with_base_url(base_url: String) -> Self {
+    pub fn with_base_url(client: reqwest::Client, base_url: String) -> Self {
         if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
             tracing::warn!(url = %base_url, "Ollama base URL should start with http:// or https://");
         }
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             base_url,
             capability_overrides: HashMap::new(),
         }
@@ -47,15 +47,15 @@ impl OllamaProvider {
 
     /// Create a new Ollama provider with a custom base URL and per-model capability overrides.
     pub fn with_overrides(
+        client: reqwest::Client,
         base_url: String,
         overrides: HashMap<String, ModelCapabilities>,
-        timeout_secs: Option<u64>,
     ) -> Self {
         if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
             tracing::warn!(url = %base_url, "Ollama base URL should start with http:// or https://");
         }
         Self {
-            client: crate::provider::build_http_client(timeout_secs),
+            client,
             base_url,
             capability_overrides: overrides,
         }
@@ -264,12 +264,6 @@ impl OllamaProvider {
             },
             finish_reason,
         })
-    }
-}
-
-impl Default for OllamaProvider {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -573,20 +567,27 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.name(), "ollama");
         assert!(provider.base_url.contains("localhost"));
     }
 
     #[test]
     fn test_custom_base_url() {
-        let provider = OllamaProvider::with_base_url("http://custom:11434".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://custom:11434".to_string(),
+        );
         assert_eq!(provider.base_url, "http://custom:11434");
     }
 
     #[test]
     fn test_parse_response() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -607,7 +608,9 @@ mod tests {
 
     #[test]
     fn test_default() {
-        let provider = OllamaProvider::default();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.name(), "ollama");
         assert!(provider.base_url.contains("localhost"));
     }
@@ -626,8 +629,11 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider =
-            OllamaProvider::with_overrides("http://localhost:11434".to_string(), overrides, None);
+        let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://localhost:11434".to_string(),
+            overrides,
+        );
         let caps = provider.capabilities("custom-model");
         assert_eq!(caps.max_context_tokens, 42);
         assert!(!caps.supports_temperature);
@@ -636,9 +642,9 @@ mod tests {
     #[test]
     fn test_capabilities_falls_through_to_builtin() {
         let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
             "http://localhost:11434".to_string(),
             HashMap::new(),
-            None,
         );
         let caps = provider.capabilities("llama3-8b");
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -646,7 +652,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_count_tokens() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let tokens = provider.count_tokens("Hello, world!", "llama3").await;
         assert!(tokens > 0);
         // ceil(13 / 4): the shared estimate rounds up
@@ -655,20 +663,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_count_tokens_empty() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.count_tokens("", "llama3").await, 0);
     }
 
     #[test]
     fn test_max_context_tokens() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.max_context_tokens("llama3-8b"), 131_072);
         assert_eq!(provider.max_context_tokens("mistral-7b"), 32_768);
     }
 
     #[test]
     fn test_builtin_capabilities_llama3() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("llama3-8b");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -678,7 +692,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_qwen2() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("qwen2-7b");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -686,7 +702,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_qwen25() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("qwen2.5-coder");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -694,7 +712,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_qwen3() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("qwen3-30b");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -702,7 +722,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_mistral() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("mistral-7b");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 32_768);
@@ -711,7 +733,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_mixtral() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("mixtral-8x7b");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 32_768);
@@ -719,7 +743,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_phi4() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("phi-4");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -727,7 +753,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_phi4_variant() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("phi4-mini");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -735,7 +763,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_deepseek_r1() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("deepseek-r1:latest");
         assert!(!caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -743,7 +773,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_deepseek_general() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("deepseek-v3");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -751,7 +783,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gemma() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("gemma-7b");
         assert!(!caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -759,7 +793,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_codellama() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         // Note: "codellama-34b" contains "llama-3" so it matches llama-3 branch.
         // Use a model name without a dash-number suffix.
         let caps = provider.builtin_capabilities("codellama:latest");
@@ -770,7 +806,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_unknown() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("totally-unknown-model");
         assert!(!caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 8192);
@@ -779,7 +817,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_no_message_returns_error() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({ "done": true });
         let result = provider.parse_response(&body);
         assert!(result.is_err());
@@ -787,7 +827,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_with_tool_calls() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -815,7 +857,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_total_tokens() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": { "role": "assistant", "content": "ok" },
             "eval_count": 30,
@@ -830,7 +874,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_missing_counts_default_zero() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": { "role": "assistant", "content": "hi" },
             "done": true
@@ -842,7 +888,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_basic() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![
@@ -876,7 +924,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_passes_extra_params_into_options() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -899,7 +949,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_prepends_system_blocks() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a local assistant.".to_string(),
@@ -928,7 +980,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_serializes_tool_history() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![
@@ -985,7 +1039,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_with_tools() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1016,7 +1072,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_empty_content() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": { "role": "assistant", "content": "" },
             "eval_count": 0,
@@ -1030,7 +1088,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_missing_content_field() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": { "role": "assistant" },
             "done": true
@@ -1041,7 +1101,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_multiple_tool_calls() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -1077,7 +1139,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_tool_call_missing_function() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -1096,7 +1160,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_tool_call_missing_arguments() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -1122,7 +1188,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_no_tools_no_tools_key() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1145,7 +1213,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_deepseek_r1_no_temperature() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1170,7 +1240,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_multiple_messages() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![
@@ -1208,7 +1280,9 @@ mod tests {
 
     #[test]
     fn test_build_request_body_multiple_tools() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1258,8 +1332,11 @@ mod tests {
                 max_output_tokens: 99,
             },
         );
-        let provider =
-            OllamaProvider::with_overrides("http://localhost:11434".to_string(), overrides, None);
+        let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://localhost:11434".to_string(),
+            overrides,
+        );
         let caps = provider.capabilities("llama3-8b");
         assert_eq!(caps.max_context_tokens, 99);
         assert!(!caps.supports_temperature);
@@ -1268,8 +1345,11 @@ mod tests {
     #[test]
     fn test_capabilities_no_override_uses_builtin() {
         let overrides = HashMap::new();
-        let provider =
-            OllamaProvider::with_overrides("http://localhost:11434".to_string(), overrides, None);
+        let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://localhost:11434".to_string(),
+            overrides,
+        );
         let caps = provider.capabilities("llama3-8b");
         assert_eq!(caps.max_context_tokens, 131_072); // builtin
     }
@@ -1278,7 +1358,9 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_llama_3_with_dash() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let caps = provider.builtin_capabilities("llama-3.1-70b");
         assert!(caps.supports_tools);
         assert_eq!(caps.max_context_tokens, 131_072);
@@ -1288,7 +1370,9 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.name(), "ollama");
     }
 
@@ -1296,7 +1380,9 @@ mod tests {
 
     #[test]
     fn test_max_context_tokens_unknown_model() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         assert_eq!(provider.max_context_tokens("unknown-model"), 8192);
     }
 
@@ -1304,7 +1390,10 @@ mod tests {
 
     #[test]
     fn test_with_base_url_stores_url() {
-        let provider = OllamaProvider::with_base_url("https://remote:11434".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "https://remote:11434".to_string(),
+        );
         assert_eq!(provider.base_url, "https://remote:11434");
     }
 
@@ -1312,7 +1401,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_infer_connection_refused() {
-        let provider = OllamaProvider::with_base_url("http://127.0.0.1:19998".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://127.0.0.1:19998".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1335,7 +1427,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_infer_stream_connection_refused() {
-        let provider = OllamaProvider::with_base_url("http://127.0.0.1:19998".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://127.0.0.1:19998".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1362,7 +1457,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_models_connection_refused() {
-        let provider = OllamaProvider::with_base_url("http://127.0.0.1:19998".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://127.0.0.1:19998".to_string(),
+        );
         let err = provider.list_models().await.unwrap_err();
         assert!(err.to_string().contains("Request failed:"));
     }
@@ -1377,7 +1475,10 @@ mod tests {
         // enabled" check with no subscriber installed.
         let _guard = always_on_tracing_guard();
         // Should log a warning but not panic
-        let provider = OllamaProvider::with_base_url("ftp://invalid:11434".to_string());
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "ftp://invalid:11434".to_string(),
+        );
         assert_eq!(provider.base_url, "ftp://invalid:11434");
     }
 
@@ -1387,8 +1488,11 @@ mod tests {
         // arguments in with_overrides's "bad protocol" branch are actually
         // exercised.
         let _guard = always_on_tracing_guard();
-        let provider =
-            OllamaProvider::with_overrides("ftp://invalid:11434".to_string(), HashMap::new(), None);
+        let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "ftp://invalid:11434".to_string(),
+            HashMap::new(),
+        );
         assert_eq!(provider.base_url, "ftp://invalid:11434");
     }
 
@@ -1396,7 +1500,9 @@ mod tests {
 
     #[test]
     fn test_parse_response_tool_call_null_function_field() {
-        let provider = OllamaProvider::new();
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
         let body = serde_json::json!({
             "message": {
                 "role": "assistant",
@@ -1831,8 +1937,11 @@ mod tests {
                 max_output_tokens: 4096,
             },
         );
-        let provider =
-            OllamaProvider::with_overrides("http://localhost:11434".to_string(), overrides, None);
+        let provider = OllamaProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://localhost:11434".to_string(),
+            overrides,
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -1874,7 +1983,10 @@ mod tests {
     #[tokio::test]
     async fn infer_non_success_status_returns_api_error() {
         let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("API error:"));
     }
@@ -1884,7 +1996,10 @@ mod tests {
         // The body never arrives, so the shared helper substitutes the read
         // error for it. The status is what matters and must survive.
         let url = spawn_mock_server_truncated_error_body(500, "Internal Server Error").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("500"), "{err}");
     }
@@ -1892,7 +2007,10 @@ mod tests {
     #[tokio::test]
     async fn infer_malformed_json_returns_invalid_response() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.infer(&mock_request()).await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
@@ -1900,7 +2018,10 @@ mod tests {
     #[tokio::test]
     async fn infer_stream_non_success_status_returns_api_error() {
         let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let result = provider.infer_stream(&mock_request()).await;
         assert!(result.is_err());
         assert!(result.err().unwrap().to_string().contains("API error:"));
@@ -1909,7 +2030,10 @@ mod tests {
     #[tokio::test]
     async fn infer_stream_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(503, "Service Unavailable").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let result = provider.infer_stream(&mock_request()).await;
         let err = result
             .err()
@@ -1922,7 +2046,10 @@ mod tests {
         let ndjson_body =
             b"{\"message\":{\"content\":\"hi\"},\"done\":true,\"eval_count\":1,\"prompt_eval_count\":1}\n";
         let url = spawn_mock_server(200, "OK", ndjson_body).await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let mut stream = provider.infer_stream(&mock_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
@@ -1950,7 +2077,10 @@ mod tests {
             let _ = socket.flush().await;
             let _ = socket.shutdown().await;
         });
-        let provider = OllamaProvider::with_base_url(format!("http://{}", addr));
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            format!("http://{}", addr),
+        );
         let mut stream = provider.infer_stream(&mock_request()).await.unwrap();
         use tokio_stream::StreamExt;
         let mut saw_error = false;
@@ -1966,7 +2096,10 @@ mod tests {
     #[tokio::test]
     async fn list_models_non_success_status_returns_error() {
         let url = spawn_mock_server(401, "Unauthorized", b"nope").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.list_models().await.unwrap_err();
         // Was `RequestFailed`, which reads as retryable; a rejected key is not.
         assert_eq!(
@@ -1979,7 +2112,10 @@ mod tests {
     #[tokio::test]
     async fn list_models_non_success_status_body_read_error_still_reports_the_status() {
         let url = spawn_mock_server_truncated_error_body(401, "Unauthorized").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.list_models().await.unwrap_err();
         assert!(err.to_string().contains("401"), "{err}");
     }
@@ -1987,7 +2123,10 @@ mod tests {
     #[tokio::test]
     async fn list_models_malformed_json_returns_error() {
         let url = spawn_mock_server(200, "OK", b"not json").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let err = provider.list_models().await.unwrap_err();
         assert!(err.to_string().contains("Invalid response:"));
     }
@@ -1996,7 +2135,10 @@ mod tests {
     async fn list_models_success_returns_models() {
         let body = br#"{"models":[{"name":"llama3-8b"},{"name":"mistral-7b"}]}"#;
         let url = spawn_mock_server(200, "OK", body).await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let models = provider.list_models().await.unwrap();
         assert_eq!(models.len(), 2);
         assert_eq!(models[0].id, "llama3-8b");
@@ -2007,7 +2149,10 @@ mod tests {
     #[tokio::test]
     async fn list_models_missing_data_field_returns_empty() {
         let url = spawn_mock_server(200, "OK", b"{}").await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let models = provider.list_models().await.unwrap();
         assert!(models.is_empty());
     }
@@ -2016,7 +2161,10 @@ mod tests {
     async fn list_models_entry_without_name_is_skipped() {
         let body = br#"{"models":[{"foo":"bar"},{"name":"llama3-8b"}]}"#;
         let url = spawn_mock_server(200, "OK", body).await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let models = provider.list_models().await.unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "llama3-8b");
@@ -2027,7 +2175,10 @@ mod tests {
         // covers the `.as_str()?` None branch in the filter_map
         let body = br#"{"models":[{"name":42},{"name":"llama3-8b"}]}"#;
         let url = spawn_mock_server(200, "OK", body).await;
-        let provider = OllamaProvider::with_base_url(url);
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
         let models = provider.list_models().await.unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "llama3-8b");

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -35,9 +35,9 @@ pub struct OpenAIProvider {
 
 impl OpenAIProvider {
     /// Create a new OpenAI provider.
-    pub fn new(api_key: String) -> Self {
+    pub fn new(client: reqwest::Client, api_key: String) -> Self {
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             api_key,
             base_url: "https://api.openai.com/v1".to_string(),
             rate_limiter: None,
@@ -46,9 +46,8 @@ impl OpenAIProvider {
     }
 
     /// Create a new OpenAI provider with full configuration.
-    pub fn with_config(config: ProviderConfig) -> Self {
+    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        let client = crate::provider::build_http_client(config.request_timeout_secs);
         Self {
             client,
             api_key: config.api_key,
@@ -62,13 +61,13 @@ impl OpenAIProvider {
 
     /// Create a new OpenAI provider with per-model capability overrides.
     pub fn with_overrides(
+        client: reqwest::Client,
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
-        timeout_secs: Option<u64>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
-            client: crate::provider::build_http_client(timeout_secs),
+            client,
             api_key,
             base_url: "https://api.openai.com/v1".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
@@ -277,13 +276,19 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.name(), "openai");
     }
 
     #[test]
     fn test_context_limits() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("gpt-5.4-mini"), 400_000);
     }
 
@@ -368,7 +373,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gpt55() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gpt-5.5");
         assert!(caps.supports_temperature);
         assert!(caps.supports_streaming);
@@ -378,7 +386,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gpt54_mini() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gpt-5.4-mini");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 400_000);
@@ -387,7 +398,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gpt54_nano() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gpt-5.4-nano");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 400_000);
@@ -396,7 +410,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_gpt41() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("gpt-4.1");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_047_576);
@@ -405,7 +422,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_o4_mini() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("o4-mini");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 200_000);
@@ -414,7 +434,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_o3() {
-        let provider = OpenAIProvider::new("test-key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let caps = provider.builtin_capabilities("o3-mini");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 200_000);
@@ -435,8 +458,12 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider =
-            OpenAIProvider::with_overrides("test-key".to_string(), overrides, None, None);
+        let provider = OpenAIProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("gpt-5.4-mini");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1);
@@ -493,7 +520,10 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.name(), "openai");
     }
 
@@ -505,7 +535,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = OpenAIProvider::with_config(config);
+        let provider = OpenAIProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://api.openai.com/v1");
     }
 
@@ -517,13 +550,19 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = OpenAIProvider::with_config(config);
+        let provider = OpenAIProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://custom.openai.com");
     }
 
     #[tokio::test]
     async fn test_count_tokens_uses_tiktoken() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let tokens = provider.count_tokens("Hello, world!", "gpt-5.4-mini").await;
         assert!(tokens > 0);
         assert!(tokens < 20);
@@ -531,14 +570,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_count_tokens_empty() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let tokens = provider.count_tokens("", "gpt-5.4-mini").await;
         assert_eq!(tokens, 0);
     }
 
     #[test]
     fn test_max_context_tokens_delegates_to_capabilities() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.max_context_tokens("gpt-5.5"), 1_050_000);
         assert_eq!(provider.max_context_tokens("gpt-4.1"), 1_047_576);
         assert_eq!(provider.max_context_tokens("o3-mini"), 200_000);
@@ -546,7 +591,10 @@ mod tests {
 
     #[test]
     fn test_builtin_capabilities_unknown_model() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.builtin_capabilities("totally-unknown");
         let default = ModelCapabilities::default();
         assert_eq!(caps.max_context_tokens, default.max_context_tokens);
@@ -566,7 +614,12 @@ mod tests {
                 max_output_tokens: 1,
             },
         );
-        let provider = OpenAIProvider::with_overrides("key".to_string(), overrides, None, None);
+        let provider = OpenAIProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("gpt-5.5");
         assert_eq!(caps.max_context_tokens, 1);
     }
@@ -606,7 +659,10 @@ mod tests {
 
     #[test]
     fn test_gpt5_family_context() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         // gpt-5.4, gpt-5-mini, etc. should all match gpt-5 pattern
         assert_eq!(provider.max_context_tokens("gpt-5.4"), 400_000);
         assert_eq!(provider.max_context_tokens("gpt-5-mini"), 400_000);
@@ -614,7 +670,10 @@ mod tests {
 
     #[test]
     fn test_o4_mini_capabilities() {
-        let provider = OpenAIProvider::new("key".to_string());
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.builtin_capabilities("o4-mini");
         assert!(!caps.supports_temperature);
         assert!(caps.supports_tools);
@@ -625,12 +684,15 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> OpenAIProvider {
-        OpenAIProvider::with_config(ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: Some(url),
-            rate_limit: None,
-            request_timeout_secs: None,
-        })
+        OpenAIProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            ProviderConfig {
+                api_key: "test-key".to_string(),
+                base_url: Some(url),
+                rate_limit: None,
+                request_timeout_secs: None,
+            },
+        )
     }
 
     fn simple_request() -> InferenceRequest {
@@ -806,10 +868,19 @@ mod tests {
             requests_per_minute: 5,
             tokens_per_minute: 1_000,
         };
-        let limited =
-            OpenAIProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        let limited = OpenAIProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            Some(&cfg),
+        );
         assert!(limited.rate_limiter.is_some());
-        let unlimited = OpenAIProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        let unlimited = OpenAIProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            None,
+        );
         assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -34,9 +34,9 @@ pub struct OpenRouterProvider {
 
 impl OpenRouterProvider {
     /// Create a new OpenRouter provider.
-    pub fn new(api_key: String) -> Self {
+    pub fn new(client: reqwest::Client, api_key: String) -> Self {
         Self {
-            client: crate::provider::build_http_client(None),
+            client,
             api_key,
             base_url: "https://openrouter.ai/api/v1".to_string(),
             rate_limiter: None,
@@ -45,9 +45,8 @@ impl OpenRouterProvider {
     }
 
     /// Create a new OpenRouter provider with full configuration.
-    pub fn with_config(config: ProviderConfig) -> Self {
+    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        let client = crate::provider::build_http_client(config.request_timeout_secs);
         Self {
             client,
             api_key: config.api_key,
@@ -61,13 +60,13 @@ impl OpenRouterProvider {
 
     /// Create a new OpenRouter provider with per-model capability overrides.
     pub fn with_overrides(
+        client: reqwest::Client,
         api_key: String,
         overrides: HashMap<String, ModelCapabilities>,
-        timeout_secs: Option<u64>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
-            client: crate::provider::build_http_client(timeout_secs),
+            client,
             api_key,
             base_url: "https://openrouter.ai/api/v1".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
@@ -502,13 +501,19 @@ mod tests {
 
     #[test]
     fn test_provider_creation() {
-        let provider = OpenRouterProvider::new("test-key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         assert_eq!(provider.name(), "openrouter");
     }
 
     #[test]
     fn test_build_request_body() {
-        let provider = OpenRouterProvider::new("test-key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -530,7 +535,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_passes_through_extra_params() {
-        let provider = OpenRouterProvider::new("test-key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -552,7 +560,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_prepends_system_blocks() {
-        let provider = OpenRouterProvider::new("test-key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a helpful assistant.".to_string(),
@@ -582,7 +593,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_serializes_tool_history() {
-        let provider = OpenRouterProvider::new("test-key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![
@@ -637,26 +651,38 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.name(), "openrouter");
     }
 
     #[tokio::test]
     async fn test_count_tokens() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let tokens = provider.count_tokens("Hello, world!", "any-model").await;
         assert_eq!(tokens, 4); // ceil(13 / 4): the shared estimate rounds up
     }
 
     #[tokio::test]
     async fn test_count_tokens_empty() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         assert_eq!(provider.count_tokens("", "any-model").await, 0);
     }
 
     #[test]
     fn test_max_context_tokens() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         // Unknown model ⇒ the conservative fallback.
         assert_eq!(provider.max_context_tokens("any-model"), 128_000);
         // A known large-context model reports its real size (not a flat 128K) -
@@ -678,7 +704,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = OpenRouterProvider::with_config(config);
+        let provider = OpenRouterProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://openrouter.ai/api/v1");
     }
 
@@ -690,7 +719,10 @@ mod tests {
             rate_limit: None,
             request_timeout_secs: None,
         };
-        let provider = OpenRouterProvider::with_config(config);
+        let provider = OpenRouterProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            config,
+        );
         assert_eq!(provider.base_url, "https://custom.openrouter.ai");
     }
 
@@ -708,14 +740,22 @@ mod tests {
                 max_output_tokens: 10,
             },
         );
-        let provider = OpenRouterProvider::with_overrides("key".to_string(), overrides, None, None);
+        let provider = OpenRouterProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+            overrides,
+            None,
+        );
         let caps = provider.capabilities("custom/model");
         assert_eq!(caps.max_context_tokens, 99);
     }
 
     #[test]
     fn test_capabilities_google_gemini() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("google/gemini-3.5-flash");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_048_576);
@@ -724,21 +764,30 @@ mod tests {
 
     #[test]
     fn test_capabilities_llama4_scout() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("meta-llama/llama-4-scout-17b");
         assert_eq!(caps.max_context_tokens, 10_000_000);
     }
 
     #[test]
     fn test_capabilities_llama4_maverick() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("meta-llama/llama-4-maverick");
         assert_eq!(caps.max_context_tokens, 1_048_576);
     }
 
     #[test]
     fn test_capabilities_deepseek_r1() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("deepseek/deepseek-r1");
         assert!(!caps.supports_temperature);
         assert!(!caps.supports_tools);
@@ -747,7 +796,10 @@ mod tests {
 
     #[test]
     fn test_capabilities_deepseek_v4_pro() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("deepseek/deepseek-v4-pro");
         assert_eq!(caps.max_context_tokens, 1_048_576);
         assert_eq!(caps.max_output_tokens, 393_216);
@@ -755,7 +807,10 @@ mod tests {
 
     #[test]
     fn test_capabilities_deepseek_v_series() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("deepseek/deepseek-v3");
         assert_eq!(caps.max_context_tokens, 1_048_576);
         assert_eq!(caps.max_output_tokens, 65_536);
@@ -763,42 +818,60 @@ mod tests {
 
     #[test]
     fn test_capabilities_mistral_large() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("mistralai/mistral-large-latest");
         assert_eq!(caps.max_context_tokens, 262_144);
     }
 
     #[test]
     fn test_capabilities_mistralai_general() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("mistralai/mistral-small-latest");
         assert_eq!(caps.max_context_tokens, 131_072);
     }
 
     #[test]
     fn test_capabilities_qwen36() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("qwen/qwen3.6-235b");
         assert_eq!(caps.max_context_tokens, 1_048_576);
     }
 
     #[test]
     fn test_capabilities_qwen3_coder() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("qwen/qwen3-coder-plus");
         assert_eq!(caps.max_context_tokens, 1_048_576);
     }
 
     #[test]
     fn test_capabilities_qwen_general() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("qwen/qwen3-32b");
         assert_eq!(caps.max_context_tokens, 131_072);
     }
 
     #[test]
     fn test_capabilities_anthropic_via_openrouter() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("anthropic/claude-sonnet-4-6");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_000_000);
@@ -807,21 +880,30 @@ mod tests {
 
     #[test]
     fn test_capabilities_anthropic_no_temp() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("anthropic/claude-opus-4-8");
         assert!(!caps.supports_temperature);
     }
 
     #[test]
     fn test_capabilities_anthropic_fable5_no_temp() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("anthropic/claude-fable-5");
         assert!(!caps.supports_temperature);
     }
 
     #[test]
     fn test_capabilities_openai_o_series() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("openai/o3-mini");
         assert!(!caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 200_000);
@@ -829,7 +911,10 @@ mod tests {
 
     #[test]
     fn test_capabilities_openai_gpt5() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("openai/gpt-5.4-mini");
         assert!(caps.supports_temperature);
         assert_eq!(caps.max_context_tokens, 1_050_000);
@@ -837,7 +922,10 @@ mod tests {
 
     #[test]
     fn test_capabilities_unknown_fallback() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let caps = provider.capabilities("totally/unknown-model");
         assert!(caps.supports_temperature);
         assert!(caps.supports_tools);
@@ -847,7 +935,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_anthropic_cache_breakpoint() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![
@@ -881,7 +972,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_non_anthropic_no_cache_breakpoint() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -905,7 +999,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_max_4_breakpoints() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let messages: Vec<crate::provider::Message> = (0..6)
             .map(|i| crate::provider::Message {
                 role: "user".to_string(),
@@ -933,7 +1030,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_with_tools() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -961,7 +1061,10 @@ mod tests {
 
     #[test]
     fn test_build_request_body_no_temp_for_deepseek_r1() {
-        let provider = OpenRouterProvider::new("key".to_string());
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
         let request = InferenceRequest {
             system: vec![],
             messages: vec![crate::provider::Message {
@@ -985,12 +1088,15 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> OpenRouterProvider {
-        OpenRouterProvider::with_config(ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: Some(url),
-            rate_limit: None,
-            request_timeout_secs: None,
-        })
+        OpenRouterProvider::with_config(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            ProviderConfig {
+                api_key: "test-key".to_string(),
+                base_url: Some(url),
+                rate_limit: None,
+                request_timeout_secs: None,
+            },
+        )
     }
 
     fn simple_request() -> InferenceRequest {
@@ -1147,11 +1253,19 @@ mod tests {
             requests_per_minute: 5,
             tokens_per_minute: 1_000,
         };
-        let limited =
-            OpenRouterProvider::with_overrides("k".to_string(), HashMap::new(), None, Some(&cfg));
+        let limited = OpenRouterProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            Some(&cfg),
+        );
         assert!(limited.rate_limiter.is_some());
-        let unlimited =
-            OpenRouterProvider::with_overrides("k".to_string(), HashMap::new(), None, None);
+        let unlimited = OpenRouterProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            HashMap::new(),
+            None,
+        );
         assert!(unlimited.rate_limiter.is_none());
     }
 }

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -134,6 +134,24 @@ pub enum ProviderError {
     #[error("API error: {0}")]
     ApiError(String),
 
+    /// The outbound HTTP client could not be constructed, so this provider
+    /// cannot make any request at all.
+    ///
+    /// This is the *client* side: the workspace builds `reqwest` with `rustls`
+    /// and `rustls-native-certs`, so constructing a client reads the machine's
+    /// root certificate store in order to speak HTTPS to a provider API. A
+    /// failure here means that store could not be read, not that any particular
+    /// request was rejected - and it has nothing to do with `lev serve`'s own
+    /// `--tls-cert` / `--tls-key`, which are a separate, already-fallible path.
+    ///
+    /// Separate from [`ProviderError::RequestFailed`] because no retry, backoff
+    /// or change of model affects it; the remedy is on the host.
+    #[error(
+        "outbound HTTPS client could not be built ({0}); leviath reads the system root \
+         certificate store to reach provider APIs"
+    )]
+    ClientBuild(String),
+
     /// The provider cannot serve any request until someone intervenes - the
     /// account is out of credits, or the key is bad. `detail` keeps the raw
     /// provider response for the logs; the message leads with what to do.
@@ -211,6 +229,10 @@ impl ProviderError {
             ProviderError::InvalidResponse(_)
             | ProviderError::TokenLimitExceeded { .. }
             | ProviderError::Unavailable { .. }
+            // The machine could not build an HTTPS client. Every retry does the
+            // same work and reads the same certificate store, so it fails the
+            // same way - and so would every other provider.
+            | ProviderError::ClientBuild(_)
             | ProviderError::Other(_) => false,
         }
     }
@@ -671,6 +693,41 @@ fn same_origin_hop(attempt: &reqwest::redirect::Attempt<'_>) -> bool {
     })
 }
 
+/// The error `reqwest` reports when a client cannot be built, re-exported for
+/// the same reason as [`HttpClient`].
+pub use reqwest::Error as HttpError;
+
+/// An [`HttpError`] instance, for tests that need to drive a failure path.
+///
+/// Constructing one otherwise is impossible: `reqwest::Error` has no public
+/// constructor, and client construction cannot be made to fail from the
+/// outside - a malformed `HTTPS_PROXY` is ignored rather than rejected, which
+/// was measured rather than assumed. Handing the builder a string that is not a
+/// URL produces one without any I/O. (An unknown *scheme* does not: reqwest
+/// accepts it here and only fails on send.)
+pub fn malformed_url_error() -> HttpError {
+    reqwest::Client::builder()
+        .build()
+        .expect("a builder with no options set always yields a client")
+        .get("http://[")
+        .build()
+        .expect_err("reqwest rejects a string that is not a URL")
+}
+
+/// The HTTP client providers hold, re-exported so callers can name the type
+/// without taking a direct `reqwest` dependency of their own.
+pub use reqwest::Client as HttpClient;
+
+/// Builds an outbound HTTPS client for a given request timeout.
+///
+/// Injected so the failure path is reachable. `reqwest` will not fail to build a
+/// client in any environment a test can arrange - a malformed `HTTPS_PROXY` is
+/// ignored rather than rejected, which was measured, not assumed - so without a
+/// seam the error arm would be unreachable code that no test could prove and the
+/// coverage gate could not accept.
+pub type HttpClientFactory<'a> =
+    &'a (dyn Fn(Option<u64>) -> std::result::Result<reqwest::Client, reqwest::Error> + Send + Sync);
+
 /// The HTTP client every provider talks through.
 ///
 /// Redirects are capped and confined to the origin the request started on. That
@@ -681,7 +738,9 @@ fn same_origin_hop(attempt: &reqwest::redirect::Attempt<'_>) -> bool {
 ///
 /// `timeout_secs` of `None` leaves the request untimed, which is what a
 /// streaming call needs - a long generation is not a stalled one.
-pub fn build_http_client(timeout_secs: Option<u64>) -> reqwest::Client {
+pub fn build_http_client(
+    timeout_secs: Option<u64>,
+) -> std::result::Result<reqwest::Client, reqwest::Error> {
     reqwest::Client::builder()
         .pool_max_idle_per_host(0)
         // Follow a redirect only while it stays on the host the key was meant
@@ -707,7 +766,6 @@ pub fn build_http_client(timeout_secs: Option<u64>) -> reqwest::Client {
             timeout_secs.unwrap_or(DEFAULT_INFERENCE_TIMEOUT_SECS),
         ))
         .build()
-        .expect("failed to build reqwest client")
 }
 
 /// Trait for LLM providers.
@@ -897,6 +955,7 @@ mod tests {
     async fn a_same_origin_redirect_is_followed() {
         let (base, hits) = serve_sequence(vec![redirect_to("/second"), OK_BODY.to_string()]).await;
         let response = build_http_client(Some(10))
+            .expect("an HTTPS client builds in tests")
             .get(format!("{base}/first"))
             .header("x-api-key", "super-secret")
             .send()
@@ -916,6 +975,7 @@ mod tests {
         let (base, _) = serve_sequence(vec![redirect_to(&format!("{thief}/steal"))]).await;
 
         let response = build_http_client(Some(10))
+            .expect("an HTTPS client builds in tests")
             .get(format!("{base}/first"))
             .header("x-api-key", "super-secret")
             .send()
@@ -931,6 +991,16 @@ mod tests {
             0,
             "no request carrying the api key may reach another origin"
         );
+    }
+
+    #[test]
+    fn malformed_url_error_yields_a_real_reqwest_error() {
+        // The only way to obtain a `reqwest::Error` without I/O, and the reason
+        // the client-build failure path is testable at all. If a future reqwest
+        // starts accepting this input, the error paths that depend on it become
+        // unreachable - so this asserts the trigger still triggers.
+        let err = malformed_url_error();
+        assert!(err.is_builder(), "expected a builder error, got {err:?}");
     }
 
     #[test]
@@ -1668,7 +1738,7 @@ mod tests {
 
     #[test]
     fn build_http_client_with_timeout() {
-        let client = build_http_client(Some(30));
+        let client = build_http_client(Some(30)).expect("an HTTPS client builds in tests");
         // Should successfully build a client; we cannot inspect the timeout
         // directly, but confirming it doesn't panic is the coverage goal.
         drop(client);
@@ -1676,7 +1746,7 @@ mod tests {
 
     #[test]
     fn build_http_client_without_timeout() {
-        let client = build_http_client(None);
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
         drop(client);
     }
 
@@ -1713,7 +1783,7 @@ mod tests {
         // The production client (no client-level duration cap) plus a short
         // per-request deadline. If the per-request timeout were not applied this
         // send would hang and the test would time out instead of asserting.
-        let client = build_http_client(None);
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
         let start = Instant::now();
         let builder = client
             .post(format!("http://{addr}/"))
@@ -1735,7 +1805,7 @@ mod tests {
     fn apply_request_timeout_none_is_a_noop() {
         // The `None` arm must return the builder unchanged (no per-request cap);
         // build a request both ways and confirm both are constructible.
-        let client = build_http_client(None);
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
         let with_none = apply_request_timeout(client.post("http://example.invalid/"), None);
         let with_some = apply_request_timeout(client.post("http://example.invalid/"), Some(5));
         assert!(with_none.build().is_ok());

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -106,10 +106,8 @@ impl ReqwestExecutor {
     /// Build an executor with a fresh-connection-per-request client (the
     /// `pool_max_idle_per_host(0)` fix); per-request deadlines come from
     /// [`HostRequest::timeout_secs`].
-    pub fn new() -> Self {
-        Self {
-            client: crate::provider::build_http_client(None),
-        }
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
     }
 
     /// Build the `reqwest::RequestBuilder` for a [`HostRequest`].
@@ -125,12 +123,6 @@ impl ReqwestExecutor {
             rb = rb.body(body.clone());
         }
         crate::provider::apply_request_timeout(rb, req.timeout_secs)
-    }
-}
-
-impl Default for ReqwestExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -167,31 +167,37 @@ fn req(method: HttpMethod, url: String, body: Option<&str>) -> HostRequest {
 #[tokio::test]
 async fn reqwest_executor_get_ok() {
     let url = mock_server("200 OK", &[], "hello-body").await;
-    let out = ReqwestExecutor::new()
-        .execute(req(HttpMethod::Get, url, None))
-        .await
-        .unwrap();
+    let out = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .unwrap();
     assert_eq!(out, "hello-body");
 }
 
 #[tokio::test]
 async fn reqwest_executor_post_with_body() {
     let url = mock_server("200 OK", &[], "{}").await;
-    let out = ReqwestExecutor::default()
-        .execute(req(HttpMethod::Post, url, Some("{\"a\":1}")))
-        .await
-        .unwrap();
+    let out = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Post, url, Some("{\"a\":1}")))
+    .await
+    .unwrap();
     assert_eq!(out, "{}");
 }
 
 #[tokio::test]
 async fn reqwest_executor_429_with_retry_after() {
     let url = mock_server("429 Too Many Requests", &[("Retry-After", "7")], "slow").await;
-    let err = ReqwestExecutor::new()
-        .execute(req(HttpMethod::Get, url, None))
-        .await
-        .err()
-        .unwrap();
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .err()
+    .unwrap();
     assert!(matches!(
         err,
         HostHttpError::RateLimited {
@@ -203,26 +209,30 @@ async fn reqwest_executor_429_with_retry_after() {
 #[tokio::test]
 async fn reqwest_executor_non_2xx_is_api_error() {
     let url = mock_server("500 Internal Server Error", &[], "boom").await;
-    let err = ReqwestExecutor::new()
-        .execute(req(HttpMethod::Get, url, None))
-        .await
-        .err()
-        .unwrap();
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .err()
+    .unwrap();
     assert!(matches!(err, HostHttpError::Api(m) if m.contains("500")));
 }
 
 #[tokio::test]
 async fn reqwest_executor_transport_error() {
     // Nothing listening on this port → connection refused.
-    let err = ReqwestExecutor::new()
-        .execute(req(
-            HttpMethod::Get,
-            "http://127.0.0.1:19998".to_string(),
-            None,
-        ))
-        .await
-        .err()
-        .unwrap();
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(
+        HttpMethod::Get,
+        "http://127.0.0.1:19998".to_string(),
+        None,
+    ))
+    .await
+    .err()
+    .unwrap();
     assert!(matches!(err, HostHttpError::Transport(_)));
 }
 
@@ -235,7 +245,7 @@ async fn reqwest_executor_stream_forwards_events() {
     )
     .await;
     let (tx, mut rx) = mpsc::channel(16);
-    ReqwestExecutor::new()
+    ReqwestExecutor::new(crate::provider::build_http_client(None).expect("a test client builds"))
         .execute_stream(req(HttpMethod::Post, url, Some("{}")), tx)
         .await;
     assert_eq!(rx.recv().await.unwrap().unwrap(), "{\"a\":1}");
@@ -245,7 +255,7 @@ async fn reqwest_executor_stream_forwards_events() {
 #[tokio::test]
 async fn reqwest_executor_stream_transport_error() {
     let (tx, mut rx) = mpsc::channel(16);
-    ReqwestExecutor::new()
+    ReqwestExecutor::new(crate::provider::build_http_client(None).expect("a test client builds"))
         .execute_stream(
             req(
                 HttpMethod::Post,
@@ -278,11 +288,13 @@ async fn reqwest_executor_body_read_error_is_transport() {
         let _ = sock.flush().await;
         let _ = sock.shutdown().await;
     });
-    let err = ReqwestExecutor::new()
-        .execute(req(HttpMethod::Get, format!("http://{addr}"), None))
-        .await
-        .err()
-        .unwrap();
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, format!("http://{addr}"), None))
+    .await
+    .err()
+    .unwrap();
     assert!(matches!(err, HostHttpError::Transport(_)));
 }
 
@@ -303,11 +315,13 @@ async fn reqwest_executor_non_2xx_body_read_error() {
         let _ = sock.flush().await;
         let _ = sock.shutdown().await;
     });
-    let err = ReqwestExecutor::new()
-        .execute(req(HttpMethod::Get, format!("http://{addr}"), None))
-        .await
-        .err()
-        .unwrap();
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, format!("http://{addr}"), None))
+    .await
+    .err()
+    .unwrap();
     assert!(matches!(err, HostHttpError::Api(_)));
 }
 
@@ -315,7 +329,7 @@ async fn reqwest_executor_non_2xx_body_read_error() {
 async fn reqwest_executor_stream_non_2xx_error() {
     let url = mock_server("503 Service Unavailable", &[], "down").await;
     let (tx, mut rx) = mpsc::channel(16);
-    ReqwestExecutor::new()
+    ReqwestExecutor::new(crate::provider::build_http_client(None).expect("a test client builds"))
         .execute_stream(req(HttpMethod::Post, url, Some("{}")), tx)
         .await;
     assert!(matches!(

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -46,7 +46,7 @@ use crate::rate_limit::RateLimiter;
 
 use convert::{map_rhai_err, parse_inference_dynamic};
 use engine::{ExecConfig, build_exec_engine, build_init_engine};
-use host::{BrokerJob, HostHttpError, HttpExecutor, ReqwestExecutor};
+use host::{BrokerJob, HostHttpError, HttpExecutor};
 
 pub use meta::{ProviderMeta, parse_provider_annotations};
 
@@ -97,18 +97,18 @@ pub struct ScriptProviderSettings {
 }
 
 impl RhaiProvider {
-    /// Load a provider from a script file, using the production reqwest-backed
-    /// HTTP executor. Reads + compiles the script and runs `initialize(config)`
-    /// **offline**; any failure (missing file, compile error, `initialize`
-    /// throw) is returned as an error so the caller can skip-with-warning.
+    /// Load a provider from a script file. Reads + compiles the script and runs
+    /// `initialize(config)` **offline**; any failure (missing file, compile
+    /// error, `initialize` throw) is returned as an error so the caller can
+    /// skip-with-warning.
+    ///
+    /// The HTTP executor is supplied rather than built here: constructing one
+    /// can fail (it reads the machine's root certificate store), and the caller
+    /// builds it once for every script provider instead of once per script.
     pub fn from_script(
-        name: String,
         script_path: &Path,
-        init_config: serde_json::Value,
-        caps: HashMap<String, ModelCapabilities>,
-        rate_limit: Option<RateLimitConfig>,
-        request_timeout_secs: Option<u64>,
-        env_allowlist: Arc<Vec<String>>,
+        executor: Arc<dyn HttpExecutor>,
+        settings: ScriptProviderSettings,
     ) -> Result<Self> {
         let src = std::fs::read_to_string(script_path).map_err(|e| {
             ProviderError::Other(format!(
@@ -116,18 +116,7 @@ impl RhaiProvider {
                 script_path.display()
             ))
         })?;
-        Self::from_source(
-            &src,
-            Arc::new(ReqwestExecutor::new()),
-            ScriptProviderSettings {
-                name,
-                init_config,
-                caps,
-                rate_limit,
-                request_timeout_secs,
-                env_allowlist,
-            },
-        )
+        Self::from_source(&src, executor, settings)
     }
 
     /// Build a provider from in-memory source with an injected [`HttpExecutor`]

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -174,13 +174,18 @@ fn from_source_initialize_receives_config() {
 #[test]
 fn from_script_reads_missing_file() {
     let err = RhaiProvider::from_script(
-        "test".into(),
         std::path::Path::new("/no/such/provider.rhai"),
-        serde_json::json!({}),
-        HashMap::new(),
-        None,
-        None,
-        no_env_allowlist(),
+        std::sync::Arc::new(crate::rhai_provider::host::ReqwestExecutor::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        )),
+        crate::rhai_provider::ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .err()
     .unwrap();
@@ -197,13 +202,18 @@ fn from_script_loads_real_file() {
     )
     .unwrap();
     let p = RhaiProvider::from_script(
-        "test".into(),
         &path,
-        serde_json::json!({}),
-        HashMap::new(),
-        None,
-        None,
-        no_env_allowlist(),
+        std::sync::Arc::new(crate::rhai_provider::host::ReqwestExecutor::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        )),
+        crate::rhai_provider::ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
     )
     .unwrap();
     assert_eq!(p.name(), "test");

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -632,7 +632,7 @@ impl ControlClient {
 
     /// Present `token` on every connection this client opens.
     pub fn with_token(self, token: ControlToken) -> Self {
-        *self.token.lock().expect("token lock never poisoned") = Some(token);
+        *leviath_core::sync::lock(&self.token) = Some(token);
         self
     }
 
@@ -659,10 +659,7 @@ impl ControlClient {
 
     /// The token to present right now, if any.
     fn current_token(&self) -> Option<ControlToken> {
-        self.token
-            .lock()
-            .expect("token lock never poisoned")
-            .clone()
+        leviath_core::sync::lock(&self.token).clone()
     }
 
     /// Re-read the token file after a refusal. Returns `true` when the file
@@ -681,7 +678,7 @@ impl ControlClient {
         let Ok(fresh) = ControlToken::load(dir) else {
             return false;
         };
-        let mut cached = self.token.lock().expect("token lock never poisoned");
+        let mut cached = leviath_core::sync::lock(&self.token);
         let changed = cached.as_ref().is_none_or(|t| !t.matches(fresh.expose()));
         if changed {
             *cached = Some(fresh);

--- a/crates/leviath-runtime/src/embed/error.rs
+++ b/crates/leviath-runtime/src/embed/error.rs
@@ -17,6 +17,11 @@ pub enum EmbedError {
     Blueprint(String),
     /// The spawn was rejected (bad workdir, unresolvable seeds, and so on).
     Spawn(String),
+    /// A configured provider's outbound HTTPS client could not be built, so
+    /// that provider could never reach its API. In practice the machine's root
+    /// certificate store could not be read; it is unrelated to any TLS
+    /// certificate the host itself serves.
+    ProviderClient(String),
     /// The world's serve loop is gone (already shut down), so the request
     /// could not be delivered or answered.
     ChannelClosed,
@@ -33,6 +38,9 @@ impl std::fmt::Display for EmbedError {
             }
             EmbedError::Blueprint(msg) => write!(f, "blueprint error: {msg}"),
             EmbedError::Spawn(msg) => write!(f, "spawn error: {msg}"),
+            EmbedError::ProviderClient(msg) => {
+                write!(f, "provider HTTPS client error: {msg}")
+            }
             EmbedError::ChannelClosed => write!(f, "the world has shut down"),
         }
     }
@@ -54,6 +62,10 @@ mod tests {
                 "blueprint error: bad",
             ),
             (EmbedError::Spawn("nope".to_string()), "spawn error: nope"),
+            (
+                EmbedError::ProviderClient("no roots".to_string()),
+                "provider HTTPS client error: no roots",
+            ),
             (EmbedError::ChannelClosed, "shut down"),
         ];
         for (err, needle) in cases {

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -16,7 +16,7 @@ use crate::host::{ControlOp, SpawnArgs, WorldEvent, WorldHost};
 use crate::inference_pool::InferencePoolConfig;
 use crate::interaction_hub::InteractionHub;
 use crate::pipeline::{ModelDefaults, ToolService};
-use crate::provider_creds::{ProviderCreds, build_provider_registry};
+use crate::provider_creds::ProviderCreds;
 use crate::providers::ProviderRegistry;
 use crate::world::PipelineWorld;
 
@@ -237,6 +237,18 @@ impl AgentWorldBuilder {
 
     /// Assemble the world and start its serve loop on the Tokio runtime.
     pub fn build(self) -> Result<AgentWorld, EmbedError> {
+        self.build_with(&leviath_providers::provider::build_http_client)
+    }
+
+    /// [`build`](Self::build), with outbound-HTTPS-client construction injected.
+    ///
+    /// Exists so the "no usable client" path is reachable from a test: `reqwest`
+    /// cannot be made to fail from the outside, so without a seam this error
+    /// would be unreachable code.
+    pub fn build_with(
+        self,
+        build_client: leviath_providers::provider::HttpClientFactory<'_>,
+    ) -> Result<AgentWorld, EmbedError> {
         if self.creds.is_empty() && self.custom_providers.is_empty() {
             return Err(EmbedError::NoProviders);
         }
@@ -245,7 +257,9 @@ impl AgentWorldBuilder {
             None => Handle::try_current().map_err(|_| EmbedError::NoRuntime)?,
         };
 
-        let mut registry: ProviderRegistry = build_provider_registry(&self.creds);
+        let mut registry: ProviderRegistry =
+            crate::provider_creds::build_provider_registry_with(&self.creds, build_client)
+                .map_err(|e| EmbedError::ProviderClient(e.to_string()))?;
         for (name, provider) in self.custom_providers {
             registry.register(name, provider);
         }
@@ -1462,5 +1476,29 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         let id = RunId("coder-1-2".to_string());
         assert_eq!(id.to_string(), "coder-1-2");
         assert_eq!(id.as_ref(), "coder-1-2");
+    }
+
+    #[tokio::test]
+    async fn a_world_whose_provider_client_will_not_build_reports_it() {
+        // The failure a machine with an unreadable root certificate store would
+        // hit. Reachable only through the injected factory: reqwest cannot be
+        // made to fail from the outside.
+        let failing = |_t: Option<u64>| Err(leviath_providers::provider::malformed_url_error());
+        let mut cred = ProviderCreds::simple("anthropic");
+        cred.api_key = Some("k".to_string());
+        let err = AgentWorld::builder()
+            .provider(cred)
+            .build_with(&failing)
+            .err()
+            .expect("a failing client factory should fail the build");
+        // Discriminant rather than `matches!`: the macro expands to a match
+        // with a `_ => false` arm that nothing reaches, which the 100% gate
+        // reads as an uncovered region. Static assert messages for the same
+        // reason - an interpolated one is only evaluated on failure.
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&EmbedError::ProviderClient(String::new()))
+        );
+        assert!(err.to_string().contains("provider HTTPS client error"));
     }
 }

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -80,9 +80,58 @@ impl ProviderCreds {
     }
 }
 
+/// Outbound HTTPS clients, one per distinct request timeout.
+#[derive(Default)]
+struct ClientCache {
+    by_timeout: std::collections::HashMap<Option<u64>, leviath_providers::provider::HttpClient>,
+}
+
+impl ClientCache {
+    /// The client for `timeout`, building it on first request.
+    ///
+    /// Providers sharing a timeout share a connection pool; before this, each
+    /// provider built its own client, so a daemon with five configured held
+    /// five pools.
+    fn get_or_build(
+        &mut self,
+        timeout: Option<u64>,
+        build: leviath_providers::provider::HttpClientFactory<'_>,
+    ) -> Result<leviath_providers::provider::HttpClient, leviath_providers::ProviderError> {
+        if let Some(client) = self.by_timeout.get(&timeout) {
+            return Ok(client.clone());
+        }
+        let built = build(timeout)
+            .map_err(|e| leviath_providers::ProviderError::ClientBuild(e.to_string()))?;
+        self.by_timeout.insert(timeout, built.clone());
+        Ok(built)
+    }
+}
+
 /// Build a [`ProviderRegistry`] from decoupled [`ProviderCreds`].
-pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
+pub fn build_provider_registry(
+    creds: &[ProviderCreds],
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    build_provider_registry_with(creds, &leviath_providers::provider::build_http_client)
+}
+
+/// [`build_provider_registry`], with client construction injected.
+///
+/// One client per distinct request timeout, shared by every provider that wants
+/// it. Previously each provider built its own, so a daemon with five providers
+/// configured held five connection pools; the timeout is part of the key because
+/// `apply_request_timeout` deliberately defers to the client-level timeout when
+/// a stage sets none, so collapsing distinct timeouts onto one client would
+/// silently retime requests.
+pub fn build_provider_registry_with(
+    creds: &[ProviderCreds],
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
     let mut registry = ProviderRegistry::new();
+    // One client per distinct timeout, built on first use. Lazy because
+    // `claude-code` drives a local CLI and needs no HTTP client at all - eager
+    // construction would let a certificate-store failure block a provider that
+    // never touches a certificate.
+    let mut clients = ClientCache::default();
 
     for c in creds {
         let caps = c.model_capabilities.clone();
@@ -93,9 +142,9 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                     registry.register(
                         "anthropic".to_string(),
                         Arc::new(leviath_providers::AnthropicProvider::with_overrides(
+                            clients.get_or_build(timeout, build_client)?,
                             key.clone(),
                             caps,
-                            timeout,
                             c.rate_limit.as_ref(),
                         )),
                     );
@@ -106,9 +155,9 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                     registry.register(
                         "openai".to_string(),
                         Arc::new(leviath_providers::OpenAIProvider::with_overrides(
+                            clients.get_or_build(timeout, build_client)?,
                             key.clone(),
                             caps,
-                            timeout,
                             c.rate_limit.as_ref(),
                         )),
                     );
@@ -119,9 +168,9 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                     registry.register(
                         "google".to_string(),
                         Arc::new(leviath_providers::GeminiProvider::with_overrides(
+                            clients.get_or_build(timeout, build_client)?,
                             key.clone(),
                             caps,
-                            timeout,
                             c.rate_limit.as_ref(),
                         )),
                     );
@@ -132,9 +181,9 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                     registry.register(
                         "openrouter".to_string(),
                         Arc::new(leviath_providers::OpenRouterProvider::with_overrides(
+                            clients.get_or_build(timeout, build_client)?,
                             key.clone(),
                             caps,
-                            timeout,
                             c.rate_limit.as_ref(),
                         )),
                     );
@@ -148,7 +197,9 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
                 registry.register(
                     "ollama".to_string(),
                     Arc::new(leviath_providers::OllamaProvider::with_overrides(
-                        url, caps, timeout,
+                        clients.get_or_build(timeout, build_client)?,
+                        url,
+                        caps,
                     )),
                 );
             }
@@ -174,7 +225,7 @@ pub fn build_provider_registry(creds: &[ProviderCreds]) -> ProviderRegistry {
         }
     }
 
-    registry
+    Ok(registry)
 }
 
 #[cfg(test)]
@@ -203,7 +254,7 @@ mod tests {
 
     #[test]
     fn build_provider_registry_from_creds_slice() {
-        // Drives `build_provider_registry(&[ProviderCreds])` directly:
+        // Drives `build_provider_registry(&[ProviderCreds]).expect("an HTTPS client builds in tests")` directly:
         // every keyed provider, the ollama-with-default-url arm, claude-code,
         // and an unknown provider name (the catch-all no-op arm).
         let caps = std::collections::HashMap::new();
@@ -272,7 +323,7 @@ mod tests {
                 options: Default::default(),
             },
         ];
-        let registry = build_provider_registry(&creds);
+        let registry = build_provider_registry(&creds).expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai"));
         assert!(registry.has("google"));
@@ -300,7 +351,7 @@ mod tests {
                 options: Default::default(),
             })
             .collect();
-        let registry = build_provider_registry(&creds);
+        let registry = build_provider_registry(&creds).expect("an HTTPS client builds in tests");
         assert!(!registry.has("anthropic"));
         assert!(!registry.has("openai"));
         assert!(!registry.has("google"));
@@ -319,7 +370,8 @@ mod tests {
         creds
             .options
             .insert("effort".to_string(), "low".to_string());
-        let registry = build_provider_registry(std::slice::from_ref(&creds));
+        let registry = build_provider_registry(std::slice::from_ref(&creds))
+            .expect("an HTTPS client builds in tests");
         assert!(registry.has("claude-code"));
 
         // Options are consumed by the provider constructor, which is where the
@@ -327,7 +379,11 @@ mod tests {
         creds
             .options
             .insert("effort".to_string(), "warp-speed".to_string());
-        assert!(build_provider_registry(&[creds]).has("claude-code"));
+        assert!(
+            build_provider_registry(&[creds])
+                .expect("an HTTPS client builds in tests")
+                .has("claude-code")
+        );
     }
 
     #[test]
@@ -339,5 +395,87 @@ mod tests {
         assert!(creds.options.is_empty());
         assert!(creds.model_capabilities.is_empty());
         assert!(creds.request_timeout_secs.is_none());
+    }
+
+    // ─── The client-build failure path ──────────────────────────────────────
+
+    /// A factory that always fails, standing in for a machine whose root
+    /// certificate store cannot be read.
+    fn failing_client(
+        _timeout: Option<u64>,
+    ) -> std::result::Result<
+        leviath_providers::provider::HttpClient,
+        leviath_providers::provider::HttpError,
+    > {
+        // The only way to obtain a `reqwest::Error` is to have reqwest produce
+        // one; a request to an unroutable scheme does that without any I/O.
+        Err(leviath_providers::provider::malformed_url_error())
+    }
+
+    #[test]
+    fn every_http_provider_fails_the_registry_when_its_client_will_not_build() {
+        // One case per branch that needs a client. A single provider would leave
+        // the other arms' error paths unproven, which is exactly the hole this
+        // seam exists to close.
+        for name in ["anthropic", "openai", "google", "openrouter", "ollama"] {
+            let mut cred = ProviderCreds::simple(name);
+            cred.api_key = Some("k".to_string());
+            let err = build_provider_registry_with(&[cred], &failing_client)
+                .err()
+                .expect("a failing client factory should fail the registry");
+            // Discriminant rather than `matches!`: the macro expands to a
+            // match with a `_ => false` arm that nothing reaches, which the
+            // 100% gate reads as an uncovered region.
+            assert_eq!(
+                std::mem::discriminant(&err),
+                std::mem::discriminant(&leviath_providers::ProviderError::ClientBuild(
+                    String::new()
+                ))
+            );
+            // The message has to name the cause; a bare "request failed" would
+            // send someone looking at their network, not their cert store.
+            assert!(err.to_string().contains("root certificate store"));
+        }
+    }
+
+    #[test]
+    fn a_provider_that_needs_no_http_client_is_unaffected() {
+        // `claude-code` drives a local CLI. Building its entry must not depend
+        // on an HTTPS client, so a failing factory leaves it registered.
+        let registry =
+            build_provider_registry_with(&[ProviderCreds::simple("claude-code")], &failing_client)
+                .expect("claude-code needs no HTTPS client");
+        assert!(registry.has("claude-code"));
+    }
+
+    #[test]
+    fn providers_sharing_a_timeout_share_one_client() {
+        // Atomic rather than `Cell`: the factory is `Send + Sync`, because the
+        // one in `verify` is held across an await.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let builds = AtomicUsize::new(0);
+        let counting = |timeout: Option<u64>| {
+            builds.fetch_add(1, Ordering::SeqCst);
+            leviath_providers::provider::build_http_client(timeout)
+        };
+        let creds: Vec<ProviderCreds> = [("anthropic", 30), ("openai", 30), ("google", 60)]
+            .into_iter()
+            .map(|(name, secs)| {
+                let mut c = ProviderCreds::simple(name);
+                c.api_key = Some("k".to_string());
+                c.request_timeout_secs = Some(secs);
+                c
+            })
+            .collect();
+        let registry =
+            build_provider_registry_with(&creds, &counting).expect("clients build in tests");
+        assert!(registry.has("anthropic") && registry.has("openai") && registry.has("google"));
+        // Two distinct timeouts, so two clients - not one per provider, which is
+        // what this crate did before and what the connection pools paid for.
+        assert_eq!(
+            builds.load(Ordering::SeqCst),
+            2,
+            "expected one client per distinct timeout"
+        );
     }
 }

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::SystemTime;
 
+use leviath_providers::rhai_provider::host::{HttpExecutor, ReqwestExecutor};
 use leviath_providers::{ModelCapabilities, Provider, RateLimitConfig, RhaiProvider};
 
 /// Per-provider configuration from `[model_providers.<name>]`. All fields are
@@ -54,6 +55,15 @@ pub struct ScriptProviderLayer {
     /// during inference, not through a tool call, so nothing it does passes an
     /// approval prompt.
     env_allowlist: Arc<Vec<String>>,
+    /// The HTTP executor every script provider shares, built once when the
+    /// layer is created.
+    ///
+    /// Kept as the `Result` rather than unwrapped: constructing it reads the
+    /// machine's root certificate store and can fail, and a layer is built
+    /// during daemon start-up where there is nothing to return an error to. A
+    /// failure therefore surfaces when a script provider is actually resolved,
+    /// which is the first moment it matters.
+    executor: std::result::Result<Arc<dyn HttpExecutor>, leviath_providers::provider::HttpError>,
     cache: Mutex<HashMap<String, Cached>>,
 }
 
@@ -67,12 +77,41 @@ impl ScriptProviderLayer {
         request_timeout_secs: Option<u64>,
         env_allowlist: Vec<String>,
     ) -> Self {
+        let executor = leviath_providers::provider::build_http_client(request_timeout_secs)
+            .map(|client| Arc::new(ReqwestExecutor::new(client)) as Arc<dyn HttpExecutor>);
+        Self::with_executor(
+            dir,
+            overrides,
+            default_caps,
+            request_timeout_secs,
+            env_allowlist,
+            executor,
+        )
+    }
+
+    /// [`new`](Self::new), with the shared HTTP executor supplied.
+    ///
+    /// The seam that makes the "no usable HTTPS client" path reachable: reqwest
+    /// cannot be made to fail from the outside, so a test has to hand in the
+    /// failure.
+    pub fn with_executor(
+        dir: PathBuf,
+        overrides: HashMap<String, ScriptProviderSpec>,
+        default_caps: HashMap<String, ModelCapabilities>,
+        request_timeout_secs: Option<u64>,
+        env_allowlist: Vec<String>,
+        executor: std::result::Result<
+            Arc<dyn HttpExecutor>,
+            leviath_providers::provider::HttpError,
+        >,
+    ) -> Self {
         Self {
             dir,
             overrides,
             default_caps,
             request_timeout_secs,
             env_allowlist: Arc::new(env_allowlist),
+            executor,
             cache: Mutex::new(HashMap::new()),
         }
     }
@@ -154,15 +193,30 @@ impl ScriptProviderLayer {
             .map(|s| s.init_config.clone())
             .unwrap_or_else(|| serde_json::json!({}));
         let rate_limit = spec.and_then(|s| s.rate_limit.clone());
+        let executor = match &self.executor {
+            Ok(executor) => Arc::clone(executor),
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "no outbound HTTPS client, so script providers cannot run; \
+                     leviath reads the system root certificate store at start-up"
+                );
+                return None;
+            }
+        };
         // No lock held here - see the note above.
         match RhaiProvider::from_script(
-            name.to_string(),
             &path,
-            init_config,
-            self.default_caps.clone(),
-            rate_limit,
-            self.request_timeout_secs,
-            self.env_allowlist.clone(),
+            executor,
+            leviath_providers::rhai_provider::ScriptProviderSettings {
+                name: name.to_string(),
+                init_config,
+                caps: self.default_caps.clone(),
+                rate_limit,
+                request_timeout_secs: self.request_timeout_secs,
+                env_allowlist: self.env_allowlist.clone(),
+            },
         ) {
             Ok(p) => {
                 let provider: Arc<dyn Provider> = Arc::new(p);
@@ -425,5 +479,33 @@ mod tests {
             Vec::new(),
         );
         assert!(l.get_or_load("echo").is_some());
+    }
+
+    #[test]
+    fn a_layer_with_no_usable_https_client_resolves_nothing() {
+        // The machine cannot build an HTTPS client, so no script provider can
+        // run. Reachable only by handing the failure in: reqwest will not fail
+        // to build a client in any environment a test can arrange.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("p.rhai");
+        std::fs::write(
+            &path,
+            "fn initialize(c) { #{} }\nfn inference(s, r) { #{ content: \"x\" } }",
+        )
+        .expect("write script");
+        let layer = ScriptProviderLayer::with_executor(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+            Err(leviath_providers::provider::malformed_url_error()),
+        );
+        // The script is present and valid; only the client is missing.
+        assert!(path.exists());
+        assert!(
+            layer.get_or_load("p").is_none(),
+            "a layer with no client must not hand back a provider"
+        );
     }
 }

--- a/crates/leviath-telemetry/src/otel.rs
+++ b/crates/leviath-telemetry/src/otel.rs
@@ -177,7 +177,7 @@ impl LaneInstruments {
             tools_parked: health.tools_parked as i64,
             dead_cycles: health.dead_cycles,
         };
-        let mut last = self.last.lock().expect("telemetry lane level lock");
+        let mut last = leviath_core::sync::lock(&self.last);
         self.tools_busy.add(now.tools_busy - last.tools_busy, &[]);
         self.tools_queued
             .add(now.tools_queued - last.tools_queued, &[]);
@@ -221,7 +221,7 @@ impl ProviderInstruments {
 
     fn record(&self, down: &[ProviderHealth]) {
         let now: HashSet<String> = down.iter().map(|p| p.provider.clone()).collect();
-        let mut last = self.last.lock().expect("telemetry provider level lock");
+        let mut last = leviath_core::sync::lock(&self.last);
         for p in down {
             let attrs = [KeyValue::new("leviath.provider", p.provider.clone())];
             if !last.contains(&p.provider) {
@@ -422,7 +422,7 @@ impl OtelSink {
     /// Emit a completed leaf span under the run's open stage (or, if no stage
     /// is open, under the run itself), spanning the last `duration_ms`.
     fn emit_leaf(&self, run_id: &str, name: &'static str, duration_ms: u64, attrs: Vec<KeyValue>) {
-        let mut open = self.open.lock().expect("telemetry span map lock");
+        let mut open = leviath_core::sync::lock(&self.open);
         let Some(run) = open.get_mut(run_id) else {
             return; // events for a run this sink never saw start
         };
@@ -476,10 +476,7 @@ impl TelemetrySink for OtelSink {
                 }
                 let span = self.start_span("agent.run", at_ms, attrs, None);
                 self.instruments.active.add(1, &[]);
-                self.open
-                    .lock()
-                    .expect("telemetry span map lock")
-                    .insert(run_id, OpenRun { span, stage: None });
+                leviath_core::sync::lock(&self.open).insert(run_id, OpenRun { span, stage: None });
             }
             TelemetryEvent::StageEntered {
                 run_id,
@@ -487,7 +484,7 @@ impl TelemetrySink for OtelSink {
                 stage_name,
                 at_ms,
             } => {
-                let mut open = self.open.lock().expect("telemetry span map lock");
+                let mut open = leviath_core::sync::lock(&self.open);
                 let Some(run) = open.get_mut(&run_id) else {
                     return;
                 };
@@ -515,7 +512,7 @@ impl TelemetrySink for OtelSink {
                 completion_tokens,
                 at_ms,
             } => {
-                let mut open = self.open.lock().expect("telemetry span map lock");
+                let mut open = leviath_core::sync::lock(&self.open);
                 let Some(run) = open.get_mut(&run_id) else {
                     return;
                 };
@@ -640,7 +637,7 @@ impl TelemetrySink for OtelSink {
                         KeyValue::new("leviath.empty_output", empty_output),
                     ],
                 );
-                let mut open = self.open.lock().expect("telemetry span map lock");
+                let mut open = leviath_core::sync::lock(&self.open);
                 let Some(mut run) = open.remove(&run_id) else {
                     return;
                 };
@@ -669,7 +666,7 @@ impl TelemetrySink for OtelSink {
                 kind,
                 line,
             } => {
-                let open = self.open.lock().expect("telemetry span map lock");
+                let open = leviath_core::sync::lock(&self.open);
                 let Some(run) = open.get(&run_id) else {
                     return;
                 };


### PR DESCRIPTION
## What

Two failure modes that took the daemon down with a panic now report themselves,
and a third thing turned up on the way: every provider was building its own HTTP
client.

## 1. Lock poisoning is no longer fatal

21 sites did `.lock().expect("...")`. A thread that panics while holding a mutex
*poisons* it, so one unrelated failure took out every later locker — a telemetry
panic aborting the daemon on a healthy run in a different subsystem.

`leviath_core::sync::lock` recovers the guard. What makes that sound is a
property of the call sites, not the function: **every critical section guarded
this way is panic-free** — take the lock, do one bounded thing to a container,
drop it. A `Vec::push` either happened or it didn't, and the `Vec` is valid
either way, so there is no intermediate state to inherit.

**`parking_lot` was considered and rejected.** It looks like the same fix and is
the opposite one: it removes the *detection* of a half-written value rather than
the possibility of one, handing the next locker a partial state silently and
always. Poisoning is the mechanism that catches exactly the case worth catching.

## 2. A machine that cannot build an HTTPS client says so

`build_http_client(...).expect("failed to build reqwest client")` × 4.

This is the **client** side: the workspace builds reqwest with `rustls` +
`rustls-native-certs`, so constructing one reads the machine's root certificate
store in order to reach a provider API. It is unrelated to `lev serve`'s own
`--tls-cert`/`--tls-key`, which already propagates errors.

It now returns `ProviderError::ClientBuild`, and `lev` refuses to start rather
than accepting runs it could never infer for.

**Making that testable drove the shape.** reqwest cannot be made to fail from the
outside — a malformed `HTTPS_PROXY` is *ignored*, not rejected, which was
measured rather than assumed — so every `?` on a client build would have been an
error arm no test could reach and the 100% gate could not accept. Construction is
injected at the boundary instead:

```
build_provider_registry_with(creds, factory)
build_provider_registry_from_config_with(config, factory)
setup_daemon_host_with(config, runs_dir, runtime, factory)
AgentWorldBuilder::build_with(factory)
ScriptProviderLayer::with_executor(..., executor)
```

Every failure path now has a test that drives it, including one per provider
branch rather than one for the set.

## 3. 22 clients became one per timeout

Providers take a client instead of building one. There were **22 separate
`build_http_client` calls**, so a daemon with five providers configured held five
connection pools.

Keyed on **timeout**, not shared outright: `apply_request_timeout` deliberately
defers to the client-level timeout when a stage sets none, so collapsing distinct
timeouts onto one client would have silently retimed requests. `timeout_secs` is
gone from the constructors it no longer reaches.

`claude-code` drives a local CLI and needs no HTTP client, so clients are built
lazily per branch — a certificate-store failure must not block a provider that
never touches a certificate. There is a test for that.

## Verification

**Live, against real provider APIs** (not just unit tests), one minimal
inference each:

| Provider | Model | Result |
|---|---|---|
| anthropic | claude-haiku-4-5 | `PONG` |
| google | gemini-3.1-flash-lite | `PONG` |
| openrouter | google/gemini-3.5-flash | `PONG` |
| openai | gpt-5.4-nano | reached the API; failed on a **pre-existing** bug, below |

Also driven end to end against a mock Ollama server: `lev models --remote`
listed the mock's model, `lev run` produced two real `POST /api/chat` calls, and
the reply landed in the run's `context.json`.

- `cargo xtask coverage` 100% on every touched package
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo test --workspace` green

## Found, not caused: OpenAI is broken for current models

```
HTTP 400: Unsupported parameter: 'max_tokens' is not supported with this
model. Use 'max_completion_tokens' instead.
```

`git diff origin/main...HEAD` does not touch that line — the request reached
OpenAI, authenticated and got a well-formed rejection, which is itself evidence
this PR's client work is sound. Fixed separately so this PR stays one subject.
