### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-08
+
 - **Security.** `uniq`, `tree` and `rg` are no longer on the default safe-command
   list. Each violated the rule that list states about itself - an entry "must
   not be able to write a file, execute another program, or open a network
@@ -258,6 +260,17 @@ same list.
   name check the caller already does, and `ToolRegistry`'s `all_tools`,
   `find_tool` and `server_tools` were superseded by the advertised-name map.
   Callers of `add_client` want `add_client_advertised(name, client, &advertised)`.
+- Breaking: giving an agent a task it declares no region for is an error rather
+  than a silent drop. Such a run used to spawn anyway and answer a question
+  nobody asked, having spent the tokens to do it, and report `complete`. The
+  error names the caller input the agent does take. Of the shipped agents only
+  `reviewer` is affected, and only when passed `--task`: it takes `--diff` and
+  `--criteria`. `lev run` no longer demands a task for an agent that takes none
+  either, so `lev run reviewer --diff @x.patch` is now a complete command line.
+- `lev validate` reports `region-seed-not-understood` for a `seed` that matches
+  none of the recognized forms. Such a seed is ignored and the region starts
+  empty, which is what a typo looks like: it is `{ caller = "task" }`, and
+  `{ caller_input = "task" }` silently seeds nothing.
 
 ## 0.2.0 - 2026-08-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "fs4",
  "keyring",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -95,17 +95,17 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.2.0" }
-leviath-core = { path = "crates/leviath-core", version = "0.2.0" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.2.0" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.2.0" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.2.0" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.2.0" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.2.0" }
-leviath-package = { path = "crates/leviath-package", version = "0.2.0" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.2.0" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.2.0" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.2.0" }
+leviath = { path = "crates/leviath", version = "0.3.0" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.0" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.0" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.0" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.0" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.0" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.0" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.0" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.0" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.0" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.0" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.2.0", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.0", optional = true }
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }


### PR DESCRIPTION
## What

`cargo xtask version 0.3.0`. **Merging this cuts the alpha** — `alpha.yml`
triggers on a push to `main` touching `Cargo.toml`, and `check-version` rules on
whether anything actually ships.

169 commits have landed since 0.2.0 and the version never moved for any of them,
so none of it is reachable from a channel today.

## Why a minor, not a patch

The release carries behaviour changes, several of them security fixes that
tighten defaults — safe-list removals (`uniq`, `tree`, `rg`), shell environment
filtering on by default, blueprints no longer able to loosen a tool policy you
never configured, seed commands gated on the safe list, and the task refusal
below. On a 0.x line that is a minor.

## Contents

- 13/13 version declarations rewritten: `[workspace.package]`, the 11
  `[workspace.dependencies]` pins, and `leviath-cli`'s allocator pin (which lives
  outside the workspace table on purpose and is invisible from the root)
- `Cargo.lock` updated, since CI rejects a lockfile that disagrees
- `## Unreleased` rolled to `## 0.3.0 - 2026-08-08`

Two changelog entries added first, for work that had merged without them. Both
are user-visible and belong in the release notes rather than in a surprise:

- giving an agent a task it declares no region for is now an error. Of the
  shipped agents only `reviewer` is affected, and only when passed `--task`
- `lev validate` reports `region-seed-not-understood`

## Verification

- `cargo xtask version --check` — every pin matches, both `[profile.release]`
  blocks agree
- `cargo test --workspace` green
- `cargo xtask docs --check` clean

## Note on channels

Only alpha is cut by this. Beta and prod are cron-driven (Monday and Thursday,
16:00 UTC), so **Monday's beta run will promote 0.3.0 on its own** unless it is
held deliberately.
