### PR TITLE
fix(runtime): a run that owed an answer and gave none is not complete

### DIFF
--- a/crates/leviath-runtime/src/pipeline/requirements.rs
+++ b/crates/leviath-runtime/src/pipeline/requirements.rs
@@ -294,9 +294,15 @@ pub fn require_final_output(
             }
             continue;
         }
-        let cap = stage
-            .max_revisits
-            .unwrap_or(leviath_core::blueprint::DEFAULT_OUTPUT_REENTRY_CAP);
+        // Its own budget, not the stage's `max_revisits`. Those are different
+        // questions - "how many times may the graph re-enter this stage" and
+        // "how many times do we nudge a model that owes an answer" - and
+        // borrowing the first for the second made a routing setting silently
+        // multiply an inference bill. Each retry re-sends the whole stage
+        // context, and an output stage runs last, when that context is at its
+        // largest: an agent with `max_revisits = 10` billed ten full prompts to
+        // fail to say one word.
+        let cap = leviath_core::blueprint::DEFAULT_OUTPUT_REENTRY_CAP;
         let round = reentries.map_or(0, |r| r.0);
         if round >= cap {
             tracing::warn!(

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5278,6 +5278,87 @@ fn transition_allow_complete_single_edge_awaits_choice() {
     assert!(world.get::<AwaitingTransitionChoice>(e).is_some());
 }
 
+// ─── A run that owed an answer and gave none is not complete ─────────────────
+
+/// A stage requiring an output that no stage ever produced.
+fn owing_output(require: bool) -> leviath_core::Blueprint {
+    let mut stages = vec![stage_named("only", None, false, None)];
+    stages[0].require_output = require;
+    blueprint(stages)
+}
+
+#[test]
+fn a_run_that_never_produced_its_required_output_errors() {
+    // `require_final_output` forces past the obligation rather than stranding
+    // the run - right, since a later stage may still answer - but nothing
+    // downgraded the terminal status, so the run reported `complete` with no
+    // `final_output` on disk. `lev result` already exited non-zero there, so
+    // status and result disagreed in exactly the case a caller most needs.
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        owing_output(true),
+        vec![si("m0")],
+        VisitCounts::default(),
+    );
+
+    run_transition(&mut world);
+
+    let status = world.get::<AgentState>(e).unwrap().status.clone();
+    let AgentStatus::Error { message } = status else {
+        panic!("a run with no answer must not read as success, got {status:?}");
+    };
+    assert!(message.contains("final output"), "{message}");
+}
+
+#[test]
+fn a_run_that_produced_its_required_output_completes() {
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        owing_output(true),
+        vec![si("m0")],
+        VisitCounts::default(),
+    );
+    world.entity_mut(e).insert(crate::persistence::FinalOutput(
+        leviath_core::output::FinalOutput {
+            stage: "only".to_string(),
+            content: "the answer".to_string(),
+            format: None,
+            submitted_at: 0,
+            truncated: false,
+            artifacts: Vec::new(),
+        },
+    ));
+
+    run_transition(&mut world);
+
+    assert!(matches!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Complete
+    ));
+}
+
+/// A run that never owed one is untouched: this must not turn every ordinary
+/// agent into a failure.
+#[test]
+fn a_run_that_owed_no_output_still_completes() {
+    let mut world = World::new();
+    let e = spawn_transition_agent(
+        &mut world,
+        owing_output(false),
+        vec![si("m0")],
+        VisitCounts::default(),
+    );
+
+    run_transition(&mut world);
+
+    assert!(matches!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Complete
+    ));
+}
+
 #[test]
 fn transition_visit_exhausted_edge_is_a_dead_end_error() {
     use leviath_core::blueprint::TransitionCondition;
@@ -10274,6 +10355,42 @@ fn a_stage_that_owes_nothing_is_never_held() {
 
 /// A missing output never strands a run. When the budget is spent the
 /// transition proceeds and the run says so, the way a forced edge gate does.
+/// The retry budget is its own, not the stage's `max_revisits`.
+///
+/// Those are different questions - how many times the graph may re-enter a
+/// stage, and how many times a model that owes an answer is nudged - and
+/// borrowing the first for the second let a routing setting silently multiply
+/// an inference bill. Each retry re-sends the whole stage context, and an
+/// output stage runs last, when that context is largest.
+#[test]
+fn a_generous_max_revisits_does_not_buy_more_output_retries() {
+    let mut world = World::new();
+    let e = world
+        .spawn((
+            owing_bp(Some(20)),
+            StageCursor { index: 0 },
+            owing_state(),
+            conversation_window(),
+            ResolveTransition,
+            OutputReentries(leviath_core::blueprint::DEFAULT_OUTPUT_REENTRY_CAP),
+            crate::persistence::RunOutcomeFlags::default(),
+        ))
+        .id();
+    run_require_output(&mut world);
+    assert!(
+        world.get::<ReadyToInfer>(e).is_none(),
+        "max_revisits = 20 must not buy 20 retries of a missing output"
+    );
+    assert_eq!(
+        world
+            .get::<crate::persistence::RunOutcomeFlags>(e)
+            .expect("flags")
+            .0
+            .output_forced,
+        1
+    );
+}
+
 #[test]
 fn an_exhausted_budget_proceeds_and_records_that_it_was_forced() {
     let mut world = World::new();
@@ -10284,7 +10401,7 @@ fn an_exhausted_budget_proceeds_and_records_that_it_was_forced() {
             owing_state(),
             conversation_window(),
             ResolveTransition,
-            OutputReentries(2),
+            OutputReentries(leviath_core::blueprint::DEFAULT_OUTPUT_REENTRY_CAP),
             crate::persistence::RunOutcomeFlags::default(),
         ))
         .id();
@@ -10317,7 +10434,7 @@ fn an_exhausted_budget_proceeds_even_with_nowhere_to_record_it() {
             owing_state(),
             conversation_window(),
             ResolveTransition,
-            OutputReentries(2),
+            OutputReentries(leviath_core::blueprint::DEFAULT_OUTPUT_REENTRY_CAP),
         ))
         .id();
     run_require_output(&mut world);

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -352,6 +352,7 @@ type ResolveTransitionQuery = (
     Option<&'static StageOutcome>,
     Option<&'static mut crate::persistence::RunOutcomeFlags>,
     Option<&'static crate::persistence::RunMetadata>,
+    Option<&'static crate::persistence::FinalOutput>,
 );
 
 /// Transition-resolution system: for each `ResolveTransition` agent, resolve the
@@ -379,6 +380,7 @@ pub fn resolve_transition(
         outcome,
         mut flags,
         metadata,
+        submitted,
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -474,7 +476,24 @@ pub fn resolve_transition(
         };
         match resolution {
             StageResolution::Terminal => {
-                state.status = AgentStatus::Complete;
+                // A run that owed a final output and never produced one is not
+                // a success. `require_final_output` forces past the obligation
+                // rather than stranding the run - correct, since a later stage
+                // may still answer - but nothing downgraded the *terminal*
+                // status, so a run ended `complete` with no `final_output` on
+                // disk. `lev result` already exits non-zero there, so the two
+                // disagreed in exactly the case a caller most needs to know
+                // about, and anything polling `status` read it as success.
+                let owed_output = bp.0.stages.iter().any(|s| s.require_output);
+                state.status = match owed_output && submitted.is_none() {
+                    true => AgentStatus::Error {
+                        message: "the run finished without the final output it \
+                                  requires; the stage that owes one never called \
+                                  submit_output"
+                            .to_string(),
+                    },
+                    false => AgentStatus::Complete,
+                };
                 commands
                     .entity(entity)
                     .remove::<ResolveTransition>()


### PR DESCRIPTION
Closes #339.

## The status was wrong

`require_final_output` forces past the obligation once its retries are spent rather than stranding the run — correct, since a later stage may still answer — but **nothing downgraded the terminal status**. So a run ended:

```
status: complete     final_output: absent     lev result: exits non-zero
```

The two disagreed in exactly the case a caller most needs to know about, and anything polling `status` read it as success. A run that required an output and never produced one now ends as an error naming that.

Scoped tightly: it fires only when some stage declares `require_output` **and** no output was ever submitted. A run that owed nothing, or that answered, is untouched — both pinned by tests, because the failure mode of this change would be turning every ordinary agent into a failure.

## The cost

The retry budget was borrowed from the stage's `max_revisits`. Those are different questions — *how many times may the graph re-enter this stage* versus *how many times do we nudge a model that owes an answer* — and conflating them let a routing setting silently multiply an inference bill. Each retry re-sends the whole stage context, and an output stage runs last, when that context is at its largest.

The dedicated cap was already 3. An agent setting `max_revisits = 10` was buying ten full prompts to fail to say one word. It now gets 3 regardless.

## One correction to the issue

The re-entry cap the report describes as `max_iterations` has been `DEFAULT_OUTPUT_REENTRY_CAP` since `56d0fb1d` (2026-08-04), five days before the issue was filed. I reproduced against current `main` before changing anything: the model called `submit_output` and the run completed normally, so the unbounded loop reported was the `max_revisits` coupling above, not the iteration limit.

The measured cost is real either way — the mechanism named in the report is not the one that was there.

## Verification

- `cargo test --workspace` green — **no existing test relied on "complete with no output"**, which is itself worth knowing
- clippy clean, `cargo xtask coverage --package leviath-runtime` 100%
- three tests pin the status change (owed-and-missing errors, owed-and-answered completes, owed-nothing completes) and one pins that `max_revisits = 20` does not buy 20 retries