### PR TITLE
fix(openrouter): take a model's window from OpenRouter, not from our table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ same list.
   every command reads that file, so refusing to load it over one stale key
   would take the CLI down rather than the one thing the key was meant to
   affect.
+- Fixed: an OpenRouter model's context window comes from OpenRouter, not from
+  the table compiled into this build (#360, and the half of #337 that was left
+  undone). The daemon reads `/models` once at start-up and uses the
+  `context_length` it reports; the 128 000-token fallback now applies only to a
+  model that neither the API nor the table describes. Region budgets are
+  percentages of the window, so a `budget = "30%"` region on a 1M-token model
+  was being sized at 38 400 instead of 314 572, silently. A
+  `[model_capabilities]` entry still outranks both, and only the two sizes come
+  from the API - whether a model accepts temperature or tools is about the
+  shape of a request, which the compiled table is the only thing that knows.
+  Reading it is bounded and never fatal: a provider that cannot answer in ten
+  seconds keeps the built-in table and the daemon starts anyway.
 
 ## 0.3.2 - 2026-08-10
 

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -94,6 +94,14 @@ pub async fn setup_daemon_host(
     .await
 }
 
+/// How long one provider gets to report its model list at start-up.
+///
+/// Short on purpose: this is the daemon's start-up path, and the answer is an
+/// optimisation over the table compiled into this build, not a requirement. A
+/// provider that cannot answer in this long is better skipped than allowed to
+/// hold up every command waiting on the daemon.
+const PROVIDER_PRIME_TIMEOUT_SECS: u64 = 10;
+
 /// [`setup_daemon_host`], with outbound-client construction injected so the
 /// start-up failure path is reachable from a test.
 pub async fn setup_daemon_host_with(
@@ -111,6 +119,16 @@ pub async fn setup_daemon_host_with(
         &config,
         build_client,
     )?;
+    // Ask each provider what its models are before anything runs on one.
+    // `capabilities()` is synchronous and sits on the inference path, so a
+    // provider whose real answer needs a network call has to be told here or
+    // never - and "never" meant an OpenRouter model this build's table does not
+    // name silently got a 128 000-token window, with every percentage region
+    // budget sized against it (#360). Awaited rather than spawned so the first
+    // run has the answer instead of racing it; failures are warnings.
+    providers
+        .prime_capabilities(std::time::Duration::from_secs(PROVIDER_PRIME_TIMEOUT_SECS))
+        .await;
     // MCP connections are shared across agents; the workdir here only seeds the
     // (discarded) built-ins - each agent gets its own over its own workdir.
     let registry = ToolRegistry::build(std::env::temp_dir(), &config).await;

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -34,6 +34,29 @@ pub struct OpenRouterProvider {
     /// Models already reported as falling back, so the warning is once per
     /// model per process rather than once per inference.
     warned_unknown: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+
+    /// What OpenRouter's own `/models` endpoint says each model's window is,
+    /// filled once by [`Provider::prime_capabilities`].
+    ///
+    /// OpenRouter fronts hundreds of models and this build's table names a few
+    /// dozen, so the table is out of date the day it ships and an unlisted
+    /// model silently got a conservative 128 000 tokens. Region budgets are
+    /// percentages of the window, so that sized a `budget = "30%"` region on a
+    /// 1M-token model at 38 400 instead of 314 572 (#337, #360).
+    ///
+    /// Empty until primed, and empty forever if the endpoint could not be
+    /// reached - both mean "fall back to the built-in table", which is what
+    /// happened before this existed.
+    api_windows: std::sync::Arc<std::sync::Mutex<HashMap<String, ApiWindow>>>,
+}
+
+/// What `/models` reports about one model's sizes.
+#[derive(Debug, Clone, Copy)]
+struct ApiWindow {
+    /// The context window OpenRouter will actually accept for this model.
+    context_length: usize,
+    /// The largest completion it will return, when the endpoint says.
+    max_completion_tokens: Option<usize>,
 }
 
 impl OpenRouterProvider {
@@ -46,6 +69,7 @@ impl OpenRouterProvider {
             rate_limiter: None,
             capability_overrides: HashMap::new(),
             warned_unknown: Default::default(),
+            api_windows: Default::default(),
         }
     }
 
@@ -61,6 +85,7 @@ impl OpenRouterProvider {
             rate_limiter,
             capability_overrides: HashMap::new(),
             warned_unknown: Default::default(),
+            api_windows: Default::default(),
         }
     }
 
@@ -78,6 +103,7 @@ impl OpenRouterProvider {
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
             warned_unknown: Default::default(),
+            api_windows: Default::default(),
         }
     }
 
@@ -352,8 +378,64 @@ impl OpenRouterProvider {
     ///
     /// Reported once per model rather than per inference, and it names the
     /// stanza that fixes it, which is now a partial entry (#338).
+    /// `base` with the sizes OpenRouter reported for this model, if it did.
+    ///
+    /// Only the two sizes. The rest of `ModelCapabilities` is about how a
+    /// request must be *shaped* - whether temperature is accepted, whether
+    /// tools work - and `/models` describes what a model is, not the quirks of
+    /// talking to it. Taking sizes from the live answer and shape from the
+    /// compiled table gives each the question it can answer.
+    fn api_corrected(&self, model: &str, base: ModelCapabilities) -> ModelCapabilities {
+        let windows = leviath_core::sync::lock(&self.api_windows);
+        let Some(api) = windows.get(model) else {
+            return base;
+        };
+        ModelCapabilities {
+            max_context_tokens: api.context_length,
+            max_output_tokens: api.max_completion_tokens.unwrap_or(base.max_output_tokens),
+            ..base
+        }
+    }
+
+    /// GET `/models`, shared by [`Provider::list_models`] and
+    /// [`Provider::prime_capabilities`] so the two cannot disagree about what
+    /// the endpoint is or how its failures read.
+    async fn fetch_models_json(&self) -> Result<serde_json::Value> {
+        let response = self
+            .client
+            .get(format!("{}/models", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(ProviderError::ApiError(format!(
+                "HTTP {}: {}",
+                status, error_body
+            )));
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+    }
+
     fn warn_if_unknown(&self, model: &str, resolved: &ModelCapabilities) {
         if resolved.max_context_tokens != FALLBACK_CAPABILITIES.max_context_tokens {
+            return;
+        }
+        // The test is "did we end up on the fallback number", which cannot tell
+        // a guess apart from a model that genuinely has a 128 000-token window.
+        // If the API told us about this model, we are not guessing, whatever
+        // the number came out as.
+        if leviath_core::sync::lock(&self.api_windows).contains_key(model) {
             return;
         }
         let mut warned = leviath_core::sync::lock(&self.warned_unknown);
@@ -474,7 +556,9 @@ impl Provider for OpenRouterProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
-        let base = builtin_capabilities(model);
+        // Three answers, narrowest first: what the user wrote, what OpenRouter
+        // says, what this build was compiled with.
+        let base = self.api_corrected(model, builtin_capabilities(model));
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {
             Some(o) => o.apply_to(base),
@@ -485,31 +569,45 @@ impl Provider for OpenRouterProvider {
         }
     }
 
-    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
-        let response = self
-            .client
-            .get(format!("{}/models", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .send()
-            .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+    async fn prime_capabilities(&self) -> Result<()> {
+        let body = self.fetch_models_json().await?;
+        let data = body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .ok_or_else(|| ProviderError::InvalidResponse("Missing 'data' array".to_string()))?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
-            return Err(ProviderError::ApiError(format!(
-                "HTTP {}: {}",
-                status, error_body
-            )));
+        let mut windows = HashMap::with_capacity(data.len());
+        for entry in data {
+            let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            // No `context_length` means the endpoint is telling us nothing
+            // useful; skipping leaves the built-in table in charge rather than
+            // recording a guess that outranks it.
+            let Some(context_length) = entry.get("context_length").and_then(|v| v.as_u64()) else {
+                continue;
+            };
+            windows.insert(
+                id.to_string(),
+                ApiWindow {
+                    context_length: context_length as usize,
+                    max_completion_tokens: entry
+                        .get("top_provider")
+                        .and_then(|tp| tp.get("max_completion_tokens"))
+                        .and_then(|v| v.as_u64())
+                        .map(|v| v as usize),
+                },
+            );
         }
 
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let count = windows.len();
+        *leviath_core::sync::lock(&self.api_windows) = windows;
+        tracing::debug!(models = count, "learned OpenRouter model windows");
+        Ok(())
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        let body = self.fetch_models_json().await?;
 
         let data = body
             .get("data")
@@ -1336,6 +1434,171 @@ mod tests {
         use tokio_stream::StreamExt;
         let chunk = stream.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
+    }
+
+    // ─── Windows come from the API, not the compiled table (#360) ────────────
+
+    /// The reported case, end to end: a model this build's table does not name,
+    /// which OpenRouter says has a 1M-token window. Before priming it resolved
+    /// to the 128 000-token fallback, and every percentage region budget was
+    /// sized against that.
+    #[tokio::test]
+    async fn priming_takes_the_window_from_the_models_api() {
+        let body = br#"{"data":[{"id":"moonshotai/kimi-k3","context_length":1048576,"top_provider":{"max_completion_tokens":32768}}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+
+        let before = provider.capabilities("moonshotai/kimi-k3");
+        assert_eq!(
+            before.max_context_tokens, 128_000,
+            "unprimed, the conservative fallback still applies"
+        );
+
+        provider.prime_capabilities().await.expect("primes");
+
+        let after = provider.capabilities("moonshotai/kimi-k3");
+        assert_eq!(after.max_context_tokens, 1_048_576);
+        assert_eq!(after.max_output_tokens, 32_768);
+    }
+
+    /// Sizes come from the API; how a request must be shaped stays with the
+    /// compiled table, which is the only thing that knows it.
+    #[tokio::test]
+    async fn priming_leaves_request_shape_alone() {
+        let body = br#"{"data":[{"id":"openai/o3","context_length":200000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+
+        let before = provider.capabilities("openai/o3");
+        provider.prime_capabilities().await.expect("primes");
+        let after = provider.capabilities("openai/o3");
+
+        assert_eq!(after.max_context_tokens, 200_000, "the size moved");
+        assert_eq!(
+            after.supports_temperature, before.supports_temperature,
+            "the shape did not"
+        );
+        assert_eq!(after.supports_tools, before.supports_tools);
+    }
+
+    /// A `[model_capabilities]` entry still wins. The user's own number is the
+    /// last word - it is how someone corrects an API that is itself wrong.
+    #[tokio::test]
+    async fn an_explicit_override_outranks_the_api() {
+        let body = br#"{"data":[{"id":"some/model","context_length":1048576}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "some/model".to_string(),
+            ModelCapabilityOverride {
+                max_context_tokens: Some(64_000),
+                ..Default::default()
+            },
+        );
+        let mut provider = OpenRouterProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            overrides,
+            None,
+        );
+        provider.base_url = url;
+
+        provider.prime_capabilities().await.expect("primes");
+        assert_eq!(
+            provider.capabilities("some/model").max_context_tokens,
+            64_000
+        );
+    }
+
+    /// An entry with no `context_length` is skipped rather than recorded, so
+    /// the built-in table stays in charge instead of being outranked by a
+    /// guess.
+    #[tokio::test]
+    async fn a_model_without_a_context_length_is_not_recorded() {
+        let body =
+            br#"{"data":[{"id":"openai/gpt-4o"},{"id":"other/model","context_length":300000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+
+        let compiled = provider.capabilities("openai/gpt-4o").max_context_tokens;
+        provider.prime_capabilities().await.expect("primes");
+
+        assert_eq!(
+            provider.capabilities("openai/gpt-4o").max_context_tokens,
+            compiled,
+            "the table still answers for a model the API said nothing about"
+        );
+        assert_eq!(
+            provider.capabilities("other/model").max_context_tokens,
+            300_000,
+            "and the one it did describe is recorded"
+        );
+    }
+
+    /// An unreachable endpoint degrades to the built-in table, which is the
+    /// behaviour that existed before priming did.
+    #[tokio::test]
+    async fn a_failed_prime_leaves_the_builtin_table_in_charge() {
+        let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
+        let provider = provider_with_url(url);
+        assert!(provider.prime_capabilities().await.is_err());
+        assert_eq!(
+            provider
+                .capabilities("moonshotai/kimi-k3")
+                .max_context_tokens,
+            128_000
+        );
+    }
+
+    /// A body that is not the documented shape is an error, not a silently
+    /// empty table that reads as "the API said nothing".
+    #[tokio::test]
+    async fn priming_rejects_a_body_with_no_data_array() {
+        let url = spawn_mock_server(200, "OK", br#"{"models":[]}"#).await;
+        let provider = provider_with_url(url);
+        let err = provider.prime_capabilities().await.unwrap_err();
+        assert!(err.to_string().contains("data"), "got: {err}");
+    }
+
+    /// A model the API describes as having exactly the fallback window is not
+    /// a guess, and must not be reported as one. The warning tests the
+    /// resolved number, which cannot tell those apart on its own.
+    #[tokio::test]
+    async fn a_model_the_api_reports_at_the_fallback_size_is_not_warned_about() {
+        let _guard = always_on_tracing_guard();
+        let body = br#"{"data":[{"id":"some/128k-model","context_length":128000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+        provider.prime_capabilities().await.expect("primes");
+
+        assert_eq!(
+            provider.capabilities("some/128k-model").max_context_tokens,
+            128_000
+        );
+        assert!(
+            !leviath_core::sync::lock(&provider.warned_unknown).contains("some/128k-model"),
+            "the API answered for this model, so nothing was assumed"
+        );
+        // The control: a model it said nothing about is still reported.
+        let _ = provider.capabilities("nobody/knows");
+        assert!(
+            leviath_core::sync::lock(&provider.warned_unknown).contains("nobody/knows"),
+            "a model with no answer anywhere is still called out"
+        );
+    }
+
+    /// An entry with no `id` cannot be looked up by one, so it is skipped.
+    #[tokio::test]
+    async fn a_model_without_an_id_is_skipped() {
+        let body =
+            br#"{"data":[{"context_length":999},{"id":"real/model","context_length":300000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+        provider.prime_capabilities().await.expect("primes");
+        assert_eq!(
+            provider.capabilities("real/model").max_context_tokens,
+            300_000
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -884,6 +884,23 @@ pub trait Provider: Send + Sync {
     /// Get the capabilities of the given model.
     fn capabilities(&self, model: &str) -> ModelCapabilities;
 
+    /// Learn what this provider's own API says about its models, before any
+    /// inference asks.
+    ///
+    /// [`Self::capabilities`] is synchronous and called on the inference path,
+    /// so it cannot go and ask. A provider whose real answer lives behind a
+    /// network call needs somewhere to fetch it once, and this is that
+    /// somewhere: the daemon awaits it at start-up, beside the other warm-up
+    /// steps, so the first run already has the answer rather than racing it.
+    ///
+    /// Providers whose capability table is compiled in need nothing here, which
+    /// is why this defaults to doing nothing. Failure is the caller's to
+    /// tolerate: a provider that cannot reach its own API should degrade to its
+    /// built-in table, not stop a daemon from starting.
+    async fn prime_capabilities(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// List models available from this provider.
     ///
     /// Returns an empty list by default; providers may override to enumerate
@@ -1629,6 +1646,16 @@ mod tests {
         fn capabilities(&self, _model: &str) -> ModelCapabilities {
             ModelCapabilities::default()
         }
+    }
+
+    /// A provider whose capability table is compiled in has nothing to fetch,
+    /// and must not have to say so.
+    #[tokio::test]
+    async fn default_prime_capabilities_does_nothing_and_succeeds() {
+        MinimalProvider
+            .prime_capabilities()
+            .await
+            .expect("a provider that needs no priming reports success");
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -48,6 +48,40 @@ impl ProviderRegistry {
         self.script_layer.as_ref()?.get_or_load(name)
     }
 
+    /// Let every registered provider learn what its own API says about its
+    /// models, before the first inference asks.
+    ///
+    /// Bounded and never fatal. A provider that cannot reach its API keeps its
+    /// built-in table, which is exactly the behaviour that existed before any
+    /// of this, so the worst case is the old answer rather than a daemon that
+    /// will not start. `timeout` covers each provider separately: this runs on
+    /// the start-up path, and an unreachable endpoint must cost a bounded wait
+    /// rather than however long a connect takes to give up.
+    ///
+    /// Script providers are deliberately not consulted. `get` compiles them on
+    /// demand, so priming would compile every `.rhai` provider on disk whether
+    /// or not the run touches one.
+    pub async fn prime_capabilities(&self, timeout: std::time::Duration) {
+        for (name, provider) in &self.providers {
+            match tokio::time::timeout(timeout, provider.prime_capabilities()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "could not read this provider's model list, so model sizes \
+                     come from the table compiled into this build; a model it \
+                     does not name gets a conservative window"
+                ),
+                Err(_) => tracing::warn!(
+                    provider = %name,
+                    timeout_secs = timeout.as_secs(),
+                    "timed out reading this provider's model list, so model \
+                     sizes come from the table compiled into this build"
+                ),
+            }
+        }
+    }
+
     /// Check if a provider is available: registered natively, or resolvable
     /// (loadable) as a script provider right now. Used at stage-model selection;
     /// network-free because script `initialize` runs offline.
@@ -73,10 +107,34 @@ mod tests {
         InferenceRequest, InferenceResponse, ModelCapabilities, ProviderError,
     };
 
-    struct StubProvider;
+    /// What a stub does when asked to prime.
+    enum PrimeOutcome {
+        Ok,
+        Fails,
+        Hangs,
+    }
+
+    struct StubProvider {
+        primed: Arc<std::sync::atomic::AtomicUsize>,
+        outcome: PrimeOutcome,
+    }
 
     #[async_trait::async_trait]
     impl Provider for StubProvider {
+        async fn prime_capabilities(&self) -> Result<(), ProviderError> {
+            self.primed
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            match self.outcome {
+                PrimeOutcome::Ok => Ok(()),
+                PrimeOutcome::Fails => Err(ProviderError::ApiError("no".to_string())),
+                PrimeOutcome::Hangs => {
+                    // Longer than any timeout a test passes, so the timeout arm
+                    // is what ends this rather than the sleep.
+                    tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                    Ok(())
+                }
+            }
+        }
         async fn infer(
             &self,
             _request: &InferenceRequest,
@@ -98,7 +156,10 @@ mod tests {
     }
 
     fn mock() -> Arc<dyn Provider> {
-        Arc::new(StubProvider)
+        Arc::new(StubProvider {
+            primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            outcome: PrimeOutcome::Ok,
+        })
     }
 
     #[test]
@@ -116,6 +177,55 @@ mod tests {
     fn default_is_empty() {
         let reg = ProviderRegistry::default();
         assert!(reg.provider_names().is_empty());
+    }
+
+    fn priming(outcome: PrimeOutcome) -> (Arc<dyn Provider>, Arc<std::sync::atomic::AtomicUsize>) {
+        let primed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        (
+            Arc::new(StubProvider {
+                primed: primed.clone(),
+                outcome,
+            }),
+            primed,
+        )
+    }
+
+    #[tokio::test]
+    async fn priming_reaches_every_registered_provider() {
+        let mut reg = ProviderRegistry::new();
+        let (p, primed) = priming(PrimeOutcome::Ok);
+        reg.register("prime".to_string(), p);
+        reg.register("other".to_string(), mock());
+
+        reg.prime_capabilities(std::time::Duration::from_secs(5))
+            .await;
+        assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// A provider that cannot answer is a warning, not a failure: the daemon
+    /// has to start whether or not an API is reachable.
+    #[tokio::test]
+    async fn a_failing_prime_does_not_stop_the_rest() {
+        let mut reg = ProviderRegistry::new();
+        let (bad, bad_calls) = priming(PrimeOutcome::Fails);
+        reg.register("bad".to_string(), bad);
+        reg.prime_capabilities(std::time::Duration::from_secs(5))
+            .await;
+        assert_eq!(bad_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// An endpoint that never answers costs the timeout, not the start-up.
+    #[tokio::test(start_paused = true)]
+    async fn priming_gives_up_on_a_provider_that_hangs() {
+        let mut reg = ProviderRegistry::new();
+        let (slow, calls) = priming(PrimeOutcome::Hangs);
+        reg.register("slow".to_string(), slow);
+        // With the clock paused this returns as soon as the timeout is the only
+        // thing left to wait on, so a regression here fails by hanging the
+        // suite rather than by sleeping through it.
+        reg.prime_capabilities(std::time::Duration::from_secs(10))
+            .await;
+        assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -155,7 +265,10 @@ mod tests {
 
     #[tokio::test]
     async fn stub_provider_methods_are_exercised() {
-        let p = StubProvider;
+        let p = StubProvider {
+            primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            outcome: PrimeOutcome::Ok,
+        };
         assert_eq!(p.name(), "stub");
         assert_eq!(p.count_tokens("abcd", "m").await, 4);
         assert_eq!(p.max_context_tokens("m"), 8192);

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -471,6 +471,27 @@ max_output_tokens    = 4096
 `lev models show <model>` prints the values a run will actually use, with any correction already
 applied.
 
+### Where a window comes from
+
+Three sources, narrowest first:
+
+1. A `[model_capabilities]` entry, if you wrote one. Your number is the last word, which is how you
+   correct an API that is itself wrong.
+2. What the provider's own API reports, read once when the daemon starts. OpenRouter fronts far more
+   models than any compiled table can name, so its `/models` endpoint is the only current answer for
+   most of them.
+3. The table compiled into this build, and for an OpenRouter model it does not name, a conservative
+   128,000 tokens.
+
+The reason this order matters is that region budgets are percentages of the window. A `budget = "30%"`
+region on a model that really holds 1M tokens is 314,572 tokens if the window is known and 38,400 if
+it fell back, with no error either way - the agent just evicts working material early and looks like
+a worse model.
+
+A provider that cannot be reached at start-up costs nothing but the fallback: Leviath warns, keeps
+the compiled table, and starts. It warns once per model when a run does land on the fallback, naming
+the line that fixes it.
+
 > [!NOTE]
 > Region budgets written as percentages resolve against `max_context_tokens`, so a wrong window is
 > not cosmetic: a `budget = "30%"` region on a model assumed to be 128k gets 38 400 tokens instead


### PR DESCRIPTION
Closes #360.

The reporter is right, and the reason is worth stating plainly: **#337 was
closed with half a fix.** That commit added a warning naming the assumed window
and the line that corrects it, and explicitly did not read the real number,
arguing that `capabilities()` is synchronous and `build_provider_registry` is
sync too, so a real fix would need either a blocking call on the inference path
or a background prefetch racing the first run.

Both facts are true. The conclusion was wrong. `build_provider_registry`'s
caller, `setup_daemon_host_with`, is `async` and already awaits two other
warm-up steps before anything can run:

```rust
let registry = ToolRegistry::build(std::env::temp_dir(), &config).await;
mcp_pool.warm_recovered(&runs_dir).await;
```

That is the seam. Making the fallback *visible* was not the same as making it
*right*, and a warning that fires on every model released after the table was
last touched is a warning people learn to scroll past.

## What changed

A new `Provider::prime_capabilities`, defaulting to a no-op, so a provider
whose real answer lives behind a network call has somewhere to fetch it once.
OpenRouter implements it by reading `/models`. The daemon awaits it at start-up,
so the first run has the answer rather than racing it.

Resolution order, narrowest first:

1. a `[model_capabilities]` entry — the user's number is the last word, which is
   how you correct an API that is itself wrong
2. what OpenRouter reported
3. the table compiled into this build
4. the 128,000 fallback, now only for a model neither source describes

**Only the two sizes come from the API.** The rest of `ModelCapabilities` is
about how a request must be *shaped* — whether temperature is accepted, whether
tools work — and `/models` describes what a model is, not the quirks of talking
to it. Each source gets the question it can answer. There is a test pinning
that split.

**Bounded and never fatal.** Ten seconds per provider; a failure or a timeout
warns and leaves the compiled table in charge, which is exactly the behaviour
that existed before. A daemon has to start whether or not an API is up.

## Verification

The reproduction is inside the test, so it cannot rot:

```rust
let before = provider.capabilities("moonshotai/kimi-k3");
assert_eq!(before.max_context_tokens, 128_000);   // the bug, as reported
provider.prime_capabilities().await.expect("primes");
let after = provider.capabilities("moonshotai/kimi-k3");
assert_eq!(after.max_context_tokens, 1_048_576);  // the fix
assert_eq!(after.max_output_tokens, 32_768);
```

Plus: an override still outranks the API; a model with no `context_length` is
skipped rather than recorded as a guess; a failed prime keeps the table; a body
with no `data` array is an error rather than a silently empty table; the
registry tolerates a provider that fails and gives up on one that hangs (driven
with a paused clock, so a regression hangs the suite instead of sleeping
through it).

- `cargo test --workspace` — 35 suites, 0 failures
- `cargo xtask coverage` — `leviath-providers`, `leviath-runtime`, `leviath-cli`
  all exit 0

## What I could not test, and what would fix that

There is no configuration key pointing the OpenRouter provider at another base
URL, so a fake `/models` cannot be put in front of a *real daemon* — I wrote the
harness for it before finding that out. `ProviderCreds` already carries a
`base_url` that the ollama arm honours and the openrouter arm drops on the
floor, so this is a few lines, but it is a new config surface and not something
to add as a side effect of a bug fix. Say the word and I will, in its own PR;
it would also close the "no knob points a provider at a proxy" gap.

What stands in for it: the unit tests drive the real provider against a mock
endpoint, and `leviath-cli` holding at 100% is what shows the daemon call site
is actually executed rather than merely written.

## One behaviour note

The fallback warning no longer fires for a model the API describes as having
exactly 128,000 tokens. The check is "did we land on the fallback number",
which on its own cannot tell a guess from a model that genuinely has that
window — and after this change the second case is common.
