### PR TITLE
fix(openai): omit a temperature the model does not take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ same list.
 
 ## Unreleased
 
+- Fixed: `o3` and `o4` could not run at all through the `openai` provider (#335).
+  A model declaring no temperature support was sent `temperature: 0.0` rather
+  than having the field left out, and the o-series accepts only its own default,
+  rejecting `0.0` as firmly as any other value - so the one flag that exists to
+  protect those models was what broke them. The field is now omitted, which is
+  what the OpenRouter provider has always done for the same models.
+
 ## 0.3.1 - 2026-08-09
 
 - Fixed: tool-using agents could not run on OpenAI's current reasoning models

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -151,6 +151,19 @@ impl OpenAIProvider {
             ("Content-Type", "application/json".to_string()),
         ];
 
+        // A model that takes no temperature is sent none, rather than being sent
+        // zero. `build_openai_request_body_with` always writes the key and the
+        // runtime substitutes `0.0` where a model declares no support, but "not
+        // supported" is not a value: the o-series accepts only its default and
+        // rejects `0.0` exactly as firmly as `0.7`, so the one flag that exists
+        // to protect these models was what broke them. Omitting is what the
+        // OpenRouter provider has always done for the same models.
+        if !self.capabilities(&request.model).supports_temperature
+            && let Some(fields) = body.as_object_mut()
+        {
+            fields.remove("temperature");
+        }
+
         // Already learned for this model: pay nothing and send it up front.
         if self.needs_reasoning_effort_none(&request.model) {
             set_reasoning_effort_none(&mut body);
@@ -773,6 +786,62 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         }
+    }
+
+    // ─── A model that takes no temperature ──────────────────────────────────
+
+    #[tokio::test]
+    async fn a_model_taking_no_temperature_is_sent_none() {
+        // o3 declares `supports_temperature: false`, and the runtime turns that
+        // into `0.0` - a value it rejects as firmly as any other, since it takes
+        // only its own default. Omitting is the only thing that works.
+        let (url, bodies) =
+            leviath_testkit::spawn_mock_sequence(vec![(200, "OK", OK_BODY.to_vec())]).await;
+        let provider = provider_with_url(url);
+        let request = InferenceRequest {
+            model: "o3".to_string(),
+            ..simple_request()
+        };
+        provider.infer(&request).await.unwrap();
+
+        let sent = bodies.lock().expect("recorder").clone();
+        let body = &sent[0];
+        assert!(!body.contains("temperature"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn a_model_taking_a_temperature_still_gets_one() {
+        // The other half, so "omit it" cannot quietly become "omit it always".
+        let (url, bodies) =
+            leviath_testkit::spawn_mock_sequence(vec![(200, "OK", OK_BODY.to_vec())]).await;
+        let provider = provider_with_url(url);
+        let request = InferenceRequest {
+            model: "gpt-4o".to_string(),
+            temperature: 0.5,
+            ..simple_request()
+        };
+        provider.infer(&request).await.unwrap();
+
+        let sent = bodies.lock().expect("recorder").clone();
+        let body = &sent[0];
+        assert!(body.contains(r#""temperature":0.5"#), "{body}");
+    }
+
+    #[tokio::test]
+    async fn streaming_omits_it_too() {
+        let sse = b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        let (url, bodies) =
+            leviath_testkit::spawn_mock_sequence(vec![(200, "OK", sse.to_vec())]).await;
+        let provider = provider_with_url(url);
+        let request = InferenceRequest {
+            model: "o4-mini".to_string(),
+            ..simple_request()
+        };
+        assert!(provider.infer_stream(&request).await.is_ok());
+
+        let sent = bodies.lock().expect("recorder").clone();
+        let body = &sent[0];
+        assert!(!body.contains("temperature"), "{body}");
     }
 
     // ─── Tools refused over a reasoning effort ──────────────────────────────


### PR DESCRIPTION
Closes #335. **No version bump** — this rides along with whatever ships next, so
merging it cuts no release.

## The bug

`o3` and `o4` could not run at all through the `openai` provider. Every inference
was rejected before it started:

```
Unsupported value: 'temperature' does not support 0.0 with this model.
Only the default (1) value is supported
```

`ModelCapabilities.supports_temperature` is already `false` for the o-series, but
the runtime turns "not supported" into the *value* `0.0`
(`pipeline/inference.rs:113`) and `build_openai_request_body_with` writes the key
unconditionally.

"Not supported" is not a value. These models accept only their own default and
reject `0.0` exactly as firmly as `0.7` — so the one flag that exists to protect
them is what broke them.

## The fix

Omit the key. That is what the **OpenRouter provider has always done** for the
same models reached through it (`openrouter.rs:118` branches on the same flag),
so this makes the two agree rather than inventing a rule.

## What this deliberately does not do

Change `InferenceRequest.temperature` to `Option<f32>`. That is the tidier shape
and would fix every provider at once, but it rewrites **93 constructions across
34 files**, nearly all test fixtures, for one provider's defect. The capability
flag already exists and already means this; the provider is where it should be
read. Worth revisiting if a second provider ever needs it.

## Verification

Live against the real API, same blueprint and task, since the suite passing is
not evidence a model can run:

| Model | Before | After |
|---|---|---|
| `o3` | fails on the first inference | `complete`, tool ran, file on disk |
| `gpt-4o` | works | works — still sends `temperature: 0.5` |
| `gpt-5.6-terra` | works (since #333) | works |

The unit tests assert on the **recorded request body** — that `o3` carries no
`temperature` key and that `gpt-4o` still carries `"temperature":0.5` — so "omit
it" cannot quietly become "omit it always". Streaming is covered too, since it
shares the same send path.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage --package leviath-providers` 100%
