### PR TITLE
fix: OpenAI and Ollama could not complete work, for two wire-format reasons

### DIFF
--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -157,7 +157,12 @@ impl OllamaProvider {
         // OpenAI format (Ollama speaks the OpenAI chat shape). The shared
         // helper matters here: a naive conversion drops the system prompt and
         // serializes tool blocks as raw JSON.
-        let messages = crate::openai_compat::openai_messages(request);
+        // Ollama declares `tool_calls.function.arguments` as an object and
+        // rejects OpenAI's JSON-string spelling, so history replays as objects.
+        let messages = crate::openai_compat::openai_messages_with(
+            request,
+            crate::openai_compat::ToolArgsFormat::Object,
+        );
 
         let caps = self.capabilities(&request.model);
         let options = if caps.supports_temperature {

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -1,7 +1,8 @@
 //! OpenAI provider implementation.
 
 use crate::openai_compat::{
-    OpenAiSseStream, build_openai_request_body, parse_openai_response, send_chat_request,
+    OpenAiSseStream, TokenLimitField, build_openai_request_body_with, parse_openai_response,
+    send_chat_request,
 };
 #[cfg(test)]
 use crate::provider::FinishReason;
@@ -132,7 +133,7 @@ impl Provider for OpenAIProvider {
             limiter.acquire().await?;
         }
 
-        let body = build_openai_request_body(request);
+        let body = build_openai_request_body_with(request, TokenLimitField::MaxCompletionTokens);
         let url = format!("{}/chat/completions", self.base_url);
 
         let response = send_chat_request(
@@ -173,7 +174,8 @@ impl Provider for OpenAIProvider {
             limiter.acquire().await?;
         }
 
-        let mut body = build_openai_request_body(request);
+        let mut body =
+            build_openai_request_body_with(request, TokenLimitField::MaxCompletionTokens);
         body["stream"] = serde_json::Value::Bool(true);
         body["stream_options"] = serde_json::json!({ "include_usage": true });
         let url = format!("{}/chat/completions", self.base_url);
@@ -316,7 +318,7 @@ mod tests {
             request_timeout_secs: None,
         };
 
-        let body = build_openai_request_body(&request);
+        let body = build_openai_request_body_with(&request, TokenLimitField::MaxCompletionTokens);
         assert_eq!(body["model"], "gpt-5.4-mini");
         assert_eq!(body["messages"].as_array().unwrap().len(), 2);
     }

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -98,6 +98,15 @@ pub async fn send_chat_request(
 /// result), so tool history round-trips correctly on OpenAI-compatible APIs
 /// instead of being serialized raw in Anthropic block form.
 pub fn message_to_openai(role: &str, content: &MessageContent) -> Vec<serde_json::Value> {
+    message_to_openai_with(role, content, ToolArgsFormat::JsonString)
+}
+
+/// [`message_to_openai`], naming how tool-call arguments are rendered.
+pub fn message_to_openai_with(
+    role: &str,
+    content: &MessageContent,
+    tool_args: ToolArgsFormat,
+) -> Vec<serde_json::Value> {
     match content {
         MessageContent::Text(text) => {
             vec![serde_json::json!({ "role": role, "content": text })]
@@ -133,7 +142,7 @@ pub fn message_to_openai(role: &str, content: &MessageContent) -> Vec<serde_json
                         let mut call = serde_json::json!({
                             "id": id,
                             "type": "function",
-                            "function": { "name": name, "arguments": input.to_string() }
+                            "function": { "name": name, "arguments": tool_args.render(input) }
                         });
                         // Echoed back exactly where the provider put it.
                         if let Some(sig) = thought_signature {
@@ -182,12 +191,20 @@ pub fn message_to_openai(role: &str, content: &MessageContent) -> Vec<serde_json
 /// converted via [`message_to_openai`]. Reused by every OpenAI-compatible
 /// provider so system prompts and tool history are handled uniformly.
 pub fn openai_messages(request: &InferenceRequest) -> Vec<serde_json::Value> {
+    openai_messages_with(request, ToolArgsFormat::JsonString)
+}
+
+/// [`openai_messages`], naming how tool-call arguments are rendered.
+pub fn openai_messages_with(
+    request: &InferenceRequest,
+    tool_args: ToolArgsFormat,
+) -> Vec<serde_json::Value> {
     let mut messages: Vec<serde_json::Value> = Vec::new();
     for block in &request.system {
         messages.push(serde_json::json!({ "role": "system", "content": block.text }));
     }
     for msg in &request.messages {
-        messages.extend(message_to_openai(&msg.role, &msg.content));
+        messages.extend(message_to_openai_with(&msg.role, &msg.content, tool_args));
     }
     satisfy_call_turn_order(drop_unpaired_tool_turns(messages))
 }
@@ -269,6 +286,38 @@ fn drop_unpaired_tool_turns(messages: Vec<serde_json::Value>) -> Vec<serde_json:
         .zip(keep)
         .filter_map(|(m, keep)| keep.then_some(m))
         .collect()
+}
+
+/// How a server wants a prior tool call's arguments replayed.
+///
+/// The second place the dialect forked. OpenAI carries `arguments` as a
+/// *JSON-encoded string*; Ollama's Go server declares the field as
+/// `api.ToolCallFunctionArguments` and rejects the string form outright:
+///
+/// ```text
+/// json: cannot unmarshal string into Go struct field
+/// ChatRequest.messages.tool_calls.function.arguments
+/// ```
+///
+/// The first call of a turn therefore succeeded and the *second* failed, once
+/// there was history to replay - which reads exactly like a model that is bad
+/// at tool use, and is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolArgsFormat {
+    /// A JSON-encoded string. OpenAI, OpenRouter, Gemini's compat endpoint.
+    JsonString,
+    /// A JSON object. Ollama.
+    Object,
+}
+
+impl ToolArgsFormat {
+    /// Render `input` the way this dialect expects it.
+    pub fn render(self, input: &serde_json::Value) -> serde_json::Value {
+        match self {
+            Self::JsonString => serde_json::Value::String(input.to_string()),
+            Self::Object => input.clone(),
+        }
+    }
 }
 
 /// Which key an OpenAI-dialect server expects the output-token cap under.
@@ -2244,5 +2293,88 @@ mod tests {
             TokenLimitField::MaxCompletionTokens.key(),
             "max_completion_tokens"
         );
+    }
+
+    // ─── Tool-call arguments are spelled per dialect ────────────────────────
+
+    fn one_tool_use() -> MessageContent {
+        MessageContent::Blocks(vec![ContentBlock::ToolUse {
+            id: "call_1".to_string(),
+            name: "read_file".to_string(),
+            input: serde_json::json!({ "path": "notes.txt" }),
+            thought_signature: None,
+        }])
+    }
+
+    #[test]
+    fn openai_gets_tool_arguments_as_a_json_string() {
+        let msgs = message_to_openai("assistant", &one_tool_use());
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_string());
+        assert_eq!(args.as_str().unwrap_or_default(), r#"{"path":"notes.txt"}"#);
+    }
+
+    #[test]
+    fn ollama_gets_tool_arguments_as_an_object() {
+        // Ollama's Go server types this field as ToolCallFunctionArguments and
+        // rejects the string spelling, so a second turn - the first one with
+        // history to replay - failed with HTTP 400.
+        let msgs = message_to_openai_with("assistant", &one_tool_use(), ToolArgsFormat::Object);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_object());
+        assert_eq!(args["path"], "notes.txt");
+    }
+
+    #[test]
+    fn each_arg_format_renders_its_own_shape() {
+        let input = serde_json::json!({ "a": 1 });
+        assert!(ToolArgsFormat::JsonString.render(&input).is_string());
+        assert!(ToolArgsFormat::Object.render(&input).is_object());
+    }
+
+    #[test]
+    fn the_arg_format_reaches_the_messages_a_provider_actually_sends() {
+        // Regression: `openai_messages_with` took the format and then called the
+        // unparameterised `message_to_openai`, so the argument was dead and
+        // Ollama kept getting the string it rejects. A test on the leaf function
+        // passed the whole time - this one asserts the path.
+        let req = InferenceRequest {
+            // The result has to be here too: `drop_unpaired_tool_turns`
+            // discards a call with no answer, which would empty the array and
+            // make this assert on nothing.
+            messages: vec![
+                Message {
+                    role: "assistant".to_string(),
+                    content: one_tool_use(),
+                    cache_breakpoint: false,
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_1".to_string(),
+                        content: "the access code is 7731".to_string(),
+                        is_error: false,
+                    }]),
+                    cache_breakpoint: false,
+                },
+            ],
+            ..sample_request()
+        };
+        let msgs = openai_messages_with(&req, ToolArgsFormat::Object);
+        let call = msgs
+            .iter()
+            .find_map(|m| m.get("tool_calls").and_then(|t| t.get(0)))
+            .expect("the assistant turn carries a tool call");
+        assert!(
+            call["function"]["arguments"].is_object(),
+            "the format did not reach the emitted message: {call}"
+        );
+
+        let msgs = openai_messages_with(&req, ToolArgsFormat::JsonString);
+        let call = msgs
+            .iter()
+            .find_map(|m| m.get("tool_calls").and_then(|t| t.get(0)))
+            .expect("the assistant turn carries a tool call");
+        assert!(call["function"]["arguments"].is_string());
     }
 }

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -271,20 +271,56 @@ fn drop_unpaired_tool_turns(messages: Vec<serde_json::Value>) -> Vec<serde_json:
         .collect()
 }
 
+/// Which key an OpenAI-dialect server expects the output-token cap under.
+///
+/// The dialect forked. OpenAI itself now *rejects* `max_tokens` on every current
+/// model with `HTTP 400 unsupported_parameter`, while OpenRouter and Gemini's
+/// compatibility endpoint still take it - so the field cannot simply be renamed
+/// for everyone without breaking the two that work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenLimitField {
+    /// `max_tokens`: the original spelling, and what every compatibility server
+    /// in this workspace other than OpenAI accepts.
+    MaxTokens,
+    /// `max_completion_tokens`: what OpenAI requires.
+    MaxCompletionTokens,
+}
+
+impl TokenLimitField {
+    /// The JSON key this variant writes.
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::MaxTokens => "max_tokens",
+            Self::MaxCompletionTokens => "max_completion_tokens",
+        }
+    }
+}
+
 /// Render a request as an OpenAI chat-completions body.
 ///
 /// Shared by every provider speaking that dialect - OpenAI itself, OpenRouter,
 /// and any `base_url` pointed at a compatible server - so one change to the wire
 /// shape reaches all of them rather than three copies drifting apart.
+///
+/// Uses [`TokenLimitField::MaxTokens`], which is what a compatibility server
+/// expects; OpenAI itself goes through [`build_openai_request_body_with`].
 pub fn build_openai_request_body(request: &InferenceRequest) -> serde_json::Value {
+    build_openai_request_body_with(request, TokenLimitField::MaxTokens)
+}
+
+/// [`build_openai_request_body`], naming the output-cap key explicitly.
+pub fn build_openai_request_body_with(
+    request: &InferenceRequest,
+    token_limit: TokenLimitField,
+) -> serde_json::Value {
     let messages = openai_messages(request);
 
     let mut body = serde_json::json!({
         "model": request.model,
-        "max_tokens": request.max_tokens,
         "temperature": request.temperature,
         "messages": messages,
     });
+    body[token_limit.key()] = serde_json::json!(request.max_tokens);
 
     if !request.tools.is_empty() {
         let tools: Vec<serde_json::Value> = request
@@ -2173,5 +2209,40 @@ mod tests {
             None,
         )
         .await;
+    }
+
+    // ─── The output-cap key is per provider ─────────────────────────────────
+
+    #[test]
+    fn a_compatibility_server_still_gets_max_tokens() {
+        let req = sample_request();
+        let body = build_openai_request_body(&req);
+        assert_eq!(body["max_tokens"], 1024);
+        assert!(
+            body.get("max_completion_tokens").is_none(),
+            "a compatibility server must not be sent the OpenAI-only key"
+        );
+    }
+
+    #[test]
+    fn openai_gets_max_completion_tokens_instead() {
+        // OpenAI rejects `max_tokens` outright on every current model:
+        // HTTP 400 unsupported_parameter. Sending both would be rejected too.
+        let req = sample_request();
+        let body = build_openai_request_body_with(&req, TokenLimitField::MaxCompletionTokens);
+        assert_eq!(body["max_completion_tokens"], 1024);
+        assert!(
+            body.get("max_tokens").is_none(),
+            "OpenAI must not be sent the key it rejects"
+        );
+    }
+
+    #[test]
+    fn each_variant_names_its_own_key() {
+        assert_eq!(TokenLimitField::MaxTokens.key(), "max_tokens");
+        assert_eq!(
+            TokenLimitField::MaxCompletionTokens.key(),
+            "max_completion_tokens"
+        );
     }
 }


### PR DESCRIPTION
## What

Two providers could not complete work, and both were leviath's fault rather than
the model's. Found by running one real inference per configured provider instead
of trusting the suite.

## 1. OpenAI could not complete a single inference

```
HTTP 400 unsupported_parameter
"Unsupported parameter: 'max_tokens' is not supported with this model.
 Use 'max_completion_tokens' instead."
```

That is gpt-5.5, gpt-5.4, gpt-5.4-mini and gpt-5.4-nano — the entire built-in
table.

**The obvious fix is wrong.** `build_openai_request_body` is shared with
OpenRouter and Gemini's compatibility endpoint, and both accept `max_tokens`
today, so renaming the field for everyone trades one broken provider for two.
The dialect forked, so the key is named per provider:

| | key |
|---|---|
| OpenRouter, Gemini compat, any compatible `base_url` | `max_tokens` (unchanged) |
| OpenAI itself | `max_completion_tokens` |

Both spellings are asserted, including that neither body carries the other's key
— OpenAI rejects `max_tokens` even alongside the one it wants, so sending both
was not a safe hedge.

## 2. Ollama tool calling was broken, and it looked like the models

Tool use died on the **second** call of a turn — the first one with history to
replay:

```
HTTP 400 json: cannot unmarshal string into Go struct field
ChatRequest.messages.tool_calls.function.arguments
of type api.ToolCallFunctionArguments
```

Ollama's Go server types `arguments` as an **object**. OpenAI carries it as a
JSON-encoded **string**, and Ollama reuses `openai_messages`, so it inherited a
spelling the server rejects. `ToolArgsFormat` names the difference; Ollama asks
for `Object` and every other provider is untouched.

Captured off the wire with a logging proxy rather than inferred:

```
before   role=assistant arguments=str:  "{\"path\":\"notes.txt\"}"
after    role=assistant arguments=dict: {"path": "notes.txt"}
```

**Not a stale-server quirk:** ollama was upgraded `0.12.3 → 0.32.6` first, and
0.32.6 still rejects the string form — only with a different message ("Value
looks like object, but can't find closing `}` symbol").

The practical effect is that local models looked bad at tool use when they were
not. `llama3.2:3b` goes from `error` to `complete`, reading a file and reporting
its contents.

### The regression test asserts the path, not the leaf

Worth calling out, because it nearly shipped broken. The first version of this
fix threaded the format into `openai_messages_with` and then called the
*unparameterised* `message_to_openai` from inside it — so the argument was dead
and the bug survived untouched, while a unit test on `message_to_openai_with`
passed the entire time. Only the wire capture caught it. The test now runs
through `openai_messages_with`, and reverting the propagation fails it
(mutation-checked).

## Verification

Live, one real inference per provider against real APIs:

| Provider | Model | Before | After |
|---|---|---|---|
| anthropic | claude-haiku-4-5 | `PONG` | `PONG` |
| google | gemini-3.1-flash-lite | `PONG` | `PONG` |
| openrouter | google/gemini-3.5-flash | `PONG` | `PONG` |
| openai | gpt-5.4-nano | **HTTP 400** | `PONG` |
| ollama | llama3.2:3b | `PONG` | `PONG` |

Tool calling, asserting on the `tool_results` region so a model that only
*talks* about reading the file fails:

| Model | Before | After |
|---|---|---|
| llama3.2:3b | `error`, HTTP 400 on replay | `complete`, file read and reported |

- `cargo xtask coverage` 100% on `leviath-providers`
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo test --workspace` green
