### PR TITLE
fix(tools): bound read_file, and let a stage cap tools separately

### DIFF
--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -1734,6 +1734,7 @@ criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
                 tool_overrides: HashMap::new(),
                 persist: true,
                 max_result_tokens: Some(2048),
+                tool_max_result_tokens: HashMap::new(),
             });
             s
         }];

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -67,6 +67,16 @@ pub struct ToolResultRouting {
     pub persist: bool,
     /// Max tokens per tool result (truncate if larger)
     pub max_result_tokens: Option<usize>,
+    /// Per-tool ceilings, by canonical tool name, overriding
+    /// [`Self::max_result_tokens`] for those tools.
+    ///
+    /// One number for a whole stage cannot fit a stage that both greps (small,
+    /// wants all of it) and reads files (potentially enormous, wants a cap):
+    /// picking a number for the second starves the first. Keyed by canonical
+    /// name for the same reason [`Self::tool_overrides`] is - `bash` is an
+    /// alias of `shell`, and a literal lookup would silently miss.
+    #[serde(default)]
+    pub tool_max_result_tokens: HashMap<String, usize>,
 }
 
 impl Default for ToolResultRouting {
@@ -76,6 +86,7 @@ impl Default for ToolResultRouting {
             tool_overrides: HashMap::new(),
             persist: true,
             max_result_tokens: None,
+            tool_max_result_tokens: HashMap::new(),
         }
     }
 }

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -90,6 +90,20 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
                 }
             }
         }
+        // Per-tool ceilings, spelled like the region overrides above so the two
+        // tables read as the same idea applied to two different limits.
+        if let Some(limits) = routing_table
+            .get("max_result_tokens_per_tool")
+            .and_then(|v| v.as_table())
+        {
+            for (tool_name, max_val) in limits {
+                if let Some(max) = max_val.as_integer() {
+                    routing
+                        .tool_max_result_tokens
+                        .insert(tool_name.clone(), max as usize);
+                }
+            }
+        }
 
         stage.tool_result_routing = Some(routing);
     }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3774,6 +3774,66 @@ kind = "vm"
     let err = parse_manifest(toml).unwrap_err().to_string();
     assert!(err.contains("unknown kind 'vm'"), "got: {err}");
 }
+/// Per-tool result ceilings parse, spelled like the region overrides beside
+/// them. Without this the table is accepted and ignored, which is the shape of
+/// bug #338 was.
+#[test]
+fn parse_manifest_reads_per_tool_result_ceilings() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing]
+default_region = "results"
+max_result_tokens = 4000
+
+[stages.work.tool_routing.max_result_tokens_per_tool]
+read_file = 20000
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let routing = bp
+        .find_stage("work")
+        .and_then(|s| s.tool_result_routing.as_ref())
+        .expect("routing survives");
+    assert_eq!(routing.max_result_tokens, Some(4000));
+    assert_eq!(
+        routing.tool_max_result_tokens.get("read_file").copied(),
+        Some(20000)
+    );
+}
+
+/// A non-integer ceiling is skipped rather than failing the manifest, matching
+/// how the region overrides beside it treat a non-string.
+#[test]
+fn parse_manifest_skips_a_non_integer_per_tool_ceiling() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing]
+default_region = "results"
+
+[stages.work.tool_routing.max_result_tokens_per_tool]
+read_file = "lots"
+grep = 500
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let routing = bp
+        .find_stage("work")
+        .and_then(|s| s.tool_result_routing.as_ref())
+        .expect("routing survives");
+    assert!(!routing.tool_max_result_tokens.contains_key("read_file"));
+    assert_eq!(
+        routing.tool_max_result_tokens.get("grep").copied(),
+        Some(500)
+    );
+}
 
 #[test]
 fn parse_manifest_sandbox_unknown_on_unavailable_errors() {

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4350,7 +4350,72 @@ fn routing(
             .collect(),
         persist,
         max_result_tokens: max_result,
+        tool_max_result_tokens: std::collections::HashMap::new(),
     }
+}
+
+// ── Per-tool result ceilings ──
+
+/// The text a tool's result ends up as, after routing applied its ceiling.
+fn routed_result(
+    routing: &leviath_core::blueprint::ToolResultRouting,
+    tool: &str,
+    text: &str,
+) -> String {
+    let mut w = ctx(&[("conversation", 1_000_000), ("results", 1_000_000)]);
+    apply_tool_results(
+        &mut w,
+        "resp",
+        &[tc("c1", tool)],
+        &[("c1".to_string(), text.to_string())],
+        Some(routing),
+        None,
+    );
+    // Whichever region it was routed to, the entry text is what matters here.
+    ["results", "conversation", "tool_results"]
+        .iter()
+        .filter_map(|name| w.get_region(name))
+        .flat_map(|r| r.content.iter())
+        .map(|e| e.content.clone())
+        .find(|c| c.starts_with("aaa"))
+        .unwrap_or_default()
+}
+
+/// A stage that both greps and reads files cannot express itself with one
+/// number: a cap sized for the file read lets a grep through untouched, and one
+/// sized for the grep truncates every file.
+#[test]
+fn a_per_tool_ceiling_overrides_the_stage_one() {
+    let mut routing = routing("results", &[], true, Some(10));
+    routing
+        .tool_max_result_tokens
+        .insert("read_file".to_string(), 1000);
+
+    // 400 chars is ~100 tokens: over the stage's 10, under read_file's 1000.
+    let text = "a".repeat(400);
+    assert!(
+        !routed_result(&routing, "read_file", &text).contains("[...truncated]"),
+        "the tool's own ceiling should win"
+    );
+    assert!(
+        routed_result(&routing, "grep", &text).contains("[...truncated]"),
+        "a tool with no ceiling of its own still gets the stage's"
+    );
+}
+
+/// Keyed by canonical name, like `tool_overrides`: `bash` is an alias of
+/// `shell`, and a literal lookup would silently miss the tool the model calls.
+#[test]
+fn a_per_tool_ceiling_is_matched_by_canonical_name() {
+    let mut routing = routing("results", &[], true, Some(10));
+    routing
+        .tool_max_result_tokens
+        .insert("bash".to_string(), 1000);
+    let text = "a".repeat(400);
+    assert!(
+        !routed_result(&routing, "shell", &text).contains("[...truncated]"),
+        "an alias should match the tool it aliases"
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -50,9 +50,19 @@ pub(crate) fn apply_tool_results(
             .map(|tc| tc.name.clone())
             .unwrap_or_default();
 
-        if let Some(routing) = routing
-            && let Some(max_tokens) = routing.max_result_tokens
-        {
+        // The tool's own ceiling when it has one, else the stage's.
+        let tool_cap = routing.and_then(|r| {
+            // Both sides canonicalized, exactly as `tool_overrides` below: the
+            // author writes `bash`, the model calls `shell`, and a literal
+            // comparison would silently miss in either direction.
+            let canon = leviath_tools::canonical_tool_name(&tool_name);
+            r.tool_max_result_tokens
+                .iter()
+                .find(|(k, _)| leviath_tools::canonical_tool_name(k) == canon)
+                .map(|(_, v)| *v)
+                .or(r.max_result_tokens)
+        });
+        if let Some(max_tokens) = tool_cap {
             let max_chars = max_tokens * 4;
             if result_text.len() > max_chars {
                 result_text = truncate_on_char_boundary(&result_text, max_chars);

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -230,7 +230,7 @@ impl BuiltinTools {
         };
 
         match std::fs::read_to_string(&path) {
-            Ok(content) => content,
+            Ok(content) => cap_file_content(&content, MAX_READ_FILE_BYTES),
             Err(e) => format!("[error] Failed to read '{}': {}", path_str, e),
         }
     }
@@ -652,6 +652,39 @@ impl BuiltinTools {
 /// shell output already overruns any region budget an agent has; keeping more
 /// of it helps nobody downstream.
 pub(crate) const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+
+/// Most of a file `read_file` returns.
+///
+/// `shell` has been capped since it existed; `read_file` had no bound at all,
+/// so a large file went whole into the routed region and the ladder in
+/// `tool_results` either truncated it or dropped it as `[result omitted]` -
+/// which of the two you got depended on how full the region already was. That
+/// is an all-or-nothing cliff rather than a limit.
+///
+/// Sized below [`MAX_CAPTURE_BYTES`] on purpose: shell output is usually a
+/// filtered answer, while a file read is raw material and a 256 KiB file is
+/// already far past any region budget an agent has. A stage that genuinely
+/// wants more sets `max_result_tokens` for the tool.
+pub(crate) const MAX_READ_FILE_BYTES: usize = 256 * 1024;
+
+/// `content` truncated to `cap` bytes, with a line saying so when it was.
+///
+/// Said rather than silently dropped, for the reason [`capture_note`] gives: an
+/// agent reading a truncated file as the whole file draws a wrong conclusion
+/// from it, and the conclusion is worse than the gap.
+pub(crate) fn cap_file_content(content: &str, cap: usize) -> String {
+    if content.len() <= cap {
+        return content.to_string();
+    }
+    // On a char boundary, or the result is not a `String` at all.
+    let kept = leviath_core::text::substring(content, 0, cap);
+    format!(
+        "{kept}\n[truncated] The file is {} bytes; the first {} are shown. Read a range, or \
+         narrow with a search, rather than re-reading the whole file.",
+        content.len(),
+        kept.len(),
+    )
+}
 
 /// What one stream produced, and how much of it was kept.
 #[derive(Debug)]

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1517,7 +1517,10 @@ mod tests {
 
     // ─── Bounded shell capture (issue #252) ──────────────────────────────────
 
-    use crate::exec::{Captured, MAX_CAPTURE_BYTES, capture_capped, capture_note};
+    use crate::exec::{
+        Captured, MAX_CAPTURE_BYTES, MAX_READ_FILE_BYTES, cap_file_content, capture_capped,
+        capture_note,
+    };
 
     /// A reader that hands back `chunk` `count` times and records how many
     /// reads it was asked for, standing in for a child's pipe.
@@ -1618,6 +1621,54 @@ mod tests {
     #[test]
     fn capture_note_is_silent_when_nothing_was_dropped() {
         assert!(capture_note(&captured(10, 10), &captured(0, 0), 10).is_none());
+    }
+
+    // ─── read_file has a bound ──────────────────────────────────────────────
+
+    #[test]
+    fn a_file_under_the_cap_comes_back_whole() {
+        let content = "hello".repeat(10);
+        assert_eq!(cap_file_content(&content, 1024), content);
+    }
+
+    #[test]
+    fn a_file_over_the_cap_is_truncated_and_says_so() {
+        // The old behaviour was an all-or-nothing cliff: the whole file went
+        // into the routed region, and the ladder in `tool_results` either
+        // truncated it or dropped it as `[result omitted]` depending on how
+        // full the region already was.
+        let content = "x".repeat(5000);
+        let capped = cap_file_content(&content, 1000);
+        assert!(capped.starts_with(&"x".repeat(1000)));
+        assert!(capped.contains("[truncated]"), "{capped}");
+        assert!(
+            capped.contains("5000"),
+            "the real size is the useful part: {capped}"
+        );
+    }
+
+    #[test]
+    fn truncation_lands_on_a_char_boundary() {
+        // The cap is a byte count and file content is arbitrary text, so a
+        // naive slice would panic on the way back to a `String`.
+        let content = "é".repeat(100);
+        let capped = cap_file_content(&content, 51);
+        assert!(capped.starts_with("é"));
+        assert!(capped.contains("[truncated]"));
+    }
+
+    #[tokio::test]
+    async fn read_file_applies_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("big.txt"),
+            "y".repeat(MAX_READ_FILE_BYTES + 4096),
+        )
+        .unwrap();
+        let tools = make_tools(dir.path());
+        let out = tools.read_file(&json!({ "path": "big.txt" })).await;
+        assert!(out.contains("[truncated]"), "an unbounded read is the bug");
+        assert!(out.len() < MAX_READ_FILE_BYTES + 4096);
     }
 
     #[test]

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -201,9 +201,23 @@ than scratch:
 ```toml
 [stages.analyze.tool_routing]
 default_region = "scratch"
+max_result_tokens = 4000          # ceiling for any tool without one of its own
 [stages.analyze.tool_routing.overrides]
 read_file = "codebase"
+# A stage that both greps and reads files needs two numbers, not one: a cap
+# sized for the file read lets every grep through untouched, and one sized for
+# the grep truncates every file.
+[stages.analyze.tool_routing.max_result_tokens_per_tool]
+read_file = 20000
 ```
+
+Both tables are keyed by tool name, and an alias matches the tool it aliases - writing `bash` covers
+the `shell` the model actually calls.
+
+`read_file` also has a hard byte cap of its own, independent of any of this, and says so in the
+result when it applies. Without one, a large file went into its region whole and was either
+truncated or dropped as `[result omitted]` depending on how full the region already was - a cliff
+rather than a limit.
 
 ## Budgets travel across models
 


### PR DESCRIPTION
Closes #344. Two holes in how a tool result is sized before it lands in a region.

## 1. `read_file` had no cap

`shell` has been bounded since it existed — 1 MiB, with a note saying so. A file read went into its region **whole**, and the ladder in `tool_results` either truncated it or dropped it as `[result omitted]` depending on how full the region already was. That is a cliff, not a limit: the same read behaves differently depending on unrelated history.

Now capped at 256 KiB, with a line saying how big the file actually was — an agent reading a truncated file as the whole file draws a wrong conclusion, which is worse than the gap.

Deliberately **below** the shell cap: shell output is usually a filtered answer, a file read is raw material.

## 2. `max_result_tokens` was per stage, not per tool

A stage that both greps and reads files had one number for both. Sized for the file read it lets every grep through untouched; sized for the grep it truncates every file.

```toml
[stages.compute.tool_routing]
max_result_tokens = 4000          # anything without a ceiling of its own
[stages.compute.tool_routing.max_result_tokens_per_tool]
read_file = 20000
```

It sits beside the existing region `overrides` and reads the same way, **including alias matching**: writing `bash` covers the `shell` the model actually calls, because both sides are canonicalised — the same thing `tool_overrides` does, and a test pins it.

## Verification

- the truncation lands on a char boundary (the cap is a byte count over arbitrary text, so a naive slice would panic)
- a file under the cap is byte-identical
- a per-tool ceiling beats the stage's, and a tool without one still gets the stage's
- a non-integer ceiling is skipped rather than failing the manifest, matching the region overrides beside it
- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-tools`, `leviath-core`, `leviath-runtime`
- `cargo xtask docs --check` clean