### PR TITLE
fix(context): a stage that omits a region hides it, rather than destroying it

### DIFF
--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -111,6 +111,19 @@ pub struct ContextWindow {
         String,
         std::sync::Arc<leviath_scripting::region_hook::RegionScript>,
     >,
+
+    /// Regions the current stage does not attend to.
+    ///
+    /// Held, not deleted. A stage layout that omits a region used to have it
+    /// dropped from the window entirely, so re-declaring it in a later stage
+    /// brought it back empty - which made the feature unusable for the thing it
+    /// looks designed for, narrowing what one stage sees in a pipeline whose
+    /// later stages still need the data. Omission now means "not assembled for
+    /// this stage" and nothing else.
+    ///
+    /// Reset on every stage entry by [`crate::context_setup::apply_layout`], so
+    /// it describes the stage in front of it rather than accumulating.
+    pub hidden: std::collections::HashSet<String>,
 }
 
 impl ContextWindow {
@@ -118,6 +131,7 @@ impl ContextWindow {
     pub fn new(max_tokens: usize) -> Self {
         Self {
             regions: Vec::new(),
+            hidden: std::collections::HashSet::new(),
             current_tokens: 0,
             max_tokens,
             region_scripts: std::collections::HashMap::new(),
@@ -528,6 +542,12 @@ impl ContextWindow {
         let mut messages: Vec<leviath_providers::Message> = Vec::new();
 
         for region in &self.regions {
+            // A region this stage does not attend to is held but not shown.
+            // Skipped here rather than dropped from the window, so a later
+            // stage that declares it again gets its contents back.
+            if self.hidden.contains(&region.name) {
+                continue;
+            }
             // Custom regions render even when empty - a script may emit
             // static scaffolding. Every other kind skips an empty region.
             let is_custom = matches!(region.kind, leviath_core::RegionKind::Custom { .. });

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -179,41 +179,49 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         new_regions.push(new_region);
     }
 
-    // Carry the message-stream regions across the transition even when the new
-    // stage layout doesn't declare them. Dropping `conversation` (the sole
-    // SlidingWindow that holds typed turns) would strand the whole message history -
-    // the next stage would assemble with no messages, and its typed tool_use/
-    // tool_result turns would have nowhere to land. `tool_results` likewise. A
-    // blueprint that DOES declare them keeps its own budget (handled above).
+    // Everything the stage layout did not declare is carried anyway, and
+    // hidden instead of deleted.
     //
-    // `final_output` carries for a different reason: an answer submitted in one
-    // stage must still be there when a later stage runs, or a blueprint that
-    // submits early and then routes onward would silently lose it. The
-    // authoritative copy lives on the `FinalOutput` component either way, so
-    // this keeps the agent's own view of its answer consistent with what the
-    // caller will receive.
-    for infra in [
+    // Dropping them made `[stages.X.context.regions]` unusable for the thing it
+    // looks designed for: narrowing what one stage attends to, in a pipeline
+    // whose later stages still need the data. Re-declaring a region downstream
+    // brought it back empty, so an author had to choose between carrying a
+    // 6,700-token data preview through every call of every stage and destroying
+    // it. Omission now means "not assembled for this stage" and nothing else.
+    //
+    // `conversation`, `tool_results` and `final_output` are carried *visible*
+    // regardless: the first two hold the typed tool_use/tool_result turns, and
+    // hiding them would strand a message history the next stage's own turns
+    // have to attach to. An answer submitted early has to survive to the end
+    // for the same reason.
+    let always_visible = [
         "conversation",
         "tool_results",
         crate::output_tool::FINAL_OUTPUT_REGION,
-    ] {
-        if !kept.contains(infra)
-            && let Some(existing) = window.get_region(infra)
-        {
-            let mut carried = Region::new(
-                existing.name.clone(),
-                existing.kind.clone(),
-                existing.max_tokens,
-            );
-            // Same verbatim carry as above: these are exactly the regions whose
-            // typed turns the transition must not flatten.
-            for entry in &existing.content {
-                let _ = carried.carry_entry(entry.clone());
-            }
-            carried.taint = existing.taint.clone();
-            new_regions.push(carried);
+    ];
+    let mut hidden = std::collections::HashSet::new();
+    for existing in &window.regions {
+        if kept.contains(existing.name.as_str()) {
+            continue;
         }
+        let mut carried = Region::new(
+            existing.name.clone(),
+            existing.kind.clone(),
+            existing.max_tokens,
+        );
+        // Verbatim, exactly as above: these are the regions whose typed turns
+        // a rebuild would flatten.
+        for entry in &existing.content {
+            let _ = carried.carry_entry(entry.clone());
+        }
+        carried.taint = existing.taint.clone();
+        if !always_visible.contains(&existing.name.as_str()) {
+            hidden.insert(existing.name.clone());
+        }
+        new_regions.push(carried);
     }
+    // Describes the stage being entered, so it replaces rather than accumulates.
+    window.hidden = hidden;
 
     window.regions = new_regions;
     window.current_tokens = window.calculate_tokens();

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5684,8 +5684,132 @@ fn enter_stage_swaps_context_layout() {
     run_transition(&mut world);
 
     let w = world.get::<ContextWindow>(e).unwrap();
-    assert!(w.get_region("scratch").is_some()); // swapped in
-    assert!(w.get_region("sys").is_none()); // old layout dropped
+    assert!(w.get_region("scratch").is_some(), "the stage's own region");
+    // The region the stage did not declare is HELD, not dropped. It used to be
+    // deleted, which made a per-stage layout unusable for narrowing a view in a
+    // pipeline whose later stages still need the data: re-declaring it
+    // downstream brought it back empty.
+    assert!(
+        w.get_region("sys").is_some(),
+        "an omitted region must survive the stage it is not shown to"
+    );
+    assert!(
+        w.hidden.contains("sys"),
+        "and it must not be assembled into this stage's prompt"
+    );
+}
+
+/// The point of holding it: a later stage that declares it again gets its
+/// contents back, rather than an empty region.
+#[test]
+fn a_region_hidden_by_one_stage_comes_back_with_its_content() {
+    use leviath_core::layout::{ContextLayout, RegionDefinition};
+
+    let mut w = pinned_window();
+    w.add_to_region("sys", "the data preview".to_string(), 4)
+        .expect("seeded");
+
+    // A stage that does not declare `sys`.
+    crate::context_setup::apply_layout(
+        &mut w,
+        &ContextLayout::new(
+            vec![RegionDefinition::new(
+                "scratch".to_string(),
+                RegionKind::Clearable,
+                5000,
+            )],
+            8000,
+        ),
+    );
+    assert!(w.hidden.contains("sys"));
+    assert!(
+        w.get_region("sys").is_some_and(|r| !r.content.is_empty()),
+        "held with its content while hidden"
+    );
+
+    // A later stage that declares it again.
+    crate::context_setup::apply_layout(
+        &mut w,
+        &ContextLayout::new(
+            vec![RegionDefinition::new(
+                "sys".to_string(),
+                RegionKind::Pinned,
+                5000,
+            )],
+            8000,
+        ),
+    );
+    assert!(!w.hidden.contains("sys"), "declared again, so shown again");
+    let restored = w.get_region("sys").expect("still there");
+    assert_eq!(
+        restored.content.first().map(|e| e.content.as_str()),
+        Some("the data preview"),
+        "and it is the same content, not an empty region with the same name"
+    );
+}
+
+/// A hidden region is held but does not reach the model.
+///
+/// The other half of the contract: holding it would be pointless if it were
+/// still assembled, and hiding it would be data loss if it were dropped.
+#[test]
+fn a_hidden_region_is_not_assembled_into_the_prompt() {
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new("notes".to_string(), RegionKind::Pinned, 5000));
+    w.add_to_region("notes", "SECRET-MARKER".to_string(), 4)
+        .expect("seeded");
+
+    let meta = crate::custom_region::AssembleMeta::default();
+    let visible = w.assemble_with_meta(&meta);
+    assert!(
+        format!("{visible:?}").contains("SECRET-MARKER"),
+        "precondition: it assembles while visible"
+    );
+
+    w.hidden.insert("notes".to_string());
+    let hidden = w.assemble_with_meta(&meta);
+    assert!(
+        !format!("{hidden:?}").contains("SECRET-MARKER"),
+        "a region this stage does not attend to must not reach the model"
+    );
+    assert!(
+        w.get_region("notes").is_some_and(|r| !r.content.is_empty()),
+        "and it is still held"
+    );
+}
+
+/// The message-stream regions are carried *visible* even when a stage omits
+/// them: hiding `conversation` would strand a history the next stage's own
+/// typed turns have to attach to.
+#[test]
+fn the_message_regions_are_never_hidden() {
+    use leviath_core::layout::{ContextLayout, RegionDefinition};
+
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new(
+        "conversation".to_string(),
+        RegionKind::SlidingWindow {
+            max_items: 10,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        5000,
+    ));
+    w.add_region(Region::new("notes".to_string(), RegionKind::Pinned, 5000));
+
+    crate::context_setup::apply_layout(
+        &mut w,
+        &ContextLayout::new(
+            vec![RegionDefinition::new(
+                "scratch".to_string(),
+                RegionKind::Clearable,
+                5000,
+            )],
+            8000,
+        ),
+    );
+
+    assert!(!w.hidden.contains("conversation"));
+    assert!(w.hidden.contains("notes"));
 }
 
 #[test]

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -175,6 +175,15 @@ kind = "pinned"
 budget = "10%"
 ```
 
+**A region the stage leaves out is hidden, not destroyed.** It keeps its contents, is left out of
+that stage's prompt, and comes back with everything in it as soon as a later stage declares it
+again. That is what makes this usable for narrowing: a compute stage need not carry a large data
+preview through every one of its calls, and a summary stage further on can still read it.
+
+`conversation`, `tool_results` and `final_output` are always visible, whatever a stage declares.
+The first two hold the typed tool-call turns the next stage's own turns attach to, and an answer
+submitted early has to survive to the end.
+
 ## Seed commands
 
 A region can be seeded before the run starts:


### PR DESCRIPTION
Closes #341.

## The bug

`[stages.X.context.regions]` rebuilt the window from the stage layout and **dropped everything it did not declare**. Only `conversation`, `tool_results` and `final_output` survived omission, so re-declaring any other region in a later stage brought it back **empty**.

That made the feature unusable for the one thing it looks designed for — narrowing what a stage attends to, in a pipeline whose later stages still need the data. The author's actual choice was: carry a 6,700-token data preview through every call of every stage, or destroy it.

## The fix

Omission now means *not assembled for this stage*, and nothing else. The window keeps the region with its content and taint intact, records it in a `hidden` set, and `assemble_with_meta` skips it. A later stage that declares it again gets it back whole.

The three message-stream regions stay visible whatever a stage declares, for the reason they were already special-cased: they carry the typed `tool_use`/`tool_result` turns that the next stage's own turns attach to.

## Verification

Live, three stages, the middle one omitting the region:

```
status: complete
notes region present: True
marker survived     : True
```

Unit tests pin both halves of the contract, which is the part worth stating: holding a region would be pointless if it were still assembled, and hiding it would be data loss if it were dropped. So there is a test that a hidden region **does not reach the model**, and one that it **comes back with its content** when a later stage declares it.

The pre-existing test `enter_stage_swaps_context_layout` asserted `get_region("sys").is_none()` — it encoded the destructive behaviour. Rewritten to assert the region survives and is hidden.

## Known limitation, stated rather than hidden

`hidden` is not part of the context snapshot (`ContextWindow` is not serialized; persistence uses a separate projection). A run resumed mid-stage therefore recomputes it at the next stage entry, and until then a hidden region is visible again. That is a wider view, never lost data — strictly better than the deletion it replaces, but not free of edges.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage --package leviath-runtime` 100%
- `cargo xtask docs --check` clean; `agents.md` now says what omission means