### PR TITLE
feat(stages): an escape that is not also a shortcut

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/graph.rs
+++ b/crates/leviath-cli/src/commands/dashboard/graph.rs
@@ -55,6 +55,7 @@ pub(super) fn load_graph_info(agent_path: &str) -> Option<GraphTransitionInfo> {
                         TransitionCondition::MaxIterations => "max_iterations".to_string(),
                         TransitionCondition::LlmChoice => "llm_choice".to_string(),
                         TransitionCondition::Stuck => "stuck".to_string(),
+                        TransitionCondition::DeadEnd => "dead_end".to_string(),
                     };
                     let transform = match &edge.transform {
                         EdgeTransform::Direct => "direct".to_string(),
@@ -287,6 +288,77 @@ mod tests {
     #[test]
     fn load_graph_info_missing_directory_returns_none() {
         assert!(load_graph_info("/nonexistent/path/to/agent").is_none());
+    }
+
+    /// Every condition renders under its own name in the dashboard graph, so an
+    /// edge the model cannot choose is not shown as one it can.
+    #[test]
+    fn load_graph_info_names_each_condition() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_agent(
+            dir.path(),
+            r#"
+[agent]
+name = "conds"
+version = "0.0.1"
+description = "d"
+entry_stage = "a"
+
+[stages.a]
+mode = "autonomous"
+system_prompt = "x"
+
+[stages.a.transitions.b]
+transform = "direct"
+[stages.a.transitions.c]
+condition = "llm_choice"
+[stages.a.transitions.d]
+condition = "error"
+[stages.a.transitions.e]
+condition = "max_iterations"
+[stages.a.transitions.f]
+condition = "stuck"
+stuck_after_iterations = 3
+[stages.a.transitions.g]
+condition = "dead_end"
+
+[stages.b]
+mode = "autonomous"
+system_prompt = "y"
+[stages.c]
+mode = "autonomous"
+system_prompt = "y"
+[stages.d]
+mode = "autonomous"
+system_prompt = "y"
+[stages.e]
+mode = "autonomous"
+system_prompt = "y"
+[stages.f]
+mode = "autonomous"
+system_prompt = "y"
+[stages.g]
+mode = "autonomous"
+system_prompt = "y"
+"#,
+        );
+        let info = load_graph_info(dir.path().to_str().unwrap()).expect("a graph agent");
+        let mut conditions: Vec<&str> = info.edges["a"]
+            .iter()
+            .map(|e| e.condition.as_str())
+            .collect();
+        conditions.sort_unstable();
+        assert_eq!(
+            conditions,
+            [
+                "always",
+                "dead_end",
+                "error",
+                "llm_choice",
+                "max_iterations",
+                "stuck"
+            ]
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -276,7 +276,21 @@ pub(super) fn lint_dead_end_possible(blueprint: &Blueprint) -> Vec<LintFinding> 
                 .find_stage(&e.target)
                 .is_none_or(|t| t.max_revisits.is_some())
         });
-        if all_exhaustible {
+        // An escape the runtime actually consults on this path. `resolve_transition`
+        // resolves a dead end down a `dead_end` edge, then an `error` edge, so
+        // either satisfies the check - provided its own target can still be
+        // entered, or it is no escape at all.
+        let has_escape = transitions.values().any(|e| {
+            matches!(
+                e.condition,
+                leviath_core::blueprint::TransitionCondition::DeadEnd
+                    | leviath_core::blueprint::TransitionCondition::Error
+            ) && blueprint
+                .find_stage(&e.target)
+                .is_some_and(|t| t.max_revisits.is_none())
+        });
+
+        if all_exhaustible && !has_escape {
             findings.push(
                 LintFinding::new(
                     LintSeverity::Warning,
@@ -287,9 +301,10 @@ pub(super) fn lint_dead_end_possible(blueprint: &Blueprint) -> Vec<LintFinding> 
                 )
                 .in_stage(&stage.name)
                 .with_fix(
-                    "add one un-exhaustible way forward - an edge to a stage without \
-                     max_revisits (the output stage, usually), or a condition = \
-                     \"max_iterations\" escape",
+                    "add a condition = \"dead_end\" edge to a stage without max_revisits \
+                     (the output stage, usually). It is taken only when the graph would \
+                     otherwise strand, so it is not a route the model can choose early - \
+                     unlike a plain edge to the same stage, which is offered on every visit",
                 ),
             );
         }

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -184,6 +184,156 @@ fn an_agent_level_model_block_is_warned_about() {
     assert!(findings[0].stage.is_none(), "{findings:?}");
 }
 
+// ─── dead-end-possible ────────────────────────────────────────────────────────
+
+/// A graph whose only way on is a stage with a spendable revisit budget.
+fn strandable(extra_edge: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "strandable"
+version = "0.1.0"
+description = "a fixture"
+
+[stages.work]
+mode = "autonomous"
+model = {{ models = [{{ provider = "anthropic", model = "claude-sonnet-5" }}] }}
+description = "Work"
+max_iterations = 10
+available_tools = ["read_file"]
+[stages.work.transitions.review]
+transform = "direct"
+{extra_edge}
+
+[stages.review]
+mode = "autonomous"
+model = {{ models = [{{ provider = "anthropic", model = "claude-sonnet-5" }}] }}
+description = "Review"
+max_iterations = 10
+max_revisits = 2
+available_tools = ["read_file"]
+
+[stages.answer]
+mode = "output"
+model = {{ models = [{{ provider = "anthropic", model = "claude-sonnet-5" }}] }}
+description = "Answer"
+max_iterations = 10
+
+[context.regions]
+system = {{ kind = "pinned", max_tokens = 1000 }}
+conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
+"#
+    )
+}
+
+#[test]
+fn a_strandable_stage_is_warned_about() {
+    let findings = lint(&strandable(""), &LintEnv::default());
+    assert!(
+        codes(&findings).contains(&"dead-end-possible"),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// The remedy the message names has to be one that silences it, or an author
+/// who follows the advice literally is left reaching for the other one - which
+/// is a route the model can take on every visit.
+#[test]
+fn a_dead_end_edge_satisfies_the_check() {
+    let toml = strandable(
+        "\n[stages.work.transitions.answer]\ncondition = \"dead_end\"\ntransform = \"direct\"\n",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        !codes(&findings).contains(&"dead-end-possible"),
+        "the recommended fix should silence it: {:?}",
+        codes(&findings)
+    );
+}
+
+/// An `error` edge is the other escape the runtime consults on this path.
+#[test]
+fn an_error_edge_also_satisfies_the_check() {
+    let toml = strandable(
+        "\n[stages.work.transitions.answer]\ncondition = \"error\"\ntransform = \"direct\"\n",
+    );
+    assert!(!codes(&lint(&toml, &LintEnv::default())).contains(&"dead-end-possible"));
+}
+
+/// `max_iterations` does **not**, and the message no longer suggests it. It
+/// fires when a stage burns its iteration budget, which is a different event:
+/// on the stranding path `resolve_transition` never consults it, so counting it
+/// would silence the warning without preventing the strand.
+#[test]
+fn a_max_iterations_edge_does_not_satisfy_the_check() {
+    let toml = strandable(
+        "\n[stages.work.transitions.answer]\ncondition = \"max_iterations\"\ntransform = \"direct\"\n",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        codes(&findings).contains(&"dead-end-possible"),
+        "{:?}",
+        codes(&findings)
+    );
+    let fix = with_code(&findings, "dead-end-possible")[0]
+        .fix
+        .clone()
+        .expect("the finding carries a fix");
+    assert!(fix.contains("dead_end"), "{fix}");
+    assert!(
+        !fix.contains("max_iterations"),
+        "it should no longer recommend an inert remedy: {fix}"
+    );
+}
+
+/// An escape to a stage that can itself run out is no escape, so it does not
+/// silence the warning.
+#[test]
+fn a_dead_end_edge_to_an_exhaustible_stage_does_not_count() {
+    let toml = r#"
+[agent]
+name = "strandable"
+version = "0.1.0"
+description = "a fixture"
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Work"
+max_iterations = 10
+available_tools = ["read_file"]
+[stages.work.transitions.review]
+transform = "direct"
+[stages.work.transitions.fallback]
+condition = "dead_end"
+transform = "direct"
+
+[stages.review]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Review"
+max_iterations = 10
+max_revisits = 2
+available_tools = ["read_file"]
+
+# The escape's own target can run out too, so following it only defers the
+# strand rather than resolving it.
+[stages.fallback]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Fallback"
+max_iterations = 10
+max_revisits = 1
+available_tools = ["read_file"]
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+"#;
+    assert!(codes(&lint(toml, &LintEnv::default())).contains(&"dead-end-possible"));
+}
+
 // ─── Seeds the parser threw away ──────────────────────────────────────────────
 
 /// A seed table with no key the parser recognizes leaves the region empty.

--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -278,6 +278,22 @@ pub enum TransitionCondition {
     MaxIterations,
     /// LLM picks from available transitions (default for multi-transition stages)
     LlmChoice,
+    /// Fires when the graph would otherwise strand here: the stage finished, and
+    /// every normal (`always`/`llm_choice`) edge's target has spent its
+    /// `max_revisits`.
+    ///
+    /// Exists because the alternatives were both bad. Declaring an ordinary edge
+    /// to the output stage silences the `dead-end-possible` lint by adding a
+    /// route the model can take at the end of *every* visit - measured, that
+    /// collapsed pipelines in 10 of 24 runs of one agent and 21 of 36 of
+    /// another. Declaring nothing leaves the run to die with everything it
+    /// established thrown away. This edge is reachable when stuck and invisible
+    /// the rest of the time, which is what "escape" actually means.
+    ///
+    /// Deliberately not `max_iterations`: that fires when a stage burns its
+    /// iteration budget, which is a different event and does not fire here at
+    /// all.
+    DeadEnd,
     /// Fires *mid-stage* when the stage's runtime metrics cross this edge's
     /// [`StuckConfig`] thresholds - the agent is burning iterations, wall clock,
     /// or edits to one file without finishing. Unlike every other condition this

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -602,6 +602,7 @@ pub(super) fn parse_transitions(
             Some("max_iterations") => TransitionCondition::MaxIterations,
             Some("llm_choice") => TransitionCondition::LlmChoice,
             Some("stuck") => TransitionCondition::Stuck,
+            Some("dead_end") => TransitionCondition::DeadEnd,
             Some("always") | None => TransitionCondition::Always,
             // Reject unknown conditions rather than silently building a
             // `Custom(..)` edge the runtime never evaluates (a dead edge).
@@ -609,7 +610,7 @@ pub(super) fn parse_transitions(
                 return Err(Error::Other(format!(
                     "transition to '{target_name}' has unknown condition \
                      '{other}' (valid: always, error, max_iterations, \
-                     llm_choice, stuck)"
+                     llm_choice, stuck, dead_end)"
                 )));
             }
         };

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -292,6 +292,36 @@ mode = "autonomous"
     assert!(err.contains("whenever_i_feel_like_it"), "got: {err}");
     // The rejection message must list every condition that IS valid.
     assert!(err.contains("stuck"), "got: {err}");
+    assert!(err.contains("dead_end"), "got: {err}");
+}
+
+/// `condition = "dead_end"` parses. It is the escape the `dead-end-possible`
+/// lint recommends, so a manifest that follows the advice has to load.
+#[test]
+fn parse_manifest_accepts_a_dead_end_condition() {
+    let toml = r#"
+[agent]
+name = "escapes"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.transitions.answer]
+condition = "dead_end"
+
+[stages.answer]
+mode = "autonomous"
+"#;
+    let bp = parse_manifest(toml).expect("dead_end is a valid condition");
+    let edge = bp
+        .find_stage("work")
+        .and_then(|s| s.transitions.as_ref())
+        .and_then(|t| t.get("answer"))
+        .expect("the edge survives");
+    assert_eq!(
+        edge.condition,
+        crate::blueprint::TransitionCondition::DeadEnd
+    );
 }
 
 // ─── stuck detection (#106) ─────────────────────────────────────────────

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5244,6 +5244,123 @@ fn transition_visit_exhausted_edge_is_a_dead_end_error() {
     assert!(message.contains("'a'"), "{message}");
 }
 
+// ─── condition = "dead_end" ──────────────────────────────────────────────────
+
+/// The stranding case the condition exists for: the stage finished, every
+/// normal target is out of revisits, and the run continues instead of dying
+/// with everything it established thrown away.
+#[test]
+fn a_dead_end_edge_catches_the_strand() {
+    use leviath_core::blueprint::TransitionCondition;
+    let bp = blueprint(vec![
+        stage_named(
+            "a",
+            Some(vec![
+                edge("b", TransitionCondition::Always),
+                edge("answer", TransitionCondition::DeadEnd),
+            ]),
+            false,
+            None,
+        ),
+        stage_named("b", None, false, Some(0)),
+        stage_named("answer", None, false, None),
+    ]);
+    let mut visits = VisitCounts::default();
+    visits.0.insert("b".to_string(), 1);
+    let mut world = World::new();
+    let e = spawn_transition_agent(&mut world, bp, vec![si("m0"), si("m1"), si("m2")], visits);
+
+    run_transition(&mut world);
+
+    let state = world.get::<AgentState>(e).unwrap();
+    assert!(
+        !matches!(state.status, AgentStatus::Error { .. }),
+        "the escape should have been taken, got {:?}",
+        state.status
+    );
+    assert_eq!(
+        world.get::<StageCursor>(e).map(|c| c.index),
+        Some(2),
+        "should have entered the stage the dead_end edge names"
+    );
+}
+
+/// The whole point of a separate condition: it is *not* a route the model can
+/// take while the graph is healthy. An ordinary edge to the same stage is
+/// offered on every visit, which is what collapsed the measured pipelines.
+#[test]
+fn a_dead_end_edge_is_not_offered_while_the_graph_is_healthy() {
+    use leviath_core::blueprint::TransitionCondition;
+    let bp = blueprint(vec![
+        stage_named(
+            "a",
+            Some(vec![
+                edge("b", TransitionCondition::Always),
+                edge("answer", TransitionCondition::DeadEnd),
+            ]),
+            false,
+            None,
+        ),
+        // `b` has budget left this time, so nothing is stranded.
+        stage_named("b", None, false, Some(5)),
+        stage_named("answer", None, false, None),
+    ]);
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1"), si("m2")],
+        VisitCounts::default(),
+    );
+
+    run_transition(&mut world);
+
+    assert_eq!(
+        world.get::<StageCursor>(e).map(|c| c.index),
+        Some(1),
+        "the normal edge should win while it still has budget"
+    );
+}
+
+/// Both declared: the one written for this situation wins, because an `error`
+/// edge is also carrying provider failures and may want to go elsewhere.
+#[test]
+fn a_dead_end_edge_wins_over_an_error_edge() {
+    use leviath_core::blueprint::TransitionCondition;
+    let bp = blueprint(vec![
+        stage_named(
+            "a",
+            Some(vec![
+                edge("b", TransitionCondition::Always),
+                edge("recover", TransitionCondition::Error),
+                edge("answer", TransitionCondition::DeadEnd),
+            ]),
+            false,
+            None,
+        ),
+        stage_named("b", None, false, Some(0)),
+        stage_named("recover", None, false, None),
+        stage_named("answer", None, false, None),
+    ]);
+    let mut visits = VisitCounts::default();
+    visits.0.insert("b".to_string(), 1);
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1"), si("m2"), si("m3")],
+        visits,
+    );
+
+    run_transition(&mut world);
+
+    assert_eq!(
+        world.get::<StageCursor>(e).map(|c| c.index),
+        Some(3),
+        "the dead_end edge, not the error edge"
+    );
+}
+
 /// A dead end with an `error` edge in budget routes down it - exhaustion is
 /// now a failure mode `error_recovery` can actually catch.
 #[test]

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -445,7 +445,21 @@ pub fn resolve_transition(
                      its max_revisits budget before an output or terminal stage was reached",
                     stage.name
                 );
-                match find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error) {
+                // A `dead_end` edge first, then the `error` edge. Both are
+                // escapes from this exact situation, but one was declared *for*
+                // it: an author who wrote both means the specific one to win,
+                // and an `error` edge is also carrying provider failures.
+                let escape =
+                    find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::DeadEnd)
+                        .or_else(|| {
+                            find_conditioned_edge(
+                                &bp.0,
+                                stage,
+                                &visits.0,
+                                TransitionCondition::Error,
+                            )
+                        });
+                match escape {
                     Some((i, t)) => {
                         note_error(&mut window, &stage.name, &message);
                         StageResolution::Next(i, t, None)

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -132,6 +132,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | warning | `unknown-model` | A model this build has not heard of, checked only against providers with a closed catalog. Ollama, OpenRouter and script providers are never checked. |
 | warning | `no-reachable-provider` | Nothing in the stage's models list is configured here, so it falls through to your default model. |
 | warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
+| warning | `dead-end-possible` | Every normal edge's target has a `max_revisits` budget, so the run errors once they are spent. Add a `condition = "dead_end"` edge to a stage without one. A `max_iterations` edge does not count: it fires on the iteration cap, never on this path. |
 | warning | `read-paths-not-granted` | The blueprint declares `[read_paths]` your `config.toml` does not grant. Declaring is not granting, so those reads are refused; the fix line carries the stanza to add. |
 | warning | `read-paths-grant-invalid` | A `read_paths` grant in your own config will not compile. It is a hard spawn error, named here first. |
 | note | `holds-under-yolo` | A checkpoint that still stops an unattended run for a person: an interaction point declaring `unattended = "ask"`, or a blocking tool a stage keeps in `required_tools`. Deliberate where it appears; noted because `--yolo` reads as "run without me". |

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -67,8 +67,8 @@ Every edge is one of two kinds:
 - A **hint** edge is chosen by the agent. When it decides the stage's goal is met, it picks the edge
   whose hint best matches what it just did.
 - A **conditional** edge fires on its own, on a signal from the runtime rather than the agent's
-  choice. The signals are `error`, `stuck`, `max_iterations` (the stage hit its iteration cap), and
-  `always` (an unconditional edge).
+  choice. The signals are `error`, `stuck`, `max_iterations` (the stage hit its iteration cap),
+  `dead_end` (the graph would otherwise strand here), and `always` (an unconditional edge).
 
 ```toml
 [stages.implement.transitions.review]
@@ -80,8 +80,38 @@ condition = "stuck"          # a runtime signal, not the agent's choice
 
 An edge with a `hint` and no `condition` is routed by the model, exactly as though you had written
 `condition = "llm_choice"`. The full set of values is `always`, `llm_choice`, `error`,
-`max_iterations`, and `stuck`. Anything else is a parse error rather than an edge that quietly does
-nothing, so a typo fails at `lev validate` instead of at 2am.
+`max_iterations`, `stuck`, and `dead_end`. Anything else is a parse error rather than an edge that
+quietly does nothing, so a typo fails at `lev validate` instead of at 2am.
+
+### The escape that is not also a shortcut
+
+`condition = "dead_end"` fires in one situation: the stage finished, and every normal edge's target
+has spent its `max_revisits`. Without it the run errors out and everything it established - a
+profiled dataset, a plan, two rounds of critique - is discarded.
+
+```toml
+[stages.plan.transitions.review]
+hint = "Plan is ready for review"
+
+# Taken only when `review` is out of revisits and there is nowhere legal to go.
+[stages.plan.transitions.answer]
+condition = "dead_end"
+```
+
+The reason this is its own condition, rather than "add an ordinary edge to the output stage": an
+ordinary edge is offered to the model at the end of **every** visit, so it becomes a shortcut past
+the rest of the pipeline. Measured on four agents, that shortcut was taken in 10 of 24 runs of one
+and 21 of 36 of another, computing nothing on the way. A `dead_end` edge is invisible to the model's
+choice and reachable only when the alternative is dying.
+
+`error` edges are also consulted on this path, so a stage that already has one is covered. When both
+are declared, `dead_end` wins: an `error` edge is carrying provider failures too and may want to go
+somewhere else.
+
+> [!NOTE]
+> `condition = "max_iterations"` does **not** cover this. It fires when a stage burns its iteration
+> budget, which is a different event - on the stranding path it is never consulted. `lev validate`
+> reflects that: a `max_iterations` edge does not silence `dead-end-possible`.
 
 ### Stage keys that shape routing
 


### PR DESCRIPTION
Closes #346, closes #340.

## The problem

A stage whose downstream targets run out of `max_revisits` had two ways to end, and both were bad:

| Option | Result |
|---|---|
| ordinary edge to the output stage | Silences the lint, **and becomes a route the model can take at the end of every visit.** Measured: pipelines collapsed in 10 of 24 runs of one agent, 21 of 36 of another |
| declare nothing | The run dies, discarding a profiled dataset, a plan, two rounds of critique |

## `condition = "dead_end"`

Fires in exactly the stranding case — the stage finished and every normal edge's target has spent its revisits — and is **invisible to the model's routing** the rest of the time. That is the difference between an escape and a shortcut.

`error` edges were already consulted on this path and still are. When both are declared `dead_end` wins: an `error` edge is carrying provider failures too and may want to go elsewhere.

## Why #340 is fixed differently than it asked

#340 asked for `max_iterations` edges to count as satisfying `dead-end-possible`. **They should not.** That condition fires when a stage burns its iteration budget — a different event, and `resolve_transition` never consults it on the stranding path (only `Always`/`LlmChoice` are followable, then it falls to `DeadEnd`).

Counting it would silence the warning *without preventing the strand* — which is the same failure the issue is about, reached from the other side. So instead:

- the lint counts what the runtime actually consults (`dead_end`, `error`)
- it requires the escape's **own** target to be un-exhaustible, since an escape that can run out only defers the strand
- its message recommends `dead_end` and no longer suggests the inert remedy

A test pins that `max_iterations` does *not* satisfy it, so this cannot quietly regress.

## Verification

Live, two agents identical but for the escape edge, `review` at `max_revisits = 0`:

```
noescape   status=error      stage=work
           "stage 'work' dead-ended: every declared transition's target has
            spent its max_revisits budget"
escape     status=complete   stage=answer
```

Unit tests cover the three behaviours that matter: the escape fires on the strand, it is **not** offered while the graph is healthy, and it beats an `error` edge when both exist.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-core`, `leviath-runtime`, `leviath-cli`
- `cargo xtask docs --check` clean; `stages.md` documents the condition and why it is not `max_iterations`