### PR TITLE
chore(release): 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,73 @@ same list.
 
 ## Unreleased
 
+## 0.3.2 - 2026-08-10
+
+- Breaking: a run that required a final output and never produced one now ends
+  as an error rather than `complete` (#339). The requirement gate forces past
+  the obligation once its retries are spent, which is right - a later stage may
+  still answer - but nothing downgraded the terminal status, so a run reported
+  success with no `final_output` on disk while `lev result` exited non-zero on
+  the same run. The output-retry budget is also no longer borrowed from the
+  stage's `max_revisits`: those are different questions, and conflating them let
+  a routing setting silently multiply an inference bill, since each retry
+  re-sends the whole stage context and an output stage runs last.
+- Breaking: `read_file` is capped at 256 KiB and says so in the result when it
+  applies (#344). It had no bound at all, so a large file went into its region
+  whole and was either truncated or dropped as `[result omitted]` depending on
+  how full the region already was - a cliff rather than a limit. `shell` has
+  been capped since it existed.
+- Changed: a stage that omits a region from `[stages.X.context.regions]` now
+  hides it rather than destroying it (#341). Omitted regions were dropped from
+  the window, so re-declaring one downstream brought it back empty, and an
+  author had to choose between carrying a large preview through every call of
+  every stage and losing it. `conversation`, `tool_results` and `final_output`
+  stay visible whatever a stage declares.
+- New: `condition = "dead_end"` fires when the graph would otherwise strand -
+  the stage finished and every normal edge's target has spent its
+  `max_revisits` (#346). The alternatives were a plain edge to the output stage,
+  which the model can take at the end of every visit (measured: pipelines
+  collapsed in 10 of 24 runs of one agent and 21 of 36 of another), or nothing,
+  which kills the run with everything it established. `lev validate`'s
+  `dead-end-possible` now counts what the runtime actually consults and stops
+  recommending `condition = "max_iterations"`, which never fires on that path
+  (#340).
+- New: a `checklist` region kind whose items carry state, with `todo_add`,
+  `todo_done` and `todo_note`, and a `require_no_open_items` gate (#342). A
+  pinned region plus `context_append` gives persistence and no state: "compute
+  the fee table" and "~~compute the fee table~~ done" are two different strings,
+  so nothing could count what was left and no gate could ask.
+- New: `gate = { require_region_updated = "plan" }` requires a region to have
+  *changed* during the stage rather than merely to exist (#343). Every other
+  gate can be satisfied by re-emitting what was already written, so a reviewer's
+  rejection could be answered with the same plan until the stage ran out of
+  revisits.
+- New: `lev stages <run-id>` prints the per-stage token ledger, with
+  `--regions` for each stage's per-region high-water marks (#347). The ledger
+  has existed for a while with no CLI reader. It also now records
+  `cache_write_tokens`, without which a stage showing no cache reads could not
+  be told apart from one paying to write a prefix nothing reuses, and Leviath
+  warns once when a stage's per-call prompt passes four times its first call -
+  the shape of a region accumulating without a cap.
+- Fixed: a `[model_capabilities]` entry naming only the field you want to change
+  was silently dropped (#338). Entries are now merged onto the provider's own
+  answer for that model, so `max_context_tokens = 1048576` on its own works and
+  leaves everything else alone. A misspelled key is refused rather than ignored.
+- Fixed: an OpenRouter model this build's table does not name was silently given
+  a 128 000-token window (#337). Percentage region budgets resolve against that,
+  so a `budget = "30%"` region on a 1M-token model was sized at 38 400 instead
+  of 314 573. It now warns once per model, naming the assumed window and the
+  line that corrects it.
+- Fixed: an Anthropic cache breakpoint landing on a tool turn consumed budget
+  and wrote nothing (#345). In an agent run nearly every message is a tool turn,
+  and the breakpoint is chosen by index, so the slot was usually spent on a
+  message that could not carry it - measured against the API, the difference
+  between no cache at all and a 4 458-token prefix. `[providers]
+  anthropic_cache_ttl = "1h"` also makes the extended TTL reachable; it was
+  implemented with no way to select it.
+- Fixed: `lev list --filter` was declared, parsed and never read, so every
+  spelling printed the same thing, and an unknown value was accepted in silence
+  (#327). It now filters, and clap rejects a spelling it does not know.
 - Fixed: `o3` and `o4` could not run at all through the `openai` provider (#335).
   A model declaring no temperature support was sent `temperature: 0.0` rather
   than having the field left out, and the o-series accepts only its own default,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fs4",
  "keyring",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "tokio",
  "tracing",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -95,17 +95,17 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.1" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.1" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.1" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.1" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.1" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.1" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.1" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.1" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.1" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.1" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.1" }
+leviath = { path = "crates/leviath", version = "0.3.2" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.2" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.2" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.2" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.2" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.2" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.2" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.2" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.2" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.2" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.2" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.1", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.2", optional = true }
 leviath-core = { workspace = true }
 leviath-agent-client = { workspace = true }
 leviath-runtime = { workspace = true, features = ["control-socket"] }


### PR DESCRIPTION
Merging this cuts the alpha — `alpha.yml` triggers on a push to `main` touching `Cargo.toml`.

## What ships

Twelve issues fixed since 0.3.1 (#327, #337–#347), plus the o3 temperature fix (#335) that was already sitting unreleased.

| | |
|---|---|
| **Breaking** | A run that required a final output and produced none now **errors** instead of reporting `complete` (#339) · `read_file` capped at 256 KiB (#344) |
| **Changed** | A stage omitting a region now **hides** it rather than destroying it (#341) |
| **New** | `condition = "dead_end"` (#346) · `checklist` regions with `todo_*` tools and an open-items gate (#342) · `require_region_updated` gate (#343) · `lev stages` (#347) |
| **Fixed** | Partial `[model_capabilities]` silently dropped (#338) · OpenRouter's silent 8× under-budget (#337) · cache breakpoints on tool turns writing nothing (#345) · `lev list --filter` never read (#327) |

## One note on the number

This is a **patch** bump carrying two breaking changes and four new features. On a 0.x line that reads more like 0.4.0. The number is the one that was asked for; each changelog entry is labelled Breaking / Changed / New / Fixed so nobody has to infer it from the version.

## Verification

- 13/13 version declarations rewritten, `cargo xtask version --check` clean
- `cargo test --workspace` green, `cargo xtask docs --check` clean
- Every entry above was verified live against a real daemon or a real provider API before its PR merged — the details are in each PR

Beta and prod remain cron-driven (Monday and Thursday, 16:00 UTC), so **Monday's beta run will promote 0.3.2 on its own** unless held.