### PR TITLE
feat(stages): a gate that requires a revision, not a repetition

### DIFF
--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -163,6 +163,20 @@ pub struct TransitionGate {
     /// [`DEFAULT_GATE_ATTEMPTS`].
     #[serde(default)]
     pub max_attempts: Option<usize>,
+
+    /// Region that must have *changed* during this stage, not merely be present.
+    ///
+    /// Every other gate asks whether something exists. That cannot express a
+    /// revise loop: a stage sent back to redo its work satisfies a presence
+    /// check by re-emitting what it already wrote, so a reviewer's rejection
+    /// can be answered with the same plan and the loop spins until it runs out
+    /// of revisits. Measured, a plan that overrode a documented definition was
+    /// re-confirmed by a verify stage and the run ended confidently wrong.
+    ///
+    /// Compared against the region's content as it stood when the stage was
+    /// entered, so "changed" means changed by *this* pass.
+    #[serde(default)]
+    pub require_region_updated: Option<String>,
 }
 
 /// Default re-run budget for an unsatisfied [`TransitionGate`].

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -747,6 +747,9 @@ pub(super) fn parse_transition_gate(
     if let Some(region) = table.get("region").and_then(|v| v.as_str()) {
         gate.region = Some(region.to_string());
     }
+    if let Some(region) = table.get("require_region_updated").and_then(|v| v.as_str()) {
+        gate.require_region_updated = Some(region.to_string());
+    }
     if let Some(tools) = table.get("tools").and_then(|v| v.as_array()) {
         gate.tools = tools
             .iter()

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3835,6 +3835,36 @@ grep = 500
     );
 }
 
+/// `require_region_updated` parses onto the edge gate. Without this the key is
+/// accepted and ignored, which is how a gate silently blocks nothing.
+#[test]
+fn parse_manifest_reads_a_region_update_gate() {
+    let toml = r#"
+[agent]
+name = "revising"
+
+[stages.plan]
+mode = "autonomous"
+
+[stages.plan.transitions.compute]
+gate = { require_region_updated = "plan", message = "Change it first." }
+
+[stages.compute]
+mode = "autonomous"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let gate = bp
+        .find_stage("plan")
+        .and_then(|s| s.transitions.as_ref())
+        .and_then(|t| t.get("compute"))
+        .and_then(|e| e.gate.as_ref())
+        .expect("the gate survives");
+    assert_eq!(gate.require_region_updated.as_deref(), Some("plan"));
+    assert_eq!(gate.message.as_deref(), Some("Change it first."));
+    // And it does not silently turn on the other gate.
+    assert!(!gate.require_modifications);
+}
+
 #[test]
 fn parse_manifest_sandbox_unknown_on_unavailable_errors() {
     let toml = r#"

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -267,6 +267,13 @@ pub struct StageProgress {
     /// gate lets the transition through when this is non-zero: the agent is
     /// trying to write and cannot, so re-running the stage only burns budget.
     pub blocked_modification_calls: usize,
+    /// Content digests of the regions this stage's outgoing gates watch, as
+    /// they stood when the stage was entered.
+    ///
+    /// Only the watched regions: hashing every region on every entry would
+    /// cost the whole window for a feature most stages do not use. Empty for a
+    /// stage with no `require_region_updated` gate, which is the common case.
+    pub entry_region_digests: std::collections::HashMap<String, u64>,
     /// How many times a transition gate has already sent this stage back for
     /// another pass. Bounded by the gate's `max_attempts`.
     pub gate_reentries: usize,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -7769,6 +7769,159 @@ fn require_context_regions_proceeds_when_met_capped_or_errored() {
     }
 }
 
+// ── transition gates: require_region_updated (#343) ──
+
+/// A gate that watches a region for change rather than for content.
+fn change_gate(region: &str) -> leviath_core::blueprint::TransitionGate {
+    leviath_core::blueprint::TransitionGate {
+        require_region_updated: Some(region.to_string()),
+        ..Default::default()
+    }
+}
+
+/// A window holding `plan` with the given text.
+fn plan_window(text: &str) -> ContextWindow {
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new("plan".to_string(), RegionKind::Pinned, 5000));
+    if !text.is_empty() {
+        w.add_to_region("plan", text.to_string(), 4)
+            .expect("seeded");
+    }
+    w
+}
+
+/// Progress whose baseline is the plan as it stood on entry.
+fn progress_with_baseline(w: &ContextWindow) -> StageProgress {
+    let mut p = StageProgress::default();
+    if let Some(region) = w.get_region("plan") {
+        p.entry_region_digests.insert(
+            "plan".to_string(),
+            crate::pipeline::transition::region_digest(region),
+        );
+    }
+    p
+}
+
+#[test]
+fn an_unchanged_region_blocks_the_edge() {
+    // The failure this exists for: a stage sent back to revise satisfies every
+    // other gate by re-emitting what it already wrote, so a reviewer's
+    // rejection can be answered with the same plan. Measured, a plan that
+    // overrode a documented definition was re-confirmed and the run ended
+    // confidently wrong.
+    let w = plan_window("fraud = largest count");
+    let progress = progress_with_baseline(&w);
+    let stage = stage_named("plan", None, false, None);
+
+    let decision = gate_blocks(Some(&change_gate("plan")), &stage, &progress, &w);
+    let GateDecision::Block(nudge) = decision else {
+        panic!("an unchanged plan must not pass, got {decision:?}");
+    };
+    assert!(nudge.contains("plan"), "{nudge}");
+}
+
+#[test]
+fn a_changed_region_passes() {
+    let before = plan_window("fraud = largest count");
+    let progress = progress_with_baseline(&before);
+
+    // The same stage, having actually revised the plan.
+    let after = plan_window("fraud = fraudulent volume / total volume");
+    let stage = stage_named("plan", None, false, None);
+
+    assert!(matches!(
+        gate_blocks(Some(&change_gate("plan")), &stage, &progress, &after),
+        GateDecision::Pass
+    ));
+}
+
+/// A gate naming a region the window does not hold cannot be satisfied by any
+/// amount of work, so it passes rather than stranding the run.
+#[test]
+fn a_gate_on_a_missing_region_passes() {
+    let w = ContextWindow::new(10_000);
+    let stage = stage_named("plan", None, false, None);
+    assert!(matches!(
+        gate_blocks(
+            Some(&change_gate("nope")),
+            &stage,
+            &StageProgress::default(),
+            &w
+        ),
+        GateDecision::Pass
+    ));
+}
+
+/// It shares the one re-run budget every other gate uses: a gate that could
+/// hold a stage forever would strand the run.
+#[test]
+fn an_unchanged_region_gives_up_after_the_budget() {
+    let w = plan_window("unchanged");
+    let mut progress = progress_with_baseline(&w);
+    progress.gate_reentries = leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS;
+    let stage = stage_named("plan", None, false, None);
+
+    assert!(matches!(
+        gate_blocks(Some(&change_gate("plan")), &stage, &progress, &w),
+        GateDecision::Forced
+    ));
+}
+
+/// The author's own wording wins, as it does for every other gate.
+#[test]
+fn a_custom_message_is_used() {
+    let w = plan_window("unchanged");
+    let progress = progress_with_baseline(&w);
+    let stage = stage_named("plan", None, false, None);
+    let mut gate = change_gate("plan");
+    gate.message = Some("The check rejected this plan.".to_string());
+
+    let GateDecision::Block(nudge) = gate_blocks(Some(&gate), &stage, &progress, &w) else {
+        panic!("should block");
+    };
+    assert_eq!(nudge, "The check rejected this plan.");
+}
+
+/// The baseline is taken only for the regions a gate actually watches.
+///
+/// Hashing every region on every stage entry would cost the whole window for a
+/// feature most stages do not use, so the collector is selective - and that
+/// selectivity is what these four cases pin.
+#[test]
+fn only_watched_regions_get_a_baseline() {
+    use leviath_core::blueprint::TransitionCondition;
+
+    let w = plan_window("the plan");
+
+    // No transitions at all.
+    let bare = stage_named("plan", None, false, None);
+    assert!(crate::pipeline::transition::watched_region_digests(&bare, &w).is_empty());
+
+    // An edge with no gate.
+    let ungated = stage_named(
+        "plan",
+        Some(vec![edge("compute", TransitionCondition::Always)]),
+        false,
+        None,
+    );
+    assert!(crate::pipeline::transition::watched_region_digests(&ungated, &w).is_empty());
+
+    // An edge whose gate watches a region the window holds.
+    let mut watching_edge = edge("compute", TransitionCondition::Always);
+    watching_edge.1.gate = Some(change_gate("plan"));
+    let watching = stage_named("plan", Some(vec![watching_edge]), false, None);
+    let digests = crate::pipeline::transition::watched_region_digests(&watching, &w);
+    assert_eq!(digests.len(), 1);
+    assert!(digests.contains_key("plan"));
+
+    // And one that watches a region it does not hold: no baseline, which the
+    // gate reads as "cannot demand an update to something absent".
+    let mut missing_edge = edge("compute", TransitionCondition::Always);
+    missing_edge.1.gate = Some(change_gate("nope"));
+    let missing = stage_named("plan", Some(vec![missing_edge]), false, None);
+    assert!(crate::pipeline::transition::watched_region_digests(&missing, &w).is_empty());
+}
+
 // ── transition gates: require_modifications (#107) ──
 
 fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint::TransitionGate {
@@ -7778,6 +7931,7 @@ fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint:
         region: region.map(str::to_string),
         tools: Vec::new(),
         max_attempts: None,
+        require_region_updated: None,
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -263,6 +263,33 @@ pub(crate) fn gate_blocks(
     let Some(gate) = gate else {
         return GateDecision::Pass;
     };
+    // Checked before `require_modifications` and independently of it: an edge
+    // may ask for a changed region without asking for a file write, and a
+    // revise loop usually does exactly that.
+    //
+    // A missing baseline means the gate names a region the window does not
+    // hold. A gate cannot demand an update to something that does not exist,
+    // and blocking on it would strand the run, so it passes.
+    if let Some(name) = &gate.require_region_updated
+        && let (Some(before), Some(region)) = (
+            progress.entry_region_digests.get(name),
+            window.get_region(name),
+        )
+        && *before == region_digest(region)
+    {
+        return spend_gate_attempt(
+            gate,
+            stage,
+            progress,
+            gate.message.clone().unwrap_or_else(|| {
+                format!(
+                    "The `{name}` region is unchanged since this stage began. Whatever sent \
+                     you back here was not answered by repeating the same content - revise it \
+                     before moving on."
+                )
+            }),
+        );
+    }
     if !gate.require_modifications {
         return GateDecision::Pass;
     }
@@ -295,6 +322,31 @@ pub(crate) fn gate_blocks(
     {
         return GateDecision::Pass;
     }
+    spend_gate_attempt(
+        gate,
+        stage,
+        progress,
+        gate.message.clone().unwrap_or_else(|| {
+            "No file modifications were recorded in this stage. Changes made through the shell \
+             (sed -i, tee, >, >>) are not tracked by the framework. Re-apply your changes with \
+             edit_file or write_file before moving on."
+                .to_string()
+        }),
+    )
+}
+
+/// Block with `nudge`, or give up and let the edge through once the gate's
+/// re-run budget is spent.
+///
+/// Shared by every gate condition so one blueprint key (`max_attempts`) bounds
+/// all of them: a gate that could block forever would strand the run, which is
+/// worse than letting a questionable transition through with a warning.
+fn spend_gate_attempt(
+    gate: &leviath_core::blueprint::TransitionGate,
+    stage: &leviath_core::Stage,
+    progress: &StageProgress,
+    nudge: String,
+) -> GateDecision {
     let cap = gate
         .max_attempts
         .unwrap_or(leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS);
@@ -302,16 +354,11 @@ pub(crate) fn gate_blocks(
         tracing::warn!(
             stage = %stage.name,
             attempts = cap,
-            "stage still has no file modifications after re-run attempts; proceeding"
+            "transition gate still unsatisfied after re-run attempts; proceeding"
         );
         return GateDecision::Forced;
     }
-    GateDecision::Block(gate.message.clone().unwrap_or_else(|| {
-        "No file modifications were recorded in this stage. Changes made through the shell \
-         (sed -i, tee, >, >>) are not tracked by the framework. Re-apply your changes with \
-         edit_file or write_file before moving on."
-            .to_string()
-    }))
+    GateDecision::Block(nudge)
 }
 
 /// Hold an agent in its current stage after a gate refused the transition: inject
@@ -640,7 +687,55 @@ pub(crate) fn enter_stage(
     *visit += 1;
     let visit = *visit;
 
-    apply_stage_context(setup, window).map(|()| visit)
+    let result = apply_stage_context(setup, window).map(|()| visit);
+    // After the layout swap, so the digest is of the region this stage will
+    // actually work on rather than the one the previous stage left behind.
+    progress.entry_region_digests = watched_region_digests(&blueprint.stages[idx], window);
+    result
+}
+
+/// Content digests of the regions this stage's outgoing gates watch.
+///
+/// Keyed by region name and taken at stage entry, so [`gate_blocks`] can ask
+/// whether *this pass* changed anything rather than whether the region merely
+/// has content. A region a gate names but the window does not hold is absent
+/// here, and an absent digest reads as "no baseline", which the gate treats as
+/// changed - a gate cannot demand an update to something that does not exist.
+pub(crate) fn watched_region_digests(
+    stage: &leviath_core::Stage,
+    window: &ContextWindow,
+) -> std::collections::HashMap<String, u64> {
+    let mut digests = std::collections::HashMap::new();
+    let Some(transitions) = &stage.transitions else {
+        return digests;
+    };
+    for edge in transitions.values() {
+        let Some(name) = edge
+            .gate
+            .as_ref()
+            .and_then(|g| g.require_region_updated.as_ref())
+        else {
+            continue;
+        };
+        if let Some(region) = window.get_region(name) {
+            digests.insert(name.clone(), region_digest(region));
+        }
+    }
+    digests
+}
+
+/// A hash of everything a region currently holds.
+///
+/// Content only: token counts and timestamps would make an unchanged region
+/// look changed, which is the failure this gate exists to prevent.
+pub(crate) fn region_digest(region: &leviath_core::Region) -> u64 {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for entry in &region.content {
+        entry.content.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 /// Push a [`StageTransition`](crate::host::WorldEvent::StageTransition) event

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -190,9 +190,29 @@ gate = { require_modifications = true, max_attempts = 3 }
 | Field | Default | Meaning |
 |---|---|---|
 | `require_modifications` | `false` | Require at least one successful file-modifying tool call in the stage being left |
+| `require_region_updated` | unset | Require that a named region **changed** during this stage, not merely that it has content. See below |
 | `message` | generated | The nudge shown when the gate blocks |
 | `region` | unset | A region that also satisfies the gate by being non-empty |
 | `tools` | `[]` | Extra tool names to count as modifying, beyond `write_file` and `edit_file` |
+
+### Requiring a revision, not a repetition
+
+Every other gate asks whether something *exists*, which a stage sent back to redo its work can
+satisfy by re-emitting what it already wrote. On a `review -> plan` back-edge that means a
+reviewer's rejection can be answered with the same plan, and the loop spins until the stage runs
+out of revisits.
+
+```toml
+[stages.plan.transitions.compute]
+gate = { require_region_updated = "plan",
+         message = "The check rejected this plan. Change it before computing again." }
+```
+
+The region's content is hashed when the stage is entered and compared when it tries to leave, so
+"changed" means changed by *this* pass. It shares the same `max_attempts` budget as every other
+gate: a gate that could hold a stage forever would strand the run, so after the budget the edge is
+taken with a warning. A gate naming a region the window does not hold passes rather than blocking,
+since no amount of work could satisfy it.
 | `max_attempts` | `3` | How many times the stage re-runs before the gate gives up and lets the transition through with a warning |
 
 Per-stage tool counters reset when a stage is entered, and they are not restored when a run resumes


### PR DESCRIPTION
Closes #343.

## The gap

Every stage-exit gate could only ask whether something **exists** — `require_modifications`, required regions, `require_output`, `requires_children`. A stage sent back to redo its work satisfies a presence check by re-emitting what it already wrote, so on a `review -> plan` back-edge a reviewer's rejection can be answered with the same plan.

## What that produced

Measured on a five-stage analysis agent. The plan stage wrote, verbatim:

> "manual §7: fraud = fraudulent volume / total volume gives BE slightly higher; but 'top country for fraud' = largest fraud incidence -> NL"

It saw the documented definition and overrode it. That plan then sat pinned for the rest of the run, compute executed it, and **verify recomputed the same wrong quantity by a second route and confirmed it.** The run ended confidently wrong.

The structure did its job — a wrong pinned plan is a wrong instruction repeated at every turn. What was missing is any way to force a revision.

## The gate

```toml
[stages.plan.transitions.compute]
gate = { require_region_updated = "plan",
         message = "The check rejected this plan. Change it before computing again." }
```

The region's content is hashed at stage entry and compared at exit, so *changed* means changed by this pass. Only the regions some outgoing gate names are hashed — doing every region on every stage entry would cost the whole window for a feature most stages do not use, and a test pins that selectivity.

## Two design points

**It shares the one re-run budget.** That needed the budget logic extracted rather than copied: a gate that could hold a stage forever would strand the run, and two budgets would be two answers to the same question. After `max_attempts` the edge is taken with a warning, exactly as `require_modifications` does.

**A gate naming a region the window does not hold passes.** No amount of work could satisfy it, so blocking would strand the run.

## Verification

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-core` and `leviath-runtime`
- `cargo xtask docs --check` clean; `stages.md` documents it under "Requiring a revision, not a repetition"
- tests cover: unchanged blocks, changed passes, missing region passes, budget exhaustion forces, custom message wins, and the digest collector's four cases