### PR TITLE
test(mcp): a live-server test that can fail for the reason it names

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -639,6 +639,29 @@ mod tests {
         false
     }
 
+    /// Pay an interpreter's cold-start cost before a test's own clock starts.
+    ///
+    /// `connect()` allows 30s for `initialize`. That is generous for an MCP
+    /// server already resident in the page cache and tight for one that is
+    /// not: on a loaded CI runner a first `python3` can spend most of that
+    /// budget in the loader, and on Windows in the virus scanner, before it
+    /// reaches its first read. That is a property of the machine, not of the
+    /// code under test, and it has failed this suite in CI.
+    ///
+    /// Running a trivial program first leaves the image cached, so the
+    /// handshake these tests actually measure starts warm. A machine with no
+    /// `python3` is unaffected: the warm-up fails, and the test that follows
+    /// reports the same spawn failure it always did.
+    async fn warm_interpreter() {
+        let _ = tokio::process::Command::new("python3")
+            .args(["-c", ""])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await;
+    }
+
     fn write_config(ctx: &McpContext, server: MCPServerConfig) {
         let mut config = Config::default();
         config.mcp_servers.push(server);
@@ -883,9 +906,18 @@ for line in sys.stdin:
             &ctx,
             MCPServerConfig::stdio("local", "python3", vec!["-c".to_string(), stub.to_string()]),
         );
+        warm_interpreter().await;
+        let outcome = run_test(&ctx, "local").await;
+        assert!(!outcome.ok, "a tools/list error must be reported");
+        // Not merely `!ok`: this server fails to start on a machine with no
+        // `python3`, and that also reports `!ok`. Naming the server's own error
+        // is what distinguishes "tools/list was answered with an error" from
+        // "nothing ever ran", which is the only thing this test is about.
         assert!(
-            !run_test(&ctx, "local").await.ok,
-            "a tools/list error must be reported"
+            outcome.message.contains("boom"),
+            "the failure must be the server's tools/list error, not a spawn \
+             or handshake failure; got: {}",
+            outcome.message
         );
     }
 
@@ -961,6 +993,7 @@ for line in sys.stdin:
             &ctx,
             MCPServerConfig::stdio("local", "python3", vec!["-c".to_string(), stub.to_string()]),
         );
+        warm_interpreter().await;
         let outcome = run_test(&ctx, "local").await;
         assert!(outcome.ok, "got: {}", outcome.message);
         assert!(


### PR DESCRIPTION
The pair of tests that drive a real stdio MCP server, one of which flaked on
`windows-latest` during the 0.3.2 release run.

## A test that could not fail for the reason it named

`background_test_reports_a_list_tools_failure` asserted only `!outcome.ok`. A
machine with no usable `python3` also yields `!ok`, so the test could not tell
"the server answered `tools/list` with an error" from "nothing ever ran". It
now asserts the server's own error reaches the outcome, which requires
`initialize` to have succeeded first.

Mutation-checked rather than assumed. Pointing the config at a binary that does
not exist:

```
the failure must be the server's tools/list error, not a spawn or handshake
failure; got: 'local' failed: Failed to spawn MCP server
'no-such-python-xyz': No such file or directory (os error 2)
```

The old assertion passes on that input; the new one fails.

## The flake

`background_test_lists_tools_of_a_live_stdio_server` failed once with

```
'local' failed: MCP server did not respond to 'initialize' within 30s
```

recovered with `gh run view <id> --attempt 1 --log-failed`, since the rerun had
overwritten the default view. The child spawned and then missed the handshake
budget.

Ruled out with evidence, not by elimination:

| Theory | Verdict |
|---|---|
| `python3` missing on Windows | `spawn` succeeded; the transport already tries `.exe/.cmd/.bat` |
| Clean-env allowlist starving the interpreter | covers `SYSTEMROOT`, `PATHEXT`, `TEMP`, `APPDATA` |
| CRLF breaking the framing | `read_frame` trims |
| `CREATE_NO_WINDOW` breaking piped stdio | suppresses the window only |
| `for line in sys.stdin` read-ahead withholding the first reply | **disproved by measurement** - a probe driving both stub shapes against an open pipe had each replying in ~14ms |

That last one had a 31-site fix written before the probe disproved the
mechanism. It was reverted rather than shipped as a fix that would have looked
like one while the flake continued.

What is left is interpreter start under CI contention. The 30s budget is a
production policy about MCP servers that are already installed and resident;
here the "server" is a cold interpreter, and this suite spawns `python3` from
27 sites across 11 files that can contend for one runner at once. Both tests
now run a trivial program first, so the loader and, on Windows, the virus
scanner are paid outside the window being measured.

## What this does not do

It narrows the window rather than bounding it. The warm-up removes the
cold-image cost but not contention between concurrent spawns, so a sufficiently
loaded runner could still exceed 30s. Bounding it needs a per-server connect
timeout - a config surface worth having for its own sake, since `npx`-launched
servers download on first run and routinely exceed 30s - and that is not
something to add as a side effect of a test fix. Happy to do it as a follow-up.

## Verification

- `cargo test -p leviath-cli --lib background_test_` - 6 passed
- `cargo xtask coverage --package leviath-cli` - exit 0, gate holds at 100%
- clippy and `cargo fmt --check` clean; pre-commit suite green
