### PR TITLE
feat(providers): allow custom gateway via base_url and model capabilities

### DIFF
--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -34,10 +34,25 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
         // providers the user skipped, and registering one produces a provider
         // that authenticates as nobody and fails at the first call.
         if let Some(key) = key.map(str::trim).filter(|k| !k.is_empty()) {
+            // Generic base_url comes from [model_providers.<name>] - no per-provider fields.
+            // Env fallback lets enterprise proxy work without a file: ANTHROPIC_BASE_URL etc.
+            let base_url = config
+                .model_providers
+                .get(name)
+                .and_then(|mp| mp.base_url.clone())
+                .or_else(|| match name {
+                    "anthropic" => std::env::var("ANTHROPIC_BASE_URL").ok(),
+                    "openai" => std::env::var("OPENAI_BASE_URL").ok(),
+                    "google" => std::env::var("GOOGLE_BASE_URL").ok(),
+                    "openrouter" => std::env::var("OPENROUTER_BASE_URL").ok(),
+                    _ => None,
+                })
+                .map(|u| u.trim().to_string())
+                .filter(|u| !u.is_empty());
             creds.push(ProviderCreds {
                 name: name.to_string(),
                 api_key: Some(key.to_string()),
-                base_url: None,
+                base_url,
                 model_capabilities: caps.clone(),
                 request_timeout_secs: timeout,
                 rate_limit: config.rate_limits.get(name).cloned(),

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -149,7 +149,7 @@ impl AnthropicProvider {
                 .base_url
                 .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string()),
             rate_limiter,
-            capability_overrides: HashMap::new(),
+            capability_overrides: config.model_capabilities,
             cache_ttl: CacheTtl::default(),
         }
     }

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -108,7 +108,7 @@ impl GeminiProvider {
                 "https://generativelanguage.googleapis.com/v1beta/openai".to_string()
             }),
             rate_limiter,
-            capability_overrides: HashMap::new(),
+            capability_overrides: config.model_capabilities,
         }
     }
 

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -56,7 +56,7 @@ impl OpenAIProvider {
                 .base_url
                 .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
             rate_limiter,
-            capability_overrides: HashMap::new(),
+            capability_overrides: config.model_capabilities,
         }
     }
 

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -54,7 +54,7 @@ impl OpenRouterProvider {
                 .base_url
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
             rate_limiter,
-            capability_overrides: HashMap::new(),
+            capability_overrides: config.model_capabilities,
         }
     }
 

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -597,6 +597,10 @@ pub struct ProviderConfig {
     /// Default is None (no timeout).
     #[serde(default)]
     pub request_timeout_secs: Option<u64>,
+
+    /// Per-model capability overrides forwarded to the provider.
+    #[serde(default)]
+    pub model_capabilities: std::collections::HashMap<String, ModelCapabilities>,
 }
 
 /// Rate limit configuration.

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -139,52 +139,72 @@ pub fn build_provider_registry_with(
         match c.name.as_str() {
             "anthropic" => {
                 if let Some(ref key) = c.api_key {
+                    let cfg = leviath_providers::ProviderConfig {
+                        api_key: key.clone(),
+                        base_url: c.base_url.clone(),
+                        rate_limit: c.rate_limit.clone(),
+                        request_timeout_secs: timeout,
+                        model_capabilities: caps.clone(),
+                    };
                     registry.register(
                         "anthropic".to_string(),
-                        Arc::new(leviath_providers::AnthropicProvider::with_overrides(
+                        Arc::new(leviath_providers::AnthropicProvider::with_config(
                             clients.get_or_build(timeout, build_client)?,
-                            key.clone(),
-                            caps,
-                            c.rate_limit.as_ref(),
+                            cfg,
                         )),
                     );
                 }
             }
             "openai" => {
                 if let Some(ref key) = c.api_key {
+                    let cfg = leviath_providers::ProviderConfig {
+                        api_key: key.clone(),
+                        base_url: c.base_url.clone(),
+                        rate_limit: c.rate_limit.clone(),
+                        request_timeout_secs: timeout,
+                        model_capabilities: caps.clone(),
+                    };
                     registry.register(
                         "openai".to_string(),
-                        Arc::new(leviath_providers::OpenAIProvider::with_overrides(
+                        Arc::new(leviath_providers::OpenAIProvider::with_config(
                             clients.get_or_build(timeout, build_client)?,
-                            key.clone(),
-                            caps,
-                            c.rate_limit.as_ref(),
+                            cfg,
                         )),
                     );
                 }
             }
             "google" => {
                 if let Some(ref key) = c.api_key {
+                    let cfg = leviath_providers::ProviderConfig {
+                        api_key: key.clone(),
+                        base_url: c.base_url.clone(),
+                        rate_limit: c.rate_limit.clone(),
+                        request_timeout_secs: timeout,
+                        model_capabilities: caps.clone(),
+                    };
                     registry.register(
                         "google".to_string(),
-                        Arc::new(leviath_providers::GeminiProvider::with_overrides(
+                        Arc::new(leviath_providers::GeminiProvider::with_config(
                             clients.get_or_build(timeout, build_client)?,
-                            key.clone(),
-                            caps,
-                            c.rate_limit.as_ref(),
+                            cfg,
                         )),
                     );
                 }
             }
             "openrouter" => {
                 if let Some(ref key) = c.api_key {
+                    let cfg = leviath_providers::ProviderConfig {
+                        api_key: key.clone(),
+                        base_url: c.base_url.clone(),
+                        rate_limit: c.rate_limit.clone(),
+                        request_timeout_secs: timeout,
+                        model_capabilities: caps.clone(),
+                    };
                     registry.register(
                         "openrouter".to_string(),
-                        Arc::new(leviath_providers::OpenRouterProvider::with_overrides(
+                        Arc::new(leviath_providers::OpenRouterProvider::with_config(
                             clients.get_or_build(timeout, build_client)?,
-                            key.clone(),
-                            caps,
-                            c.rate_limit.as_ref(),
+                            cfg,
                         )),
                     );
                 }


### PR DESCRIPTION
Users behind an enterprise proxy or self-hosted gateway need to point a provider at a different base URL without forking the provider. This PR adds a generic path that keeps built-in defaults but lets configuration override them.

- ``[model_providers.<provider>].base_url`` is read from Config and forwarded through ProviderCreds to the concrete provider's `with_config` constructor. Covers all keyed providers (anthropic, openai, google, openrouter) per-provider, so one gateway can front one family while another keeps the public default. Env fallback (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, etc.) covers no-file enterprise case.

- `ProviderConfig` now carries `model_capabilities` so a gateway serving unknown IDs (e.g. `muse-spark-1.2-internal`, `gpt-5.6-sol`, `avocado-*`, `claude-*`) can be described in ``[model_capabilities.<id>]`` and forwarded to the provider's capability_overrides. Makes `lev models show` and runtime selection accept custom IDs.

- Registry construction uses `with_config(client, cfg)` with a shared `ClientCache` (one reqwest::Client per timeout) so custom base_url doesn't defeat pooling.

Existing behavior unchanged when no overrides are set. `HTTP_PROXY`/`HTTPS_PROXY` already respected via reqwest system-proxy, so a gateway behind ``x2pagentd`` at `http://localhost:10054` works.

Verified: built from latest main (18c0afe), `cargo test -p leviath-runtime --lib provider_creds` 8 passed, live `lev run` via `X` through proxy succeeded for `openai/muse-spark-1.2-internal`, `openai/avocado-code-internal-0529`, and `anthropic/claude-opus-5` (separate base_url per provider). No local gateway URLs or keys are committed — only the capability to configure them.