### PR TITLE
feat(context): a checklist region whose items carry state

### DIFF
--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -218,9 +218,11 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         // filesystem. They fell through to `Ask` below, so a run that used them
         // to keep notes paid a prompt per note: 25 of them on the run that
         // prompted this work, none of which a person could act on.
-        "context_write" | "context_append" | "context_read" | "context_delete" | "context_list" => {
-            ToolPolicy::Allow
-        }
+        "context_write" | "context_append" | "context_read" | "context_delete" | "context_list"
+        // The same reasoning for the checklist tools: they write to the agent's
+        // own context and touch nothing outside it, and prompting per item
+        // would make tracking work cost more than not tracking it.
+        | "todo_add" | "todo_done" | "todo_note" => ToolPolicy::Allow,
         "write_file" | "edit_file" | "shell" => ToolPolicy::Ask,
         // The sub-agent tools default to `Allow`, and the point of routing them
         // through this function at all is the *config*, not the prompt.
@@ -2280,6 +2282,14 @@ mod policy_tests {
         "context_read",
         "context_delete",
         "context_list",
+        // Reviewed: these write item state into the agent's own checklist
+        // region and reach nothing outside the context window - the same
+        // standard the `context_*` tools above are held to. Prompting per item
+        // would make tracking work cost more than not tracking it, which is how
+        // the feature would end up unused.
+        "todo_add",
+        "todo_done",
+        "todo_note",
         "spawn_agent",
         "check_agent",
         "wait_for_agent",

--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -177,6 +177,14 @@ pub struct TransitionGate {
     /// entered, so "changed" means changed by *this* pass.
     #[serde(default)]
     pub require_region_updated: Option<String>,
+    /// Checklist region that must have no open items before this edge is taken.
+    ///
+    /// The other gates ask whether a region has content, which cannot tell a
+    /// list of three unfinished items from a list of three finished ones. This
+    /// is the gate a checklist exists for: it makes "did you actually finish"
+    /// a mechanical question rather than one the model answers about itself.
+    #[serde(default)]
+    pub require_no_open_items: Option<String>,
 }
 
 /// Default re-run budget for an unsatisfied [`TransitionGate`].

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -135,6 +135,7 @@ pub(super) fn parse_region_layout(
                     source_region: source,
                 }
             }
+            "checklist" => RegionKind::Checklist,
             "hashmap" | "hash_map" => {
                 let max_entries = region_value
                     .get("max_entries")

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -750,6 +750,9 @@ pub(super) fn parse_transition_gate(
     if let Some(region) = table.get("require_region_updated").and_then(|v| v.as_str()) {
         gate.require_region_updated = Some(region.to_string());
     }
+    if let Some(region) = table.get("require_no_open_items").and_then(|v| v.as_str()) {
+        gate.require_no_open_items = Some(region.to_string());
+    }
     if let Some(tools) = table.get("tools").and_then(|v| v.as_array()) {
         gate.tools = tools
             .iter()

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3865,6 +3865,42 @@ mode = "autonomous"
     assert!(!gate.require_modifications);
 }
 
+/// A checklist region and its gate both parse. Without the parse the key is
+/// accepted and ignored, which is a gate that silently blocks nothing.
+#[test]
+fn parse_manifest_reads_a_checklist_and_its_gate() {
+    let toml = r#"
+[agent]
+name = "tracking"
+
+[stages.implement]
+mode = "autonomous"
+
+[stages.implement.transitions.review]
+gate = { require_no_open_items = "todos" }
+
+[stages.review]
+mode = "autonomous"
+
+[context.regions]
+todos = { kind = "checklist", max_tokens = 2000 }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    assert_eq!(
+        bp.context_layout
+            .get_region("todos")
+            .map(|r| r.kind.clone()),
+        Some(crate::RegionKind::Checklist)
+    );
+    let gate = bp
+        .find_stage("implement")
+        .and_then(|s| s.transitions.as_ref())
+        .and_then(|t| t.get("review"))
+        .and_then(|e| e.gate.as_ref())
+        .expect("the gate survives");
+    assert_eq!(gate.require_no_open_items.as_deref(), Some("todos"));
+}
+
 #[test]
 fn parse_manifest_sandbox_unknown_on_unavailable_errors() {
     let toml = r#"

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -157,6 +157,17 @@ pub enum RegionKind {
         max_entries: Option<usize>,
     },
 
+    /// A task list whose entries carry state: open or done.
+    ///
+    /// Never evicted, like [`Self::Pinned`] - a checklist that quietly loses
+    /// items is worse than no checklist. What it adds over a pinned region is
+    /// that the state is *real*: "compute the fee table" and "~~compute the fee
+    /// table~~ done" are two different strings to every other region kind, so
+    /// nothing could count what was left and no gate could ask. Written through
+    /// the `todo_*` tools rather than free text, so the state cannot drift from
+    /// what the model believes it wrote.
+    Checklist,
+
     /// Script-backed region: a user-authored Rhai script owns how the region
     /// renders into the assembled context (`render`), may transform or reject
     /// each incoming entry (`on_write`), and may choose what to drop under
@@ -211,6 +222,7 @@ impl PartialEq for RegionKind {
                 Self::CompactHistory { source_region: b },
             ) => a == b,
             (Self::HashMap { max_entries: a }, Self::HashMap { max_entries: b }) => a == b,
+            (Self::Checklist, Self::Checklist) => true,
             (
                 Self::Custom {
                     script: a,
@@ -227,6 +239,152 @@ impl PartialEq for RegionKind {
 }
 impl Eq for RegionKind {}
 
+/// One row of a [`RegionKind::Checklist`] region.
+///
+/// A projection of a [`RegionEntry`], not a second storage: the item's text is
+/// the entry's content and its state is the entry's metadata, so a checklist
+/// persists, carries across a stage swap and restores from a snapshot with no
+/// extra plumbing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChecklistItem {
+    /// Stable identifier the `todo_*` tools address, assigned on add.
+    pub id: usize,
+    /// What the item says.
+    pub text: String,
+    /// Whether it has been ticked off.
+    pub done: bool,
+    /// Anything the agent recorded against it.
+    pub note: Option<String>,
+}
+
+/// The metadata key holding a checklist item's id.
+const ITEM_ID: &str = "checklist_id";
+/// The metadata key holding whether a checklist item is done.
+const ITEM_DONE: &str = "checklist_done";
+/// The metadata key holding a checklist item's note.
+const ITEM_NOTE: &str = "checklist_note";
+
+impl RegionEntry {
+    /// Read this entry as a checklist item, when it is one.
+    pub fn as_checklist_item(&self) -> Option<ChecklistItem> {
+        let meta = self.metadata.as_ref()?;
+        Some(ChecklistItem {
+            id: meta.get(ITEM_ID)?.as_u64()? as usize,
+            text: self.content.clone(),
+            done: meta
+                .get(ITEM_DONE)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            note: meta
+                .get(ITEM_NOTE)
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        })
+    }
+}
+
+impl Region {
+    /// Every checklist item this region holds, in the order they were added.
+    pub fn checklist_items(&self) -> Vec<ChecklistItem> {
+        self.content
+            .iter()
+            .filter_map(RegionEntry::as_checklist_item)
+            .collect()
+    }
+
+    /// Items still open. The number a gate asks about.
+    pub fn open_checklist_items(&self) -> Vec<ChecklistItem> {
+        self.checklist_items()
+            .into_iter()
+            .filter(|i| !i.done)
+            .collect()
+    }
+
+    /// Append an item and return its id.
+    ///
+    /// Ids come from a counter over what is already there rather than the
+    /// entry count, so an id stays valid for the life of the region even if an
+    /// entry is dropped under budget pressure - a `todo_done(3)` that silently
+    /// ticked off a different item would be worse than one that failed.
+    pub fn add_checklist_item(
+        &mut self,
+        text: String,
+        tokens: usize,
+    ) -> crate::error::Result<usize> {
+        let id = self
+            .checklist_items()
+            .iter()
+            .map(|i| i.id)
+            .max()
+            .unwrap_or(0)
+            + 1;
+        self.add_entry_with_metadata(
+            text,
+            tokens,
+            serde_json::json!({ ITEM_ID: id, ITEM_DONE: false }),
+        )?;
+        Ok(id)
+    }
+
+    /// Tick an item off. `false` when no item carries that id.
+    pub fn complete_checklist_item(&mut self, id: usize) -> bool {
+        self.set_item_field(id, ITEM_DONE, serde_json::Value::Bool(true))
+    }
+
+    /// Record a note against an item. `false` when no item carries that id.
+    pub fn note_checklist_item(&mut self, id: usize, note: &str) -> bool {
+        self.set_item_field(id, ITEM_NOTE, serde_json::Value::String(note.to_string()))
+    }
+
+    /// Write one metadata field of the item carrying `id`.
+    fn set_item_field(&mut self, id: usize, key: &str, value: serde_json::Value) -> bool {
+        for entry in &mut self.content {
+            let is_target = entry
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get(ITEM_ID))
+                .and_then(serde_json::Value::as_u64)
+                .is_some_and(|found| found as usize == id);
+            if is_target && let Some(serde_json::Value::Object(meta)) = entry.metadata.as_mut() {
+                meta.insert(key.to_string(), value);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The checklist as the model sees it: open items first, then done.
+    ///
+    /// Ordering is the point. This region's value is that it stays in front of
+    /// the model every turn as *instruction* rather than history, and what is
+    /// left to do belongs at the top of an instruction.
+    pub fn render_checklist(&self) -> String {
+        let items = self.checklist_items();
+        if items.is_empty() {
+            return String::new();
+        }
+        let (open, done): (Vec<_>, Vec<_>) = items.into_iter().partition(|i| !i.done);
+        let mut out = String::new();
+        for item in open.iter().chain(done.iter()) {
+            let box_ = match item.done {
+                true => "[x]",
+                false => "[ ]",
+            };
+            out.push_str(&format!("{box_} {} {}", item.id, item.text));
+            if let Some(note) = &item.note {
+                out.push_str(&format!("\n    note: {note}"));
+            }
+            out.push('\n');
+        }
+        format!(
+            "Checklist ({} open, {} done):\n{}",
+            open.len(),
+            done.len(),
+            out.trim_end()
+        )
+    }
+}
+
 impl RegionKind {
     /// Return the cache hint appropriate for this region kind.
     pub fn cache_hint(&self) -> crate::cache::CacheHint {
@@ -239,6 +397,9 @@ impl RegionKind {
                 stable_fraction: 0.75,
             },
             RegionKind::HashMap { .. } => crate::cache::CacheHint::UntilChanged,
+            // Changes only when an item is added or ticked off, which is rarer
+            // than a tool result and far rarer than a turn.
+            RegionKind::Checklist => crate::cache::CacheHint::UntilChanged,
             RegionKind::Temporary | RegionKind::Clearable => crate::cache::CacheHint::Never,
             // A persistent custom region is Pinned-like: its rendered output is
             // expected to be stable. Non-persistent custom content changes on
@@ -921,6 +1082,171 @@ pub trait Validator: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── Checklist items ────────────────────────────────────────────────────
+
+    fn checklist() -> Region {
+        Region::new("todos".to_string(), RegionKind::Checklist, 10_000)
+    }
+
+    /// Anything in the region that is not a well-formed item is not an item.
+    ///
+    /// A checklist region can still receive an ordinary write - a seed, a
+    /// carried entry from an older run, a `context_append` - and counting one
+    /// of those as an open item would hold a stage on work nobody recorded.
+    #[test]
+    fn a_malformed_entry_is_not_an_item() {
+        let mut r = checklist();
+        // No metadata at all.
+        r.add_entry("a plain note".to_string(), 3).unwrap();
+        // Metadata, but not an item's.
+        r.add_entry_with_metadata(
+            "something else".to_string(),
+            3,
+            serde_json::json!({ "unrelated": true }),
+        )
+        .unwrap();
+        // An id of the wrong type.
+        r.add_entry_with_metadata(
+            "bad id".to_string(),
+            3,
+            serde_json::json!({ "checklist_id": "one" }),
+        )
+        .unwrap();
+
+        assert!(r.checklist_items().is_empty(), "none of those are items");
+        assert!(r.open_checklist_items().is_empty());
+        assert!(
+            r.render_checklist().is_empty(),
+            "and they do not render as a checklist"
+        );
+    }
+
+    /// A checklist is cached like a hashmap, not like a turn: it changes only
+    /// when an item is added or ticked off.
+    #[test]
+    fn a_checklist_caches_until_it_changes() {
+        assert_eq!(
+            RegionKind::Checklist.cache_hint(),
+            crate::cache::CacheHint::UntilChanged
+        );
+    }
+
+    #[test]
+    fn a_note_appears_in_the_render() {
+        let mut r = checklist();
+        let id = r.add_checklist_item("blocked".to_string(), 2).unwrap();
+        r.note_checklist_item(id, "waiting on the manual");
+        let rendered = r.render_checklist();
+        assert!(
+            rendered.contains("note: waiting on the manual"),
+            "{rendered}"
+        );
+    }
+
+    /// An item that will not fit is refused rather than silently dropped: a
+    /// checklist that loses items is worse than no checklist.
+    #[test]
+    fn an_item_over_budget_is_refused() {
+        let mut r = Region::new("todos".to_string(), RegionKind::Checklist, 4);
+        assert!(r.add_checklist_item("x".to_string(), 99).is_err());
+        assert!(r.checklist_items().is_empty());
+    }
+
+    #[test]
+    fn an_added_item_starts_open_and_gets_an_id() {
+        let mut r = checklist();
+        let first = r
+            .add_checklist_item("compute the fee table".to_string(), 5)
+            .unwrap();
+        let second = r
+            .add_checklist_item("check the manual".to_string(), 5)
+            .unwrap();
+        assert_eq!((first, second), (1, 2), "ids are stable and sequential");
+        assert_eq!(r.open_checklist_items().len(), 2);
+    }
+
+    #[test]
+    fn completing_an_item_closes_it_and_nothing_else() {
+        let mut r = checklist();
+        let id = r.add_checklist_item("one".to_string(), 2).unwrap();
+        r.add_checklist_item("two".to_string(), 2).unwrap();
+
+        assert!(r.complete_checklist_item(id));
+        let open = r.open_checklist_items();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].text, "two");
+        assert_eq!(
+            r.checklist_items().len(),
+            2,
+            "done items are kept, not deleted"
+        );
+    }
+
+    #[test]
+    fn an_unknown_id_reports_failure_rather_than_ticking_something_else() {
+        // A `todo_done(3)` that silently closed a different item would be worse
+        // than one that fails: the model would believe work was finished.
+        let mut r = checklist();
+        r.add_checklist_item("one".to_string(), 2).unwrap();
+        assert!(!r.complete_checklist_item(99));
+        assert!(!r.note_checklist_item(99, "x"));
+        assert_eq!(r.open_checklist_items().len(), 1);
+    }
+
+    #[test]
+    fn a_note_records_without_closing() {
+        let mut r = checklist();
+        let id = r
+            .add_checklist_item("blocked thing".to_string(), 2)
+            .unwrap();
+        assert!(r.note_checklist_item(id, "waiting on the manual"));
+        let item = &r.checklist_items()[0];
+        assert!(!item.done, "a note is not a completion");
+        assert_eq!(item.note.as_deref(), Some("waiting on the manual"));
+    }
+
+    /// Ordering is the point: this region is instruction, not history, so what
+    /// is left to do belongs at the top of what the model reads every turn.
+    #[test]
+    fn the_render_puts_open_items_first() {
+        let mut r = checklist();
+        let done = r
+            .add_checklist_item("already finished".to_string(), 2)
+            .unwrap();
+        r.add_checklist_item("still to do".to_string(), 2).unwrap();
+        r.complete_checklist_item(done);
+
+        let rendered = r.render_checklist();
+        let open_at = rendered.find("still to do").expect("open item rendered");
+        let done_at = rendered
+            .find("already finished")
+            .expect("done item rendered");
+        assert!(open_at < done_at, "open before done:\n{rendered}");
+        assert!(rendered.contains("1 open, 1 done"), "{rendered}");
+        assert!(
+            rendered.contains("[x]") && rendered.contains("[ ]"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn an_empty_checklist_renders_nothing() {
+        // Rather than an empty heading taking up the window every turn.
+        assert!(checklist().render_checklist().is_empty());
+    }
+
+    /// Ids survive an entry being dropped, so a later `todo_done` cannot land on
+    /// the wrong item.
+    #[test]
+    fn ids_do_not_get_reused_after_a_drop() {
+        let mut r = checklist();
+        r.add_checklist_item("one".to_string(), 2).unwrap();
+        let second = r.add_checklist_item("two".to_string(), 2).unwrap();
+        r.content.remove(0);
+        let third = r.add_checklist_item("three".to_string(), 2).unwrap();
+        assert!(third > second, "a reused id would tick off the wrong item");
+    }
 
     #[test]
     fn test_region_creation() {

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -569,6 +569,20 @@ impl ContextWindow {
                         cache_hint: CacheHint::Always,
                     });
                 }
+                // A checklist renders as instruction rather than history: one
+                // stable block, open items first, so what is left to do is at
+                // the top of what the model reads every turn. The whole value
+                // of the state being real is that this block is derived from
+                // it rather than from whatever prose the model last wrote.
+                leviath_core::RegionKind::Checklist => {
+                    let text = region.render_checklist();
+                    if !text.is_empty() {
+                        system_blocks.push(leviath_providers::SystemBlock {
+                            text,
+                            cache_hint: CacheHint::UntilChanged,
+                        });
+                    }
+                }
                 leviath_core::RegionKind::CompactHistory { .. } => {
                     let text = region
                         .content

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -13,7 +13,11 @@ use crate::components::ContextWindow;
 
 /// Whether a tool name is a context self-management tool this module handles.
 pub fn is_context_tool(name: &str) -> bool {
-    name.starts_with("context_")
+    // `todo_*` are context tools by every property that matters here: they
+    // write to a region, need no workspace, and are answered by this module
+    // rather than the tool executor. Only the prefix differs, and it differs
+    // because `context_todo_add` reads worse than `todo_add`.
+    name.starts_with("context_") || name.starts_with("todo_")
 }
 
 /// Build the "section not found" error listing the writable regions.
@@ -32,6 +36,25 @@ fn region_not_found(name: &str, window: &ContextWindow) -> String {
     )
 }
 
+/// The named region, when it exists and is a checklist.
+///
+/// A `todo_*` call against an ordinary region is an error rather than a write:
+/// the item state has nowhere to live there, so accepting it would record
+/// something the checklist tools could never read back.
+fn checklist_region<'w>(
+    window: &'w mut ContextWindow,
+    name: &str,
+) -> Result<&'w mut leviath_core::Region, String> {
+    match window.get_region(name) {
+        None => Err(region_not_found(name, window)),
+        Some(r) if !matches!(r.kind, RegionKind::Checklist) => Err(format!(
+            "[error] region '{name}' is not a checklist; declare it as \
+             kind = \"checklist\" to track items in it"
+        )),
+        Some(_) => Ok(window.get_region_mut(name).expect("region present")),
+    }
+}
+
 /// Apply one `context_*` tool call to `window`, returning the result text the
 /// model sees. Unknown tools and missing arguments yield `[error] …` strings
 /// (never a hard failure - the model reads and adjusts).
@@ -41,6 +64,59 @@ pub fn handle_context_tool(
     window: &mut ContextWindow,
 ) -> String {
     match name {
+        // ── checklist items ────────────────────────────────────────────────
+        //
+        // Written through tools rather than as free text so the state cannot
+        // drift from what the model believes it wrote: a region holding three
+        // unfinished items and one holding three finished ones are the same
+        // string to every other region kind, which is why no gate could ask.
+        "todo_add" => {
+            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
+                return "[error] missing 'region' argument".to_string();
+            };
+            let Some(item) = args.get("item").and_then(|v| v.as_str()) else {
+                return "[error] missing 'item' argument".to_string();
+            };
+            let tokens = leviath_core::estimate_tokens(item);
+            match checklist_region(window, region_name) {
+                Err(e) => e,
+                Ok(region) => match region.add_checklist_item(item.to_string(), tokens) {
+                    Ok(id) => format!("[ok] added item {id}"),
+                    Err(e) => format!("[error] {e}"),
+                },
+            }
+        }
+        "todo_done" | "todo_note" => {
+            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
+                return "[error] missing 'region' argument".to_string();
+            };
+            let Some(id) = args.get("id").and_then(|v| v.as_u64()) else {
+                return "[error] missing 'id' argument".to_string();
+            };
+            let note = args.get("note").and_then(|v| v.as_str());
+            if name == "todo_note" && note.is_none() {
+                return "[error] missing 'note' argument".to_string();
+            }
+            match checklist_region(window, region_name) {
+                Err(e) => e,
+                Ok(region) => {
+                    let id = id as usize;
+                    let found = match note {
+                        // `todo_done` and `todo_note` differ only in which field
+                        // they write, so they share everything up to here.
+                        Some(text) if name == "todo_note" => region.note_checklist_item(id, text),
+                        _ => region.complete_checklist_item(id),
+                    };
+                    match found {
+                        // Named rather than silently ignored: an id that
+                        // matches nothing usually means the model invented one,
+                        // and it needs to know its list is not what it thinks.
+                        false => format!("[error] no item {id} in '{region_name}'"),
+                        true => format!("[ok] item {id} updated"),
+                    }
+                }
+            }
+        }
         "context_write" => {
             let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
                 return "[error] missing 'region' argument".to_string();
@@ -216,6 +292,7 @@ pub fn handle_context_tool(
                         RegionKind::Compacting { .. } => "summarized when full",
                         RegionKind::Clearable => "temporary",
                         RegionKind::CompactHistory { .. } => "summary archive",
+                        RegionKind::Checklist => "checklist",
                         RegionKind::HashMap { .. } => "key-value store",
                         RegionKind::Custom { .. } => "scripted",
                     };
@@ -242,6 +319,187 @@ pub fn handle_context_tool(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── todo_* ─────────────────────────────────────────────────────────────
+
+    fn window_with_checklist() -> ContextWindow {
+        let mut w = ContextWindow::new(10_000);
+        w.add_region(leviath_core::Region::new(
+            "todos".to_string(),
+            RegionKind::Checklist,
+            5000,
+        ));
+        w
+    }
+
+    #[test]
+    fn todo_add_reports_the_id_the_other_tools_take() {
+        let mut w = window_with_checklist();
+        let out = handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "todos", "item": "compute the fee table" }),
+            &mut w,
+        );
+        assert!(out.contains("added item 1"), "{out}");
+        assert_eq!(
+            w.get_region("todos").unwrap().open_checklist_items().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn todo_done_closes_the_item() {
+        let mut w = window_with_checklist();
+        handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "todos", "item": "one" }),
+            &mut w,
+        );
+        let out = handle_context_tool(
+            "todo_done",
+            &serde_json::json!({ "region": "todos", "id": 1 }),
+            &mut w,
+        );
+        assert!(out.starts_with("[ok]"), "{out}");
+        assert!(
+            w.get_region("todos")
+                .unwrap()
+                .open_checklist_items()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn todo_note_records_without_closing() {
+        let mut w = window_with_checklist();
+        handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "todos", "item": "one" }),
+            &mut w,
+        );
+        let out = handle_context_tool(
+            "todo_note",
+            &serde_json::json!({ "region": "todos", "id": 1, "note": "blocked" }),
+            &mut w,
+        );
+        assert!(out.starts_with("[ok]"), "{out}");
+        assert_eq!(
+            w.get_region("todos").unwrap().open_checklist_items().len(),
+            1,
+            "a note is not a completion"
+        );
+    }
+
+    #[test]
+    fn an_unknown_id_is_an_error_the_model_can_read() {
+        let mut w = window_with_checklist();
+        let out = handle_context_tool(
+            "todo_done",
+            &serde_json::json!({ "region": "todos", "id": 7 }),
+            &mut w,
+        );
+        assert!(out.contains("no item 7"), "{out}");
+    }
+
+    /// A `todo_*` call against an ordinary region is refused: the item state has
+    /// nowhere to live there, so accepting it would record something the
+    /// checklist tools could never read back.
+    #[test]
+    fn todo_tools_refuse_a_region_that_is_not_a_checklist() {
+        let mut w = ContextWindow::new(10_000);
+        w.add_region(leviath_core::Region::new(
+            "notes".to_string(),
+            RegionKind::Pinned,
+            5000,
+        ));
+        let out = handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "notes", "item": "x" }),
+            &mut w,
+        );
+        assert!(out.contains("not a checklist"), "{out}");
+    }
+
+    /// An item that will not fit is reported rather than silently dropped: the
+    /// model has to know its list is not what it thinks.
+    #[test]
+    fn todo_add_reports_a_region_that_is_full() {
+        let mut w = ContextWindow::new(10_000);
+        w.add_region(leviath_core::Region::new(
+            "todos".to_string(),
+            RegionKind::Checklist,
+            1,
+        ));
+        let out = handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "todos", "item": "a long item that will not fit" }),
+            &mut w,
+        );
+        assert!(out.starts_with("[error]"), "{out}");
+    }
+
+    /// The same refusal for the closing tools, not only for `todo_add`: an id
+    /// written into an ordinary region could never be read back.
+    #[test]
+    fn todo_done_also_refuses_a_region_that_is_not_a_checklist() {
+        let mut w = ContextWindow::new(10_000);
+        w.add_region(leviath_core::Region::new(
+            "notes".to_string(),
+            RegionKind::Pinned,
+            5000,
+        ));
+        let out = handle_context_tool(
+            "todo_done",
+            &serde_json::json!({ "region": "notes", "id": 1 }),
+            &mut w,
+        );
+        assert!(out.contains("not a checklist"), "{out}");
+    }
+
+    /// `context_list` names a checklist as one, so an agent reading its own
+    /// window can tell which region takes the `todo_*` tools.
+    #[test]
+    fn context_list_names_a_checklist() {
+        let mut w = window_with_checklist();
+        let out = handle_context_tool("context_list", &serde_json::json!({}), &mut w);
+        assert!(out.contains("checklist"), "{out}");
+    }
+
+    #[test]
+    fn todo_tools_report_a_missing_region() {
+        let mut w = window_with_checklist();
+        let out = handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "nope", "item": "x" }),
+            &mut w,
+        );
+        assert!(out.contains("[error]"), "{out}");
+    }
+
+    #[test]
+    fn todo_tools_report_missing_arguments() {
+        let mut w = window_with_checklist();
+        for (tool, args) in [
+            ("todo_add", serde_json::json!({ "item": "x" })),
+            ("todo_add", serde_json::json!({ "region": "todos" })),
+            ("todo_done", serde_json::json!({ "region": "todos" })),
+            (
+                "todo_note",
+                serde_json::json!({ "region": "todos", "id": 1 }),
+            ),
+            ("todo_done", serde_json::json!({ "id": 1 })),
+        ] {
+            let out = handle_context_tool(tool, &args, &mut w);
+            assert!(out.contains("[error] missing"), "{tool}: {out}");
+        }
+    }
+
+    #[test]
+    fn the_todo_tools_are_routed_here() {
+        for name in ["todo_add", "todo_done", "todo_note"] {
+            assert!(is_context_tool(name), "{name}");
+        }
+    }
     use leviath_core::{EvictionStrategy, Region};
     use serde_json::json;
 

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -219,6 +219,7 @@ fn region_kind_str(kind: &RegionKind) -> &'static str {
         RegionKind::Compacting { .. } => "compacting",
         RegionKind::CompactHistory { .. } => "history",
         RegionKind::HashMap { .. } => "hashmap",
+        RegionKind::Checklist => "checklist",
         RegionKind::Custom { .. } => "custom",
     }
 }
@@ -920,6 +921,7 @@ mod tests {
             },
             100,
         ));
+        w.add_region(Region::new("todos".to_string(), RegionKind::Checklist, 100));
         let _ = w.add_to_region("pin", "hello".to_string(), 3);
         w.current_tokens = w.calculate_tokens();
 
@@ -937,7 +939,8 @@ mod tests {
                 "compacting",
                 "history",
                 "hashmap",
-                "custom"
+                "custom",
+                "checklist"
             ]
         );
         // The pinned region's entry is captured.

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -7974,6 +7974,229 @@ fn a_zero_baseline_cannot_run_away() {
     assert!(!rec.runaway_warned);
 }
 
+// ── transition gates: require_no_open_items (#342) ──
+
+/// A window whose checklist holds `open` open items and `done` closed ones.
+fn checklist_window(open: usize, done: usize) -> ContextWindow {
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new(
+        "todos".to_string(),
+        RegionKind::Checklist,
+        5000,
+    ));
+    let region = w.get_region_mut("todos").expect("region");
+    for i in 0..open {
+        region.add_checklist_item(format!("open {i}"), 2).unwrap();
+    }
+    for i in 0..done {
+        let id = region.add_checklist_item(format!("done {i}"), 2).unwrap();
+        region.complete_checklist_item(id);
+    }
+    w
+}
+
+fn items_gate() -> leviath_core::blueprint::TransitionGate {
+    leviath_core::blueprint::TransitionGate {
+        require_no_open_items: Some("todos".to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn open_items_block_the_edge_and_the_nudge_names_them() {
+    let w = checklist_window(2, 1);
+    let stage = stage_named("implement", None, false, None);
+    let GateDecision::Block(nudge) =
+        gate_blocks(Some(&items_gate()), &stage, &StageProgress::default(), &w)
+    else {
+        panic!("open items must hold the stage");
+    };
+    assert!(nudge.contains("2 item(s)"), "{nudge}");
+    assert!(
+        nudge.contains("open 0"),
+        "naming them is the useful part: {nudge}"
+    );
+}
+
+/// The distinction no other gate could make: three finished items look exactly
+/// like three unfinished ones to a presence check.
+#[test]
+fn a_fully_ticked_checklist_passes() {
+    let w = checklist_window(0, 3);
+    let stage = stage_named("implement", None, false, None);
+    assert!(matches!(
+        gate_blocks(Some(&items_gate()), &stage, &StageProgress::default(), &w),
+        GateDecision::Pass
+    ));
+}
+
+#[test]
+fn an_empty_checklist_gate_passes() {
+    let w = checklist_window(0, 0);
+    let stage = stage_named("implement", None, false, None);
+    assert!(matches!(
+        gate_blocks(Some(&items_gate()), &stage, &StageProgress::default(), &w),
+        GateDecision::Pass
+    ));
+}
+
+/// It cannot wedge a run: after the shared budget the edge is taken with a
+/// warning, like every other gate.
+#[test]
+fn open_items_give_up_after_the_budget() {
+    let w = checklist_window(2, 0);
+    let progress = StageProgress {
+        gate_reentries: leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS,
+        ..Default::default()
+    };
+    let stage = stage_named("implement", None, false, None);
+    assert!(matches!(
+        gate_blocks(Some(&items_gate()), &stage, &progress, &w),
+        GateDecision::Forced
+    ));
+}
+
+/// A gate naming a region the window does not hold passes rather than
+/// stranding the run over a typo in a region name.
+#[test]
+fn a_gate_on_a_missing_checklist_passes() {
+    let w = ContextWindow::new(10_000);
+    let stage = stage_named("implement", None, false, None);
+    assert!(matches!(
+        gate_blocks(Some(&items_gate()), &stage, &StageProgress::default(), &w),
+        GateDecision::Pass
+    ));
+}
+
+// ── a checklist assembles as one stable block ──
+
+#[test]
+fn a_checklist_assembles_as_a_system_block() {
+    let w = checklist_window(2, 1);
+    let assembled = w.assemble_with_meta(&crate::custom_region::AssembleMeta::default());
+    let text = format!("{assembled:?}");
+    assert!(text.contains("2 open, 1 done"), "{text}");
+    // Instruction, not history: it belongs in the system section rather than
+    // as a message the model could mistake for something it said.
+    assert!(!assembled.system_blocks.is_empty());
+}
+
+/// A checklist holding entries that are not items renders nothing.
+///
+/// The empty-region skip above this arm handles a region with no entries at
+/// all, so this is the only way the guard inside it is reached: a seed, a
+/// carried entry, or a `context_append` landing in a checklist region.
+#[test]
+fn a_checklist_of_non_items_assembles_nothing() {
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new(
+        "todos".to_string(),
+        RegionKind::Checklist,
+        5000,
+    ));
+    w.add_to_region("todos", "a plain note, not an item".to_string(), 6)
+        .expect("seeded");
+
+    let assembled = w.assemble_with_meta(&crate::custom_region::AssembleMeta::default());
+    assert!(
+        !format!("{assembled:?}").contains("Checklist ("),
+        "nothing to show is nothing to send"
+    );
+}
+
+#[test]
+fn an_empty_checklist_assembles_nothing() {
+    let w = checklist_window(0, 0);
+    let assembled = w.assemble_with_meta(&crate::custom_region::AssembleMeta::default());
+    assert!(
+        !format!("{assembled:?}").contains("Checklist ("),
+        "an empty checklist should not render"
+    );
+}
+
+// ── the whole checklist path, end to end ──
+
+/// Tool call -> region state -> what the model sees -> what the gate decides.
+///
+/// Written as one test on purpose. Each half of this feature is tested in
+/// isolation elsewhere, and each of those could pass while the path between
+/// them is broken - which is exactly the shape of a feature that looks
+/// implemented and does nothing.
+#[test]
+fn the_checklist_path_holds_together() {
+    use crate::context_tools::handle_context_tool;
+
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new(
+        "todos".to_string(),
+        RegionKind::Checklist,
+        5000,
+    ));
+    let stage = stage_named("implement", None, false, None);
+    let gate = items_gate();
+
+    // 1. The model records three things through the tool.
+    for item in [
+        "check the fee table",
+        "read the manual",
+        "write the summary",
+    ] {
+        let out = handle_context_tool(
+            "todo_add",
+            &serde_json::json!({ "region": "todos", "item": item }),
+            &mut w,
+        );
+        assert!(out.contains("added item"), "{out}");
+    }
+    assert_eq!(
+        w.get_region("todos").unwrap().open_checklist_items().len(),
+        3
+    );
+
+    // 2. They reach the model as one system block, open items first.
+    let assembled = w.assemble_with_meta(&crate::custom_region::AssembleMeta::default());
+    let seen = format!("{assembled:?}");
+    assert!(seen.contains("3 open, 0 done"), "{seen}");
+    assert!(seen.contains("check the fee table"), "{seen}");
+
+    // 3. The gate holds the stage while any of them is open.
+    let GateDecision::Block(nudge) =
+        gate_blocks(Some(&gate), &stage, &StageProgress::default(), &w)
+    else {
+        panic!("three open items must hold the stage");
+    };
+    assert!(nudge.contains("3 item(s)"), "{nudge}");
+
+    // 4. Two done is still not done.
+    for id in [1, 2] {
+        handle_context_tool(
+            "todo_done",
+            &serde_json::json!({ "region": "todos", "id": id }),
+            &mut w,
+        );
+    }
+    assert!(matches!(
+        gate_blocks(Some(&gate), &stage, &StageProgress::default(), &w),
+        GateDecision::Block(_)
+    ));
+
+    // 5. The last one closes it, and the edge opens.
+    handle_context_tool(
+        "todo_done",
+        &serde_json::json!({ "region": "todos", "id": 3 }),
+        &mut w,
+    );
+    assert!(matches!(
+        gate_blocks(Some(&gate), &stage, &StageProgress::default(), &w),
+        GateDecision::Pass
+    ));
+
+    // 6. And nothing was thrown away on the way.
+    let region = w.get_region("todos").unwrap();
+    assert_eq!(region.checklist_items().len(), 3);
+    assert!(region.render_checklist().contains("0 open, 3 done"));
+}
+
 // ── transition gates: require_modifications (#107) ──
 
 fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint::TransitionGate {
@@ -7984,6 +8207,7 @@ fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint:
         tools: Vec::new(),
         max_attempts: None,
         require_region_updated: None,
+        require_no_open_items: None,
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -79,10 +79,14 @@ pub(crate) enum StageResolution {
     DeadEnd,
     /// Advance to this stage index, applying the edge's context transform once
     /// the edge's gate (if any) is satisfied.
+    /// Boxed rather than inline: `TransitionGate` grows every time a gate
+    /// condition is added, and this variant is otherwise a `usize` and a small
+    /// enum - carrying it by value made every `StageResolution` the size of the
+    /// largest gate, including the five variants that hold nothing.
     Next(
         usize,
         leviath_core::blueprint::EdgeTransform,
-        Option<leviath_core::blueprint::TransitionGate>,
+        Option<Box<leviath_core::blueprint::TransitionGate>>,
     ),
     /// Multiple candidate edges - an LLM must choose among them.
     Choose(Vec<leviath_core::blueprint::TransitionEdge>),
@@ -208,7 +212,7 @@ pub(crate) fn resolve_transition_sync(
                     StageResolution::Next(
                         idx,
                         choosable[0].transform.clone(),
-                        choosable[0].gate.clone(),
+                        choosable[0].gate.clone().map(Box::new),
                     )
                 }
                 _ => StageResolution::Choose(choosable.into_iter().cloned().collect()),
@@ -289,6 +293,43 @@ pub(crate) fn gate_blocks(
                 )
             }),
         );
+    }
+    // Checked before `require_modifications` and independently of it: a stage
+    // whose work is a set of items usually has no file write to require.
+    //
+    // A gate naming a region the window does not hold passes rather than
+    // blocking - no amount of work could satisfy it, and stranding the run over
+    // a typo in a region name would be worse than the missing check.
+    if let Some(name) = &gate.require_no_open_items
+        && let Some(region) = window.get_region(name)
+    {
+        let open = region.open_checklist_items();
+        if !open.is_empty() {
+            let cap = gate
+                .max_attempts
+                .unwrap_or(leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS);
+            if progress.gate_reentries >= cap {
+                tracing::warn!(
+                    stage = %stage.name,
+                    open = open.len(),
+                    attempts = cap,
+                    "stage still has open checklist items after re-run attempts; proceeding"
+                );
+                return GateDecision::Forced;
+            }
+            let listed = open
+                .iter()
+                .map(|i| format!("{} {}", i.id, i.text))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return GateDecision::Block(gate.message.clone().unwrap_or_else(|| {
+                format!(
+                    "{} item(s) are still open in `{name}`: {listed}. Finish them, or use \
+                     todo_done to drop the ones that no longer apply, before moving on.",
+                    open.len()
+                )
+            }));
+        }
     }
     if !gate.require_modifications {
         return GateDecision::Pass;
@@ -560,7 +601,7 @@ pub fn resolve_transition(
                 // Check the edge's gate BEFORE the transform runs: the transform
                 // compacts/clears regions, and a held stage must keep its context.
                 let gate = outcome.is_none().then_some(gate).flatten();
-                match gate_blocks(gate.as_ref(), stage, &progress, &window) {
+                match gate_blocks(gate.as_deref(), stage, &progress, &window) {
                     GateDecision::Block(nudge) => {
                         hold_for_gate(entity, &nudge, &mut progress, &mut window, &mut commands);
                         continue;

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -273,6 +273,64 @@ impl BuiltinTools {
                 }),
             },
             Tool {
+                name: "todo_add".to_string(),
+                description: "Add an item to a checklist region. Returns the item's id, which todo_done and todo_note take. Use this for work you have identified but not finished, so that what is left is tracked rather than remembered.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "region": {
+                            "type": "string",
+                            "description": "Name of the checklist region (e.g. 'todos')"
+                        },
+                        "item": {
+                            "type": "string",
+                            "description": "What needs doing, in one line"
+                        }
+                    },
+                    "required": ["region", "item"]
+                }),
+            },
+            Tool {
+                name: "todo_done".to_string(),
+                description: "Mark a checklist item finished, by the id todo_add returned. Items you have finished must be ticked off: a stage can be held until its checklist has no open items.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "region": {
+                            "type": "string",
+                            "description": "Name of the checklist region"
+                        },
+                        "id": {
+                            "type": "integer",
+                            "description": "The item's id, as returned by todo_add"
+                        }
+                    },
+                    "required": ["region", "id"]
+                }),
+            },
+            Tool {
+                name: "todo_note".to_string(),
+                description: "Record a note against a checklist item without closing it - what you tried, what blocked you, what it depends on.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "region": {
+                            "type": "string",
+                            "description": "Name of the checklist region"
+                        },
+                        "id": {
+                            "type": "integer",
+                            "description": "The item's id"
+                        },
+                        "note": {
+                            "type": "string",
+                            "description": "The note to record"
+                        }
+                    },
+                    "required": ["region", "id", "note"]
+                }),
+            },
+            Tool {
                 name: "context_append".to_string(),
                 description: "Add content to an existing section of your context window without replacing what's already there.".to_string(),
                 parameters: json!({
@@ -517,6 +575,9 @@ impl BuiltinTools {
             "context_read",
             "context_delete",
             "context_list",
+            "todo_add",
+            "todo_done",
+            "todo_note",
             crate::SUBMIT_OUTPUT_TOOL,
         ]
         .iter()

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -166,11 +166,11 @@ mod tests {
     // ── Tool definitions ──────────────────────────────────────────────────
 
     #[test]
-    fn tool_defs_returns_seventeen_tools() {
+    fn tool_defs_returns_twenty_tools() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         let defs = tools.tool_defs();
-        assert_eq!(defs.len(), 17);
+        assert_eq!(defs.len(), 20);
     }
 
     #[test]
@@ -419,10 +419,10 @@ mod tests {
     }
 
     #[test]
-    fn names_returns_eighteen_entries() {
+    fn names_returns_twenty_one_entries() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        assert_eq!(tools.names().len(), 18);
+        assert_eq!(tools.names().len(), 21);
     }
 
     // ── Sub-agent tool definitions ────────────────────────────────────────
@@ -2097,7 +2097,7 @@ mod tests {
         let names: Vec<String> = tools.tool_defs().iter().map(|t| t.name.clone()).collect();
         assert!(!names.contains(&"shell".to_string()));
         // The other 16 built-ins remain.
-        assert_eq!(tools.tool_defs().len(), 16);
+        assert_eq!(tools.tool_defs().len(), 19);
         assert!(names.contains(&"read_file".to_string()));
         assert!(names.contains(&"context_write".to_string()));
         assert!(names.contains(&"present_for_review".to_string()));

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -45,7 +45,7 @@ conversation = { kind = "sliding_window", budget = "33%", max_items = 20 }
 history      = { kind = "compact_history", budget = "15%", source_region = "codebase" }
 ```
 
-## The eight region kinds
+## The nine region kinds
 
 | Kind | Behavior |
 |---|---|
@@ -56,6 +56,7 @@ history      = { kind = "compact_history", budget = "15%", source_region = "code
 | `compact_history` | Carries summaries from earlier stages forward, so a later stage knows what happened without holding the raw content. Names the region it summarizes with `source_region`. |
 | `clearable` | Wiped in one shot when space is needed (scratch). |
 | `hashmap` | Keyed entries (alias `hash_map`); a write to a key replaces it. |
+| `checklist` | A task list whose entries carry state. Written through `todo_add` / `todo_done` / `todo_note`, never evicted, and rendered open-items-first. |
 | `custom` | Behavior defined by a Rhai script (see [Rhai regions](/docs/rhai-regions)). |
 
 An unrecognized `kind` is a hard parse error, not a silently ignored region.
@@ -91,6 +92,44 @@ kind       = "custom"
 script     = "context_hooks/brain.rhai"   # relative to the agent directory
 persistent = false             # true behaves pinned-like: never evicted
 ```
+
+### Tracking work with a checklist
+
+A pinned region plus `context_append` gives persistence, which is the easy half. What it does not
+give is *state*: "compute the fee table" and "~~compute the fee table~~ done" are two different
+strings, so nothing can count what is left and no gate can ask.
+
+```toml
+[context.regions]
+todos = { kind = "checklist", budget = "3%" }
+```
+
+The agent writes to it through tools rather than free text, so the state cannot drift from what the
+model believes it wrote:
+
+| Tool | Effect |
+|---|---|
+| `todo_add(region, item)` | Adds an open item, returns its id |
+| `todo_done(region, id)` | Ticks it off |
+| `todo_note(region, id, note)` | Records a note **without** closing it |
+
+It renders as one stable block with open items first, because the value of it being in the system
+section is that it stays in front of the model every turn as instruction rather than history.
+
+An id is never reused, so a `todo_done` cannot land on a different item than the one it names, and
+an id that matches nothing is an error the model can read rather than a silent no-op.
+
+The gate is the part that makes any of this enforceable:
+
+```toml
+[stages.implement.transitions.review]
+gate = { require_no_open_items = "todos",
+         message = "Finish or explicitly drop the open items first." }
+```
+
+The nudge names the items that are still open. It shares the same `max_attempts` budget as every
+other gate, so it cannot wedge a run, and a gate naming a region that does not exist passes rather
+than stranding one.
 
 ### Keys every region accepts
 

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -191,6 +191,7 @@ gate = { require_modifications = true, max_attempts = 3 }
 |---|---|---|
 | `require_modifications` | `false` | Require at least one successful file-modifying tool call in the stage being left |
 | `require_region_updated` | unset | Require that a named region **changed** during this stage, not merely that it has content. See below |
+| `require_no_open_items` | unset | Name a [checklist region](/docs/context) that must have no open items before this edge is taken |
 | `message` | generated | The nudge shown when the gate blocks |
 | `region` | unset | A region that also satisfies the gate by being non-empty |
 | `tools` | `[]` | Extra tool names to count as modifying, beyond `write_file` and `edit_file` |


### PR DESCRIPTION
Closes #342.

## The gap

There was no way to model a task list. The closest thing was a pinned region plus `context_append`, which gives persistence — the easy half — and **no state**: "compute the fee table" and "~~compute the fee table~~ done" are two different strings, so nothing could count what was left, and none of the four stage-exit gates could ask. A region holding three unfinished items and one holding three finished ones were indistinguishable to every one of them.

## What this adds

```toml
[context.regions]
todos = { kind = "checklist", budget = "3%" }
```

| Tool | Effect |
|---|---|
| `todo_add(region, item)` | Adds an open item, returns its id |
| `todo_done(region, id)` | Ticks it off |
| `todo_note(region, id, note)` | Records a note **without** closing it |

Item state lives in entry metadata, so a checklist persists, carries across a stage swap and restores from a snapshot with no extra plumbing. Never evicted, for the same reason a pinned region is not.

It renders as one stable block, **open items first** — the value of sitting in the system section is that it reads as instruction rather than history, and what is left belongs at the top of an instruction.

```toml
[stages.implement.transitions.review]
gate = { require_no_open_items = "todos" }
```

The gate is what makes any of this enforceable, and the nudge names the items still open. It shares the same `max_attempts` budget as every other gate, so it cannot wedge a run.

## Two details worth stating

- **Ids are never reused.** A `todo_done(3)` that silently ticked off a different item after an entry was dropped would be worse than one that fails.
- **Anything that is not a well-formed item is not counted as one.** A seed or a carried entry landing in a checklist region would otherwise hold a stage on work nobody recorded.

## Verification

**The lint caught the mistake this could have shipped with.** The tools were defined and handled, but missing from the known-tool list — so a blueprint granting them failed validation and the model never saw them. My first live run recorded zero items for exactly that reason.

Live, after fixing it — a real model driving it through the gate:

```
snapshot 1  stage=work    items=3  done=0
snapshot 2  stage=work    items=3  done=3
snapshot 3  stage=report  items=3  done=3   ← gate opened
```

There is also one deterministic end-to-end test covering tool call → region state → assembled prompt → gate blocks → gate passes. Each half is tested in isolation elsewhere, and each of those could pass while the path between them is broken — which is the shape of a feature that looks implemented and does nothing. **Proven by mutation:** stubbing `open_checklist_items` to return empty fails it.

- `cargo test --workspace` green, clippy clean
- `cargo xtask coverage` 100% on `leviath-core`, `leviath-tools`, `leviath-runtime`, `leviath-cli`
- `cargo xtask docs --check` clean; documented in `context.md` and `stages.md`