### PR TITLE
fix(config): a [model_capabilities] entry corrects, it does not replace

### DIFF
--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -547,7 +547,7 @@ async fn list_with_registry(
 
     for entry in entries.iter_mut() {
         if let Some(user_caps) = config.model_capabilities.get(&entry.id) {
-            entry.capabilities = user_caps.clone();
+            entry.capabilities = user_caps.apply_to(entry.capabilities.clone());
         }
     }
 
@@ -639,15 +639,28 @@ async fn show_with_registry(
 
     let model_id = &args.model;
 
-    // 1. Check user overrides first (highest precedence).
-    if let Some(user_caps) = config.model_capabilities.get(model_id) {
-        print_model_detail(model_id, None, "config (user override)", user_caps, true);
+    // 1. The built-in row, which a `[model_capabilities]` entry corrects rather
+    //    than replaces - so it has to be found before the override is applied.
+    //    Printing the override alone would report `Default` for every field the
+    //    operator did not mention, which is not what the run will use.
+    let builtin = builtin_table();
+    let builtin_entry = builtin.iter().find(|e| e.model_id == model_id);
+    let user_caps = config.model_capabilities.get(model_id);
+
+    if let Some(user_caps) = user_caps {
+        let base = builtin_entry.map(|e| e.caps.clone()).unwrap_or_default();
+        print_model_detail(
+            model_id,
+            builtin_entry.map(|e| e.display_name),
+            "config (user override)",
+            &user_caps.apply_to(base),
+            true,
+        );
         return Ok(());
     }
 
-    // 2. Check built-in table.
-    let builtin = builtin_table();
-    if let Some(entry) = builtin.iter().find(|e| e.model_id == model_id) {
+    // 2. The built-in table on its own.
+    if let Some(entry) = builtin_entry {
         print_model_detail(
             model_id,
             Some(entry.display_name),
@@ -1783,7 +1796,7 @@ mod tests {
                 let mut config = Config::default();
                 config.model_capabilities.insert(
                     "claude-sonnet-5".to_string(),
-                    leviath_providers::ModelCapabilities::default(),
+                    leviath_providers::ModelCapabilityOverride::default(),
                 );
                 config
                     .save_to_path(&Config::config_path())
@@ -1944,7 +1957,8 @@ mod tests {
                         supports_system_prompt: false,
                         max_context_tokens: 1,
                         max_output_tokens: 1,
-                    },
+                    }
+                    .into(),
                 );
                 std::fs::write(
                     Config::config_path(),
@@ -1982,7 +1996,8 @@ mod tests {
                         supports_system_prompt: false,
                         max_context_tokens: 1,
                         max_output_tokens: 1,
-                    },
+                    }
+                    .into(),
                 );
                 std::fs::write(
                     Config::config_path(),

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -514,7 +514,8 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 9999,
                 max_output_tokens: 999,
-            },
+            }
+            .into(),
         );
         let config = crate::config::Config {
             model_capabilities: caps,
@@ -552,7 +553,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 99,
-            },
+            }
+            .into(),
         );
         let config = crate::config::Config {
             ollama_base_url: Some("http://custom-ollama:11434".to_string()),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1,7 +1,7 @@
 //! CLI configuration management.
 
 use leviath_mcp::MCPServerConfig;
-use leviath_providers::ModelCapabilities;
+use leviath_providers::ModelCapabilityOverride;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -52,7 +52,7 @@ pub struct Config {
     /// Per-model capability overrides. Key is model ID (e.g. "my-local-llama").
     /// Takes precedence over the provider's built-in capability table.
     #[serde(default)]
-    pub model_capabilities: HashMap<String, ModelCapabilities>,
+    pub model_capabilities: HashMap<String, ModelCapabilityOverride>,
 
     /// Optional overrides for Rhai *script providers*. Key is the
     /// provider name an agent references (e.g. `"groq"`). A script activates by
@@ -2458,33 +2458,38 @@ url = "https://mcp.example.com/mcp"
 
     #[test]
     fn config_from_toml_with_model_capabilities() {
-        let toml_content = r#"
-default_provider = "anthropic"
-agent_paths = []
-
-[providers]
-
+        // A one-field entry, which is what someone correcting a wrong context
+        // window actually writes. It used to fail to deserialize and be dropped
+        // in silence (#338); now it parses and names only that field, so
+        // everything it did not mention comes from the provider.
+        let toml = r#"
 [model_capabilities."my-custom-model"]
-supports_temperature = true
-supports_streaming = false
-supports_tools = true
-supports_system_prompt = true
-max_context_tokens = 4096
-max_output_tokens = 2048
+max_context_tokens = 1048576
 "#;
-        let config: Config = toml::from_str(toml_content).unwrap();
-        let caps = config.model_capabilities.get("my-custom-model").unwrap();
-        assert!(caps.supports_temperature);
-        assert!(!caps.supports_streaming);
-        assert_eq!(caps.max_context_tokens, 4096);
-        assert_eq!(caps.max_output_tokens, 2048);
+        let config: Config = toml::from_str(toml).expect("a partial entry parses");
+        let entry = config
+            .model_capabilities
+            .get("my-custom-model")
+            .expect("the entry survives");
+        assert_eq!(entry.max_context_tokens, Some(1_048_576));
+        assert_eq!(
+            entry.max_output_tokens, None,
+            "an unmentioned field stays unset rather than defaulting"
+        );
+        assert_eq!(entry.supports_tools, None);
     }
 
-    // ─── validate_keys with both keys ──────────────────────────────────────
+    /// A misspelled key is refused rather than ignored, so a typo cannot look
+    /// like a working override.
+    #[test]
+    fn config_model_capabilities_rejects_an_unknown_key() {
+        let toml = r#"
+[model_capabilities."my-custom-model"]
+max_contxt_tokens = 1048576
+"#;
+        assert!(toml::from_str::<Config>(toml).is_err());
+    }
 
-    /// A blank key means "not configured" (what `lev setup` writes for a
-    /// skipped provider), so it must not draw a shape warning - noise about
-    /// keys nobody set trains users to ignore the warnings that matter.
     #[test]
     fn validate_keys_is_quiet_about_blank_keys() {
         let mut config = Config::default();
@@ -2838,13 +2843,13 @@ enabled = false
         let mut model_caps = HashMap::new();
         model_caps.insert(
             "my-model".to_string(),
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 8192,
-                max_output_tokens: 4096,
+            ModelCapabilityOverride {
+                supports_temperature: Some(true),
+                supports_streaming: Some(true),
+                supports_tools: Some(true),
+                supports_system_prompt: Some(true),
+                max_context_tokens: Some(8192),
+                max_output_tokens: Some(4096),
             },
         );
         let mut tool_perms = HashMap::new();
@@ -3058,10 +3063,10 @@ max_output_tokens = 1024
         let config: Config = toml::from_str(toml_content).unwrap();
         assert_eq!(config.model_capabilities.len(), 2);
         let caps_a = config.model_capabilities.get("model-a").unwrap();
-        assert!(caps_a.supports_temperature);
-        assert_eq!(caps_a.max_context_tokens, 8192);
+        assert_eq!(caps_a.supports_temperature, Some(true));
+        assert_eq!(caps_a.max_context_tokens, Some(8192));
         let caps_b = config.model_capabilities.get("model-b").unwrap();
-        assert!(!caps_b.supports_temperature);
-        assert_eq!(caps_b.max_context_tokens, 2048);
+        assert_eq!(caps_b.supports_temperature, Some(false));
+        assert_eq!(caps_b.max_context_tokens, Some(2048));
     }
 }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -1,8 +1,9 @@
 //! Anthropic Claude provider implementation.
 
 use crate::provider::{
-    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider,
-    ProviderConfig, ProviderError, Result, StreamChunk, TokenUsage, ToolCall, ToolCallDelta,
+    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk, TokenUsage, ToolCall,
+    ToolCallDelta,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -120,7 +121,7 @@ pub struct AnthropicProvider {
     rate_limiter: Option<RateLimiter>,
 
     /// Per-model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
 
     /// Cache TTL for prompt caching breakpoints.
     cache_ttl: CacheTtl,
@@ -158,7 +159,7 @@ impl AnthropicProvider {
     pub fn with_overrides(
         client: reqwest::Client,
         api_key: String,
-        overrides: HashMap<String, ModelCapabilities>,
+        overrides: HashMap<String, ModelCapabilityOverride>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
@@ -648,10 +649,10 @@ impl Provider for AnthropicProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(overridden) = self.capability_overrides.get(model) {
-            overridden.clone()
-        } else {
-            self.builtin_capabilities(model)
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(self.builtin_capabilities(model)),
+            None => self.builtin_capabilities(model),
         }
     }
 
@@ -1227,7 +1228,8 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 32_768,
-            },
+            }
+            .into(),
         );
         let provider = AnthropicProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -1853,7 +1855,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
-            },
+            }
+            .into(),
         );
         let provider = AnthropicProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -66,7 +66,7 @@ pub struct ClaudeCodeProvider {
     /// Reasoning effort passed as `--effort`.
     effort: String,
     /// Model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
     /// Source of tool-call ids. The CLI gives us no ids of its own, and ids must
     /// stay unique for the life of a transcript, so they are handed out
     /// monotonically rather than restarting at zero each response.
@@ -93,7 +93,7 @@ impl ClaudeCodeProvider {
     pub fn with_overrides(
         binary: String,
         effort: Option<String>,
-        overrides: Option<HashMap<String, ModelCapabilities>>,
+        overrides: Option<HashMap<String, ModelCapabilityOverride>>,
     ) -> Self {
         let effort = effort
             .filter(|e| EFFORT_LEVELS.contains(&e.as_str()))
@@ -450,8 +450,12 @@ impl Provider for ClaudeCodeProvider {
     }
 
     fn max_context_tokens(&self, model: &str) -> usize {
-        if let Some(caps) = self.capability_overrides.get(model) {
-            return caps.max_context_tokens;
+        if let Some(tokens) = self
+            .capability_overrides
+            .get(model)
+            .and_then(|o| o.max_context_tokens)
+        {
+            return tokens;
         }
         200_000 - INJECTION_RESERVE_TOKENS
     }
@@ -461,10 +465,11 @@ impl Provider for ClaudeCodeProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(caps) = self.capability_overrides.get(model) {
-            return caps.clone();
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(self.builtin_capabilities(model)),
+            None => self.builtin_capabilities(model),
         }
-        self.builtin_capabilities(model)
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
@@ -548,7 +553,8 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 100_000,
                 max_output_tokens: 8_000,
-            },
+            }
+            .into(),
         );
         let provider =
             ClaudeCodeProvider::with_overrides("claude".to_string(), None, Some(overrides));

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -6,8 +6,8 @@ use crate::openai_compat::{
 #[cfg(test)]
 use crate::provider::FinishReason;
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider, ProviderConfig,
-    ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
+    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -83,7 +83,7 @@ pub struct GeminiProvider {
     rate_limiter: Option<RateLimiter>,
 
     /// Per-model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
 }
 
 impl GeminiProvider {
@@ -116,7 +116,7 @@ impl GeminiProvider {
     pub fn with_overrides(
         client: reqwest::Client,
         api_key: String,
-        overrides: HashMap<String, ModelCapabilities>,
+        overrides: HashMap<String, ModelCapabilityOverride>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
@@ -298,10 +298,10 @@ impl Provider for GeminiProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(caps) = self.capability_overrides.get(model) {
-            caps.clone()
-        } else {
-            self.builtin_capabilities(model)
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(self.builtin_capabilities(model)),
+            None => self.builtin_capabilities(model),
         }
     }
 
@@ -518,7 +518,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
-            },
+            }
+            .into(),
         );
         let provider = GeminiProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -788,7 +789,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
-            },
+            }
+            .into(),
         );
         let provider = GeminiProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -36,8 +36,8 @@ pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use provider::{
     ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FinishReason, InferenceRequest,
-    InferenceResponse, Message, MessageContent, ModelCapabilities, ModelInfo, Provider,
-    ProviderConfig, ProviderError, RateLimitConfig, Result, SystemBlock, TokenUsage, Tool,
-    ToolCall, UnavailableReason, build_http_client,
+    InferenceResponse, Message, MessageContent, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderConfig, ProviderError, RateLimitConfig, Result, SystemBlock,
+    TokenUsage, Tool, ToolCall, UnavailableReason, build_http_client,
 };
 pub use rhai_provider::RhaiProvider;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -3,8 +3,8 @@
 //! Ollama provides local LLM execution via NDJSON streaming.
 
 use crate::provider::{
-    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider,
-    ProviderError, Result, StreamChunk, TokenUsage,
+    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
 };
 use async_trait::async_trait;
 use futures_core::Stream;
@@ -20,7 +20,7 @@ pub struct OllamaProvider {
     base_url: String,
 
     /// Per-model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
 }
 
 impl OllamaProvider {
@@ -49,7 +49,7 @@ impl OllamaProvider {
     pub fn with_overrides(
         client: reqwest::Client,
         base_url: String,
-        overrides: HashMap<String, ModelCapabilities>,
+        overrides: HashMap<String, ModelCapabilityOverride>,
     ) -> Self {
         if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
             tracing::warn!(url = %base_url, "Ollama base URL should start with http:// or https://");
@@ -341,10 +341,11 @@ impl Provider for OllamaProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(overridden) = self.capability_overrides.get(model) {
-            return overridden.clone();
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(self.builtin_capabilities(model)),
+            None => self.builtin_capabilities(model),
         }
-        self.builtin_capabilities(model)
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
@@ -632,7 +633,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
-            },
+            }
+            .into(),
         );
         let provider = OllamaProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -1335,7 +1337,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 99,
-            },
+            }
+            .into(),
         );
         let provider = OllamaProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -1940,7 +1943,8 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 8192,
                 max_output_tokens: 4096,
-            },
+            }
+            .into(),
         );
         let provider = OllamaProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -7,8 +7,8 @@ use crate::openai_compat::{
 #[cfg(test)]
 use crate::provider::FinishReason;
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider, ProviderConfig,
-    ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
+    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -31,7 +31,7 @@ pub struct OpenAIProvider {
     rate_limiter: Option<RateLimiter>,
 
     /// Per-model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
 
     /// Models the API has refused tools for until told `reasoning_effort:
     /// "none"`, learned from its own error rather than declared up front.
@@ -75,7 +75,7 @@ impl OpenAIProvider {
     pub fn with_overrides(
         client: reqwest::Client,
         api_key: String,
-        overrides: HashMap<String, ModelCapabilities>,
+        overrides: HashMap<String, ModelCapabilityOverride>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
@@ -288,10 +288,10 @@ impl Provider for OpenAIProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(caps) = self.capability_overrides.get(model) {
-            caps.clone()
-        } else {
-            self.builtin_capabilities(model)
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(self.builtin_capabilities(model)),
+            None => self.builtin_capabilities(model),
         }
     }
 
@@ -532,7 +532,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
-            },
+            }
+            .into(),
         );
         let provider = OpenAIProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -688,7 +689,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
-            },
+            }
+            .into(),
         );
         let provider = OpenAIProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -5,8 +5,8 @@
 
 use crate::openai_compat::{OpenAiSseStream, parse_openai_response, send_chat_request};
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider, ProviderConfig,
-    ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
+    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -29,7 +29,11 @@ pub struct OpenRouterProvider {
     rate_limiter: Option<RateLimiter>,
 
     /// Per-model capability overrides
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
+
+    /// Models already reported as falling back, so the warning is once per
+    /// model per process rather than once per inference.
+    warned_unknown: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
 }
 
 impl OpenRouterProvider {
@@ -41,6 +45,7 @@ impl OpenRouterProvider {
             base_url: "https://openrouter.ai/api/v1".to_string(),
             rate_limiter: None,
             capability_overrides: HashMap::new(),
+            warned_unknown: Default::default(),
         }
     }
 
@@ -55,6 +60,7 @@ impl OpenRouterProvider {
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
             rate_limiter,
             capability_overrides: HashMap::new(),
+            warned_unknown: Default::default(),
         }
     }
 
@@ -62,7 +68,7 @@ impl OpenRouterProvider {
     pub fn with_overrides(
         client: reqwest::Client,
         api_key: String,
-        overrides: HashMap<String, ModelCapabilities>,
+        overrides: HashMap<String, ModelCapabilityOverride>,
         rate_limit: Option<&crate::provider::RateLimitConfig>,
     ) -> Self {
         Self {
@@ -71,6 +77,7 @@ impl OpenRouterProvider {
             base_url: "https://openrouter.ai/api/v1".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
+            warned_unknown: Default::default(),
         }
     }
 
@@ -155,6 +162,212 @@ impl OpenRouterProvider {
             &request.extra,
         );
         body
+    }
+}
+
+/// OpenRouter's own answer for a model, before any `[model_capabilities]`
+/// entry is merged onto it.
+///
+/// A free function rather than a method: it reads nothing from the provider,
+/// and lifting it out is what lets `capabilities` merge an override onto it
+/// instead of replacing it wholesale.
+fn builtin_capabilities(model: &str) -> ModelCapabilities {
+    // ── Google Gemini ─────────────────────────────────────────────────────
+    if model.starts_with("google/gemini") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_048_576,
+            max_output_tokens: 65_536,
+        };
+    }
+    // ── Meta Llama 4 Scout - 10M context ─────────────────────────────────
+    if model.contains("llama-4-scout") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 10_000_000,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── Meta Llama 4 (Maverick + others) - 1M context ────────────────────
+    if model.starts_with("meta-llama/llama-4") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_048_576,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── DeepSeek R1 - reasoning-only, no tools, no temperature ───────────
+    if model.contains("deepseek-r1") {
+        return ModelCapabilities {
+            supports_temperature: false,
+            supports_streaming: true,
+            supports_tools: false,
+            supports_system_prompt: true,
+            max_context_tokens: 163_840,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── DeepSeek V4 Pro - 1M context, 384K output ────────────────────────
+    if model.contains("deepseek-v4-pro") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_048_576,
+            max_output_tokens: 393_216,
+        };
+    }
+    // ── DeepSeek V4 Flash / V3.x ─────────────────────────────────────────
+    if model.starts_with("deepseek/deepseek-v") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_048_576,
+            max_output_tokens: 65_536,
+        };
+    }
+    // ── Mistral Large ─────────────────────────────────────────────────────
+    if model.contains("mistral-large") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 262_144,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── Mistral Medium / Small ────────────────────────────────────────────
+    if model.starts_with("mistralai/") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 131_072,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── Qwen 3.6+ / Qwen3 Coder - 1M context ────────────────────────────
+    if model.contains("qwen3.6") || model.contains("qwen3-coder") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_048_576,
+            max_output_tokens: 65_536,
+        };
+    }
+    // ── Qwen3 general ─────────────────────────────────────────────────────
+    if model.starts_with("qwen/") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 131_072,
+            max_output_tokens: 32_768,
+        };
+    }
+    // ── Anthropic models via OpenRouter - inherit direct-provider flags ───
+    let anthropic_no_temp = model.contains("claude-opus-4-8")
+        || model.contains("claude-opus-4-7")
+        || model.contains("claude-fable-5")
+        || model.contains("claude-mythos-5");
+    if model.starts_with("anthropic/") {
+        return ModelCapabilities {
+            supports_temperature: !anthropic_no_temp,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_000_000,
+            max_output_tokens: 128_000,
+        };
+    }
+    // ── OpenAI o-series via OpenRouter - no temperature ───────────────────
+    if model.starts_with("openai/o") {
+        return ModelCapabilities {
+            supports_temperature: false,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 200_000,
+            max_output_tokens: 100_000,
+        };
+    }
+    // ── OpenAI GPT-5.x via OpenRouter ────────────────────────────────────
+    if model.starts_with("openai/gpt-5") {
+        return ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 1_050_000,
+            max_output_tokens: 128_000,
+        };
+    }
+    // ── Conservative fallback for unknown OpenRouter models ───────────────
+    FALLBACK_CAPABILITIES
+}
+
+/// What an OpenRouter model this build has never heard of is assumed to be.
+///
+/// Deliberately conservative: guessing high would size regions past what the
+/// model accepts and turn a quiet inefficiency into an API error. The cost of
+/// guessing low is that percentage budgets resolve against a window eight times
+/// smaller than a 1M-token model really has, which is why reaching this is
+/// worth saying out loud - see [`OpenRouterProvider::warn_if_unknown`].
+const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    supports_temperature: true,
+    supports_streaming: true,
+    supports_tools: true,
+    supports_system_prompt: true,
+    max_context_tokens: 128_000,
+    max_output_tokens: 8_192,
+};
+
+impl OpenRouterProvider {
+    /// Say so when a model fell through to [`FALLBACK_CAPABILITIES`].
+    ///
+    /// OpenRouter fronts hundreds of models and this build's table names a few
+    /// dozen, so an unlisted model is ordinary rather than exceptional - and it
+    /// silently got a 128 000-token window. Region budgets are percentages of
+    /// that window, so a `budget = "30%"` region on a model that really has
+    /// 1M tokens was being sized at 38 400 instead of 314 572: no error, no
+    /// warning, just an agent that evicts working material early and looks like
+    /// a worse model.
+    ///
+    /// Reported once per model rather than per inference, and it names the
+    /// stanza that fixes it, which is now a partial entry (#338).
+    fn warn_if_unknown(&self, model: &str, resolved: &ModelCapabilities) {
+        if resolved.max_context_tokens != FALLBACK_CAPABILITIES.max_context_tokens {
+            return;
+        }
+        let mut warned = leviath_core::sync::lock(&self.warned_unknown);
+        if !warned.insert(model.to_string()) {
+            return;
+        }
+        tracing::warn!(
+            model = %model,
+            assumed_context_tokens = FALLBACK_CAPABILITIES.max_context_tokens,
+            "this build has no context window for this OpenRouter model, so it is \
+             assuming a conservative one; percentage region budgets resolve against \
+             it. Set the real window with [model_capabilities.\"{model}\"] \
+             max_context_tokens = <n> (see `lev models show {model}`)",
+        );
     }
 }
 
@@ -261,164 +474,14 @@ impl Provider for OpenRouterProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(overrides) = self.capability_overrides.get(model) {
-            return overrides.clone();
-        }
-        // ── Google Gemini ─────────────────────────────────────────────────────
-        if model.starts_with("google/gemini") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_048_576,
-                max_output_tokens: 65_536,
-            };
-        }
-        // ── Meta Llama 4 Scout - 10M context ─────────────────────────────────
-        if model.contains("llama-4-scout") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 10_000_000,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── Meta Llama 4 (Maverick + others) - 1M context ────────────────────
-        if model.starts_with("meta-llama/llama-4") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_048_576,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── DeepSeek R1 - reasoning-only, no tools, no temperature ───────────
-        if model.contains("deepseek-r1") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: false,
-                supports_system_prompt: true,
-                max_context_tokens: 163_840,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── DeepSeek V4 Pro - 1M context, 384K output ────────────────────────
-        if model.contains("deepseek-v4-pro") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_048_576,
-                max_output_tokens: 393_216,
-            };
-        }
-        // ── DeepSeek V4 Flash / V3.x ─────────────────────────────────────────
-        if model.starts_with("deepseek/deepseek-v") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_048_576,
-                max_output_tokens: 65_536,
-            };
-        }
-        // ── Mistral Large ─────────────────────────────────────────────────────
-        if model.contains("mistral-large") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 262_144,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── Mistral Medium / Small ────────────────────────────────────────────
-        if model.starts_with("mistralai/") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── Qwen 3.6+ / Qwen3 Coder - 1M context ────────────────────────────
-        if model.contains("qwen3.6") || model.contains("qwen3-coder") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_048_576,
-                max_output_tokens: 65_536,
-            };
-        }
-        // ── Qwen3 general ─────────────────────────────────────────────────────
-        if model.starts_with("qwen/") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 32_768,
-            };
-        }
-        // ── Anthropic models via OpenRouter - inherit direct-provider flags ───
-        let anthropic_no_temp = model.contains("claude-opus-4-8")
-            || model.contains("claude-opus-4-7")
-            || model.contains("claude-fable-5")
-            || model.contains("claude-mythos-5");
-        if model.starts_with("anthropic/") {
-            return ModelCapabilities {
-                supports_temperature: !anthropic_no_temp,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-            };
-        }
-        // ── OpenAI o-series via OpenRouter - no temperature ───────────────────
-        if model.starts_with("openai/o") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 200_000,
-                max_output_tokens: 100_000,
-            };
-        }
-        // ── OpenAI GPT-5.x via OpenRouter ────────────────────────────────────
-        if model.starts_with("openai/gpt-5") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_050_000,
-                max_output_tokens: 128_000,
-            };
-        }
-        // ── Conservative fallback for unknown OpenRouter models ───────────────
-        ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 128_000,
-            max_output_tokens: 8_192,
+        let base = builtin_capabilities(model);
+        // Merged, not swapped: an entry names only what it corrects.
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(base),
+            None => {
+                self.warn_if_unknown(model, &base);
+                base
+            }
         }
     }
 
@@ -726,6 +789,75 @@ mod tests {
         assert_eq!(provider.base_url, "https://custom.openrouter.ai");
     }
 
+    // ─── The conservative fallback is no longer silent ──────────────────────
+
+    #[test]
+    fn a_known_model_keeps_its_own_window() {
+        // The table is what makes the warning meaningful: if everything fell
+        // through, warning would be noise.
+        let caps = builtin_capabilities("google/gemini-3.5-flash");
+        assert_ne!(
+            caps.max_context_tokens, FALLBACK_CAPABILITIES.max_context_tokens,
+            "a listed model should not be resolving to the fallback"
+        );
+    }
+
+    #[test]
+    fn an_unlisted_model_lands_on_the_fallback() {
+        // The reported models. OpenRouter fronts hundreds and this table names
+        // a few dozen, so this is the ordinary case rather than the odd one.
+        for model in ["moonshotai/kimi-k3", "meta/muse-spark-1.2"] {
+            assert_eq!(
+                builtin_capabilities(model).max_context_tokens,
+                FALLBACK_CAPABILITIES.max_context_tokens,
+                "{model}"
+            );
+        }
+    }
+
+    /// The warning fires once per model, not once per inference.
+    ///
+    /// Asserted through the public path because that is where the run reaches
+    /// it: `capabilities` is called for every call a stage makes.
+    #[test]
+    fn the_fallback_warning_is_once_per_model() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
+        for _ in 0..3 {
+            provider.capabilities("moonshotai/kimi-k3");
+            provider.capabilities("meta/muse-spark-1.2");
+        }
+        let warned = leviath_core::sync::lock(&provider.warned_unknown);
+        assert_eq!(warned.len(), 2, "one entry per model: {warned:?}");
+    }
+
+    /// An override silences it, because the window is then known.
+    #[test]
+    fn a_corrected_window_does_not_warn() {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "moonshotai/kimi-k3".to_string(),
+            ModelCapabilityOverride {
+                max_context_tokens: Some(1_048_576),
+                ..Default::default()
+            },
+        );
+        let provider = OpenRouterProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            overrides,
+            None,
+        );
+        let caps = provider.capabilities("moonshotai/kimi-k3");
+        assert_eq!(caps.max_context_tokens, 1_048_576);
+        assert!(
+            leviath_core::sync::lock(&provider.warned_unknown).is_empty(),
+            "nothing to warn about once the window is known"
+        );
+    }
+
     #[test]
     fn test_with_overrides() {
         let mut overrides = HashMap::new();
@@ -738,7 +870,8 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 10,
-            },
+            }
+            .into(),
         );
         let provider = OpenRouterProvider::with_overrides(
             crate::provider::build_http_client(None).expect("a test client builds"),

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -299,6 +299,68 @@ impl Default for ModelCapabilities {
     }
 }
 
+/// A `[model_capabilities]` entry: the fields an operator chose to change.
+///
+/// Every field is optional and unset means "leave it alone", so an entry names
+/// only what it is correcting. The alternative - deserializing straight into
+/// [`ModelCapabilities`] - has two failure modes, and this repo has now seen
+/// both. Without field defaults a partial table fails to deserialize and the
+/// override is dropped in silence (#338). With `#[serde(default)]` it succeeds
+/// and quietly substitutes [`ModelCapabilities::default`] for everything the
+/// operator did not mention, so correcting one boolean would drop a 400 000
+/// token window to 8 192.
+///
+/// Merging onto the provider's own answer for that model is the only reading
+/// that matches what the table looks like it does.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ModelCapabilityOverride {
+    /// See [`ModelCapabilities::supports_temperature`].
+    pub supports_temperature: Option<bool>,
+    /// See [`ModelCapabilities::supports_streaming`].
+    pub supports_streaming: Option<bool>,
+    /// See [`ModelCapabilities::supports_tools`].
+    pub supports_tools: Option<bool>,
+    /// See [`ModelCapabilities::supports_system_prompt`].
+    pub supports_system_prompt: Option<bool>,
+    /// See [`ModelCapabilities::max_context_tokens`].
+    pub max_context_tokens: Option<usize>,
+    /// See [`ModelCapabilities::max_output_tokens`].
+    pub max_output_tokens: Option<usize>,
+}
+
+impl ModelCapabilityOverride {
+    /// `base` with every field this entry names replaced.
+    pub fn apply_to(&self, base: ModelCapabilities) -> ModelCapabilities {
+        ModelCapabilities {
+            supports_temperature: self
+                .supports_temperature
+                .unwrap_or(base.supports_temperature),
+            supports_streaming: self.supports_streaming.unwrap_or(base.supports_streaming),
+            supports_tools: self.supports_tools.unwrap_or(base.supports_tools),
+            supports_system_prompt: self
+                .supports_system_prompt
+                .unwrap_or(base.supports_system_prompt),
+            max_context_tokens: self.max_context_tokens.unwrap_or(base.max_context_tokens),
+            max_output_tokens: self.max_output_tokens.unwrap_or(base.max_output_tokens),
+        }
+    }
+}
+
+impl From<ModelCapabilities> for ModelCapabilityOverride {
+    /// Every field named, for a caller that already has a complete set.
+    fn from(c: ModelCapabilities) -> Self {
+        Self {
+            supports_temperature: Some(c.supports_temperature),
+            supports_streaming: Some(c.supports_streaming),
+            supports_tools: Some(c.supports_tools),
+            supports_system_prompt: Some(c.supports_system_prompt),
+            max_context_tokens: Some(c.max_context_tokens),
+            max_output_tokens: Some(c.max_output_tokens),
+        }
+    }
+}
+
 /// Information about a model offered by a provider.
 #[derive(Debug, Clone)]
 pub struct ModelInfo {
@@ -913,6 +975,71 @@ mod stream_once {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── A partial [model_capabilities] entry corrects, it does not replace ──
+
+    /// A model whose built-in answer is nothing like `Default`.
+    fn base() -> ModelCapabilities {
+        ModelCapabilities {
+            supports_temperature: false,
+            supports_streaming: false,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 400_000,
+            max_output_tokens: 64_000,
+        }
+    }
+
+    #[test]
+    fn an_entry_naming_one_field_leaves_the_rest_alone() {
+        // The reported case: correcting a wrong context window and nothing else.
+        let over = ModelCapabilityOverride {
+            max_context_tokens: Some(1_048_576),
+            ..Default::default()
+        };
+        let merged = over.apply_to(base());
+        assert_eq!(merged.max_context_tokens, 1_048_576);
+        // Everything unmentioned is the provider's, not `Default`'s. Taking
+        // `Default` here would have dropped a 64k output cap to 4096 and turned
+        // two `false`s into `true`.
+        assert_eq!(merged.max_output_tokens, 64_000);
+        assert!(!merged.supports_temperature);
+        assert!(!merged.supports_streaming);
+    }
+
+    #[test]
+    fn an_entry_naming_nothing_changes_nothing() {
+        let merged = ModelCapabilityOverride::default().apply_to(base());
+        assert_eq!(merged.max_context_tokens, base().max_context_tokens);
+        assert_eq!(merged.max_output_tokens, base().max_output_tokens);
+        assert_eq!(merged.supports_tools, base().supports_tools);
+    }
+
+    #[test]
+    fn every_field_is_individually_overridable() {
+        // Each field on its own, so a typo in `apply_to` that read the wrong
+        // one cannot hide behind a neighbour that happens to match.
+        let full = ModelCapabilityOverride::from(ModelCapabilities {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: false,
+            supports_system_prompt: false,
+            max_context_tokens: 7,
+            max_output_tokens: 9,
+        });
+        let merged = full.apply_to(base());
+        assert!(merged.supports_temperature);
+        assert!(merged.supports_streaming);
+        assert!(!merged.supports_tools);
+        assert!(!merged.supports_system_prompt);
+        assert_eq!(merged.max_context_tokens, 7);
+        assert_eq!(merged.max_output_tokens, 9);
+    }
+
+    // The TOML shapes this type exists for - a one-field table, and a
+    // misspelled key - are asserted where the config is actually loaded, in
+    // `leviath-cli`'s `config` tests, rather than pulling a TOML parser into
+    // this crate's dev-dependencies to say the same thing twice.
 
     // ─── redirect policy ──────────────────────────────────────────────────
 

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -39,8 +39,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelInfo, Provider, ProviderError,
-    RateLimitConfig, Result, StreamChunk, ToolCallDelta,
+    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
+    Provider, ProviderError, RateLimitConfig, Result, StreamChunk, ToolCallDelta,
 };
 use crate::rate_limit::RateLimiter;
 
@@ -65,7 +65,7 @@ pub struct RhaiProvider {
     rate_limiter: Option<RateLimiter>,
     request_timeout_secs: Option<u64>,
     meta: ProviderMeta,
-    capability_overrides: HashMap<String, ModelCapabilities>,
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
     has_stream: bool,
     has_count_tokens: bool,
     has_list_models: bool,
@@ -87,7 +87,7 @@ pub struct ScriptProviderSettings {
     /// The `initialize` block from the config.
     pub init_config: serde_json::Value,
     /// Per-model capabilities the config declares.
-    pub caps: HashMap<String, ModelCapabilities>,
+    pub caps: HashMap<String, ModelCapabilityOverride>,
     /// Rate limiting, when configured.
     pub rate_limit: Option<RateLimitConfig>,
     /// Per-request timeout, when configured.
@@ -431,7 +431,7 @@ impl Provider for RhaiProvider {
     fn max_context_tokens(&self, model: &str) -> usize {
         self.capability_overrides
             .get(model)
-            .map(|c| c.max_context_tokens)
+            .and_then(|c| c.max_context_tokens)
             .unwrap_or(self.meta.max_context_tokens)
     }
 
@@ -440,14 +440,17 @@ impl Provider for RhaiProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        if let Some(c) = self.capability_overrides.get(model) {
-            return c.clone();
-        }
-        ModelCapabilities {
+        // What the script itself declares, before any `[model_capabilities]`
+        // entry is merged onto it.
+        let base = ModelCapabilities {
             max_context_tokens: self.meta.max_context_tokens,
             max_output_tokens: self.meta.max_output_tokens,
             supports_streaming: true,
             ..Default::default()
+        };
+        match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(base),
+            None => base,
         }
     }
 

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -409,10 +409,11 @@ fn capabilities_and_metadata() {
          // @default_model dm\n{NOOP_INIT}fn inference(s, r) {{ #{{}} }}"
     );
     let mut caps = HashMap::new();
+    // Names one field, which is what a `[model_capabilities]` entry looks like.
     caps.insert(
         "special".to_string(),
-        crate::provider::ModelCapabilities {
-            max_context_tokens: 999,
+        crate::provider::ModelCapabilityOverride {
+            max_context_tokens: Some(999),
             ..Default::default()
         },
     );
@@ -432,9 +433,15 @@ fn capabilities_and_metadata() {
 
     assert_eq!(p.name(), "test");
     assert_eq!(p.meta().default_model.as_deref(), Some("dm"));
-    // override wins
+    // The named field wins, and the ones it did not name are the script's own
+    // rather than `Default`'s - a partial entry corrects, it does not replace.
     assert_eq!(p.max_context_tokens("special"), 999);
-    assert_eq!(p.capabilities("special").max_context_tokens, 999);
+    let special = p.capabilities("special");
+    assert_eq!(special.max_context_tokens, 999);
+    assert_eq!(
+        special.max_output_tokens, 8000,
+        "the script's own output cap should survive an entry that never mentioned it"
+    );
     // metadata default for an unknown model
     assert_eq!(p.max_context_tokens("other"), 40000);
     let c = p.capabilities("other");

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -24,7 +24,8 @@ pub struct ProviderCreds {
     /// Base URL override (used by `ollama`; `None` uses the built-in default).
     pub base_url: Option<String>,
     /// Per-model capability overrides forwarded to the provider.
-    pub model_capabilities: std::collections::HashMap<String, leviath_providers::ModelCapabilities>,
+    pub model_capabilities:
+        std::collections::HashMap<String, leviath_providers::ModelCapabilityOverride>,
     /// HTTP request timeout in seconds (`None` uses the provider default).
     pub request_timeout_secs: Option<u64>,
     /// Client-side rate limit (requests/tokens per minute) enforced before

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::time::SystemTime;
 
 use leviath_providers::rhai_provider::host::{HttpExecutor, ReqwestExecutor};
-use leviath_providers::{ModelCapabilities, Provider, RateLimitConfig, RhaiProvider};
+use leviath_providers::{ModelCapabilityOverride, Provider, RateLimitConfig, RhaiProvider};
 
 /// Per-provider configuration from `[model_providers.<name>]`. All fields are
 /// optional overrides - a script activates by an agent referencing its name and
@@ -48,7 +48,7 @@ struct Cached {
 pub struct ScriptProviderLayer {
     dir: PathBuf,
     overrides: HashMap<String, ScriptProviderSpec>,
-    default_caps: HashMap<String, ModelCapabilities>,
+    default_caps: HashMap<String, ModelCapabilityOverride>,
     request_timeout_secs: Option<u64>,
     /// `[security] allow_env_vars`: credential-shaped environment variables a
     /// provider script may read. Empty by default - a provider script runs
@@ -73,7 +73,7 @@ impl ScriptProviderLayer {
     pub fn new(
         dir: PathBuf,
         overrides: HashMap<String, ScriptProviderSpec>,
-        default_caps: HashMap<String, ModelCapabilities>,
+        default_caps: HashMap<String, ModelCapabilityOverride>,
         request_timeout_secs: Option<u64>,
         env_allowlist: Vec<String>,
     ) -> Self {
@@ -97,7 +97,7 @@ impl ScriptProviderLayer {
     pub fn with_executor(
         dir: PathBuf,
         overrides: HashMap<String, ScriptProviderSpec>,
-        default_caps: HashMap<String, ModelCapabilities>,
+        default_caps: HashMap<String, ModelCapabilityOverride>,
         request_timeout_secs: Option<u64>,
         env_allowlist: Vec<String>,
         executor: std::result::Result<

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -438,8 +438,19 @@ Script providers configure theirs under `[model_providers.<name>.rate_limit]` in
 
 ## `[model_capabilities.<model_id>]`
 
-Per-model overrides that take precedence over the provider's built-in capability table. Useful for
-a local or self-hosted model Leviath does not know.
+Per-model corrections to the provider's built-in capability table. Useful for a local or
+self-hosted model Leviath does not know, or one whose window it has wrong.
+
+**Name only what you are changing.** Every field is optional and an unnamed one keeps whatever the
+provider already reports for that model, so the common case is one line:
+
+```toml
+[model_capabilities."moonshotai/kimi-k3"]
+max_context_tokens = 1048576
+```
+
+A misspelled key is refused at load rather than ignored, so a typo cannot look like a working
+override. The full set, when you do want to state all of it:
 
 ```toml
 [model_capabilities.my-local-llama]
@@ -450,6 +461,16 @@ supports_system_prompt = true
 max_context_tokens   = 32768
 max_output_tokens    = 4096
 ```
+
+`lev models show <model>` prints the values a run will actually use, with any correction already
+applied.
+
+> [!NOTE]
+> Region budgets written as percentages resolve against `max_context_tokens`, so a wrong window is
+> not cosmetic: a `budget = "30%"` region on a model assumed to be 128k gets 38 400 tokens instead
+> of the 314 572 a 1M-token model would give it. OpenRouter fronts far more models than any built-in
+> table names, so Leviath warns once per model when it falls back to a conservative window and tells
+> you the line to add here.
 
 <a id="model_providersname"></a>
 

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -120,6 +120,8 @@ allow_blueprint = true
 requests_per_minute = 50
 tokens_per_minute = 100000
 
+# Every field is optional: name only what you are correcting, and the rest keeps
+# whatever the provider reports for that model.
 [model_capabilities."my-local-llama"]
 supports_temperature = true
 supports_streaming = true
@@ -127,6 +129,10 @@ supports_tools = false
 supports_system_prompt = true
 max_context_tokens = 32768
 max_output_tokens = 4096
+
+# The common shape - one wrong number, one line.
+[model_capabilities."moonshotai/kimi-k3"]
+max_context_tokens = 1048576
 
 [model_providers.groq]
 script = "groq.rhai"


### PR DESCRIPTION
Closes #338, closes #337.

## #338: a partial entry was silently dropped

`ModelCapabilities` derives `Deserialize` with no field defaults, so the one-line correction someone actually writes:

```toml
[model_capabilities."moonshotai/kimi-k3"]
max_context_tokens = 1048576
```

failed to deserialize and the override never reached the provider. No error, no warning.

### Why not `#[serde(default)]`

That is the issue's suggestion, and it fixes the drop while **introducing a second silent footgun**: missing fields would come from `ModelCapabilities::default()`, so correcting one boolean on a 400 000-token model would quietly resize it to 8 192.

The fields have to be optional and merged onto the provider's own answer for that model — the only reading that matches what the table looks like it does. New `ModelCapabilityOverride` carries that shape, with `deny_unknown_fields` so a typo is refused rather than ignored, and all six providers merge instead of swapping.

## #337: OpenRouter's silent 8x under-budget

OpenRouter fronts far more models than the built-in table names, so an unlisted model silently got 128 000 tokens. Percentage budgets resolve against that, so `budget = "30%"` on a 1M-token model was sized at 38 400 instead of 314 573.

It now warns **once per model**, naming the assumed window and the exact line that fixes it — a line that works as of this PR.

### What is deliberately not done

Reading the real window off the models API. `capabilities()` is sync and called per inference, and `build_provider_registry` is sync too, so it would need either a blocking network call on the inference path or a background prefetch that races the first run. A fix that sometimes silently does nothing is the same class of bug as the one being fixed. Worth doing properly if provider construction becomes async.

## Verification

Against a real daemon, reading `max_tokens` back out of the run's own `context.json` exactly as the issue does:

| config | window | `task` region (30%) |
|---|---|---|
| no override | 128 000 | 38 400 |
| **one-line override** | 1 048 576 | 314 573 |

The warning is asserted by unit test (once per model, silent once the window is known); the daemon routes it to `daemon.log` under a service install, which is unchanged here.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-providers` and `leviath-cli`
- `cargo xtask docs --check` clean; `[model_capabilities]` docs and the example config now show the partial form