### PR TITLE
fix(spawn): a task the blueprint cannot hold is an error, not a shrug

### DIFF
--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -166,6 +166,28 @@ mod tests {
     use crate::commands::serve::types::ServerEvent;
     use crate::config::Config;
 
+    /// A default config whose ollama endpoint cannot answer.
+    ///
+    /// Ollama is always registered, so on a machine running `ollama serve` its
+    /// `list_models` *succeeds* and the `if let Ok(list)` in `models_with` never
+    /// takes its other arm - which made `cargo xtask coverage --package
+    /// leviath-cli` fail locally while passing in CI, where nothing is
+    /// listening. Port 1 is reserved and never bound, so the result stops
+    /// depending on what happens to be running on the developer's machine.
+    fn state_without_a_reachable_ollama() -> AppState {
+        let (tx, _) = broadcast::channel::<ServerEvent>(64);
+        AppState {
+            config: Arc::new(Config {
+                ollama_base_url: Some("http://127.0.0.1:1".to_string()),
+                ..Config::default()
+            }),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        }
+    }
+
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
@@ -358,9 +380,11 @@ mod tests {
 
     #[tokio::test]
     async fn get_models_returns_ok() {
+        // A reachable ollama would make `list_models` succeed and leave the
+        // other arm of `if let Ok(list)` unrun - see `state_without_a_reachable_ollama`.
         let app = Router::new()
             .route("/api/models", get(get_models))
-            .with_state(test_state());
+            .with_state(state_without_a_reachable_ollama());
         let req = Request::builder()
             .uri("/api/models")
             .body(Body::empty())

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use anyhow::bail;
-use leviath_core::layout::RegionSeed;
 use leviath_runtime::control_socket::{ControlClient, ControlResponse};
 use leviath_runtime::host::SpawnArgs;
 
@@ -77,18 +76,10 @@ fn resolve_regions(
     blueprint: &leviath_core::Blueprint,
     regions: HashMap<String, String>,
 ) -> anyhow::Result<HashMap<String, String>> {
-    let declared: Vec<String> = blueprint
-        .context_layout
-        .regions
-        .iter()
-        .filter_map(|r| match &r.seed {
-            Some(RegionSeed::CallerInput { name }) => Some(name.clone()),
-            _ => None,
-        })
-        .collect();
+    let declared = blueprint.caller_inputs();
     let mut out = HashMap::new();
     for (name, raw) in regions {
-        if !declared.contains(&name) {
+        if !declared.contains(&name.as_str()) {
             bail!(
                 "unknown region '--{name}'; this agent's caller-input regions are: {}",
                 if declared.is_empty() {
@@ -153,7 +144,9 @@ pub struct LaunchRequest<'a> {
 /// `task` is what `--task` was given, if anything. Left off, [`resolve_task`]
 /// opens the user's editor, which is why `stdin_is_terminal` is threaded
 /// through: the probe itself is real I/O and belongs to the binary, so callers
-/// inject it (tests pass a `fn` that always says no).
+/// inject it (tests pass a `fn` that always says no). None of that happens for a
+/// blueprint that takes no task: it is not asked for one, and giving it one is
+/// an error rather than text with nowhere to go.
 ///
 /// Regions are resolved *before* the task on purpose. A typo'd `--foo` has to
 /// fail before the user is dropped into an editor and types a paragraph they
@@ -174,12 +167,22 @@ pub fn resolve_spawn_args(req: LaunchRequest<'_>) -> anyhow::Result<SpawnArgs> {
     } = req;
     let source = load_agent_source(path)?;
     let resolved_regions = resolve_regions(&source.blueprint, regions)?;
-    let task = resolve_task(
-        task,
-        &source.blueprint.name,
-        &source.blueprint.description,
-        stdin_is_terminal,
-    )?;
+    // An agent driven by named regions takes no task, so neither demanding one
+    // nor opening an editor to write one would make sense - `lev run reviewer
+    // --diff @x.patch` is a complete command line. Handing it one anyway is the
+    // error, and it is the same message the daemon would give.
+    let task = match source.blueprint.accepts_task() {
+        true => resolve_task(
+            task,
+            &source.blueprint.name,
+            &source.blueprint.description,
+            stdin_is_terminal,
+        )?,
+        false => match task.map(str::trim).unwrap_or("") {
+            "" => String::new(),
+            _ => anyhow::bail!(source.blueprint.task_refusal()),
+        },
+    };
 
     Ok(SpawnArgs {
         run_id: new_run_id(&source.run_stem),
@@ -620,6 +623,117 @@ mod tests {
         })
         .unwrap_err();
         assert!(err.to_string().contains("No task provided"), "got: {err}");
+    }
+
+    /// A blueprint driven by named regions, taking no task at all.
+    fn write_taskless_manifest(dir: &std::path::Path) -> std::path::PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("agent.leviath"),
+            r#"
+[agent]
+name = "diffonly"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+diff = { kind = "pinned", max_tokens = 4000, seed = "diff" }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#,
+        )
+        .unwrap();
+        dir.join("agent.leviath")
+    }
+
+    /// `lev run diffonly --diff ...` is a complete command line, so no task is
+    /// demanded and no editor is opened - which is the whole reason the demand
+    /// is conditional rather than unconditional.
+    #[test]
+    fn an_agent_that_takes_no_task_is_not_asked_for_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_taskless_manifest(&dir.path().join("diffonly"));
+        let mut regions = HashMap::new();
+        regions.insert("diff".to_string(), "a patch".to_string());
+
+        let args = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: None,
+            // Says stdin is not a TTY, so an unconditional demand would error
+            // here rather than fall through to the editor.
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions,
+            no_seed_commands: false,
+            output_request: None,
+        })
+        .expect("no task is required of an agent that takes none");
+        assert_eq!(args.task, "");
+        assert_eq!(
+            args.regions.get("diff").map(String::as_str),
+            Some("a patch")
+        );
+    }
+
+    /// The other half: handing that agent a task is the error, and the message
+    /// points at the input it does take.
+    #[test]
+    fn an_agent_that_takes_no_task_refuses_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_taskless_manifest(&dir.path().join("diffonly"));
+
+        let err = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("review my code"),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("declares no region to put it in"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("it takes: diff"), "got: {msg}");
+    }
+
+    /// A `--task` of nothing but whitespace is the same as none, so it must not
+    /// trip the refusal.
+    #[test]
+    fn a_blank_task_is_not_a_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = write_taskless_manifest(&dir.path().join("diffonly"));
+
+        let args = resolve_spawn_args(LaunchRequest {
+            path: manifest.to_str().unwrap(),
+            task: Some("   "),
+            stdin_is_terminal: &never_interactive,
+            model: None,
+            workdir: "/work",
+            yolo: false,
+            allow: Vec::new(),
+            max_depth: None,
+            regions: HashMap::new(),
+            no_seed_commands: false,
+            output_request: None,
+        })
+        .expect("blank is the same as absent");
+        assert_eq!(args.task, "");
     }
 
     /// Pins the ordering: a typo'd region flag must fail *before* the user is

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -376,7 +376,8 @@ mod tests {
     fn two_stage_manifest() -> String {
         "[agent]\nname = \"host\"\nversion = \"0.1.0\"\ndescription = \"d\"\nentry_stage = \"first\"\n\n\
          [stages.first]\nmodel = { provider = \"anthropic\", model = \"m\" }\nsystem_prompt = \"first\"\n\n\
-         [stages.second]\nmodel = { provider = \"anthropic\", model = \"m\" }\nallow_as_worker = true\nsystem_prompt = \"second\"\n"
+         [stages.second]\nmodel = { provider = \"anthropic\", model = \"m\" }\nallow_as_worker = true\nsystem_prompt = \"second\"\n\n\
+         [context.regions]\ntask = { kind = \"pinned\", max_tokens = 2000 }\n"
             .to_string()
     }
 
@@ -627,9 +628,14 @@ mod tests {
         std::fs::create_dir_all(&bad_dir).unwrap();
         std::fs::write(
             bad_dir.join("agent.leviath"),
+            // The `task` region is not incidental: a fan-out hands each worker
+            // its item as the task, and a worker with nowhere to put one is
+            // refused before validation ever runs - which would make this test
+            // pass on the wrong error.
             "[agent]\nname = \"bad\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
              [stages.only]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
-             [stages.only.transitions.nowhere]\n",
+             [stages.only.transitions.nowhere]\n\n\
+             [context.regions]\ntask = { kind = \"pinned\", max_tokens = 500 }\n",
         )
         .unwrap();
         let err = spawner

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -1010,7 +1010,7 @@ available_tools = ["stub_search"]
 system_prompt = "use stub_search"
 
 [context.regions]
-task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller_input = "task" }} }}
+task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
 "#,
                 stub_py.to_string_lossy()
             ),

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -3985,11 +3985,13 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
                 .expect("every bundled agent ships an agent.leviath");
             let bp = leviath_core::manifest::parse_manifest(content)
                 .expect("every bundled agent's manifest parses");
-            let args = args_with("a task", HashMap::new(), "/w");
-            let refused =
-                resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths()).is_err();
+            // The question is `accepts_task`, not "did `resolve_seeds` error".
+            // Driving the whole resolver here reported `coder` as refusing a
+            // task on Windows only, because one of its *path* seeds failed
+            // against the fixture workdir - an unrelated error the proxy could
+            // not tell apart from the one under test.
             assert!(
-                !(content.contains("--task") && refused),
+                !content.contains("--task") || bp.accepts_task(),
                 "{name} tells the user to pass --task but declares no region to hold one"
             );
         }

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -1118,7 +1118,10 @@ system = { kind = "pinned", max_tokens = 1000 }
         SpawnArgs {
             run_id: "run-x".to_string(),
             blueprint_path: path.to_string(),
-            task: "do the thing".to_string(),
+            // No task by default: most of these fixtures declare no region to
+            // receive one, and supplying a task a blueprint cannot hold is now
+            // refused. Tests that care about the task set it explicitly.
+            task: String::new(),
             regions: HashMap::new(),
             model: None,
             workdir: std::env::temp_dir().to_string_lossy().to_string(),
@@ -1594,8 +1597,11 @@ system = { kind = "pinned", max_tokens = 1000 }
         let manifest = dir.path().join("agent.leviath");
         std::fs::write(
             &manifest,
+            // Titling is gated on a non-empty task, so this blueprint has to
+            // accept one - a region named `task` picks it up implicitly.
             "[agent]\nname = \"titler\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
-             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [context.regions]\ntask = { kind = \"pinned\", max_tokens = 1000 }\n",
         )
         .unwrap();
         let (mut world, cli) = test_world();
@@ -1613,7 +1619,10 @@ system = { kind = "pinned", max_tokens = 1000 }
                 now_secs: 100,
                 subagent_tx: sub_tx(),
             },
-            &spawn_args(&manifest.to_string_lossy()),
+            &SpawnArgs {
+                task: "title me".to_string(),
+                ..spawn_args(&manifest.to_string_lossy())
+            },
         )
         .expect("spawn succeeds");
         assert!(
@@ -3226,6 +3235,14 @@ system_prompt = "be brief"
     // ─── resolve_seeds ────────────────────────────────────────────────────────
 
     fn bp(regions_toml: &str) -> Blueprint {
+        // A region named `task` picks up the caller's task implicitly, which is
+        // how a real blueprint accepts one - and without it a supplied task is
+        // refused. Skipped when the caller declares its own, or the key would
+        // be duplicated.
+        let implicit_task = match regions_toml.contains("task") {
+            true => "",
+            false => "task = { kind = \"pinned\", max_tokens = 1000 }",
+        };
         let toml = format!(
             r#"
 [agent]
@@ -3240,6 +3257,7 @@ model = "claude-sonnet-5"
 
 [context.regions]
 {regions_toml}
+{implicit_task}
 conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
 "#
         );
@@ -3871,5 +3889,109 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let scripts = resolve_stage_hook_scripts(&blueprint, bp_path.to_str().expect("utf8"))
             .expect("a script beside the blueprint loads");
         assert!(scripts.contains_key("h.rhai"));
+    }
+
+    // ─── A task the blueprint cannot hold ───────────────────────────────────
+
+    /// The same fixture as [`bp`] but without the implicit `task` region, for
+    /// the tests that are *about* a blueprint which accepts no task.
+    fn bp_taking_no_task(regions_toml: &str) -> Blueprint {
+        let toml = format!(
+            r#"
+[agent]
+name = "seedy"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+{regions_toml}
+conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
+"#
+        );
+        leviath_core::manifest::parse_manifest(&toml).unwrap()
+    }
+
+    #[test]
+    fn a_task_the_blueprint_cannot_hold_is_refused() {
+        // Observed live: an agent handed a task it had no region for answered
+        // "I'm ready, what would you like?" and finished successfully, having
+        // spent a full turn on a question nobody asked.
+        let bp = bp_taking_no_task(r#"notes = { kind = "pinned", max_tokens = 100 }"#);
+        let args = args_with("do the thing", HashMap::new(), "/w");
+        let err = resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
+            .expect_err("a task with nowhere to go should be refused");
+        assert!(err.contains("declares no region to put it in"), "{err}");
+        // The message has to say what the agent *does* take, or the user is left
+        // guessing which flag to reach for instead.
+        assert!(err.contains("takes no caller input at all"), "{err}");
+    }
+
+    #[test]
+    fn the_refusal_names_the_input_the_agent_does_take() {
+        let bp =
+            bp_taking_no_task(r#"diff = { kind = "pinned", max_tokens = 100, seed = "diff" }"#);
+        let args = args_with("do the thing", HashMap::new(), "/w");
+        let err =
+            resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths()).expect_err("refused");
+        assert!(err.contains("it takes: diff"), "{err}");
+    }
+
+    #[test]
+    fn an_agent_driven_by_named_regions_still_spawns_with_no_task() {
+        // `lev run reviewer --diff @x.patch` supplies no task at all. Refusing
+        // *that* would break every agent that takes named input instead.
+        let bp =
+            bp_taking_no_task(r#"diff = { kind = "pinned", max_tokens = 100, seed = "diff" }"#);
+        let mut regions = HashMap::new();
+        regions.insert("diff".to_string(), "a patch".to_string());
+        let args = args_with("", regions, "/w");
+        let seeds = resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
+            .expect("no task was supplied, so there is nothing to refuse");
+        assert_eq!(seeds.get("diff").map(String::as_str), Some("a patch"));
+    }
+
+    #[test]
+    fn a_whitespace_only_task_is_not_treated_as_a_task() {
+        let bp = bp_taking_no_task(r#"notes = { kind = "pinned", max_tokens = 100 }"#);
+        let args = args_with("   \n ", HashMap::new(), "/w");
+        resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
+            .expect("blank is the same as absent");
+    }
+
+    /// Every bundled agent that tells the user to pass `--task` can hold one.
+    ///
+    /// The refusal above is only safe if no shipped agent trips it while being
+    /// driven the documented way. `reviewer` takes `--diff`, not `--task`, and
+    /// that is fine; what would not be fine is an agent whose own description
+    /// says `--task` while its blueprint has nowhere to put it.
+    #[test]
+    fn every_bundled_agent_that_documents_a_task_accepts_one() {
+        for agent in crate::bundled::BUNDLED_AGENTS {
+            let name = agent.name;
+            // Static `expect` messages rather than an interpolated `panic!`:
+            // both facts already have their own named test (`bundled.rs` for
+            // the manifest's presence, `manifest_integration.rs` for its
+            // parse), so naming the agent here buys nothing and the closure
+            // would leave a region no test can reach.
+            let (_, content) = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .expect("every bundled agent ships an agent.leviath");
+            let bp = leviath_core::manifest::parse_manifest(content)
+                .expect("every bundled agent's manifest parses");
+            let args = args_with("a task", HashMap::new(), "/w");
+            let refused =
+                resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths()).is_err();
+            assert!(
+                !(content.contains("--task") && refused),
+                "{name} tells the user to pass --task but declares no region to hold one"
+            );
+        }
     }
 }

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -88,6 +88,18 @@ pub(super) fn resolve_seeds(
     // Unknown caller keys are tolerated here (silently unused): the CLI already
     // rejects typos client-side in `resolve_spawn_args`, and an ACP host sending
     // a stray `---region:...---` marker shouldn't fail the whole turn over it.
+    //
+    // `task` is the exception, because it is not a stray marker - it is the
+    // request. A blueprint that seeds no region from it drops the task on the
+    // floor and runs anyway: the agent answers a question nobody asked, having
+    // spent the tokens to do it. Four different models were observed replying
+    // "I'm ready, what would you like?" to a task that had been supplied.
+    // Refusing here costs one clear error instead of a plausible-looking run.
+    // The CLI refuses this earlier and with the same message, but the API and
+    // ACP paths do not go through the CLI at all, so the check lives here too.
+    if !args.task.trim().is_empty() && !blueprint.accepts_task() {
+        return Err(blueprint.task_refusal());
+    }
 
     let base = std::path::Path::new(workdir);
     let mut seeds: HashMap<String, String> = HashMap::new();

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -596,6 +596,12 @@ description = "child"
 
 [stages.main]
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+
+# Every caller here spawns the child with a task, and a child with nowhere to
+# put one is refused - which is the point: a sub-agent that silently discards
+# its parent's instructions is the failure this fixture would otherwise model.
+[context.regions]
+task = { kind = "pinned", max_tokens = 1000 }
 "#,
         )
         .unwrap();

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -263,6 +263,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
         );
     }
 
+    findings.extend(lint_dropped_seeds(&declared, blueprint));
     findings.extend(lint_command_seeds(blueprint));
     findings.extend(lint_read_paths(blueprint, env));
     findings.extend(lint_safe_commands(blueprint, env));
@@ -289,6 +290,43 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
     findings
 }
 
+/// A region wrote a `seed` the parser could not read, so it has none.
+///
+/// `parse_region_seed` returns `None` for a seed table with no recognized key
+/// and for a seed that is neither a string nor a table, and the region then
+/// simply starts empty. That is deliberate - an unknown key is not worth
+/// rejecting a whole manifest over - but it is invisible, and a one-character
+/// typo (`caller_input` for `caller`) reads exactly like a working blueprint
+/// until an agent answers a question it was never given. This is the check that
+/// says so.
+fn lint_dropped_seeds(declared: &Declared, blueprint: &Blueprint) -> Vec<LintFinding> {
+    declared
+        .seeded_regions
+        .iter()
+        .filter(|name| {
+            blueprint
+                .context_layout
+                .get_region(name)
+                .is_some_and(|r| r.seed.is_none())
+        })
+        .map(|name| {
+            LintFinding::new(
+                LintSeverity::Warning,
+                "region-seed-not-understood",
+                format!(
+                    "region '{name}' declares a seed that isn't one of the \
+                     recognized forms, so it is ignored and the region starts empty"
+                ),
+            )
+            .with_fix(
+                "use a string (the caller input key), or one of \
+                 { caller = }, { literal = }, { files = }, { glob = }, \
+                 { rhai = }, { command = }",
+            )
+        })
+        .collect()
+}
+
 // ─── Declared keys ────────────────────────────────────────────────────────────
 
 /// Which optional keys the manifest text actually writes, per stage, plus the
@@ -297,6 +335,9 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
 struct Declared {
     /// A top-level `[model]` table exists. Nothing reads it.
     agent_model_block: bool,
+    /// Regions whose text writes a `seed` key, whatever its shape. Compared
+    /// against the parsed seed to catch the ones the parser threw away.
+    seeded_regions: Vec<String>,
     /// Per stage name, the keys that stage wrote.
     stages: HashMap<String, StageKeys>,
     /// The manifest text could not be re-read. Every key is then reported as
@@ -322,6 +363,22 @@ impl Declared {
             };
         };
         let agent_model_block = root.get("model").is_some_and(toml::Value::is_table);
+        // Both region spellings - inline `name = { seed = ... }` under
+        // `[context.regions]` and a `[context.regions.name]` section - land here
+        // as the same nested table, so one path covers both.
+        let seeded_regions = root
+            .get("context")
+            .and_then(toml::Value::as_table)
+            .and_then(|c| c.get("regions"))
+            .and_then(toml::Value::as_table)
+            .map(|regions| {
+                regions
+                    .iter()
+                    .filter(|(_, body)| body.get("seed").is_some())
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
         let stages = root
             .get("stages")
             .and_then(toml::Value::as_table)
@@ -341,6 +398,7 @@ impl Declared {
             .unwrap_or_default();
         Self {
             agent_model_block,
+            seeded_regions,
             stages,
             opaque: false,
         }

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -184,6 +184,73 @@ fn an_agent_level_model_block_is_warned_about() {
     assert!(findings[0].stage.is_none(), "{findings:?}");
 }
 
+// ─── Seeds the parser threw away ──────────────────────────────────────────────
+
+/// A seed table with no key the parser recognizes leaves the region empty.
+///
+/// This is what a one-character typo looks like, and it is what a "coder-shaped"
+/// fixture in this repo shipped with for months: `caller_input` instead of
+/// `caller`, silently seeding nothing.
+#[test]
+fn a_seed_table_with_no_recognized_key_is_warned_about() {
+    let toml = format!(
+        "{}\n[context.regions.notes]\nkind = \"pinned\"\nmax_tokens = 100\n\
+         seed = {{ caller_input = \"task\" }}\n",
+        manifest(CLEAN_STAGE)
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["region-seed-not-understood"]);
+    assert!(findings[0].message.contains("notes"), "{findings:?}");
+}
+
+/// A seed that is neither a string nor a table goes the same way.
+#[test]
+fn a_seed_of_the_wrong_type_is_warned_about() {
+    let toml = format!(
+        "{}\n[context.regions.notes]\nkind = \"pinned\"\nmax_tokens = 100\nseed = 42\n",
+        manifest(CLEAN_STAGE)
+    );
+    assert_eq!(
+        codes(&lint(&toml, &LintEnv::default())),
+        ["region-seed-not-understood"]
+    );
+}
+
+/// Every recognized form stays silent, so the check cannot become noise.
+#[test]
+fn the_recognized_seed_forms_are_not_warned_about() {
+    for seed in [
+        r#""task""#,
+        r#""input""#,
+        r#"{ caller = "extra" }"#,
+        r#"{ literal = "x" }"#,
+        r#"{ files = ["a.txt"] }"#,
+        r#"{ glob = "*.rs" }"#,
+        r#"{ rhai = "\"x\"" }"#,
+        r#"{ command = "git ls-files" }"#,
+    ] {
+        let toml = format!(
+            "{}\n[context.regions.notes]\nkind = \"pinned\"\nmax_tokens = 100\nseed = {seed}\n",
+            manifest(CLEAN_STAGE)
+        );
+        let codes = codes(&lint(&toml, &LintEnv::default()));
+        assert!(
+            !codes.contains(&"region-seed-not-understood"),
+            "seed {seed} was reported as unreadable: {codes:?}"
+        );
+    }
+}
+
+/// A region with no `seed` key at all is not a dropped seed.
+#[test]
+fn a_region_declaring_no_seed_is_not_warned_about() {
+    let findings = lint(&manifest(CLEAN_STAGE), &LintEnv::default());
+    assert!(
+        !codes(&findings).contains(&"region-seed-not-understood"),
+        "{findings:?}"
+    );
+}
+
 // ─── Declared: the fallbacks ──────────────────────────────────────────────────
 
 /// Text the linter cannot re-read yields no declaration findings at all, rather

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -39,7 +39,9 @@ pub(crate) fn write_test_agent(
 /// those tests exercise spawn/reload *logic*, not the shipped blueprint, so they
 /// must stay isolated from blueprint edits. Budgets are absolute (window-
 /// independent) so a fake small-context test model can't starve the region the
-/// stage system prompt is injected into.
+/// stage system prompt is injected into. The `task` region is load-bearing:
+/// every caller spawns this with a task, and a blueprint with nowhere to put one
+/// is refused at spawn.
 #[cfg(test)]
 pub(crate) fn inline_coder_manifest() -> String {
     r#"[agent]
@@ -82,6 +84,7 @@ system_prompt = "Review the implementation."
 
 [context.regions]
 system = { kind = "pinned", max_tokens = 8000 }
+task = { kind = "pinned", max_tokens = 2000 }
 codebase = { kind = "temporary", max_tokens = 20000 }
 conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
 "#

--- a/crates/leviath-cli/tests/agent_end_to_end.rs
+++ b/crates/leviath-cli/tests/agent_end_to_end.rs
@@ -47,8 +47,11 @@ use leviath_runtime::{AgentStatus, ProviderRegistry};
 /// call and the test passes while proving nothing. Asking "have I already been
 /// handed a tool result?" cannot drift that way.
 struct WritesThenAnswers {
-    /// Workdir-relative path the model asks to create.
-    target: String,
+    // No target field, deliberately: handing the provider the filename would
+    // let this test pass with the task text dropped somewhere between `--task`
+    // and the prompt, which is a bug this repo has actually shipped. The target
+    // is read back out of the prompt instead, so the file on disk is evidence
+    // that the task arrived.
     /// How many times the model was consulted *after* the tool had run, so the
     /// test can prove the result made it back into context.
     ///
@@ -60,6 +63,25 @@ struct WritesThenAnswers {
 }
 
 impl WritesThenAnswers {
+    /// The word after `write ` in whatever the model was shown.
+    ///
+    /// Scans the system blocks as well as the messages, because which of the
+    /// two a pinned region is rendered into is the context assembler's business
+    /// and not something this test should pin.
+    fn target_from_prompt(request: &InferenceRequest) -> Option<String> {
+        let from_system = request.system.iter().map(|b| b.text.clone());
+        let from_messages = request.messages.iter().filter_map(|m| match &m.content {
+            MessageContent::Text(t) => Some(t.clone()),
+            MessageContent::Blocks(_) => None,
+        });
+        from_system.chain(from_messages).find_map(|text| {
+            text.split_whitespace()
+                .skip_while(|w| !w.eq_ignore_ascii_case("write"))
+                .nth(1)
+                .map(str::to_string)
+        })
+    }
+
     fn already_ran_the_tool(request: &InferenceRequest) -> bool {
         request.messages.iter().any(|m| match &m.content {
             MessageContent::Blocks(blocks) => blocks
@@ -85,7 +107,8 @@ impl Provider for WritesThenAnswers {
                 id: "call-1".to_string(),
                 name: "write_file".to_string(),
                 arguments: serde_json::json!({
-                    "path": self.target,
+                    "path": Self::target_from_prompt(request)
+                        .unwrap_or_else(|| "the-task-never-arrived".to_string()),
                     "content": "written by the agent\n",
                 }),
                 thought_signature: None,
@@ -142,6 +165,13 @@ model = { provider = "e2e", model = "m" }
 description = "Write the file"
 available_tools = ["write_file"]
 system_prompt = "Write the file you were asked for, then stop."
+
+# Without this the task text has nowhere to land, and the run would answer a
+# question it was never given. The provider below reads its target back out of
+# the prompt, so a missing region fails the test rather than passing it.
+[context.regions]
+task = { kind = "pinned", max_tokens = 500, seed = "task" }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
 "#
 }
 
@@ -165,7 +195,6 @@ async fn an_agent_runs_a_tool_and_the_file_lands_on_disk() {
     providers.register(
         "e2e".to_string(),
         Arc::new(WritesThenAnswers {
-            target: "output.txt".to_string(),
             answering_turns: answering_turns.clone(),
         }),
     );

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -6,7 +6,7 @@
 //! shared, installed, and versioned.
 
 use crate::error::ValidationError;
-use crate::layout::ContextLayout;
+use crate::layout::{ContextLayout, RegionSeed};
 use crate::lifecycle::CompactionConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -189,6 +189,55 @@ impl Blueprint {
             safe_commands: None,
             output: None,
         }
+    }
+
+    /// Whether any region is seeded from the caller's `task`.
+    ///
+    /// The blueprint's answer to "do you take a task?", which is a different
+    /// question from whether one was supplied. An agent driven by named regions
+    /// (`reviewer` takes `--diff` and `--criteria`) answers no, and handing it a
+    /// task would put that text nowhere at all - so both the CLI, before it asks
+    /// for one, and the daemon, before it spawns, ask this first.
+    pub fn accepts_task(&self) -> bool {
+        self.context_layout
+            .regions
+            .iter()
+            .any(|r| matches!(&r.seed, Some(RegionSeed::CallerInput { name }) if name == "task"))
+    }
+
+    /// The caller input keys this blueprint does read, in declaration order.
+    ///
+    /// Used to turn "that agent takes no task" into a message naming what it
+    /// takes instead, which is the difference between a dead end and a fix.
+    pub fn caller_inputs(&self) -> Vec<&str> {
+        self.context_layout
+            .regions
+            .iter()
+            .filter_map(|r| match &r.seed {
+                Some(RegionSeed::CallerInput { name }) => Some(name.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Why a task cannot be given to this blueprint, phrased for the user.
+    ///
+    /// One message rather than two, because the CLI refuses before it asks for a
+    /// task and the daemon refuses before it spawns, and a user who hit one and
+    /// then the other should not be told two different things.
+    pub fn task_refusal(&self) -> String {
+        let inputs = self.caller_inputs();
+        let takes = match inputs.is_empty() {
+            true => "it takes no caller input at all".to_string(),
+            false => format!("it takes: {}", inputs.join(", ")),
+        };
+        format!(
+            "agent '{}' was given a task but declares no region to put it in, so the task \
+             would be ignored - {takes}. Add a region seeded from the task, for example:\n\
+             [context.regions]\ntask = {{ kind = \"pinned\", max_tokens = 2000, \
+             required = true, seed = \"task\" }}",
+            self.name,
+        )
     }
 
     /// Agent-level tool permissions, keyed by tool name.
@@ -492,6 +541,65 @@ mod tests {
     use crate::layout::ContextLayout;
     use crate::layout::RegionDefinition;
     use crate::region::RegionKind;
+
+    /// Build a blueprint from a manifest, so these read as the TOML an author
+    /// would actually write rather than as hand-assembled structs.
+    fn bp_with_regions(regions_toml: &str) -> Blueprint {
+        crate::manifest::parse_manifest(&format!(
+            r#"
+[agent]
+name = "asked"
+
+[stages.main]
+mode = "autonomous"
+model = {{ provider = "anthropic", model = "m" }}
+
+[context.regions]
+{regions_toml}
+"#
+        ))
+        .expect("fixture parses")
+    }
+
+    #[test]
+    fn a_blueprint_accepts_a_task_when_some_region_seeds_from_it() {
+        // Both spellings: the explicit seed and the region named `task`, which
+        // gets the same seed implicitly.
+        assert!(
+            bp_with_regions(r#"brief = { kind = "pinned", max_tokens = 10, seed = "task" }"#)
+                .accepts_task()
+        );
+        assert!(bp_with_regions(r#"task = { kind = "pinned", max_tokens = 10 }"#).accepts_task());
+    }
+
+    #[test]
+    fn a_blueprint_taking_other_caller_input_does_not_accept_a_task() {
+        let bp = bp_with_regions(r#"diff = { kind = "pinned", max_tokens = 10, seed = "diff" }"#);
+        assert!(!bp.accepts_task());
+        assert_eq!(bp.caller_inputs(), ["diff"]);
+    }
+
+    #[test]
+    fn the_refusal_names_what_the_agent_takes_instead() {
+        let bp = bp_with_regions(
+            r#"diff = { kind = "pinned", max_tokens = 10, seed = "diff" }
+criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
+        );
+        let msg = bp.task_refusal();
+        assert!(msg.contains("agent 'asked'"), "{msg}");
+        assert!(msg.contains("it takes: diff, criteria"), "{msg}");
+    }
+
+    #[test]
+    fn the_refusal_says_so_when_the_agent_takes_nothing() {
+        let bp = bp_with_regions(r#"notes = { kind = "pinned", max_tokens = 10 }"#);
+        assert!(bp.caller_inputs().is_empty());
+        // Bound rather than called inside the assert message: a message
+        // expression only runs when the assert fails, so it would be an
+        // uncovered region on every green run.
+        let msg = bp.task_refusal();
+        assert!(msg.contains("it takes no caller input at all"), "{msg}");
+    }
 
     #[test]
     fn resolve_nudge_defaults_when_nothing_is_configured() {

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -78,7 +78,9 @@ dropped.
 > [!NOTE]
 > `--task` fills the caller-input key `task`. A blueprint receives it only if some region asks for
 > that key, either with `seed = "task_input"` or by being named `task` (which gets the seed
-> implicitly). A blueprint with neither has nowhere to put the prompt, and it is dropped.
+> implicitly). Passing a task to a blueprint with neither is refused at spawn rather than dropped,
+> because the run would otherwise answer a question it was never given. The error names the caller
+> input the agent does take, so `lev run reviewer -t "..."` points you at `--diff` instead.
 
 #### Writing the task in your editor
 
@@ -124,6 +126,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
 | warning | `stage-missing-max-iterations` | Unbounded unless `[limits] default_max_iterations` is set. Fan-out stages are exempt. |
 | warning | `agent-model-block-ignored` | A top-level `[model]` block. Nothing reads it; model selection is per stage. |
+| warning | `region-seed-not-understood` | A region's `seed` is not one of the recognized forms, so it is ignored and the region starts empty. Usually a typo in the table key: it is `{ caller = "task" }`, not `{ caller_input = "task" }`. |
 | warning | `blocking-tool-in-autonomous-stage` | An autonomous stage grants `ask_user_*`, `present_for_review` or `edit_document`. With nobody attached the run parks there until it is killed. Set `allow_blocking_tools = true` on the stage to say you meant it. |
 | warning | `implicit-shell-policy` | A shell grant with no policy behind it. The default is `ask`, and an unattended run waits on that prompt rather than being denied. |
 | warning | `unknown-model` | A model this build has not heard of, checked only against providers with a closed catalog. Ollama, OpenRouter and script providers are never checked. |

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -145,6 +145,12 @@ inherited = { kind = "pinned", seed = { caller = "brief" } }
 A region literally named `task` gets `seed = "task_input"` implicitly, so older blueprints keep
 working.
 
+A `seed` that matches none of the forms above is ignored and the region starts empty. `lev validate`
+reports that as `region-seed-not-understood`, which is worth reading before wondering why a region
+came out blank: the table keys are exactly the ones in the left column, so `{ caller_input = "..." }`
+is a typo for `{ caller = "..." }` and seeds nothing. And a blueprint that seeds no region from the
+task refuses a task outright rather than running without it.
+
 > [!WARNING]
 > A `command` seed runs at spawn, before the first inference and therefore before any tool-approval
 > prompt. Because there is nobody to ask in the moment, it must also be covered by


### PR DESCRIPTION
## The bug

A blueprint receives `--task` only if some region seeds from the caller key
`task`. One that seeds no region from it had the text **dropped on the floor and
ran anyway** — the agent answered a question nobody asked, having spent the
tokens to do it, and reported `complete`. Four different models were observed
replying "I'm ready, what would you like?" to a task that had in fact been
supplied.

## The fix

Both ends refuse it, with one message:

```
agent 'reviewer' was given a task but declares no region to put it in, so the
task would be ignored - it takes: diff, criteria. Add a region seeded from the
task, for example:
[context.regions]
task = { kind = "pinned", max_tokens = 2000, required = true, seed = "task" }
```

`Blueprint::accepts_task` / `caller_inputs` / `task_refusal` live in
`leviath-core`, so the CLI and the daemon answer the same question the same way.
The daemon check is **not** redundant with the CLI one: the API and ACP paths
never touch the CLI.

### The CLI also stops demanding a task the agent cannot use

This turned up while verifying live, and without it the change would have been a
regression. `lev run` required a task *unconditionally*, so an agent driven by
named regions was about to become unrunnable: `lev run reviewer --diff @x.patch`
errored with "No task provided" if you left `-t` off, and would now error on the
task if you passed it. It asks only when the blueprint can hold one.

## Three fixtures were relying on the old behaviour

Which is the evidence that this is worth catching at all:

| Fixture | What it was hiding |
|---|---|
| `inline_coder_manifest` | "coder-shaped" with no task region, while the real `coder` has one |
| the sub-agent fixture | the `spawn_agent` tool's task went nowhere |
| `agent_end_to_end` | the provider was **handed** the filename to write, so the test passed with the task dropped |

The last one is fixed properly rather than papered over: the provider reads its
target back out of the prompt, so the file on disk is evidence the task arrived.

**Proven by mutation, not by rerunning** — changing only the task wording
(`"write output.txt"` → `"create output.txt"`) fails the test.

## Bonus: a seed the parser could not read was invisible

`{ caller_input = "task" }` is a typo for `{ caller = "task" }`. It matches no
recognized key, parses to no seed at all, and the region silently starts empty —
which is exactly how the `setup.rs` fixture above came to be wrong, apparently
for months.

`lev validate` now reports `region-seed-not-understood`. Deliberately a warning
and not a parse error: an unknown key is not worth rejecting a whole manifest
over, it just should not be invisible. Every recognized form is pinned as silent
so the check cannot become noise.

## Verification

Live, against a real daemon and a real provider on an isolated `LEVIATH_HOME`:

| Command | Result |
|---|---|
| `lev run noholder -t "..."` | refused, naming `notes` as what it takes |
| `lev run noholder --notes "..."` | runs, no task demanded |
| `lev run holder -t "..."` | runs, text lands in the `task` region |

The run contexts confirm placement: the text appears under `name: task` for the
first agent and `name: notes` for the second.

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets --all-features` clean
- `cargo xtask coverage` 100% on `leviath-core` and `leviath-cli`
- `cargo xtask docs --check` clean

Two coverage traps hit on the way, both from the known list: an
`unwrap_or_else(|| panic!(...))` leaves a region no green run reaches, and an
expression inside an `assert!` message is only evaluated on failure.

## One behaviour note

`reviewer` is the only bundled agent that takes no task, and `lev run reviewer -t
"..."` now errors instead of silently ignoring the text. That is the intended
effect. A test asserts no bundled agent that documents `--task` is caught by it.
