### PR TITLE
fix(openai): let the API say when tools need no reasoning effort (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ same list.
 
 ## Unreleased
 
+- Fixed: tool-using agents could not run on OpenAI's current reasoning models
+  (#333). Those models apply a reasoning effort by default and reject function
+  tools alongside one on `/v1/chat/completions`, so every such run failed on its
+  first inference over a field Leviath never set. It now retries once with
+  `reasoning_effort: "none"` when the API says that is the remedy, and remembers
+  the model so later calls in the same process pay nothing. Keyed on what the
+  API reports rather than on a list of model names, since an out-of-date model
+  list is what broke this. Models that reject the field outright, or reject the
+  value `none`, are untouched: neither ever sees it. A `reasoning_effort` you set
+  yourself in `[model.parameters]` is left exactly as written.
+
 ## 0.3.0 - 2026-08-08
 
 - **Security.** `uniq`, `tree` and `rg` are no longer on the default safe-command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.3.1 - 2026-08-09
+
 - Fixed: tool-using agents could not run on OpenAI's current reasoning models
   (#333). Those models apply a reasoning effort by default and reject function
   tools alongside one on `/v1/chat/completions`, so every such run failed on its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fs4",
  "keyring",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "tracing",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -95,17 +95,17 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.0" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.0" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.0" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.0" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.0" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.0" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.0" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.0" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.0" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.0" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.0" }
+leviath = { path = "crates/leviath", version = "0.3.1" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.1" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.1" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.1" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.1" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.1" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.1" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.1" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.1" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.1" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.1" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.0", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.1", optional = true }
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -2,7 +2,7 @@
 
 use crate::openai_compat::{
     OpenAiSseStream, TokenLimitField, build_openai_request_body_with, parse_openai_response,
-    send_chat_request,
+    send_chat_request, tools_refused_over_reasoning_effort,
 };
 #[cfg(test)]
 use crate::provider::FinishReason;
@@ -32,6 +32,15 @@ pub struct OpenAIProvider {
 
     /// Per-model capability overrides
     capability_overrides: HashMap<String, ModelCapabilities>,
+
+    /// Models the API has refused tools for until told `reasoning_effort:
+    /// "none"`, learned from its own error rather than declared up front.
+    ///
+    /// Remembered so the cost is one extra round trip per model per process,
+    /// not one per inference: a run makes many calls and they would each pay it.
+    /// A `HashSet` behind a lock rather than a field on the request, because the
+    /// provider is shared across every agent talking to it.
+    reasoning_effort_none: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
 }
 
 impl OpenAIProvider {
@@ -43,6 +52,7 @@ impl OpenAIProvider {
             base_url: "https://api.openai.com/v1".to_string(),
             rate_limiter: None,
             capability_overrides: HashMap::new(),
+            reasoning_effort_none: Default::default(),
         }
     }
 
@@ -57,6 +67,7 @@ impl OpenAIProvider {
                 .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
             rate_limiter,
             capability_overrides: HashMap::new(),
+            reasoning_effort_none: Default::default(),
         }
     }
 
@@ -73,6 +84,7 @@ impl OpenAIProvider {
             base_url: "https://api.openai.com/v1".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
+            reasoning_effort_none: Default::default(),
         }
     }
 
@@ -122,6 +134,83 @@ impl OpenAIProvider {
             ModelCapabilities::default()
         }
     }
+
+    /// POST a chat-completions body, teaching the retry described on
+    /// [`tools_refused_over_reasoning_effort`].
+    ///
+    /// Shared by both entry points so streaming and non-streaming cannot learn
+    /// different things about the same model.
+    async fn post_chat(
+        &self,
+        request: &InferenceRequest,
+        mut body: serde_json::Value,
+    ) -> Result<reqwest::Response> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let headers = [
+            ("Authorization", format!("Bearer {}", self.api_key)),
+            ("Content-Type", "application/json".to_string()),
+        ];
+
+        // Already learned for this model: pay nothing and send it up front.
+        if self.needs_reasoning_effort_none(&request.model) {
+            set_reasoning_effort_none(&mut body);
+        }
+        // A caller who set `reasoning_effort` themselves (via the manifest's
+        // `[model.parameters]`) has said what they want. Overriding it, or
+        // retrying to override it, would quietly ignore them - so the retry is
+        // only for a body that never mentioned the field.
+        let ours_to_set = body.get("reasoning_effort").is_none();
+
+        let sent = send_chat_request(
+            &self.client,
+            "openai",
+            &url,
+            &headers,
+            &body,
+            self.rate_limiter.as_ref(),
+            request.request_timeout_secs,
+        )
+        .await;
+
+        match sent {
+            Err(ProviderError::ApiError(detail))
+                if ours_to_set && tools_refused_over_reasoning_effort(&detail) =>
+            {
+                tracing::debug!(
+                    model = %request.model,
+                    "OpenAI refused tools alongside a reasoning effort; retrying with none"
+                );
+                self.remember_reasoning_effort_none(&request.model);
+                set_reasoning_effort_none(&mut body);
+                send_chat_request(
+                    &self.client,
+                    "openai",
+                    &url,
+                    &headers,
+                    &body,
+                    self.rate_limiter.as_ref(),
+                    request.request_timeout_secs,
+                )
+                .await
+            }
+            other => other,
+        }
+    }
+
+    /// Whether this model has already refused tools over a reasoning effort.
+    fn needs_reasoning_effort_none(&self, model: &str) -> bool {
+        leviath_core::sync::lock(&self.reasoning_effort_none).contains(model)
+    }
+
+    /// Record that it did, for the rest of this process.
+    fn remember_reasoning_effort_none(&self, model: &str) {
+        leviath_core::sync::lock(&self.reasoning_effort_none).insert(model.to_string());
+    }
+}
+
+/// Say "no reasoning" in the field the API rejected the request over.
+fn set_reasoning_effort_none(body: &mut serde_json::Value) {
+    body["reasoning_effort"] = serde_json::Value::String("none".to_string());
 }
 
 #[async_trait]
@@ -134,21 +223,7 @@ impl Provider for OpenAIProvider {
         }
 
         let body = build_openai_request_body_with(request, TokenLimitField::MaxCompletionTokens);
-        let url = format!("{}/chat/completions", self.base_url);
-
-        let response = send_chat_request(
-            &self.client,
-            "openai",
-            &url,
-            &[
-                ("Authorization", format!("Bearer {}", self.api_key)),
-                ("Content-Type", "application/json".to_string()),
-            ],
-            &body,
-            self.rate_limiter.as_ref(),
-            request.request_timeout_secs,
-        )
-        .await?;
+        let response = self.post_chat(request, body).await?;
 
         let response_body: serde_json::Value = response
             .json()
@@ -178,21 +253,7 @@ impl Provider for OpenAIProvider {
             build_openai_request_body_with(request, TokenLimitField::MaxCompletionTokens);
         body["stream"] = serde_json::Value::Bool(true);
         body["stream_options"] = serde_json::json!({ "include_usage": true });
-        let url = format!("{}/chat/completions", self.base_url);
-
-        let response = send_chat_request(
-            &self.client,
-            "openai",
-            &url,
-            &[
-                ("Authorization", format!("Bearer {}", self.api_key)),
-                ("Content-Type", "application/json".to_string()),
-            ],
-            &body,
-            self.rate_limiter.as_ref(),
-            request.request_timeout_secs,
-        )
-        .await?;
+        let response = self.post_chat(request, body).await?;
 
         let byte_stream = response.bytes_stream();
         let stream = OpenAiSseStream::new(byte_stream);
@@ -712,6 +773,141 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         }
+    }
+
+    // ─── Tools refused over a reasoning effort ──────────────────────────────
+
+    /// Verbatim from `api.openai.com`, captured while reproducing #333.
+    const TOOLS_REFUSED: &[u8] = br#"{"error":{"message":"Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.","type":"invalid_request_error","param":"reasoning_effort","code":null}}"#;
+
+    const OK_BODY: &[u8] = br#"{"choices":[{"message":{"content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
+
+    fn request_with_a_tool() -> InferenceRequest {
+        InferenceRequest {
+            tools: vec![crate::provider::Tool {
+                name: "get_time".to_string(),
+                description: "Get the time".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }],
+            ..simple_request()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_refusal_over_reasoning_effort_is_retried_with_none() {
+        let _guard = always_on_tracing_guard();
+        let (url, bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (400, "Bad Request", TOOLS_REFUSED.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+        ])
+        .await;
+        let provider = provider_with_url(url);
+        let resp = provider.infer(&request_with_a_tool()).await.unwrap();
+        assert_eq!(resp.content, "hi there");
+
+        // The assertion that matters. "It eventually succeeded" would also pass
+        // against a retry that resent the identical body.
+        let sent = bodies.lock().expect("recorder").clone();
+        assert_eq!(sent.len(), 2, "expected exactly one retry: {sent:?}");
+        // Bound rather than indexed inside the message: a message expression
+        // only runs when the assert fails, so `sent[0]` there would be a region
+        // no passing run ever reaches.
+        let (first, retry) = (&sent[0], &sent[1]);
+        assert!(
+            !first.contains("reasoning_effort"),
+            "the first attempt should not mention the field: {first}"
+        );
+        assert!(
+            retry.contains(r#""reasoning_effort":"none""#),
+            "the retry should carry it: {retry}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_second_call_for_a_learned_model_asks_once() {
+        // The point of remembering: a run makes many inferences and only the
+        // first should pay for the discovery.
+        let (url, bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (400, "Bad Request", TOOLS_REFUSED.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+        ])
+        .await;
+        let provider = provider_with_url(url);
+        provider.infer(&request_with_a_tool()).await.unwrap();
+        provider.infer(&request_with_a_tool()).await.unwrap();
+
+        let sent = bodies.lock().expect("recorder").clone();
+        assert_eq!(
+            sent.len(),
+            3,
+            "the second inference should not retry: {sent:?}"
+        );
+        let third = &sent[2];
+        assert!(
+            third.contains(r#""reasoning_effort":"none""#),
+            "the learned setting should be sent up front: {third}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_bad_request_is_not_retried() {
+        // A model that takes a reasoning effort but not the value `none` says so
+        // in a message that never mentions tools. Retrying it with `none` would
+        // resend the same rejection.
+        let other = br#"{"error":{"message":"Unsupported value: 'reasoning_effort' does not support 'none' with this model. Supported values are: 'low', 'medium', 'high', and 'xhigh'.","type":"invalid_request_error","param":"reasoning_effort"}}"#;
+        let (url, bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (400, "Bad Request", other.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+        ])
+        .await;
+        let provider = provider_with_url(url);
+        let err = provider.infer(&request_with_a_tool()).await.unwrap_err();
+        assert!(err.to_string().contains("API error:"), "{err}");
+        assert_eq!(
+            bodies.lock().expect("recorder").len(),
+            1,
+            "should not retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_caller_supplied_reasoning_effort_is_left_alone() {
+        // `[model.parameters] reasoning_effort = "low"` is the caller saying
+        // what they want. Overriding it would ignore them silently.
+        let (url, bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (400, "Bad Request", TOOLS_REFUSED.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+        ])
+        .await;
+        let provider = provider_with_url(url);
+        let request = InferenceRequest {
+            extra: serde_json::json!({ "reasoning_effort": "low" }),
+            ..request_with_a_tool()
+        };
+        let err = provider.infer(&request).await.unwrap_err();
+        assert!(err.to_string().contains("API error:"), "{err}");
+        let sent = bodies.lock().expect("recorder").clone();
+        assert_eq!(sent.len(), 1, "should not retry over the caller's setting");
+        let first = &sent[0];
+        assert!(first.contains(r#""reasoning_effort":"low""#), "{first}");
+    }
+
+    #[tokio::test]
+    async fn streaming_learns_the_same_thing() {
+        let _guard = always_on_tracing_guard();
+        let sse = b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        let (url, bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (400, "Bad Request", TOOLS_REFUSED.to_vec()),
+            (200, "OK", sse.to_vec()),
+        ])
+        .await;
+        let provider = provider_with_url(url);
+        assert!(provider.infer_stream(&request_with_a_tool()).await.is_ok());
+        let sent = bodies.lock().expect("recorder").clone();
+        assert_eq!(sent.len(), 2);
+        let retry = &sent[1];
+        assert!(retry.contains(r#""reasoning_effort":"none""#), "{retry}");
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -397,6 +397,27 @@ pub fn build_openai_request_body_with(
     body
 }
 
+/// Whether an API error is OpenAI refusing tools *because* a reasoning effort
+/// is in play, which it resolves by being sent `reasoning_effort: "none"`.
+///
+/// The current reasoning models reject function tools together with a reasoning
+/// effort on `/v1/chat/completions`, and they apply an effort by default - so a
+/// request that never mentions `reasoning_effort` is refused for a field it did
+/// not set. The error says exactly that, and names the remedy.
+///
+/// Keyed on what the API said rather than on which model was asked, and
+/// deliberately: a model list is what failed here. Nothing in this crate knew
+/// `gpt-5.6` existed, and nothing should have to before it works.
+///
+/// The pairing is what makes this precise. A model that supports a reasoning
+/// effort but not the value `none` reports a different problem in a message
+/// that never mentions tools, and retrying *that* with `none` would resend the
+/// same rejection.
+pub(crate) fn tools_refused_over_reasoning_effort(detail: &str) -> bool {
+    let detail = detail.to_ascii_lowercase();
+    detail.contains("reasoning_effort") && detail.contains("function tool")
+}
+
 /// Merge a request's pass-through `extra` params (the manifest's
 /// `[model.parameters]` beyond temperature/max_output_tokens - `top_p`, `stop`,
 /// `seed`, `frequency_penalty`, …) into an OpenAI-shaped request `target`.

--- a/crates/leviath-testkit/src/lib.rs
+++ b/crates/leviath-testkit/src/lib.rs
@@ -139,6 +139,59 @@ pub async fn spawn_mock_server_with_headers(
     spawn_mock_raw(response).await
 }
 
+/// The request bodies a [`spawn_mock_sequence`] server has received, in order.
+pub type RecordedBodies = std::sync::Arc<Mutex<Vec<String>>>;
+
+/// An HTTP server that answers a *series* of requests, one canned response
+/// each, and records every request body it was sent.
+///
+/// The one-shot helpers above cannot express "fails, then succeeds", which is
+/// what a retry looks like from the outside. Recording the bodies is the other
+/// half: a retry test that only asserts the call eventually succeeded would
+/// pass against a retry that resent the identical request, so what has to be
+/// asserted is that the *second* body differs in the intended way.
+///
+/// Requests beyond the last response get a 500. Each response closes its
+/// connection, so `reqwest` opens a fresh one per request.
+pub async fn spawn_mock_sequence(
+    responses: Vec<(u16, &'static str, Vec<u8>)>,
+) -> (String, RecordedBodies) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let bodies: RecordedBodies = std::sync::Arc::new(Mutex::new(Vec::new()));
+    let recorder = std::sync::Arc::clone(&bodies);
+    tokio::spawn(async move {
+        for (status, reason, body) in responses {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 65536];
+            let read = socket.read(&mut buf).await.unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..read]).to_string();
+            // The body is whatever follows the header terminator. Good enough
+            // for a test client that always sends its JSON in one write.
+            let recorded = match request.split_once("\r\n\r\n") {
+                Some((_, body)) => body.to_string(),
+                None => String::new(),
+            };
+            recorder.lock().expect("recorder lock").push(recorded);
+            let mut response = format!(
+                "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n",
+                status,
+                reason,
+                body.len()
+            )
+            .into_bytes();
+            response.extend_from_slice(&body);
+            let _ = socket.write_all(&response).await;
+            let _ = socket.flush().await;
+            let _ = socket.shutdown().await;
+        }
+    });
+    (format!("http://{}", addr), bodies)
+}
+
 /// A one-shot HTTP server that declares a `Content-Length` far larger than
 /// the bytes it actually sends, then closes - forcing a genuine I/O error
 /// when the caller reads the response body, so `.text()`-failure fallbacks


### PR DESCRIPTION
Closes #333. Ships as **0.3.1** — merging cuts the alpha.

## The bug

Every tool-using agent on OpenAI's current reasoning models failed on its *first*
inference:

```
Function tools with reasoning_effort are not supported for gpt-5.6-terra in
/v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

Leviath never sent `reasoning_effort`. Those models apply one by default, so the
request was refused over a field it did not set.

## The fix

Retry once with `reasoning_effort: "none"` when the API says that is the remedy,
then remember the model so the rest of the process sends it up front — a run
makes many calls and only the first should pay the round trip.

**Keyed on what the API reported, not on a model list.** Nothing in this crate
knew `gpt-5.6` existed and nothing should have to; an out-of-date model list is
what broke this in the first place.

## Why not just always send it

Measured against the live API first, because the blanket version looked simpler
and would have broken working setups:

| Model | tools, field unset | tools + `"none"` |
|---|---|---|
| `gpt-5.6-terra` / `-sol` | **400** | OK |
| `gpt-5.4-nano` | OK | OK |
| `gpt-4o` | OK | **400** — rejects the field outright |
| `o3` | OK | **400** — rejects the value `none` |

The bottom two never see it: the retry fires only on an error that names
*function tools*, and theirs do not. A `reasoning_effort` set in
`[model.parameters]` is the caller saying what they want, so it is left alone and
never retried over.

## Verification

The suite green is not the evidence here. Same blueprint, same model, same task,
two binaries:

| Binary | Result |
|---|---|
| released 0.3.0 | fails with the error above |
| this branch | `complete`, and `proof.txt` on disk with the content its tool was told to write |

Also live-checked end to end through a real daemon: `gpt-5.6-terra` ✅,
`gpt-5.6-sol` ✅, `gpt-4o` ✅ (the regression case — it must never receive the
field).

The retry tests assert on the **recorded second request body**, not on "it
eventually succeeded", which would pass against a retry that resent an identical
request. That needed a mock that answers a *sequence* and records what it was
sent, added to `leviath-testkit`.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage --package leviath-providers` 100%
- `cargo xtask version --check` clean

## Separate issue found while testing

`o3` cannot run at all, for an unrelated and pre-existing reason: a model
declaring `supports_temperature: false` is sent `temperature: 0.0`
(`inference.rs:113`) rather than having the field omitted, and o3 accepts only
the default. Not touched here — it is not #333, it predates 0.3.0, and the honest
fix is wider than a patch release. Filed separately.
