### PR TITLE
fix(runtime): an agent id remembers which world minted it

### DIFF
--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -509,7 +509,10 @@ mod tests {
             .expect("worker spawns");
         // The worker entered the `second` stage (index 1).
         assert_eq!(world.world().get::<StageCursor>(child).unwrap().index, 1);
-        assert_eq!(world.agent_status(child), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(child)),
+            Some(AgentStatus::Active)
+        );
     }
 
     /// A worker of an unattended parent is unattended. Spawning workers attended

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -58,7 +58,7 @@ pub fn reload_persisted_agents(
     world: &mut PipelineWorld,
     deps: SpawnDeps<'_>,
     runs_dir: &Path,
-) -> Vec<(String, Entity)> {
+) -> Vec<(String, leviath_runtime::world::AgentId)> {
     let mut reloaded: Vec<(RunMeta, Entity)> = Vec::new();
     let Ok(dir_entries) = std::fs::read_dir(runs_dir) else {
         return Vec::new(); // no runs dir yet - nothing to recover
@@ -93,9 +93,11 @@ pub fn reload_persisted_agents(
     // resume any parent that was parked mid fan-out.
     relink_tree(world, &reloaded);
     restore_fan_outs(world, &reloaded, runs_dir);
+    // Scoped on the way out: the host stores these for the life of the daemon,
+    // which is exactly where a bare entity would lose track of its world.
     reloaded
         .into_iter()
-        .map(|(meta, entity)| (meta.run_id, entity))
+        .map(|(meta, entity)| (meta.run_id, world.own_agent(entity)))
         .collect()
 }
 
@@ -109,13 +111,14 @@ pub fn reload_run(
     deps: SpawnDeps<'_>,
     run_id: &str,
     runs_dir: &std::path::Path,
-) -> Option<Entity> {
+) -> Option<leviath_runtime::world::AgentId> {
     let run_dir = runs_dir.join(run_id);
     let meta = read_meta(&run_dir)?;
     if is_terminal(&meta.status) {
         return None; // a finished run isn't paged back in
     }
-    reload_one(world, deps, &meta, &run_dir).ok()
+    let entity = reload_one(world, deps, &meta, &run_dir).ok()?;
+    Some(world.own_agent(entity))
 }
 
 /// Rebuild `FanOutWaiting` for any reloaded parent that was parked mid fan-out
@@ -424,7 +427,8 @@ fn reload_one(
     // A run the user paused stays paused across the restart: the default
     // restore presents it `Active`, which would silently resume it.
     if meta.status == RunStatus::Paused {
-        world.pause(entity);
+        // Built against this world's ECS, so it is ours.
+        world.pause(world.own_agent(entity));
     }
 
     Ok(entity)
@@ -814,7 +818,7 @@ mod tests {
         assert_eq!(restored.len(), 1);
         assert_eq!(restored[0].0, run_id);
         let entity = restored[0].1;
-        (world, entity)
+        (world, entity.entity())
     }
 
     /// An unattended run comes back unattended. Dropping `--yolo` on reload was
@@ -951,18 +955,18 @@ mod tests {
         assert_eq!(run_id, "run-live");
         assert_eq!(world.agent_status(*entity), Some(AgentStatus::Active));
         // Iteration + preserved metadata restored.
-        let md = world.world().get::<RunMetadata>(*entity).unwrap();
+        let md = world.world().get::<RunMetadata>(entity.entity()).unwrap();
         assert_eq!(md.started_at, 111);
         assert_eq!(md.title.as_deref(), Some("Resume Me"));
         assert_eq!(md.callback_url.as_deref(), Some("http://cb"));
-        let totals = world.world().get::<TokenTotals>(*entity).unwrap();
+        let totals = world.world().get::<TokenTotals>(entity.entity()).unwrap();
         assert_eq!(totals.prompt_tokens, 42);
         assert_eq!(totals.tool_calls, 3);
         // ...as are the run's productivity flags, so a resumed run doesn't report
         // itself as having modified nothing.
         let flags = world
             .world()
-            .get::<leviath_runtime::persistence::RunOutcomeFlags>(*entity)
+            .get::<leviath_runtime::persistence::RunOutcomeFlags>(entity.entity())
             .unwrap();
         assert_eq!(flags.0.modified_files, vec!["src/a.rs".to_string()]);
         assert_eq!(flags.0.modified_file_count, 1);
@@ -974,7 +978,7 @@ mod tests {
         // erase the copy already on disk.
         let output = world
             .world()
-            .get::<leviath_runtime::persistence::FinalOutput>(*entity)
+            .get::<leviath_runtime::persistence::FinalOutput>(entity.entity())
             .expect("a submitted answer survives the restart");
         assert_eq!(output.0.content, "already answered");
         assert_eq!(output.0.stage, "implement");
@@ -1055,7 +1059,7 @@ mod tests {
         );
 
         assert_eq!(restored.len(), 1);
-        assert_restored_from_archive(&world, restored[0].1);
+        assert_restored_from_archive(&world, restored[0].1.entity());
     }
 
     /// A crash *during* the journal append can leave a torn trailing frame. Recovery
@@ -1117,7 +1121,7 @@ mod tests {
 
         assert_eq!(restored.len(), 1);
         // The valid prefix folds → resume still uses the journal's fresh state.
-        assert_restored_from_archive(&world, restored[0].1);
+        assert_restored_from_archive(&world, restored[0].1.entity());
     }
 
     /// Append raw journal records to an existing `run.lvr`, the way the live
@@ -1228,7 +1232,7 @@ mod tests {
 
         assert_eq!(restored.len(), 1);
         let entity = restored[0].1;
-        let entries = conversation_of(&world, entity);
+        let entries = conversation_of(&world, entity.entity());
         // The assistant turn landed with both calls...
         assert!(entries.iter().any(|e| matches!(
             &e.kind,
@@ -1247,7 +1251,7 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<leviath_runtime::pipeline::ReadyToInfer>(entity)
+                .get::<leviath_runtime::pipeline::ReadyToInfer>(entity.entity())
                 .is_some()
         );
     }
@@ -1337,7 +1341,7 @@ mod tests {
         );
 
         assert_eq!(restored.len(), 1);
-        let entries = conversation_of(&world, restored[0].1);
+        let entries = conversation_of(&world, restored[0].1.entity());
         // Exactly the persisted turn - no second copy, no interrupted synthesis.
         assert_eq!(
             entries
@@ -1414,13 +1418,15 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<leviath_runtime::interaction_points::AwaitingInteractionPoint>(*entity)
+                .get::<leviath_runtime::interaction_points::AwaitingInteractionPoint>(
+                    entity.entity()
+                )
                 .is_some()
         );
         assert!(
             world
                 .world()
-                .get::<leviath_runtime::pipeline::ReadyToInfer>(*entity)
+                .get::<leviath_runtime::pipeline::ReadyToInfer>(entity.entity())
                 .is_none(),
             "the spawn-set ReadyToInfer is cleared so the inference lane won't fire"
         );
@@ -1617,13 +1623,13 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<FanOutWaiting>(by_id["parent-fo"])
+                .get::<FanOutWaiting>(by_id["parent-fo"].entity())
                 .is_some()
         );
         assert!(
             world
                 .world()
-                .get::<FanOutWaiting>(by_id["bad-fo"])
+                .get::<FanOutWaiting>(by_id["bad-fo"].entity())
                 .is_none()
         );
     }
@@ -1696,19 +1702,24 @@ mod tests {
         let child_b = by_id["child-b"];
 
         // Parent's SubAgentChildren rebuilt with both children + the depth cap.
-        let kids = world.world().get::<SubAgentChildren>(parent).unwrap();
+        let kids = world
+            .world()
+            .get::<SubAgentChildren>(parent.entity())
+            .unwrap();
         assert_eq!(kids.max_child_depth, 4);
         assert_eq!(kids.children.len(), 2);
-        assert!(kids.children.contains(&child_a) && kids.children.contains(&child_b));
+        assert!(
+            kids.children.contains(&child_a.entity()) && kids.children.contains(&child_b.entity())
+        );
         // Each child's ParentRef points back at the parent, at its stored depth.
-        let pr = world.world().get::<ParentRef>(child_a).unwrap();
-        assert_eq!(pr.parent_entity, parent);
+        let pr = world.world().get::<ParentRef>(child_a.entity()).unwrap();
+        assert_eq!(pr.parent_entity, parent.entity());
         assert_eq!(pr.parent_agent_id, "parent");
         assert_eq!(pr.depth, 1);
         // The serializable child list is kept in sync for the next snapshot.
         let state = world
             .world()
-            .get::<leviath_runtime::components::AgentState>(parent)
+            .get::<leviath_runtime::components::AgentState>(parent.entity())
             .unwrap();
         assert_eq!(state.spawned_children_ids, vec!["child-a", "child-b"]);
     }
@@ -1794,11 +1805,16 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<SubAgentChildren>(by_id["lonely-parent"])
+                .get::<SubAgentChildren>(by_id["lonely-parent"].entity())
                 .is_none()
         );
         // Orphan's parent didn't reload → no ParentRef attached.
-        assert!(world.world().get::<ParentRef>(by_id["orphan"]).is_none());
+        assert!(
+            world
+                .world()
+                .get::<ParentRef>(by_id["orphan"].entity())
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1831,7 +1847,12 @@ mod tests {
             runs.path(),
         );
         assert_eq!(restored.len(), 1);
-        assert!(world.world().get::<TokenTotals>(restored[0].1).is_some());
+        assert!(
+            world
+                .world()
+                .get::<TokenTotals>(restored[0].1.entity())
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -648,8 +648,8 @@ mod tests {
             read_paths: None,
             output_request: None,
         },));
-        reaper(&mut world, with_meta);
-        assert!(tool_service.take(with_meta).is_none());
+        reaper(&mut world, with_meta.entity());
+        assert!(tool_service.take(with_meta.entity()).is_none());
     }
 
     struct FakeProvider;

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -1935,7 +1935,10 @@ system = { kind = "pinned", max_tokens = 1000 }
         )
         .expect("spawn succeeds");
 
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
         let meta = world
             .world()
             .get::<RunMetadata>(entity)
@@ -2261,7 +2264,10 @@ system = { kind = "pinned", max_tokens = 1000 }
         )
         .expect("spawn succeeds");
 
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
         // The run metadata was attached.
         let md = world
             .world()
@@ -2369,7 +2375,10 @@ system = { kind = "pinned", max_tokens = 1000 }
             &args,
         )
         .expect("spawn succeeds");
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
 
         // The config deny stands: read_file is refused, not executed.
         let out = leviath_runtime::pipeline::ToolService::exec_for(
@@ -2985,7 +2994,10 @@ system_prompt = "be brief"
             &spawn_args(&manifest.to_string_lossy()),
         )
         .expect("spawn succeeds");
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
         // Compaction settings were attached.
         assert!(world.world().get::<CompactionSettings>(entity).is_some());
     }
@@ -3123,7 +3135,10 @@ system_prompt = "be brief"
             &spawn_args(&manifest.to_string_lossy()),
         )
         .expect("spawn succeeds");
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
     }
 
     /// A declared-but-ungranted `[read_paths]` still spawns; the warning-logging
@@ -3149,7 +3164,10 @@ system_prompt = "be brief"
             &spawn_args(&manifest.to_string_lossy()),
         )
         .expect("spawn succeeds even when nothing grants the declaration");
-        assert_eq!(world.agent_status(entity), Some(AgentStatus::Active));
+        assert_eq!(
+            world.agent_status(world.own_agent(entity)),
+            Some(AgentStatus::Active)
+        );
     }
 
     /// A malformed grant entry in the user's own config fails the spawn - the

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -24,7 +24,7 @@ impl WorldHost {
     /// Called after each drive to quiescence, so subscribers see every change.
     pub(super) fn emit_events(&mut self) {
         self.adopt_unregistered_runs();
-        let pairs: Vec<(String, Entity)> = self
+        let pairs: Vec<(String, AgentId)> = self
             .by_run_id
             .iter()
             .map(|(k, &v)| (k.clone(), v))
@@ -38,7 +38,10 @@ impl WorldHost {
         let mut to_reap: Vec<(String, Entity, RunListEntry)> = Vec::new();
         let mut to_park: Vec<(String, Entity, RunListEntry)> = Vec::new();
         let now = chrono::Utc::now().timestamp();
-        for (run_id, entity) in pairs {
+        for (run_id, agent) in pairs {
+            // Unwrapped once: everything below reaches into this world's ECS,
+            // where same-world is true by construction.
+            let entity = agent.entity();
             let Some(state) = self.world.world().get::<AgentState>(entity) else {
                 continue; // reaped between registration and now
             };

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -139,9 +139,9 @@ impl WorldHost {
         let world = self.world.world();
         self.by_run_id
             .iter()
-            .filter_map(|(run_id, &entity)| {
-                let state = world.get::<AgentState>(entity)?;
-                Some(self.entry_for(run_id, entity, state))
+            .filter_map(|(run_id, &agent)| {
+                let state = world.get::<AgentState>(agent.entity())?;
+                Some(self.entry_for(run_id, agent.entity(), state))
             })
             // Parked (paused, paged-out) runs are still the daemon's runs; an
             // operator must not lose sight of one just because it left memory.

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -27,7 +27,7 @@ use crate::components::{
 };
 use crate::interaction_hub::InteractionHub;
 use crate::persistence::{RunMetadata, TokenTotals};
-use crate::world::{LaneSnapshot, PipelineWorld};
+use crate::world::{AgentId, LaneSnapshot, PipelineWorld};
 
 // Sections of the former single-file host, one per concern. Glob re-exported so
 // every existing `host::ControlOp` / `host::WorldEvent` path keeps working and
@@ -40,7 +40,7 @@ pub use types::*;
 /// Owns the world and the run-id map; drives the world and services control ops.
 pub struct WorldHost {
     world: PipelineWorld,
-    by_run_id: HashMap<String, Entity>,
+    by_run_id: HashMap<String, AgentId>,
     interactions: InteractionHub,
     spawner: Option<Spawner>,
     spawn_preprocessor: Option<SpawnPreprocessor>,
@@ -221,8 +221,10 @@ impl WorldHost {
             .map(|(entity, md)| (md.run_id.clone(), entity))
             .collect();
         for (run_id, entity) in live {
-            if self.live_entity(&run_id) != Some(entity) {
-                self.by_run_id.insert(run_id, entity);
+            // Straight out of this world's query, so it is ours by construction.
+            let agent = self.world.own_agent(entity);
+            if self.live_entity(&run_id) != Some(agent) {
+                self.by_run_id.insert(run_id, agent);
             }
         }
     }
@@ -315,7 +317,7 @@ impl WorldHost {
     /// Resolve a run id to a live entity, paging it in from disk if it has been
     /// unloaded (and a reloader is installed). Returns `None` if the run is
     /// neither live nor resumable from disk. Newly-reloaded runs are registered.
-    fn resolve_or_reload(&mut self, run_id: &str) -> Option<Entity> {
+    fn resolve_or_reload(&mut self, run_id: &str) -> Option<AgentId> {
         if let Some(entity) = self.live_entity(run_id) {
             return Some(entity);
         }
@@ -337,16 +339,19 @@ impl WorldHost {
     }
 
     /// Record the run-id → entity mapping for a freshly-spawned agent.
-    pub fn register(&mut self, run_id: impl Into<String>, entity: Entity) {
+    pub fn register(&mut self, run_id: impl Into<String>, agent: AgentId) {
         let run_id = run_id.into();
         self.parked.remove(&run_id);
-        self.by_run_id.insert(run_id, entity);
+        self.by_run_id.insert(run_id, agent);
     }
 
     /// Resolve a run id to a **live** entity (one that still exists in the world).
-    fn live_entity(&self, run_id: &str) -> Option<Entity> {
-        let entity = *self.by_run_id.get(run_id)?;
-        self.world.world().get::<AgentState>(entity).map(|_| entity)
+    fn live_entity(&self, run_id: &str) -> Option<AgentId> {
+        let agent = *self.by_run_id.get(run_id)?;
+        self.world
+            .world()
+            .get::<AgentState>(agent.entity())
+            .map(|_| agent)
     }
 
     /// Apply one control op and reply on its channel. A dropped reply receiver is
@@ -366,7 +371,9 @@ impl WorldHost {
                             spawner(&mut self.world, &args)
                         })) {
                             Ok(Ok(entity)) => {
-                                self.by_run_id.insert(args.run_id.clone(), entity);
+                                // Spawned into this world, so it is ours.
+                                let agent = self.world.own_agent(entity);
+                                self.by_run_id.insert(args.run_id.clone(), agent);
                                 Ok(args.run_id.clone())
                             }
                             Ok(Err(e)) => Err(e),
@@ -397,7 +404,11 @@ impl WorldHost {
                 // point of bounding the finished buffer.
                 let output = self
                     .live_entity(&run_id)
-                    .and_then(|e| self.world.world().get::<crate::persistence::FinalOutput>(e))
+                    .and_then(|agent| {
+                        self.world
+                            .world()
+                            .get::<crate::persistence::FinalOutput>(agent.entity())
+                    })
                     .map(|o| o.0.clone());
                 let _ = reply.send(output);
             }

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -21,13 +21,13 @@ impl WorldHost {
                 let _ = reply.send(self.spawn_child(*args, &parent_run_id, max_depth));
             }
             SubAgentOp::Check { run_id, reply } => {
-                let report = self.live_entity(&run_id).and_then(|e| {
-                    self.world.agent_status(e).map(|status| SubAgentReport {
+                let report = self.live_entity(&run_id).and_then(|agent| {
+                    self.world.agent_status(agent).map(|status| SubAgentReport {
                         status,
                         final_output: self
                             .world
                             .world()
-                            .get::<crate::persistence::FinalOutput>(e)
+                            .get::<crate::persistence::FinalOutput>(agent.entity())
                             .map(|o| o.0.clone()),
                     })
                 });
@@ -80,7 +80,10 @@ impl WorldHost {
         args.parent_run_id = Some(parent_run_id.to_string());
         let parent = self
             .live_entity(parent_run_id)
-            .ok_or_else(|| format!("parent run '{parent_run_id}' is not live"))?;
+            .ok_or_else(|| format!("parent run '{parent_run_id}' is not live"))?
+            // Same world as the child about to be spawned into it, so the raw
+            // entity is what the ECS links want.
+            .entity();
         let parent_depth = self
             .world
             .world()
@@ -123,7 +126,9 @@ impl WorldHost {
         // Seed the child's context from the parent per any declared blueprint
         // context transform (planner→coder region mapping, etc.).
         crate::context_transform::apply_context_transforms(world, parent, child);
-        self.by_run_id.insert(run_id.clone(), child);
+        // The spawner ran against this world, so the child is ours.
+        let child_agent = self.world.own_agent(child);
+        self.by_run_id.insert(run_id.clone(), child_agent);
         Ok(run_id)
     }
 
@@ -162,7 +167,10 @@ impl WorldHost {
         ) else {
             return false;
         };
-        let mut stack = vec![root];
+        // `SubAgentChildren` links are raw entities within this world, so the
+        // walk stays in that space and only the endpoints are world-scoped.
+        let target = target.entity();
+        let mut stack = vec![root.entity()];
         while let Some(e) = stack.pop() {
             if e == target {
                 return true;
@@ -180,7 +188,7 @@ impl WorldHost {
         };
         // Collect the subtree (parent before children), then cancel each.
         let mut subtree = Vec::new();
-        let mut stack = vec![root];
+        let mut stack = vec![root.entity()];
         while let Some(e) = stack.pop() {
             subtree.push(e);
             if let Some(kids) = self.world.world().get::<SubAgentChildren>(e) {
@@ -196,7 +204,7 @@ impl WorldHost {
                 .world()
                 .get::<AgentState>(e)
                 .map(|s| s.agent_id.clone());
-            cancelled |= self.world.cancel(e);
+            cancelled |= self.world.cancel(self.world.own_agent(e));
             if let Some(agent_id) = agent_id {
                 self.interactions.cancel_for_agent(&agent_id);
                 // The hub is keyed by agent id but the emitted-interaction set is

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -10,6 +10,8 @@
 use std::collections::HashMap;
 
 use bevy_ecs::entity::Entity;
+
+use crate::world::AgentId;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
@@ -226,7 +228,7 @@ pub type Spawner = Box<dyn FnMut(&mut PipelineWorld, &SpawnArgs) -> Result<Entit
 /// control/sub-agent op targeting a run that isn't currently in memory pages it
 /// in first via the host's internal resolve-or-reload step. Installed with
 /// [`super::WorldHost::set_reloader`].
-pub type Reloader = Box<dyn FnMut(&mut PipelineWorld, &str) -> Option<Entity> + Send>;
+pub type Reloader = Box<dyn FnMut(&mut PipelineWorld, &str) -> Option<AgentId> + Send>;
 
 /// The daemon-installed last resort for cancelling a run the world cannot hold:
 /// given a run id, it forces that run's **on-disk** state to a terminal status

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -10,6 +10,7 @@
 //! (see CONTRIBUTING, "Where a test module lives").
 
 use super::*;
+use crate::world::AgentId;
 // Named here rather than inherited through `super::*`: the host itself no
 // longer mentions these (the types that do moved into `host::types`), so
 // leaning on the parent's imports would mean re-adding two it does not use.
@@ -175,7 +176,7 @@ fn setup() -> StageSetup {
 }
 
 /// Spawn a simple agent into the host and register it under `run_id`.
-fn spawn(host: &mut WorldHost, run_id: &str, agent_id: &str) -> Entity {
+fn spawn(host: &mut WorldHost, run_id: &str, agent_id: &str) -> AgentId {
     let e = host.world_mut().spawn_agent((
         AgentBlueprint(blueprint()),
         StageCursor { index: 0 },
@@ -356,12 +357,15 @@ async fn releasing_a_cancelled_runs_permit_wakes_the_starved_agent_behind_it() {
     // single permit is decided here rather than by the parallel dispatch.
     let holder = spawn(&mut host, "run-a", "agent-a");
     host.world_mut().run_to_fixed_point();
-    assert!(is_inferring(&mut host, holder), "the holder takes the slot");
+    assert!(
+        is_inferring(&mut host, holder.entity()),
+        "the holder takes the slot"
+    );
 
     let starved = spawn(&mut host, "run-b", "agent-b");
     host.world_mut().run_to_fixed_point();
     assert!(
-        !is_inferring(&mut host, starved),
+        !is_inferring(&mut host, starved.entity()),
         "the second agent is starved on the full pool"
     );
     // And it stays starved for as long as the slot is genuinely held - the
@@ -369,7 +373,7 @@ async fn releasing_a_cancelled_runs_permit_wakes_the_starved_agent_behind_it() {
     // first park consumes the wake the spawn itself stored; the loop has to
     // reach a park with nothing pending before "wedged" means anything.
     assert!(
-        !serve_until_inferring(&mut host, 3, PARK, starved).await,
+        !serve_until_inferring(&mut host, 3, PARK, starved.entity()).await,
         "no slot, no dispatch"
     );
 
@@ -384,7 +388,7 @@ async fn releasing_a_cancelled_runs_permit_wakes_the_starved_agent_behind_it() {
     );
 
     assert!(
-        serve_until_inferring(&mut host, 8, PARK, starved).await,
+        serve_until_inferring(&mut host, 8, PARK, starved.entity()).await,
         "the freed slot must wake the loop so the starved agent can take it; \
          without that wake the daemon parks with capacity it cannot see"
     );
@@ -477,7 +481,7 @@ fn spawn_two_stage(host: &mut WorldHost, run_id: &str, agent_id: &str) -> Entity
         ReadyToInfer,
     ));
     host.register(run_id, e);
-    e
+    e.entity()
 }
 
 /// A response that asks for one tool call - what a working stage returns
@@ -613,7 +617,7 @@ async fn a_run_that_moves_clears_the_dead_cycle_count() {
     // is built to notice.
     host.world_mut()
         .world_mut()
-        .get_mut::<AgentState>(entity)
+        .get_mut::<AgentState>(entity.entity())
         .expect("the agent is loaded")
         .iteration += 1;
     host.emit_events();
@@ -1049,7 +1053,7 @@ async fn result_reports_the_submitted_answer() {
 
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .insert(crate::persistence::FinalOutput(
             leviath_core::output::FinalOutput::new(
                 "<report/>",
@@ -1111,13 +1115,16 @@ async fn a_persisted_paused_root_is_parked_and_pages_back_in() {
     // Stamp the watermark as though the paused snapshot was dispatched.
     let mut wm = crate::pipeline::PersistWatermark::default();
     wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
-    host.world_mut().world_mut().entity_mut(e).insert(wm);
+    host.world_mut()
+        .world_mut()
+        .entity_mut(e.entity())
+        .insert(wm);
 
     host.emit_events();
 
     // Paged out: the entity is despawned, the run id unmapped, and the
     // reap hook tore the agent's state down first.
-    assert!(host.world.world().get::<AgentState>(e).is_none());
+    assert!(host.world.world().get::<AgentState>(e.entity()).is_none());
     assert!(!host.by_run_id.contains_key("run-a"));
     assert_eq!(*reaped.lock().unwrap(), 1);
     // But not lost: the listing still carries the paused row...
@@ -1167,14 +1174,14 @@ async fn a_paused_run_stays_resident_until_persisted_and_when_linked() {
     // Paused, but no watermark proof the paused snapshot was dispatched.
     host.emit_events();
     assert!(
-        host.world.world().get::<AgentState>(e).is_some(),
+        host.world.world().get::<AgentState>(e.entity()).is_some(),
         "an unpersisted pause stays resident"
     );
 
     // Persisted now, but carrying a child link: still resident.
     let mut wm = crate::pipeline::PersistWatermark::default();
     wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
-    host.world_mut().world_mut().entity_mut(e).insert((
+    host.world_mut().world_mut().entity_mut(e.entity()).insert((
         wm,
         SubAgentChildren {
             children: vec![],
@@ -1183,7 +1190,7 @@ async fn a_paused_run_stays_resident_until_persisted_and_when_linked() {
     ));
     host.emit_events();
     assert!(
-        host.world.world().get::<AgentState>(e).is_some(),
+        host.world.world().get::<AgentState>(e.entity()).is_some(),
         "a run with tree links keeps the restart question open"
     );
 
@@ -1191,11 +1198,11 @@ async fn a_paused_run_stays_resident_until_persisted_and_when_linked() {
     // the park teardown's no-reaper path is exercised too.
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .remove::<SubAgentChildren>();
     host.emit_events();
     assert!(
-        host.world.world().get::<AgentState>(e).is_none(),
+        host.world.world().get::<AgentState>(e.entity()).is_none(),
         "unlinked and persisted: parked without a reaper"
     );
     assert!(host.parked.contains_key("run-a"));
@@ -1278,7 +1285,7 @@ async fn pause_resume_cancel_by_run_id() {
 async fn spawn_op_uses_installed_spawner_and_registers() {
     let mut host = host_with(vec![]);
     host.set_spawner(Box::new(|world, args| {
-        Ok(world.spawn_agent((agent_state(&args.run_id),)))
+        Ok(world.spawn_agent((agent_state(&args.run_id),)).entity())
     }));
 
     let result = ask(&mut host, |reply| ControlOp::Spawn {
@@ -1359,7 +1366,7 @@ async fn ask_sub<T>(
 
 /// A spawner that adds a bare child agent and returns it.
 fn child_spawner() -> Spawner {
-    Box::new(|world, args| Ok(world.spawn_agent((agent_state(&args.run_id),))))
+    Box::new(|world, args| Ok(world.spawn_agent((agent_state(&args.run_id),)).entity()))
 }
 
 #[tokio::test]
@@ -1382,12 +1389,16 @@ async fn subagent_spawn_links_child_and_registers() {
 
     let child = host.by_run_id["child"];
     // The child links back to the parent at depth 1.
-    let pref = host.world.world().get::<ParentRef>(child).unwrap();
-    assert_eq!(pref.parent_entity, parent);
+    let pref = host.world.world().get::<ParentRef>(child.entity()).unwrap();
+    assert_eq!(pref.parent_entity, parent.entity());
     assert_eq!(pref.depth, 1);
     // The parent tracks the child.
-    let kids = host.world.world().get::<SubAgentChildren>(parent).unwrap();
-    assert_eq!(kids.children, vec![child]);
+    let kids = host
+        .world
+        .world()
+        .get::<SubAgentChildren>(parent.entity())
+        .unwrap();
+    assert_eq!(kids.children, vec![child.entity()]);
 }
 
 #[tokio::test]
@@ -1409,7 +1420,11 @@ async fn subagent_spawn_appends_to_existing_children() {
         assert!(r.is_ok());
     }
     let parent = host.by_run_id["parent"];
-    let kids = host.world.world().get::<SubAgentChildren>(parent).unwrap();
+    let kids = host
+        .world
+        .world()
+        .get::<SubAgentChildren>(parent.entity())
+        .unwrap();
     assert_eq!(kids.children.len(), 2);
 }
 
@@ -1480,7 +1495,7 @@ async fn subagent_check_carries_the_childs_submitted_answer() {
     let entity = spawn(&mut host, "run-a", "run-a");
     host.world
         .world_mut()
-        .entity_mut(entity)
+        .entity_mut(entity.entity())
         .insert(crate::persistence::FinalOutput(
             leviath_core::output::FinalOutput::new(
                 "changed src/lib.rs and its test",
@@ -1540,9 +1555,9 @@ async fn subagent_ops_reach_a_run_the_caller_spawned() {
     let child = spawn(&mut host, "child", "child");
     host.world_mut()
         .world_mut()
-        .entity_mut(parent)
+        .entity_mut(parent.entity())
         .insert(SubAgentChildren {
-            children: vec![child],
+            children: vec![child.entity()],
             max_child_depth: 3,
         });
 
@@ -1619,7 +1634,7 @@ async fn subagent_send_delivers_into_the_target_region() {
     let e = spawn(&mut host, "run-a", "run-a");
     host.world
         .world_mut()
-        .get_mut::<crate::components::ContextWindow>(e)
+        .get_mut::<crate::components::ContextWindow>(e.entity())
         .unwrap()
         .add_region(Region::new(
             "notes".to_string(),
@@ -1641,7 +1656,7 @@ async fn subagent_send_delivers_into_the_target_region() {
     let window = host
         .world
         .world()
-        .get::<crate::components::ContextWindow>(e)
+        .get::<crate::components::ContextWindow>(e.entity())
         .unwrap();
     assert!(window.get_region("notes").unwrap().current_tokens > 0);
     assert_eq!(window.get_region("conversation").unwrap().current_tokens, 0);
@@ -1734,12 +1749,12 @@ async fn cancel_tolerates_a_child_that_has_already_been_reaped() {
     let ghost = host.world_mut().spawn_agent((agent_state("ghost"),));
     host.world_mut()
         .world_mut()
-        .entity_mut(parent)
+        .entity_mut(parent.entity())
         .insert(SubAgentChildren {
-            children: vec![ghost],
+            children: vec![ghost.entity()],
             max_child_depth: 3,
         });
-    host.world_mut().world_mut().despawn(ghost);
+    host.world_mut().world_mut().despawn(ghost.entity());
 
     assert!(
         ask(&mut host, |reply| ControlOp::Cancel {
@@ -2001,7 +2016,7 @@ async fn message_op_is_delivered() {
     assert!(
         host.world
             .world()
-            .get::<crate::components::ContextWindow>(e)
+            .get::<crate::components::ContextWindow>(e.entity())
             .unwrap()
             .get_region("conversation")
             .unwrap()
@@ -2067,7 +2082,7 @@ async fn serve_awaits_spawn_preprocessor_before_spawning() {
     host.set_spawner(Box::new(move |world, args| {
         // The preprocessor must have completed before the spawner runs.
         assert!(ran_spawn.load(Ordering::SeqCst));
-        Ok(world.spawn_agent((agent_state(&args.run_id),)))
+        Ok(world.spawn_agent((agent_state(&args.run_id),)).entity())
     }));
     let (op_tx, op_rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(async move {
@@ -2157,7 +2172,7 @@ async fn serve_spawns_without_a_preprocessor() {
     // `None` arm of the preprocessor branch.
     let mut host = host_with(vec![]);
     host.set_spawner(Box::new(|world, args| {
-        Ok(world.spawn_agent((agent_state(&args.run_id),)))
+        Ok(world.spawn_agent((agent_state(&args.run_id),)).entity())
     }));
     let (op_tx, op_rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(async move {
@@ -2253,7 +2268,7 @@ async fn a_completed_event_carries_the_answer() {
     let entity = spawn(&mut host, "run-out", "agent-out");
     host.world_mut()
         .world_mut()
-        .entity_mut(entity)
+        .entity_mut(entity.entity())
         .insert(crate::persistence::FinalOutput(
             leviath_core::output::FinalOutput::new(
                 "what the run concluded",
@@ -2306,7 +2321,7 @@ async fn emit_events_broadcasts_agent_changes() {
     // Attach run metadata so the `Spawned` event carries the blueprint name.
     host.world_mut()
         .world_mut()
-        .entity_mut(entity)
+        .entity_mut(entity.entity())
         .insert(RunMetadata {
             run_id: "run-a".to_string(),
             agent_name: "coder".to_string(),
@@ -2372,7 +2387,10 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
     let root = {
         let mut s = agent_state("root");
         s.status = AgentStatus::Complete;
-        host.world.world_mut().spawn(s).id()
+        {
+            let e = host.world.world_mut().spawn(s).id();
+            host.world.own_agent(e)
+        }
     };
     host.register("root", root);
     host.emit_events();
@@ -2383,27 +2401,36 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
     host.emit_events();
     assert!(host.live_entity("root").is_none(), "reaped after emit");
     assert!(
-        host.world.world().get::<AgentState>(root).is_none(),
+        host.world
+            .world()
+            .get::<AgentState>(root.entity())
+            .is_none(),
         "entity despawned"
     );
 
     // A terminal child under a LIVE (Active) parent is deferred.
-    let parent = host.world.world_mut().spawn(agent_state("parent")).id();
+    let parent = {
+        let e = host.world.world_mut().spawn(agent_state("parent")).id();
+        host.world.own_agent(e)
+    };
     host.register("parent", parent);
     let child = {
         let mut s = agent_state("child");
         s.status = AgentStatus::Complete;
-        host.world
+        let e = host
+            .world
             .world_mut()
             .spawn((
                 s,
                 ParentRef {
-                    parent_entity: parent,
+                    // `ParentRef` links are raw entities within one world.
+                    parent_entity: parent.entity(),
                     parent_agent_id: "parent".to_string(),
                     depth: 1,
                 },
             ))
-            .id()
+            .id();
+        host.world.own_agent(e)
     };
     host.register("child", child);
     host.emit_events();
@@ -2416,7 +2443,7 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
     // Once the parent is terminal, the child becomes reapable.
     host.world
         .world_mut()
-        .get_mut::<AgentState>(parent)
+        .get_mut::<AgentState>(parent.entity())
         .unwrap()
         .status = AgentStatus::Complete;
     host.emit_events();
@@ -2432,7 +2459,8 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
     let orphan = {
         let mut s = agent_state("orphan");
         s.status = AgentStatus::Complete;
-        host.world
+        let e = host
+            .world
             .world_mut()
             .spawn((
                 s,
@@ -2442,7 +2470,8 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
                     depth: 1,
                 },
             ))
-            .id()
+            .id();
+        host.world.own_agent(e)
     };
     host.register("orphan", orphan);
     host.emit_events();
@@ -2456,7 +2485,10 @@ async fn emit_events_unloads_terminal_agents_when_safe() {
 #[tokio::test]
 async fn emit_events_does_not_reap_non_terminal_agents() {
     let mut host = host_with(vec![]);
-    let active = host.world.world_mut().spawn(agent_state("active")).id();
+    let active = {
+        let e = host.world.world_mut().spawn(agent_state("active")).id();
+        host.world.own_agent(e)
+    };
     host.register("active", active);
     host.emit_events();
     host.emit_events();
@@ -2482,7 +2514,10 @@ async fn reaper_runs_once_per_agent_before_despawn() {
     let root = {
         let mut s = agent_state("root");
         s.status = AgentStatus::Complete;
-        host.world.world_mut().spawn(s).id()
+        {
+            let e = host.world.world_mut().spawn(s).id();
+            host.world.own_agent(e)
+        }
     };
     host.register("root", root);
     host.emit_events(); // first pass: emit terminal event, not yet reaped
@@ -2503,7 +2538,10 @@ async fn reaper_runs_once_per_agent_before_despawn() {
 fn unload_with(host: &mut WorldHost, run_id: &str, status: AgentStatus) {
     let mut s = agent_state(run_id);
     s.status = status;
-    let e = host.world.world_mut().spawn(s).id();
+    let e = {
+        let e = host.world.world_mut().spawn(s).id();
+        host.world.own_agent(e)
+    };
     host.register(run_id, e);
     host.emit_events();
     host.emit_events();
@@ -2639,10 +2677,13 @@ async fn the_status_of_an_unloaded_run_is_still_answerable() {
 
 /// Spawn a `Waiting` agent (optionally with an extra marker component) and
 /// register it under `run_id`.
-fn register_waiting(host: &mut WorldHost, run_id: &str) -> Entity {
+fn register_waiting(host: &mut WorldHost, run_id: &str) -> AgentId {
     let mut s = agent_state(run_id);
     s.status = AgentStatus::Waiting;
-    let e = host.world.world_mut().spawn(s).id();
+    let e = {
+        let e = host.world.world_mut().spawn(s).id();
+        host.world.own_agent(e)
+    };
     host.register(run_id, e);
     e
 }
@@ -2663,13 +2704,13 @@ async fn emit_events_never_unloads_waiting_agents() {
     let asking = register_waiting(&mut host, "asking");
     host.world
         .world_mut()
-        .entity_mut(asking)
+        .entity_mut(asking.entity())
         .insert(AwaitingInteraction);
     // Gated on children, and a plain parked agent.
     let gated = register_waiting(&mut host, "gated");
     host.world
         .world_mut()
-        .entity_mut(gated)
+        .entity_mut(gated.entity())
         .insert(WaitingForChildren);
     register_waiting(&mut host, "parked");
 
@@ -2787,7 +2828,7 @@ async fn event_sender_feeds_subscribers() {
 async fn emit_events_skips_despawned_agents() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "agent-a");
-    host.world_mut().world_mut().despawn(e);
+    host.world_mut().world_mut().despawn(e.entity());
     // The stale run-id mapping is skipped; must not panic.
     host.emit_events();
 }
@@ -2841,7 +2882,7 @@ async fn list_skips_despawned_entity() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "agent-a");
     // Despawn the entity behind the world's back; the run-id map is now stale.
-    host.world_mut().world_mut().despawn(e);
+    host.world_mut().world_mut().despawn(e.entity());
 
     let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;
     assert!(list.is_empty()); // stale mapping filtered out
@@ -2882,9 +2923,9 @@ async fn wait_reason_is_none_unless_the_agent_is_waiting() {
     let e = spawn(&mut host, "run-a", "run-a");
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .insert(crate::pipeline::WaitingForChildren);
-    assert_eq!(host.wait_reason(e), None);
+    assert_eq!(host.wait_reason(e.entity()), None);
 }
 
 /// An entity the world no longer holds cannot be explained either.
@@ -2892,8 +2933,8 @@ async fn wait_reason_is_none_unless_the_agent_is_waiting() {
 async fn wait_reason_is_none_for_an_unknown_entity() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    host.world_mut().world_mut().despawn(e);
-    assert_eq!(host.wait_reason(e), None);
+    host.world_mut().world_mut().despawn(e.entity());
+    assert_eq!(host.wait_reason(e.entity()), None);
 }
 
 /// `Waiting` with nothing claiming it: report nothing rather than guess.
@@ -2901,14 +2942,14 @@ async fn wait_reason_is_none_for_an_unknown_entity() {
 async fn wait_reason_is_none_when_nothing_claims_the_wait() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    assert_eq!(waiting_because(&mut host, e, |_| {}), None);
+    assert_eq!(waiting_because(&mut host, e.entity(), |_| {}), None);
 }
 
 #[tokio::test]
 async fn wait_reason_reports_a_taint_gate() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(crate::gate_prompt::AwaitingGatePrompt(1));
     });
     assert_eq!(reason, Some(WaitReason::TaintGate));
@@ -2918,7 +2959,7 @@ async fn wait_reason_reports_a_taint_gate() {
 async fn wait_reason_reports_an_interaction_point() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(crate::interaction_points::AwaitingInteractionPoint);
     });
     assert_eq!(reason, Some(WaitReason::InteractionPoint));
@@ -2935,15 +2976,15 @@ async fn wait_reason_counts_unfinished_children() {
     {
         let world = host.world_mut().world_mut();
         world
-            .get_mut::<AgentState>(done)
+            .get_mut::<AgentState>(done.entity())
             .expect("child has state")
             .status = AgentStatus::Complete;
     }
-    let reason = waiting_because(&mut host, parent, |entity| {
+    let reason = waiting_because(&mut host, parent.entity(), |entity| {
         entity.insert((
             crate::pipeline::WaitingForChildren,
             SubAgentChildren {
-                children: vec![running, done],
+                children: vec![running.entity(), done.entity()],
                 max_child_depth: 3,
             },
         ));
@@ -2957,7 +2998,7 @@ async fn wait_reason_counts_unfinished_children() {
 async fn wait_reason_reports_children_with_none_recorded() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(crate::pipeline::WaitingForChildren);
     });
     assert_eq!(reason, Some(WaitReason::Children { outstanding: 0 }));
@@ -3010,7 +3051,7 @@ async fn wait_reason_distinguishes_a_tool_approval_from_a_question() {
         ),
     );
     await_pending(&host, "run-a").await;
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(AwaitingInteraction);
     });
     assert_eq!(reason, Some(WaitReason::ToolApproval));
@@ -3025,7 +3066,7 @@ async fn wait_reason_distinguishes_a_tool_approval_from_a_question() {
         InteractionRequest::free_text("req-2", "which one?", "implement", true),
     );
     await_pending(&host, "run-a").await;
-    assert_eq!(host.wait_reason(e), Some(WaitReason::UserPrompt));
+    assert_eq!(host.wait_reason(e.entity()), Some(WaitReason::UserPrompt));
     assert_eq!(host.interactions().cancel_for_agent("run-a"), 1);
     question.await.expect("the asking task finishes");
 }
@@ -3036,7 +3077,7 @@ async fn wait_reason_distinguishes_a_tool_approval_from_a_question() {
 async fn wait_reason_falls_back_to_user_prompt_without_a_hub_entry() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(AwaitingInteraction);
     });
     assert_eq!(reason, Some(WaitReason::UserPrompt));
@@ -3049,7 +3090,7 @@ async fn wait_reason_falls_back_to_user_prompt_without_a_hub_entry() {
 async fn a_gate_outranks_the_generic_interaction_marker() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    let reason = waiting_because(&mut host, e, |entity| {
+    let reason = waiting_because(&mut host, e.entity(), |entity| {
         entity.insert((
             AwaitingInteraction,
             crate::gate_prompt::AwaitingGatePrompt(1),
@@ -3068,13 +3109,13 @@ async fn wait_reason_counts_outstanding_fan_out_workers() {
     {
         let world = host.world_mut().world_mut();
         world
-            .get_mut::<AgentState>(parent)
+            .get_mut::<AgentState>(parent.entity())
             .expect("parent has state")
             .status = AgentStatus::Waiting;
         // One worker in flight and two items not yet started ⇒ three left.
         crate::fanout::restore_fan_out_waiting(
             world,
-            parent,
+            parent.entity(),
             crate::fanout::FanOutState {
                 config: leviath_core::blueprint::FanOutConfig {
                     worker_agent: None,
@@ -3096,11 +3137,11 @@ async fn wait_reason_counts_outstanding_fan_out_workers() {
                 summaries: Vec::new(),
                 failures: Vec::new(),
             },
-            &|run_id| (run_id == "run-b").then_some(worker),
+            &|run_id| (run_id == "run-b").then_some(worker.entity()),
         );
     }
     assert_eq!(
-        host.wait_reason(parent),
+        host.wait_reason(parent.entity()),
         Some(WaitReason::FanOutWorkers { outstanding: 3 })
     );
 }
@@ -3112,7 +3153,7 @@ async fn wait_reason_counts_outstanding_fan_out_workers() {
 async fn list_reports_blueprint_shape_and_unattended() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    host.world_mut().world_mut().entity_mut(e).insert((
+    host.world_mut().world_mut().entity_mut(e.entity()).insert((
         RunMetadata {
             run_id: "run-a".to_string(),
             agent_name: "coder".to_string(),
@@ -3159,14 +3200,14 @@ async fn list_reports_a_finished_run_that_produced_nothing() {
     let e = spawn(&mut host, "run-a", "run-a");
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .insert(crate::persistence::RunOutcomeFlags::default());
     // Still running: nothing to say yet.
     assert!(!ask(&mut host, |reply| ControlOp::List { reply }).await.runs[0].empty_output);
 
     host.world_mut()
         .world_mut()
-        .get_mut::<AgentState>(e)
+        .get_mut::<AgentState>(e.entity())
         .expect("spawned agent has state")
         .status = AgentStatus::Complete;
     assert!(ask(&mut host, |reply| ControlOp::List { reply }).await.runs[0].empty_output);
@@ -3174,7 +3215,7 @@ async fn list_reports_a_finished_run_that_produced_nothing() {
     // ...unless it never had a way to write, which is not its failing.
     host.world_mut()
         .world_mut()
-        .get_mut::<crate::persistence::RunOutcomeFlags>(e)
+        .get_mut::<crate::persistence::RunOutcomeFlags>(e.entity())
         .expect("just inserted")
         .0
         .no_output_tools = true;
@@ -3191,11 +3232,11 @@ async fn a_submitted_answer_clears_the_listing_s_empty_verdict() {
     let e = spawn(&mut host, "run-a", "run-a");
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .insert(crate::persistence::RunOutcomeFlags::default());
     host.world_mut()
         .world_mut()
-        .get_mut::<AgentState>(e)
+        .get_mut::<AgentState>(e.entity())
         .expect("spawned agent has state")
         .status = AgentStatus::Complete;
     // Finished having written nothing: empty, and no answer to point at.
@@ -3205,7 +3246,7 @@ async fn a_submitted_answer_clears_the_listing_s_empty_verdict() {
 
     host.world_mut()
         .world_mut()
-        .entity_mut(e)
+        .entity_mut(e.entity())
         .insert(crate::persistence::FinalOutput(
             leviath_core::output::FinalOutput::new(
                 "here is what I found",
@@ -3225,7 +3266,7 @@ async fn a_submitted_answer_clears_the_listing_s_empty_verdict() {
 async fn list_explains_a_waiting_run() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
-    waiting_because(&mut host, e, |entity| {
+    waiting_because(&mut host, e.entity(), |entity| {
         entity.insert(crate::pipeline::WaitingForChildren);
     });
     let list = ask(&mut host, |reply| ControlOp::List { reply }).await.runs;

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -173,8 +173,56 @@ impl LaneSnapshot {
     }
 }
 
+/// Identifies one [`PipelineWorld`] within this process.
+///
+/// Only ever compared, never interpreted. A counter rather than a random value
+/// because a mismatch is easier to read in a test failure as `1 != 2`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WorldId(u64);
+
+/// An agent, together with the world that spawned it.
+///
+/// `Entity` is an index plus a generation minted *per world*, so two worlds
+/// hand out the same id for their first agent. Nothing in `Entity` records
+/// which one it came from, so passing one world's entity to another was not
+/// refused - it named a real, different agent there, and the call acted on that
+/// one instead. `b.pause(a_entity)` paused B's own agent while the caller
+/// believed it had paused A's, silently.
+///
+/// The provenance has to travel *with* the id, which is what this is. It cannot
+/// be built outside this module: the only sources are [`PipelineWorld::spawn_agent`]
+/// and [`PipelineWorld::spawn_from_blueprint`], so an id always names an agent
+/// in the world that minted it.
+///
+/// A tag component on the agent was tried first and does not work: looking the
+/// tag up on the foreign id resolves to the *local* agent, whose tag naturally
+/// matches, so the check passes and guards nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AgentId {
+    world: WorldId,
+    entity: Entity,
+}
+
+impl AgentId {
+    /// The raw ECS entity.
+    ///
+    /// For code already inside the owning world - systems, queries, direct
+    /// `World` access - where same-world is true by construction. Crossing a
+    /// world boundary with the result is the bug this type exists to prevent.
+    pub fn entity(self) -> Entity {
+        self.entity
+    }
+
+    /// Which world minted this id.
+    pub fn world(self) -> WorldId {
+        self.world
+    }
+}
+
 /// The shared ECS world that hosts and drives every agent.
 pub struct PipelineWorld {
+    /// This world's identity, carried by every [`AgentId`] it mints.
+    id: WorldId,
     world: World,
     schedule: Schedule,
     wake: Arc<Notify>,
@@ -214,6 +262,8 @@ impl PipelineWorld {
         // runs in parallel. (The schedule executor itself is single-threaded -
         // see `tick_schedule`.)
         bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
+        static NEXT_WORLD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        let id = WorldId(NEXT_WORLD_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
 
         let wake = Arc::new(Notify::new());
         let shutdown = Arc::new(Notify::new());
@@ -431,6 +481,7 @@ impl PipelineWorld {
         );
 
         Self {
+            id,
             world,
             schedule,
             wake,
@@ -482,10 +533,13 @@ impl PipelineWorld {
 
     /// Spawn an agent from its pre-built component bundle and wake the driver so
     /// the next fixed-point picks it up. Returns the new entity.
-    pub fn spawn_agent(&mut self, bundle: impl Bundle) -> Entity {
-        let e = self.world.spawn(bundle).id();
+    pub fn spawn_agent(&mut self, bundle: impl Bundle) -> AgentId {
+        let entity = self.world.spawn(bundle).id();
         self.wake.notify_one();
-        e
+        AgentId {
+            world: self.id,
+            entity,
+        }
     }
 
     /// Spawn an agent from a blueprint + task + per-stage resolution (see
@@ -498,8 +552,8 @@ impl PipelineWorld {
         task: &str,
         stages: Vec<crate::pipeline::ResolvedStage>,
         global_hints: leviath_core::config::PromptHints,
-    ) -> Result<Entity, String> {
-        let e = crate::pipeline::spawn_agent(
+    ) -> Result<AgentId, String> {
+        let entity = crate::pipeline::spawn_agent(
             &mut self.world,
             agent_id,
             blueprint,
@@ -508,7 +562,10 @@ impl PipelineWorld {
             global_hints,
         )?;
         self.wake.notify_one();
-        Ok(e)
+        Ok(AgentId {
+            world: self.id,
+            entity,
+        })
     }
 
     /// Deliver a message to a running agent (routed to its inbox on the next
@@ -645,10 +702,39 @@ impl PipelineWorld {
         self.tool_lane.narrow(upto)
     }
 
+    /// Wrap an entity that came out of this world, for callers that hold one.
+    ///
+    /// Exposed for the host and for recovery: both query this world directly,
+    /// so the entities they get back are ours by construction. Not a general
+    /// escape - there is no way to build an [`AgentId`] for a world you do not
+    /// already have in hand.
+    pub fn own_agent(&self, entity: Entity) -> AgentId {
+        self.own(entity)
+    }
+
+    /// Wrap an entity this world already owns.
+    ///
+    /// For entities that came out of this world's own queries, where same-world
+    /// is true by construction. Private: outside code must get its ids from a
+    /// spawn, which is what makes [`AgentId`] mean anything.
+    fn own(&self, entity: Entity) -> AgentId {
+        AgentId {
+            world: self.id,
+            entity,
+        }
+    }
+
     /// The status of an agent, if it still exists.
-    pub fn agent_status(&self, entity: Entity) -> Option<AgentStatus> {
+    ///
+    /// An id another world minted reports `None` rather than this world's agent
+    /// of the same raw entity - see [`AgentId`]. `pause`, `resume` and `cancel`
+    /// all read status through here, so guarding it guards them.
+    pub fn agent_status(&self, agent: AgentId) -> Option<AgentStatus> {
+        if agent.world != self.id {
+            return None;
+        }
         self.world
-            .get::<AgentState>(entity)
+            .get::<AgentState>(agent.entity)
             .map(|s| s.status.clone())
     }
 
@@ -656,8 +742,13 @@ impl PipelineWorld {
     /// longer exists. The async-starting dispatchers only act on `Active` agents,
     /// so this is how the world pauses/resumes/cancels an agent - a non-`Active`
     /// agent is simply data the systems skip until it is `Active` again.
-    pub fn set_status(&mut self, entity: Entity, status: AgentStatus) -> bool {
-        let Some(mut state) = self.world.get_mut::<AgentState>(entity) else {
+    pub fn set_status(&mut self, agent: AgentId, status: AgentStatus) -> bool {
+        // Every status mutation funnels through here, so this is the one place a
+        // foreign id has to be refused.
+        if agent.world != self.id {
+            return false;
+        }
+        let Some(mut state) = self.world.get_mut::<AgentState>(agent.entity) else {
             return false;
         };
         state.status = status;
@@ -671,10 +762,10 @@ impl PipelineWorld {
     /// resolution depend on, so overwriting it would wedge the run, and pausing
     /// a terminal agent is meaningless. Returns `false` if the agent no longer
     /// exists or is not in a pausable state.
-    pub fn pause(&mut self, entity: Entity) -> bool {
-        match self.agent_status(entity) {
+    pub fn pause(&mut self, agent: AgentId) -> bool {
+        match self.agent_status(agent) {
             Some(AgentStatus::Active | AgentStatus::Idle) => {
-                self.set_status(entity, AgentStatus::Paused)
+                self.set_status(agent, AgentStatus::Paused)
             }
             _ => false,
         }
@@ -682,18 +773,18 @@ impl PipelineWorld {
 
     /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
     /// agent that has not ticked yet); anything else returns `false`.
-    pub fn resume(&mut self, entity: Entity) -> bool {
-        match self.agent_status(entity) {
+    pub fn resume(&mut self, agent: AgentId) -> bool {
+        match self.agent_status(agent) {
             Some(AgentStatus::Paused | AgentStatus::Idle) => {
-                self.set_status(entity, AgentStatus::Active)
+                self.set_status(agent, AgentStatus::Active)
             }
             _ => false,
         }
     }
 
     /// Cancel an agent (it stops starting new work; in-flight results still land).
-    pub fn cancel(&mut self, entity: Entity) -> bool {
-        self.set_status(entity, AgentStatus::Cancelled)
+    pub fn cancel(&mut self, agent: AgentId) -> bool {
+        self.set_status(agent, AgentStatus::Cancelled)
     }
 
     /// Run one schedule tick over every agent, catching a panic from any system
@@ -714,7 +805,7 @@ impl PipelineWorld {
         };
         let message = panic_status_message(&panicked.message);
         match panicked.entity {
-            Some(entity) if self.set_status(entity, AgentStatus::Error { message }) => {
+            Some(entity) if self.set_status(self.own(entity), AgentStatus::Error { message }) => {
                 tracing::error!(
                     ?entity,
                     panic = %panicked.message,
@@ -761,7 +852,7 @@ impl PipelineWorld {
                 message: panic_status_message(&message),
             };
             // The entity came straight out of the query above, so it exists.
-            let _ = self.set_status(entity, status);
+            let _ = self.set_status(self.own(entity), status);
         }
         TickOutcome::AgentFailed
     }
@@ -1229,7 +1320,7 @@ mod tests {
     }
 
     /// Spawn a single-stage agent, initially ready to infer.
-    fn spawn(world: &mut PipelineWorld) -> Entity {
+    fn spawn(world: &mut PipelineWorld) -> AgentId {
         world.spawn_agent((
             AgentBlueprint(blueprint()),
             StageCursor { index: 0 },
@@ -1385,7 +1476,7 @@ mod tests {
         assert!(
             world
                 .world()
-                .entity(entity)
+                .entity(entity.entity())
                 .get::<crate::tick_scope::PanickedInParallel>()
                 .is_none(),
             "the marker must be drained once acted on"
@@ -1428,7 +1519,11 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
-        assert_eq!(victim, Some(entity), "the system saw the spawned agent");
+        assert_eq!(
+            victim,
+            Some(entity.entity()),
+            "the system saw the spawned agent"
+        );
         let status = world.agent_status(entity);
         assert!(
             matches!(status, Some(AgentStatus::Error { ref message })
@@ -1469,12 +1564,15 @@ mod tests {
 
         // Nothing has dispatched, and within the grace period that is still
         // just a wait - but it is now a *recorded* one.
-        let state = world.world().get::<AgentState>(e).expect("the agent");
+        let state = world
+            .world()
+            .get::<AgentState>(e.entity())
+            .expect("the agent");
         assert_eq!(state.iteration, 0, "not a single inference happened");
         assert_eq!(state.status, AgentStatus::Active);
         let stall = world
             .world()
-            .get::<crate::pipeline::DispatchStall>(e)
+            .get::<crate::pipeline::DispatchStall>(e.entity())
             .expect("the decline is recorded");
         assert_eq!(stall.reason, crate::pipeline::StallReason::ProviderMissing);
 
@@ -1485,7 +1583,7 @@ mod tests {
             chrono::Utc::now().timestamp() - crate::pipeline::DEFAULT_STALL_TIMEOUT_SECS as i64 - 1;
         world
             .world_mut()
-            .get_mut::<crate::pipeline::DispatchStall>(e)
+            .get_mut::<crate::pipeline::DispatchStall>(e.entity())
             .expect("the stall record")
             .since = past;
         world.run_to_fixed_point();
@@ -1497,7 +1595,7 @@ mod tests {
             "got: {status:?}"
         );
         assert!(
-            world.world().get::<ReadyToInfer>(e).is_none(),
+            world.world().get::<ReadyToInfer>(e.entity()).is_none(),
             "and it is out of the dispatch systems"
         );
     }
@@ -1521,7 +1619,10 @@ mod tests {
         // Strip the agent of the marker it spawned with. Nothing in the engine
         // does this; a panicking system that dropped a marker without landing a
         // successor is what it stands in for.
-        world.world_mut().entity_mut(e).remove::<ReadyToInfer>();
+        world
+            .world_mut()
+            .entity_mut(e.entity())
+            .remove::<ReadyToInfer>();
         world.run_to_fixed_point();
 
         // First pass records it. Inside the grace period it is still just a wait.
@@ -1532,14 +1633,14 @@ mod tests {
         );
         let since = world
             .world()
-            .get::<crate::pipeline::Wedged>(e)
+            .get::<crate::pipeline::Wedged>(e.entity())
             .expect("the wedge is recorded")
             .since;
 
         // Backdate past the grace period, as the host's redrive would find it.
         world
             .world_mut()
-            .get_mut::<crate::pipeline::Wedged>(e)
+            .get_mut::<crate::pipeline::Wedged>(e.entity())
             .expect("the wedge record")
             .since = since - 61;
         world.run_to_fixed_point();
@@ -1618,7 +1719,7 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<ContextWindow>(e)
+                .get::<ContextWindow>(e.entity())
                 .unwrap()
                 .get_region("conversation")
                 .unwrap()
@@ -1693,7 +1794,7 @@ mod tests {
         assert!(
             world
                 .world()
-                .get::<ContextWindow>(e)
+                .get::<ContextWindow>(e.entity())
                 .unwrap()
                 .get_region("conversation")
                 .unwrap()
@@ -1764,9 +1865,12 @@ mod tests {
     async fn agent_status_is_none_for_unknown_entity() {
         let world = build_world(registry_with(vec![]));
         assert_eq!(
+            // Scoped to this world, but naming an entity it never spawned.
             world.agent_status(
-                Entity::from_raw_u32(999)
-                    .expect("a small literal index is always a valid entity id")
+                world.own_agent(
+                    Entity::from_raw_u32(999)
+                        .expect("a small literal index is always a valid entity id")
+                )
             ),
             None
         );
@@ -1849,15 +1953,13 @@ mod tests {
     #[tokio::test]
     async fn status_ops_return_false_for_unknown_entity() {
         let mut world = build_world(registry_with(vec![]));
-        assert!(!world.pause(
-            Entity::from_raw_u32(999).expect("a small literal index is always a valid entity id")
-        ));
-        assert!(!world.resume(
-            Entity::from_raw_u32(999).expect("a small literal index is always a valid entity id")
-        ));
-        assert!(!world.cancel(
-            Entity::from_raw_u32(999).expect("a small literal index is always a valid entity id")
-        ));
+        // Scoped to this world, but naming an entity it never spawned.
+        let unknown = world.own_agent(
+            Entity::from_raw_u32(999).expect("a small literal index is always a valid entity id"),
+        );
+        assert!(!world.pause(unknown));
+        assert!(!world.resume(unknown));
+        assert!(!world.cancel(unknown));
     }
 
     #[tokio::test]
@@ -2338,7 +2440,7 @@ mod tests {
         };
         crate::restore::restore_agent(
             world.world_mut(),
-            entity,
+            entity.entity(),
             &snapshot,
             0,
             3,
@@ -2347,13 +2449,13 @@ mod tests {
 
         let state = world
             .world()
-            .get::<crate::components::AgentState>(entity)
+            .get::<crate::components::AgentState>(entity.entity())
             .unwrap();
         assert_eq!(state.status, AgentStatus::Active);
         assert_eq!(state.iteration, 3);
         let win = world
             .world()
-            .get::<crate::components::ContextWindow>(entity)
+            .get::<crate::components::ContextWindow>(entity.entity())
             .unwrap();
         assert_eq!(
             win.get_region("conversation").unwrap().content[0].content,
@@ -2447,38 +2549,62 @@ mod tests {
         assert!(b.agent_status(in_a).is_none());
     }
 
-    /// **A known hazard, pinned rather than fixed.**
+    /// `set_status` guards separately, and needs its own case.
     ///
-    /// `Entity` is an index plus a generation minted *per world*, so two worlds
-    /// hand out the same id for their first agent - asserted below, because the
-    /// collision is the normal case and not a corner one. Nothing in the type
-    /// records which world minted it, so passing one world's entity to another
-    /// is not refused: it names a real, different agent there, and the call acts
-    /// on that one instead. Silently.
-    ///
-    /// This cannot be closed from inside the world. A tag component was tried
-    /// and does not work: looking the tag up on the foreign id resolves to the
-    /// *local* agent, whose tag naturally matches, so the check passes. The
-    /// provenance has to travel with the id - a handle carrying the world's
-    /// identity, returned by `spawn_agent` and required by the entity-taking
-    /// methods - which changes every signature that stores an `Entity` (the
-    /// host's run-id map, recovery, fan-out).
-    ///
-    /// Harmless today: one world exists per process, so no entity can be
-    /// foreign. It has to be closed before a second one is introduced, and this
-    /// test is here so that lands as a failing assertion rather than a bug.
+    /// `pause`/`resume`/`cancel` read status first, so a foreign id stops at
+    /// `agent_status` and never reaches the mutation. A caller holding a foreign
+    /// id can still call `set_status` directly, which is the path this covers.
     #[tokio::test]
-    async fn a_foreign_entity_silently_names_the_wrong_agent() {
+    async fn set_status_refuses_a_foreign_agent_id() {
         let mut a = build_world(ProviderRegistry::new());
         let mut b = build_world(ProviderRegistry::new());
         let in_a = spawn(&mut a);
         let in_b = spawn(&mut b);
-        assert_eq!(in_a, in_b, "the ids collide, which is the whole problem");
 
-        // Pause "A's agent" against world B: B pauses its own instead.
-        assert!(b.pause(in_a));
+        assert!(!b.set_status(in_a, AgentStatus::Complete), "B accepted it");
+        // B's own agent, which shares the raw id, is untouched.
+        assert_ne!(b.agent_status(in_b), Some(AgentStatus::Complete));
+        // And B still works on its own.
+        assert!(b.set_status(in_b, AgentStatus::Complete));
+        assert_eq!(b.agent_status(in_b), Some(AgentStatus::Complete));
+    }
+
+    /// The hazard [`AgentId`] exists for, now closed.
+    ///
+    /// The raw entities still collide - that is a property of bevy, not
+    /// something this can change - but an [`AgentId`] carries the world that
+    /// minted it, so the collision no longer means the two name the same agent.
+    /// Before this, `b.pause(a_entity)` paused B's own agent while the caller
+    /// believed it had paused A's, silently.
+    #[tokio::test]
+    async fn a_foreign_agent_id_is_refused_rather_than_naming_the_wrong_agent() {
+        let mut a = build_world(ProviderRegistry::new());
+        let mut b = build_world(ProviderRegistry::new());
+        let in_a = spawn(&mut a);
+        let in_b = spawn(&mut b);
+
+        // The underlying ids do collide - the problem is real, not hypothetical.
+        assert_eq!(
+            in_a.entity(),
+            in_b.entity(),
+            "the raw ids collide, which is what made this silent"
+        );
+        // But the handles do not, because they remember where they came from.
+        assert_ne!(in_a, in_b);
+        assert_ne!(in_a.world(), in_b.world());
+
+        // B refuses A's agent instead of acting on its own.
+        assert!(!b.pause(in_a), "B accepted a foreign id");
+        assert!(
+            b.agent_status(in_a).is_none(),
+            "B answered for a foreign id"
+        );
+        assert_ne!(b.agent_status(in_b), Some(AgentStatus::Paused));
+
+        // Each world still works normally on its own.
+        assert!(a.pause(in_a));
+        assert_eq!(a.agent_status(in_a), Some(AgentStatus::Paused));
+        assert!(b.pause(in_b));
         assert_eq!(b.agent_status(in_b), Some(AgentStatus::Paused));
-        // A's agent never moved - the caller's intent was lost in silence.
-        assert_ne!(a.agent_status(in_a), Some(AgentStatus::Paused));
     }
 }


### PR DESCRIPTION
## The problem

`Entity` is an index plus a generation minted **per world**, so two worlds hand
out the *same id* for their first agent. Nothing in the type recorded which one
it came from, so passing one world's entity to another was **not refused** — it
named a real, different agent there, and the call acted on that one instead:

```rust
assert_eq!(in_a, in_b);   // the ids collide
b.pause(in_a);            // B pauses its OWN agent
                          // A's agent never moved — silently
```

The pinned test from #324 asserted exactly that. This closes it.

## The fix

`AgentId` carries the world alongside the entity. It **cannot be built outside
`world.rs`**, so the only sources are the two spawn points and `own_agent`,
which a world only offers for entities that came out of its own queries.

The five entity-taking methods refuse an id they did not mint. `pause`, `resume`
and `cancel` read status through `agent_status`, so the check lives in the two
places all of them funnel through.

**The host's `by_run_id` is why this matters.** It is the one long-lived store of
agent ids in the process — the one place an id can outlive the moment it made
sense — and it now holds `AgentId`.

## A tag component was tried first, and does not work

Stamping every agent with its world and checking on the way in guards nothing:
looking the tag up on a **foreign** id resolves to the **local** agent, whose tag
naturally matches, so the check always passes.

Provenance cannot be recovered from inside the world — it has to travel *with*
the id. That attempt was reverted rather than shipped, because a check that
cannot fail reads as protection.

## Raw entities are kept where they are correct

Queries, `ParentRef` and `SubAgentChildren` links, and the recovery relink passes
all live inside one world, where same-world is true by construction.
`AgentId::entity()` is the documented way through. What got scoped is the
*boundaries*: what recovery returns, and what the host stores.

## Verification

Live, because this is the daemon's run bookkeeping and a green suite has
certified a no-op here before. The control ops are the ones that resolve through
`by_run_id`, which is the map whose type changed:

```
active -> paused -> active -> cancelled
```

Real inference on every configured provider, after the change:

| Provider | Model | Reply |
|---|---|---|
| anthropic | claude-haiku-4-5 | `PONG` |
| google | gemini-3.1-flash-lite | `PONG` |
| openrouter | google/gemini-3.5-flash | `PONG` |
| openai | gpt-5.4-nano | `PONG` |

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo xtask coverage` 100% on `leviath-runtime` and `leviath-cli`
- `ast-grep scan` clean

The hazard test flipped from asserting the silent corruption to asserting the
refusal. `set_status` needed a case of its own — the other three stop at
`agent_status` first and never reach its guard, which the coverage gate caught.
