### PR TITLE
fix(manifest): a blueprint key that does nothing is refused, not dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,39 @@ same list.
 
 ## Unreleased
 
+- Breaking: a blueprint key the parser does not read is now refused, naming
+  what is valid, in `[stages.X]`, `[stages.X.context]`,
+  `[stages.X.tool_routing]`, a transition edge and its `gate` (#362). The
+  parser walks the TOML by hand, so anything it did not recognise was accepted
+  and dropped: `lev validate` called the blueprint good and the only symptom
+  was a stage behaving as though the line had not been written. That is worst
+  for the features whose whole value is expressing intent precisely - an
+  ignored gate is a review loop that never gates, which reads as the model
+  behaving well. Region names are checked the same way: routing targets and
+  gate targets must name a region some stage declares, and
+  `require_no_open_items` must name a `checklist` region, since pointed at any
+  other kind it can only ever count zero and pass on the first attempt.
+- Breaking: `[stages.X.tool_routing.overrides]` accepts
+  `tool = { region = "...", max_result_tokens = N }` as well as
+  `tool = "region"`, and refuses anything else (#361). The table form parsed
+  clean and did nothing - and cost more than an unsupported shape should,
+  because the entry fell through the string-only match arm entirely, so the
+  tool lost the region it named *as well as* the cap and landed in
+  `default_region` uncapped. A non-integer or negative ceiling is now an error
+  in both this table and `max_result_tokens_per_tool`, where it used to be
+  skipped in silence.
+- Fixed: a stage's `description` is read. Every bundled agent writes one,
+  `Stage` had the field and a builder for it, and the manifest parser never
+  looked at the key.
+- Fixed: `checklist` is listed among the valid region kinds when a kind is
+  misspelled. It has always parsed; a user who typo'd it was told it does not
+  exist.
+- Fixed: a top-level key in `config.toml` that nothing reads is named in a
+  warning rather than ignored (#362). A warning and not an error on purpose:
+  every command reads that file, so refusing to load it over one stale key
+  would take the CLI down rather than the one thing the key was meant to
+  affect.
+
 ## 0.3.2 - 2026-08-10
 
 - Breaking: a run that required a final output and never produced one now ends

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -430,7 +430,7 @@ mod capability_tests {
     #[test]
     fn an_ordinary_agent_has_nothing_to_report() {
         let manifest = "[agent]\nname = \"x\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n\
-                        [stages.main]\nprompt = \"p\"\n";
+                        [stages.main]\nsystem_prompt = \"p\"\n";
         assert!(describe_capabilities(manifest, &[]).is_empty());
     }
 
@@ -666,7 +666,7 @@ mod capability_tests {
             let plain = tempfile::tempdir().unwrap();
             std::fs::write(
                 plain.path().join("agent.leviath"),
-                "[agent]\nname = \"p\"\n\n[stages.main]\nprompt = \"p\"\n",
+                "[agent]\nname = \"p\"\n\n[stages.main]\nsystem_prompt = \"p\"\n",
             )
             .unwrap();
             super::print_capabilities("p", plain.path(), None);

--- a/crates/leviath-cli/src/commands/agent_client/session.rs
+++ b/crates/leviath-cli/src/commands/agent_client/session.rs
@@ -108,7 +108,7 @@ version = "1.0.0"
 description = "test blueprint"
 
 [stages.plan]
-prompt = "Plan the work"
+system_prompt = "Plan the work"
 "#
             ),
         )

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -319,7 +319,7 @@ version = "1.0.0"
 description = "test"
 
 [stages.implement]
-prompt = "Do it"
+system_prompt = "Do it"
 "#,
     )
     .unwrap();

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -849,7 +849,7 @@ mod tests {
         std::fs::write(
             bp.join("agent.leviath"),
             "[agent]\nname = \"probe\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n\
-             [stages.main]\nprompt = \"p\"\n",
+             [stages.main]\nsystem_prompt = \"p\"\n",
         )
         .unwrap();
 
@@ -1147,7 +1147,7 @@ version = "1.0.0"
 description = "A spawnable test blueprint"
 
 [stages.plan]
-prompt = "Plan the work"
+system_prompt = "Plan the work"
 "#
             ),
         )

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -462,7 +462,7 @@ version = "1.0.0"
 description = "{description}"
 
 [stages.zzstage-work]
-prompt = "do it"
+system_prompt = "do it"
 "#
         )
     }
@@ -751,7 +751,7 @@ version = "1.0.0"
 description = "A test blueprint"
 
 [stages.plan]
-prompt = "Plan the work"
+system_prompt = "Plan the work"
 "#
     }
 
@@ -888,7 +888,7 @@ version = "1.0.0"
 description = "Created via API"
 
 [stages.plan]
-prompt = "Plan the work"
+system_prompt = "Plan the work"
 "#
         );
 
@@ -925,7 +925,7 @@ version = "1.0.0"
 description = "d"
 
 [stages.plan]
-prompt = "p"
+system_prompt = "p"
 "#;
         for name in [
             "../../../../tmp/leviath-traversal-probe",
@@ -992,7 +992,7 @@ prompt = "p"
 
         let app = Router::new().route("/api/blueprints", post(create_blueprint));
         let manifest = format!(
-            "\n[agent]\nname = \"{name}\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n[stages.plan]\nprompt = \"p\"\n"
+            "\n[agent]\nname = \"{name}\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n[stages.plan]\nsystem_prompt = \"p\"\n"
         );
         let body = serde_json::json!({ "name": name, "manifest": manifest });
         let req = Request::builder()
@@ -1037,7 +1037,7 @@ prompt = "p"
 
         let app = Router::new().route("/api/blueprints", post(create_blueprint));
         let manifest = format!(
-            "\n[agent]\nname = \"{name}\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n[stages.plan]\nprompt = \"p\"\n"
+            "\n[agent]\nname = \"{name}\"\nversion = \"1.0.0\"\ndescription = \"d\"\n\n[stages.plan]\nsystem_prompt = \"p\"\n"
         );
         let body = serde_json::json!({ "name": name, "manifest": manifest });
         let req = Request::builder()
@@ -1109,7 +1109,7 @@ version = "1.0.0"
 description = "Original"
 
 [stages.plan]
-prompt = "Plan"
+system_prompt = "Plan"
 "#
             ),
         )
@@ -1124,10 +1124,10 @@ version = "2.0.0"
 description = "Updated"
 
 [stages.plan]
-prompt = "Plan"
+system_prompt = "Plan"
 
 [stages.implement]
-prompt = "Implement"
+system_prompt = "Implement"
 "#
         );
         let body = serde_json::json!({ "manifest": updated_manifest });
@@ -1181,7 +1181,7 @@ version = "1.0.0"
 description = "d"
 
 [stages.plan]
-prompt = "p"
+system_prompt = "p"
 "#;
         for name in ["..", "%2e%2e", "."] {
             let app = Router::new().route("/api/blueprints/{name}", put(update_blueprint));
@@ -1214,7 +1214,7 @@ version = "1.0.0"
 description = "Missing"
 
 [stages.run]
-prompt = "Run"
+system_prompt = "Run"
 "#
         });
         let req = Request::builder()
@@ -1482,7 +1482,7 @@ description = "Entry stage doesn't exist"
 entry_stage = "does-not-exist"
 
 [stages.plan]
-prompt = "Plan"
+system_prompt = "Plan"
 "#;
         let body = serde_json::json!({"manifest": manifest});
         let req = Request::builder()
@@ -1526,7 +1526,7 @@ version = "1.0.0"
 description = "A test blueprint"
 
 [stages.plan]
-prompt = "Plan the work"
+system_prompt = "Plan the work"
 "#;
         std::fs::write(&manifest_path, content).unwrap();
 
@@ -1566,13 +1566,13 @@ version = "0.2.0"
 description = "Multi-stage"
 
 [stages.plan]
-prompt = "Plan"
+system_prompt = "Plan"
 
 [stages.implement]
-prompt = "Implement"
+system_prompt = "Implement"
 
 [stages.review]
-prompt = "Review"
+system_prompt = "Review"
 "#;
         std::fs::write(&manifest_path, content).unwrap();
 
@@ -1594,7 +1594,7 @@ version = "1.0.0"
 description = "Should be discovered"
 
 [stages.work]
-prompt = "Do work"
+system_prompt = "Do work"
 "#;
         write_test_agent(agent_dir, content);
 
@@ -1651,7 +1651,7 @@ version = "0.1.0"
 description = "Directly in scan dir"
 
 [stages.run]
-prompt = "Run"
+system_prompt = "Run"
 "#;
         write_test_agent(dir.path(), content);
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -1062,7 +1062,7 @@ version = "1.0.0"
 description = "Missing"
 
 [stages.run]
-prompt = "Run"
+system_prompt = "Run"
 "#
         });
         let req = Request::builder()

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -499,7 +499,6 @@ mode = "autonomous"
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 description = "A"
 max_iterations = 5
-entry = true
 max_revisits = 3
 [stages.a.transitions]
 b = "true"
@@ -526,7 +525,6 @@ mode = "autonomous"
 model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 description = "A"
 max_iterations = 5
-entry = true
 [stages.a.transitions]
 b = "true"
 

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -18,6 +18,41 @@ pub use providers::*;
 mod security;
 pub use security::*;
 
+/// Every top-level key `config.toml` may set.
+///
+/// One entry per [`Config`] field. Kept beside the struct so the two are read
+/// together, and held to the shipped example by
+/// `every_config_section_is_a_known_key`.
+const KNOWN_CONFIG_KEYS: &[&str] = &[
+    "agent_paths",
+    "agent_read_paths",
+    "agent_safe_commands",
+    "agent_tool_permissions",
+    "batch_tool_hint",
+    "default_model",
+    "default_provider",
+    "limits",
+    "mcp_servers",
+    "model_capabilities",
+    "model_providers",
+    "nudge",
+    "observability",
+    "ollama_base_url",
+    "openrouter_api_key",
+    "providers",
+    "rate_limits",
+    "request_timeout_secs",
+    "safe_commands",
+    "sandbox",
+    "security",
+    "shell_hint",
+    "taint_tracking",
+    "title",
+    "tool_permissions",
+    "tool_script_permissions",
+    "webhook",
+];
+
 /// CLI configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -407,6 +442,60 @@ impl Config {
         Ok(config)
     }
 
+    /// Say so when the config file holds a key nothing reads.
+    ///
+    /// Serde ignores unknown fields, so a misspelled or long-removed table sat
+    /// in `config.toml` doing nothing and saying nothing - `[cache] ttl` being
+    /// the reported case (#362). A warning rather than a hard error on
+    /// purpose: a blueprint is authored and validated deliberately, but this
+    /// file is long-lived and read by *every* command, so refusing to load it
+    /// over one stale key would take the whole CLI down rather than the one
+    /// thing that key was meant to affect.
+    ///
+    /// The known set is spelled out below rather than derived by serializing
+    /// the default, which was the first attempt: TOML cannot represent null,
+    /// so every `Option` field still at `None` vanishes from the serialized
+    /// form and five real keys would have been reported as unknown.
+    /// `every_config_section_is_a_known_key` holds this list against the
+    /// shipped example, which sets every section.
+    fn warn_unknown_config_keys(content: &str) {
+        let unknown = Self::unknown_config_keys(content);
+        if !unknown.is_empty() {
+            // Joined before the macro, not inside it: a field expression only
+            // runs when a subscriber is interested at the callsite, so as an
+            // argument this read as uncovered under the 100% gate however the
+            // test installed its subscriber.
+            let keys = unknown.join(", ");
+            tracing::warn!(
+                %keys,
+                "config.toml has keys nothing reads; they are being ignored. \
+                 Check the spelling against `lev config schema`."
+            );
+        }
+    }
+
+    /// The decision behind [`Self::warn_unknown_config_keys`], as data.
+    ///
+    /// Split out because the warning-shaped version could only be tested by
+    /// asserting the config still loaded, which it does whether or not a single
+    /// key is ever reported - the first version of this shipped a `parse` that
+    /// silently returned early on every real config, and that test passed
+    /// anyway.
+    ///
+    /// `toml::from_str::<Table>` and not `content.parse::<toml::Value>()`: the
+    /// latter parses a bare TOML *value*, so a document failed at the first
+    /// `=` and this returned empty every time.
+    fn unknown_config_keys(content: &str) -> Vec<String> {
+        let Ok(found) = toml::from_str::<toml::value::Table>(content) else {
+            return Vec::new();
+        };
+        found
+            .keys()
+            .filter(|k| !KNOWN_CONFIG_KEYS.contains(&k.as_str()))
+            .cloned()
+            .collect()
+    }
+
     /// Core of `load()`, parameterized by path so it can be exercised in
     /// tests against a tempfile instead of the real `~/.leviath/config.toml`.
     fn load_from_path(path: &std::path::Path) -> anyhow::Result<Self> {
@@ -421,6 +510,8 @@ impl Config {
 
             let c: Self = toml::from_str(&content)
                 .map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
+
+            Self::warn_unknown_config_keys(&content);
 
             // Catch a malformed MCP server entry here, at load, rather than at
             // the first tool call: a typo that drops a server's tools should
@@ -1217,6 +1308,68 @@ mod tests {
             .iter_errors(value)
             .map(|e| format!("{}: {e}", e.instance_path()))
             .collect()
+    }
+
+    /// A key the warning does not know is a key it reports, so a field added
+    /// to `Config` and left out of `KNOWN_CONFIG_KEYS` would tell every user
+    /// who sets it that it does nothing. The shipped example exercises every
+    /// section, which makes it the right thing to hold the list against.
+    #[test]
+    fn every_config_section_is_a_known_key() {
+        // Straight to `Table` rather than `Value` + a match: the match's other
+        // arm can never run, and an arm that cannot run is a coverage hole.
+        let example: toml::value::Table =
+            toml::from_str(CONFIG_EXAMPLE).expect("the example is a TOML table");
+        let unreported: Vec<&str> = example
+            .keys()
+            .filter(|k| !KNOWN_CONFIG_KEYS.contains(&k.as_str()))
+            .map(String::as_str)
+            .collect();
+        assert!(
+            unreported.is_empty(),
+            "the shipped example sets keys the warning would call unknown: {unreported:?}"
+        );
+    }
+
+    /// The reported case: a table nothing reads, in a file that also sets a
+    /// real key. Both halves matter - the unknown one is named, the real one
+    /// is not, and the config still loads because every command reads it.
+    #[test]
+    fn an_unknown_config_key_is_reported_and_the_config_still_loads() {
+        const CONTENT: &str = "default_provider = \"anthropic\"\n\n[cache]\nttl = \"banana\"\n";
+        assert_eq!(
+            Config::unknown_config_keys(CONTENT),
+            vec!["cache".to_string()],
+            "the unknown table is named and the real key is not"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, CONTENT).unwrap();
+        // A subscriber has to be interested at this callsite or the `warn!`
+        // body never runs. `tracing_guard` sets a thread-local default, which
+        // holds whatever another test in this binary did to the global one.
+        let _guard = leviath_testkit::tracing_guard();
+        let config = Config::load_from_path(&path).expect("an unknown key does not stop the load");
+        assert_eq!(config.default_provider, "anthropic");
+    }
+
+    /// A config using only real keys reports nothing. Without this the test
+    /// above passes against a function that calls everything unknown.
+    #[test]
+    fn a_config_of_known_keys_reports_nothing() {
+        assert!(
+            Config::unknown_config_keys(CONFIG_EXAMPLE).is_empty(),
+            "the shipped example must be clean"
+        );
+    }
+
+    /// Content that is not TOML reports nothing rather than guessing. The
+    /// caller has already failed to deserialize it and said so; a second,
+    /// vaguer complaint about every line would only bury the first.
+    #[test]
+    fn unparseable_content_reports_no_unknown_keys() {
+        assert!(Config::unknown_config_keys("this is not [[[ toml").is_empty());
     }
 
     #[test]

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1258,7 +1258,6 @@ fn a_fully_reachable_graph_reports_nothing() {
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
-entry = true
 [stages.entry.transitions]
 b = "true"
 c = "true"
@@ -1299,7 +1298,6 @@ mode = "fan_out"
 worker_stage = "work"
 merge_stage = "merge"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
-entry = true
 [stages.split.transitions]
 
 [stages.work]
@@ -1326,7 +1324,6 @@ fn a_stage_the_entry_cannot_reach_is_warned_about() {
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
-entry = true
 [stages.a.transitions]
 b = "true"
 
@@ -1354,7 +1351,6 @@ fn a_cycle_with_no_revisit_cap_is_warned_about() {
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
-entry = true
 [stages.a.transitions]
 b = "true"
 
@@ -1384,7 +1380,6 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
 max_revisits = 2
-entry = true
 [stages.a.transitions]
 b = "true"
 
@@ -1417,7 +1412,6 @@ fn self_loops_and_terminal_stages_are_not_cycles() {
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
-entry = true
 [stages.a.transitions]
 a = "true"
 b = "true"

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -288,6 +288,118 @@ impl Blueprint {
         // Graph validation
         self.validate_graph()?;
 
+        self.validate_region_references()?;
+
+        Ok(())
+    }
+
+    /// Every region a stage can name, anywhere in this blueprint.
+    ///
+    /// The union of the global layout, every stage's own layout, and the three
+    /// the runtime adds if nobody declared them. It is a union rather than the
+    /// per-stage set on purpose: a stage that omits a region from its
+    /// `[context.regions]` hides it, it does not destroy it, so naming a region
+    /// another stage declared is legitimate. Only a name that exists nowhere is
+    /// a typo.
+    fn known_region_names(&self) -> std::collections::HashSet<&str> {
+        let mut names: std::collections::HashSet<&str> = self
+            .context_layout
+            .regions
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect();
+        for stage in &self.stages {
+            if let Some(layout) = &stage.context_layout {
+                names.extend(layout.regions.iter().map(|r| r.name.as_str()));
+            }
+        }
+        // Added by `setup_context_window` when a blueprint does not declare
+        // them, so they are always addressable.
+        names.extend(["conversation", "tool_results", "final_output"]);
+        names
+    }
+
+    /// Refuse a region name that exists nowhere in the blueprint.
+    ///
+    /// Routing and gates are addressed by name, and a name that matches nothing
+    /// used to be accepted in silence: the routed tool result went to the
+    /// default region and the gate held nothing back, both looking exactly like
+    /// a working config (#362). A gate that silently never fires is the
+    /// expensive case - it reads as the model behaving well.
+    fn validate_region_references(&self) -> std::result::Result<(), ValidationError> {
+        let known = self.known_region_names();
+        let checklists: std::collections::HashSet<&str> = self
+            .context_layout
+            .regions
+            .iter()
+            .chain(
+                self.stages
+                    .iter()
+                    .filter_map(|s| s.context_layout.as_ref())
+                    .flat_map(|l| l.regions.iter()),
+            )
+            .filter(|r| matches!(r.kind, crate::RegionKind::Checklist))
+            .map(|r| r.name.as_str())
+            .collect();
+
+        for stage in &self.stages {
+            let bad = |message: String| ValidationError::Stage {
+                stage: stage.name.clone(),
+                message,
+            };
+
+            if let Some(routing) = &stage.tool_result_routing {
+                if !known.contains(routing.default_region.as_str()) {
+                    return Err(bad(format!(
+                        "tool_routing.default_region names region '{}', which no \
+                         stage declares",
+                        routing.default_region
+                    )));
+                }
+                for (tool, region) in &routing.tool_overrides {
+                    if !known.contains(region.as_str()) {
+                        return Err(bad(format!(
+                            "tool_routing.overrides.{tool} names region '{region}', \
+                             which no stage declares"
+                        )));
+                    }
+                }
+            }
+
+            for edge in stage.transitions.iter().flat_map(|t| t.values()) {
+                let Some(gate) = &edge.gate else { continue };
+                for (key, region) in [
+                    ("region", gate.region.as_ref()),
+                    (
+                        "require_region_updated",
+                        gate.require_region_updated.as_ref(),
+                    ),
+                    ("require_no_open_items", gate.require_no_open_items.as_ref()),
+                ] {
+                    let Some(region) = region else { continue };
+                    if !known.contains(region.as_str()) {
+                        return Err(bad(format!(
+                            "transition to '{}': gate.{key} names region \
+                             '{region}', which no stage declares",
+                            edge.target
+                        )));
+                    }
+                }
+                // A checklist gate counts open items, which only a checklist
+                // region has. Pointed at any other kind it can only ever read
+                // zero, so it would pass on the first attempt every time.
+                if let Some(region) = &gate.require_no_open_items
+                    && !checklists.contains(region.as_str())
+                {
+                    return Err(bad(format!(
+                        "transition to '{}': gate.require_no_open_items names \
+                         region '{region}', which is not a checklist region \
+                         (set kind = \"checklist\" on it)",
+                        edge.target
+                    )));
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -170,7 +170,7 @@ pub(super) fn parse_region_layout(
                 return Err(Error::Other(format!(
                     "region '{region_name}': unknown kind \"{unknown}\" (valid kinds: \
                      pinned, sliding_window, temporary, compacting, clearable, \
-                     compact_history, hashmap, custom)"
+                     compact_history, checklist, hashmap, custom)"
                 )));
             }
         };

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -3,11 +3,206 @@
 
 use super::*;
 
+/// Every key `parse_stage` reads off a `[stages.<name>]` table.
+///
+/// Kept beside the parser because it is only true of the parser: a key added
+/// below and not added here is refused, which is the failure mode worth having
+/// - the alternative was accepting it and doing nothing, forever.
+const STAGE_KEYS: &[&str] = &[
+    "accepts_messages",
+    "allow_as_worker",
+    "allow_blocking_tools",
+    "allow_complete",
+    "available_tools",
+    "batch_tool_hint",
+    "context",
+    "description",
+    "hooks",
+    "interaction_points",
+    "max_items",
+    "max_iterations",
+    "max_revisits",
+    "max_workers",
+    "merge_stage",
+    "mode",
+    "model",
+    "nudge",
+    "on_worker_failure",
+    "output",
+    "require_output",
+    "required_tools",
+    "requires_children",
+    "results_region",
+    "sandbox",
+    "security",
+    "shell_hint",
+    "split_prompt",
+    "system_prompt",
+    "tool_permissions",
+    "tool_routing",
+    "transition_prompt",
+    "transitions",
+    "worker_agent",
+    "worker_query",
+    "worker_stage",
+];
+
+/// Every key read off `[stages.<name>.context]`.
+///
+/// Just the one. A stage narrows its window by listing the regions it wants;
+/// what it leaves out is hidden rather than destroyed, so there is no separate
+/// `hidden`/`visible` key to write - and an author who guesses one now hears
+/// about it instead of quietly carrying the region they meant to drop.
+const CONTEXT_KEYS: &[&str] = &["regions"];
+
+/// Every key read off `[stages.<name>.tool_routing]`.
+const TOOL_ROUTING_KEYS: &[&str] = &[
+    "default_region",
+    "max_result_tokens",
+    "max_result_tokens_per_tool",
+    "overrides",
+    "persist",
+];
+
+/// Every key read off a transition edge's `gate = { ... }`.
+const GATE_KEYS: &[&str] = &[
+    "max_attempts",
+    "message",
+    "region",
+    "require_modifications",
+    "require_no_open_items",
+    "require_region_updated",
+    "tools",
+];
+
+/// Every key read off one `[stages.<name>.transitions.<target>]` edge.
+const EDGE_KEYS: &[&str] = &[
+    "condition",
+    "gate",
+    "hint",
+    "stuck_after_iterations",
+    "stuck_after_minutes",
+    "stuck_after_same_file_edits",
+    "stuck_after_tool_calls",
+    "transform",
+    "transform_config",
+];
+
+/// Refuse a key the parser does not read.
+///
+/// The manifest parser walks the TOML by hand, so every unrecognised key was
+/// accepted and ignored: a blueprint could be wrong in a way `lev validate`
+/// called good, and the only symptom was a stage behaving as though the line
+/// had not been written - which is what it was doing (#362). Region kinds and
+/// transition conditions have always been strict; this extends that to the
+/// tables holding them, with the same "valid: …" phrasing.
+fn reject_unknown_keys(where_: &str, table: &toml::value::Table, allowed: &[&str]) -> Result<()> {
+    for key in table.keys() {
+        if !allowed.contains(&key.as_str()) {
+            return Err(Error::Other(format!(
+                "{where_} has unknown key '{key}' (valid: {})",
+                allowed.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Parse one entry of `[stages.<name>.tool_routing.overrides]`.
+///
+/// Two shapes, because the table answers two questions that authors reach for
+/// together:
+///
+/// ```toml
+/// read_file = "bulk"                                  # route it
+/// read_file = { region = "bulk", max_result_tokens = 500 }   # route and cap it
+/// ```
+///
+/// Anything else is an error. It used to be silently skipped, which cost more
+/// than the unsupported shape did: the entry fell through, so the tool lost the
+/// region it named *as well as* the cap, and landed in `default_region`
+/// uncapped - while `lev validate` called the blueprint good. A config that
+/// reads as if two limits are in force while neither is costs real money before
+/// anyone thinks to check (#361).
+fn parse_tool_override(
+    stage_name: &str,
+    tool_name: &str,
+    value: &toml::Value,
+    routing: &mut crate::blueprint::ToolResultRouting,
+) -> Result<()> {
+    let where_ = || format!("stage '{stage_name}': tool_routing.overrides.{tool_name}");
+
+    if let Some(region_name) = value.as_str() {
+        routing
+            .tool_overrides
+            .insert(tool_name.to_string(), region_name.to_string());
+        return Ok(());
+    }
+
+    let Some(table) = value.as_table() else {
+        return Err(Error::Other(format!(
+            "{} must be a region name or a table of \
+             {{ region, max_result_tokens }}, not {}",
+            where_(),
+            value.type_str()
+        )));
+    };
+
+    for key in table.keys() {
+        if !matches!(key.as_str(), "region" | "max_result_tokens") {
+            return Err(Error::Other(format!(
+                "{} has unknown key '{key}' (valid: region, max_result_tokens)",
+                where_()
+            )));
+        }
+    }
+
+    if let Some(region) = table.get("region") {
+        let region = region
+            .as_str()
+            .ok_or_else(|| Error::Other(format!("{}.region must be a region name", where_())))?;
+        routing
+            .tool_overrides
+            .insert(tool_name.to_string(), region.to_string());
+    }
+
+    if let Some(max) = table.get("max_result_tokens") {
+        let max = max.as_integer().ok_or_else(|| {
+            Error::Other(format!("{}.max_result_tokens must be a number", where_()))
+        })?;
+        // `as usize` on a negative would wrap to an astronomically large cap,
+        // which reads at a glance like "no limit" and is the opposite of what
+        // was written.
+        let max = usize::try_from(max).map_err(|_| {
+            Error::Other(format!(
+                "{}.max_result_tokens must not be negative (got {max})",
+                where_()
+            ))
+        })?;
+        routing
+            .tool_max_result_tokens
+            .insert(tool_name.to_string(), max);
+    }
+
+    if table.is_empty() {
+        return Err(Error::Other(format!(
+            "{} is empty (set region, max_result_tokens, or both)",
+            where_()
+        )));
+    }
+
+    Ok(())
+}
+
 /// Parse one `[stages.<name>]` table into a [`Stage`].
 ///
 /// Reads nothing outside its own table, so the manifest's stage order is the
 /// only thing the caller contributes.
 pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result<Stage> {
+    if let Some(table) = stage_value.as_table() {
+        reject_unknown_keys(&format!("stage '{stage_name}'"), table, STAGE_KEYS)?;
+    }
+
     let model_config = parse_stage_model(stage_value);
 
     let mut stage = Stage::new(stage_name.to_string(), model_config);
@@ -40,6 +235,14 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
             .collect();
     }
 
+    // Every bundled agent writes one and nothing read it: `Stage::description`
+    // had a field and a builder, but the parser never looked at the key, so the
+    // line was accepted and dropped. Found while enumerating the keys above,
+    // and the same bug in miniature.
+    if let Some(desc) = stage_value.get("description").and_then(|v| v.as_str()) {
+        stage.description = Some(desc.trim().to_string());
+    }
+
     if let Some(sp) = stage_value.get("system_prompt").and_then(|v| v.as_str()) {
         stage.config.insert(
             "system_prompt".to_string(),
@@ -67,6 +270,11 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     // Parse tool_routing configuration
     if let Some(routing_table) = stage_value.get("tool_routing").and_then(|v| v.as_table()) {
+        reject_unknown_keys(
+            &format!("stage '{stage_name}': tool_routing"),
+            routing_table,
+            TOOL_ROUTING_KEYS,
+        )?;
         let mut routing = crate::blueprint::ToolResultRouting::default();
 
         if let Some(dr) = routing_table.get("default_region").and_then(|v| v.as_str()) {
@@ -83,11 +291,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         }
         if let Some(overrides_table) = routing_table.get("overrides").and_then(|v| v.as_table()) {
             for (tool_name, region_val) in overrides_table {
-                if let Some(region_name) = region_val.as_str() {
-                    routing
-                        .tool_overrides
-                        .insert(tool_name.clone(), region_name.to_string());
-                }
+                parse_tool_override(stage_name, tool_name, region_val, &mut routing)?;
             }
         }
         // Per-tool ceilings, spelled like the region overrides above so the two
@@ -97,11 +301,23 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
             .and_then(|v| v.as_table())
         {
             for (tool_name, max_val) in limits {
-                if let Some(max) = max_val.as_integer() {
-                    routing
-                        .tool_max_result_tokens
-                        .insert(tool_name.clone(), max as usize);
-                }
+                let max = max_val.as_integer().ok_or_else(|| {
+                    Error::Other(format!(
+                        "stage '{stage_name}': \
+                         tool_routing.max_result_tokens_per_tool.{tool_name} \
+                         must be a number"
+                    ))
+                })?;
+                let max = usize::try_from(max).map_err(|_| {
+                    Error::Other(format!(
+                        "stage '{stage_name}': \
+                         tool_routing.max_result_tokens_per_tool.{tool_name} \
+                         must not be negative (got {max})"
+                    ))
+                })?;
+                routing
+                    .tool_max_result_tokens
+                    .insert(tool_name.clone(), max);
             }
         }
 
@@ -243,13 +459,16 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // inherits the global [context.regions] layout. NOTE (TOML nesting):
     // like [stages.<name>.model], this must be its own `[...]` section;
     // don't place `context = ...` inline keys after other sub-tables.
-    if let Some(regions_table) = stage_value
-        .get("context")
-        .and_then(|v| v.get("regions"))
-        .and_then(|v| v.as_table())
-    {
-        let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
-        stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
+    if let Some(context_table) = stage_value.get("context").and_then(|v| v.as_table()) {
+        reject_unknown_keys(
+            &format!("stage '{stage_name}': context"),
+            context_table,
+            CONTEXT_KEYS,
+        )?;
+        if let Some(regions_table) = context_table.get("regions").and_then(|v| v.as_table()) {
+            let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
+            stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
+        }
     }
 
     // Parse max_revisits
@@ -606,6 +825,21 @@ pub(super) fn parse_transitions(
 ) -> Result<std::collections::HashMap<String, TransitionEdge>> {
     let mut transitions = std::collections::HashMap::new();
     for (target_name, edge_value) in transitions_table {
+        if let Some(edge_table) = edge_value.as_table() {
+            reject_unknown_keys(
+                &format!("transition to '{target_name}'"),
+                edge_table,
+                EDGE_KEYS,
+            )?;
+            if let Some(gate_table) = edge_table.get("gate").and_then(|v| v.as_table()) {
+                reject_unknown_keys(
+                    &format!("transition to '{target_name}': gate"),
+                    gate_table,
+                    GATE_KEYS,
+                )?;
+            }
+        }
+
         let hint = edge_value
             .get("hint")
             .and_then(|v| v.as_str())

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3612,10 +3612,11 @@ compact_count = { kind = "sliding_window", max_items = 20, max_tokens = 3000, st
 }
 
 #[test]
-fn parse_manifest_tool_routing_override_non_string_value_is_skipped() {
-    // A non-string override value fails `region_val.as_str()` and is
-    // skipped, exercising the `if let Some(region_name)` false path; the
-    // string-valued override is still inserted.
+fn parse_manifest_tool_routing_override_non_string_value_is_rejected() {
+    // This asserted the opposite until #361: a non-string value was skipped,
+    // so `write_file` kept neither the region named here nor any cap, and the
+    // manifest still parsed. Silently discarding the line an author wrote is
+    // the failure, not the recovery.
     let toml = r#"
 [agent]
 name = "routing-nonstring"
@@ -3630,14 +3631,11 @@ default_region = "temp"
 read_file = "files"
 write_file = 123
 "#;
-    let bp = parse_manifest(toml).unwrap();
-    let stage = bp.find_stage("main").unwrap();
-    let routing = stage.tool_result_routing.as_ref().unwrap();
-    assert_eq!(
-        routing.tool_overrides.get("read_file").map(|s| s.as_str()),
-        Some("files")
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(
+        err.contains("write_file"),
+        "names the offending tool: {err}"
     );
-    assert!(!routing.tool_overrides.contains_key("write_file"));
 }
 
 #[test]
@@ -3805,10 +3803,15 @@ read_file = 20000
     );
 }
 
-/// A non-integer ceiling is skipped rather than failing the manifest, matching
-/// how the region overrides beside it treat a non-string.
+/// A non-integer ceiling fails the manifest.
+///
+/// This test used to assert the opposite - that the entry was skipped and the
+/// rest of the table survived - on the grounds that it matched how the region
+/// overrides beside it treated a non-string. Both were wrong for the same
+/// reason (#361, #362): the author wrote a ceiling, no ceiling was applied, and
+/// nothing said so.
 #[test]
-fn parse_manifest_skips_a_non_integer_per_tool_ceiling() {
+fn parse_manifest_rejects_a_non_integer_per_tool_ceiling() {
     let toml = r#"
 [agent]
 name = "capped"
@@ -3823,16 +3826,483 @@ default_region = "results"
 read_file = "lots"
 grep = 500
 "#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("read_file"), "names the offending tool: {err}");
+    assert!(err.contains("must be a number"), "got: {err}");
+}
+
+// ─── Keys that do not exist (#362) ───────────────────────────────────────────
+//
+// Every one of these parsed clean before, which is what made a typo in any
+// 0.3.2 feature indistinguishable from a working config.
+
+/// The smallest manifest with a `bulk` region and one stage, for the key tests.
+fn keys_fixture(stage_extra: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "keys"
+entry_stage = "work"
+
+[context.regions]
+bulk = {{ kind = "pinned", max_tokens = 1000 }}
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+{stage_extra}
+"#
+    )
+}
+
+#[test]
+fn parse_manifest_rejects_an_unknown_stage_key() {
+    let err = parse_manifest(&keys_fixture("totally_made_up_key = 42"))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("unknown key 'totally_made_up_key'"),
+        "got: {err}"
+    );
+    // The valid list is the message, same as region kinds and conditions.
+    assert!(err.contains("system_prompt"), "lists what is valid: {err}");
+}
+
+/// The reporter's case: a stage narrows its window by listing what it wants,
+/// so there is no `hidden` key - and guessing one used to mean the stage
+/// carried the region it meant to drop, at full cost, silently.
+#[test]
+fn parse_manifest_rejects_an_unknown_context_key() {
+    let err = parse_manifest(&keys_fixture("[stages.work.context]\nhidden = [\"bulk\"]"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unknown key 'hidden'"), "got: {err}");
+    assert!(err.contains("valid: regions"), "got: {err}");
+}
+
+#[test]
+fn parse_manifest_rejects_an_unknown_tool_routing_key() {
+    let err = parse_manifest(&keys_fixture(
+        "[stages.work.tool_routing]\nmax_tokens = 100",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("unknown key 'max_tokens'"), "got: {err}");
+}
+
+#[test]
+fn parse_manifest_rejects_an_unknown_gate_key() {
+    let err = parse_manifest(&keys_fixture(
+        "[stages.work.transitions.work]\ncondition = \"always\"\ngate = { require_regions = \"bulk\" }",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("unknown key 'require_regions'"), "got: {err}");
+}
+
+#[test]
+fn parse_manifest_rejects_an_unknown_transition_key() {
+    let err = parse_manifest(&keys_fixture(
+        "[stages.work.transitions.work]\nconditon = \"always\"",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("unknown key 'conditon'"), "got: {err}");
+}
+
+/// A stage `description` is now read. Every bundled agent writes one and the
+/// parser never looked at the key, so the field was permanently `None`.
+#[test]
+fn parse_manifest_reads_a_stage_description() {
+    let bp = parse_manifest(&keys_fixture("description = \"map the codebase\"")).expect("parses");
+    assert_eq!(
+        bp.find_stage("work").and_then(|s| s.description.as_deref()),
+        Some("map the codebase")
+    );
+}
+
+// ─── Region names that match nothing (#362) ──────────────────────────────────
+
+#[test]
+fn validate_rejects_a_routing_override_naming_no_region() {
+    let bp = parse_manifest(&keys_fixture(
+        "[stages.work.tool_routing.overrides]\nread_file = \"ghost\"",
+    ))
+    .expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("'ghost'"), "names the region: {err}");
+}
+
+#[test]
+fn validate_rejects_a_gate_naming_no_region() {
+    let bp = parse_manifest(&keys_fixture(
+        "[stages.work.transitions.done]\ncondition = \"always\"\ngate = { require_region_updated = \"nope\" }\n\n[stages.done]\nmode = \"autonomous\"\nsystem_prompt = \"end\"",
+    ))
+    .expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("'nope'"), "names the region: {err}");
+}
+
+/// A checklist gate counts open items, which only a checklist region has.
+/// Pointed at a text region it reads zero every time, so it passes on the
+/// first attempt - a gate that looks armed and holds nothing.
+#[test]
+fn validate_rejects_a_checklist_gate_on_a_non_checklist_region() {
+    let bp = parse_manifest(&keys_fixture(
+        "[stages.work.transitions.done]\ncondition = \"always\"\ngate = { require_no_open_items = \"bulk\" }\n\n[stages.done]\nmode = \"autonomous\"\nsystem_prompt = \"end\"",
+    ))
+    .expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("not a checklist region"), "got: {err}");
+}
+
+/// A stage may name a region another stage declares: omitting a region hides
+/// it rather than destroying it, so this is legitimate and must not be
+/// mistaken for a typo.
+#[test]
+fn validate_allows_a_region_declared_by_another_stage() {
+    let toml = r#"
+[agent]
+name = "keys"
+entry_stage = "work"
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.work.tool_routing.overrides]
+read_file = "notes"
+
+[stages.other]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.other.context.regions]
+notes = { kind = "pinned", max_tokens = 1000 }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    bp.validate()
+        .expect("a cross-stage region reference is fine");
+}
+
+#[test]
+fn validate_rejects_a_default_region_naming_no_region() {
+    let bp = parse_manifest(&keys_fixture(
+        "[stages.work.tool_routing]\ndefault_region = \"ghost\"",
+    ))
+    .expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("'ghost'"), "names the region: {err}");
+}
+
+/// A checklist gate pointed at a real checklist region validates, which is
+/// what makes the rejection beside it mean something.
+#[test]
+fn validate_allows_a_checklist_gate_on_a_checklist_region() {
+    let toml = r#"
+[agent]
+name = "keys"
+entry_stage = "work"
+
+[context.regions]
+todos = { kind = "checklist", max_tokens = 2000 }
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.work.transitions.done]
+condition = "always"
+gate = { require_no_open_items = "todos" }
+
+[stages.done]
+mode = "autonomous"
+system_prompt = "end"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    bp.validate()
+        .expect("a checklist gate on a checklist region is fine");
+}
+
+/// The three the runtime adds when nobody declares them stay addressable.
+#[test]
+fn validate_allows_the_auto_added_regions() {
+    let bp = parse_manifest(&keys_fixture(
+        "[stages.work.tool_routing]\ndefault_region = \"tool_results\"",
+    ))
+    .expect("parses");
+    bp.validate().expect("tool_results always exists");
+}
+
+/// The `{ region, max_result_tokens }` shape routes *and* caps.
+///
+/// The reachable spelling of #361: this parsed clean and did nothing, and the
+/// tool lost its region as well as its cap because the entry fell through the
+/// string-only match arm entirely.
+#[test]
+fn parse_manifest_reads_a_tool_override_table() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing]
+default_region = "conversation"
+
+[stages.work.tool_routing.overrides]
+read_file = { region = "bulk", max_result_tokens = 500 }
+grep = "conversation"
+"#;
     let bp = parse_manifest(toml).expect("parses");
     let routing = bp
         .find_stage("work")
         .and_then(|s| s.tool_result_routing.as_ref())
         .expect("routing survives");
-    assert!(!routing.tool_max_result_tokens.contains_key("read_file"));
     assert_eq!(
-        routing.tool_max_result_tokens.get("grep").copied(),
+        routing.tool_overrides.get("read_file").map(String::as_str),
+        Some("bulk"),
+        "the table form must still route"
+    );
+    assert_eq!(
+        routing.tool_max_result_tokens.get("read_file").copied(),
+        Some(500),
+        "and must carry the cap"
+    );
+    // The bare-string form beside it is untouched.
+    assert_eq!(
+        routing.tool_overrides.get("grep").map(String::as_str),
+        Some("conversation")
+    );
+}
+
+/// Either half of the table on its own is meaningful.
+#[test]
+fn parse_manifest_reads_a_half_filled_tool_override_table() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing]
+default_region = "conversation"
+
+[stages.work.tool_routing.overrides]
+read_file = { max_result_tokens = 500 }
+grep = { region = "bulk" }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let routing = bp
+        .find_stage("work")
+        .and_then(|s| s.tool_result_routing.as_ref())
+        .expect("routing survives");
+    // Capped, but left in the stage's default region.
+    assert_eq!(
+        routing.tool_max_result_tokens.get("read_file").copied(),
         Some(500)
     );
+    assert!(!routing.tool_overrides.contains_key("read_file"));
+    // Routed, but uncapped.
+    assert_eq!(
+        routing.tool_overrides.get("grep").map(String::as_str),
+        Some("bulk")
+    );
+    assert!(!routing.tool_max_result_tokens.contains_key("grep"));
+}
+
+/// A misspelled key inside the table is refused, naming what is valid.
+#[test]
+fn parse_manifest_rejects_an_unknown_tool_override_key() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = { region = "bulk", max_tokens = 500 }
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("unknown key 'max_tokens'"), "got: {err}");
+    assert!(
+        err.contains("valid: region, max_result_tokens"),
+        "names what is valid: {err}"
+    );
+}
+
+/// A value that is neither a region name nor a table is refused rather than
+/// skipped.
+#[test]
+fn parse_manifest_rejects_a_tool_override_of_the_wrong_type() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = 500
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(
+        err.contains("tool_routing.overrides.read_file"),
+        "got: {err}"
+    );
+    assert!(err.contains("integer"), "names the type it got: {err}");
+}
+
+/// A negative ceiling is refused rather than wrapping.
+///
+/// `as usize` on a negative turns 500 tokens into 18 exabytes, which reads at a
+/// glance like "no limit" - the opposite of what was written.
+#[test]
+fn parse_manifest_rejects_a_negative_tool_override_ceiling() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = { max_result_tokens = -1 }
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("must not be negative"), "got: {err}");
+}
+
+/// A `region` that is not a name.
+#[test]
+fn parse_manifest_rejects_a_non_string_region_in_a_tool_override() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = { region = 5 }
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("must be a region name"), "got: {err}");
+}
+
+/// A cap inside the table that is not a number.
+#[test]
+fn parse_manifest_rejects_a_non_integer_cap_in_a_tool_override() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = { max_result_tokens = "lots" }
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("must be a number"), "got: {err}");
+}
+
+/// The same negative guard on the sibling table.
+#[test]
+fn parse_manifest_rejects_a_negative_per_tool_ceiling() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.max_result_tokens_per_tool]
+read_file = -1
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("must not be negative"), "got: {err}");
+}
+
+/// A stage that is not a table at all has no keys to check, and still parses
+/// into a default stage as it always did.
+#[test]
+fn parse_manifest_tolerates_a_stage_that_is_not_a_table() {
+    let toml = r#"
+[agent]
+name = "odd"
+
+[stages]
+work = 5
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    assert!(bp.find_stage("work").is_some());
+}
+
+/// `[stages.X.context]` with no `regions` leaves the stage on the global
+/// layout rather than an empty one.
+#[test]
+fn parse_manifest_tolerates_a_context_table_without_regions() {
+    let toml = r#"
+[agent]
+name = "ctx"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.context]
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    assert!(
+        bp.find_stage("work")
+            .expect("stage")
+            .context_layout
+            .is_none()
+    );
+}
+
+/// A string edge (`b = "true"`) carries no keys to check.
+#[test]
+fn parse_manifest_tolerates_a_string_transition_edge() {
+    let toml = r#"
+[agent]
+name = "edge"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.transitions]
+done = "true"
+
+[stages.done]
+mode = "autonomous"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    assert!(
+        bp.find_stage("work")
+            .and_then(|s| s.transitions.as_ref())
+            .is_some_and(|t| t.contains_key("done"))
+    );
+}
+
+/// An empty table says nothing, so it is a mistake rather than a default.
+#[test]
+fn parse_manifest_rejects_an_empty_tool_override_table() {
+    let toml = r#"
+[agent]
+name = "capped"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_routing.overrides]
+read_file = {}
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("is empty"), "got: {err}");
 }
 
 /// `require_region_updated` parses onto the edge gate. Without this the key is

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -128,8 +128,9 @@ gate = { require_no_open_items = "todos",
 ```
 
 The nudge names the items that are still open. It shares the same `max_attempts` budget as every
-other gate, so it cannot wedge a run, and a gate naming a region that does not exist passes rather
-than stranding one.
+other gate, so it cannot wedge a run. A gate naming a region no stage declares, or a region that is
+not a `checklist`, is refused by `lev validate`: at runtime it could only ever count zero and pass
+on the first attempt, which looks exactly like a stage that finished its work.
 
 ### Keys every region accepts
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -253,6 +253,20 @@ read_file = 20000
 Both tables are keyed by tool name, and an alias matches the tool it aliases - writing `bash` covers
 the `shell` the model actually calls.
 
+An override entry can also carry both answers at once, which is usually what you mean when a tool
+needs its own region *and* its own ceiling:
+
+```toml
+[stages.analyze.tool_routing.overrides]
+read_file = { region = "codebase", max_result_tokens = 20000 }
+grep = "scratch"                     # just route it
+```
+
+Either key on its own is fine: `{ region = "codebase" }` routes without capping, and
+`{ max_result_tokens = 500 }` caps without moving the result out of `default_region`. A value that
+is neither a region name nor one of these tables is an error rather than a line that is quietly
+skipped.
+
 `read_file` also has a hard byte cap of its own, independent of any of this, and says so in the
 result when it applies. Without one, a large file went into its region whole and was either
 truncated or dropped as `[result omitted]` depending on how full the region already was - a cliff

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -212,8 +212,9 @@ gate = { require_region_updated = "plan",
 The region's content is hashed when the stage is entered and compared when it tries to leave, so
 "changed" means changed by *this* pass. It shares the same `max_attempts` budget as every other
 gate: a gate that could hold a stage forever would strand the run, so after the budget the edge is
-taken with a warning. A gate naming a region the window does not hold passes rather than blocking,
-since no amount of work could satisfy it.
+taken with a warning. A gate naming a region no stage declares is refused by `lev validate`: at
+runtime it passes rather than blocking, since no amount of work could satisfy it, so a typo there
+would read as a gate that is simply never reached.
 | `max_attempts` | `3` | How many times the stage re-runs before the gate gives up and lets the transition through with a warning |
 
 Per-stage tool counters reset when a stage is entered, and they are not restored when a run resumes

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -231,8 +231,26 @@
             "max_result_tokens": { "type": "integer", "minimum": 1 },
             "overrides": {
               "type": "object",
-              "description": "Tool name to region name.",
-              "additionalProperties": { "type": "string" }
+              "description": "Tool name to a region name, or to a table carrying that tool's region, its result ceiling, or both.",
+              "additionalProperties": {
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "minProperties": 1,
+                    "properties": {
+                      "region": { "type": "string" },
+                      "max_result_tokens": { "type": "integer", "minimum": 0 }
+                    }
+                  }
+                ]
+              }
+            },
+            "max_result_tokens_per_tool": {
+              "type": "object",
+              "description": "Tool name to that tool's result ceiling, overriding max_result_tokens for it.",
+              "additionalProperties": { "type": "integer", "minimum": 0 }
             }
           }
         },


### PR DESCRIPTION
Closes #361, closes #362.

Both reports are the same defect wearing two hats: the manifest parser walks
the TOML by hand, so anything it did not recognise was accepted and dropped.
`lev validate` called the blueprint good, and the only symptom was a stage
behaving as though the line had never been written.

## Reproduced first

Driven through the real parser with the reporter's exact TOML, before any fix:

```
REPRO361 default_region       = "conversation"
REPRO361 tool_overrides       = {}      <- the region is gone too
REPRO361 tool_max_result_tokens = {}
REPRO362 ACCEPTED  (totally_made_up_key, and `hidden` on a context table)
```

`tool_overrides` being empty is the part worth staring at. The entry fell
through the string-only match arm, so `read_file` lost the region it named
**as well as** the cap, and landed in `default_region` uncapped — while the
config read as if both limits were in force.

## What changed

Unknown keys are refused, naming what is valid, in `[stages.X]`,
`[stages.X.context]`, `[stages.X.tool_routing]`, a transition edge, and its
`gate`. Region names are checked the same way: routing and gate targets must
name a region some stage declares, and `require_no_open_items` must name a
`checklist` region — pointed at any other kind it counts zero and passes on
the first attempt, which is a gate that looks armed and holds nothing.

References are checked against the union of every stage's layout, not the
stage's own. Omitting a region from `[context.regions]` hides it rather than
destroying it, so naming a region another stage declares is legitimate; only a
name that exists nowhere is a typo. There is a test for that specific
allowance so the check cannot tighten into a false rejection later.

`overrides` gains the shape #361 reached for:

```toml
read_file = { region = "bulk", max_result_tokens = 500 }
grep = "bulk"                    # the old form, untouched
```

Either key alone is meaningful; anything that is neither shape is an error. A
non-integer or negative ceiling is refused in both this table and
`max_result_tokens_per_tool` — `as usize` on a negative was turning 500 tokens
into 18 exabytes, which reads at a glance like "no limit".

## Verified through the CLI, not just the parser

Every row of #362's table, against a built `lev`:

| written in the blueprint | before | now |
|---|---|---|
| `totally_made_up_key = 42` | ✓ valid | exit 1, names the key |
| `[stages.X.context] hidden = [...]` | ✓ valid | exit 1, `valid: regions` |
| `gate = { require_region_updated = "nope" }` | ✓ valid | exit 1, names `nope` |
| `gate = { require_no_open_items = "bulk" }` | ✓ valid | exit 1, not a checklist |
| `overrides.read_file = { region = "ghost" }` | ✓ valid | exit 1, names `ghost` |
| `[cache] ttl` in config.toml | silent | `WARN … keys=cache` |

and the #361 blueprint itself now validates with the region *and* the cap in
force.

## Three things this turned up

**Our own fixtures were wrong in exactly the way the issue describes.** 33 of
them: 20 wrote `prompt` where a stage takes `system_prompt` — so those stages
ran with no instructions at all, including one a test called "a valid
manifest" — and 8 wrote `entry = true`, which nothing has ever read.

**A stage's `description` was never parsed.** Every bundled agent writes one,
and `Stage` has had the field and a builder for it all along.

**`checklist` was missing from the valid-kinds message**, so anyone who
misspelled it was told the kind does not exist.

## The `read_file` half of #361 does not reproduce

It has had a 256 KiB cap since `4be003b6`, at `exec.rs:233` — one line below
the `read_to_string` the issue quotes. The report's own figure agrees: 57,164
tokens is roughly 228 KB, under the cap, so it correctly did not fire. What
actually let that read through uncapped was the dropped `max_result_tokens`
above, which is fixed here.

## `config.toml` is a warning, not an error

Deliberately asymmetric with the blueprint. A blueprint is authored and
validated deliberately; `config.toml` is long-lived and read by *every*
command, so refusing to load it over one stale key would take the whole CLI
down rather than the one thing that key was meant to affect.

The first version of that warning was a no-op — `content.parse::<toml::Value>()`
parses a bare TOML *value*, so it failed at the first `=` and returned empty
for every real config. The test passed anyway, because it only asserted the
config still loaded. It now asserts the reported keys, and the decision is a
pure function returning `Vec<String>` so it can be.

## Verification

- `cargo test --workspace` — 35 suites, 0 failures
- `cargo xtask coverage --package leviath-core` — exit 0
- `cargo xtask coverage --package leviath-cli` — exit 0
- clippy, `cargo fmt --check`, `cargo xtask docs --check` clean
- docs + published blueprint schema updated for the new shape
