### PR TITLE
fix(runtime): a raw World can check an agent id too

### DIFF
--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -168,7 +168,11 @@ impl FanOutSpawner for DaemonFanOutSpawner {
                 .get::<AgentBlueprint>(child)
                 .and_then(|bp| bp.0.stages.iter().position(|s| s.name == stage))
             {
-                Some(idx) => force_transition(world, child, idx),
+                Some(idx) => force_transition(
+                    world,
+                    leviath_runtime::world::AgentId::in_world(world, child),
+                    idx,
+                ),
                 None => return Err(format!("worker stage '{stage}' not found in blueprint")),
             }
         }

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -417,9 +417,11 @@ fn reload_one(
         .ok()
         .and_then(|s| serde_json::from_str::<InteractionPointState>(&s).ok())
     {
+        // Built against this world's ECS a few lines above, so it is ours.
+        let agent = world.own_agent(entity);
         leviath_runtime::interaction_points::restore_interaction_point(
             world.world_mut(),
-            entity,
+            agent,
             state,
         );
     }

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -25,7 +25,16 @@ use crate::pipeline::{AgentBlueprint, CompactionSettings, InferenceStage, Provid
 /// Seed `child`'s context from `parent`'s per a declared blueprint transform.
 /// No-op unless both carry an [`AgentBlueprint`] with different names and a
 /// matching [`ContextTransform`](leviath_core::blueprint::ContextTransform) exists.
-pub fn apply_context_transforms(world: &mut World, parent: Entity, child: Entity) {
+pub fn apply_context_transforms(
+    world: &mut World,
+    parent: crate::world::AgentId,
+    child: crate::world::AgentId,
+) {
+    // Both ends have to be in this world: seeding a child's context from a
+    // *different* world's parent would copy one run's data into another.
+    let (Some(parent), Some(child)) = (parent.resolve_in(world), child.resolve_in(world)) else {
+        return;
+    };
     let Some(mappings) = collect_transform_mappings(world, parent, child) else {
         return;
     };
@@ -429,7 +438,9 @@ mod tests {
             ))
             .id();
 
-        apply_context_transforms(&mut w, parent, child);
+        let parent_id = crate::world::AgentId::in_world(&w, parent);
+        let child_id = crate::world::AgentId::in_world(&w, child);
+        apply_context_transforms(&mut w, parent_id, child_id);
 
         let cw = w.get::<ContextWindow>(child).unwrap();
         let task = cw.get_region("task").unwrap();
@@ -456,7 +467,9 @@ mod tests {
                 window_with(&[("task", "")]),
             ))
             .id();
-        apply_context_transforms(&mut w, p, c);
+        let parent_id = crate::world::AgentId::in_world(&w, p);
+        let child_id = crate::world::AgentId::in_world(&w, c);
+        apply_context_transforms(&mut w, parent_id, child_id);
         assert_eq!(
             w.get::<ContextWindow>(c)
                 .unwrap()
@@ -478,7 +491,9 @@ mod tests {
                 window_with(&[("task", "")]),
             ))
             .id();
-        apply_context_transforms(&mut w2, p2, c2);
+        let parent_id = crate::world::AgentId::in_world(&w2, p2);
+        let child_id = crate::world::AgentId::in_world(&w2, c2);
+        apply_context_transforms(&mut w2, parent_id, child_id);
         assert_eq!(
             w2.get::<ContextWindow>(c2)
                 .unwrap()
@@ -499,7 +514,9 @@ mod tests {
             ))
             .id();
         let c3 = w3.spawn(bp_with_transforms("b", vec![])).id(); // no window
-        apply_context_transforms(&mut w3, p3, c3);
+        let parent_id = crate::world::AgentId::in_world(&w3, p3);
+        let child_id = crate::world::AgentId::in_world(&w3, c3);
+        apply_context_transforms(&mut w3, parent_id, child_id);
         assert!(w3.get::<ContextWindow>(c3).is_none());
     }
 
@@ -659,7 +676,9 @@ mod tests {
             ))
             .id();
 
-        apply_context_transforms(&mut w, parent, child);
+        let parent_id = crate::world::AgentId::in_world(&w, parent);
+        let child_id = crate::world::AgentId::in_world(&w, child);
+        apply_context_transforms(&mut w, parent_id, child_id);
 
         // Raw content is written now (fallback)...
         assert_eq!(

--- a/crates/leviath-runtime/src/embed/tool_service.rs
+++ b/crates/leviath-runtime/src/embed/tool_service.rs
@@ -35,6 +35,15 @@ struct AgentTools {
 /// it does and does not provide.
 pub struct BasicToolService {
     hub: InteractionHub,
+    /// Keyed by raw `Entity`, deliberately.
+    ///
+    /// Two worlds mint the same entity id, so an entity-keyed map shared between
+    /// them would hand one world's tool state to the other's agent. This map is
+    /// not shared: a `BasicToolService` is built once per `AgentWorld`, and the
+    /// only writer is that world's own spawner. An [`crate::world::AgentId`] key
+    /// would carry a world the `ToolService::execute` signature has no way to
+    /// supply - it is handed a bare `Entity` by the tool lane, with no world in
+    /// reach - so it would buy nothing and cost the trait.
     agents: Mutex<HashMap<Entity, Arc<AgentTools>>>,
 }
 

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -415,7 +415,11 @@ fn finish_fan_out(world: &mut World, parent: Entity, w: FanOutWaiting) {
             .get::<AgentBlueprint>(parent)
             .and_then(|bp| bp.0.stages.iter().position(|s| s.name == name))
     }) {
-        Some(idx) => crate::pipeline::force_transition(world, parent, idx),
+        Some(idx) => crate::pipeline::force_transition(
+            world,
+            crate::world::AgentId::in_world(world, parent),
+            idx,
+        ),
         None => {
             world.entity_mut(parent).insert(ResolveTransition);
         }
@@ -486,7 +490,11 @@ fn start_worker(
         .push(worker_id);
     // Seed the worker's context from the parent per any declared blueprint
     // context transform (when a fan-out worker runs a different blueprint).
-    crate::context_transform::apply_context_transforms(world, parent, child);
+    crate::context_transform::apply_context_transforms(
+        world,
+        crate::world::AgentId::in_world(world, parent),
+        crate::world::AgentId::in_world(world, child),
+    );
     Ok(child)
 }
 
@@ -1954,16 +1962,17 @@ mod tests {
                 window(),
             ))
             .id();
-        force_transition(&mut world, e, 1);
+        let agent = crate::world::AgentId::in_world(&world, e);
+        force_transition(&mut world, agent, 1);
         assert!(world.get::<ToolResultRoutingComponent>(e).is_some());
         assert!(world.get::<ReadyToInfer>(e).is_some());
 
         // Despawned entity: no panic, no effect.
-        force_transition(
-            &mut world,
+        let gone = crate::world::AgentId::in_world(
+            &world,
             Entity::from_raw_u32(9191).expect("a small literal index is always a valid entity id"),
-            1,
         );
+        force_transition(&mut world, gone, 1);
     }
 
     #[test]
@@ -2000,7 +2009,8 @@ mod tests {
         let mut w = ContextWindow::new(1000);
         w.add_region(Region::new("task".to_string(), RegionKind::Pinned, 20));
         let (mut world, e) = world_with(bp, setups, w);
-        force_transition(&mut world, e, 1);
+        let agent = crate::world::AgentId::in_world(&world, e);
+        force_transition(&mut world, agent, 1);
         assert_errored(&world, e);
     }
 

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -20,8 +20,11 @@ impl WorldHost {
     /// request of their own, so both also carry [`AwaitingInteraction`]; asking
     /// the specific markers first is what keeps them from all reporting as a
     /// generic prompt.
-    pub fn wait_reason(&self, entity: Entity) -> Option<WaitReason> {
+    pub fn wait_reason(&self, agent: crate::world::AgentId) -> Option<WaitReason> {
         let world = self.world.world();
+        // An id from another world names a different agent here, which would
+        // report that one's wait reason as this run's.
+        let entity = agent.resolve_in(world)?;
         let state = world.get::<AgentState>(entity)?;
         if state.status != AgentStatus::Waiting {
             return None;
@@ -102,7 +105,7 @@ impl WorldHost {
         RunListEntry {
             run_id: run_id.to_string(),
             status: state.status.clone(),
-            wait_reason: self.wait_reason(entity),
+            wait_reason: self.wait_reason(crate::world::AgentId::in_world(world, entity)),
             stage: state.current_stage.clone(),
             stage_index: world
                 .get::<crate::pipeline::StageCursor>(entity)

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -125,7 +125,11 @@ impl WorldHost {
             .push(run_id.clone());
         // Seed the child's context from the parent per any declared blueprint
         // context transform (planner→coder region mapping, etc.).
-        crate::context_transform::apply_context_transforms(world, parent, child);
+        crate::context_transform::apply_context_transforms(
+            world,
+            crate::world::AgentId::in_world(world, parent),
+            crate::world::AgentId::in_world(world, child),
+        );
         // The spawner ran against this world, so the child is ours.
         let child_agent = self.world.own_agent(child);
         self.by_run_id.insert(run_id.clone(), child_agent);

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2912,7 +2912,7 @@ fn waiting_because(
         let mut e = world.entity_mut(entity);
         attach(&mut e);
     }
-    host.wait_reason(entity)
+    host.wait_reason(AgentId::in_world(host.world.world(), entity))
 }
 
 /// A run that is not waiting has nothing to explain, whatever markers it
@@ -2925,7 +2925,7 @@ async fn wait_reason_is_none_unless_the_agent_is_waiting() {
         .world_mut()
         .entity_mut(e.entity())
         .insert(crate::pipeline::WaitingForChildren);
-    assert_eq!(host.wait_reason(e.entity()), None);
+    assert_eq!(host.wait_reason(e), None);
 }
 
 /// An entity the world no longer holds cannot be explained either.
@@ -2934,7 +2934,7 @@ async fn wait_reason_is_none_for_an_unknown_entity() {
     let mut host = host_with(vec![]);
     let e = spawn(&mut host, "run-a", "run-a");
     host.world_mut().world_mut().despawn(e.entity());
-    assert_eq!(host.wait_reason(e.entity()), None);
+    assert_eq!(host.wait_reason(e), None);
 }
 
 /// `Waiting` with nothing claiming it: report nothing rather than guess.
@@ -3066,7 +3066,7 @@ async fn wait_reason_distinguishes_a_tool_approval_from_a_question() {
         InteractionRequest::free_text("req-2", "which one?", "implement", true),
     );
     await_pending(&host, "run-a").await;
-    assert_eq!(host.wait_reason(e.entity()), Some(WaitReason::UserPrompt));
+    assert_eq!(host.wait_reason(e), Some(WaitReason::UserPrompt));
     assert_eq!(host.interactions().cancel_for_agent("run-a"), 1);
     question.await.expect("the asking task finishes");
 }
@@ -3141,7 +3141,7 @@ async fn wait_reason_counts_outstanding_fan_out_workers() {
         );
     }
     assert_eq!(
-        host.wait_reason(parent.entity()),
+        host.wait_reason(parent),
         Some(WaitReason::FanOutWorkers { outstanding: 3 })
     );
 }
@@ -3356,4 +3356,44 @@ fn every_world_event_variant_carries_its_run_id() {
     for ev in events {
         assert_eq!(ev.run_id(), "run-x");
     }
+}
+
+/// `wait_reason` refuses an id from another world.
+///
+/// Without the check it would answer with the wait reason of whichever local
+/// agent shared the raw entity - reporting one run's state as another's in
+/// `lev ps`.
+#[tokio::test]
+async fn wait_reason_refuses_a_foreign_agent_id() {
+    let mut host = host_with(vec![]);
+    let mine = register_waiting(&mut host, "mine");
+    host.world
+        .world_mut()
+        .entity_mut(mine.entity())
+        .insert(crate::pipeline::WaitingForChildren);
+    // This world does answer for its own.
+    assert!(host.wait_reason(mine).is_some());
+
+    // A second world's id names nothing here, even though the raw entity is
+    // valid in both.
+    let mut other = PipelineWorld::new(
+        crate::providers::ProviderRegistry::new(),
+        Arc::new(NoTools),
+        InferencePoolConfig::new(),
+        1,
+        None,
+        Handle::current(),
+    );
+    // Spawn in the other world until it mints the *same* raw entity, so this
+    // tests a genuine collision rather than an id that simply is not there.
+    let theirs = loop {
+        let candidate = other.spawn_agent((agent_state("theirs"),));
+        if candidate.entity() == mine.entity() {
+            break candidate;
+        }
+    };
+    assert!(
+        host.wait_reason(theirs).is_none(),
+        "answered for a foreign id"
+    );
 }

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -376,7 +376,16 @@ async fn run_interaction_point(ask: PointAsk, lane: PromptLane<InteractionPointO
 /// A no-op (leaving the default restore in place) when the interaction-point lane
 /// isn't wired (a test world), or when the stage is no longer an interactive-points
 /// stage / the cursor is out of range (e.g. the blueprint changed under the run).
-pub fn restore_interaction_point(world: &mut World, entity: Entity, state: InteractionPointState) {
+pub fn restore_interaction_point(
+    world: &mut World,
+    agent: crate::world::AgentId,
+    state: InteractionPointState,
+) {
+    // An id from another world would name a different agent here, and this
+    // writes a pending prompt onto it.
+    let Some(entity) = agent.resolve_in(world) else {
+        return;
+    };
     // The lane + hub must both be wired (they are in the daemon; absent in a test
     // world) - otherwise there is nothing to await the re-opened request.
     let Some(((outcomes, wake, runtime), hub)) = world
@@ -2003,9 +2012,10 @@ mod tests {
     async fn restore_rearms_waiting_and_reopens_the_prompt() {
         let (mut world, hub, _rx) = resume_world();
         let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        let agent = crate::world::AgentId::in_world(&world, e);
         restore_interaction_point(
             &mut world,
-            e,
+            agent,
             InteractionPointState {
                 cursor: 0,
                 round: 2,
@@ -2038,9 +2048,10 @@ mod tests {
     async fn restore_then_answer_drives_the_transition() {
         let (mut world, hub, mut rx) = resume_world();
         let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        let agent = crate::world::AgentId::in_world(&world, e);
         restore_interaction_point(
             &mut world,
-            e,
+            agent,
             InteractionPointState {
                 cursor: 0,
                 round: 0,
@@ -2077,9 +2088,10 @@ mod tests {
     async fn restore_noop_on_noninteractive_stage() {
         let (mut world, hub, _rx) = resume_world();
         let e = restored_agent(&mut world, noninteractive_bp());
+        let agent = crate::world::AgentId::in_world(&world, e);
         restore_interaction_point(
             &mut world,
-            e,
+            agent,
             InteractionPointState {
                 cursor: 0,
                 round: 0,
@@ -2104,9 +2116,10 @@ mod tests {
         // No InteractionPointStage / hub resources (a test world) ⇒ no-op.
         let mut world = World::new();
         let e = restored_agent(&mut world, blueprint_with(vec![plan_point()]));
+        let agent = crate::world::AgentId::in_world(&world, e);
         restore_interaction_point(
             &mut world,
-            e,
+            agent,
             InteractionPointState {
                 cursor: 0,
                 round: 0,

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -716,7 +716,12 @@ pub(crate) fn attach_stage_components(
 /// or the daemon (spawning a fan-out worker directly at its worker stage) where no
 /// [`Commands`] queue is available. On a system-prompt overflow the agent is
 /// marked `Error`, mirroring the transition systems.
-pub fn force_transition(world: &mut World, entity: Entity, target_idx: usize) {
+pub fn force_transition(world: &mut World, agent: crate::world::AgentId, target_idx: usize) {
+    // Moving the wrong agent to a stage is how a run silently ends up somewhere
+    // its blueprint never sent it.
+    let Some(entity) = agent.resolve_in(world) else {
+        return;
+    };
     // Phase 1 (scoped borrow): mutate the agent's own state via `enter_stage`,
     // returning the components Phase 2 must insert - or `None` if the agent is
     // gone or its system prompt overflowed (already marked `Error` in-place).

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -180,6 +180,15 @@ impl LaneSnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WorldId(u64);
 
+/// The identity of the world this resource lives in.
+///
+/// Stored *inside* the world so that code holding only a
+/// [`bevy_ecs::world::World`] - a system, or a free function called from one -
+/// can still tell whether an [`AgentId`] belongs to it. Without this the check
+/// would only be possible on [`PipelineWorld`], which is not what a system has.
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OwnWorldId(pub WorldId);
+
 /// An agent, together with the world that spawned it.
 ///
 /// `Entity` is an index plus a generation minted *per world*, so two worlds
@@ -204,6 +213,41 @@ pub struct AgentId {
 }
 
 impl AgentId {
+    /// Scope a raw entity to the world it came out of.
+    ///
+    /// The reverse of [`Self::resolve_in`], for a system holding a query result
+    /// that needs to call something taking an [`AgentId`]. Wrapping and then
+    /// resolving inside the same world always round-trips; an id built this way
+    /// in one world and resolved in another does not, which is the point.
+    pub fn in_world(world: &World, entity: Entity) -> Self {
+        Self {
+            // A world assembled by hand in a test has no identity to borrow;
+            // `resolve_in` accepts any id against such a world, so the pair
+            // still round-trips.
+            world: world
+                .get_resource::<OwnWorldId>()
+                .map_or(WorldId(0), |own| own.0),
+            entity,
+        }
+    }
+
+    /// The entity, if this id belongs to `world`.
+    ///
+    /// The check any code holding a raw [`World`] should make before touching an
+    /// agent it was handed. `None` means the id came from a different world, in
+    /// which case its raw entity would name some *other* agent here - which is
+    /// the whole failure this type exists to prevent.
+    ///
+    /// A world with no [`OwnWorldId`] resource (a bare test world assembled by
+    /// hand) accepts any id: it never minted one, so there is nothing to
+    /// disagree with.
+    pub fn resolve_in(self, world: &World) -> Option<Entity> {
+        match world.get_resource::<OwnWorldId>() {
+            Some(own) if own.0 != self.world => None,
+            _ => Some(self.entity),
+        }
+    }
+
     /// The raw ECS entity.
     ///
     /// For code already inside the owning world - systems, queries, direct
@@ -297,6 +341,7 @@ impl PipelineWorld {
         let gp_runtime = runtime.clone();
 
         let mut world = World::new();
+        world.insert_resource(OwnWorldId(id));
         world.insert_resource(Providers(providers));
         world.insert_resource(InferenceStage {
             // The wake goes into the pools, not just the bridges: freeing a slot
@@ -2567,6 +2612,82 @@ mod tests {
         // And B still works on its own.
         assert!(b.set_status(in_b, AgentStatus::Complete));
         assert_eq!(b.agent_status(in_b), Some(AgentStatus::Complete));
+    }
+
+    /// The world carries its own identity, so a *raw* `World` can check too.
+    ///
+    /// This is what lets the free functions called from inside systems -
+    /// `force_transition`, `apply_context_transforms`,
+    /// `restore_interaction_point` - refuse a foreign id. They are handed a
+    /// `&mut World`, never a `PipelineWorld`, so without the resource there is
+    /// nothing for them to compare against.
+    #[tokio::test]
+    async fn a_raw_world_refuses_an_id_another_world_minted() {
+        let mut a = build_world(ProviderRegistry::new());
+        let mut b = build_world(ProviderRegistry::new());
+        let in_a = spawn(&mut a);
+        let in_b = spawn(&mut b);
+
+        // Resolving in its own world yields the entity...
+        assert_eq!(in_a.resolve_in(a.world()), Some(in_a.entity()));
+        // ...and in the other world, nothing - even though the raw id is valid
+        // there and names one of B's own agents.
+        assert_eq!(in_a.resolve_in(b.world()), None);
+        assert_eq!(in_b.resolve_in(a.world()), None);
+
+        // Round-tripping through the same world always works, which is what the
+        // systems do with their query results.
+        let round = AgentId::in_world(a.world(), in_a.entity());
+        assert_eq!(round.resolve_in(a.world()), Some(in_a.entity()));
+    }
+
+    /// The free functions a system calls refuse a foreign id, and do nothing.
+    ///
+    /// Each takes a `&mut World` and would otherwise act on whichever local
+    /// agent happened to share the raw entity: move it to another stage, seed it
+    /// from a stranger's context, or park it on a prompt it never asked for.
+    #[tokio::test]
+    async fn the_world_taking_helpers_refuse_a_foreign_agent_id() {
+        let mut a = build_world(ProviderRegistry::new());
+        let mut b = build_world(ProviderRegistry::new());
+        let in_a = spawn(&mut a);
+        let in_b = spawn(&mut b);
+        let before = b.agent_status(in_b);
+
+        // Stage transition: B's agent must not move because A asked.
+        let stage_before = b
+            .world()
+            .get::<crate::pipeline::StageCursor>(in_b.entity())
+            .map(|c| c.index);
+        crate::pipeline::force_transition(b.world_mut(), in_a, 1);
+        let stage_after = b
+            .world()
+            .get::<crate::pipeline::StageCursor>(in_b.entity())
+            .map(|c| c.index);
+        assert_eq!(stage_before, stage_after, "a foreign id moved a stage");
+
+        // Context seeding: nothing copied between worlds.
+        crate::context_transform::apply_context_transforms(b.world_mut(), in_a, in_a);
+
+        // A restored interaction point must not land on B's agent.
+        crate::interaction_points::restore_interaction_point(
+            b.world_mut(),
+            in_a,
+            crate::interaction_points::InteractionPointState {
+                cursor: 0,
+                round: 0,
+                body: "not for you".to_string(),
+            },
+        );
+        assert!(
+            b.world()
+                .get::<crate::components::AwaitingInteraction>(in_b.entity())
+                .is_none(),
+            "a foreign id parked B's agent on a prompt"
+        );
+
+        // And B's agent is exactly as it was.
+        assert_eq!(b.agent_status(in_b), before);
     }
 
     /// The hazard [`AgentId`] exists for, now closed.


### PR DESCRIPTION
## What

#325 gave `PipelineWorld`'s methods a world-scoped id. Four public functions
were left behind, still taking a bare `Entity` alongside a world:

```
force_transition(world, entity, target_idx)
apply_context_transforms(world, parent, child)
restore_interaction_point(world, entity, state)
WorldHost::wait_reason(entity)
```

**Why they were left:** the first three are called *from inside systems*, which
hold a `&mut bevy_ecs::World` and never a `PipelineWorld` — so there was no world
identity within reach to compare an id against.

## The fix: the world carries its own identity

`OwnWorldId` is inserted as a resource at construction, so **any** code holding a
`World` can ask which one it is:

```rust
AgentId::resolve_in(&World) -> Option<Entity>   // is this id mine?
AgentId::in_world(&World, Entity) -> AgentId    // scope a query result
```

Wrapping and resolving inside the same world always round-trips; across worlds it
never does.

All four now take an `AgentId` and do nothing when handed a foreign one — no
stage moved, no context seeded from a stranger's run, no prompt parked on an
agent that never asked for it, no other run's wait reason reported as this one's.

## One of the six stays `Entity`, deliberately

`BasicToolService`'s map is keyed by entity and stays that way:

- The service is built **once per `AgentWorld`**, and only that world's spawner
  writes to it — there is no second world to collide with.
- `ToolService::execute` is handed a bare `Entity` by the tool lane with **no
  world in reach**, so an `AgentId` key would have cost the trait and bought
  nothing.

The reason is recorded on the field rather than left for the next reader to
re-derive.

## Verification

Each guard has a test that hands it an id from a second world and asserts nothing
moved.

**`wait_reason`'s test is worth noting:** the first version passed for the wrong
reason — the two worlds happened to mint different raw entities, so it proved an
*absence*, not a refusal. It now spawns into the second world until the raw
entity genuinely collides.

Live, because this is the daemon's run bookkeeping:

```
control ops:  active -> paused -> active -> cancelled
```

| Provider | Model | Reply |
|---|---|---|
| anthropic | claude-haiku-4-5 | `PONG` |
| google | gemini-3.1-flash-lite | `PONG` |
| openrouter | google/gemini-3.5-flash | `PONG` |
| openai | gpt-5.4-nano | `PONG` |

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo xtask coverage` 100% on `leviath-runtime` and `leviath-cli`
