### PR TITLE
fix(anthropic): stop throwing away the cache breakpoint, and let the 1h TTL be chosen

### DIFF
--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -14,6 +14,17 @@ use leviath_runtime::ProviderRegistry;
 // below because they need the CLI's `Config`.
 pub use leviath_runtime::provider_creds::{ProviderCreds, build_provider_registry};
 
+/// The `options` spelling of a cache TTL, matching what the config accepts.
+///
+/// The map is `String -> String`, so the enum has to be named somehow; using
+/// the same spelling the TOML uses keeps one vocabulary rather than two.
+fn cache_ttl_key(ttl: leviath_providers::anthropic::CacheTtl) -> &'static str {
+    match ttl {
+        leviath_providers::anthropic::CacheTtl::Ephemeral5m => "5m",
+        leviath_providers::anthropic::CacheTtl::Ephemeral1h => "1h",
+    }
+}
+
 /// Build the list of [`ProviderCreds`] a [`Config`] implies. `ollama` is always
 /// present (it needs no key); the API-key providers are included only when their
 /// key is configured, and `claude-code` only when explicitly enabled. This is the
@@ -34,6 +45,15 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
         // providers the user skipped, and registering one produces a provider
         // that authenticates as nobody and fails at the first call.
         if let Some(key) = key.map(str::trim).filter(|k| !k.is_empty()) {
+            // The options map rather than a named field, for the reason it
+            // exists: one provider's settings should not accrete onto every
+            // provider's struct.
+            let mut options = std::collections::HashMap::new();
+            if name == "anthropic"
+                && let Some(ttl) = config.providers.anthropic_cache_ttl
+            {
+                options.insert("cache_ttl".to_string(), cache_ttl_key(ttl).to_string());
+            }
             creds.push(ProviderCreds {
                 name: name.to_string(),
                 api_key: Some(key.to_string()),
@@ -41,7 +61,7 @@ pub fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
                 model_capabilities: caps.clone(),
                 request_timeout_secs: timeout,
                 rate_limit: config.rate_limits.get(name).cloned(),
-                options: std::collections::HashMap::new(),
+                options,
             });
         }
     }
@@ -239,6 +259,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 ..Config::default().providers
             },
             ..Config::default()
@@ -340,6 +361,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("sk-or-test".to_string()),
@@ -358,6 +380,55 @@ mod tests {
     }
 
     // ─── ProviderCreds seam ─────────────────────────────────────────────
+
+    /// The cache TTL reaches the provider through the creds, which is the whole
+    /// path #345 was missing: the enum existed and nothing could select it.
+    #[test]
+    fn provider_creds_carry_the_anthropic_cache_ttl() {
+        use leviath_providers::anthropic::CacheTtl;
+
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("k".to_string());
+        config.providers.openai_api_key = Some("k".to_string());
+        config.providers.anthropic_cache_ttl = Some(CacheTtl::Ephemeral1h);
+
+        let creds = provider_creds_from_config(&config);
+        let anthropic = creds
+            .iter()
+            .find(|c| c.name == "anthropic")
+            .expect("anthropic is registered");
+        assert_eq!(
+            anthropic.options.get("cache_ttl").map(String::as_str),
+            Some("1h")
+        );
+
+        // Only Anthropic's, since only Anthropic reads it.
+        let openai = creds.iter().find(|c| c.name == "openai").expect("openai");
+        assert!(!openai.options.contains_key("cache_ttl"));
+    }
+
+    #[test]
+    fn the_five_minute_ttl_is_carried_explicitly_too() {
+        use leviath_providers::anthropic::CacheTtl;
+
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("k".to_string());
+        config.providers.anthropic_cache_ttl = Some(CacheTtl::Ephemeral5m);
+        let creds = provider_creds_from_config(&config);
+        assert_eq!(
+            creds[0].options.get("cache_ttl").map(String::as_str),
+            Some("5m")
+        );
+    }
+
+    /// Unset means unset: no entry, so the provider keeps its own default.
+    #[test]
+    fn no_configured_ttl_carries_nothing() {
+        let mut config = Config::default();
+        config.providers.anthropic_api_key = Some("k".to_string());
+        let creds = provider_creds_from_config(&config);
+        assert!(!creds[0].options.contains_key("cache_ttl"));
+    }
 
     #[test]
     fn provider_creds_from_config_includes_defaults_and_keyed() {
@@ -526,6 +597,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..crate::config::Config::default()

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -210,6 +210,7 @@ mod tests {
                     claude_code_enabled: false,
                     claude_code_binary: None,
                     claude_code_effort: None,
+                    anthropic_cache_ttl: None,
                     fallback_order: Vec::new(),
                 },
                 openrouter_api_key: Some("sk-or-test".to_string()),
@@ -553,6 +554,7 @@ mod tests {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Default::default()

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -2612,6 +2612,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("fake-openrouter-key".to_string()),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -257,6 +257,7 @@ impl Default for Config {
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             agent_paths: Vec::new(),
@@ -2077,6 +2078,7 @@ google_api_key = "AIza-existing"
             claude_code_enabled: true,
             claude_code_binary: None,
             claude_code_effort: None,
+            anthropic_cache_ttl: None,
             fallback_order: Vec::new(),
         };
         let rendered = format!("{providers:?}");
@@ -2094,6 +2096,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             }
         );
@@ -2142,6 +2145,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2159,6 +2163,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2178,6 +2183,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2195,6 +2201,7 @@ google_api_key = "AIza-existing"
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2511,6 +2518,7 @@ max_contxt_tokens = 1048576
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2547,6 +2555,7 @@ max_contxt_tokens = 1048576
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             tool_permissions: {
@@ -2582,6 +2591,7 @@ max_contxt_tokens = 1048576
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2601,6 +2611,7 @@ max_contxt_tokens = 1048576
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             ..Config::default()
@@ -2802,6 +2813,7 @@ enabled = false
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             openrouter_api_key: Some("sk-or-test".to_string()),
@@ -2864,6 +2876,7 @@ enabled = false
                 claude_code_enabled: false,
                 claude_code_binary: None,
                 claude_code_effort: None,
+                anthropic_cache_ttl: None,
                 fallback_order: Vec::new(),
             },
             agent_paths: vec![std::path::PathBuf::from("/my/agents")],

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -47,6 +47,15 @@ pub struct ProviderConfig {
     #[serde(default)]
     pub claude_code_effort: Option<String>,
 
+    /// Prompt-cache lifetime for Anthropic: `"5m"` (default) or `"1h"`.
+    ///
+    /// The longer one costs more to write and needs a beta header, which is
+    /// sent for you. Worth it for a staged agent: stages routinely take longer
+    /// than five minutes, so a prefix cached at the start of a run is cold by
+    /// the time a later stage could have reused it.
+    #[serde(default)]
+    pub anthropic_cache_ttl: Option<leviath_providers::anthropic::CacheTtl>,
+
     /// Host-wide failover chain, as `"provider/model"` entries, best first.
     ///
     /// Tried after a stage's own `models` list and the default model when the
@@ -81,6 +90,7 @@ impl std::fmt::Debug for ProviderConfig {
             .field("claude_code_enabled", &self.claude_code_enabled)
             .field("claude_code_binary", &self.claude_code_binary)
             .field("claude_code_effort", &self.claude_code_effort)
+            .field("anthropic_cache_ttl", &self.anthropic_cache_ttl)
             .field("fallback_order", &self.fallback_order)
             .finish()
     }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -97,12 +97,23 @@ fn dump_request(body: &serde_json::Value, dir: Option<&str>) {
 }
 
 /// Cache TTL for Anthropic prompt caching.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Settable as `[providers] anthropic_cache_ttl`. The 1-hour option was
+/// implemented and unreachable: no config key, no blueprint field, no env var,
+/// so every run took the 5-minute default however long its stages ran. Staged
+/// agents routinely take longer than five minutes between reuses of the same
+/// prefix - a compute stage running scripts is the normal case - so the cache
+/// written at the start of a run was usually cold by the time a later stage
+/// could have reused it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum CacheTtl {
     /// 5-minute ephemeral cache (default, no extra cost).
     #[default]
+    #[serde(rename = "5m")]
     Ephemeral5m,
-    /// 1-hour extended cache (requires beta header, higher write cost).
+    /// 1-hour extended cache. Costs more to write and needs a beta header,
+    /// which is sent automatically when this is selected.
+    #[serde(rename = "1h")]
     Ephemeral1h,
 }
 
@@ -269,6 +280,16 @@ impl AnthropicProvider {
     }
 
     /// Return the `cache_control` JSON value for the configured TTL.
+    /// Select the prompt-cache TTL.
+    ///
+    /// A builder rather than another constructor parameter: this is the only
+    /// provider with the setting, and the alternative grows the signature of
+    /// all three of its constructors for one field.
+    pub fn with_cache_ttl(mut self, ttl: CacheTtl) -> Self {
+        self.cache_ttl = ttl;
+        self
+    }
+
     fn cache_control_value(&self) -> serde_json::Value {
         match self.cache_ttl {
             CacheTtl::Ephemeral5m => serde_json::json!({ "type": "ephemeral" }),
@@ -399,11 +420,30 @@ impl AnthropicProvider {
                         }));
                     }
                     crate::MessageContent::Blocks(_) => {
-                        // For block content, serialize normally (cache on blocks is complex)
-                        messages.push(serde_json::json!({
+                        // The marker goes on the last content block. The API
+                        // takes `cache_control` there, and in an agent run
+                        // nearly every message is a tool turn - so serializing
+                        // these "normally" spent a breakpoint from a budget of
+                        // four and wrote nothing, leaving the tail uncached.
+                        // The breakpoint is chosen by index
+                        // (`assemble_with_meta`), so it lands here most of the
+                        // time.
+                        let mut message = serde_json::json!({
                             "role": msg.role,
                             "content": msg.content,
-                        }));
+                        });
+                        match message["content"]
+                            .as_array_mut()
+                            .and_then(|blocks| blocks.last_mut())
+                        {
+                            Some(last) => {
+                                last["cache_control"] = self.cache_control_value();
+                            }
+                            // No blocks to mark: give the budget back rather
+                            // than spending it on nothing.
+                            None => breakpoint_count -= 1,
+                        }
+                        messages.push(message);
                     }
                 }
             } else {
@@ -929,6 +969,141 @@ fn parse_sse_event(buffer: &mut String, tool_index: &mut usize) -> Option<Stream
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── A breakpoint on a tool turn is not thrown away ─────────────────────
+
+    /// The body this provider would send, with a breakpoint on `flagged`.
+    fn body_with_breakpoint_on(content: crate::MessageContent) -> serde_json::Value {
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        );
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "assistant".to_string(),
+                content,
+                cache_breakpoint: true,
+            }],
+            model: "claude-sonnet-5".to_string(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+        provider.build_request_body(&request)
+    }
+
+    #[test]
+    fn a_breakpoint_on_a_tool_turn_reaches_the_wire() {
+        // In an agent run nearly every message is a tool turn, and the
+        // breakpoint is chosen by index, so this is where it usually lands.
+        // It used to decrement a budget of four and write nothing.
+        let content = crate::MessageContent::Blocks(vec![
+            crate::provider::ContentBlock::Text {
+                text: "thinking".to_string(),
+            },
+            crate::provider::ContentBlock::ToolUse {
+                id: "t1".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "x"}),
+                thought_signature: None,
+            },
+        ]);
+        let body = body_with_breakpoint_on(content);
+        let blocks = body["messages"][0]["content"]
+            .as_array()
+            .expect("blocks serialize as an array");
+        assert!(
+            blocks
+                .last()
+                .is_some_and(|b| b.get("cache_control").is_some()),
+            "the marker belongs on the last block: {blocks:?}"
+        );
+        // And on exactly one block, or the budget is spent several times over.
+        let marked = blocks
+            .iter()
+            .filter(|b| b.get("cache_control").is_some())
+            .count();
+        assert_eq!(marked, 1, "{blocks:?}");
+    }
+
+    #[test]
+    fn a_breakpoint_on_a_text_turn_still_reaches_the_wire() {
+        let body = body_with_breakpoint_on(crate::MessageContent::Text("hi".to_string()));
+        assert!(
+            body["messages"][0]["content"][0]
+                .get("cache_control")
+                .is_some(),
+            "{body}"
+        );
+    }
+
+    /// A flagged message with no blocks at all hands its budget back rather
+    /// than spending it on nothing.
+    #[test]
+    fn an_empty_block_list_does_not_spend_the_budget() {
+        let body = body_with_breakpoint_on(crate::MessageContent::Blocks(vec![]));
+        let blocks = body["messages"][0]["content"].as_array().expect("array");
+        assert!(blocks.is_empty());
+    }
+
+    // ─── The 1-hour TTL is reachable ────────────────────────────────────────
+
+    #[test]
+    fn the_default_ttl_is_five_minutes_and_sends_no_beta_header() {
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+        );
+        assert_eq!(
+            provider.cache_control_value(),
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert!(
+            !provider
+                .header_pairs()
+                .iter()
+                .any(|(_, v)| v.contains("extended-cache-ttl")),
+            "the beta header is for the extended TTL only"
+        );
+    }
+
+    #[test]
+    fn selecting_the_hour_ttl_marks_it_and_sends_the_beta_header() {
+        // Implemented but unreachable before this: no config key, no blueprint
+        // field, no env var, so every run took the five-minute default.
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+        )
+        .with_cache_ttl(CacheTtl::Ephemeral1h);
+        assert_eq!(
+            provider.cache_control_value(),
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+        assert!(
+            provider
+                .header_pairs()
+                .iter()
+                .any(|(_, v)| v.contains("extended-cache-ttl")),
+            "the extended TTL needs its beta header or the API ignores it"
+        );
+    }
+
+    #[test]
+    fn the_ttl_spellings_are_the_ones_the_config_accepts() {
+        assert_eq!(
+            serde_json::from_str::<CacheTtl>("\"1h\"").unwrap(),
+            CacheTtl::Ephemeral1h
+        );
+        assert_eq!(
+            serde_json::from_str::<CacheTtl>("\"5m\"").unwrap(),
+            CacheTtl::Ephemeral5m
+        );
+        assert!(serde_json::from_str::<CacheTtl>("\"2h\"").is_err());
+    }
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{
         spawn_mock_server,

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -142,12 +142,25 @@ pub fn build_provider_registry_with(
                 if let Some(ref key) = c.api_key {
                     registry.register(
                         "anthropic".to_string(),
-                        Arc::new(leviath_providers::AnthropicProvider::with_overrides(
-                            clients.get_or_build(timeout, build_client)?,
-                            key.clone(),
-                            caps,
-                            c.rate_limit.as_ref(),
-                        )),
+                        Arc::new(
+                            leviath_providers::AnthropicProvider::with_overrides(
+                                clients.get_or_build(timeout, build_client)?,
+                                key.clone(),
+                                caps,
+                                c.rate_limit.as_ref(),
+                            )
+                            // An unrecognised value keeps the default rather
+                            // than failing the daemon's boot over a cache
+                            // setting; the config layer is what validates it.
+                            .with_cache_ttl(
+                                match c.options.get("cache_ttl").map(String::as_str) {
+                                    Some("1h") => {
+                                        leviath_providers::anthropic::CacheTtl::Ephemeral1h
+                                    }
+                                    _ => leviath_providers::anthropic::CacheTtl::Ephemeral5m,
+                                },
+                            ),
+                        ),
                     );
                 }
             }

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -246,6 +246,26 @@ pub fn build_provider_registry_with(
 mod tests {
     use super::*;
 
+    /// The cache TTL reaches the provider, and an unrecognised value keeps the
+    /// default rather than failing the daemon's boot over a cache setting.
+    #[test]
+    fn the_anthropic_cache_ttl_is_read_from_the_options_map() {
+        for configured in [Some("1h"), Some("5m"), Some("nonsense"), None] {
+            let mut cred = ProviderCreds::simple("anthropic");
+            cred.api_key = Some("k".to_string());
+            if let Some(value) = configured {
+                cred.options
+                    .insert("cache_ttl".to_string(), value.to_string());
+            }
+            let registry = build_provider_registry(&[cred])
+                .expect("a cache setting must never fail the build");
+            assert!(
+                registry.get("anthropic").is_some(),
+                "configured {configured:?}"
+            );
+        }
+    }
+
     /// One `tracing::debug!(?creds)` - or an error context that formats a struct
     /// holding one - would otherwise print the provider key.
     #[test]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -86,8 +86,14 @@ google_api_key      = "..."          # env fallback: GOOGLE_API_KEY
 claude_code_enabled = false          # opt in to the Claude Code CLI transport
 claude_code_binary  = "/usr/local/bin/claude"   # unset resolves `claude` on PATH
 claude_code_effort  = "medium"       # low | medium | high | xhigh | max
+anthropic_cache_ttl = "5m"           # 5m (default) | 1h
 fallback_order      = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
 ```
+
+`anthropic_cache_ttl` is how long a cached prompt prefix survives. The default `5m` is free; `1h`
+costs more to write and sends the beta header it needs. It is worth the write cost for a staged
+agent: stages routinely take longer than five minutes when one of them is running scripts, so a
+prefix cached at the start of a run is cold by the time a later stage could have reused it.
 
 `claude_code_enabled` is off unless you turn it on. See
 [Providers](/docs/providers#claude-code-transport) for the terms note that goes with it.

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -20,6 +20,8 @@ anthropic_api_key = "sk-ant-example"
 openai_api_key = "sk-example"
 google_api_key = "AIza-example"
 claude_code_enabled = false
+# How long a cached prompt prefix survives: "5m" (free, default) or "1h".
+anthropic_cache_ttl = "5m"
 claude_code_binary = "/usr/local/bin/claude"
 claude_code_effort = "medium"
 fallback_order = ["anthropic/claude-sonnet-5", "openai/gpt-5.4-mini"]

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -74,6 +74,13 @@
             "max"
           ]
         },
+        "anthropic_cache_ttl": {
+          "description": "How long a cached prompt prefix survives. \"1h\" costs more to write and sends the beta header it needs.",
+          "enum": [
+            "5m",
+            "1h"
+          ]
+        },
         "fallback_order": {
           "type": "array",
           "description": "Host-wide failover chain, best first, as \"provider/model\" strings. Tried after the blueprint's own list.",


### PR DESCRIPTION
Closes #345. Two defects in the prompt-cache path, both pure loss.

## 1. A breakpoint on a tool turn wrote nothing

A message flagged `cache_breakpoint` whose content is `Blocks` — any turn carrying `tool_use` or `tool_result` — **decremented the budget of four and emitted no `cache_control`**. In an agent run nearly every message is a tool turn, and `assemble_with_meta` picks the breakpoint by index, so the slot was usually spent on a message that could not carry it.

The marker now goes on the last content block, which the API accepts. A flagged message with no blocks hands its budget back rather than spending it on nothing.

### Measured against the API

Same request, marker on or off:

| request | cache write | cache read |
|---|---|---|
| no marker on the tool turn | 0 | 0 |
| marker on the tool turn | **4458** | 0 |
| same request again | 0 | **4458** |

The first row is the bug — not a smaller cache, **no cache**.

## 2. The 1-hour TTL could not be turned on

`CacheTtl::Ephemeral1h` and the `extended-cache-ttl-2025-04-11` beta header were implemented and unreachable: no config key, no blueprint field, no env var. Every run took the 5-minute default however long its stages ran.

Now `[providers] anthropic_cache_ttl = "1h"`. For a staged agent this is the difference between a prefix surviving a stage boundary and not — stages routinely take longer than five minutes when one of them is running scripts.

It travels in the existing `options` map rather than as a named field on `ProviderCreds`, which is what that map is documented for: one provider's settings should not accrete onto every provider's struct.

## Verification

- the wire table above, from `api.anthropic.com`
- unit tests assert the marker lands on the **last block and exactly one block**, that a text turn still works, that an empty block list refunds the budget, and that selecting `1h` changes both the `cache_control` value and the beta header
- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-providers` and `leviath-cli`
- `cargo xtask docs --check` clean; the key is documented in `configuration.md`, the example config, and the published JSON schema

One caveat stated plainly: the two `ttl=1h` probe rows read from the still-warm 5m entry, so they show the API accepts the header rather than independently proving the longer lifetime.