### PR TITLE
fix(windows): decide the console once, at construction

### DIFF
--- a/.sgrules/no-raw-command-new.yml
+++ b/.sgrules/no-raw-command-new.yml
@@ -1,0 +1,46 @@
+id: no-raw-command-new
+language: rust
+severity: error
+message: >-
+  Build child processes with `leviath_sys::child_command` (or
+  `child_command_async` for a `tokio::process::Command`), not `Command::new`.
+  On Windows a child of a process that has no console - the daemon started from
+  Explorer, from a service, or from a UI console - gets a brand new window on
+  the interactive desktop, and agent tooling spawns shells many times per run
+  (issue #228). Hiding it used to be a *second* call made after building the
+  command, at seven sites across five crates, which meant a new spawn site that
+  forgot looked exactly like one that did not need it. The constructors make the
+  decision part of construction, so the only way to get a child process is to
+  have already answered the question.
+  The one child that is meant to be seen - the editor `lev run` opens, which
+  draws in the terminal it inherits - uses `terminal_command`, so the exception
+  is a decision in the source rather than an omission.
+  Tests may use `Command::new` freely: nothing they spawn reaches an interactive
+  desktop, and this rule does not read test modules.
+rule:
+  any:
+    - pattern: Command::new($$$)
+    - pattern: TokioCommand::new($$$)
+    - pattern: std::process::Command::new($$$)
+    - pattern: tokio::process::Command::new($$$)
+  not:
+    inside:
+      kind: mod_item
+      has:
+        kind: identifier
+        regex: 'tests$'
+      stopBy: end
+files:
+  - "crates/**/*.rs"
+ignores:
+  # Build scripts run at compile time on a developer's machine, never on a
+  # user's desktop.
+  - "**/build.rs"
+  # The constructors themselves, and the platform code that writes the flag.
+  - "crates/leviath-sys/src/process.rs"
+  - "crates/leviath-sys/src/platform/**"
+  - "crates/leviath-sys/src/browser.rs"
+  # Test modules and sibling test files.
+  - "**/tests.rs"
+  - "**/*_tests.rs"
+  - "**/tests/**"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,7 @@ dependencies = [
  "nix 0.31.3",
  "temp-env",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -122,11 +122,11 @@ fn yank_to_clipboard_with(
     osc52_fallback: fn(&str) -> bool,
 ) -> bool {
     use std::io::Write as IoWrite;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     // Try native clipboard tools first - most reliable
     for (cmd, args) in clipboard_cmds {
-        let mut command = Command::new(cmd);
+        let mut command = leviath_sys::child_command(cmd);
         command
             .args(*args)
             .stdin(Stdio::piped())
@@ -134,7 +134,6 @@ fn yank_to_clipboard_with(
             .stderr(Stdio::null());
         // The dashboard is a full-screen TUI; a console window popping over it
         // on every yank would be the worst place for one.
-        leviath_sys::hide_console_window(&mut command);
         if let Ok(mut child) = command.spawn() {
             // `child.stdin` is guaranteed `Some` here because the child was
             // spawned with `.stdin(Stdio::piped())` above - an `if let`

--- a/crates/leviath-cli/src/daemon/readiness.rs
+++ b/crates/leviath-cli/src/daemon/readiness.rs
@@ -9,7 +9,19 @@
 use std::time::Duration;
 
 /// How long to keep asking before giving up.
-pub const READY_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// Windows gets longer. Starting the daemon there has to bind a named pipe and
+/// detach into a job object, and under a supervisor opening many sessions at
+/// once those serialise: the 5s that is generous on Unix was regularly missed,
+/// leaving sessions `runtime-missing` and the control pipe reporting "All pipe
+/// instances are busy" (os error 231). The cost of the longer window is paid
+/// only by a start that would otherwise have failed - the poll returns as soon
+/// as the daemon answers, and a healthy one answers in ~20ms on either
+/// platform.
+pub const READY_TIMEOUT: Duration = match cfg!(windows) {
+    true => Duration::from_secs(15),
+    false => Duration::from_secs(5),
+};
 
 /// First gap between polls.
 const FIRST_DELAY: Duration = Duration::from_millis(2);
@@ -116,5 +128,21 @@ mod tests {
         // stays there rather than growing without bound.
         assert_eq!(gaps[6], MAX_DELAY);
         assert_eq!(gaps[7], MAX_DELAY);
+    }
+
+    /// The window is a platform decision, so assert the decision rather than a
+    /// number: Windows has to bind a named pipe and detach into a job object,
+    /// and a supervisor starting many sessions serialises those.
+    #[test]
+    fn windows_gets_a_longer_readiness_window_than_unix() {
+        // Arithmetic rather than a branch: a `match`/`if` on `cfg!` leaves the
+        // other platform's arm unreachable here, which the 100% gate reads as an
+        // uncovered region.
+        let expected = 5 + 10 * u64::from(cfg!(windows));
+        assert_eq!(READY_TIMEOUT.as_secs(), expected);
+        // Whatever the platform, the window has to outlast the backoff ceiling
+        // by enough to poll more than once - a window shorter than MAX_DELAY
+        // would give up after a single sleep.
+        assert!(READY_TIMEOUT > MAX_DELAY * 10);
     }
 }

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -88,7 +88,7 @@ fn sanitize(run_id: &str) -> String {
 
 /// Build the host shell command (no sandbox) - the exact prior behavior.
 fn host_command(shell: &str, flag: &str, command: &str, workdir: &Path) -> TokioCommand {
-    let mut c = TokioCommand::new(shell);
+    let mut c = leviath_sys::child_command_async(shell);
     c.arg(flag).arg(command).current_dir(workdir);
     c
 }
@@ -266,7 +266,6 @@ fn real_run(argv: &[String]) -> Result<(), String> {
     cmd.args(&argv[1..]);
     // `docker run`/`docker rm` are bookkeeping the operator never watches, so
     // they get no console window on Windows.
-    leviath_sys::hide_console_window(&mut cmd);
     let output = cmd.output().map_err(|e| e.to_string())?;
     if output.status.success() {
         Ok(())
@@ -293,7 +292,7 @@ impl ShellExecutor for SandboxManager {
             SandboxKind::Namespace => {
                 if self.namespace_ok {
                     let argv = leviath_sys::namespace_argv(shell, flag, command, cfg.network);
-                    let mut c = TokioCommand::new(&argv[0]);
+                    let mut c = leviath_sys::child_command_async(&argv[0]);
                     c.args(&argv[1..]).current_dir(workdir);
                     c
                 } else {
@@ -315,7 +314,7 @@ impl ShellExecutor for SandboxManager {
                         CONTAINER_SHELL_FLAG,
                         command,
                     );
-                    let mut c = TokioCommand::new(&argv[0]);
+                    let mut c = leviath_sys::child_command_async(&argv[0]);
                     c.args(&argv[1..]);
                     c
                 }

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -720,10 +720,6 @@ impl ScriptIo for RealScriptIo {
         // tool, which does the same.
         cmd.kill_on_drop(true);
         leviath_tools::own_process_group(&mut cmd);
-        // No console window on Windows - a script tool's `shell()` is as chatty
-        // as the built-in one. Applied here, after the sandbox has had its say,
-        // so the sandboxed command is covered too.
-        leviath_tools::hide_console_window(&mut cmd);
         // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
         // command's output is still captured.
         cmd.stdout(std::process::Stdio::piped())
@@ -806,7 +802,7 @@ pub(crate) fn host_shell_command(
     command: &str,
     workdir: &Path,
 ) -> TokioCommand {
-    let mut c = TokioCommand::new(shell);
+    let mut c = leviath_sys::child_command_async(shell);
     c.arg(flag).arg(command).current_dir(workdir);
     c
 }

--- a/crates/leviath-cli/src/daemon/seed_command.rs
+++ b/crates/leviath-cli/src/daemon/seed_command.rs
@@ -209,9 +209,6 @@ fn build_seed_command(
 /// orphaning it.
 fn run_seed_command(mut cmd: TokioCommand, timeout: Duration) -> Result<String, String> {
     cmd.kill_on_drop(true);
-    // One per seeded region at spawn, and `output()` pipes both streams, so
-    // there is no console for this to want on Windows.
-    leviath_tools::hide_console_window(&mut cmd);
     std::thread::spawn(move || {
         // A current-thread runtime with no ambient runtime present only fails on
         // OS resource exhaustion, at which point the spawn itself is doomed

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -347,7 +347,9 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
         poll_until(&mut || !is_daemon_running(&id)).await;
     }
     let exe = std::env::current_exe()?;
-    let mut cmd = std::process::Command::new(exe);
+    // The daemon is a background process: started from Explorer or a
+    // service it has no console to share, so a raw spawn would open one.
+    let mut cmd = leviath_sys::child_command(exe);
     cmd.arg("daemon")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -357,7 +359,10 @@ async fn ensure_daemon_running() -> anyhow::Result<()> {
     if poll_until(&mut || is_daemon_running(&id)).await {
         return Ok(());
     }
-    anyhow::bail!("the leviath daemon did not start within 5s");
+    anyhow::bail!(
+        "the leviath daemon did not start within {:?}",
+        leviath_cli::daemon::readiness::READY_TIMEOUT
+    );
 }
 
 /// `lev daemon start`: auto-start a detached daemon if none is running.
@@ -457,7 +462,7 @@ fn resolve_service_unit() -> anyhow::Result<commands::daemon_service::ServiceUni
 /// failure. The real subprocess spawn - the argv it runs is built and tested in
 /// `commands::daemon_service`.
 fn run_supervisor(cmd: &(String, Vec<String>)) -> anyhow::Result<()> {
-    let out = std::process::Command::new(&cmd.0).args(&cmd.1).output()?;
+    let out = leviath_sys::child_command(&cmd.0).args(&cmd.1).output()?;
     if out.status.success() {
         return Ok(());
     }

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStdin, ChildStdout};
 
 use super::Transport;
 use super::jsonrpc::{self, Inbound, JsonRpcRequest, JsonRpcResponse};
@@ -141,7 +141,7 @@ impl StdioTransport {
         args: &[&str],
         env: &HashMap<String, String>,
     ) -> std::io::Result<Child> {
-        let mut cmd = Command::new(command);
+        let mut cmd = leviath_sys::child_command_async(command);
 
         // Build a clean environment, then layer the explicitly configured vars
         // (intentional, from MCP config) on top.
@@ -157,7 +157,6 @@ impl StdioTransport {
         // The server talks JSON-RPC over those pipes and has no use for a
         // console. It matters most here: `command_candidates` resolves `npx` to
         // `npx.cmd`, a batch file, which Windows always runs through `cmd.exe`.
-        leviath_sys::hide_console_window(cmd.as_std_mut());
 
         cmd.spawn()
     }

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -183,7 +183,7 @@ impl ClaudeCodeProvider {
         let prompt_file = stage_prompt_file(temp_dir, &Self::build_system_prompt(request))
             .map_err(prompt_file_error)?;
 
-        let mut cmd = tokio::process::Command::new(&self.binary_path);
+        let mut cmd = leviath_sys::child_command_async(&self.binary_path);
         cmd.args([
             "--print",
             "--output-format",
@@ -210,7 +210,6 @@ impl ClaudeCodeProvider {
         cmd.stderr(std::process::Stdio::piped());
         // This runs once per inference call, so on Windows it would be a
         // console window per turn of every agent.
-        leviath_sys::hide_console_window(cmd.as_std_mut());
 
         let mut child = retry_etxtbsy(|| cmd.spawn()).await.map_err(|e| {
             // Permanent: a missing or unusable binary will not fix itself, and

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -30,6 +30,11 @@ tracing = { workspace = true }
 # is otherwise pure Rust plus its TLS stack.
 fs4 = { workspace = true }
 
+# Only for `tokio::process::Command`, so the console-window decision can be made
+# once for both command flavours here rather than duplicated in every crate that
+# spawns children. `process` alone - this crate runs no runtime of its own.
+tokio = { workspace = true, features = ["process"] }
+
 # The OS credential store (macOS Keychain / Windows Credential Manager / Secret
 # Service). Optional: see the `keychain` feature above. `keyring-core` is used
 # directly for the `Entry` API so tests can install an in-memory store as the

--- a/crates/leviath-sys/src/editor.rs
+++ b/crates/leviath-sys/src/editor.rs
@@ -129,13 +129,13 @@ pub fn launch_via(
         let Some((program, args)) = editor_argv(candidate, path_str.as_ref()) else {
             continue;
         };
-        let mut cmd = Command::new(program);
+        // The one child meant to be seen: it inherits this process's stdio and
+        // draws in the user's terminal, so starting `vim` or `edit` without a
+        // console would leave it nowhere to draw and nothing to read from.
+        // `terminal_command` says that, where a bare `Command::new` would only
+        // have looked like a forgotten `child_command`.
+        let mut cmd = crate::process::terminal_command(program);
         cmd.args(args);
-        // Deliberately *not* `hide_console_window`, unlike every other spawn in
-        // this workspace: the editor is the one child that is meant to be seen.
-        // It inherits this process's stdio and draws in the user's terminal, so
-        // starting `vim` or `edit` without a console would leave it nowhere to
-        // draw and nothing to read from.
 
         match run(&mut cmd) {
             // Exited, even non-zero: the user closed the editor.

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -46,7 +46,10 @@ pub use perms::{
 };
 #[cfg(unix)]
 pub use process::peer_uid;
-pub use process::{configure_detached, current_uid, hide_console_window, kill_process_group};
+pub use process::{
+    child_command, child_command_async, configure_detached, current_uid, hide_console_window,
+    kill_process_group, terminal_command,
+};
 pub use sandbox::{
     ContainerRunSpec, container_exec_argv, container_rm_argv, container_run_argv,
     detect_container_engine, namespace_argv, namespace_supported,

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -1,5 +1,6 @@
 //! Process control: detached spawning and console-window suppression.
 
+use std::ffi::OsStr;
 use std::process::Command;
 
 /// Configure `cmd` so the spawned child detaches into its own process group,
@@ -33,6 +34,45 @@ pub fn configure_detached(cmd: &mut Command) {
 /// here, alongside `CREATE_NO_WINDOW`, rather than at a call site.
 pub fn hide_console_window(cmd: &mut Command) {
     crate::platform::hide_console_window(cmd);
+}
+
+/// A [`Command`] for a child that must not take a console window.
+///
+/// **This is where the decision is made.** Hiding used to be a second call the
+/// caller made after building the command, at seven sites across five crates,
+/// and a new spawn site that forgot it looked exactly like one that did not
+/// need it. Making it part of construction means the only way to get a child
+/// process is to have already answered the question.
+///
+/// The counterpart is [`terminal_command`], for the single child that is meant
+/// to be seen. There is no third option on purpose: a `Command::new` outside
+/// this module is rejected by `.sgrules/no-raw-command-new.yml`.
+pub fn child_command(program: impl AsRef<OsStr>) -> Command {
+    let mut cmd = Command::new(program);
+    hide_console_window(&mut cmd);
+    cmd
+}
+
+/// The tokio twin of [`child_command`].
+///
+/// `tokio::process::Command` wraps a `std::process::Command`, so `as_std_mut`
+/// reaches the one the flag is written on and both flavours share a single
+/// implementation rather than a second copy of the `#[cfg]`.
+pub fn child_command_async(program: impl AsRef<OsStr>) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(program);
+    hide_console_window(cmd.as_std_mut());
+    cmd
+}
+
+/// A [`Command`] for a child that *must* inherit the user's terminal.
+///
+/// The editor `lev run` opens is the only one: it draws in the terminal it
+/// inherits, and starting `vim` without a console leaves it nowhere to draw and
+/// nothing to read from. Named rather than reached for with a bare
+/// `Command::new` so the exception is a decision in the source instead of an
+/// omission, and so the lint has something to point at.
+pub fn terminal_command(program: impl AsRef<OsStr>) -> Command {
+    Command::new(program)
 }
 
 /// SIGKILL every process in the group led by `pgid` (a no-op on platforms
@@ -135,5 +175,30 @@ mod tests {
         // observable on Windows, and is asserted in that platform module.
         let mut cmd = Command::new("true");
         hide_console_window(&mut cmd);
+    }
+
+    /// The constructors have to *be* the decision, not just offer it: a caller
+    /// that builds through them gets a hidden console without a second call.
+    /// The flag itself is only observable on Windows and is asserted in that
+    /// platform module; here the point is that construction succeeds and the
+    /// program survives, so a caller cannot be silently handed a broken command.
+    #[test]
+    fn child_command_builds_a_usable_command() {
+        let cmd = child_command("true");
+        assert_eq!(cmd.get_program(), "true");
+    }
+
+    #[test]
+    fn child_command_async_builds_a_usable_command() {
+        let cmd = child_command_async("true");
+        assert_eq!(cmd.as_std().get_program(), "true");
+    }
+
+    /// The editor is the one child meant to be seen, so this deliberately does
+    /// *not* hide the console - see `editor.rs`, its only caller.
+    #[test]
+    fn terminal_command_builds_a_usable_command() {
+        let cmd = terminal_command("true");
+        assert_eq!(cmd.get_program(), "true");
     }
 }

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -525,7 +525,7 @@ impl BuiltinTools {
         let mut cmd = match &self.shell_executor {
             Some(executor) => executor.build_command(shell, flag, command, &workdir),
             None => {
-                let mut c = Command::new(shell);
+                let mut c = crate::platform::child_command(shell);
                 c.arg(flag).arg(command).current_dir(&workdir);
                 c
             }
@@ -556,7 +556,6 @@ impl BuiltinTools {
         // An agent runs this dozens of times per run, and on Windows each spawn
         // would otherwise be given a console window. Applied here rather than in
         // either branch above so it covers the sandboxed command too.
-        hide_console_window(&mut cmd);
         // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
         // command's output is still captured.
         cmd.stdout(std::process::Stdio::piped())

--- a/crates/leviath-tools/src/platform.rs
+++ b/crates/leviath-tools/src/platform.rs
@@ -14,17 +14,13 @@ pub fn own_process_group(cmd: &mut Command) {
     let _ = cmd;
 }
 
-/// Start `cmd` without a console window, so an agent's shell calls do not flash
-/// consoles across the desktop on Windows (issue #228).
+/// Build a child-process command with no console window.
 ///
-/// The tokio twin of [`leviath_sys::hide_console_window`], which takes a
-/// `std::process::Command`; `as_std_mut` reaches the one tokio wraps, so the
-/// flag has a single implementation rather than a second copy of the `#[cfg]`.
-/// A no-op everywhere but Windows. Only for a child whose stdio is piped, which
-/// is every caller here.
-pub fn hide_console_window(cmd: &mut Command) {
-    leviath_sys::hide_console_window(cmd.as_std_mut());
-}
+/// Re-exported from [`leviath_sys::child_command_async`] so the tool lane names
+/// it without reaching across crates at every call site. The decision lives
+/// there, once, for both command flavours - see that function for why it is
+/// made at construction rather than by a second call the caller can forget.
+pub use leviath_sys::child_command_async as child_command;
 
 /// SIGKILLs a shell's whole process group when dropped.
 ///


### PR DESCRIPTION
## What

Two Windows problems, both the same shape: a decision that had to be *remembered*
at every call site.

## 1. The console window is now decided at construction

On Windows a child of a process with no console — the daemon started from
Explorer, from a service, or from a UI console — gets a brand new window on the
interactive desktop, and agent tooling spawns shells many times per run
(issue #228).

Hiding it was a **second call** made after building the command, at seven sites
across five crates:

```
claude_code.rs   stdio.rs   script_host.rs   sandbox_manager.rs
seed_command.rs  dashboard/helpers.rs        exec.rs
```

A new spawn site that forgot looked exactly like one that did not need it — and
**two production sites had in fact never called it**: the daemon spawn in
`main.rs` and `run_supervisor`.

The decision now belongs to construction:

| | |
|---|---|
| `leviath_sys::child_command` | `std::process::Command`, console hidden |
| `leviath_sys::child_command_async` | `tokio::process::Command`, console hidden |
| `leviath_sys::terminal_command` | the one child meant to be seen |

There is no way to get a child process without having answered the question.
`leviath-sys` grows a `tokio` dependency (`process` feature only) so **one crate
owns both flavours** — the alternative was a constructor per crate, which is the
original problem again.

The editor `lev run` opens keeps its console via `terminal_command`: it draws in
the terminal it inherits, and `vim` with no console has nowhere to draw. Naming
it makes the exception a decision in the source rather than an omission.

`.sgrules/no-raw-command-new.yml` keeps it singular — a bare `Command::new` in
production is now an error, mutation-checked. Tests may use it freely; nothing
they spawn reaches an interactive desktop.

## 2. The readiness window is platform-aware

`READY_TIMEOUT` was a flat 5s. Starting the daemon on Windows has to bind a named
pipe and detach into a job object, and under a supervisor opening many sessions
those serialise: 5s was regularly missed, leaving sessions `runtime-missing` and
the control pipe reporting `All pipe instances are busy` (os error 231). Windows
now gets 15s.

The longer window is paid **only by a start that would otherwise have failed** —
the poll returns as soon as the daemon answers, and a healthy one answers in
~20ms either way. The bail message now reads the constant instead of repeating
"5s", which was already wrong for anyone who changed it.

## Verification

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo xtask coverage` 100% on `leviath-sys`, `leviath-tools`, `leviath-mcp`,
  `leviath-providers`, `leviath-cli`
- `ast-grep scan` clean; the new rule mutation-checked by reintroducing a
  production `Command::new` and confirming it fails

The Windows behaviour itself cannot be exercised from macOS — both changes are
no-ops here by construction (`CREATE_NO_WINDOW` exists only on Windows; the
15s window is `cfg!(windows)`). What is verified locally is that every spawn
path still builds and runs, and that the lint holds the invariant.

### Running coverage locally

`cargo xtask coverage --package leviath-cli` fails on a machine with a live
`ollama serve`: ollama is always registered, so `list_models` succeeds and the
`if let Ok(list)` in `serve/config.rs` never takes its other arm. CI has nothing
listening, which is why it passes there. **Stop ollama before trusting a local
coverage run** — this cost me a false failure on pristine `main` before I
spotted it.
